### PR TITLE
 Refactor: use one subprojects property

### DIFF
--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/benchmarks/macrobenchmarks/android/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/benchmarks/microbenchmarks/android/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/benchmarks/platform_views_layout/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/benchmarks/test_apps/stocks/android/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
@@ -25,8 +25,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
@@ -25,8 +25,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/android_semantics_testing/android/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/android_views/android/build.gradle
+++ b/dev/integration_tests/android_views/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/channels/android/build.gradle
+++ b/dev/integration_tests/channels/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/external_ui/android/build.gradle
+++ b/dev/integration_tests/external_ui/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/flavors/android/build.gradle
+++ b/dev/integration_tests/flavors/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/flutter_gallery/android/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/build.gradle
@@ -26,8 +26,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/hybrid_android_views/android/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/non_nullable/android/build.gradle
+++ b/dev/integration_tests/non_nullable/android/build.gradle
@@ -25,8 +25,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/platform_interaction/android/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/release_smoke_test/android/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/integration_tests/ui/android/build.gradle
+++ b/dev/integration_tests/ui/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/dev/manual_tests/android/build.gradle
+++ b/dev/manual_tests/android/build.gradle
@@ -25,8 +25,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/flutter_view/android/build.gradle
+++ b/examples/flutter_view/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/hello_world/android/build.gradle
+++ b/examples/hello_world/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/image_list/android/build.gradle
+++ b/examples/image_list/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/layers/android/build.gradle
+++ b/examples/layers/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/platform_channel/android/build.gradle
+++ b/examples/platform_channel/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/examples/platform_view/android/build.gradle
+++ b/examples/platform_view/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app/android-java.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/build.gradle
@@ -19,8 +19,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/build.gradle
@@ -21,8 +21,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -131,8 +131,6 @@ class BasicDeferredComponentsConfig extends DeferredComponentsConfig {
   rootProject.buildDir = '../build'
   subprojects {
       project.buildDir = "${rootProject.buildDir}/${project.name}"
-  }
-  subprojects {
       project.evaluationDependsOn(':app')
   }
 

--- a/packages/integration_test/example/android/build.gradle
+++ b/packages/integration_test/example/android/build.gradle
@@ -23,8 +23,6 @@ allprojects {
 rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
-}
-subprojects {
     project.evaluationDependsOn(':app')
 }
 


### PR DESCRIPTION
Refactor build.gradle to have one subprojects property instead of two.