### PR TITLE
[flutter_tools] io cleanups to simplify null safety migration

### DIFF
--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -24,8 +24,8 @@ abstract class Signals {
 
   // The default list of signals that should cause the process to exit.
   static const List<ProcessSignal> defaultExitSignals = <ProcessSignal>[
-    ProcessSignal.SIGTERM,
-    ProcessSignal.SIGINT,
+    ProcessSignal.sigterm,
+    ProcessSignal.sigint,
   ];
 
   /// Adds a signal handler to run on receipt of signal.

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -368,7 +368,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
             logger: globals.logger,
             terminal: globals.terminal,
             signals: globals.signals,
-            processInfo: processInfo,
+            processInfo: globals.processInfo,
             reportReady: boolArg('report-ready'),
             pidFile: stringArg('pid-file'),
           )

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -67,12 +67,12 @@ class LogsCommand extends FlutterCommand {
     );
 
     // When terminating, close down the log reader.
-    ProcessSignal.SIGINT.watch().listen((ProcessSignal signal) {
+    ProcessSignal.sigint.watch().listen((ProcessSignal signal) {
       subscription.cancel();
       globals.printStatus('');
       exitCompleter.complete(0);
     });
-    ProcessSignal.SIGTERM.watch().listen((ProcessSignal signal) {
+    ProcessSignal.sigterm.watch().listen((ProcessSignal signal) {
       subscription.cancel();
       exitCompleter.complete(0);
     });

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -12,7 +12,6 @@ import 'package:vm_service/vm_service.dart';
 import '../android/android_device.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../device.dart';
@@ -639,7 +638,7 @@ class RunCommand extends RunCommandBase {
             logger: globals.logger,
             terminal: globals.terminal,
             signals: globals.signals,
-            processInfo: processInfo,
+            processInfo: globals.processInfo,
             reportReady: boolArg('report-ready'),
             pidFile: stringArg('pid-file'),
           )

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -280,7 +280,7 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         platform: globals.platform,
       ),
-      ProcessInfo: () => ProcessInfo(),
+      ProcessInfo: () => ProcessInfo(globals.fs),
       ProcessManager: () => ErrorHandlingProcessManager(
         delegate: const LocalProcessManager(),
         platform: globals.platform,

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -122,6 +122,8 @@ Future<bool> get isRunningOnBot => botDetector.isRunningOnBot;
 /// The current system clock instance.
 SystemClock get systemClock => context.get<SystemClock>();
 
+ProcessInfo get processInfo => context.get<ProcessInfo>();
+
 /// Display an error level message to the user. Commands should use this if they
 /// fail in some way.
 ///

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -209,7 +209,7 @@ class CommandResultEvent extends UsageEvent {
     // so that we can get the command result even if trying to grab maxRss
     // throws an exception.
     try {
-      final int maxRss = processInfo.maxRss;
+      final int maxRss = globals.processInfo.maxRss;
       flutterUsage.sendEvent(
         'tool-command-max-rss',
         category,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1498,11 +1498,11 @@ class TerminalHandler {
 
   void registerSignalHandlers() {
     assert(residentRunner.stayResident);
-    _addSignalHandler(io.ProcessSignal.SIGINT, _cleanUp);
-    _addSignalHandler(io.ProcessSignal.SIGTERM, _cleanUp);
+    _addSignalHandler(io.ProcessSignal.sigint, _cleanUp);
+    _addSignalHandler(io.ProcessSignal.sigterm, _cleanUp);
     if (residentRunner.supportsServiceProtocol && residentRunner.supportsRestart) {
-      _addSignalHandler(io.ProcessSignal.SIGUSR1, _handleSignal);
-      _addSignalHandler(io.ProcessSignal.SIGUSR2, _handleSignal);
+      _addSignalHandler(io.ProcessSignal.sigusr1, _handleSignal);
+      _addSignalHandler(io.ProcessSignal.sigusr2, _handleSignal);
       if (_pidFile != null) {
         _logger.printTrace('Writing pid to: $_pidFile');
         _actualPidFile = _processInfo.writePidFile(_pidFile);
@@ -1660,7 +1660,7 @@ class TerminalHandler {
     }
     _processingUserRequest = true;
 
-    final bool fullRestart = signal == io.ProcessSignal.SIGUSR2;
+    final bool fullRestart = signal == io.ProcessSignal.sigusr2;
 
     try {
       await residentRunner.restart(fullRestart: fullRestart);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1076,8 +1076,8 @@ abstract class FlutterCommand extends Command<void> {
         globals.systemClock.now(),
       );
     }
-    globals.signals.addHandler(io.ProcessSignal.SIGTERM, handler);
-    globals.signals.addHandler(io.ProcessSignal.SIGINT, handler);
+    globals.signals.addHandler(io.ProcessSignal.sigterm, handler);
+    globals.signals.addHandler(io.ProcessSignal.sigint, handler);
   }
 
   /// Logs data about this command.

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -9,6 +9,7 @@ import 'dart:io' as io;
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -99,6 +100,18 @@ void main() {
     expect(await listNetworkInterfaces(), isEmpty);
 
     resetNetworkInterfaceLister();
+  });
+
+  testWithoutContext('Does not listen to Posix process signals on windows', () async {
+    final FakePlatform windows = FakePlatform(operatingSystem: 'windows');
+    final FakePlatform linux = FakePlatform(operatingSystem: 'linux');
+    final FakeProcessSignal fakeSignalA = FakeProcessSignal();
+    final FakeProcessSignal fakeSignalB = FakeProcessSignal();
+    fakeSignalA.controller.add(fakeSignalA);
+    fakeSignalB.controller.add(fakeSignalB);
+
+    expect(await PosixProcessSignal(fakeSignalA, platform: windows).watch().isEmpty, true);
+    expect(await PosixProcessSignal(fakeSignalB, platform: linux).watch().first, isNotNull);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/base/io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/io_test.dart
@@ -66,7 +66,7 @@ void main() {
   });
 
   testUsingContext('ProcessSignal toString() works', () async {
-    expect(io.ProcessSignal.sigint.toString(), ProcessSignal.SIGINT.toString());
+    expect(io.ProcessSignal.sigint.toString(), ProcessSignal.sigint.toString());
   });
 
   test('exit throws a StateError if called without being overriden', () {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -639,7 +639,7 @@ class FakeSignals implements Signals {
 
   @override
   Object addHandler(ProcessSignal signal, SignalHandler handler) {
-    if (signal == ProcessSignal.SIGTERM) {
+    if (signal == ProcessSignal.sigterm) {
       return delegate.addHandler(subForSigTerm, handler);
     }
     return delegate.addHandler(signal, handler);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -204,7 +204,7 @@ abstract class FlutterTestDriver {
 
   Future<int> _killForcefully() {
     _debugPrint('Sending SIGKILL to $_processPid..');
-    ProcessSignal.SIGKILL.send(_processPid);
+    ProcessSignal.sigkill.send(_processPid);
     return _process.exitCode;
   }
 


### PR DESCRIPTION
Currently io uses globals which means it depends on almost the entire tool, transitively. Remove this dependency to make it possible to migrate to null safety in one shot.

Renames signals away from SCREAMING_CAPS. Makes the possix signal check and assert use the real platform.
