### PR TITLE
[flutter_tools] provide more context for invalidation

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/invalidated_reason_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/invalidated_reason_test.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter_tools/test/general.shard/build_system/invalidated_reason_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/invalidated_reason_test.dart
@@ -1,0 +1,31 @@
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter_tools/src/build_system/build_system.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('InvalidatedReason formats message per invalidation kind', () {
+    final InvalidatedReason inputChanged = InvalidatedReason(InvalidatedReasonKind.inputChanged)
+      ..data.add('a.dart');
+    final InvalidatedReason outputChanged = InvalidatedReason(InvalidatedReasonKind.outputChanged)
+      ..data.add('b.dart');
+    final InvalidatedReason inputMissing = InvalidatedReason(InvalidatedReasonKind.inputMissing)
+      ..data.add('c.dart');
+    final InvalidatedReason outputMissing = InvalidatedReason(InvalidatedReasonKind.outputMissing)
+      ..data.add('d.dart');
+    final InvalidatedReason outputSetChanged = InvalidatedReason(InvalidatedReasonKind.outputSetChanged)
+      ..data.add('e.dart');
+
+    expect(inputChanged.toString(), 'The following inputs have updated contents: a.dart');
+    expect(outputChanged.toString(), 'The following outputs have updated contents: b.dart');
+    expect(inputMissing.toString(), 'The following inputs were missing: c.dart');
+    expect(outputMissing.toString(), 'The following outputs were missing: d.dart');
+    expect(outputSetChanged.toString(), 'The following outputs were removed from the output set: e.dart');
+  });
+}


### PR DESCRIPTION
I recently provided guidance to both @GaryQian and @cyanglaz to debug the compute changes method of the build_system to see why things are re-running. Instead, lets just log more information in verbose mode
