### PR TITLE
Remove mocks from web devices test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -19,7 +19,6 @@ import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:flutter_tools/src/mdns_discovery.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
@@ -718,7 +717,6 @@ void main() {
 class MockHotRunner extends Mock implements HotRunner {}
 class MockHotRunnerFactory extends Mock implements HotRunnerFactory {}
 class MockIOSDevice extends Mock implements IOSDevice {}
-class MockMDnsObservatoryDiscovery extends Mock implements MDnsObservatoryDiscovery {}
 class MockPortForwarder extends Mock implements DevicePortForwarder {}
 
 class StreamLogger extends Logger {

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -1277,8 +1277,6 @@ class FuchsiaModulePackage extends ApplicationPackage {
   final String name;
 }
 
-class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
-
 class MockProcessManager extends Mock implements ProcessManager {}
 
 class MockProcessResult extends Mock implements ProcessResult {}

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -7,7 +7,6 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_pm.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:mockito/mockito.dart';
@@ -74,6 +73,4 @@ void main() {
 }
 
 class MockFuchsiaArtifacts extends Mock implements FuchsiaArtifacts {}
-class MockProcessUtils extends Mock implements ProcessUtils {}
-class MockProcess extends Mock implements Process {}
 class MockProcessManager extends Mock implements ProcessManager {}

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:io' hide Directory, File;
 
-import 'package:dwds/dwds.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -1084,4 +1083,3 @@ void main() {
 
 class MockHttpServer extends Mock implements HttpServer {}
 class MockResidentCompiler extends Mock implements ResidentCompiler {}
-class MockDwds extends Mock implements Dwds {}

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -126,8 +125,8 @@ void main() {
   });
 
   testWithoutContext('Chrome device is not listed when Chrome cannot be run', () async {
-    final MockProcessManager processManager = MockProcessManager();
-    when(processManager.canRun(any)).thenReturn(false);
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
+    processManager.excludedExecutables = <String>{kLinuxExecutable};
     final WebDevices webDevices = WebDevices(
       featureFlags: TestFeatureFlags(isWebEnabled: true),
       fileSystem: MemoryFileSystem.test(),
@@ -141,24 +140,6 @@ void main() {
 
     expect(await webDevices.pollingGetDevices(),
       isNot(contains(isA<GoogleChromeDevice>())));
-  });
-
-  testWithoutContext('Edge device is not listed when Edge cannot be run', () async {
-    final MockProcessManager processManager = MockProcessManager();
-    when(processManager.canRun(any)).thenReturn(false);
-    final WebDevices webDevices = WebDevices(
-      featureFlags: TestFeatureFlags(isWebEnabled: true),
-      fileSystem: MemoryFileSystem.test(),
-      logger: BufferLogger.test(),
-      platform: FakePlatform(
-        operatingSystem: 'linux',
-        environment: <String, String>{}
-      ),
-      processManager: processManager,
-    );
-
-    expect(await webDevices.pollingGetDevices(),
-      isNot(contains(isA<MicrosoftEdgeDevice>())));
   });
 
   testWithoutContext('Web Server device is listed if enabled via showWebServerDevice', () async {
@@ -329,6 +310,3 @@ void main() {
     expect((await macosWebDevices.pollingGetDevices()).whereType<MicrosoftEdgeDevice>(), isEmpty);
   });
 }
-
-// This is used to set `canRun` to false in a test.
-class MockProcessManager extends Mock implements ProcessManager {}


### PR DESCRIPTION
Remove mocks from web `devices_test.dart` and a few other unrelated unused Mock classes.

Delete `Edge device is not listed when Edge cannot be run`.
1. This wasn't testing any Edge device case because the test platform was Linux.  So the test was passing because `_edgeDevice` was always null, not because an executable was unrunnable.
2. When I tried to fix the test, there's nothing related to Edge devices not being found due to some executable being unrunnable.  I fixed the test to find Edge devices, and it never calls `canRun` anywhere.  It only does a version check to decide whether to show the Edge device, which is covered in another test
https://github.com/flutter/flutter/blob/021311ed8a2c182d3237330e5d8ae4c4937b3d76/packages/flutter_tools/lib/src/web/web_device.dart#L354-L355
https://github.com/flutter/flutter/blob/021311ed8a2c182d3237330e5d8ae4c4937b3d76/packages/flutter_tools/lib/src/web/web_device.dart#L259-L266

Part of #71511