### PR TITLE
[flutter_tools] simplify shutdown hooks

### DIFF
--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -347,9 +347,6 @@ abstract class IOSApp extends ApplicationPackage {
     } else {
       // Try to unpack as an ipa.
       final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_app.');
-      shutdownHooks.addShutdownHook(() async {
-        await tempDir.delete(recursive: true);
-      }, ShutdownStage.STILL_RECORDING);
       globals.os.unzip(globals.fs.file(applicationBinary), tempDir);
       final Directory payloadDir = globals.fs.directory(
         globals.fs.path.join(tempDir.path, 'Payload'),

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -235,7 +235,6 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
       // exits normally.
       shutdownHooks?.addShutdownHook(
         _tryToDeleteTemp,
-        ShutdownStage.CLEANUP,
       );
     }
     return _systemTemp;

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -48,35 +48,17 @@ void main() {
   group('shutdownHooks', () {
     testWithoutContext('runInExpectedOrder', () async {
       int i = 1;
-      int serializeRecording1;
-      int serializeRecording2;
-      int postProcessRecording;
       int cleanup;
 
       final ShutdownHooks shutdownHooks = ShutdownHooks(logger: BufferLogger.test());
 
       shutdownHooks.addShutdownHook(() async {
-        serializeRecording1 = i++;
-      }, ShutdownStage.SERIALIZE_RECORDING);
-
-      shutdownHooks.addShutdownHook(() async {
         cleanup = i++;
-      }, ShutdownStage.CLEANUP);
-
-      shutdownHooks.addShutdownHook(() async {
-        postProcessRecording = i++;
-      }, ShutdownStage.POST_PROCESS_RECORDING);
-
-      shutdownHooks.addShutdownHook(() async {
-        serializeRecording2 = i++;
-      }, ShutdownStage.SERIALIZE_RECORDING);
+      });
 
       await shutdownHooks.runShutdownHooks();
 
-      expect(serializeRecording1, lessThanOrEqualTo(2));
-      expect(serializeRecording2, lessThanOrEqualTo(2));
-      expect(postProcessRecording, 3);
-      expect(cleanup, 4);
+      expect(cleanup, 1);
     });
   });
 


### PR DESCRIPTION
We don't use any of the different shutdown stages besides cleanup. remove the priority system entirely.