### PR TITLE
Removed ProgressIndicator accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -43,6 +43,7 @@ abstract class ProgressIndicator extends StatefulWidget {
     Key? key,
     this.value,
     this.backgroundColor,
+    this.color,
     this.valueColor,
     this.semanticsLabel,
     this.semanticsValue,
@@ -62,18 +63,25 @@ abstract class ProgressIndicator extends StatefulWidget {
 
   /// The progress indicator's background color.
   ///
-  /// The current theme's [ThemeData.backgroundColor] by default.
+  /// The current theme's [ColorScheme.background] by default.
   ///
   /// This property is ignored if used in an adaptive constructor inside an iOS
   /// environment.
   final Color? backgroundColor;
 
+  /// The progress indicator's color.
+  ///
+  /// This is only used if [valueColor] is null. If [color] is also null,
+  /// then it defaults to the current theme's [ColorScheme.primary] by default.
+  ///
+  /// This property is ignored if used in an adaptive constructor inside an iOS
+  /// environment.
+  final Color? color;
+
   /// The progress indicator's color as an animated value.
   ///
-  /// To specify a constant color use: `AlwaysStoppedAnimation<Color>(color)`.
-  ///
-  /// If null, the progress indicator is rendered with the current theme's
-  /// [ThemeData.accentColor].
+  /// If null, the progress indicator is rendered with [color], or if that is
+  /// also null then with the current theme's [ColorScheme.primary].
   ///
   /// This property is ignored if used in an adaptive constructor inside an iOS
   /// environment.
@@ -108,8 +116,8 @@ abstract class ProgressIndicator extends StatefulWidget {
   /// {@endtemplate}
   final String? semanticsValue;
 
-  Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).backgroundColor;
-  Color _getValueColor(BuildContext context) => valueColor?.value ?? Theme.of(context).accentColor;
+  Color _getBackgroundColor(BuildContext context) => backgroundColor ?? Theme.of(context).colorScheme.background;
+  Color _getValueColor(BuildContext context) => valueColor?.value ?? color ?? Theme.of(context).colorScheme.primary;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -304,6 +312,7 @@ class LinearProgressIndicator extends ProgressIndicator {
     Key? key,
     double? value,
     Color? backgroundColor,
+    Color? color,
     Animation<Color?>? valueColor,
     this.minHeight,
     String? semanticsLabel,
@@ -313,6 +322,7 @@ class LinearProgressIndicator extends ProgressIndicator {
         key: key,
         value: value,
         backgroundColor: backgroundColor,
+        color: color,
         valueColor: valueColor,
         semanticsLabel: semanticsLabel,
         semanticsValue: semanticsValue,
@@ -542,6 +552,7 @@ class CircularProgressIndicator extends ProgressIndicator {
     Key? key,
     double? value,
     Color? backgroundColor,
+    Color? color,
     Animation<Color?>? valueColor,
     this.strokeWidth = 4.0,
     String? semanticsLabel,
@@ -551,6 +562,7 @@ class CircularProgressIndicator extends ProgressIndicator {
          key: key,
          value: value,
          backgroundColor: backgroundColor,
+         color: color,
          valueColor: valueColor,
          semanticsLabel: semanticsLabel,
          semanticsValue: semanticsValue,

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -172,6 +172,7 @@ void main() {
   });
 
   testWidgets('LinearProgressIndicator with colors', (WidgetTester tester) async {
+    // With valueColor & color provided
     await tester.pumpWidget(
       const Directionality(
         textDirection: TextDirection.ltr,
@@ -180,19 +181,75 @@ void main() {
             width: 200.0,
             child: LinearProgressIndicator(
               value: 0.25,
-              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
               backgroundColor: Colors.black,
+              color: Colors.blue,
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
             ),
           ),
         ),
       ),
     );
 
+    // Should use valueColor
     expect(
       find.byType(LinearProgressIndicator),
       paints
         ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 200.0, 4.0))
         ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 50.0, 4.0), color: Colors.white),
+    );
+
+    // With just color provided
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 200.0,
+            child: LinearProgressIndicator(
+              value: 0.25,
+              backgroundColor: Colors.black,
+              color: Colors.white12,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Should use color
+    expect(
+      find.byType(LinearProgressIndicator),
+      paints
+        ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 200.0, 4.0))
+        ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 50.0, 4.0), color: Colors.white12),
+    );
+
+    // With no color provided
+    const Color primaryColor = Color(0xff008800);
+    final ThemeData theme = ThemeData(colorScheme: ColorScheme.fromSwatch().copyWith(primary: primaryColor));
+    await tester.pumpWidget(
+      Theme(
+        data: theme,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 200.0,
+              child: LinearProgressIndicator(
+                value: 0.25,
+                backgroundColor: Colors.black,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Should use the theme's primary color
+    expect(
+      find.byType(LinearProgressIndicator),
+      paints
+        ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 200.0, 4.0))
+        ..rect(rect: const Rect.fromLTRB(0.0, 0.0, 50.0, 4.0), color: primaryColor),
     );
   });
 
@@ -275,22 +332,39 @@ void main() {
     expect(find.byType(CircularProgressIndicator), paints..arc(strokeWidth: 16.0));
   });
 
-  testWidgets('CircularProgressIndicator paint background color', (WidgetTester tester) async {
+  testWidgets('CircularProgressIndicator paint colors', (WidgetTester tester) async {
     const Color green = Color(0xFF00FF00);
     const Color blue = Color(0xFF0000FF);
+    const Color red = Color(0xFFFF0000);
 
+    // With valueColor & color provided
     await tester.pumpWidget(const CircularProgressIndicator(
+      color: red,
       valueColor: AlwaysStoppedAnimation<Color>(blue),
     ));
-
     expect(find.byType(CircularProgressIndicator), paintsExactlyCountTimes(#drawArc, 1));
     expect(find.byType(CircularProgressIndicator), paints..arc(color: blue));
 
+    // With just color provided
+    await tester.pumpWidget(const CircularProgressIndicator(
+      color: red,
+    ));
+    expect(find.byType(CircularProgressIndicator), paintsExactlyCountTimes(#drawArc, 1));
+    expect(find.byType(CircularProgressIndicator), paints..arc(color: red));
+
+    // With no color provided
+    await tester.pumpWidget(Theme(
+      data: ThemeData(colorScheme: ColorScheme.fromSwatch().copyWith(primary: green)),
+      child: const CircularProgressIndicator(),
+    ));
+    expect(find.byType(CircularProgressIndicator), paintsExactlyCountTimes(#drawArc, 1));
+    expect(find.byType(CircularProgressIndicator), paints..arc(color: green));
+
+    // With background
     await tester.pumpWidget(const CircularProgressIndicator(
       backgroundColor: green,
-      valueColor: AlwaysStoppedAnimation<Color>(blue),
+      color: blue,
     ));
-
     expect(find.byType(CircularProgressIndicator), paintsExactlyCountTimes(#drawArc, 2));
     expect(find.byType(CircularProgressIndicator), paints..arc(color: green)..arc(color: blue));
   });


### PR DESCRIPTION
This PR removes the ProgressIndicator widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

The previous implementation painted the color of the indicator with the value of the `valueColor` animated color. If that was null then it would default to the theme's `ThemeData.accentColor`. With this PR we are changing the default to the theme's  `colorScheme.primary`. In addition we have added a new 'color' property to the indicator that makes it easier to set a constant color. 

So to summarize, the color of the ProgressIndicator is now:

```
valueColor.value ??
color ??
theme.colorScheme.primary
```

We have also changed the `backgroundColor` to default to the theme's `colorScheme.background` instead of `theme.backgroundColor`. This is usually the same color, but will help with the transition to using the color scheme for everything.

## Breaking change

This is a breaking change. For apps that do need a specific color for a progress indicator, you can use the `color` parameter on the indicator directly:

```dart
  CircularProgressIndicator(color: Colors.purple),
```

You can also of course set the value for the background color as well:

```dart
  LinearProgressIndicator(
    color: Colors.red,
    backgroundColor: Colors.blue,
  ),
```

A new tests were added to verify the default values for the indicators' color are now `ColorScheme.primary`.

This PR was tested against internal Google apps in cl/360773269
