### PR TITLE
MockProcessUtils->FakeProcessManager in version_test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -206,7 +206,7 @@ void main() {
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
     await stdin.stream.first;
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('Can run AnalysisService with customized cache location --watch', () async {
@@ -244,6 +244,6 @@ void main() {
     unawaited(commandRunner.run(<String>['analyze', '--watch']));
     await stdin.stream.first;
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/analyze_continuously_test.dart
@@ -23,6 +23,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   setUpAll(() {

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -456,7 +456,7 @@ void main() {
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
@@ -481,7 +481,7 @@ void main() {
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),
@@ -510,7 +510,7 @@ void main() {
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', '--verbose', 'pub', 'run', '--foo', 'bar']);
 
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       Platform: () => FakePlatform(operatingSystem: 'linux', environment: <String, String>{}),

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/testbed.dart';
 

--- a/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
@@ -43,7 +43,7 @@ void main() {
       processManager,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AdbLogReader calls adb logcat with expected flags apiVersion < 21', () async {
@@ -66,7 +66,7 @@ void main() {
       processManager,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AdbLogReader calls adb logcat with expected flags null apiVersion', () async {
@@ -89,7 +89,7 @@ void main() {
       processManager,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AdbLogReader calls adb logcat with expected flags when requesting past logs', () async {
@@ -115,7 +115,7 @@ void main() {
       includePastLogs: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AdbLogReader handles process early exit', () async {

--- a/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
@@ -11,6 +11,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const int kLollipopVersionCode = 21;
 const String kLastLogcatTimestamp = '11-27 15:39:04.506';

--- a/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/device.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('AndroidDevicePortForwarder returns the generated host '

--- a/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
@@ -123,7 +123,7 @@ void main() {
 
     await forwarder.dispose();
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('failures to unforward port do not throw if the forward is missing', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -17,6 +17,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const FakeCommand kAdbVersionCommand = FakeCommand(
   command: <String>['adb', 'version'],

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -121,7 +121,7 @@ void main() {
       );
 
       expect(launchResult.started, true);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   }
 
@@ -160,7 +160,7 @@ void main() {
     );
 
     expect(launchResult.started, false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AndroidDevice.startApp forwards all supported debugging options', () async {
@@ -285,7 +285,7 @@ void main() {
 
     // This fails to start due to observatory discovery issues.
     expect(launchResult.started, false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -372,7 +372,7 @@ void main() {
         );
       },
       throwsA(isA<ProcessException>()));
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('logs success event after a successful retry', () async {
@@ -470,7 +470,7 @@ void main() {
           parameters: <String, String>{},
         ),
       ));
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('performs code size analysis and sends analytics', () async {
@@ -678,7 +678,7 @@ void main() {
           parameters: <String, String>{},
         ),
       ));
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('indicates that an APK has been built successfully', () async {
@@ -742,7 +742,7 @@ void main() {
         logger.statusText,
         contains('Built build/app/outputs/flutter-apk/app-release.apk (0.0MB)'),
       );
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext("doesn't indicate how to consume an AAR when printHowToConsumeAar is false", () async {
@@ -805,7 +805,7 @@ void main() {
         logger.statusText.contains('Consuming the Module'),
         isFalse,
       );
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('gradle exit code and stderr is forwarded to tool exit', () async {
@@ -861,7 +861,7 @@ void main() {
           target: '',
           buildNumber: '1.0',
         ), throwsToolExit(exitCode: 108, message: 'Gradle task assembleAarRelease failed with exit code 108.'));
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build apk uses selected local engine with arm32 ABI', () async {
@@ -935,7 +935,7 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build apk uses selected local engine with arm64 ABI', () async {
@@ -1009,7 +1009,7 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build apk uses selected local engine with x86 ABI', () async {
@@ -1083,7 +1083,7 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build apk uses selected local engine with x64 ABI', () async {
@@ -1157,7 +1157,7 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('honors --no-android-gradle-daemon setting', () async {
@@ -1212,7 +1212,7 @@ void main() {
           localGradleErrors: const <GradleHandledError>[],
         );
       }, throwsToolExit());
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build aar uses selected local engine with arm32 ABI', () async {
@@ -1297,7 +1297,7 @@ void main() {
         '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
         'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom'
       ), exists);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build aar uses selected local engine with x64 ABI', () async {
@@ -1382,7 +1382,7 @@ void main() {
         '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
         'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom'
       ), exists);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build aar uses selected local engine with x86 ABI', () async {
@@ -1467,7 +1467,7 @@ void main() {
         '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
         'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom'
       ), exists);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('build aar uses selected local engine on x64 ABI', () async {
@@ -1552,7 +1552,7 @@ void main() {
         '1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b/'
         'flutter_embedding_release-1.0.0-73fd6b049a80bcea2db1f26c7cee434907cd188b.pom'
       ), exists);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -23,6 +23,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   group('gradle build', () {

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -84,7 +84,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk), false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Cannot install app if APK file is missing', () async {
@@ -128,7 +128,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: '10'), true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Defaults to API level 16 if adb returns a null response', () async {
@@ -157,7 +157,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: '10'), true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('displays error if user not found', () async {
@@ -202,7 +202,7 @@ void main() {
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: 'jane'), false);
     expect(logger.errorText, contains('Error: User "jane" not found. Run "adb shell pm list users" to see list of available identifiers.'));
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Will skip install if the correct version is up to date', () async {
@@ -235,7 +235,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: '10'), true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Will uninstall if the correct version is not up to date and install fails', () async {
@@ -276,7 +276,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: '10'), true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Will fail to install if the apk was never installed and it fails the first time', () async {
@@ -309,7 +309,7 @@ void main() {
     );
 
     expect(await androidDevice.installApp(androidApk, userIdentifier: '10'), false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -15,6 +15,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const FakeCommand kAdbVersionCommand = FakeCommand(
   command: <String>['adb', 'version'],

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -296,7 +296,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds iOS armv7 snapshot with dwarStackTraces', () async {
@@ -354,7 +354,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds iOS armv7 snapshot with obfuscate', () async {
@@ -410,7 +410,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
 
@@ -465,7 +465,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds iOS arm64 snapshot', () async {
@@ -517,7 +517,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds shared library for android-arm (32bit)', () async {
@@ -546,7 +546,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds shared library for android-arm with dwarf stack traces', () async {
@@ -578,7 +578,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds shared library for android-arm with obfuscate', () async {
@@ -608,7 +608,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds shared library for android-arm without dwarf stack traces due to empty string', () async {
@@ -637,7 +637,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-       expect(processManager.hasRemainingExpectations, false);
+       expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('builds shared library for android-arm64', () async {
@@ -664,7 +664,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('--no-strip in extraGenSnapshotOptions suppresses --strip', () async {
@@ -691,7 +691,7 @@ void main() {
       );
 
       expect(genSnapshotExitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/macos/xcode.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const FakeCommand kWhichSysctlCommand = FakeCommand(
   command: <String>[

--- a/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 
 final Platform platform = FakePlatform(operatingSystem: 'linux', environment: const <String, String>{});
 void main() {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
@@ -204,7 +204,7 @@ void main() {
 
     await androidAot.build(environment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -246,7 +246,7 @@ void main() {
 
     await androidAot.build(environment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/compile.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 
 const String kBoundaryKey = '4d2d9609-c662-4571-afde-31410f96caa6';
 const String kElfAot = '--snapshot_kind=app-aot-elf';

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -105,7 +105,7 @@ void main() {
 
     await expectLater(() => const KernelSnapshot().build(androidEnvironment),
       throwsA(isA<Exception>()));
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot does not use track widget creation on profile builds', () async {
@@ -141,7 +141,7 @@ void main() {
 
     await const KernelSnapshot().build(androidEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot correctly handles an empty string in ExtraFrontEndOptions', () async {
@@ -178,7 +178,7 @@ void main() {
     await const KernelSnapshot()
       .build(androidEnvironment..defines[kExtraFrontEndOptions] = '');
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot correctly forwards ExtraFrontEndOptions', () async {
@@ -217,7 +217,7 @@ void main() {
     await const KernelSnapshot()
       .build(androidEnvironment..defines[kExtraFrontEndOptions] = 'foo,bar');
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot can disable track-widget-creation on debug builds', () async {
@@ -254,7 +254,7 @@ void main() {
       ..defines[kBuildMode] = getNameForBuildMode(BuildMode.debug)
       ..defines[kTrackWidgetCreation] = 'false');
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot forces platform linking on debug for darwin target platforms', () async {
@@ -292,7 +292,7 @@ void main() {
       ..defines[kTrackWidgetCreation] = 'false'
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('KernelSnapshot does use track widget creation on debug builds', () async {
@@ -339,7 +339,7 @@ void main() {
 
     await const KernelSnapshot().build(testEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('AotElfProfile Produces correct output directory', () async {
@@ -364,7 +364,7 @@ void main() {
 
     await const AotElfProfile(TargetPlatform.android_arm).build(androidEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('AotElfRelease configures gen_snapshot with code size directory', () async {
@@ -392,7 +392,7 @@ void main() {
 
     await const AotElfRelease(TargetPlatform.android_arm).build(androidEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('AotElfProfile throws error if missing build mode', () async {
@@ -548,7 +548,7 @@ void main() {
 
     await const AotAssemblyProfile().build(iosEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Platform: () => macPlatform,
     FileSystem: () => fileSystem,
@@ -620,7 +620,7 @@ void main() {
 
     await const AotAssemblyProfile().build(iosEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Platform: () => macPlatform,
     FileSystem: () => fileSystem,
@@ -695,7 +695,7 @@ void main() {
 
     await const AotAssemblyProfile().build(iosEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Platform: () => macPlatform,
     FileSystem: () => fileSystem,
@@ -729,6 +729,6 @@ void main() {
 
     await const AotElfRelease(TargetPlatform.android_arm).build(androidEnvironment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -76,7 +76,7 @@ void main() {
 
     await const DebugUnpackMacOS().build(environment);
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 
 void main() {
   Environment environment;

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_tools/src/test/coverage_collector.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
-import '../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('Coverage collector Can handle coverage SentinelException', () async {
@@ -45,6 +44,6 @@ void main() {
     );
 
     expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 }

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/test/coverage_collector.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('Coverage collector Can handle coverage SentinelException', () async {

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -44,6 +44,6 @@ void main() {
     );
 
     expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 }

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -20,6 +20,7 @@ import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/mocks.dart' as mocks;
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -93,7 +93,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
@@ -131,7 +131,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
@@ -169,7 +169,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
@@ -206,7 +206,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
@@ -245,7 +245,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 
@@ -286,7 +286,7 @@ void main() {
       checkUpToDate: true,
     );
 
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
     expect(fileSystem.file('.dart_tool/version').readAsStringSync(), 'b');
   });
 

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -22,6 +22,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   FakePlatform platform;

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -155,7 +155,7 @@ void main() {
     testUsingContext('Can pass additional arguments to tester binary', () async {
       await device.start(compiledEntrypointPath: 'example.dill');
 
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_tools/src/ios/ios_deploy.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 void main () {

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -80,7 +80,7 @@ void main () {
 
       expect(await iosDeployDebugger.launchAndAttach(), isTrue);
       expect(await iosDeployDebugger.logLines.toList(), <String>['Did finish launching.']);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
       expect(appDeltaDirectory, exists);
     });
   });
@@ -294,7 +294,7 @@ void main () {
       );
 
       expect(exitCode, 0);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('returns non-zero exit code when ios-deploy does the same', () async {
@@ -317,7 +317,7 @@ void main () {
       );
 
       expect(exitCode, 1);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -21,6 +21,7 @@ import 'package:meta/meta.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 const Map<String, String> kDyLdLibEntry = <String, String>{

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -64,7 +64,7 @@ void main() {
     final bool wasInstalled = await device.installApp(iosApp);
 
     expect(wasInstalled, true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('IOSDevice.installApp calls ios-deploy correctly with network', () async {
@@ -94,7 +94,7 @@ void main() {
     final bool wasInstalled = await device.installApp(iosApp);
 
     expect(wasInstalled, true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('IOSDevice.uninstallApp calls ios-deploy correctly', () async {
@@ -116,7 +116,7 @@ void main() {
     final bool wasUninstalled = await device.uninstallApp(iosApp);
 
     expect(wasUninstalled, true);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   group('isAppInstalled', () {
@@ -141,7 +141,7 @@ void main() {
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
       expect(isAppInstalled, false);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('returns true when app is installed', () async {
@@ -165,7 +165,7 @@ void main() {
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
       expect(isAppInstalled, isTrue);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('returns false when app is not installed', () async {
@@ -190,7 +190,7 @@ void main() {
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
       expect(isAppInstalled, isFalse);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
       expect(logger.traceText, contains('${iosApp.id} not installed on ${device.id}'));
     });
 
@@ -218,7 +218,7 @@ void main() {
       final bool isAppInstalled = await device.isAppInstalled(iosApp);
 
       expect(isAppInstalled, isFalse);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
       expect(logger.traceText, contains(stderr));
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -11,6 +11,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const Map<String, String> kDyLdLibEntry = <String, String>{
   'DYLD_LIBRARY_PATH': '/path/to/libs',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -49,7 +49,7 @@ void main() {
 
     // First port tried (49154) should fail, then succeed on the next
     expect(hostPort, 49154 + 1);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -163,7 +163,7 @@ void main() {
 
       expect(fileSystem.directory('build/ios/iphoneos'), exists);
       expect(launchResult.started, true);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
@@ -252,7 +252,7 @@ void main() {
 
       expect(launchResult?.started, true);
       expect(fileSystem.directory('build/ios/iphoneos'), exists);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       FileSystem: () => fileSystem,
@@ -316,7 +316,7 @@ void main() {
         expect(logger.statusText,
           contains('Xcode build failed due to concurrent builds, will retry in 2 seconds'));
         expect(launchResult.started, true);
-        expect(processManager.hasRemainingExpectations, false);
+        expect(processManager, hasNoRemainingExpectations);
       });
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -23,6 +23,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 // The command used to actually launch the app with args in release/profile.

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -200,7 +200,7 @@ void main() {
     expect(launchResult.started, true);
     expect(launchResult.hasObservatory, false);
     expect(await device.stopApp(iosApp), false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('IOSDevice.startApp forwards all supported debugging options', () async {
@@ -290,7 +290,7 @@ void main() {
 
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -20,6 +20,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 FakePlatform _kNoColorTerminalPlatform() => FakePlatform(stdoutSupportsAnsi: false);

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -471,7 +471,7 @@ Exited (sigterm)''',
       ]);
 
       await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('ignores errors', () async {
@@ -488,7 +488,7 @@ Exited (sigterm)''',
 
       await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
       expect(logger.traceText, contains('Failed to remove xattr com.apple.FinderInfo'));
-      expect(processManager.hasRemainingExpectations, false);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -39,6 +39,7 @@ import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 import '../src/testbed.dart';
 

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -239,7 +239,7 @@ void main() {
     expect(futureConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -287,7 +287,7 @@ void main() {
       packageConfig: anyNamed('packageConfig'),
       suppressErrors: true,
     )).called(1);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -425,7 +425,7 @@ void main() {
       packageConfig: anyNamed('packageConfig'),
       suppressErrors: false,
     )).called(1);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -499,7 +499,7 @@ void main() {
     expect(futureConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -546,7 +546,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -572,7 +572,7 @@ void main() {
     expect(result.fatal, false);
     expect(result.code, 1);
     expect(result.message, contains('Device initialization has not completed.'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
@@ -619,7 +619,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -682,7 +682,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
     Usage: () => TestUsage(),
@@ -745,7 +745,7 @@ void main() {
     final OperationResult result = await residentRunner.restart(fullRestart: false);
 
     expect(result.code, 0);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1148,7 +1148,7 @@ void main() {
     expect(event.parameters, containsPair(
       cdKey(CustomDimensions.hotEventTargetPlatform), getNameForTargetPlatform(TargetPlatform.android_arm),
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -1219,7 +1219,7 @@ void main() {
     final OperationResult result = await residentRunner.restart(fullRestart: true);
 
     expect(result.isOk, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1344,7 +1344,7 @@ void main() {
     await residentRunner.restart(fullRestart: true);
     await residentRunner.restart(fullRestart: true);
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1391,7 +1391,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'true',
       }),
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -1561,7 +1561,7 @@ void main() {
     await residentRunner.writeSkSL();
 
     expect(testLogger.statusText, contains('No data was received'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
@@ -1589,7 +1589,7 @@ void main() {
       'engineRevision': 'abcdefg',
       'data': <String, Object>{'A': 'B'}
     });
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystemUtils: () => FileSystemUtils(
       fileSystem: globals.fs,
@@ -1665,7 +1665,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.statusText, contains('1kB'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner can take screenshot on release device', () => testbed.run(() async {
@@ -1709,7 +1709,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner bails taking screenshot on debug device if debugAllowBanner during second request', () => testbed.run(() async {
@@ -1735,7 +1735,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner bails taking screenshot on debug device if takeScreenshot throws', () => testbed.run(() async {
@@ -1770,7 +1770,7 @@ void main() {
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
         throwsAssertionError);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {
@@ -1788,7 +1788,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.statusText, contains('1kB'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('FlutterDevice will not exit a paused isolate', () => testbed.run(() async {
@@ -1817,7 +1817,7 @@ void main() {
     await flutterDevice.exitApps();
 
     expect(mockDevice.appStopped, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
@@ -1866,7 +1866,7 @@ void main() {
     );
 
     expect(mockDevice.appStopped, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('FlutterDevice will exit an un-paused isolate', () => testbed.run(() async {
@@ -1902,7 +1902,7 @@ void main() {
     final Future<void> exitFuture = flutterDevice.exitApps();
 
     await expectLater(exitFuture, completes);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner debugDumpApp calls flutter device', () => testbed.run(() async {
@@ -2086,7 +2086,7 @@ void main() {
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
     expect(await flutterDevice.toggleBrightness(), Brightness.dark);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner debugToggleInvertOversizedImages calls flutter device', () => testbed.run(() async {
@@ -2148,7 +2148,7 @@ void main() {
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
     await flutterDevice.toggleInvertOversizedImages();
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }));
 
   testUsingContext('ResidentRunner debugToggleDebugCheckElevationsEnabled calls flutter device', () => testbed.run(() async {
@@ -2268,7 +2268,7 @@ void main() {
     });
     await residentRunner.run(enableDevTools: true);
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
@@ -2500,7 +2500,7 @@ void main() {
     await residentRunner.run(enableDevTools: true);
 
     expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
   }), overrides: <Type, Generator>{
@@ -2531,7 +2531,7 @@ void main() {
     await residentRunner.run(enableDevTools: true);
 
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -240,7 +240,7 @@ void main() {
     expect(futureConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -288,7 +288,7 @@ void main() {
       packageConfig: anyNamed('packageConfig'),
       suppressErrors: true,
     )).called(1);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -426,7 +426,7 @@ void main() {
       packageConfig: anyNamed('packageConfig'),
       suppressErrors: false,
     )).called(1);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -500,7 +500,7 @@ void main() {
     expect(futureConnectionInfo.isCompleted, true);
     expect((await connectionInfo).baseUri, 'foo://bar');
     expect(futureAppStart.isCompleted, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -547,7 +547,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -573,7 +573,7 @@ void main() {
     expect(result.fatal, false);
     expect(result.code, 1);
     expect(result.message, contains('Device initialization has not completed.'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner can handle an reload-barred exception from hot reload', () => testbed.run(() async {
@@ -620,7 +620,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -683,7 +683,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'false',
       }),
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
     Usage: () => TestUsage(),
@@ -746,7 +746,7 @@ void main() {
     final OperationResult result = await residentRunner.restart(fullRestart: false);
 
     expect(result.code, 0);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1149,7 +1149,7 @@ void main() {
     expect(event.parameters, containsPair(
       cdKey(CustomDimensions.hotEventTargetPlatform), getNameForTargetPlatform(TargetPlatform.android_arm),
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -1220,7 +1220,7 @@ void main() {
     final OperationResult result = await residentRunner.restart(fullRestart: true);
 
     expect(result.isOk, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1345,7 +1345,7 @@ void main() {
     await residentRunner.restart(fullRestart: true);
     await residentRunner.restart(fullRestart: true);
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });
@@ -1392,7 +1392,7 @@ void main() {
         cdKey(CustomDimensions.hotEventFullRestart): 'true',
       }),
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Usage: () => TestUsage(),
   }), overrides: <Type, Generator>{
@@ -1562,7 +1562,7 @@ void main() {
     await residentRunner.writeSkSL();
 
     expect(testLogger.statusText, contains('No data was received'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner can write SkSL data to a unique file with engine revision, platform, and device name', () => testbed.run(() async {
@@ -1590,7 +1590,7 @@ void main() {
       'engineRevision': 'abcdefg',
       'data': <String, Object>{'A': 'B'}
     });
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystemUtils: () => FileSystemUtils(
       fileSystem: globals.fs,
@@ -1666,7 +1666,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.statusText, contains('1kB'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner can take screenshot on release device', () => testbed.run(() async {
@@ -1710,7 +1710,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner bails taking screenshot on debug device if debugAllowBanner during second request', () => testbed.run(() async {
@@ -1736,7 +1736,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.errorText, contains('Error'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner bails taking screenshot on debug device if takeScreenshot throws', () => testbed.run(() async {
@@ -1771,7 +1771,7 @@ void main() {
 
     expect(() => residentRunner.screenshot(mockFlutterDevice),
         throwsAssertionError);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner does not toggle banner in non-debug mode', () => testbed.run(() async {
@@ -1789,7 +1789,7 @@ void main() {
     await residentRunner.screenshot(mockFlutterDevice);
 
     expect(testLogger.statusText, contains('1kB'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('FlutterDevice will not exit a paused isolate', () => testbed.run(() async {
@@ -1818,7 +1818,7 @@ void main() {
     await flutterDevice.exitApps();
 
     expect(mockDevice.appStopped, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('FlutterDevice can exit from a release mode isolate with no VmService', () => testbed.run(() async {
@@ -1867,7 +1867,7 @@ void main() {
     );
 
     expect(mockDevice.appStopped, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('FlutterDevice will exit an un-paused isolate', () => testbed.run(() async {
@@ -1903,7 +1903,7 @@ void main() {
     final Future<void> exitFuture = flutterDevice.exitApps();
 
     await expectLater(exitFuture, completes);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner debugDumpApp calls flutter device', () => testbed.run(() async {
@@ -2087,7 +2087,7 @@ void main() {
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
     expect(await flutterDevice.toggleBrightness(), Brightness.dark);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner debugToggleInvertOversizedImages calls flutter device', () => testbed.run(() async {
@@ -2149,7 +2149,7 @@ void main() {
     flutterDevice.vmService = fakeVmServiceHost.vmService;
 
     await flutterDevice.toggleInvertOversizedImages();
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }));
 
   testUsingContext('ResidentRunner debugToggleDebugCheckElevationsEnabled calls flutter device', () => testbed.run(() async {
@@ -2269,7 +2269,7 @@ void main() {
     });
     await residentRunner.run(enableDevTools: true);
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
@@ -2501,7 +2501,7 @@ void main() {
     await residentRunner.run(enableDevTools: true);
 
     expect(testLogger.errorText, contains('Failed to write vmservice-out-file at foo'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => ThrowingForwardingFileSystem(MemoryFileSystem.test()),
   }), overrides: <Type, Generator>{
@@ -2532,7 +2532,7 @@ void main() {
     await residentRunner.run(enableDevTools: true);
 
     expect(await globals.fs.file('foo').readAsString(), testUri.toString());
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }), overrides: <Type, Generator>{
     DevtoolsLauncher: () => mockDevtoolsLauncher,
   });

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -34,6 +34,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 import '../src/testbed.dart';
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -186,7 +186,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(MockChromeDevice());
 
     expect(residentWebRunner.debuggingEnabled, true);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -792,7 +792,7 @@ void main() {
 
     expect(logger.statusText,
       contains('    This is a message with 4 leading and trailing spaces    '));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -921,7 +921,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpApp();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -946,7 +946,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpLayerTree();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -971,7 +971,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpRenderTree();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -996,7 +996,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpSemanticsTreeInTraversalOrder();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1022,7 +1022,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1061,7 +1061,7 @@ void main() {
 
     await residentWebRunner.debugToggleDebugPaintSizeEnabled();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1100,7 +1100,7 @@ void main() {
 
     await residentWebRunner.debugTogglePerformanceOverlayOverride();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1139,7 +1139,7 @@ void main() {
 
     await residentWebRunner.debugToggleInvertOversizedImages();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1178,7 +1178,7 @@ void main() {
 
     await residentWebRunner.debugToggleWidgetInspector();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1217,7 +1217,7 @@ void main() {
 
     await residentWebRunner.debugToggleProfileWidgetBuilds();
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1259,7 +1259,7 @@ void main() {
 
     expect(logger.statusText,
       contains('Switched operating system to fuchsia'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1301,7 +1301,7 @@ void main() {
 
     expect(logger.statusText,
       contains('Changed brightness to Brightness.dark.'));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1331,7 +1331,7 @@ void main() {
     await residentWebRunner.exit();
 
     verifyNever(mockDebugConnection.close());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1355,7 +1355,7 @@ void main() {
     onDone.complete();
 
     await result;
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1379,7 +1379,7 @@ void main() {
       'Launching ${fileSystem.path.join('lib', 'main.dart')} on '
       'Chromez in debug mode',
     ));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1446,7 +1446,7 @@ void main() {
         },
       },
     )));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
@@ -1494,7 +1494,7 @@ void main() {
         },
       },
     )));
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1509,7 +1509,7 @@ void main() {
       .thenThrow(const WebSocketException());
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1524,7 +1524,7 @@ void main() {
       .thenThrow(AppConnectionException(''));
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1539,7 +1539,7 @@ void main() {
       .thenThrow(ChromeDebugException(<String, dynamic>{}));
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1552,7 +1552,7 @@ void main() {
     when(mockWebDevFS.connect(any)).thenThrow(Exception());
 
     await expectLater(residentWebRunner.run, throwsException);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1571,7 +1571,7 @@ void main() {
 
     await expectLater(residentWebRunner.run, throwsStateError);
     verify(mockStatus.stop()).called(1);
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -187,7 +187,7 @@ void main() {
     when(mockFlutterDevice.device).thenReturn(MockChromeDevice());
 
     expect(residentWebRunner.debuggingEnabled, true);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -793,7 +793,7 @@ void main() {
 
     expect(logger.statusText,
       contains('    This is a message with 4 leading and trailing spaces    '));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -922,7 +922,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpApp();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -947,7 +947,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpLayerTree();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -972,7 +972,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpRenderTree();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -997,7 +997,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpSemanticsTreeInTraversalOrder();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1023,7 +1023,7 @@ void main() {
     await connectionInfoCompleter.future;
     await residentWebRunner.debugDumpSemanticsTreeInInverseHitTestOrder();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1062,7 +1062,7 @@ void main() {
 
     await residentWebRunner.debugToggleDebugPaintSizeEnabled();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1101,7 +1101,7 @@ void main() {
 
     await residentWebRunner.debugTogglePerformanceOverlayOverride();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1140,7 +1140,7 @@ void main() {
 
     await residentWebRunner.debugToggleInvertOversizedImages();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1179,7 +1179,7 @@ void main() {
 
     await residentWebRunner.debugToggleWidgetInspector();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1218,7 +1218,7 @@ void main() {
 
     await residentWebRunner.debugToggleProfileWidgetBuilds();
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1260,7 +1260,7 @@ void main() {
 
     expect(logger.statusText,
       contains('Switched operating system to fuchsia'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1302,7 +1302,7 @@ void main() {
 
     expect(logger.statusText,
       contains('Changed brightness to Brightness.dark.'));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1332,7 +1332,7 @@ void main() {
     await residentWebRunner.exit();
 
     verifyNever(mockDebugConnection.close());
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1356,7 +1356,7 @@ void main() {
     onDone.complete();
 
     await result;
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1380,7 +1380,7 @@ void main() {
       'Launching ${fileSystem.path.join('lib', 'main.dart')} on '
       'Chromez in debug mode',
     ));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1447,7 +1447,7 @@ void main() {
         },
       },
     )));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     Logger: () => FakeStatusLogger(BufferLogger.test()),
     FileSystem: () => fileSystem,
@@ -1495,7 +1495,7 @@ void main() {
         },
       },
     )));
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1510,7 +1510,7 @@ void main() {
       .thenThrow(const WebSocketException());
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1525,7 +1525,7 @@ void main() {
       .thenThrow(AppConnectionException(''));
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1540,7 +1540,7 @@ void main() {
       .thenThrow(ChromeDebugException(<String, dynamic>{}));
 
     await expectLater(residentWebRunner.run, throwsToolExit());
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1553,7 +1553,7 @@ void main() {
     when(mockWebDevFS.connect(any)).thenThrow(Exception());
 
     await expectLater(residentWebRunner.run, throwsException);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1572,7 +1572,7 @@ void main() {
 
     await expectLater(residentWebRunner.run, throwsStateError);
     verify(mockStatus.stop()).called(1);
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -20,6 +20,7 @@ import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 
 final SystemClock _testClock = SystemClock.fixed(DateTime(2015, 1, 1));
 final DateTime _stampUpToDate = _testClock.ago(FlutterVersion.checkAgeConsideredUpToDate ~/ 2);
@@ -578,168 +579,97 @@ void main() {
   });
 
   testUsingContext('determine does not call fetch --tags', () {
-    final MockProcessUtils processUtils = MockProcessUtils();
-    when(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(105, 0, '', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(106, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
-    when(processUtils.runSync(
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(
-      RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-    ));
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['git', 'tag', '--points-at', 'HEAD'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
+        stdout: 'v0.1.2-3-1234abcd',
+      ),
+    ]);
+    final ProcessUtils processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
 
     GitTagVersion.determine(processUtils, workingDirectory: '.');
-
-    verifyNever(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    ));
-    verifyNever(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    ));
-    verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('determine does not fetch tags on dev/stable/beta', () {
-    final MockProcessUtils processUtils = MockProcessUtils();
-    when(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(105, 0, 'dev', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(106, 0, '', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(107, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
-    when(processUtils.runSync(
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(
-      RunResult(ProcessResult(108, 0, '', ''),
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-    ));
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout: 'dev',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'tag', '--points-at', 'HEAD'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
+        stdout: 'v0.1.2-3-1234abcd',
+      ),
+    ]);
+    final ProcessUtils processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
-
-    verify(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
-    verifyNever(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    ));
-    verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('determine calls fetch --tags on master', () {
-    final MockProcessUtils processUtils = MockProcessUtils();
-    when(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(108, 0, 'master', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags', '-f'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(109, 0, '', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(
-      RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-    ));
-    when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(111, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout: 'master',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags', '-f'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'tag', '--points-at', 'HEAD'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
+        stdout: 'v0.1.2-3-1234abcd',
+      ),
+    ]);
+    final ProcessUtils processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
-
-    verify(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
-    verify(processUtils.runSync(
-      <String>['git', 'fetch', 'https://github.com/flutter/flutter.git', '--tags', '-f'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
-    verify(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('determine uses overridden git url', () {
-    final MockProcessUtils processUtils = MockProcessUtils();
-    when(processUtils.runSync(
-      <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(108, 0, 'master', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'fetch', 'https://githubmirror.com/flutter.git', '--tags', '-f'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(109, 0, '', ''), <String>['git', 'fetch']));
-    when(processUtils.runSync(
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(
-      RunResult(ProcessResult(110, 0, '', ''),
-      <String>['git', 'tag', '--points-at', 'HEAD'],
-    ));
-    when(processUtils.runSync(
-      <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).thenReturn(RunResult(ProcessResult(111, 0, 'v0.1.2-3-1234abcd', ''), <String>['git', 'describe']));
+    final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout: 'master',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'fetch', 'https://githubmirror.com/flutter.git', '--tags', '-f'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'tag', '--points-at', 'HEAD'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', 'HEAD'],
+        stdout: 'v0.1.2-3-1234abcd',
+      ),
+    ]);
+    final ProcessUtils processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
 
     GitTagVersion.determine(processUtils, workingDirectory: '.', fetchTags: true);
-
-    verify(processUtils.runSync(
-      <String>['git', 'fetch', 'https://githubmirror.com/flutter.git', '--tags', '-f'],
-      workingDirectory: anyNamed('workingDirectory'),
-      environment: anyNamed('environment'),
-    )).called(1);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     Platform: () => FakePlatform(environment: <String, String>{
       'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter.git',
@@ -873,5 +803,4 @@ void fakeData(
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
-class MockProcessUtils extends Mock implements ProcessUtils {}
 class MockCache extends Mock implements Cache {}

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -19,6 +19,7 @@ import 'package:fake_async/fake_async.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 
 final Map<String, Object> vm = <String, dynamic>{
   'type': 'VM',

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -19,7 +19,6 @@ import 'package:fake_async/fake_async.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/fake_process_manager.dart';
 
 final Map<String, Object> vm = <String, dynamic>{
   'type': 'VM',
@@ -310,7 +309,7 @@ void main() {
       main: Uri.file('main.dart'),
       assetsDirectory: Uri.file('flutter_assets/'),
     );
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
   testWithoutContext('Framework service extension invocations return null if service disappears ', () async {
@@ -369,7 +368,7 @@ void main() {
     final vm_service.Response timeline = await fakeVmServiceHost.vmService.getTimeline();
     expect(timeline, isNull);
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
   testWithoutContext('getIsolateOrNull returns null if service disappears ', () async {
@@ -386,7 +385,7 @@ void main() {
     );
     expect(isolate, null);
 
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
   testWithoutContext('getFlutterViews polls until a view is returned', () async {
@@ -414,7 +413,7 @@ void main() {
       ),
       isNotEmpty,
     );
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
   testWithoutContext('getFlutterViews does not poll if returnEarly is true', () async {
@@ -435,7 +434,7 @@ void main() {
       ),
       isEmpty,
     );
-    expect(fakeVmServiceHost, hasNoRemainingExpectations);
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
   group('findExtensionIsolate', () {

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -309,7 +309,7 @@ void main() {
       main: Uri.file('main.dart'),
       assetsDirectory: Uri.file('flutter_assets/'),
     );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Framework service extension invocations return null if service disappears ', () async {
@@ -368,7 +368,7 @@ void main() {
     final vm_service.Response timeline = await fakeVmServiceHost.vmService.getTimeline();
     expect(timeline, isNull);
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 
   testWithoutContext('getIsolateOrNull returns null if service disappears ', () async {
@@ -385,7 +385,7 @@ void main() {
     );
     expect(isolate, null);
 
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 
   testWithoutContext('getFlutterViews polls until a view is returned', () async {
@@ -413,7 +413,7 @@ void main() {
       ),
       isNotEmpty,
     );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 
   testWithoutContext('getFlutterViews does not poll if returnEarly is true', () async {
@@ -434,7 +434,7 @@ void main() {
       ),
       isEmpty,
     );
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(fakeVmServiceHost, hasNoRemainingExpectations);
   });
 
   group('findExtensionIsolate', () {

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -15,6 +15,7 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -225,7 +225,7 @@ void main() {
 
     // Verify caching works correctly.
     expect(await chromeDevice.sdkNameAndVersion, 'ABC');
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Chrome and Edge version check invokes registry query on windows.', () async {
@@ -271,7 +271,7 @@ void main() {
 
     // Verify caching works correctly.
     expect(await chromeDevice.sdkNameAndVersion, 'Google Chrome 74.0.0');
-    expect(processManager.hasRemainingExpectations, false);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Edge is not supported on versions less than 73', () async {

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -393,8 +393,8 @@ class _SequenceProcessManager extends FakeProcessManager {
   List<FakeCommand> get _remainingExpectations => _commands;
 }
 
-/// Matcher that successfully matches against a [FileSystemEntity] that
-/// exists ([FileSystemEntity.existsSync] returns true).
+/// Matcher that successfully matches against a [FakeProcessManager] with
+/// no remaining expectations ([item.hasRemainingExpectations] returns false).
 const Matcher hasNoRemainingExpectations = _HasNoRemainingExpectations();
 
 class _HasNoRemainingExpectations extends Matcher {
@@ -417,6 +417,6 @@ class _HasNoRemainingExpectations extends Matcher {
       ) {
     final FakeProcessManager fakeProcessManager = item as FakeProcessManager;
     return description.add(
-        'has remaining expectations:\n${fakeProcessManager._remainingExpectations.map((FakeCommand command) => command.command.toString()).join('\n')}');
+        'has remaining expectations:\n${fakeProcessManager._remainingExpectations.map((FakeCommand command) => command.command).join('\n')}');
   }
 }

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -215,6 +215,9 @@ abstract class FakeProcessManager implements ProcessManager {
   /// This is always `true` for [FakeProcessManager.any].
   bool get hasRemainingExpectations;
 
+  /// The expected [FakeCommand]s that have not yet run.
+  List<FakeCommand> get _remainingExpectations;
+
   @protected
   FakeCommand findCommand(
     List<String> command,
@@ -353,6 +356,9 @@ class _FakeAnyProcessManager extends FakeProcessManager {
 
   @override
   bool get hasRemainingExpectations => true;
+
+  @override
+  List<FakeCommand> get _remainingExpectations => <FakeCommand>[];
 }
 
 class _SequenceProcessManager extends FakeProcessManager {
@@ -382,4 +388,35 @@ class _SequenceProcessManager extends FakeProcessManager {
 
   @override
   bool get hasRemainingExpectations => _commands.isNotEmpty;
+
+  @override
+  List<FakeCommand> get _remainingExpectations => _commands;
+}
+
+/// Matcher that successfully matches against a [FileSystemEntity] that
+/// exists ([FileSystemEntity.existsSync] returns true).
+const Matcher hasNoRemainingExpectations = _HasNoRemainingExpectations();
+
+class _HasNoRemainingExpectations extends Matcher {
+  const _HasNoRemainingExpectations();
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) =>
+      item is FakeProcessManager && !item.hasRemainingExpectations;
+
+  @override
+  Description describe(Description description) =>
+      description.add('a fake process manager with no remaining expectations');
+
+  @override
+  Description describeMismatch(
+      dynamic item,
+      Description description,
+      Map<dynamic, dynamic> matchState,
+      bool verbose,
+      ) {
+    final FakeProcessManager fakeProcessManager = item as FakeProcessManager;
+    return description.add(
+        'has remaining expectations:\n${fakeProcessManager._remainingExpectations.map((FakeCommand command) => command.command.toString()).join('\n')}');
+  }
 }


### PR DESCRIPTION
Replace `MockProcessUtils` with `FakeProcessManager` in version_test.

Create `hasNoRemainingExpectations` matcher for `FakeProcessManager` so the expect failure prints the remaining fake processes that were expected to run.  This replaces `expect(processManager.hasRemainingExpectations, false)` pattern so the failure isn't just "was true, expected false"

Part of #71511