### PR TITLE
MockOperatingSystemUtils -> FakeOperatingSystemUtils

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -5,9 +5,7 @@
 // @dart = 2.8
 
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
-import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -22,36 +20,32 @@ void main() {
   // and 65535; this test verifies we are killing iproxy processes when
   // we timeout on a port
   testWithoutContext('IOSDevicePortForwarder.forward will kill iproxy processes before invoking a second', () async {
-    const int devicePort = 456;
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
-        command: <String>['iproxy', '49154:456', '--udid', '1234'],
+        command: <String>['iproxy', '12345:456', '--udid', '1234'],
         // iproxy does not exit with 0 when it cannot forward.
         exitCode: 0,
         stdout: null, // no stdout indicates failure.
         environment: kDyLdLibEntry,
       ),
       const FakeCommand(
-        command: <String>['iproxy', '49155:456', '--udid', '1234'],
+        command: <String>['iproxy', '12346:456', '--udid', '1234'],
         exitCode: 0,
         stdout: 'not empty',
         environment: kDyLdLibEntry,
       ),
     ]);
-    final MockOperatingSystemUtils operatingSystemUtils = MockOperatingSystemUtils();
-    when(operatingSystemUtils.findFreePort()).thenAnswer((Invocation invocation) => Future<int>.value(49154));
+    final FakeOperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
 
     final IOSDevicePortForwarder portForwarder = IOSDevicePortForwarder.test(
       processManager: processManager,
       logger: BufferLogger.test(),
         operatingSystemUtils: operatingSystemUtils,
     );
-    final int hostPort = await portForwarder.forward(devicePort);
+    final int hostPort = await portForwarder.forward(456);
 
-    // First port tried (49154) should fail, then succeed on the next
-    expect(hostPort, 49154 + 1);
+    // First port tried (12345) should fail, then succeed on the next
+    expect(hostPort, 12345 + 1);
     expect(processManager, hasNoRemainingExpectations);
   });
 }
-
-class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -27,7 +27,7 @@ import 'package:package_config/package_config.dart';
 import 'package:yaml/yaml.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/context.dart' hide FakeOperatingSystemUtils;
 import '../src/fakes.dart';
 import '../src/pubspec_schema.dart';
 import '../src/testbed.dart';
@@ -2159,8 +2159,7 @@ void main() {
 
     testWithoutContext('Symlink failures give developer mode instructions on recent versions of Windows', () async {
       final Platform platform = FakePlatform(operatingSystem: 'windows');
-      final MockOperatingSystemUtils os = MockOperatingSystemUtils();
-      when(os.name).thenReturn('Microsoft Windows [Version 10.0.14972.1]');
+      final FakeOperatingSystemUtils os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14972.1]');
 
       const FileSystemException e = FileSystemException('', '', OSError('', 1314));
 
@@ -2170,8 +2169,7 @@ void main() {
 
     testWithoutContext('Symlink failures instruct developers to run as administrator on older versions of Windows', () async {
       final Platform platform = FakePlatform(operatingSystem: 'windows');
-      final MockOperatingSystemUtils os = MockOperatingSystemUtils();
-      when(os.name).thenReturn('Microsoft Windows [Version 10.0.14393]');
+      final FakeOperatingSystemUtils os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14393]');
 
       const FileSystemException e = FileSystemException('', '', OSError('', 1314));
 
@@ -2181,8 +2179,7 @@ void main() {
 
     testWithoutContext('Symlink failures only give instructions for specific errors', () async {
       final Platform platform = FakePlatform(operatingSystem: 'windows');
-      final MockOperatingSystemUtils os = MockOperatingSystemUtils();
-      when(os.name).thenReturn('Microsoft Windows [Version 10.0.14393]');
+      final FakeOperatingSystemUtils os = FakeOperatingSystemUtils('Microsoft Windows [Version 10.0.14393]');
 
       const FileSystemException e = FileSystemException('', '', OSError('', 999));
 
@@ -2200,7 +2197,13 @@ class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterprete
 class MockWebProject extends Mock implements WebProject {}
 class MockWindowsProject extends Mock implements WindowsProject {}
 class MockLinuxProject extends Mock implements LinuxProject {}
-class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
+
+class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
+  FakeOperatingSystemUtils(this.name);
+
+  @override
+  final String name;
+}
 
 class FakeSystemClock extends Fake implements SystemClock {
   DateTime currentTime;

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
-import 'package:mockito/mockito.dart';
+
 import '../../src/common.dart';
 import '../../src/context.dart';
 
@@ -39,11 +39,7 @@ void main() {
 
   setUp(() {
     exceptionHandler = FileExceptionHandler();
-    operatingSystemUtils = MockOperatingSystemUtils();
-    when(operatingSystemUtils.findFreePort())
-        .thenAnswer((Invocation invocation) async {
-      return 1234;
-    });
+    operatingSystemUtils = FakeOperatingSystemUtils();
     platform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{
       kChromeEnvironment: 'example_chrome',
     });
@@ -119,7 +115,7 @@ void main() {
       command: <String>[
         'example_chrome',
         '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-        '--remote-debugging-port=1234',
+        '--remote-debugging-port=12345',
         ...kChromeArgs,
         'example_url',
       ],
@@ -171,7 +167,7 @@ void main() {
       command: <String>[
         'example_chrome',
         '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-        '--remote-debugging-port=1234',
+        '--remote-debugging-port=12345',
         ...kChromeArgs,
         'example_url',
       ],
@@ -220,7 +216,7 @@ void main() {
       command: <String>[
         'example_chrome',
         '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-        '--remote-debugging-port=1234',
+        '--remote-debugging-port=12345',
         ...kChromeArgs,
         '--headless',
         '--disable-gpu',
@@ -260,7 +256,7 @@ void main() {
       command: const <String>[
         'example_chrome',
         '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-        '--remote-debugging-port=1234',
+        '--remote-debugging-port=12345',
         ...kChromeArgs,
         'example_url',
       ],
@@ -294,7 +290,7 @@ void main() {
     const List<String> args = <String>[
       'example_chrome',
       '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-      '--remote-debugging-port=1234',
+      '--remote-debugging-port=12345',
       ...kChromeArgs,
       '--headless',
       '--disable-gpu',
@@ -334,7 +330,7 @@ void main() {
       command: <String>[
         'example_chrome',
         '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
-        '--remote-debugging-port=1234',
+        '--remote-debugging-port=12345',
         ...kChromeArgs,
         '--headless',
         '--disable-gpu',
@@ -356,14 +352,12 @@ void main() {
   });
 }
 
-class MockOperatingSystemUtils extends Mock implements OperatingSystemUtils {}
-
 Future<Chromium> _testLaunchChrome(String userDataDir, FakeProcessManager processManager, ChromiumLauncher chromeLauncher) {
   processManager.addCommand(FakeCommand(
     command: <String>[
       'example_chrome',
       '--user-data-dir=$userDataDir',
-      '--remote-debugging-port=1234',
+      '--remote-debugging-port=12345',
       ...kChromeArgs,
       'example_url',
     ],


### PR DESCRIPTION
In `plugins_test.dart` create a new FakeOperatingSystemUtils, otherwise use the one already in `context.dart`.

Part of #71511