### PR TITLE
Removed TabPageSelector accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1577,7 +1577,7 @@ class TabPageSelector extends StatelessWidget {
   /// for all indicator circles.
   ///
   /// If this parameter is null, then the indicator is filled with the theme's
-  /// accent color, [ThemeData.accentColor].
+  /// [ColorScheme.secondary].
   final Color? selectedColor;
 
   Widget _buildTabIndicator(
@@ -1620,7 +1620,7 @@ class TabPageSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color fixColor = color ?? Colors.transparent;
-    final Color fixSelectedColor = selectedColor ?? Theme.of(context).accentColor;
+    final Color fixSelectedColor = selectedColor ?? Theme.of(context).colorScheme.secondary;
     final ColorTween selectedColorTween = ColorTween(begin: fixColor, end: fixSelectedColor);
     final ColorTween previousColorTween = ColorTween(begin: fixSelectedColor, end: fixColor);
     final TabController? tabController = controller ?? DefaultTabController.of(context);

--- a/packages/flutter/test/material/page_selector_test.dart
+++ b/packages/flutter/test/material/page_selector_test.dart
@@ -12,7 +12,7 @@ Widget buildFrame(TabController tabController, { Color? color, Color? selectedCo
   return Directionality(
     textDirection: TextDirection.ltr,
     child: Theme(
-      data: ThemeData(accentColor: kSelectedColor),
+      data: ThemeData(colorScheme: const ColorScheme.light().copyWith(secondary: kSelectedColor)),
       child: SizedBox.expand(
         child: Center(
           child: SizedBox(


### PR DESCRIPTION
This PR removes the TabPageSelector widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

The previous implementation painted the color of the selected tab indicator with `ThemeData.accentColor` by default. This PR changes it to the theme's `colorScheme.secondary`.

## Breaking change

This is a breaking change. For apps that need a specific color for the selected tab indicator, you can use the `selectedColor` parameter on the selector directly:

```dart
  TabPageSelector(selectedColor: Colors.purple),
```

Also updated the tests to verify the new default value for the selected color.

This PR was tested against internal Google apps in cl/361916343.
