### PR TITLE
WIP [AnimatedList] Add seperatedBuilder to AnimatedList

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -285,6 +285,36 @@ class AnimatedList extends StatefulWidget {
        assert(initialItemCount != null && initialItemCount >= 0),
        super(key: key);
 
+  /// Creates a scrolling container with separators that animates items and
+  /// separators when they are inserted or removed.
+  AnimatedList.separated({
+    Key? key,
+    required AnimatedListItemBuilder itemBuilder,
+    required AnimatedListItemBuilder separatorBuilder,
+    this.initialItemCount = 0,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.controller,
+    this.primary,
+    this.physics,
+    this.shrinkWrap = false,
+    this.padding,
+    this.clipBehavior = Clip.hardEdge,
+  })  : assert(itemBuilder != null),
+        assert(separatorBuilder != null),
+        assert(initialItemCount != null && initialItemCount >= 0),
+        itemBuilder =
+        ((BuildContext context, int index, Animation<double> animation) =>
+            Flex(
+              direction: scrollDirection,
+              children: <Widget>[
+                itemBuilder(context, index, animation),
+                separatorBuilder(context, index, animation),
+              ],
+            )),
+        super(key: key);
+
+
   /// Called, as needed, to build list item widgets.
   ///
   /// List items are only built when they're scrolled into view.

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/src/material/divider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/src/foundation/diagnostics.dart';
 import 'package:flutter/widgets.dart';
@@ -53,6 +54,64 @@ void main() {
     await tester.pump();
     expect(find.text('removing item'), findsOneWidget);
     expect(find.text('item 2'), findsNothing);
+
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+    expect(find.text('removing item'), findsNothing);
+  });
+
+testWidgets('AnimatedList.separated', (WidgetTester tester) async {
+
+    final GlobalKey<AnimatedListState> listKey = GlobalKey<AnimatedListState>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedList.separated(
+          key: listKey,
+          initialItemCount: 2,
+          itemBuilder: (BuildContext context, int index, Animation<double> animation) {
+            return SizedBox(
+              height: 100.0,
+              child: Center(
+                child: Text('item $index'),
+              ),
+            );
+          },
+          separatorBuilder: (BuildContext context, int index, Animation<double> animation) {
+            return Divider(key: Key('separatorKey $index'), height: 1, thickness: 1,);
+          },
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('separatorKey 0')), findsOneWidget);
+    expect(find.byKey(const Key('separatorKey 1')), findsOneWidget);
+    expect(find.byWidgetPredicate((Widget widget) {
+      return widget is SliverAnimatedList
+          && widget.initialItemCount == 2
+          && widget.itemBuilder is AnimatedListItemBuilder;
+    }), findsOneWidget);
+
+    listKey.currentState!.insertItem(0);
+    await tester.pump();
+    expect(find.text('item 2'), findsOneWidget);
+    expect(find.byKey(const Key('separatorKey 2')), findsOneWidget);
+
+    listKey.currentState!.removeItem(
+      2,
+          (BuildContext context, Animation<double> animation) {
+        return const SizedBox(
+          height: 100.0,
+          child: Center(child: Text('removing item')),
+        );
+      },
+      duration: const Duration(milliseconds: 100),
+    );
+
+    await tester.pump();
+    expect(find.text('removing item'), findsOneWidget);
+    expect(find.text('item 2'), findsNothing);
+    expect(find.byKey(const Key('separatorKey 2')), findsNothing);
 
     await tester.pumpAndSettle(const Duration(milliseconds: 100));
     expect(find.text('removing item'), findsNothing);


### PR DESCRIPTION
Adds a `AnimatedList.separatedBuilder` constrcutor to AnimatedList.

closes   flutter/flutter#48226

Maybe needs some more logic for the removeItem, although the test passes, happy to follow up.

I added the following test to pacakges/flutter/test/widgets/animated_list_test.dart
 -`AnimatedList.separated`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
