### PR TITLE
Fix bug in ButtonStyle.lerp(), in _LerpSides

### DIFF
--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -475,7 +475,7 @@ class _LerpSides implements MaterialStateProperty<BorderSide?> {
     if (resolvedA == null)
       return BorderSide.lerp(BorderSide(width: 0, color: resolvedB!.color.withAlpha(0)), resolvedB, t);
     if (resolvedB == null)
-      return BorderSide.lerp(BorderSide(width: 0, color: resolvedA.color.withAlpha(0)), resolvedA, t);
+      return BorderSide.lerp(resolvedA, BorderSide(width: 0, color: resolvedA.color.withAlpha(0)), t);
     return BorderSide.lerp(resolvedA, resolvedB, t);
   }
 }

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -160,17 +160,14 @@ void main() {
 
     const BorderSide blackSide = BorderSide(width: 1, color: Color(0xFF000000));
     const BorderSide whiteSide = BorderSide(width: 1, color: Color(0xFFFFFFFF));
-    const BorderSide emptyBlackSide = BorderSide(width: 0, color: Color(0));
-    const BorderSide emptyWhiteSide = BorderSide(width: 0, color: Color(0x00FFFFFF));
+    const BorderSide emptyBlackSide = BorderSide(width: 0, color: Color(0x00000000));
 
     final ButtonStyle blackStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(blackSide));
     final ButtonStyle whiteStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(whiteSide));
-    final ButtonStyle emptyBlackStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(emptyBlackSide));
-    final ButtonStyle emptyWhiteStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(emptyWhiteSide));
 
     // MaterialState.all<Foo>(value) properties resolve to value
     // for any set of MaterialStates.
-    Set<MaterialState> states = <MaterialState>{ };
+    const Set<MaterialState> states = <MaterialState>{ };
 
     expect(ButtonStyle.lerp(blackStyle, blackStyle, 0)?.side?.resolve(states), blackSide);
     expect(ButtonStyle.lerp(blackStyle, blackStyle, 0.5)?.side?.resolve(states), blackSide);

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -151,4 +151,41 @@ void main() {
       style.merge(const ButtonStyle())
     );
   });
+
+  test('ButtonStyle.lerp BorderSide', () {
+    // This is regression test for https://github.com/flutter/flutter/pull/78051
+    expect(ButtonStyle.lerp(null, null, 0), null);
+    expect(ButtonStyle.lerp(null, null, 0.5), null);
+    expect(ButtonStyle.lerp(null, null, 1), null);
+
+    const BorderSide blackSide = BorderSide(width: 1, color: Color(0xFF000000));
+    const BorderSide whiteSide = BorderSide(width: 1, color: Color(0xFFFFFFFF));
+    const BorderSide emptyBlackSide = BorderSide(width: 0, color: Color(0));
+    const BorderSide emptyWhiteSide = BorderSide(width: 0, color: Color(0x00FFFFFF));
+
+    final ButtonStyle blackStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(blackSide));
+    final ButtonStyle whiteStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(whiteSide));
+    final ButtonStyle emptyBlackStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(emptyBlackSide));
+    final ButtonStyle emptyWhiteStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(emptyWhiteSide));
+
+    // MaterialState.all<Foo>(value) properties resolve to value
+    // for any set of MaterialStates.
+    Set<MaterialState> states = <MaterialState>{ };
+
+    expect(ButtonStyle.lerp(blackStyle, blackStyle, 0)?.side?.resolve(states), blackSide);
+    expect(ButtonStyle.lerp(blackStyle, blackStyle, 0.5)?.side?.resolve(states), blackSide);
+    expect(ButtonStyle.lerp(blackStyle, blackStyle, 1)?.side?.resolve(states), blackSide);
+
+    expect(ButtonStyle.lerp(blackStyle, null, 0)?.side?.resolve(states), blackSide);
+    expect(ButtonStyle.lerp(blackStyle, null, 0.5)?.side?.resolve(states), BorderSide.lerp(blackSide, emptyBlackSide, 0.5));
+    expect(ButtonStyle.lerp(blackStyle, null, 1)?.side?.resolve(states), emptyBlackSide);
+
+    expect(ButtonStyle.lerp(null, blackStyle, 0)?.side?.resolve(states), emptyBlackSide);
+    expect(ButtonStyle.lerp(null, blackStyle, 0.5)?.side?.resolve(states), BorderSide.lerp(emptyBlackSide, blackSide, 0.5));
+    expect(ButtonStyle.lerp(null, blackStyle, 1)?.side?.resolve(states), blackSide);
+
+    expect(ButtonStyle.lerp(blackStyle, whiteStyle, 0)?.side?.resolve(states), blackSide);
+    expect(ButtonStyle.lerp(blackStyle, whiteStyle, 0.5)?.side?.resolve(states), BorderSide.lerp(blackSide, whiteSide, 0.5));
+    expect(ButtonStyle.lerp(blackStyle, whiteStyle, 1)?.side?.resolve(states), whiteSide);
+  });
 }


### PR DESCRIPTION
ButtonStyle.lerp between a ButtonStyle with a null `MaterialStateProperty<BorderSide>` side and a second ButtonStyle with a non-null `MaterialStateProprety<BorderSide>` property now correctly interpolates between an "empty" BorderSide and the final BorderSide value.

Fixes https://github.com/flutter/flutter/issues/77842
