### PR TITLE
[integration_test] delay for at least one frame timing.

### DIFF
--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -305,10 +305,14 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // TODO(CareF): remove this when flush FrameTiming is readly in engine.
     //              See https://github.com/flutter/flutter/issues/64808
     //              and https://github.com/flutter/flutter/issues/67593
-    Future<void> delayForFrameTimings() => Future<void>.delayed(const Duration(seconds: 2));
+    final List<FrameTiming> frameTimings = <FrameTiming>[];
+    Future<void> delayForFrameTimings() async {
+      while (frameTimings.isEmpty) {
+        await Future<void>.delayed(const Duration(seconds: 2));
+      }
+    }
 
     await delayForFrameTimings(); // flush old FrameTimings
-    final List<FrameTiming> frameTimings = <FrameTiming>[];
     final TimingsCallback watcher = frameTimings.addAll;
     addTimingsCallback(watcher);
     await action();

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -307,12 +307,17 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     //              and https://github.com/flutter/flutter/issues/67593
     final List<FrameTiming> frameTimings = <FrameTiming>[];
     Future<void> delayForFrameTimings() async {
+      int count = 0;
       while (frameTimings.isEmpty) {
+        count++;
         await Future<void>.delayed(const Duration(seconds: 2));
+        if (count > 20) {
+          print('delayForFrameTimings is taking longer than expected...');
+        }
       }
     }
 
-    await delayForFrameTimings(); // flush old FrameTimings
+    await Future<void>.delayed(const Duration(seconds: 2)); // flush old FrameTimings
     final TimingsCallback watcher = frameTimings.addAll;
     addTimingsCallback(watcher);
     await action();


### PR DESCRIPTION

If there is not at least one frame timing collected, the summary measurements will crash. https://github.com/flutter/flutter/issues/78047


Originally added in https://github.com/flutter/flutter/pull/64780/
