### PR TITLE
[flutter_tools] Deferred components: Encode base module loading units in manifest metadata

### DIFF
--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -127,14 +127,16 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
     // Check for existing metadata entry and see if needs changes.
     bool exists = false;
     bool modified = false;
-    for (final XmlElement metaData in document.findAllElements('meta-data')) {
-      final String name = metaData.getAttribute('android:name');
-      if (name == _mappingKey) {
-        exists = true;
-        final String storedMappingString = metaData.getAttribute('android:value');
-        if (storedMappingString != encodedMapping) {
-          metaData.setAttribute('android:value', encodedMapping);
-          modified = true;
+    for (final XmlElement application in document.findAllElements('application')) {
+      for (final XmlElement metaData in application.findElements('meta-data')) {
+        final String name = metaData.getAttribute('android:name');
+        if (name == _mappingKey) {
+          exists = true;
+          final String storedMappingString = metaData.getAttribute('android:value');
+          if (storedMappingString != encodedMapping) {
+            metaData.setAttribute('android:value', encodedMapping);
+            modified = true;
+          }
         }
       }
     }

--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -107,6 +107,13 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
         }
       }
     }
+    for (final LoadingUnit unit in generatedLoadingUnits) {
+      if (!mapping.containsKey(unit.id)) {
+        // Store an empty string for unassigned loading units,
+        // indicating that it is in the base component.
+        mapping[unit.id] = '';
+      }
+    }
     // Encode the mapping as a string.
     final StringBuffer mappingBuffer = StringBuffer();
     for (final int key in mapping.keys) {

--- a/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
@@ -93,7 +93,7 @@ loading-units:
       - lib2
       - lib3
 ''';
-    expect(expectedFile.readAsStringSync().contains(expectedContents), true);
+    expect(expectedFile.readAsStringSync(), contains(expectedContents));
   });
 
   testWithoutContext('loadingUnitCache identical passes', () async {
@@ -103,9 +103,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -116,7 +113,7 @@ loading-units:
     libraries:
       - lib2
       - lib3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 2, libraries: <String>['lib1']),
@@ -136,9 +133,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -146,7 +140,7 @@ loading-units:
     libraries:
       - lib2
       - lib3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 2, libraries: <String>['lib1']),
@@ -156,7 +150,7 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('New loading units were found:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'), true);
+    expect(logger.statusText, contains('New loading units were found:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
   });
 
   testWithoutContext('loadingUnitCache finds missing loading units', () async {
@@ -166,9 +160,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -179,7 +170,7 @@ loading-units:
     libraries:
       - lib2
       - lib3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -188,7 +179,7 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'), true);
+    expect(logger.statusText, contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
   });
 
   testWithoutContext('missing cache file counts as all new loading units', () async {
@@ -198,9 +189,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 2, libraries: <String>['lib1']),
@@ -209,7 +197,7 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('New loading units were found:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'), true);
+    expect(logger.statusText, contains('New loading units were found:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: missing main entry', () async {
@@ -219,9 +207,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units-spelled-wrong:
@@ -232,7 +217,7 @@ loading-units-spelled-wrong:
     libraries:
       - lib2
       - lib3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -241,10 +226,10 @@ loading-units-spelled-wrong:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, \'loading-units\' entry did not exist.'), true);
+    expect(logger.statusText, contains('Errors checking the following files:');
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' entry did not exist.');
 
-    expect(logger.statusText.contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'), false);
+    expect(logger.statusText, contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: not a list', () async {
@@ -254,13 +239,10 @@ loading-units-spelled-wrong:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units: hello
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -269,8 +251,8 @@ loading-units: hello
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, \'loading-units\' is not a list.'), true);
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' is not a list.'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: not a list', () async {
@@ -280,15 +262,12 @@ loading-units: hello
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
   - 2
   - 3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -297,8 +276,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, \'loading-units\' is not a list of maps.'), true);
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' is not a list of maps.'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: missing id', () async {
@@ -308,9 +287,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -320,7 +296,7 @@ loading-units:
   - libraries:
       - lib2
       - lib3
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -329,8 +305,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, all loading units must have an \'id\''), true);
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, all loading units must have an \'id\''));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: libraries is list', () async {
@@ -340,9 +316,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -351,7 +324,7 @@ loading-units:
       - lib1
   - id: 3
     libraries: hello
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -360,8 +333,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, \'libraries\' is not a list.'), true);
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'libraries\' is not a list.'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: libraries is list of strings', () async {
@@ -371,9 +344,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -384,7 +354,7 @@ loading-units:
     libraries:
       - blah: hello
         blah2: hello2
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -393,8 +363,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Errors checking the following files:'), true);
-    expect(logger.statusText.contains('Invalid loading units yaml file, \'libraries\' is not a list of strings.'), true);
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'libraries\' is not a list of strings.'));
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: empty libraries allowed', () async {
@@ -404,9 +374,6 @@ loading-units:
       title: 'test check',
     );
     final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
-    if (cacheFile.existsSync()) {
-      cacheFile.deleteSync();
-    }
     cacheFile.createSync(recursive: true);
     cacheFile.writeAsStringSync('''
 loading-units:
@@ -415,7 +382,7 @@ loading-units:
       - lib1
   - id: 3
     libraries:
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 3, libraries: <String>['lib2', 'lib3']),
@@ -464,7 +431,7 @@ loading-units:
             />
     </application>
 </manifest>
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAppAndroidManifestComponentLoadingUnitMapping(
       <DeferredComponent>[
         DeferredComponent(name: 'component1', libraries: <String>['lib2']),
@@ -479,8 +446,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Modified android files:\n'), true);
-    expect(logger.statusText.contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'), true);
+    expect(logger.statusText, contains('Modified android files:\n'));
+    expect(logger.statusText, contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'));
 
     final File manifestOutput = env.projectDir
       .childDirectory('build')
@@ -503,9 +470,6 @@ loading-units:
     );
     final Directory baseModuleDir = env.projectDir.childDirectory('android').childDirectory('app');
     final File manifest = baseModuleDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
-    if (manifest.existsSync()) {
-      manifest.deleteSync();
-    }
     manifest.createSync(recursive: true);
     manifest.writeAsStringSync('''
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -526,7 +490,7 @@ loading-units:
             android:value="2" />
     </application>
 </manifest>
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAppAndroidManifestComponentLoadingUnitMapping(
       <DeferredComponent>[
         DeferredComponent(name: 'component1', libraries: <String>['lib2']),
@@ -541,8 +505,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Modified android files:\n'), true);
-    expect(logger.statusText.contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'), true);
+    expect(logger.statusText, contains('Modified android files:\n'));
+    expect(logger.statusText, contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'));
 
     final File manifestOutput = env.projectDir
       .childDirectory('build')
@@ -552,8 +516,8 @@ loading-units:
       .childDirectory('main')
       .childFile('AndroidManifest.xml');
     expect(manifestOutput.existsSync(), true);
-    expect(manifestOutput.readAsStringSync().contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'), true);
-    expect(manifestOutput.readAsStringSync().contains('<!-- Don\'t delete the meta-data below.'), true);
+    expect(manifestOutput.readAsStringSync(), contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'));
+    expect(manifestOutput.readAsStringSync(), contains('<!-- Don\'t delete the meta-data below.'));
   });
 
   // The mapping is incorrectly placed in the activity instead of application.
@@ -565,9 +529,6 @@ loading-units:
     );
     final Directory baseModuleDir = env.projectDir.childDirectory('android').childDirectory('app');
     final File manifest = baseModuleDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
-    if (manifest.existsSync()) {
-      manifest.deleteSync();
-    }
     manifest.createSync(recursive: true);
     manifest.writeAsStringSync('''
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -590,7 +551,7 @@ loading-units:
             android:value="2" />
     </application>
 </manifest>
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAppAndroidManifestComponentLoadingUnitMapping(
       <DeferredComponent>[
         DeferredComponent(name: 'component1', libraries: <String>['lib2']),
@@ -605,8 +566,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Modified android files:\n'), true);
-    expect(logger.statusText.contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'), true);
+    expect(logger.statusText, contains('Modified android files:\n'));
+    expect(logger.statusText, contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'));
 
     final File manifestOutput = env.projectDir
       .childDirectory('build')
@@ -616,8 +577,8 @@ loading-units:
       .childDirectory('main')
       .childFile('AndroidManifest.xml');
     expect(manifestOutput.existsSync(), true);
-    expect(manifestOutput.readAsStringSync().contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'), true);
-    expect(manifestOutput.readAsStringSync().contains('<!-- Don\'t delete the meta-data below.'), true);
+    expect(manifestOutput.readAsStringSync(), contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'), true);
+    expect(manifestOutput.readAsStringSync(), contains('<!-- Don\'t delete the meta-data below.'));
   });
 
   testWithoutContext('androidStringMapping generates base module loading unit mapping', () async {
@@ -628,9 +589,6 @@ loading-units:
     );
     final Directory baseModuleDir = env.projectDir.childDirectory('android').childDirectory('app');
     final File manifest = baseModuleDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
-    if (manifest.existsSync()) {
-      manifest.deleteSync();
-    }
     manifest.createSync(recursive: true);
     manifest.writeAsStringSync('''
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -651,7 +609,7 @@ loading-units:
             android:value="2" />
     </application>
 </manifest>
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAppAndroidManifestComponentLoadingUnitMapping(
       <DeferredComponent>[
         DeferredComponent(name: 'component1', libraries: <String>['lib2']),
@@ -669,8 +627,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Modified android files:\n'), true);
-    expect(logger.statusText.contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'), true);
+    expect(logger.statusText, contains('Modified android files:\n'));
+    expect(logger.statusText, contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'));
 
     final File manifestOutput = env.projectDir
       .childDirectory('build')
@@ -680,8 +638,8 @@ loading-units:
       .childDirectory('main')
       .childFile('AndroidManifest.xml');
     expect(manifestOutput.existsSync(), true);
-    expect(manifestOutput.readAsStringSync().contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2,5:,6:"/>'), true);
-    expect(manifestOutput.readAsStringSync().contains('<!-- Don\'t delete the meta-data below.'), true);
+    expect(manifestOutput.readAsStringSync(), contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2,5:,6:"/>'));
+    expect(manifestOutput.readAsStringSync(), contains('<!-- Don\'t delete the meta-data below.'));
   });
 
   // Tests if all of the regexp whitespace detection is working.
@@ -693,9 +651,6 @@ loading-units:
     );
     final Directory baseModuleDir = env.projectDir.childDirectory('android').childDirectory('app');
     final File manifest = baseModuleDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
-    if (manifest.existsSync()) {
-      manifest.deleteSync();
-    }
     manifest.createSync(recursive: true);
     manifest.writeAsStringSync('''
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -723,7 +678,7 @@ loading-units:
             />
     </application>
 </manifest>
-''', flush: true, mode: FileMode.append);
+''');
     validator.checkAppAndroidManifestComponentLoadingUnitMapping(
       <DeferredComponent>[
         DeferredComponent(name: 'component1', libraries: <String>['lib2']),
@@ -738,8 +693,8 @@ loading-units:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText.contains('Modified android files:\n'), true);
-    expect(logger.statusText.contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'), true);
+    expect(logger.statusText, contains('Modified android files:\n'));
+    expect(logger.statusText, contains('build/${DeferredComponentsValidator.kDeferredComponentsTempDirectory}/app/src/main/AndroidManifest.xml\n'));
 
     final File manifestOutput = env.projectDir
       .childDirectory('build')

--- a/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
@@ -226,8 +226,8 @@ loading-units-spelled-wrong:
     validator.displayResults();
     validator.attemptToolExit();
 
-    expect(logger.statusText, contains('Errors checking the following files:');
-    expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' entry did not exist.');
+    expect(logger.statusText, contains('Errors checking the following files:'));
+    expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' entry did not exist.'));
 
     expect(logger.statusText, contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
   });

--- a/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
@@ -228,7 +228,7 @@ loading-units-spelled-wrong:
     expect(logger.statusText, contains('Errors checking the following files:'));
     expect(logger.statusText, contains('Invalid loading units yaml file, \'loading-units\' entry did not exist.'));
 
-    expect(logger.statusText, contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'));
+    expect(logger.statusText.contains('Previously existing loading units no longer exist:\n\n  LoadingUnit 2\n    Libraries:\n    - lib1\n'), false);
   });
 
   testWithoutContext('loadingUnitCache validator detects malformed file: not a list', () async {

--- a/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/deferred_components_gen_snapshot_validator_test.dart
@@ -188,7 +188,6 @@ loading-units:
       exitOnFail: false,
       title: 'test check',
     );
-    final File cacheFile = env.projectDir.childFile(DeferredComponentsValidator.kLoadingUnitsCacheFileName);
     validator.checkAgainstLoadingUnitsCache(
       <LoadingUnit>[
         LoadingUnit(id: 2, libraries: <String>['lib1']),
@@ -577,7 +576,7 @@ loading-units:
       .childDirectory('main')
       .childFile('AndroidManifest.xml');
     expect(manifestOutput.existsSync(), true);
-    expect(manifestOutput.readAsStringSync(), contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'), true);
+    expect(manifestOutput.readAsStringSync(), contains('<meta-data android:name="io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping" android:value="3:component1,2:component2,4:component2"/>'));
     expect(manifestOutput.readAsStringSync(), contains('<!-- Don\'t delete the meta-data below.'));
   });
 


### PR DESCRIPTION
Tooling change to generate the encoding read by https://github.com/flutter/engine/pull/24983

This encodes base loading units so that the download can be skipped and directly installed from local .so files.