### PR TITLE
Allow local networking Info.plist insertion to fail

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -235,8 +235,10 @@ AddObservatoryBonjourService() {
   local built_products_plist="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"
 
   if [[ ! -f "${built_products_plist}" ]]; then
-    EchoError "error: ${INFOPLIST_PATH} does not exist. The Flutter \"Thin Binary\" build phase must run after \"Copy Bundle Resources\"."
-    exit -1
+    # Very occasionally Xcode hasn't created an Info.plist when this runs.
+    # The file will be present on re-run.
+    echo "${INFOPLIST_PATH} does not exist. Skipping _dartobservatory._tcp NSBonjourServices insertion. Try re-building to enable \"flutter attach\"."
+    return
   fi
   # If there are already NSBonjourServices specified by the app (uncommon), insert the observatory service name to the existing list.
   if plutil -extract NSBonjourServices xml1 -o - "${built_products_plist}"; then

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -96,7 +96,7 @@ void main() {
       infoPlist = buildDirectory.childFile('Info.plist');
     });
 
-    test('fails when the Info.plist is missing', () async {
+    test('handles when the Info.plist is missing', () async {
       final ProcessResult result = await Process.run(
         xcodeBackendPath,
         <String>['test_observatory_bonjour_service'],
@@ -106,8 +106,8 @@ void main() {
           'INFOPLIST_PATH': 'Info.plist',
         },
       );
-      expect(result.stderr, startsWith('error: Info.plist does not exist.'));
-      expect(result.exitCode, isNot(0));
+      expect(result.stdout, contains('Info.plist does not exist.'));
+      expect(result.exitCode, 0);
     });
 
     const String emptyPlist = '''


### PR DESCRIPTION
Very occasionally Xcode hasn't created an Info.plist by the time the "Thin Binary" script phase runs, which currently causes the build to fail.  My guess is that Xcode is parallelizing the steps and the script phase runs right before Info.plist processing, though I'm not 100% sure why this happens.

Instead, allow the insertion to fail, knowing that it will always succeed on a second run (because the last run's `Info.plist` still exists).  The VM service URL won't be published in the app, which means `flutter attach` won't work until the app is built a second time.  #64988

Prefer the rarer `flutter attach` failing than a normal `build` or `run`.

Fixes https://github.com/flutter/flutter/issues/70422