### PR TITLE
Remove mocks from compile_expression_test

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -71,7 +71,7 @@ void main() {
     @required CompleterIOSink stdinSink,
   }) {
     assert(stdinSink != null);
-    stdinSink.writes.clear();
+    stdinSink.clear();
     when(fontSubsetProcess.exitCode).thenAnswer((_) async => exitCode);
     when(fontSubsetProcess.stdout).thenAnswer((_) => Stream<List<int>>.fromIterable(<List<int>>[utf8.encode(stdout)]));
     when(fontSubsetProcess.stderr).thenAnswer((_) => Stream<List<int>>.fromIterable(<List<int>>[utf8.encode(stderr)]));
@@ -257,7 +257,7 @@ void main() {
       outputPath: outputPath,
       relativePath: relativePath,
     );
-    expect(stdinSink.writes, <List<int>>[utf8.encode('59470\n')]);
+    expect(stdinSink.getAndClear(), '59470\n');
     _resetFontSubsetInvocation(stdinSink: stdinSink);
 
     expect(subsetted, true);
@@ -267,7 +267,7 @@ void main() {
       relativePath: relativePath,
     );
     expect(subsetted, true);
-    expect(stdinSink.writes, <List<int>>[utf8.encode('59470\n')]);
+    expect(stdinSink.getAndClear(), '59470\n');
 
     verify(mockProcessManager.run(_getConstFinderArgs(appDill.path))).called(1);
     verify(mockProcessManager.start(fontSubsetArgs)).called(2);

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
@@ -48,7 +48,7 @@ void main() {
       process.sendCommand(imageFile, goldenKey, false);
 
       final Map<String, dynamic> response = await process.getResponse();
-      final String stringToStdin = stringFromMemoryIOSink(ioSink);
+      final String stringToStdin = ioSink.getAndClear();
 
       expect(response, expectedResponse);
       expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n');
@@ -75,7 +75,7 @@ void main() {
       process.sendCommand(imageFile2, goldenKey2, true);
 
       final Map<String, dynamic> response2 = await process.getResponse();
-      final String stringToStdin = stringFromMemoryIOSink(ioSink);
+      final String stringToStdin = ioSink.getAndClear();
 
       expect(response1, expectedResponse1);
       expect(response2, expectedResponse2);
@@ -101,7 +101,7 @@ Other JSON data after the initial data
       process.sendCommand(imageFile, goldenKey, false);
 
       final Map<String, dynamic> response = await process.getResponse();
-      final String stringToStdin = stringFromMemoryIOSink(ioSink);
+      final String stringToStdin = ioSink.getAndClear();
 
       expect(response, expectedResponse);
       expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n');
@@ -112,5 +112,3 @@ Other JSON data after the initial data
 Stream<List<int>> stdoutFromString(String string) => Stream<List<int>>.fromIterable(<List<int>>[
   utf8.encode(string),
 ]);
-
-String stringFromMemoryIOSink(MemoryIOSink ioSink) => utf8.decode(ioSink.writes.expand((List<int> l) => l).toList());

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -252,6 +252,16 @@ class MemoryIOSink implements IOSink {
 
   @override
   Future<void> flush() async { }
+
+  void clear() {
+    writes.clear();
+  }
+
+  String getAndClear() {
+    final String result = utf8.decode(writes.expand((List<int> l) => l).toList());
+    clear();
+    return result;
+  }
 }
 
 class MemoryStdout extends MemoryIOSink implements io.Stdout {


### PR DESCRIPTION
In `compile_expression_test` replace `MockStdIn` with `MemoryIOSink`.  Add convenience methods on `MemoryIOSink` to easily get and clear the string written to stdin, and adopt the new methods in a few places.

Part of #71511