### PR TITLE
[flutter_tools] Add support for versioned Android cmdline tools

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -383,7 +383,24 @@ class AndroidSdk {
   ///
   /// The sdkmanager was previously in the tools directory but this component
   /// was marked as obsolete in 3.6.
-  String get sdkManagerPath => getCmdlineToolsPath(globals.platform.isWindows ? 'sdkmanager.bat': 'sdkmanager');
+  String get sdkManagerPath {
+    final String executable = globals.platform.isWindows
+      ? 'sdkmanager.bat'
+      : 'sdkmanager';
+    final File cmdlineTool = directory
+      .childDirectory('cmdline-tools')
+      .childDirectory('latest')
+      .childDirectory('bin')
+      .childFile(executable);
+    if (cmdlineTool.existsSync()) {
+      return cmdlineTool.path;
+    }
+    return directory
+      .childDirectory('tools')
+      .childDirectory('bin')
+      .childFile(executable)
+      .path;
+  }
 
   /// First try Java bundled with Android Studio, then sniff JAVA_HOME, then fallback to PATH.
   static String findJavaBinary({

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -387,14 +387,11 @@ class AndroidSdk {
     final String executable = globals.platform.isWindows
       ? 'sdkmanager.bat'
       : 'sdkmanager';
-    final File cmdlineTool = directory
-      .childDirectory('cmdline-tools')
-      .childDirectory('latest')
-      .childDirectory('bin')
-      .childFile(executable);
-    if (cmdlineTool.existsSync()) {
-      return cmdlineTool.path;
+    final String path = getCmdlineToolsPath(executable);
+    if (path != null) {
+      return path;
     }
+    // If no binary was found, return the default location
     return directory
       .childDirectory('tools')
       .childDirectory('bin')

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -277,9 +277,10 @@ class AndroidSdk {
     if (cmdlineToolsDir.existsSync()) {
       final List<Version> cmdlineTools = cmdlineToolsDir
         .listSync()
-        .map((FileSystemEntity entity) {
+        .whereType<Directory>()
+        .map((Directory subDirectory) {
           try {
-            return Version.parse(entity.basename);
+            return Version.parse(subDirectory.basename);
           } on Exception {
             return null;
           }

--- a/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_sdk_test.dart
@@ -80,6 +80,26 @@ void main() {
       Config: () => config,
     });
 
+    testUsingContext('returns sdkmanager path under cmdline tools (highest version) on Linux/macOS', () {
+      sdkDir = MockAndroidSdk.createSdkDirectory();
+      config.setValue('android-sdk', sdkDir.path);
+
+      final AndroidSdk sdk = AndroidSdk.locateAndroidSdk();
+      final List<String> versions = <String>['3.0', '2.1', '1.0'];
+      for (final String version in versions) {
+        fileSystem.file(
+          fileSystem.path.join(sdk.directory.path, 'cmdline-tools', version, 'bin', 'sdkmanager')
+        ).createSync(recursive: true);
+      }
+
+      expect(sdk.sdkManagerPath, fileSystem.path.join(sdk.directory.path, 'cmdline-tools', '3.0', 'bin', 'sdkmanager'));
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Platform: () => FakePlatform(operatingSystem: 'linux'),
+      Config: () => config,
+    });
+
     testUsingContext('Caches adb location after first access', () {
       sdkDir = MockAndroidSdk.createSdkDirectory();
       config.setValue('android-sdk', sdkDir.path);


### PR DESCRIPTION
Added a fallback to the highest cmdline-tools version if latest isn't present, and only then fallback to the deprecated SDK tools.

Closes #76527