### PR TITLE
Point "flutter build ipa --analyze-size" to archive app output

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -57,6 +57,9 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 
   @override
   bool get shouldCodesign => boolArg('codesign');
+
+  @override
+  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs.directory(xcodeResultOutput);
 }
 
 /// Builds an .xcarchive and optionally .ipa for an iOS app to be generated for
@@ -97,6 +100,12 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final bool shouldCodesign = true;
 
   String get exportOptionsPlist => stringArg('export-options-plist');
+
+  @override
+  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs
+      .directory(xcodeResultOutput)
+      .childDirectory('Products')
+      .childDirectory('Applications');
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -209,6 +218,8 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
 
   BuildableIOSApp _buildableIOSApp;
 
+  Directory _outputAppDirectory(String xcodeResultOutput);
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     defaultBuildMode = forSimulator ? BuildMode.debug : BuildMode.release;
@@ -273,16 +284,19 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       final File precompilerTrace = globals.fs.directory(buildInfo.codeSizeDirectory)
         .childFile('trace.$arch.json');
 
-      // This analysis is only supported for release builds, which also excludes the simulator.
-      // Attempt to guess the correct .app by picking the first one.
-      final Directory candidateDirectory = globals.fs.directory(
-        globals.fs.path.join(getIosBuildDirectory(), 'Release-iphoneos'),
-      );
-      final Directory appDirectory = candidateDirectory.listSync()
-        .whereType<Directory>()
-        .firstWhere((Directory directory) {
-        return globals.fs.path.extension(directory.path) == '.app';
-      });
+      final Directory outputAppDirectoryCandidate = _outputAppDirectory(result.output);
+
+      Directory appDirectory;
+      if (outputAppDirectoryCandidate.existsSync()) {
+        appDirectory = outputAppDirectoryCandidate.listSync()
+            .whereType<Directory>()
+            .firstWhere((Directory directory) {
+          return globals.fs.path.extension(directory.path) == '.app';
+        }, orElse: () => null);
+      }
+      if (appDirectory == null) {
+        throwToolExit('Could not find app to analyze code size in ${outputAppDirectoryCandidate.path}');
+      }
       final Map<String, Object> output = await sizeAnalyzer.analyzeAotSnapshot(
         aotSnapshot: aotSnapshot,
         precompilerTrace: precompilerTrace,


### PR DESCRIPTION
1. Fix `flutter build ipa --analyze-size` to analyze `build/ios/archive/*.xcarchive/Products/Applications/*.app` (fixes the crash).
2. Instead of `flutter build ios --analyze-size` analyzing `build/ios/Release-iphoneos/*app`, instead analyze at `build/ios/iphoneos/*app` to avoid knowing anything about the `Release-iphoneos` path.  The command already enforces that analyzing the size requires release mode (added a test confirming that).
3. Create command-level test of `build_ios_test.dart` based on `build_ipa_test.dart`.

Validated both `flutter build ipa --analyze-size` and `flutter build ios --analyze-size` work after respective `flutter clean`s.

Fixes https://github.com/flutter/flutter/issues/77571
Fixes https://github.com/flutter/flutter/issues/78231