### PR TITLE
Inline some element methods for better stack overflow affinity

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3310,6 +3310,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// See the [RenderObjectElement] documentation for more information on slots.
   @protected
+  @pragma('vm:prefer-inline')
   Element? updateChild(Element? child, Widget? newWidget, Object? newSlot) {
     if (newWidget == null) {
       if (child != null)
@@ -3583,6 +3584,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// The element returned by this function will already have been mounted and
   /// will be in the "active" lifecycle state.
   @protected
+  @pragma('vm:prefer-inline')
   Element inflateWidget(Widget newWidget, Object? newSlot) {
     assert(newWidget != null);
     final Key? key = newWidget.key;
@@ -4236,6 +4238,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// Called by the [BuildOwner] when [BuildOwner.scheduleBuildFor] has been
   /// called to mark this element dirty, by [mount] when the element is first
   /// built, and by [update] when the widget has changed.
+  @pragma('vm:prefer-inline')
   void rebuild() {
     assert(_lifecycleState != _ElementLifecycle.initial);
     if (_lifecycleState != _ElementLifecycle.active || !_dirty)


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/73730.

Locally, this reduced the stack_size benchmark by 30% in release mode at the expense of slightly higher binary size. Example binary increase for the Gallery app on android-arm64:

- `libapp.so` (the Dart AOT) increased by 53.9 KB (+0.2%) uncompressed
- the overall APK increased by 15.0 KB (+0.02%) compressed

A local spot check with the gallery transition perf benchmark did not reveal any notable changes in build performance.

Last, but not least, this allows developers to nest more widget before facing a stack overflow. In a test setup, an additional ~900 containers could be nested before a stack overflow occurred.

See also https://github.com/flutter/flutter/issues/73730 for details on the points discussed above.