### PR TITLE
Download platform artifacts from assemble if needed

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -147,15 +147,29 @@ class AssembleCommand extends FlutterCommand {
       return const <CustomDimensions, String>{};
     }
     try {
-      final Environment localEnvironment = createEnvironment();
       return <CustomDimensions, String>{
-        CustomDimensions.commandBuildBundleTargetPlatform: localEnvironment.defines['TargetPlatform'],
+        CustomDimensions.commandBuildBundleTargetPlatform: environment.defines[kTargetPlatform],
         CustomDimensions.commandBuildBundleIsModule: '${flutterProject.isModule}',
       };
     } on Exception {
       // We've failed to send usage.
     }
     return const <CustomDimensions, String>{};
+  }
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async {
+    final String platform = environment.defines[kTargetPlatform];
+    if (platform == null) {
+      return super.requiredArtifacts;
+    }
+
+    final TargetPlatform targetPlatform = getTargetPlatformForName(platform);
+    final DevelopmentArtifact artifact = artifactFromTargetPlatform(targetPlatform);
+    if (artifact != null) {
+      return <DevelopmentArtifact>{artifact};
+    }
+    return super.requiredArtifacts;
   }
 
   /// The target(s) we are building.
@@ -196,6 +210,9 @@ class AssembleCommand extends FlutterCommand {
     }
     return false;
   }
+
+  Environment get environment => _environment ??= createEnvironment();
+  Environment _environment;
 
   /// The environmental configuration for a build invocation.
   Environment createEnvironment() {
@@ -259,7 +276,6 @@ class AssembleCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final Environment env = createEnvironment();
     final List<Target> targets = createTargets();
     final List<Target> nonDeferredTargets = <Target>[];
     final List<Target> deferredTargets = <AndroidAotDeferredComponentsBundle>[];
@@ -271,7 +287,7 @@ class AssembleCommand extends FlutterCommand {
       }
     }
     Target target;
-    final List<String> decodedDefines = decodeDartDefines(env.defines, kDartDefines);
+    final List<String> decodedDefines = decodeDartDefines(environment.defines, kDartDefines);
     if (FlutterProject.current().manifest.deferredComponents != null
         && decodedDefines.contains('validate-deferred-components=true')
         && deferredTargets.isNotEmpty
@@ -289,7 +305,7 @@ class AssembleCommand extends FlutterCommand {
     }
     final BuildResult result = await _buildSystem.build(
       target,
-      env,
+      environment,
       buildSystemConfig: BuildSystemConfig(
         resourcePoolSize: argResults.wasParsed('resource-pool-size')
           ? int.tryParse(stringArg('resource-pool-size'))

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1365,7 +1365,7 @@ mixin DeviceBasedDevelopmentArtifacts on FlutterCommand {
     };
     for (final Device device in devices) {
       final TargetPlatform targetPlatform = await device.targetPlatform;
-      final DevelopmentArtifact developmentArtifact = _artifactFromTargetPlatform(targetPlatform);
+      final DevelopmentArtifact developmentArtifact = artifactFromTargetPlatform(targetPlatform);
       if (developmentArtifact != null) {
         artifacts.add(developmentArtifact);
       }
@@ -1374,31 +1374,10 @@ mixin DeviceBasedDevelopmentArtifacts on FlutterCommand {
   }
 }
 
-/// A mixin which applies an implementation of [requiredArtifacts] that only
-/// downloads artifacts corresponding to a target device.
-mixin TargetPlatformBasedDevelopmentArtifacts on FlutterCommand {
-  @override
-  Future<Set<DevelopmentArtifact>> get requiredArtifacts async {
-    // If there is no specified target device, fallback to the default
-    // configuration.
-    final String rawTargetPlatform = stringArg('target-platform');
-    final TargetPlatform targetPlatform = getTargetPlatformForName(rawTargetPlatform);
-    if (targetPlatform == null) {
-      return super.requiredArtifacts;
-    }
-
-    final Set<DevelopmentArtifact> artifacts = <DevelopmentArtifact>{};
-    final DevelopmentArtifact developmentArtifact = _artifactFromTargetPlatform(targetPlatform);
-    if (developmentArtifact != null) {
-      artifacts.add(developmentArtifact);
-    }
-    return artifacts;
-  }
-}
-
 // Returns the development artifact for the target platform, or null
 // if none is supported
-DevelopmentArtifact _artifactFromTargetPlatform(TargetPlatform targetPlatform) {
+@protected
+DevelopmentArtifact artifactFromTargetPlatform(TargetPlatform targetPlatform) {
   switch (targetPlatform) {
     case TargetPlatform.android:
     case TargetPlatform.android_arm:

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/assemble.dart';
 import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
@@ -54,18 +55,35 @@ void main() {
   });
 
   testUsingContext('flutter assemble can parse inputs', () async {
-    final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand(
+    final AssembleCommand command = AssembleCommand(
       buildSystem: TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
         expect(environment.inputs, containsPair('Foo', 'Bar.txt'));
-      })
-    ));
+    }));
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
     await commandRunner.run(<String>['assemble', '-o Output', '-iFoo=Bar.txt', 'debug_macos_bundle_flutter_assets']);
 
     expect(testLogger.traceText, contains('build succeeded.'));
+    expect(await command.requiredArtifacts, isEmpty);
   }, overrides: <Type, Generator>{
     Cache: () => Cache.test(processManager: FakeProcessManager.any()),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('flutter assemble sets required artifacts from target platform', () async {
+    final AssembleCommand command = AssembleCommand(
+        buildSystem: TestBuildSystem.all(BuildResult(success: true)));
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    await commandRunner.run(<String>['assemble', '-o Output', '-dTargetPlatform=darwin-x64', 'debug_macos_bundle_flutter_assets']);
+
+    expect(await command.requiredArtifacts, <DevelopmentArtifact>{
+      DevelopmentArtifact.macOS,
+    });
+  }, overrides: <Type, Generator>{
+    Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
   });
 
   testUsingContext('flutter assemble throws ToolExit if not provided with output', () async {


### PR DESCRIPTION
Download missing target platform artifacts when run from `flutter assemble -dTargetPlatform`.  This isn't needed from `flutter build` or `flutter run`, but is if the user upgrades, then tries to run from Xcode or Gradle.

From Xcode we can see it work:
```
Showing Recent Messages
[        ] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[  +10 ms] Downloading ios tools...
[ +371 ms] Content https://storage.googleapis.com/flutter_infra_release/flutter/20375cebcf3584a23e424e8a722806f77702fa85/ios/artifacts.zip md5 hash: /OZ8Zg+JOPPP+hpcLdYAFQ==
...
```

Fixes https://github.com/flutter/flutter/issues/68475
I KNOW there was an iOS version of this issue but now I can't find it, but I've hit this problems with engine/dart mismatches myself.