### PR TITLE
Added iconColor and textColor properties to ExpansionTile

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -20,12 +20,17 @@ const Duration _kExpand = Duration(milliseconds: 200);
 /// [ExpansionTile] to save and restore its expanded state when it is scrolled
 /// in and out of view.
 ///
+/// This class overrides the [ListTileTheme.iconColor] and [ListTileTheme.textColor]
+/// theme properties for its [ListTile]. These colors animate between values when
+/// the tile is expanded and collapsed: between [iconColor], [collapsedIconColor] and
+/// between [textColor] and [collapsedTextColor].
+///
 /// See also:
 ///
 ///  * [ListTile], useful for creating expansion tile [children] when the
 ///    expansion tile represents a sublist.
-///  * The "Expand/collapse" section of
-///    <https://material.io/components/lists#types>.
+///  * The "Expand and collapse" section of
+///    <https://material.io/components/lists#types>
 class ExpansionTile extends StatefulWidget {
   /// Creates a single-line [ListTile] with a trailing button that expands or collapses
   /// the tile to reveal or hide the [children]. The [initiallyExpanded] property must
@@ -35,7 +40,6 @@ class ExpansionTile extends StatefulWidget {
     this.leading,
     required this.title,
     this.subtitle,
-    this.backgroundColor,
     this.onExpansionChanged,
     this.children = const <Widget>[],
     this.trailing,
@@ -45,7 +49,12 @@ class ExpansionTile extends StatefulWidget {
     this.expandedCrossAxisAlignment,
     this.expandedAlignment,
     this.childrenPadding,
+    this.backgroundColor,
     this.collapsedBackgroundColor,
+    this.textColor,
+    this.collapsedTextColor,
+    this.iconColor,
+    this.collapsedIconColor,
   }) : assert(initiallyExpanded != null),
        assert(maintainState != null),
        assert(
@@ -146,6 +155,29 @@ class ExpansionTile extends StatefulWidget {
   ///
   /// When the value is null, the value of `childrenPadding` is [EdgeInsets.zero].
   final EdgeInsetsGeometry? childrenPadding;
+
+  /// The icon color of tile's [trailing] expansion icon when the
+  /// sublist is expanded.
+  ///
+  /// Used to override to the [ListTileTheme.iconColor].
+  final Color? iconColor;
+
+  /// The icon color of tile's [trailing] expansion icon when the
+  /// sublist is collapsed.
+  ///
+  /// Used to override to the [ListTileTheme.iconColor].
+  final Color? collapsedIconColor;
+
+
+  /// The color of the tile's titles when the sublist is expanded.
+  ///
+  /// Used to override to the [ListTileTheme.textColor].
+  final Color? textColor;
+
+  /// The color of the tile's titles when the sublist is collapsed.
+  ///
+  /// Used to override to the [ListTileTheme.textColor].
+  final Color? collapsedTextColor;
 
   @override
   _ExpansionTileState createState() => _ExpansionTileState();
@@ -259,11 +291,11 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ThemeData theme = Theme.of(context);
     _borderColorTween.end = theme.dividerColor;
     _headerColorTween
-      ..begin = theme.textTheme.subtitle1!.color
-      ..end = theme.accentColor;
+      ..begin = widget.collapsedTextColor ?? theme.textTheme.subtitle1!.color
+      ..end = widget.textColor ?? theme.accentColor;
     _iconColorTween
-      ..begin = theme.unselectedWidgetColor
-      ..end = theme.accentColor;
+      ..begin = widget.collapsedIconColor ?? theme.unselectedWidgetColor
+      ..end = widget.iconColor ?? theme.accentColor;
     _backgroundColorTween
       ..begin = widget.collapsedBackgroundColor
       ..end = widget.backgroundColor;

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -520,4 +520,40 @@ void main() {
 
     expect(boxDecoration.color, backgroundColor);
   });
+
+  testWidgets('ExpansionTile iconColor, textColor', (WidgetTester tester) async {
+    const Color iconColor = Color(0xff00ff00);
+    const Color collapsedIconColor = Color(0xff0000ff);
+    const Color textColor = Color(0xff00ffff);
+    const Color collapsedTextColor = Color(0xffff00ff);
+
+    await tester.pumpWidget(const MaterialApp(
+      home: Material(
+        child: ExpansionTile(
+          iconColor: iconColor,
+          collapsedIconColor: collapsedIconColor,
+          textColor: textColor,
+          collapsedTextColor: collapsedTextColor,
+          initiallyExpanded: false,
+          title: TestText('title'),
+          trailing: TestIcon(),
+          children: <Widget>[
+            SizedBox(height: 100, width: 100),
+          ],
+        ),
+      ),
+    ));
+
+    Color getIconColor() => tester.state<TestIconState>(find.byType(TestIcon)).iconTheme.color!;
+    Color getTextColor() => tester.state<TestTextState>(find.byType(TestText)).textStyle.color!;
+
+    expect(getIconColor(), collapsedIconColor);
+    expect(getTextColor(), collapsedTextColor);
+
+    await tester.tap(find.text('title'));
+    await tester.pumpAndSettle();
+
+    expect(getIconColor(), iconColor);
+    expect(getTextColor(), textColor);
+  });
 }

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -522,6 +522,8 @@ void main() {
   });
 
   testWidgets('ExpansionTile iconColor, textColor', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/pull/78281
+
     const Color iconColor = Color(0xff00ff00);
     const Color collapsedIconColor = Color(0xff0000ff);
     const Color textColor = Color(0xff00ffff);


### PR DESCRIPTION
Added `iconColor`, `collapsedIconColor`, `textColor` and `collapsedTextColor` properties to ExpansionTile. If specified, they define the colors of the trailing expand/collapse icon and the colors of the tile's title and subtitle. Although the default values for these colors were never documented, some apps have created dependencies on the default values and were using Theme overrides to set them.

The new properties were added to so that apps could specify the colors directly, rather on depending the undocumented defaults - which included `accentColor` just for the trailing icon's color -  per https://github.com/flutter/flutter/issues/56918. 

Tested against internal apps: /cl/362300735