### PR TITLE
Removed FloatingActionButton accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -9,7 +9,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
-import 'colors.dart';
 import 'floating_action_button_theme.dart';
 import 'scaffold.dart';
 import 'theme.dart';
@@ -242,11 +241,6 @@ class FloatingActionButton extends StatelessWidget {
   /// [ThemeData.floatingActionButtonTheme] is used. If that property is also
   /// null, then the [ColorScheme.onSecondary] color of [ThemeData.colorScheme]
   /// is used.
-  ///
-  /// Although the color of theme's `accentIconTheme` currently provides a
-  /// default that supersedes the `onSecondary` color, this dependency
-  /// has been deprecated:  https://flutter.dev/go/remove-fab-accent-theme-dependency.
-  /// It will be removed in the future.
   final Color? foregroundColor;
 
   /// The button's background color.
@@ -428,25 +422,6 @@ class FloatingActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final FloatingActionButtonThemeData floatingActionButtonTheme = theme.floatingActionButtonTheme;
-
-    // Applications should no longer use accentIconTheme's color to configure
-    // the foreground color of floating action buttons. For more information, see
-    // https://flutter.dev/go/remove-fab-accent-theme-dependency.
-    if (this.foregroundColor == null && floatingActionButtonTheme.foregroundColor == null) {
-      final bool accentIsDark = theme.accentColorBrightness == Brightness.dark;
-      final Color defaultAccentIconThemeColor = accentIsDark ? Colors.white : Colors.black;
-      if (theme.accentIconTheme.color != defaultAccentIconThemeColor) {
-        debugPrint(
-          'Warning: '
-          'The support for configuring the foreground color of '
-          'FloatingActionButtons using ThemeData.accentIconTheme '
-          'has been deprecated. Please use ThemeData.floatingActionButtonTheme '
-          'instead. See '
-          'https://flutter.dev/go/remove-fab-accent-theme-dependency. '
-          'This feature was deprecated after v1.13.2.'
-        );
-      }
-    }
 
     final Color foregroundColor = this.foregroundColor
       ?? floatingActionButtonTheme.foregroundColor


### PR DESCRIPTION
This PR removes the FloatingActionButton widget's accentColor dependency per https://github.com/flutter/flutter/issues/56918.

This just removes a warning message that depended on `accentIconTheme` which was the last reference to anything accent color related in the FloatingActionButton.

This PR was tested against internal Google apps in cl/363076403.

