### PR TITLE
[Fonts] Fix update_icons double newline bug

### DIFF
--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -36,7 +36,7 @@ const Map<String, List<String>> _platformAdaptiveIdentifiers = <String, List<Str
 };
 
 // Rewrite certain Flutter IDs (reserved keywords, numbers) using prefix matching.
-const Map<String, String> _identifierRewrites = <String, String>{
+const Map<String, String> identifierRewrites = <String, String>{
   '1x': 'one_x',
   '360': 'threesixty',
   '2d': 'twod',
@@ -348,9 +348,9 @@ class _Icon {
     }
 
     flutterId = id;
-    for (final MapEntry<String, String> rewritePair in _identifierRewrites.entries) {
+    for (final MapEntry<String, String> rewritePair in identifierRewrites.entries) {
       if (id.startsWith(rewritePair.key)) {
-        flutterId = id.replaceFirst(rewritePair.key, _identifierRewrites[rewritePair.key]);
+        flutterId = id.replaceFirst(rewritePair.key, identifierRewrites[rewritePair.key]);
       }
     }
 

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -204,7 +204,7 @@ void main(List<String> args) {
   if (argResults[_dryRunOption] as bool) {
     stdout.write(newIconData);
   } else {
-    stderr.write('\nWriting to ${iconClassFile.path}.');
+    stderr.writeln('\nWriting to ${iconClassFile.path}.');
     iconClassFile.writeAsStringSync(newIconData);
     _overwriteOldCodepoints(newCodepointsFile, oldCodepointsFile);
   }

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -202,9 +202,9 @@ void main(List<String> args) {
   final String newIconData = regenerateIconsFile(iconClassFileData, newTokenPairMap);
 
   if (argResults[_dryRunOption] as bool) {
-    stdout.writeln(newIconData);
+    stdout.write(newIconData);
   } else {
-    stderr.writeln('\nWriting to ${iconClassFile.path}.');
+    stderr.write('\nWriting to ${iconClassFile.path}.');
     iconClassFile.writeAsStringSync(newIconData);
     _overwriteOldCodepoints(newCodepointsFile, oldCodepointsFile);
   }


### PR DESCRIPTION
Fixes a small bug where using the `dry-run` flag results in a double trailing newline.

Also makes `identifierRewrites` public to anticipate a future CL.