### PR TITLE
Add Padding option on PopupMenuItem

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -221,6 +221,7 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
     this.value,
     this.enabled = true,
     this.height = kMinInteractiveDimension,
+    this.padding = const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
     this.textStyle,
     this.mouseCursor,
     required this.child,
@@ -242,6 +243,11 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   /// Defaults to [kMinInteractiveDimension] pixels.
   @override
   final double height;
+
+  /// The padding around the item's child. The entire padded child will react to input gestures.
+  ///
+  /// This property must not be null. It defaults to 16.0 padding on horizontal sides.
+  final EdgeInsetsGeometry padding;
 
   /// The text style of the popup menu item.
   ///
@@ -327,7 +333,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
       child: Container(
         alignment: AlignmentDirectional.centerStart,
         constraints: BoxConstraints(minHeight: widget.height),
-        padding: const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
+        padding: widget.padding,
         child: buildChild(),
       ),
     );

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -1802,6 +1802,52 @@ void main() {
     );
   });
 
+  testWidgets('PopupMenuItem padding', (WidgetTester tester) async {
+    final Key firstKey = UniqueKey();
+    final Key secondKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              SizedBox(
+                width: 100,
+                height: 100,
+                child: PopupMenuItem<String>(
+                  value: 'value',
+                  child: SizedBox(
+                    key: firstKey,
+                    width: 100,
+                    height: 100,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: 100,
+                height: 100,
+                child: PopupMenuItem<String>(
+                  value: 'value',
+                  padding: const EdgeInsets.all(8),
+                  child: SizedBox(
+                    key: secondKey,
+                    width: 100,
+                    height: 100,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox child = tester.renderObject(find.byKey(firstKey));
+    expect(child.size, const Size(100 - 16 * 2, 100));
+
+    final RenderBox child2 = tester.renderObject(find.byKey(secondKey));
+    expect(child2.size, const Size(100 - 8 * 2, 100 - 8 * 2));
+  });
+
   group('feedback', () {
     late FeedbackTester feedback;
 


### PR DESCRIPTION
Add the possibility to modify the padding of the PopupMenuItem for a greater possibility of customization.

![image](https://user-images.githubusercontent.com/25029876/111356890-17086600-8689-11eb-99c0-f4dd77d4e170.png)

#78349

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
