### PR TITLE
[flutter_tools] remove globals from logger

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1024,6 +1024,7 @@ class NotifyingLogger extends DelegatingLogger {
     @required Duration timeout,
     String progressId,
     bool multilineOutput = false,
+    bool includeTiming = true,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     assert(timeout != null);
@@ -1152,6 +1153,7 @@ class AppRunLogger extends DelegatingLogger {
     @required Duration timeout,
     String progressId,
     bool multilineOutput = false,
+    bool includeTiming = true,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     final int id = _nextProgressId++;

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -357,7 +357,6 @@ Future<T> runInContext<T>(
         processManager: globals.processManager,
         platform: globals.platform,
         fileSystem: globals.fs,
-        terminal: globals.terminal,
         usage: globals.flutterUsage,
       ),
     },

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -308,10 +308,7 @@ class Doctor {
 
     for (final ValidatorTask validatorTask in startValidatorTasks()) {
       final DoctorValidator validator = validatorTask.validator;
-      final Status status = Status.withSpinner(
-        stopwatch: Stopwatch(),
-        terminal: globals.terminal,
-      );
+      final Status status = _logger.startSpinner();
       ValidationResult result;
       try {
         result = await validatorTask.result;

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -246,7 +246,6 @@ class XcodeProjectInterpreter {
     @required ProcessManager processManager,
     @required Logger logger,
     @required FileSystem fileSystem,
-    @required Terminal terminal,
     @required Usage usage,
   }) {
     return XcodeProjectInterpreter._(
@@ -254,7 +253,6 @@ class XcodeProjectInterpreter {
       processManager: processManager,
       logger: logger,
       fileSystem: fileSystem,
-      terminal: terminal,
       usage: usage,
     );
   }
@@ -264,14 +262,12 @@ class XcodeProjectInterpreter {
     @required ProcessManager processManager,
     @required Logger logger,
     @required FileSystem fileSystem,
-    @required Terminal terminal,
     @required Usage usage,
     int majorVersion,
     int minorVersion,
     int patchVersion,
   }) : _platform = platform,
         _fileSystem = fileSystem,
-        _terminal = terminal,
         _logger = logger,
         _processUtils = ProcessUtils(logger: logger, processManager: processManager),
         _operatingSystemUtils = OperatingSystemUtils(
@@ -307,7 +303,6 @@ class XcodeProjectInterpreter {
       processManager: processManager,
       usage: TestUsage(),
       logger: BufferLogger.test(),
-      terminal: Terminal.test(),
       majorVersion: majorVersion,
       minorVersion: minorVersion,
       patchVersion: patchVersion,
@@ -318,7 +313,6 @@ class XcodeProjectInterpreter {
   final FileSystem _fileSystem;
   final ProcessUtils _processUtils;
   final OperatingSystemUtils _operatingSystemUtils;
-  final Terminal _terminal;
   final Logger _logger;
   final Usage _usage;
 
@@ -415,10 +409,7 @@ class XcodeProjectInterpreter {
     String scheme,
     Duration timeout = const Duration(minutes: 1),
   }) async {
-    final Status status = Status.withSpinner(
-      stopwatch: Stopwatch(),
-      terminal: _terminal,
-    );
+    final Status status = _logger.startSpinner();
     final List<String> showBuildSettingsCommand = <String>[
       ...xcrunCommand(),
       'xcodebuild',

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -760,11 +760,20 @@ class StreamLogger extends Logger {
     @required Duration timeout,
     String progressId,
     bool multilineOutput = false,
+    bool includeTiming = true,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
     _log('[progress] $message');
     return SilentStatus(
       stopwatch: Stopwatch(),
+    )..start();
+  }
+
+  @override
+  Status startSpinner({ VoidCallback onFinish }) {
+    return SilentStatus(
+      stopwatch: Stopwatch(),
+      onFinish: onFinish,
     )..start();
   }
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -18,7 +18,6 @@ import 'package:meta/meta.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fakes.dart';
 
 final Platform _kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false);
@@ -659,7 +658,7 @@ void main() {
       expect(lines[3], equals('0123456789' * 3));
     });
 
-    testUsingContext('AppRunLogger writes plain text statuses when no app is active', () async {
+    testWithoutContext('AppRunLogger writes plain text statuses when no app is active', () async {
       final BufferLogger buffer = BufferLogger.test();
       final AppRunLogger logger = AppRunLogger(parent: buffer);
 

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -41,7 +40,6 @@ void main() {
         fileSystem: fileSystem,
         platform: platform,
         processManager: processManager,
-        terminal: Terminal.test(),
         usage: null,
       );
     });
@@ -101,7 +99,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: Terminal.test(),
       usage: null,
     );
   });
@@ -218,7 +215,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: Terminal.test(),
       usage: TestUsage(),
     );
     fileSystem.file(xcodebuild).deleteSync();
@@ -422,7 +418,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: Terminal.test(),
       usage: TestUsage(),
     );
 
@@ -449,7 +444,6 @@ void main() {
       fileSystem: fileSystem,
       platform: platform,
       processManager: fakeProcessManager,
-      terminal: Terminal.test(),
       usage: TestUsage(),
     );
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -618,7 +618,7 @@ class FakeStatusLogger extends DelegatingLogger {
   Status status;
 
   @override
-  Status startProgress(String message, {Duration timeout, String progressId, bool multilineOutput = false, int progressIndicatorPadding = kDefaultStatusPadding}) {
+  Status startProgress(String message, {Duration timeout, String progressId, bool multilineOutput = false, bool includeTiming = true, int progressIndicatorPadding = kDefaultStatusPadding}) {
     return status;
   }
 }


### PR DESCRIPTION
Remove the last globals from logger. This should make it much easier to migrate logger/terminal to null safety.

This moves the Factory helper for creating a blank spinner onto the logger class, which already has the dependencies necessary to create one without globals.