### PR TITLE
Removed accentTextTheme references from Typography API doc

### DIFF
--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -41,17 +41,16 @@ enum ScriptCategory {
 
 /// The color and geometry [TextTheme]s for Material apps.
 ///
-/// The text themes provided by the overall [Theme], like
-/// [ThemeData.textTheme], are based on the current locale's
-/// [MaterialLocalizations.scriptCategory] and are created
-/// by merging a color text theme, [black] or [white]
-/// and a geometry text theme, one of [englishLike], [dense],
+/// The text theme provided by the overall [Theme],
+/// [ThemeData.textTheme], is based on the current locale's
+/// [MaterialLocalizations.scriptCategory] and is created
+/// by merging a color text theme - [black] for
+/// [Brightness.light] themes and [white] for [Brightness.dark]
+/// themes -  and a geometry text theme, one of [englishLike], [dense],
 /// or [tall], depending on the locale.
 ///
-/// To lookup a localized text theme use
-/// `Theme.of(context).textTheme` or
-/// `Theme.of(context).primaryTextTheme` or
-/// `Theme.of(context).accentTextTheme`.
+/// To lookup the localized text theme use
+/// `Theme.of(context).textTheme`.
 ///
 /// The color text themes are [blackMountainView], [whiteMountainView],
 /// [blackCupertino], and [whiteCupertino]. The Mountain View theme [TextStyle]s
@@ -77,9 +76,6 @@ enum ScriptCategory {
 ///
 /// See also:
 ///
-///  * [ThemeData.typography], which can be used to configure the
-///    text themes used to create [ThemeData.textTheme],
-///    [ThemeData.primaryTextTheme], [ThemeData.accentTextTheme].
 ///  * <https://material.io/design/typography/>
 @immutable
 class Typography with Diagnosticable {


### PR DESCRIPTION
Removed the references to primaryTextTheme and accentTextTheme from the Typography API doc per #56918.

