### PR TITLE
Removed accentColor refs from API docs

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -50,7 +50,8 @@ import 'theme.dart';
 ///
 /// ```dart
 ///  Widget build(BuildContext context) {
-///    final TextStyle textStyle = Theme.of(context).textTheme.bodyText2!;
+///    final ThemeData theme = Theme.of(context);
+///    final TextStyle textStyle = theme.textTheme.bodyText2!;
 ///    final List<Widget> aboutBoxChildren = <Widget>[
 ///      const SizedBox(height: 24),
 ///      RichText(
@@ -63,7 +64,7 @@ import 'theme.dart';
 ///              'from a single codebase. Learn more about Flutter at '
 ///            ),
 ///            TextSpan(
-///              style: textStyle.copyWith(color: Theme.of(context).accentColor),
+///              style: textStyle.copyWith(color: theme.colorScheme.primary),
 ///              text: 'https://flutter.dev'
 ///            ),
 ///            TextSpan(

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -90,9 +90,9 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// [color palette](https://material.io/design/color/).
 ///
 /// Instead of using an absolute color from these palettes, consider using
-/// [Theme.of] to obtain the local [ThemeData] structure, which exposes the
-/// colors selected for the current theme, such as [ThemeData.primaryColor] and
-/// [ThemeData.accentColor] (among many others).
+/// [Theme.of] to obtain the local [ThemeData.colorScheme], which defines
+/// the colors that most of the Material components use by default.
+///
 ///
 /// Most swatches have colors from 100 to 900 in increments of one hundred, plus
 /// the color 50. The smaller the number, the more pale the color. The greater

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -151,19 +151,26 @@ enum MaterialTapTargetSize {
 ///
 /// {@tool snippet}
 ///
-/// This sample creates a [MaterialApp] widget that stores `ThemeData` and
-/// passes the `ThemeData` to descendant widgets. The [AppBar] widget uses the
-/// [primaryColor] to create a blue background. The [Text] widget uses the
-/// [TextTheme.bodyText2] to create purple text. The [FloatingActionButton] widget
-/// uses the [accentColor] to create a green background.
+/// This sample creates a [MaterialApp] with a [Theme] whose
+/// [ColorScheme] is based on [Colors.blue], but with the color
+/// scheme's [ColorScheme.secondary] color overridden to be green. The
+/// [AppBar] widget uses the color scheme's [ColorScheme.primary] as
+/// its default background color and the [FloatingActionButton] widget
+/// uses the color scheme's [ColorScheme.secondary] for its default
+/// background. By default, the [Text] widget uses
+/// [TextTheme.bodyText2], and the color of that [TextStyle] has been
+/// changed to purple.
 ///
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/material_app_theme_data.png)
 ///
 /// ```dart
 /// MaterialApp(
 ///   theme: ThemeData(
-///     primaryColor: Colors.blue,
-///     accentColor: Colors.green,
+///     colorScheme: ColorScheme.fromSwatch(
+///       primarySwatch: Colors.blue,
+///     ).copyWith(
+///       secondary: Colors.green,
+///     ),
 ///     textTheme: const TextTheme(bodyText2: TextStyle(color: Colors.purple)),
 ///   ),
 ///   home: Scaffold(

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -30,7 +30,8 @@ import 'ticker_provider.dart';
 /// Created automatically by [ScrollBehavior.buildViewportChrome] on platforms
 /// (e.g., Android) that commonly use this type of overscroll indication.
 ///
-/// In a [MaterialApp], the edge glow color is the [ThemeData.accentColor].
+/// In a [MaterialApp], the edge glow color is the overall theme's
+/// [ColorScheme.secondary] color.
 ///
 /// ## Customizing the Glow Position for Advanced Scroll Views
 ///

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -694,7 +694,8 @@ class BouncingScrollPhysics extends ScrollPhysics {
 ///  * [GlowingOverscrollIndicator], which is used by [ScrollConfiguration] to
 ///    provide the glowing effect that is usually found with this clamping effect
 ///    on Android. When using a [MaterialApp], the [GlowingOverscrollIndicator]'s
-///    glow color is specified to use [ThemeData.accentColor].
+///    glow color is specified to use the overall theme's
+///    [ColorScheme.secondary] color.
 class ClampingScrollPhysics extends ScrollPhysics {
   /// Creates scroll physics that prevent the scroll offset from exceeding the
   /// bounds of the content.


### PR DESCRIPTION
Removed accentColor references from the API doc for `AboutListTile`, `Colors`, `GlowingOverscrollIndicator`, `ClampingScrollPhysics`, and `ThemeData  per #56918.