### PR TITLE
Removed accentColor and accentTextTheme dependencies from flutter_gallery

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -43,10 +43,11 @@ class NavigationIconView {
     if (type == BottomNavigationBarType.shifting) {
       iconColor = _color;
     } else {
-      final ThemeData themeData = Theme.of(context);
-      iconColor = themeData.brightness == Brightness.light
-          ? themeData.primaryColor
-          : themeData.accentColor;
+      final ThemeData theme = Theme.of(context);
+      final ColorScheme colorScheme = theme.colorScheme;
+      iconColor = theme.brightness == Brightness.light
+          ? colorScheme.primary
+          : colorScheme.secondary;
     }
 
     return FadeTransition(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_tile_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_tile_list_demo.dart
@@ -24,7 +24,7 @@ class ExpansionTileListDemo extends StatelessWidget {
             const ListTile(title: Text('Top')),
             ExpansionTile(
               title: const Text('Sublist'),
-              backgroundColor: Theme.of(context).accentColor.withOpacity(0.025),
+              backgroundColor: Theme.of(context).colorScheme.secondary.withOpacity(0.025),
               children: const <Widget>[
                 ListTile(title: Text('One')),
                 ListTile(title: Text('Two')),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/modal_bottom_sheet_demo.dart
@@ -28,7 +28,7 @@ class ModalBottomSheetDemo extends StatelessWidget {
                 child: Text('This is the modal bottom sheet. Slide down to dismiss.',
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                    color: Theme.of(context).accentColor,
+                    color: Theme.of(context).colorScheme.secondary,
                     fontSize: 24.0,
                   ),
                 ),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/page_selector_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/page_selector_demo.dart
@@ -20,7 +20,7 @@ class _PageSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final TabController? controller = DefaultTabController.of(context);
-    final Color color = Theme.of(context).accentColor;
+    final Color color = Theme.of(context).colorScheme.secondary;
     return SafeArea(
       top: false,
       bottom: false,

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
@@ -41,7 +41,7 @@ class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {
           child: Text('This is a Material persistent bottom sheet. Drag downwards to dismiss it.',
             textAlign: TextAlign.center,
             style: TextStyle(
-              color: themeData.accentColor,
+              color: themeData.colorScheme.secondary,
               fontSize: 24.0,
             ),
           ),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/scrollable_tabs_demo.dart
@@ -123,7 +123,7 @@ class ScrollableTabsDemoState extends State<ScrollableTabsDemo> with SingleTicke
 
   @override
   Widget build(BuildContext context) {
-    final Color iconColor = Theme.of(context).accentColor;
+    final Color iconColor = Theme.of(context).colorScheme.secondary;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Scrollable tabs'),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -334,7 +334,7 @@ class _SlidersState extends State<_Sliders> {
                   valueIndicatorColor: Colors.deepPurpleAccent,
                   thumbShape: _CustomThumbShape(),
                   valueIndicatorShape: _CustomValueIndicatorShape(),
-                  valueIndicatorTextStyle: theme.accentTextTheme.bodyText1!.copyWith(color: theme.colorScheme.onSurface),
+                  valueIndicatorTextStyle: theme.textTheme.bodyText1!.copyWith(color: theme.colorScheme.onSurface),
                 ),
                 child: Slider(
                   value: _discreteCustomValue,

--- a/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
@@ -25,7 +25,6 @@ final Set<Recipe?> _favoriteRecipes = <Recipe?>{};
 final ThemeData _kTheme = ThemeData(
   brightness: Brightness.light,
   primarySwatch: Colors.teal,
-  accentColor: Colors.redAccent,
 );
 
 class PestoHome extends StatelessWidget {
@@ -84,12 +83,13 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
       data: _kTheme.copyWith(platform: Theme.of(context).platform),
       child: Scaffold(
         floatingActionButton: FloatingActionButton(
-          child: const Icon(Icons.edit),
+          backgroundColor: Colors.redAccent,
           onPressed: () {
             ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
               content: Text('Not supported.'),
             ));
           },
+          child: const Icon(Icons.edit),
         ),
         body: CustomScrollView(
           semanticChildCount: widget.recipes!.length,
@@ -392,8 +392,9 @@ class _RecipePageState extends State<RecipePage> {
                     Positioned(
                       right: 16.0,
                       child: FloatingActionButton(
-                        child: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
+                        backgroundColor: Colors.redAccent,
                         onPressed: _toggleFavorite,
+                        child: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
                       ),
                     ),
                   ],

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -79,21 +79,14 @@ ThemeData _buildShrineTheme() {
   final ThemeData base = ThemeData.light();
   return base.copyWith(
     colorScheme: kShrineColorScheme,
-    accentColor: kShrineBrown900,
     primaryColor: kShrinePink100,
-    buttonColor: kShrinePink100,
     scaffoldBackgroundColor: kShrineBackgroundWhite,
     cardColor: kShrineBackgroundWhite,
     errorColor: kShrineErrorRed,
-    buttonTheme: const ButtonThemeData(
-      colorScheme: kShrineColorScheme,
-      textTheme: ButtonTextTheme.normal,
-    ),
     primaryIconTheme: _customIconTheme(base.iconTheme),
     inputDecorationTheme: const InputDecorationTheme(border: CutCornersBorder()),
     textTheme: _buildShrineTextTheme(base.textTheme),
     primaryTextTheme: _buildShrineTextTheme(base.primaryTextTheme),
-    accentTextTheme: _buildShrineTextTheme(base.accentTextTheme),
     iconTheme: _customIconTheme(base.iconTheme),
   );
 }

--- a/dev/integration_tests/flutter_gallery/lib/gallery/about.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/about.dart
@@ -35,7 +35,7 @@ class _LinkTextSpan extends TextSpan {
 void showGalleryAboutDialog(BuildContext context) {
   final ThemeData themeData = Theme.of(context);
   final TextStyle? aboutTextStyle = themeData.textTheme.bodyText1;
-  final TextStyle linkStyle = themeData.textTheme.bodyText1!.copyWith(color: themeData.accentColor);
+  final TextStyle linkStyle = themeData.textTheme.bodyText1!.copyWith(color: themeData.colorScheme.primary);
 
   showAboutDialog(
     context: context,

--- a/dev/integration_tests/flutter_gallery/lib/gallery/themes.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/themes.dart
@@ -25,14 +25,12 @@ ThemeData _buildDarkTheme() {
   );
   final ThemeData base = ThemeData(
     brightness: Brightness.dark,
-    accentColorBrightness: Brightness.dark,
     colorScheme: colorScheme,
     primaryColor: primaryColor,
     primaryColorDark: const Color(0xFF0050a0),
     primaryColorLight: secondaryColor,
     indicatorColor: Colors.white,
     toggleableActiveColor: const Color(0xFF6997DF),
-    accentColor: secondaryColor,
     canvasColor: const Color(0xFF202124),
     scaffoldBackgroundColor: const Color(0xFF202124),
     backgroundColor: const Color(0xFF202124),
@@ -41,7 +39,6 @@ ThemeData _buildDarkTheme() {
   return base.copyWith(
     textTheme: _buildTextTheme(base.textTheme),
     primaryTextTheme: _buildTextTheme(base.primaryTextTheme),
-    accentTextTheme: _buildTextTheme(base.accentTextTheme),
   );
 }
 
@@ -54,14 +51,12 @@ ThemeData _buildLightTheme() {
   );
   final ThemeData base = ThemeData(
     brightness: Brightness.light,
-    accentColorBrightness: Brightness.dark,
     colorScheme: colorScheme,
     primaryColor: primaryColor,
     indicatorColor: Colors.white,
     toggleableActiveColor: const Color(0xFF1E88E5),
     splashColor: Colors.white24,
     splashFactory: InkRipple.splashFactory,
-    accentColor: secondaryColor,
     canvasColor: Colors.white,
     scaffoldBackgroundColor: Colors.white,
     backgroundColor: Colors.white,
@@ -70,6 +65,5 @@ ThemeData _buildLightTheme() {
   return base.copyWith(
     textTheme: _buildTextTheme(base.textTheme),
     primaryTextTheme: _buildTextTheme(base.primaryTextTheme),
-    accentTextTheme: _buildTextTheme(base.accentTextTheme),
   );
 }


### PR DESCRIPTION
Removed the accentColor and accentTextTheme dependencies from flutter_gallery per https://github.com/flutter/flutter/issues/56918.

In nearly all cases that just meant replacing `theme.accentColor` with `theme.colorScheme.secondary`.