### PR TITLE
Add test for dart compilation error build output

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -19,6 +19,8 @@ void main() {
     'web',
     if (platform.isWindows)
       'windows',
+    if (platform.isLinux)
+      'linux',
     if (platform.isMacOS)
       ...<String>['macos', 'ios'],
   ];

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -30,6 +30,12 @@ void main() {
       'bin',
       'flutter',
     );
+    processManager.runSync(<String>[flutterBin, 'config',
+      '--enable-macos-desktop',
+      '--enable-windows-desktop',
+      '--enable-linux-desktop',
+      '--enable-web',
+    ]);
 
     processManager.runSync(<String>[
       flutterBin,
@@ -50,9 +56,6 @@ int x = 'String';
 
   for (final String targetPlatform in targetPlatforms) {
     testWithoutContext('flutter build $targetPlatform shows dart compilation error in non-verbose', () {
-      if (targetPlatform == 'windows') {
-        processManager.runSync(<String>[flutterBin, 'config', '--enable-windows-desktop']);
-      }
       final ProcessResult result = processManager.runSync(<String>[
         flutterBin,
         ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  Directory projectRoot;
+  String flutterBin;
+  final List<String> targetPlatforms = <String>[
+    'apk',
+    'web',
+    if (platform.isWindows)
+      'windows',
+    if (platform.isMacOS)
+      ...<String>['macos', 'ios'],
+  ];
+
+  setUpAll(() {
+    tempDir = createResolvedTempDirectorySync('build_compilation_error_test.');
+    flutterBin = fileSystem.path.join(
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
+
+    processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      'hello',
+    ], workingDirectory: tempDir.path);
+
+    projectRoot = tempDir.childDirectory('hello');
+    writeFile(fileSystem.path.join(projectRoot.path, 'lib', 'main.dart'), '''
+int x = 'String';
+''');
+  });
+
+  tearDownAll(() {
+    tryToDelete(tempDir);
+  });
+
+  for (final String targetPlatform in targetPlatforms) {
+    testWithoutContext('flutter build $targetPlatform shows dart compilation error in non-verbose', () {
+      final ProcessResult result = processManager.runSync(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'build',
+        targetPlatform,
+        '--no-pub',
+        if (targetPlatform == 'ios')
+          '--no-codesign',
+      ], workingDirectory: projectRoot.path);
+
+      expect(
+        // iOS shows this as stdout.
+        targetPlatform == 'ios' ? result.stdout : result.stderr,
+        contains("A value of type 'String' can't be assigned to a variable of type 'int'."),
+      );
+      expect(result.exitCode, 1);
+    }, timeout: const Timeout(Duration(minutes: 3)));
+  }
+}

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -50,6 +50,9 @@ int x = 'String';
 
   for (final String targetPlatform in targetPlatforms) {
     testWithoutContext('flutter build $targetPlatform shows dart compilation error in non-verbose', () {
+      if (targetPlatform == 'windows') {
+        processManager.runSync(<String>[flutterBin, 'config', '--enable-windows-desktop']);
+      }
       final ProcessResult result = processManager.runSync(<String>[
         flutterBin,
         ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -19,8 +19,6 @@ void main() {
     'web',
     if (platform.isWindows)
       'windows',
-    if (platform.isLinux)
-      'linux',
     if (platform.isMacOS)
       ...<String>['macos', 'ios'],
   ];
@@ -35,7 +33,6 @@ void main() {
     processManager.runSync(<String>[flutterBin, 'config',
       '--enable-macos-desktop',
       '--enable-windows-desktop',
-      '--enable-linux-desktop',
       '--enable-web',
     ]);
 

--- a/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
@@ -57,26 +57,6 @@ void main() {
         File outputAppFrameworkBinary;
 
         setUpAll(() {
-          flutterRoot = getFlutterRoot();
-          tempDir = createResolvedTempDirectorySync('ios_content_validation.');
-          flutterBin = fileSystem.path.join(
-            flutterRoot,
-            'bin',
-            'flutter',
-          );
-
-          processManager.runSync(<String>[
-            flutterBin,
-            ...getLocalEngineArguments(),
-            'create',
-            '--platforms=ios',
-            '-i',
-            'objc',
-            'hello',
-          ], workingDirectory: tempDir.path);
-
-          projectRoot = tempDir.childDirectory('hello').path;
-
           processManager.runSync(<String>[
             flutterBin,
             ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
@@ -107,7 +107,7 @@ void main() {
       expect(outputFlutterFramework.childDirectory('Modules'), isNot(exists));
 
       // Archiving should contain a bitcode blob, but not building.
-      // This mimics Xcode behavior and present a developer from having to install a
+      // This mimics Xcode behavior and prevents a developer from having to install a
       // 300+MB app.
       final File outputFlutterFrameworkBinary = outputFlutterFramework
           .childDirectory('Versions')


### PR DESCRIPTION
Add an integration test that `flutter build`s on all available target platforms in a project with a dart compilation error.

1. The compilation error is shown on stderr without needing a `--verbose` flag.
2. The overall build command fails.

Validates issues like https://github.com/flutter/flutter/issues/72608 don't happen for newly created projects.

Passing tests:
[Windows](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8852551339440366912/+/steps/run_test.dart_for_tool_integration_tests_shard_and_subshard_2_3/0/stdout)
[Mac](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8852551339440367184/+/steps/run_test.dart_for_tool_integration_tests_shard_and_subshard_1_3/0/stdout)