### PR TITLE
Add Linux shard builders to Flutter build dashboard

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -133,6 +133,18 @@
       "flaky": false
     },
     {
+      "name": "Linux build_tests_1_2",
+      "repo": "flutter",
+      "task_name": "linux_build_tests_1_2",
+      "flaky": true
+    },
+    {
+      "name": "Linux build_tests_2_2",
+      "repo": "flutter",
+      "task_name": "linux_build_tests_2_2",
+      "flaky": true
+    },
+    {
       "name": "Linux fast_scroll_heavy_gridview__memory",
       "repo": "flutter",
       "task_name": "linux_fast_scroll_heavy_gridview__memory",
@@ -257,6 +269,24 @@
       "repo": "flutter",
       "task_name": "linux_framework_tests",
       "flaky": false
+    },
+    {
+      "name": "Linux framework_tests_libraries",
+      "repo": "flutter",
+      "task_name": "linux_framework_tests_libraries",
+      "flaky": true
+    },
+    {
+      "name": "Linux framework_tests_misc",
+      "repo": "flutter",
+      "task_name": "linux_framework_tests_misc",
+      "flaky": true
+    },
+    {
+      "name": "Linux framework_tests_widgets",
+      "repo": "flutter",
+      "task_name": "linux_framework_tests_widgets",
+      "flaky": true
     },
     {
       "name": "Linux fuchsia_precache",
@@ -391,10 +421,40 @@
       "flaky": false
     },
     {
+      "name": "Linux tool_tests_general",
+      "repo": "flutter",
+      "task_name": "linux_tool_tests_general",
+      "flaky": true
+    },
+    {
+      "name": "Linux tool_tests_commands",
+      "repo": "flutter",
+      "task_name": "linux_tool_tests_commands",
+      "flaky": true
+    },
+    {
       "name": "Linux tool_integration_tests",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests",
       "flaky": false
+    },
+    {
+      "name": "Linux tool_integration_tests_1_3",
+      "repo": "flutter",
+      "task_name": "linux_tool_integration_tests_1_3",
+      "flaky": true
+    },
+    {
+      "name": "Linux tool_integration_tests_2_3",
+      "repo": "flutter",
+      "task_name": "linux_tool_integration_tests_2_3",
+      "flaky": true
+    },
+    {
+      "name": "Linux tool_integration_tests_3_3",
+      "repo": "flutter",
+      "task_name": "linux_tool_integration_tests_3_3",
+      "flaky": true
     },
     {
       "name": "Linux web_tool_tests",
@@ -427,6 +487,54 @@
       "flaky": false
     },
     {
+      "name": "Linux web_tests_0",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_0",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_1",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_1",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_2",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_2",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_3",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_3",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_4",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_4",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_5",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_5",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_6",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_6",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_tests_7_last",
+      "repo": "flutter",
+      "task_name": "linux_web_tests_7_last",
+      "flaky": true
+    },
+    {
       "name": "Linux web_integration_tests",
       "repo": "flutter",
       "task_name": "linux_web_integration_tests",
@@ -437,6 +545,24 @@
       "repo": "flutter",
       "task_name": "linux_web_long_running_tests",
       "flaky": false
+    },
+    {
+      "name": "Linux web_long_running_tests_1_3",
+      "repo": "flutter",
+      "task_name": "linux_web_long_running_tests_1_3",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_long_running_tests_2_3",
+      "repo": "flutter",
+      "task_name": "linux_web_long_running_tests_2_3",
+      "flaky": true
+    },
+    {
+      "name": "Linux web_long_running_tests_3_3",
+      "repo": "flutter",
+      "task_name": "linux_web_long_running_tests_3_3",
+      "flaky": true
     },
     {
       "name": "Linux web_e2e_test",


### PR DESCRIPTION
This is a follow up of migrating shards into independent builders.

Separated Linux builders have been running in Milo for a while, and stable.
![Screen Shot 2021-03-17 at 9 23 33 AM](https://user-images.githubusercontent.com/54558023/111501754-7bb3d700-8702-11eb-9412-7b52c068ed79.png)

This PR enables these builders in Flutter build dashboard, but they are marked as flaky first to avoid unexpected tree closure.
A follow up PR will mark them as unflaky when they are running successfully.

Related issue: https://github.com/flutter/flutter/issues/77947 