### PR TITLE
Improve documentation for highContrast, invertColors, and boldText

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -314,8 +314,8 @@ class MediaQueryData {
 
   /// Whether the device is inverting the colors of the platform.
   ///
-  /// Setting it, for instace by using: 
-  /// 
+  /// Setting it, for instance by using:
+  ///
   /// ```dart
   /// MediaQuery(
   ///   data: MediaQuery.of(context).copyWith(
@@ -337,8 +337,8 @@ class MediaQueryData {
   /// Whether the user requested a high contrast between foreground and background
   /// content on iOS, via Settings -> Accessibility -> Increase Contrast.
   ///
-  /// Setting it, for instace by using: 
-  /// 
+  /// Setting it, for instance by using:
+  ///
   /// ```dart
   /// MediaQuery(
   ///   data: MediaQuery.of(context).copyWith(
@@ -365,8 +365,8 @@ class MediaQueryData {
   /// Whether the platform is requesting that text be drawn with a bold font
   /// weight.
   ///
-  /// Setting it, for instace by using: 
-  /// 
+  /// Setting it, for instance by using:
+  ///
   /// ```dart
   /// MediaQuery(
   ///   data: MediaQuery.of(context).copyWith(

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -312,21 +312,7 @@ class MediaQueryData {
   ///  * [dart:ui.PlatformDispatcher.accessibilityFeatures], where the setting originates.
   final bool accessibleNavigation;
 
-  /// Whether the device is inverting the colors of the platform.
-  ///
-  /// {@tool snippet}
-  /// Setting it, for instance by using:
-  ///
-  /// ```dart
-  /// MediaQuery(
-  ///   data: MediaQuery.of(context).copyWith(
-  ///     invertColors: false),
-  ///   child: child
-  /// ),
-  /// ```
-  ///
-  /// will have no effect on `child`, and the platform requested value will be used.
-  /// {@end-tool}
+  /// Whether the platform is inverting the colors of the platform.
   ///
   /// This flag is currently only updated on iOS devices.
   ///
@@ -336,22 +322,8 @@ class MediaQueryData {
   ///    originates.
   final bool invertColors;
 
-  /// Whether the user requested a high contrast between foreground and background
+  /// Whether the platform is requesting a high contrast between foreground and background
   /// content on iOS, via Settings -> Accessibility -> Increase Contrast.
-  ///
-  /// {@tool snippet}
-  /// Setting it, for instance by using:
-  ///
-  /// ```dart
-  /// MediaQuery(
-  ///   data: MediaQuery.of(context).copyWith(
-  ///     highContrast: false),
-  ///   child: child
-  /// ),
-  /// ```
-  ///
-  /// will have no effect on `child`, and the platform requested value will be used.
-  /// {@end-tool}
   ///
   /// This flag is currently only updated on iOS devices that are running iOS 13
   /// or above.
@@ -369,19 +341,7 @@ class MediaQueryData {
   /// Whether the platform is requesting that text be drawn with a bold font
   /// weight.
   ///
-  /// {@tool snippet}
-  /// Setting it, for instance by using:
-  ///
-  /// ```dart
-  /// MediaQuery(
-  ///   data: MediaQuery.of(context).copyWith(
-  ///     boldText: false),
-  ///   child: child
-  /// ),
-  /// ```
-  ///
-  /// will override the value that the platform is requesting.
-  /// {@end-tool}
+  /// Setting this property overrides the value requested by the platform.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -314,6 +314,18 @@ class MediaQueryData {
 
   /// Whether the device is inverting the colors of the platform.
   ///
+  /// Setting it, for instace by using: 
+  /// 
+  /// ```dart
+  /// MediaQuery(
+  ///   data: MediaQuery.of(context).copyWith(
+  ///     invertColors: false),
+  ///   child: child
+  /// ),
+  /// ```
+  ///
+  /// will have no effect on `child`, and the platform requested value will be used.
+  ///
   /// This flag is currently only updated on iOS devices.
   ///
   /// See also:
@@ -324,6 +336,18 @@ class MediaQueryData {
 
   /// Whether the user requested a high contrast between foreground and background
   /// content on iOS, via Settings -> Accessibility -> Increase Contrast.
+  ///
+  /// Setting it, for instace by using: 
+  /// 
+  /// ```dart
+  /// MediaQuery(
+  ///   data: MediaQuery.of(context).copyWith(
+  ///     highContrast: false),
+  ///   child: child
+  /// ),
+  /// ```
+  ///
+  /// will have no effect on `child`, and the platform requested value will be used.
   ///
   /// This flag is currently only updated on iOS devices that are running iOS 13
   /// or above.
@@ -340,6 +364,18 @@ class MediaQueryData {
 
   /// Whether the platform is requesting that text be drawn with a bold font
   /// weight.
+  ///
+  /// Setting it, for instace by using: 
+  /// 
+  /// ```dart
+  /// MediaQuery(
+  ///   data: MediaQuery.of(context).copyWith(
+  ///     boldText: false),
+  ///   child: child
+  /// ),
+  /// ```
+  ///
+  /// will override the value that the platform is requesting.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -314,6 +314,7 @@ class MediaQueryData {
 
   /// Whether the device is inverting the colors of the platform.
   ///
+  /// {@tool snippet}
   /// Setting it, for instance by using:
   ///
   /// ```dart
@@ -325,6 +326,7 @@ class MediaQueryData {
   /// ```
   ///
   /// will have no effect on `child`, and the platform requested value will be used.
+  /// {@end-tool}
   ///
   /// This flag is currently only updated on iOS devices.
   ///
@@ -337,6 +339,7 @@ class MediaQueryData {
   /// Whether the user requested a high contrast between foreground and background
   /// content on iOS, via Settings -> Accessibility -> Increase Contrast.
   ///
+  /// {@tool snippet}
   /// Setting it, for instance by using:
   ///
   /// ```dart
@@ -348,6 +351,7 @@ class MediaQueryData {
   /// ```
   ///
   /// will have no effect on `child`, and the platform requested value will be used.
+  /// {@end-tool}
   ///
   /// This flag is currently only updated on iOS devices that are running iOS 13
   /// or above.
@@ -365,6 +369,7 @@ class MediaQueryData {
   /// Whether the platform is requesting that text be drawn with a bold font
   /// weight.
   ///
+  /// {@tool snippet}
   /// Setting it, for instance by using:
   ///
   /// ```dart
@@ -376,6 +381,7 @@ class MediaQueryData {
   /// ```
   ///
   /// will override the value that the platform is requesting.
+  /// {@end-tool}
   ///
   /// See also:
   ///


### PR DESCRIPTION
Improve the documentation for `highContrast`, `invertColors`, and `boldText`.

While playing with them I was confused by the fact that changing `boldText` had an effect on the app, while changing the other two did not.

Does not solve #78323, but it is a suggested change in that issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
