### PR TITLE
Remove accentColor et al.  from tests

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
@@ -40,7 +40,7 @@ import 'stock_strings_es.dart';
 ///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
-///   intl: any # Use the pinned version from flutter_localizations
+///   intl: 0.16.1
 ///
 ///   # rest of dependencies
 /// ```
@@ -65,12 +65,12 @@ import 'stock_strings_es.dart';
 /// be consistent with the languages listed in the StockStrings.supportedLocales
 /// property.
 abstract class StockStrings {
-  StockStrings(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  StockStrings(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
 
-  static StockStrings? of(BuildContext context) {
+  static StockStrings of(BuildContext context) {
     return Localizations.of<StockStrings>(context, StockStrings);
   }
 
@@ -100,22 +100,13 @@ abstract class StockStrings {
     Locale('es')
   ];
 
-  /// Title for the Stocks application
-  ///
-  /// In en, this message translates to:
-  /// **'Stocks'**
+  // Title for the Stocks application
   String get title;
 
-  /// Label for the Market tab
-  ///
-  /// In en, this message translates to:
-  /// **'MARKET'**
+  // Label for the Market tab
   String get market;
 
-  /// Label for the Portfolio tab
-  ///
-  /// In en, this message translates to:
-  /// **'PORTFOLIO'**
+  // Label for the Portfolio tab
   String get portfolio;
 }
 
@@ -135,29 +126,24 @@ class _StockStringsDelegate extends LocalizationsDelegate<StockStrings> {
 }
 
 StockStrings _lookupStockStrings(Locale locale) {
-  
 
-// Lookup logic when language+country codes are specified.
-switch (locale.languageCode) {
-  case 'en': {
-  switch (locale.countryCode) {
-    case 'US': return StockStringsEnUs();
+
+  // Lookup logic when language+country codes are specified.
+  switch (locale.languageCode) {
+    case 'en': {
+      switch (locale.countryCode) {
+        case 'US': return StockStringsEnUs();
+      }
+      break;
+    }
   }
-  break;
-}
-}
 
-// Lookup logic when only language code is specified.
-switch (locale.languageCode) {
-  case 'en': return StockStringsEn();
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en': return StockStringsEn();
     case 'es': return StockStringsEs();
-}
+  }
 
-
-  throw FlutterError(
-    'StockStrings.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
-  );
+  assert(false, 'StockStrings.delegate failed to load unsupported locale "$locale"');
+  return null;
 }

--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
@@ -40,7 +40,7 @@ import 'stock_strings_es.dart';
 ///   # Internationalization support.
 ///   flutter_localizations:
 ///     sdk: flutter
-///   intl: 0.16.1
+///   intl: any # Use the pinned version from flutter_localizations
 ///
 ///   # rest of dependencies
 /// ```
@@ -65,12 +65,12 @@ import 'stock_strings_es.dart';
 /// be consistent with the languages listed in the StockStrings.supportedLocales
 /// property.
 abstract class StockStrings {
-  StockStrings(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  StockStrings(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
 
-  static StockStrings of(BuildContext context) {
+  static StockStrings? of(BuildContext context) {
     return Localizations.of<StockStrings>(context, StockStrings);
   }
 
@@ -100,13 +100,22 @@ abstract class StockStrings {
     Locale('es')
   ];
 
-  // Title for the Stocks application
+  /// Title for the Stocks application
+  ///
+  /// In en, this message translates to:
+  /// **'Stocks'**
   String get title;
 
-  // Label for the Market tab
+  /// Label for the Market tab
+  ///
+  /// In en, this message translates to:
+  /// **'MARKET'**
   String get market;
 
-  // Label for the Portfolio tab
+  /// Label for the Portfolio tab
+  ///
+  /// In en, this message translates to:
+  /// **'PORTFOLIO'**
   String get portfolio;
 }
 
@@ -126,24 +135,29 @@ class _StockStringsDelegate extends LocalizationsDelegate<StockStrings> {
 }
 
 StockStrings _lookupStockStrings(Locale locale) {
+  
 
-
-  // Lookup logic when language+country codes are specified.
-  switch (locale.languageCode) {
-    case 'en': {
-      switch (locale.countryCode) {
-        case 'US': return StockStringsEnUs();
-      }
-      break;
-    }
+// Lookup logic when language+country codes are specified.
+switch (locale.languageCode) {
+  case 'en': {
+  switch (locale.countryCode) {
+    case 'US': return StockStringsEnUs();
   }
+  break;
+}
+}
 
-  // Lookup logic when only language code is specified.
-  switch (locale.languageCode) {
-    case 'en': return StockStringsEn();
+// Lookup logic when only language code is specified.
+switch (locale.languageCode) {
+  case 'en': return StockStringsEn();
     case 'es': return StockStringsEs();
-  }
+}
 
-  assert(false, 'StockStrings.delegate failed to load unsupported locale "$locale"');
-  return null;
+
+  throw FlutterError(
+    'StockStrings.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.'
+  );
 }

--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -286,7 +286,7 @@ class StockHomeState extends State<StockHome> {
   AppBar buildSearchBar() {
     return AppBar(
       leading: BackButton(
-        color: Theme.of(context).accentColor,
+        color: Theme.of(context).colorScheme.secondary,
       ),
       title: TextField(
         controller: _searchQuery,
@@ -310,7 +310,7 @@ class StockHomeState extends State<StockHome> {
     return FloatingActionButton(
       tooltip: 'Create company',
       child: const Icon(Icons.add),
-      backgroundColor: Theme.of(context).accentColor,
+      backgroundColor: Theme.of(context).colorScheme.secondary,
       onPressed: _handleCreateCompany,
     );
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -437,7 +437,7 @@ class _DiamondFab extends StatelessWidget {
           width: 56.0,
           height: 56.0,
           child: IconTheme.merge(
-            data: IconThemeData(color: Theme.of(context).accentIconTheme.color),
+            data: IconThemeData(color: Theme.of(context).colorScheme.secondary),
             child: child!,
           ),
         ),

--- a/dev/manual_tests/lib/overlay_geometry.dart
+++ b/dev/manual_tests/lib/overlay_geometry.dart
@@ -204,8 +204,10 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
 }
 
 void main() {
-  runApp(MaterialApp(
-    title: 'Cards',
-    home: const OverlayGeometryApp(),
-  ));
+  runApp(
+    const MaterialApp(
+      title: 'Cards',
+      home: OverlayGeometryApp(),
+    ),
+  );
 }

--- a/dev/manual_tests/lib/overlay_geometry.dart
+++ b/dev/manual_tests/lib/overlay_geometry.dart
@@ -205,11 +205,6 @@ class OverlayGeometryAppState extends State<OverlayGeometryApp> {
 
 void main() {
   runApp(MaterialApp(
-    theme: ThemeData(
-      brightness: Brightness.light,
-      primarySwatch: Colors.blue,
-      accentColor: Colors.redAccent,
-    ),
     title: 'Cards',
     home: const OverlayGeometryApp(),
   ));

--- a/dev/manual_tests/lib/page_view.dart
+++ b/dev/manual_tests/lib/page_view.dart
@@ -143,11 +143,6 @@ class PageViewAppState extends State<PageViewApp> {
 void main() {
   runApp(MaterialApp(
     title: 'PageView',
-    theme: ThemeData(
-      brightness: Brightness.light,
-      primarySwatch: Colors.blue,
-      accentColor: Colors.redAccent,
-    ),
     home: const PageViewApp(),
   ));
 }

--- a/dev/manual_tests/lib/page_view.dart
+++ b/dev/manual_tests/lib/page_view.dart
@@ -141,8 +141,10 @@ class PageViewAppState extends State<PageViewApp> {
 }
 
 void main() {
-  runApp(MaterialApp(
-    title: 'PageView',
-    home: const PageViewApp(),
-  ));
+  runApp(
+    const MaterialApp(
+      title: 'PageView',
+      home: PageViewApp(),
+    ),
+  );
 }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1848,7 +1848,7 @@ void main() {
                 child: Text('This is a Material persistent bottom sheet. Drag downwards to dismiss it.',
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                    color: themeData.accentColor,
+                    color: themeData.colorScheme.secondary,
                     fontSize: 24.0,
                   ),
                 ),

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -690,14 +690,12 @@ void main() {
       },
     );
 
-    final ThemeData theme = ThemeData.raw(
+    final ThemeData theme = ThemeData.light().copyWith(
       visualDensity: VisualDensity.standard,
       primaryColor: Colors.black,
       primaryColorBrightness: Brightness.dark,
       primaryColorLight: Colors.black,
       primaryColorDark: Colors.black,
-      accentColor: Colors.black,
-      accentColorBrightness: Brightness.dark,
       canvasColor: Colors.black,
       shadowColor: Colors.black,
       scaffoldBackgroundColor: Colors.black,
@@ -727,11 +725,9 @@ void main() {
       toggleableActiveColor: Colors.black,
       textTheme: ThemeData.dark().textTheme,
       primaryTextTheme: ThemeData.dark().textTheme,
-      accentTextTheme: ThemeData.dark().textTheme,
       inputDecorationTheme: ThemeData.dark().inputDecorationTheme.copyWith(border: const OutlineInputBorder()),
       iconTheme: ThemeData.dark().iconTheme,
       primaryIconTheme: ThemeData.dark().iconTheme,
-      accentIconTheme: ThemeData.dark().iconTheme,
       sliderTheme: sliderTheme,
       tabBarTheme: const TabBarTheme(labelColor: Colors.black),
       tooltipTheme: const TooltipThemeData(height: 100),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5888,8 +5888,11 @@ void main() {
     testWidgets('TextEditingController.buildTextSpan receives build context', (WidgetTester tester) async {
       final _AccentColorTextEditingController controller = _AccentColorTextEditingController('a');
       const Color color = Color.fromARGB(255, 1, 2, 3);
+      final ThemeData lightTheme = ThemeData.light();
       await tester.pumpWidget(MaterialApp(
-        theme: ThemeData.light().copyWith(accentColor: color),
+        theme: lightTheme.copyWith(
+          colorScheme: lightTheme.colorScheme.copyWith(secondary: color),
+        ),
         home: EditableText(
           controller: controller,
           focusNode: FocusNode(),
@@ -7559,7 +7562,7 @@ class _AccentColorTextEditingController extends TextEditingController {
 
   @override
   TextSpan buildTextSpan({required BuildContext context, TextStyle? style, required bool withComposing}) {
-    final Color color = Theme.of(context).accentColor;
+    final Color color = Theme.of(context).colorScheme.secondary;
     return super.buildTextSpan(context: context, style: TextStyle(color: color), withComposing: withComposing);
   }
 }


### PR DESCRIPTION
Removed the accentColor, accentTextTheme, and accentIconTheme dependencies from Flutter tests per https://github.com/flutter/flutter/issues/56918.

In most cases that just meant replacing `theme.accentColor` with `theme.colorScheme.secondary`.