### PR TITLE
Add rootOverlay and hitTestBehavior flags to LongPressDraggable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@ vimerzhao <vimerzhao@gmail.com>
 Pedro Massango <pedromassango.developer@gmail.com>
 Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
 Perqin Xie <perqinxie@gmail.com>
+Muhammed Salih Guler <muhammedsalihguler@gmail.com>

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -442,6 +442,8 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
     DraggableCanceledCallback? onDraggableCanceled,
     DragEndCallback? onDragEnd,
     VoidCallback? onDragCompleted,
+    bool rootOverlay = false,
+    HitTestBehavior hitTestBehavior = HitTestBehavior.deferToChild,
     this.hapticFeedbackOnStart = true,
     bool ignoringFeedbackSemantics = true,
     this.delay = kLongPressTimeout,
@@ -461,6 +463,8 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
     onDragEnd: onDragEnd,
     onDragCompleted: onDragCompleted,
     ignoringFeedbackSemantics: ignoringFeedbackSemantics,
+    rootOverlay: rootOverlay,
+    hitTestBehavior: hitTestBehavior,
   );
 
   /// Whether haptic feedback should be triggered on drag start.

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 
 import 'semantics_tester.dart';
 

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/semantics.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'semantics_tester.dart';
 
@@ -3082,6 +3082,51 @@ void main() {
     );
 
     expect(tester.widget<MetaData>(find.byType(MetaData)).behavior, hitTestBehavior);
+  });
+
+  testWidgets(
+      'configurable LongPressDraggable with opaque hit test behavior and false rootOverlay',
+      (WidgetTester tester) async {
+    const HitTestBehavior hitTestBehavior = HitTestBehavior.opaque;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: LongPressDraggable<int>(
+          hitTestBehavior: hitTestBehavior,
+          feedback: SizedBox(height: 50.0, child: Text('Draggable')),
+          child: SizedBox(height: 50.0, child: Text('Target')),
+        ),
+      ),
+    );
+
+    final LongPressDraggable<int> widgetFound =
+        tester.widget<LongPressDraggable<int>>(find.byWidgetPredicate(
+            (Widget widget) => widget is LongPressDraggable<int>));
+    expect(widgetFound.hitTestBehavior, hitTestBehavior);
+
+    expect(widgetFound.rootOverlay, isFalse);
+  });
+
+  testWidgets(
+      'configurable LongPressDraggable with deferToChild hit test behavior and true rootOverlay',
+      (WidgetTester tester) async {
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: LongPressDraggable<int>(
+          rootOverlay: true,
+          feedback: SizedBox(height: 50.0, child: Text('Draggable')),
+          child: SizedBox(height: 50.0, child: Text('Target')),
+        ),
+      ),
+    );
+
+    final LongPressDraggable<int> widgetFound =
+        tester.widget<LongPressDraggable<int>>(find.byWidgetPredicate(
+            (Widget widget) => widget is LongPressDraggable<int>));
+    expect(widgetFound.hitTestBehavior, HitTestBehavior.deferToChild);
+
+    expect(widgetFound.rootOverlay, isTrue);
   });
 }
 


### PR DESCRIPTION
Adds a rootOverlay boolean and hitTestBehavior HitTestBehavior value to LongPressDraggable and passes them to Draggable (its parent class)

Fixes https://github.com/flutter/flutter/issues/78443

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. (Asked Hixie about the test, waiting for the answer)
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
