### PR TITLE
Remove flaky flag for Linux shard builders

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -127,22 +127,16 @@
       "flaky": false
     },
     {
-      "name": "Linux build_tests",
-      "repo": "flutter",
-      "task_name": "linux_build_tests",
-      "flaky": false
-    },
-    {
       "name": "Linux build_tests_1_2",
       "repo": "flutter",
       "task_name": "linux_build_tests_1_2",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux build_tests_2_2",
       "repo": "flutter",
       "task_name": "linux_build_tests_2_2",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux fast_scroll_heavy_gridview__memory",
@@ -265,28 +259,22 @@
       "flaky": false
     },
     {
-      "name": "Linux framework_tests",
-      "repo": "flutter",
-      "task_name": "linux_framework_tests",
-      "flaky": false
-    },
-    {
       "name": "Linux framework_tests_libraries",
       "repo": "flutter",
       "task_name": "linux_framework_tests_libraries",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux framework_tests_misc",
       "repo": "flutter",
       "task_name": "linux_framework_tests_misc",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux framework_tests_widgets",
       "repo": "flutter",
       "task_name": "linux_framework_tests_widgets",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux fuchsia_precache",
@@ -415,46 +403,34 @@
       "flaky": false
     },
     {
-      "name": "Linux tool_tests",
-      "repo": "flutter",
-      "task_name": "linux_tool_tests",
-      "flaky": false
-    },
-    {
       "name": "Linux tool_tests_general",
       "repo": "flutter",
       "task_name": "linux_tool_tests_general",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux tool_tests_commands",
       "repo": "flutter",
       "task_name": "linux_tool_tests_commands",
-      "flaky": true
-    },
-    {
-      "name": "Linux tool_integration_tests",
-      "repo": "flutter",
-      "task_name": "linux_tool_integration_tests",
       "flaky": false
     },
     {
       "name": "Linux tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_1_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_2_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_3_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tool_tests",
@@ -481,58 +457,52 @@
       "flaky": false
     },
     {
-      "name": "Linux web_tests",
-      "repo": "flutter",
-      "task_name": "linux_web_tests",
-      "flaky": false
-    },
-    {
       "name": "Linux web_tests_0",
       "repo": "flutter",
       "task_name": "linux_web_tests_0",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_1",
       "repo": "flutter",
       "task_name": "linux_web_tests_1",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_2",
       "repo": "flutter",
       "task_name": "linux_web_tests_2",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_3",
       "repo": "flutter",
       "task_name": "linux_web_tests_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_4",
       "repo": "flutter",
       "task_name": "linux_web_tests_4",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_5",
       "repo": "flutter",
       "task_name": "linux_web_tests_5",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_6",
       "repo": "flutter",
       "task_name": "linux_web_tests_6",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_tests_7_last",
       "repo": "flutter",
       "task_name": "linux_web_tests_7_last",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_integration_tests",
@@ -541,28 +511,22 @@
       "flaky": false
     },
     {
-      "name": "Linux web_long_running_tests",
-      "repo": "flutter",
-      "task_name": "linux_web_long_running_tests",
-      "flaky": false
-    },
-    {
       "name": "Linux web_long_running_tests_1_3",
       "repo": "flutter",
       "task_name": "linux_web_long_running_tests_1_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_long_running_tests_2_3",
       "repo": "flutter",
       "task_name": "linux_web_long_running_tests_2_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_long_running_tests_3_3",
       "repo": "flutter",
       "task_name": "linux_web_long_running_tests_3_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux web_e2e_test",


### PR DESCRIPTION
The newly added Linux shard builders are pretty stable.
![Screen Shot 2021-03-17 at 4 21 43 PM](https://user-images.githubusercontent.com/54558023/111551215-f39ef300-873c-11eb-99d7-efd6d01b84f3.png)

This is a follow up of https://github.com/flutter/flutter/pull/78430, removing flaky flag of Linux shard builders. The consolidated builders are removed as well.

Related issue: https://github.com/flutter/flutter/issues/77947