### PR TITLE
Parse engine src path from an absolute --local-engine

### DIFF
--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -55,7 +55,7 @@ class LocalEngineLocator {
     if (engineSourcePath == null && localEngine != null) {
       try {
         engineSourcePath = _findEngineSourceByLocalEngine(localEngine);
-        engineSourcePath ??= await _findEngineSourceBySkyEngine(packagePath);
+        engineSourcePath ??= await _findEngineSourceByPackageConfig(packagePath);
       } on FileSystemException catch (e) {
         _logger.printTrace('Local engine auto-detection file exception: $e');
         engineSourcePath = null;
@@ -97,7 +97,7 @@ class LocalEngineLocator {
       final Directory localEngineDirectory = _fileSystem.directory(localEngine);
       final Directory outDirectory = localEngineDirectory?.parent;
       final Directory srcDirectory = outDirectory?.parent;
-      if (localEngineDirectory.existsSync() && outDirectory.basename == 'out' && srcDirectory.basename == 'src') {
+      if (localEngineDirectory.existsSync() && outDirectory?.basename == 'out' && srcDirectory?.basename == 'src') {
         _logger.printTrace('Parsed engine source from local engine as ${srcDirectory.path}.');
         return srcDirectory.path;
       }
@@ -105,7 +105,7 @@ class LocalEngineLocator {
     return null;
   }
 
-  Future<String> _findEngineSourceBySkyEngine(String packagePath) async {
+  Future<String> _findEngineSourceByPackageConfig(String packagePath) async {
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(
       _fileSystem.file(
         // TODO(jonahwilliams): update to package_config

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -54,45 +54,8 @@ class LocalEngineLocator {
 
     if (engineSourcePath == null && localEngine != null) {
       try {
-        final PackageConfig packageConfig = await loadPackageConfigWithLogging(
-          _fileSystem.file(
-            // TODO(jonahwilliams): update to package_config
-            packagePath ?? _fileSystem.path.join('.packages'),
-          ),
-          logger: _logger,
-          throwOnError: false,
-        );
-        // Skip if sky_engine is the version in bin/cache.
-        Uri engineUri = packageConfig[kFlutterEnginePackageName]?.packageUriRoot;
-        final String cachedPath = _fileSystem.path.join(_flutterRoot, 'bin', 'cache', 'pkg', kFlutterEnginePackageName, 'lib');
-        if (engineUri != null && _fileSystem.identicalSync(cachedPath, engineUri.path)) {
-          _logger.printTrace('Local engine auto-detection sky_engine in $packagePath is the same version in bin/cache.');
-          engineUri = null;
-        }
-        // If sky_engine is specified and the engineSourcePath not set, try to
-        // determine the engineSourcePath by sky_engine setting. A typical engine Uri
-        // looks like:
-        // file://flutter-engine-local-path/src/out/host_debug_unopt/gen/dart-pkg/sky_engine/lib/
-        if (engineUri?.path != null) {
-          engineSourcePath = _fileSystem.directory(engineUri.path)
-            ?.parent
-            ?.parent
-            ?.parent
-            ?.parent
-            ?.parent
-            ?.parent
-            ?.path;
-          if (engineSourcePath != null && (engineSourcePath == _fileSystem.path.dirname(engineSourcePath) || engineSourcePath.isEmpty)) {
-            engineSourcePath = null;
-            throwToolExit(
-              _userMessages.runnerNoEngineSrcDir(
-                kFlutterEnginePackageName,
-                kFlutterEngineEnvironmentVariableName,
-              ),
-              exitCode: 2,
-            );
-          }
-        }
+        engineSourcePath = _findEngineSourceByLocalEngine(localEngine);
+        engineSourcePath ??= await _findEngineSourceBySkyEngine(packagePath);
       } on FileSystemException catch (e) {
         _logger.printTrace('Local engine auto-detection file exception: $e');
         engineSourcePath = null;
@@ -113,10 +76,77 @@ class LocalEngineLocator {
     if (engineSourcePath != null) {
       _logger.printTrace('Local engine source at $engineSourcePath');
       return _findEngineBuildPath(localEngine, engineSourcePath);
-    } else if (localEngine != null) {
-      _logger.printTrace('Could not find engine source for $localEngine, skipping');
+    }
+    if (localEngine != null) {
+      throwToolExit(
+        _userMessages.runnerNoEngineSrcDir(
+          kFlutterEnginePackageName,
+          kFlutterEngineEnvironmentVariableName,
+        ),
+        exitCode: 2,
+      );
     }
     return null;
+  }
+
+  String _findEngineSourceByLocalEngine(String localEngine) {
+    // When the local engine is an absolute path to a variant inside the
+    // out directory, parse the engine source.
+    // --local-engine /path/to/cache/builder/src/out/host_debug_unopt
+    if (_fileSystem.path.isAbsolute(localEngine)) {
+      final Directory localEngineDirectory = _fileSystem.directory(localEngine);
+      final Directory outDirectory = localEngineDirectory?.parent;
+      final Directory srcDirectory = outDirectory?.parent;
+      if (localEngineDirectory.existsSync() && outDirectory.basename == 'out' && srcDirectory.basename == 'src') {
+        _logger.printTrace('Parsed engine source from local engine as ${srcDirectory.path}.');
+        return srcDirectory.path;
+      }
+    }
+    return null;
+  }
+
+  Future<String> _findEngineSourceBySkyEngine(String packagePath) async {
+    final PackageConfig packageConfig = await loadPackageConfigWithLogging(
+      _fileSystem.file(
+        // TODO(jonahwilliams): update to package_config
+        packagePath ?? _fileSystem.path.join('.packages'),
+      ),
+      logger: _logger,
+      throwOnError: false,
+    );
+    // Skip if sky_engine is the version in bin/cache.
+    Uri engineUri = packageConfig[kFlutterEnginePackageName]?.packageUriRoot;
+    final String cachedPath = _fileSystem.path.join(_flutterRoot, 'bin', 'cache', 'pkg', kFlutterEnginePackageName, 'lib');
+    if (engineUri != null && _fileSystem.identicalSync(cachedPath, engineUri.path)) {
+      _logger.printTrace('Local engine auto-detection sky_engine in $packagePath is the same version in bin/cache.');
+      engineUri = null;
+    }
+    // If sky_engine is specified and the engineSourcePath not set, try to
+    // determine the engineSourcePath by sky_engine setting. A typical engine Uri
+    // looks like:
+    // file://flutter-engine-local-path/src/out/host_debug_unopt/gen/dart-pkg/sky_engine/lib/
+    String engineSourcePath;
+    if (engineUri?.path != null) {
+      engineSourcePath = _fileSystem.directory(engineUri.path)
+        ?.parent
+        ?.parent
+        ?.parent
+        ?.parent
+        ?.parent
+        ?.parent
+        ?.path;
+      if (engineSourcePath != null && (engineSourcePath == _fileSystem.path.dirname(engineSourcePath) || engineSourcePath.isEmpty)) {
+        engineSourcePath = null;
+        throwToolExit(
+          _userMessages.runnerNoEngineSrcDir(
+            kFlutterEnginePackageName,
+            kFlutterEngineEnvironmentVariableName,
+          ),
+          exitCode: 2,
+        );
+      }
+    }
+    return engineSourcePath;
   }
 
   // Determine the host engine directory associated with the local engine:

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -97,6 +97,79 @@ void main() {
   });
 
   testWithoutContext('works if --local-engine is specified and --local-engine-src-path '
+      'is determined by --local-engine', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Directory localEngine = fileSystem
+        .directory('$kArbitraryEngineRoot/src/out/ios_debug/')
+        ..createSync(recursive: true);
+    fileSystem.directory('$kArbitraryEngineRoot/src/out/host_debug/').createSync(recursive: true);
+
+    final BufferLogger logger = BufferLogger.test();
+    final LocalEngineLocator localEngineLocator = LocalEngineLocator(
+      fileSystem: fileSystem,
+      flutterRoot: 'flutter/flutter',
+      logger: logger,
+      userMessages: UserMessages(),
+      platform: FakePlatform(environment: <String, String>{}),
+    );
+
+    expect(
+      await localEngineLocator.findEnginePath(null, localEngine.path, null),
+      matchesEngineBuildPaths(
+        hostEngine: '/arbitrary/engine/src/out/host_debug',
+        targetEngine: '/arbitrary/engine/src/out/ios_debug',
+      ),
+    );
+    expect(logger.traceText, contains('Parsed engine source from local engine as /arbitrary/engine/src'));
+    expect(logger.traceText, contains('Local engine source at /arbitrary/engine/src'));
+  });
+
+  testWithoutContext('works if local engine is host engine', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Directory localEngine = fileSystem
+        .directory('$kArbitraryEngineRoot/src/out/host_debug/')
+      ..createSync(recursive: true);
+
+    final BufferLogger logger = BufferLogger.test();
+    final LocalEngineLocator localEngineLocator = LocalEngineLocator(
+      fileSystem: fileSystem,
+      flutterRoot: 'flutter/flutter',
+      logger: logger,
+      userMessages: UserMessages(),
+      platform: FakePlatform(environment: <String, String>{}),
+    );
+
+    expect(
+      await localEngineLocator.findEnginePath(null, localEngine.path, null),
+      matchesEngineBuildPaths(
+        hostEngine: '/arbitrary/engine/src/out/host_debug',
+        targetEngine: '/arbitrary/engine/src/out/host_debug',
+      ),
+    );
+    expect(logger.traceText, contains('Local engine source at /arbitrary/engine/src'));
+  });
+
+  testWithoutContext('fails if host_debug does not exist', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Directory localEngine = fileSystem
+        .directory('$kArbitraryEngineRoot/src/out/ios_debug/')
+      ..createSync(recursive: true);
+
+    final LocalEngineLocator localEngineLocator = LocalEngineLocator(
+      fileSystem: fileSystem,
+      flutterRoot: 'flutter/flutter',
+      logger: BufferLogger.test(),
+      userMessages: UserMessages(),
+      platform: FakePlatform(environment: <String, String>{}),
+    );
+
+    await expectToolExitLater(
+      localEngineLocator.findEnginePath(null, localEngine.path, null),
+      contains('No Flutter engine build found at /arbitrary/engine/src/out/host_debug'),
+    );
+  });
+
+  testWithoutContext('works if --local-engine is specified and --local-engine-src-path '
     'is determined by flutter root', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     fileSystem.file(kDotPackages).writeAsStringSync('\n');
@@ -127,6 +200,24 @@ void main() {
       ),
     );
     expect(logger.traceText, contains('Local engine source at flutter/engine/src'));
+  });
+
+  testWithoutContext('fails if --local-engine is specified and --local-engine-src-path '
+      'cannot be determined', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+
+    final LocalEngineLocator localEngineLocator = LocalEngineLocator(
+      fileSystem: fileSystem,
+      flutterRoot: 'flutter/flutter',
+      logger: BufferLogger.test(),
+      userMessages: UserMessages(),
+      platform: FakePlatform(environment: <String, String>{}),
+    );
+
+    await expectToolExitLater(
+      localEngineLocator.findEnginePath(null, '/path/to/nothing', null),
+      contains('Unable to detect local Flutter engine src directory'),
+    );
   });
 }
 


### PR DESCRIPTION
This PR parses the `src` directory from `--local-engine` if it is an absolute path when `--local-engine-src-path` is not specified.  This will support LUCI recipes with local engine builds that are not a sibling to the flutter root (like `--local-engine=/b/s/w/ir/cache/builder/src/out/host_debug_unopt`).  

The tool will then continue with the previous resolution steps: parse the `src` directory from `.packages` `sky_engine` path, then checks if the `engine` is a sibling directory to the `flutter` checkout.

It also exits the tool with a failure if `--local-engine` is set but the `src` directory cannot be found, instead of silently failing and using the `bin/cache` engine.

Fixes https://github.com/flutter/flutter/issues/78072