### PR TITLE
Migrate our custom ignore syntax to flutter_ignore

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -126,7 +126,7 @@ Future<void> run(List<String> arguments) async {
 // TESTS
 
 final RegExp _findDeprecationPattern = RegExp(r'@[Dd]eprecated');
-final RegExp _deprecationPattern1 = RegExp(r'^( *)@Deprecated\($'); // ignore: flutter_deprecation_syntax (see analyze.dart)
+final RegExp _deprecationPattern1 = RegExp(r'^( *)@Deprecated\($'); // flutter_ignore: deprecation_syntax (see analyze.dart)
 final RegExp _deprecationPattern2 = RegExp(r"^ *'(.+) '$");
 final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9]+\.[0-9]+\.pre)?\.'$");
 final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
@@ -136,10 +136,10 @@ final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
 /// (One example would be a library that intentionally conflicts with a member in another
 /// library to indicate that it is incompatible with that other library. Another would be
 /// the regexp just above...)
-const String _ignoreDeprecation = ' // ignore: flutter_deprecation_syntax (see analyze.dart)';
+const String _ignoreDeprecation = ' // flutter_ignore: deprecation_syntax (see analyze.dart)';
 
 /// Some deprecation notices are exempt for historical reasons. They must have an issue listed.
-final RegExp _legacyDeprecation = RegExp(r' // ignore: flutter_deprecation_syntax, https://github.com/flutter/flutter/issues/[0-9]+$');
+final RegExp _legacyDeprecation = RegExp(r' // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/[0-9]+$');
 
 Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 2000 }) async {
   final List<String> errors = <String>[];

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -26,7 +26,7 @@ final RegExp ignoreForFilePattern = RegExp(r'// *ignore_for_file:');
 final RegExp asDynamicPattern = RegExp(r'\bas dynamic\b');
 final RegExp deprecationPattern = RegExp(r'^ *@[dD]eprecated');
 const Pattern globalsPattern = 'globals.';
-const String legacyDeprecationPattern = '// ignore: flutter_deprecation_syntax, https';
+const String legacyDeprecationPattern = '// flutter_ignore: deprecation_syntax, https';
 
 Future<double> findCostsForFile(File file) async {
   if (path.extension(file.path) == '.py')

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -803,7 +803,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   bool get allowImplicitScrolling => physics.allowImplicitScrolling;
 
   /// Deprecated. Use [jumpTo] or a custom [ScrollPosition] instead.
-  @Deprecated('This will lead to bugs.') // ignore: flutter_deprecation_syntax, https://github.com/flutter/flutter/issues/44609
+  @Deprecated('This will lead to bugs.') // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/44609
   void jumpToWithoutSettling(double value);
 
   /// Stop the current activity and start a [HoldScrollActivity].

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -224,7 +224,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   }
 
 
-  @Deprecated('This will lead to bugs.') // ignore: flutter_deprecation_syntax, https://github.com/flutter/flutter/issues/44609
+  @Deprecated('This will lead to bugs.') // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/44609
   @override
   void jumpToWithoutSettling(double value) {
     goIdle();

--- a/packages/flutter/test/scheduler/scheduler_tester.dart
+++ b/packages/flutter/test/scheduler/scheduler_tester.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/scheduler.dart';
 
-@Deprecated('scheduler_tester is not compatible with dart:async') // ignore: flutter_deprecation_syntax (see analyze.dart)
+@Deprecated('scheduler_tester is not compatible with dart:async') // flutter_ignore: deprecation_syntax (see analyze.dart)
 class Future { } // so that people can't import us and dart:async
 
 void tick(Duration duration) {

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -5,8 +5,8 @@
 // @dart = 2.8
 
 // Do not add package imports to this file.
-import 'dart:convert'; // ignore: dart_convert_import.
-import 'dart:io'; // ignore: dart_io_import.
+import 'dart:convert'; // flutter_ignore: dart_convert_import.
+import 'dart:io'; // flutter_ignore: dart_io_import.
 
 /// Executes the required flutter tasks for a desktop build.
 Future<void> main(List<String> arguments) async {

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -10,7 +10,7 @@ import 'dart:typed_data';
 
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p; // ignore: package_path_import
+import 'package:path/path.dart' as p; // flutter_ignore: package_path_import
 import 'package:process/process.dart';
 
 import '../reporting/reporting.dart';

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -6,7 +6,7 @@
 
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
-import 'package:path/path.dart' as path; // ignore: package_path_import
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:yaml/yaml.dart';
 
 import 'android/gradle.dart';
@@ -1115,7 +1115,7 @@ const String _dartPluginRegistryForDesktopTemplate = '''
 // @dart = {{dartLanguageVersion}}
 
 import '{{mainEntrypoint}}' as entrypoint;
-import 'dart:io'; // ignore: dart_io_import.
+import 'dart:io'; // flutter_ignore: dart_io_import.
 {{#linux}}
 import 'package:{{pluginName}}/{{pluginName}}.dart';
 {{/linux}}

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -130,8 +130,8 @@ String generateTestBootstrap({
   buffer.write('''
 $languageVersionHeader
 import 'dart:async';
-import 'dart:convert';  // ignore: dart_convert_import
-import 'dart:io';  // ignore: dart_io_import
+import 'dart:convert';  // flutter_ignore: dart_convert_import
+import 'dart:io';  // flutter_ignore: dart_io_import
 import 'dart:isolate';
 ''');
   if (flutterTestDep) {

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -5,7 +5,7 @@
 // @dart = 2.8
 
 import 'dart:async';
-import 'dart:io' as io; // ignore: dart_io_import;
+import 'dart:io' as io; // flutter_ignore: dart_io_import;
 
 import 'package:dds/dds.dart';
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
@@ -151,8 +151,8 @@ class TestGoldenComparatorProcess {
     final File testConfigFile = findTestConfigFile(globals.fs.file(testUri));
     // Generate comparator process for the file.
     return '''
-import 'dart:convert'; // ignore: dart_convert_import
-import 'dart:io'; // ignore: dart_io_import
+import 'dart:convert'; // flutter_ignore: dart_convert_import
+import 'dart:io'; // flutter_ignore: dart_io_import
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -4,7 +4,7 @@
 
 // @dart = 2.8
 
-import 'dart:io' as io; // ignore: dart_io_import;
+import 'dart:io' as io; // flutter_ignore: dart_io_import;
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/globals.dart' as globals show flutterUsage;
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
-import 'package:path/path.dart' as path; // ignore: package_path_import
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:process/process.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -1919,7 +1919,7 @@ void main() {
             '// @dart = 2.8\n'
             '\n'
             'import \'package:app/main.dart\' as entrypoint;\n'
-            'import \'dart:io\'; // ignore: dart_io_import.\n'
+            'import \'dart:io\'; // flutter_ignore: dart_io_import.\n'
             'import \'package:url_launcher_linux${fs.path.separator}url_launcher_linux.dart\';\n'
             'import \'package:awesome_macos/awesome_macos.dart\';\n'
             'import \'package:url_launcher_macos${fs.path.separator}url_launcher_macos.dart\';\n'

--- a/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
@@ -77,7 +77,7 @@ void main() {
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*dart:io')) &&
-              !line.contains('ignore: dart_io_import')) {
+              !line.contains('flutter_ignore: dart_io_import')) {
             final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'dart:io'; import 'lib/src/base/io.dart' instead");
           }
@@ -102,7 +102,7 @@ void main() {
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*package:http/')) &&
-              !line.contains('ignore: package_http_import')) {
+              !line.contains('flutter_ignore: package_http_import')) {
             final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'package:http'; import 'lib/src/base/io.dart' instead");
           }
@@ -128,7 +128,7 @@ void main() {
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*package:test_api')) &&
-              !line.contains('ignore: test_api_import')) {
+              !line.contains('flutter_ignore: test_api_import')) {
             final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'package:test_api/test_api.dart';");
           }
@@ -151,7 +151,7 @@ void main() {
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*package:path/path.dart')) &&
-              !line.contains('ignore: package_path_import')) {
+              !line.contains('flutter_ignore: package_path_import')) {
             final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'package:path/path.dart'; use 'fileSystem.path' instead");
           }
@@ -198,7 +198,7 @@ void main() {
       for (final File file in files) {
         for (final String line in file.readAsLinesSync()) {
           if (line.startsWith(RegExp(r'import.*dart:convert')) &&
-              !line.contains('ignore: dart_convert_import')) {
+              !line.contains('flutter_ignore: dart_convert_import')) {
             final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
             fail("$relativePath imports 'dart:convert'; import 'lib/src/convert.dart' instead");
           }

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -6,7 +6,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io; // ignore: dart_io_import
+import 'dart:io' as io; // flutter_ignore: dart_io_import
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/common.dart';

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -26,7 +26,7 @@ import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path; // ignore: package_path_import
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test_api/test_api.dart' as test_package show test; // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' hide test; // ignore: deprecated_member_use
 import 'package:vm_service/vm_service.dart' as vm_service;


### PR DESCRIPTION
This is in preparation for https://github.com/dart-lang/sdk/issues/35234, which will warn on `// ignore:`s that are not actually ignoring analyzer-produced warnings. Since these ignores are not analyzer-produced, they'd trigger the warning. Switching them to a new syntax avoids that.