### PR TITLE
Remove flaky flag for Mac and Windows shard builders

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -793,34 +793,28 @@
       "flaky": false
     },
     {
-      "name": "Mac build_tests",
-      "repo": "flutter",
-      "task_name": "mac_build_tests",
-      "flaky": false
-    },
-    {
       "name": "Mac build_tests_1_4",
       "repo": "flutter",
       "task_name": "mac_build_tests_1_4",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac build_tests_2_4",
       "repo": "flutter",
       "task_name": "mac_build_tests_2_4",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac build_tests_3_4",
       "repo": "flutter",
       "task_name": "mac_build_tests_3_4",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac build_tests_4_4",
       "repo": "flutter",
       "task_name": "mac_build_tests_4_4",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac customer_testing",
@@ -829,28 +823,22 @@
       "flaky": false
     },
     {
-      "name": "Mac framework_tests",
-      "repo": "flutter",
-      "task_name": "mac_framework_tests",
-      "flaky": false
-    },
-    {
       "name": "Mac framework_tests_libraries",
       "repo": "flutter",
       "task_name": "mac_framework_testslibraries",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac framework_tests_misc",
       "repo": "flutter",
       "task_name": "mac_framework_tests_misc",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac framework_tests_widgets",
       "repo": "flutter",
       "task_name": "mac_framework_tests_widgets",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac gradle_non_android_plugin_test",
@@ -919,46 +907,34 @@
       "flaky": false
     },
     {
-      "name": "Mac tool_tests",
-      "repo": "flutter",
-      "task_name": "mac_tool_tests",
-      "flaky": false
-    },
-    {
       "name": "Mac tool_tests_general",
       "repo": "flutter",
       "task_name": "mac_tool_tests_general",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac tool_tests_commands",
       "repo": "flutter",
       "task_name": "mac_tool_tests_commands",
-      "flaky": true
-    },
-    {
-      "name": "Mac tool_integration_tests",
-      "repo": "flutter",
-      "task_name": "mac_tool_integration_tests",
       "flaky": false
     },
     {
       "name": "Mac tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_1_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_2_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_3_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios backdrop_filter_perf_ios__timeline_summary",
@@ -1195,28 +1171,22 @@
       "flaky": false
     },
     {
-      "name": "Windows build_tests",
-      "repo": "flutter",
-      "task_name": "win_build_tests",
-      "flaky": false
-    },
-    {
       "name": "Windows build_tests_1_3",
       "repo": "flutter",
       "task_name": "win_build_tests_1_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows build_tests_2_3",
       "repo": "flutter",
       "task_name": "win_build_tests_2_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows build_tests_3_3",
       "repo": "flutter",
       "task_name": "win_build_tests_3_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows customer_testing",
@@ -1225,28 +1195,22 @@
       "flaky": false
     },
     {
-      "name": "Windows framework_tests",
-      "repo": "flutter",
-      "task_name": "win_framework_tests",
-      "flaky": false
-    },
-    {
       "name": "Windows framework_tests_libraries",
       "repo": "flutter",
       "task_name": "win_framework_tests_libraries",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows framework_tests_misc",
       "repo": "flutter",
       "task_name": "win_framework_tests_misc",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows framework_tests_widgets",
       "repo": "flutter",
       "task_name": "win_framework_tests_widgets",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows gradle_plugin_light_apk_test",
@@ -1297,46 +1261,34 @@
       "flaky": false
     },
     {
-      "name": "Windows tool_tests",
-      "repo": "flutter",
-      "task_name": "win_tool_tests",
-      "flaky": false
-    },
-    {
       "name": "Windows tool_tests_general",
       "repo": "flutter",
       "task_name": "win_tool_tests_general",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows tool_tests_commands",
       "repo": "flutter",
       "task_name": "win_tool_tests_commands",
-      "flaky": true
-    },
-    {
-      "name": "Windows tool_integration_tests",
-      "repo": "flutter",
-      "task_name": "win_tool_integration_tests",
       "flaky": false
     },
     {
       "name": "Windows tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_1_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_2_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_3_3",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows web_tool_tests",


### PR DESCRIPTION
The newly added Mac and Windows shard builders are stable.

This is a follow up of https://github.com/flutter/flutter/pull/78459, removing flaky flag of Mac and Windows shard builders. The consolidated builders are removed as well.

Related issue: https://github.com/flutter/flutter/issues/77947