### PR TITLE
Move web tool test per-test timeout to shard

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -309,6 +309,7 @@ Future<void> _runWebToolTests() async {
           forceSingleCore: true,
           testPaths: <String>[path.join(kTest, '$kWeb$kDotShard', '')],
           enableFlutterToolAsserts: true,
+          perTestTimeout: const Duration(minutes: 3),
         );
       }
   };

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1342,7 +1342,7 @@
       "name": "Windows web_tool_tests",
       "repo": "flutter",
       "task_name": "win_web_tool_tests",
-      "flaky": true
+      "flaky": false
     }
   ]
 }

--- a/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-@Timeout(Duration(minutes: 3))
 import 'package:file/file.dart';
 
 import '../integration.shard/test_data/stepping_project.dart';

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-@Timeout(Duration(minutes: 3))
 import 'package:file/file.dart';
 import 'package:matcher/matcher.dart';
 import 'package:vm_service/vm_service.dart';

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-@Timeout(Duration(minutes: 3))
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/web.shard/web_run_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_run_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-@Timeout(Duration(minutes: 3))
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 


### PR DESCRIPTION
Move per-test timeout for tools web shard into the test runner so new files will also pick up the timeout.

Mark `Windows web_tool_tests` as unflaky in prod.  Passing:
 https://ci.chromium.org/p/flutter/builders/prod/Windows%20web_tool_tests/1287

Follow up to https://github.com/flutter/flutter/pull/78386