### PR TITLE
Manually close the tree for https://github.com/flutter/flutter/issues/78567

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 
 Future<void> main() async {
   await task(createHotModeTest(deviceIdOverride: 'macos'));
+
+  // TODO(zra): https://github.com/flutter/flutter/issues/78567
+  throw TaskResult.failure(
+      'Tree was manually closed for Android version of this test https://github.com/flutter/flutter/issues/78567');
 }


### PR DESCRIPTION
The internal roll is severely backed up.