### PR TITLE
Mac word modifier TextEditingActions

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -828,8 +828,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     final int leftOffset = _getLeftByWord(textPainter, selection.extentOffset, includeWhitespace);
 
-    if (stopAtReversal
-        && selection.extentOffset > selection.baseOffset
+    if (stopAtReversal && selection.extentOffset > selection.baseOffset
         && leftOffset < selection.baseOffset) {
       return selection.copyWith(
         extentOffset: selection.baseOffset,
@@ -843,7 +842,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   // Return the given TextSelection extended right to the end of the nearest
   // word.
-  static TextSelection _extendGivenSelectionRightByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true]) {
+  //
+  // See extendSelectionRightByWord for a detailed explanation of the two
+  // optional parameters.
+  static TextSelection _extendGivenSelectionRightByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true, bool stopAtReversal = false]) {
     // If the selection is already all the way right, there is nothing to do.
     final String text = textPainter.text!.toPlainText();
     if (selection.isCollapsed && selection.extentOffset == text.length) {
@@ -851,6 +853,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final int rightOffset = _getRightByWord(textPainter, selection.extentOffset, includeWhitespace);
+
+    if (stopAtReversal && selection.baseOffset > selection.extentOffset
+        && rightOffset > selection.baseOffset) {
+      return selection.copyWith(
+        extentOffset: selection.baseOffset,
+      );
+    }
+
     return selection.copyWith(
       extentOffset: rightOffset,
     );
@@ -1352,9 +1362,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, `includeWhitespace` is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// extended past any whitespace and the first word following the whitespace.
+  /// By default, `includeWhitespace` is set to true, meaning that whitespace
+  /// can be considered a word in itself.  If set to false, the selection will
+  /// be extended past any whitespace and the first word following the
+  /// whitespace.
   ///
   /// {@template flutter.rendering.RenderEditable.stopAtReversal}
   /// The `stopAtReversal` parameter is false by default, meaning that it's
@@ -1394,15 +1405,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// extended past any whitespace and the first word following the whitespace.
+  /// By default, `includeWhitespace` is set to true, meaning that whitespace
+  /// can be considered a word in itself.  If set to false, the selection will
+  /// be extended past any whitespace and the first word following the
+  /// whitespace.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
   ///
   /// See also:
   ///
   ///   * [extendSelectionLeftByWord], which is the same but in the opposite
   ///     direction.
-  void extendSelectionRightByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
+  void extendSelectionRightByWord(SelectionChangedCause cause, [bool includeWhitespace = true, bool stopAtReversal = false]) {
     assert(selection != null);
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1417,6 +1431,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       _textPainter,
       selection!,
       includeWhitespace,
+      stopAtReversal,
     );
     if (nextSelection == selection) {
       return;

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -43,6 +43,7 @@ class DefaultTextEditingActions extends Actions{
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
     ExtendSelectionLeftByWordAndStopAtReversalTextIntent: _ExtendSelectionLeftByWordAndStopAtReversalTextAction(),
     ExtendSelectionLeftTextIntent: _ExtendSelectionLeftTextAction(),
+    ExtendSelectionRightByWordAndStopAtReversalTextIntent: _ExtendSelectionRightByWordAndStopAtReversalTextAction(),
     ExtendSelectionRightByWordTextIntent: _ExtendSelectionRightByWordTextAction(),
     ExtendSelectionRightByLineTextIntent: _ExtendSelectionRightByLineTextAction(),
     ExtendSelectionRightTextIntent: _ExtendSelectionRightTextAction(),
@@ -144,6 +145,13 @@ class _ExtendSelectionRightByLineTextAction extends TextEditingAction<ExtendSele
   @override
   Object? invoke(ExtendSelectionRightByLineTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.extendSelectionRightByLine(SelectionChangedCause.keyboard);
+  }
+}
+
+class _ExtendSelectionRightByWordAndStopAtReversalTextAction extends TextEditingAction<ExtendSelectionRightByWordAndStopAtReversalTextIntent> {
+  @override
+  Object? invoke(ExtendSelectionRightByWordAndStopAtReversalTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.extendSelectionRightByWord(SelectionChangedCause.keyboard, false, true);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -41,6 +41,7 @@ class DefaultTextEditingActions extends Actions{
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
+    ExtendSelectionLeftByWordAndStopAtReversalTextIntent: _ExtendSelectionLeftByWordAndStopAtReversalTextAction(),
     ExtendSelectionLeftTextIntent: _ExtendSelectionLeftTextAction(),
     ExtendSelectionRightByWordTextIntent: _ExtendSelectionRightByWordTextAction(),
     ExtendSelectionRightByLineTextIntent: _ExtendSelectionRightByLineTextAction(),
@@ -115,6 +116,13 @@ class _ExtendSelectionLeftByLineTextAction extends TextEditingAction<ExtendSelec
   @override
   Object? invoke(ExtendSelectionLeftByLineTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.extendSelectionLeftByLine(SelectionChangedCause.keyboard);
+  }
+}
+
+class _ExtendSelectionLeftByWordAndStopAtReversalTextAction extends TextEditingAction<ExtendSelectionLeftByWordAndStopAtReversalTextIntent> {
+  @override
+  Object? invoke(ExtendSelectionLeftByWordAndStopAtReversalTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.extendSelectionLeftByWord(SelectionChangedCause.keyboard, false, true);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -314,7 +314,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByWordTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowUp): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowDown): const ExtendSelectionRightByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowLeft): const ExtendSelectionLeftByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowLeft): const ExtendSelectionLeftByWordAndStopAtReversalTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowRight): const ExtendSelectionRightByWordTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowUp): const ExtendSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.arrowDown): const MoveSelectionDownTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -315,7 +315,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowUp): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowDown): const ExtendSelectionRightByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowLeft): const ExtendSelectionLeftByWordAndStopAtReversalTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowRight): const ExtendSelectionRightByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowRight): const ExtendSelectionRightByWordAndStopAtReversalTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.shift, LogicalKeyboardKey.arrowUp): const ExtendSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.arrowDown): const MoveSelectionDownTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftTextIntent(),

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -105,6 +105,16 @@ class ExtendSelectionRightByLineTextIntent extends Intent{
   const ExtendSelectionRightByLineTextIntent();
 }
 
+/// An [Intent] to extend the selection right past the nearest word, collapsing
+/// the selection if the order of [TextSelection.extentOffset] and
+/// [TextSelection.baseOffset] would reverse.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionRightByWordAndStopAtReversalTextIntent extends Intent{
+  /// Creates an instance of ExtendSelectionRightByWordAndStopAtReversalTextIntent.
+  const ExtendSelectionRightByWordAndStopAtReversalTextIntent();
+}
+
 /// An [Intent] to extend the selection right past the nearest word.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -69,6 +69,16 @@ class ExtendSelectionLeftByLineTextIntent extends Intent{
   const ExtendSelectionLeftByLineTextIntent();
 }
 
+/// An [Intent] to extend the selection left past the nearest word, collapsing
+/// the selection if the order of [TextSelection.extentOffset] and
+/// [TextSelection.baseOffset] would reverse.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionLeftByWordAndStopAtReversalTextIntent extends Intent{
+  /// Creates an instance of ExtendSelectionLeftByWordAndStopAtReversalTextIntent.
+  const ExtendSelectionLeftByWordAndStopAtReversalTextIntent();
+}
+
 /// An [Intent] to extend the selection left past the nearest word.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7224,6 +7224,147 @@ void main() {
     // On web, using keyboard for selection is handled by the browser.
   }, skip: kIsWeb);
 
+  testWidgets('navigating by word', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(text: 'word word word');
+    // word wo|rd| word
+    controller.selection = const TextSelection(
+      baseOffset: 7,
+      extentOffset: 9,
+      affinity: TextAffinity.upstream,
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 400,
+          child: EditableText(
+            maxLines: 10,
+            controller: controller,
+            autofocus: true,
+            focusNode: focusNode,
+            style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!,
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            keyboardType: TextInputType.text,
+          ),
+        ),
+      ),
+    ));
+
+    await tester.pump(); // Wait for autofocus to take effect.
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 9);
+
+    final String targetPlatform = defaultTargetPlatform.toString();
+    final String platform = targetPlatform.substring(targetPlatform.indexOf('.') + 1).toLowerCase();
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowRight],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    await tester.pump();
+    // word wo|rd word|
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 14);
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowLeft],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    // word wo|rd |word
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 10);
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowLeft],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    if (platform == 'macos') {
+      // word wo|rd word
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 7);
+      expect(controller.selection.extentOffset, 7);
+
+      await sendKeys(
+        tester,
+        <LogicalKeyboardKey>[LogicalKeyboardKey.arrowLeft],
+        shift: true,
+        wordModifier: true,
+        platform: platform,
+      );
+    }
+
+    // word |wo|rd word
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 5);
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowLeft],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    // |word wo|rd word
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 0);
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowRight],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    // word| wo|rd word
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 4);
+
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.arrowRight],
+      shift: true,
+      wordModifier: true,
+      platform: platform,
+    );
+    if (platform == 'macos') {
+      // word wo|rd word
+      expect(controller.selection.isCollapsed, true);
+      expect(controller.selection.baseOffset, 7);
+      expect(controller.selection.extentOffset, 7);
+
+      await sendKeys(
+        tester,
+        <LogicalKeyboardKey>[LogicalKeyboardKey.arrowRight],
+        shift: true,
+        wordModifier: true,
+        platform: platform,
+      );
+    }
+
+    // word wo|rd| word
+    expect(controller.selection.isCollapsed, false);
+    expect(controller.selection.baseOffset, 7);
+    expect(controller.selection.extentOffset, 9);
+
+    // On web, using keyboard for selection is handled by the browser.
+  }, skip: kIsWeb, variant: TargetPlatformVariant.all());
+
   testWidgets('can change behavior by overriding text editing actions', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(text: testText);
     controller.selection = const TextSelection(


### PR DESCRIPTION
Before this PR, Mac had some incorrect behavior when navigating through text with word modifier keys, as noted in this table: https://github.com/flutter/flutter/issues/57679#issuecomment-742848741

For "word wo|rd| word" selected left to right...

On Mac, pressing word modifier + shift + left should now correctly result in "word wo|rd word".  Other platforms result in "word |word| word".

And vice versa for the right arrow and a right to left selection.

Closes https://github.com/flutter/flutter/issues/57679
A similar problem in Windows not fixed by this: https://github.com/flutter/flutter/issues/78572