### PR TITLE
Removed GridTileBar accentColor dependency.

### DIFF
--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -67,9 +67,7 @@ class GridTileBar extends StatelessWidget {
       end: trailing != null ? 8.0 : 16.0,
     );
 
-    final ThemeData darkTheme = ThemeData(
-      brightness: Brightness.dark,
-    );
+    final ThemeData darkTheme = ThemeData.dark();
     return Container(
       padding: padding,
       decoration: decoration,

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -67,11 +67,8 @@ class GridTileBar extends StatelessWidget {
       end: trailing != null ? 8.0 : 16.0,
     );
 
-    final ThemeData theme = Theme.of(context);
     final ThemeData darkTheme = ThemeData(
       brightness: Brightness.dark,
-      accentColor: theme.accentColor,
-      accentColorBrightness: theme.accentColorBrightness,
     );
     return Container(
       padding: padding,


### PR DESCRIPTION
This PR removes the `GridTileBar` widget's `accentColor` dependency per https://github.com/flutter/flutter/issues/56918.

The previous implementation wrapped the contents in a dark theme that copied the `accentColor` and `accentColorBrightness` from the surrounding theme. As we are no longer using these properties, this PR removes them from the `GridTileBar`.

This PR was tested against internal Google apps in cl/363286503.
