### PR TITLE
Skip linking against Flutter for CocoaPods transitive dependencies

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -33,6 +33,9 @@ end
 def flutter_additional_ios_build_settings(target)
   return unless target.platform_name == :ios
 
+  # Return if it's not a Flutter plugin (transitive dependency).
+  return unless target.dependencies.any? { |dependency| dependency.name == 'Flutter' }
+
   # [target.deployment_target] is a [String] formatted as "8.0".
   inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
 
@@ -77,6 +80,9 @@ end
 # Same as flutter_ios_podfile_setup for macOS.
 def flutter_additional_macos_build_settings(target)
   return unless target.platform_name == :osx
+
+  # Return if it's not a Flutter plugin (transitive dependency).
+  return unless target.dependencies.any? { |dependency| dependency.name == 'FlutterMacOS' }
 
   # [target.deployment_target] is a [String] formatted as "10.8".
   deployment_target_major, deployment_target_minor = target.deployment_target.match(/(\d+).?(\d*)/).captures


### PR DESCRIPTION
### Background
Flutter plugins need to link against `Flutter.framework` or `FlutterMacOS.framework`.  That work is done in the app's Podfile like:
```ruby
post_install do |installer|
  installer.pods_project.targets.each do |target|
    flutter_additional_ios_build_settings(target)
  end
end
```
`flutter_additional_ios_build_settings` and `flutter_additional_macos_build_settings` sets up the search paths to point to the `bin/cache` version of `Flutter.framework` or `FlutterMacOS.framework`, and for iOS additionally links against `Flutter`.
https://github.com/flutter/flutter/blob/efbde443d2a6f810d0ceb6097fc79ed0b30bddce/packages/flutter_tools/bin/podhelper.rb#L63

ALL pods, even non-Flutter plugins transitive dependencies, were therefore linking against Flutter.  
For example, Flutter plugin `firebase_admob` needs to link against Flutter.  That plugin has [a transitive dependency on `Google-Mobile-Ads-SDK`](https://github.com/FirebaseExtended/flutterfire/blob/991dd4e01e61bb02bb27de9ef64d20e7ffdb414a/packages/firebase_admob/ios/firebase_admob.podspec#L22) which being incorrectly also linked to `Flutter.framework`.

### The problem
https://github.com/flutter/flutter/pull/72151 causes an issue where, if a transitive dependency contained bitcode, it fails when linking against the debug version of Flutter (which isn't necessary since the transitive dependencies don't need to know anything about Flutter) because debug Flutter only contains a bitcode marker, not full bitcode.
```
ld: bitcode bundle could not be generated because 'bin/cache/artifacts/engine/ios/Flutter.xcframework/ios-armv7_arm64/Flutter.framework/Flutter'
was built without full bitcode.
```

### The fix
Change the `podhelper` logic to only set up all the Flutter build settings ONLY for Flutter plugins and not their transitive dependencies.


Add a a plugin with a transitive dependency to `build_ios_framework_module_test` and test that the dependency doesn't link against Flutter.
https://ci.chromium.org/p/flutter/builders/try/Mac%20build_ios_framework_module_test/4725
On master this test fails:
```
Task result:
{
  "success": false,
  "reason": "Transitive dependency /var/folders/bx/pyplw7v92lj58gm3_lztz5sc00mfq2/T/flutter_module_test.o1howC/hello_module/flutter-frameworks/Debug/Reachability.xcframework/ios-arm64_armv7/Reachability.framework/Reachability unexpectedly links on Flutter"
}
```

Fixes https://github.com/flutter/flutter/issues/78589