### PR TITLE
[flutter_tools] add skeleton for build uwp

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -20,6 +20,7 @@ import 'build_fuchsia.dart';
 import 'build_ios.dart';
 import 'build_ios_framework.dart';
 import 'build_web.dart';
+import 'build_winuwp.dart';
 
 class BuildCommand extends FlutterCommand {
   BuildCommand({ bool verboseHelp = false }) {
@@ -40,6 +41,7 @@ class BuildCommand extends FlutterCommand {
       verboseHelp: verboseHelp
     ));
     addSubcommand(BuildWindowsCommand(verboseHelp: verboseHelp));
+    addSubcommand(BuildWindowsUwpCommand(verboseHelp: verboseHelp));
     addSubcommand(BuildFuchsiaCommand(verboseHelp: verboseHelp));
   }
 

--- a/packages/flutter_tools/lib/src/commands/build_winuwp.dart
+++ b/packages/flutter_tools/lib/src/commands/build_winuwp.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:meta/meta.dart';
+
+import '../base/analyze_size.dart';
+import '../base/common.dart';
+import '../build_info.dart';
+import '../cache.dart';
+import '../features.dart';
+import '../globals.dart' as globals;
+import '../project.dart';
+import '../runner/flutter_command.dart' show FlutterCommandResult;
+import '../windows/build_windows.dart';
+import '../windows/visual_studio.dart';
+import 'build.dart';
+
+/// A command to build a Windows UWP desktop target.
+class BuildWindowsUwpCommand extends BuildSubCommand {
+  BuildWindowsUwpCommand({ bool verboseHelp = false }) {
+    addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
+  }
+
+  @override
+  final String name = 'winuwp';
+
+  @override
+  bool get hidden => !featureFlags.isWindowsUwpEnabled || !globals.platform.isWindows;
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
+    // TODO(flutter): add a windows_uwp artifact here once that is updated.
+  };
+
+  @override
+  String get description => 'Build a Windows UWP desktop application.';
+
+  @visibleForTesting
+  VisualStudio visualStudioOverride;
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final FlutterProject flutterProject = FlutterProject.current();
+    final BuildInfo buildInfo = await getBuildInfo();
+    if (!featureFlags.isWindowsUwpEnabled) {
+      throwToolExit('"build windows" is not currently supported.');
+    }
+    if (!globals.platform.isWindows) {
+      throwToolExit('"build windows" only supported on Windows hosts.');
+    }
+    displayNullSafetyMode(buildInfo);
+    await buildWindowsUwp(
+      flutterProject.windowsUwp,
+      buildInfo,
+      target: targetFile,
+      visualStudioOverride: visualStudioOverride,
+    );
+    return FlutterCommandResult.success();
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/build_winuwp.dart
+++ b/packages/flutter_tools/lib/src/commands/build_winuwp.dart
@@ -32,6 +32,7 @@ class BuildWindowsUwpCommand extends BuildSubCommand {
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
     // TODO(flutter): add a windows_uwp artifact here once that is updated.
+    // https://github.com/flutter/flutter/issues/78627
   };
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_winuwp.dart
+++ b/packages/flutter_tools/lib/src/commands/build_winuwp.dart
@@ -6,7 +6,6 @@
 
 import 'package:meta/meta.dart';
 
-import '../base/analyze_size.dart';
 import '../base/common.dart';
 import '../build_info.dart';
 import '../cache.dart';

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -1211,7 +1211,7 @@ class WindowsUwpProject extends WindowsProject {
   WindowsUwpProject._(FlutterProject parent) : super._(parent);
 
   @override
-  String get _childDirectory => 'windows-uwp';
+  String get _childDirectory => 'winuwp';
 
   /// Eventually this will be used to check if the user's unstable project needs to be regenerated.
   int get projectVersion => int.tryParse(_editableDirectory.childFile('project_version').readAsStringSync());

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -124,7 +124,8 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
     throwToolExit(
       'No Windows UWP desktop project configured. See '
       'https://flutter.dev/desktop#add-desktop-support-to-an-existing-flutter-app '
-      'to learn about adding Windows support to a project.');
+      'to learn about adding Windows support to a project.',
+    );
   }
   if (windowsProject.projectVersion != kCurrentUwpTemplateVersion) {
     throwToolExit(

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -26,6 +26,9 @@ import 'visual_studio.dart';
 // future major versions of Visual Studio.
 const String _cmakeVisualStudioGeneratorIdentifier = 'Visual Studio 16 2019';
 
+/// Update the string when non-backwards compatible changes are made to the UWP template.
+const int kCurrentUwpTemplateVersion = 0;
+
 /// Builds the Windows project using msbuild.
 Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
   String target,
@@ -108,6 +111,29 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
       '--appSizeBase=$relativeAppSizePath'
     );
   }
+}
+
+/// Build the Windows UWP project.
+///
+/// Note that this feature is currently unfinished.
+Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildInfo, {
+  String target,
+  VisualStudio visualStudioOverride,
+}) async {
+  if (!windowsProject.existsSync()) {
+    throwToolExit(
+      'No Windows UWP desktop project configured. See '
+      'https://flutter.dev/desktop#add-desktop-support-to-an-existing-flutter-app '
+      'to learn about adding Windows support to a project.');
+  }
+  if (windowsProject.projectVersion != kCurrentUwpTemplateVersion) {
+    throwToolExit(
+      'The Windows UWP project template and build process has changed. In order to build '
+      'you must delete the winuwp directory and re-create the project.'
+    );
+  }
+  // TODO: actually build stuff.
+  throwToolExit('Windows UWP builds are not implemented.');
 }
 
 Future<void> _runCmakeGeneration(String cmakePath, Directory buildDir, Directory sourceDir) async {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -130,7 +130,7 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
   if (windowsProject.projectVersion != kCurrentUwpTemplateVersion) {
     throwToolExit(
       'The Windows UWP project template and build process has changed. In order to build '
-      'you must delete the winuwp directory and re-create the project.'
+      'you must delete the winuwp directory and re-create the project.',
     );
   }
   throwToolExit('Windows UWP builds are not implemented.');

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -132,7 +132,6 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
       'you must delete the winuwp directory and re-create the project.'
     );
   }
-  // TODO: actually build stuff.
   throwToolExit('Windows UWP builds are not implemented.');
 }
 


### PR DESCRIPTION
Adds the rest of the scaffolding for building a UWP application. The actual build functionality needs to be implemented, but could use buildWindows as an example (if it is going through cmake)


https://github.com/flutter/flutter/issues/14967