### PR TITLE
Treat some exceptions as unhandled when a debugger is attached

### DIFF
--- a/packages/flutter/lib/src/animation/listener_helpers.dart
+++ b/packages/flutter/lib/src/animation/listener_helpers.dart
@@ -135,6 +135,7 @@ mixin AnimationLocalListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {
     final List<VoidCallback> localListeners = List<VoidCallback>.from(_listeners);
     for (final VoidCallback listener in localListeners) {
@@ -223,6 +224,7 @@ mixin AnimationLocalStatusListenersMixin {
   /// If listeners are added or removed during this function, the modifications
   /// will not change which listeners are called during this iteration.
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   void notifyStatusListeners(AnimationStatus status) {
     final List<AnimationStatusListener> localListeners = List<AnimationStatusListener>.from(_statusListeners);
     for (final AnimationStatusListener listener in localListeners) {

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -1105,7 +1105,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   /// containing the `catch` block with
   /// `@pragma('vm:notify-debugger-on-exception')` to allow an attached debugger
   /// to treat the exception as unhandled. This means instead of executing the
-  /// `catch` black, the debugger can break at the original source location from
+  /// `catch` block, the debugger can break at the original source location from
   /// which the exception was thrown.
   ///
   /// ```dart

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -15,6 +15,7 @@ import 'stack_frame.dart';
 // late bool draconisAlive;
 // late bool draconisAmulet;
 // late Diagnosticable draconis;
+// void methodThatMayThrow() { }
 
 /// Signature for [FlutterError.onError] handler.
 typedef FlutterExceptionHandler = void Function(FlutterErrorDetails details);

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -1099,6 +1099,29 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   }
 
   /// Calls [onError] with the given details, unless it is null.
+  ///
+  /// {@tool snippet}
+  /// When calling this from a `catch` block consider annotating the
+  /// surrounding methods with `@pragma('vm:notify-debugger-on-exception')`.
+  /// This allows an attached debugger to break at the source location from
+  /// which the caught error originated.
+  ///
+  /// ```dart
+  /// @pragma('vm:notify-debugger-on-exception')
+  /// void doSomething() {
+  ///   try {
+  ///     methodThatMayThrow();
+  ///   } catch (exception, stack) {
+  ///     FlutterError.reportError(FlutterErrorDetails(
+  ///       exception: exception,
+  ///       stack: stack,
+  ///       library: 'example library',
+  ///       context: ErrorDescription('while doing something'),
+  ///     ));
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
   static void reportError(FlutterErrorDetails details) {
     assert(details != null);
     assert(details.exception != null);

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -876,9 +876,7 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   ///
   /// Do not call [onError] directly, instead, call [reportError], which
   /// forwards to [onError] if it is not null.
-  static FlutterExceptionHandler? onError = _defaultErrorHandler;
-
-  static void _defaultErrorHandler(FlutterErrorDetails details) => presentError(details);
+  static FlutterExceptionHandler? onError = presentError;
 
   /// Called by the Flutter framework before attempting to parse a [StackTrace].
   ///

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -1101,10 +1101,12 @@ class FlutterError extends Error with DiagnosticableTreeMixin implements Asserti
   /// Calls [onError] with the given details, unless it is null.
   ///
   /// {@tool snippet}
-  /// When calling this from a `catch` block consider annotating the
-  /// surrounding methods with `@pragma('vm:notify-debugger-on-exception')`.
-  /// This allows an attached debugger to break at the source location from
-  /// which the caught error originated.
+  /// When calling this from a `catch` block consider annotating the method
+  /// containing the `catch` block with
+  /// `@pragma('vm:notify-debugger-on-exception')` to allow an attached debugger
+  /// to treat the exception as unhandled. This means instead of executing the
+  /// `catch` black, the debugger can break at the original source location from
+  /// which the exception was thrown.
   ///
   /// ```dart
   /// @pragma('vm:notify-debugger-on-exception')

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -283,6 +283,7 @@ class ChangeNotifier implements Listenable {
   /// See the discussion at [removeListener].
   @protected
   @visibleForTesting
+  @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {
     assert(_debugAssertNotDisposed());
     if (_count == 0)

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -390,6 +390,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   /// The `hitTestResult` argument may only be null for [PointerAddedEvent]s or
   /// [PointerRemovedEvent]s.
   @override // from HitTestDispatcher
+  @pragma('vm:notify-debugger-on-exception')
   void dispatchEvent(PointerEvent event, HitTestResult? hitTestResult) {
     assert(!locked);
     // No hit test information implies that this is a [PointerHoverEvent],

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -87,6 +87,7 @@ class PointerRouter {
     throw UnsupportedError('debugGlobalRouteCount is not supported in release builds');
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _dispatch(PointerEvent event, PointerRoute route, Matrix4? transform) {
     try {
       event = event.transformed(transform);

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'package:flutter/foundation.dart';
 
 import 'events.dart';
@@ -189,6 +188,7 @@ class PointerSignalResolver {
   ///
   /// This is called by the [GestureBinding] after the framework has finished
   /// dispatching the pointer signal event.
+  @pragma('vm:notify-debugger-on-exception')
   void resolve(PointerSignalEvent event) {
     if (_firstRegisteredCallback == null) {
       assert(_currentEvent == null);

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -165,6 +165,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// callback that returns a string describing useful debugging information,
   /// e.g. the arguments passed to the callback.
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   T? invokeCallback<T>(String name, RecognizerCallback<T> callback, { String Function()? debugReport }) {
     assert(callback != null);
     T? result;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -614,6 +614,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
 
   /// Calls all the registered listeners to notify them of a new image.
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   void setImage(ImageInfo image) {
     _checkDisposed();
     _currentImage?.dispose();
@@ -668,6 +669,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
   ///
   /// See [FlutterErrorDetails] for further details on these values.
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   void reportError({
     DiagnosticsNode? context,
     required Object exception,

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1617,6 +1617,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     owner!._nodesNeedingLayout.add(this);
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _layoutWithoutResize() {
     assert(_relayoutBoundary == this);
     RenderObject? debugPreviousActiveLayout;
@@ -1671,6 +1672,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// children unconditionally. It is the [layout] method's responsibility (as
   /// implemented here) to return early if the child does not need to do any
   /// work to update its layout information.
+  @pragma('vm:notify-debugger-on-exception')
   void layout(Constraints constraints, { bool parentUsesSize = false }) {
     if (!kReleaseMode && debugProfileLayoutsEnabled)
       Timeline.startSync('$runtimeType',  arguments: timelineArgumentsIndicatingLandmarkEvent);

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -280,6 +280,7 @@ mixin SchedulerBinding on BindingBase {
     }
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _executeTimingsCallbacks(List<FrameTiming> timings) {
     final List<TimingsCallback> clonedCallbacks =
         List<TimingsCallback>.from(_timingsCallbacks);
@@ -450,6 +451,7 @@ mixin SchedulerBinding on BindingBase {
   ///
   /// Also returns false if there are no tasks remaining.
   @visibleForTesting
+  @pragma('vm:notify-debugger-on-exception')
   bool handleEventLoopCallback() {
     if (_taskQueue.isEmpty || locked)
       return false;
@@ -1133,6 +1135,7 @@ mixin SchedulerBinding on BindingBase {
   // Wraps the callback in a try/catch and forwards any error to
   // [debugSchedulerExceptionHandler], if set. If not set, then simply prints
   // the error.
+  @pragma('vm:notify-debugger-on-exception')
   void _invokeFrameCallback(FrameCallback callback, Duration timeStamp, [ StackTrace? callbackStack ]) {
     assert(callback != null);
     assert(_FrameCallbackEntry.debugCurrentCallbackStack == null);

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -451,7 +451,9 @@ mixin SchedulerBinding on BindingBase {
   ///
   /// Also returns false if there are no tasks remaining.
   @visibleForTesting
-  // TODO(goderbauer): figure out why the pragma doesn't work here.
+  // TODO(goderbauer): Add pragma (and enable test in
+  //   break_on_framework_exceptions_test.dart) once debugger breaks on correct
+  //   line, https://github.com/dart-lang/sdk/issues/45684
   // @pragma('vm:notify-debugger-on-exception')
   bool handleEventLoopCallback() {
     if (_taskQueue.isEmpty || locked)

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -451,7 +451,8 @@ mixin SchedulerBinding on BindingBase {
   ///
   /// Also returns false if there are no tasks remaining.
   @visibleForTesting
-  @pragma('vm:notify-debugger-on-exception')
+  // TODO(goderbauer): figure out why the pragma doesn't work here.
+  // @pragma('vm:notify-debugger-on-exception')
   bool handleEventLoopCallback() {
     if (_taskQueue.isEmpty || locked)
       return false;

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -272,7 +272,9 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
-  // TODO(goderbauer): uncomment pragma when it works on async methods, https://github.com/dart-lang/sdk/issues/45673
+  // TODO(goderbauer): Add pragma (and enable test in
+  //   break_on_framework_exceptions_test.dart) when it works on async methods,
+  //   https://github.com/dart-lang/sdk/issues/45673
   // @pragma('vm:notify-debugger-on-exception')
   Future<void> handlePlatformMessage(
     String channel,

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -272,7 +272,7 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
-  // TODO(goderbauer): pragme doesn't work on async methods, https://github.com/flutter/flutter/issues/17007#issuecomment-818318520
+  // TODO(goderbauer): uncomment pragma when it works on async methods, https://github.com/dart-lang/sdk/issues/45673
   // @pragma('vm:notify-debugger-on-exception')
   Future<void> handlePlatformMessage(
     String channel,

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -272,7 +272,8 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
-  @pragma('vm:notify-debugger-on-exception')
+  // TODO(goderbauer): pragme doesn't work on async methods, https://github.com/flutter/flutter/issues/17007#issuecomment-818318520
+  // @pragma('vm:notify-debugger-on-exception')
   Future<void> handlePlatformMessage(
     String channel,
     ByteData? data,

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -272,6 +272,7 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
+  @pragma('vm:notify-debugger-on-exception')
   Future<void> handlePlatformMessage(
     String channel,
     ByteData? data,

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -198,6 +198,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
   /// See the discussion at [removeActionListener].
   @protected
   @visibleForTesting
+  @pragma('vm:notify-debugger-on-exception')
   void notifyActionListeners() {
     if (_listeners.isEmpty) {
       return;

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1184,6 +1184,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
     assert(_newWidget == null);
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _rebuild() {
     try {
       _child = updateChild(_child, widget.child, _rootChildSlot);

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1873,6 +1873,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _finalizeEditing(TextInputAction action, {required bool shouldUnfocus}) {
     // Take any actions necessary now that the user has completed editing.
     if (widget.onEditingComplete != null) {
@@ -2126,6 +2127,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
     // We return early if the selection is not valid. This can happen when the
     // text of [EditableText] is updated at the same time as the selection is
@@ -2259,6 +2261,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _lastBottomViewInset = WidgetsBinding.instance!.window.viewInsets.bottom;
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _formatAndSetValue(TextEditingValue value, SelectionChangedCause? cause, {bool userInteraction = false}) {
     // Only apply input formatters if the text has changed (including uncommited
     // text in the composing region), or when the user committed the composing

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1596,6 +1596,7 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
   /// [FocusManager] notifies.
   void removeHighlightModeListener(ValueChanged<FocusHighlightMode> listener) => _listeners.remove(listener);
 
+  @pragma('vm:notify-debugger-on-exception')
   void _notifyHighlightModeListeners() {
     if (_listeners.isEmpty) {
       return;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2834,7 +2834,9 @@ class BuildOwner {
   ///
   /// After the current call stack unwinds, a microtask that notifies listeners
   /// about changes to global keys will run.
-  // TODO(goderbauer): Figure out why the pragma doesn't work on this method.
+  // TODO(goderbauer): Add pragma (and enable test in
+  //   break_on_framework_exceptions_test.dart) once debugger breaks on correct
+  //   line, https://github.com/dart-lang/sdk/issues/45684
   // @pragma('vm:notify-debugger-on-exception')
   void finalizeTree() {
     Timeline.startSync('Finalize tree', arguments: timelineArgumentsIndicatingLandmarkEvent);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2505,6 +2505,7 @@ class BuildOwner {
   /// [debugPrintBuildScope] to true. This is useful when debugging problems
   /// involving widgets not getting marked dirty, or getting marked dirty too
   /// often.
+  @pragma('vm:notify-debugger-on-exception')
   void buildScope(Element context, [ VoidCallback? callback ]) {
     if (callback == null && _dirtyElements.isEmpty)
       return;
@@ -2833,6 +2834,7 @@ class BuildOwner {
   ///
   /// After the current call stack unwinds, a microtask that notifies listeners
   /// about changes to global keys will run.
+  @pragma('vm:notify-debugger-on-exception')
   void finalizeTree() {
     Timeline.startSync('Finalize tree', arguments: timelineArgumentsIndicatingLandmarkEvent);
     try {
@@ -4579,6 +4581,7 @@ abstract class ComponentElement extends Element {
   /// Called automatically during [mount] to generate the first build, and by
   /// [rebuild] when the element needs updating.
   @override
+  @pragma('vm:notify-debugger-on-exception')
   void performRebuild() {
     if (!kReleaseMode && debugProfileBuildsEnabled)
       Timeline.startSync('${widget.runtimeType}',  arguments: timelineArgumentsIndicatingLandmarkEvent);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2834,7 +2834,8 @@ class BuildOwner {
   ///
   /// After the current call stack unwinds, a microtask that notifies listeners
   /// about changes to global keys will run.
-  @pragma('vm:notify-debugger-on-exception')
+  // TODO(goderbauer): Figure out why the pragma doesn't work on this method.
+  // @pragma('vm:notify-debugger-on-exception')
   void finalizeTree() {
     Timeline.startSync('Finalize tree', arguments: timelineArgumentsIndicatingLandmarkEvent);
     try {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -114,11 +114,11 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     super.unmount();
   }
 
-  // TODO(goderbauer): Figure out how to apply the pragma to the closure passed
-  //   to buildScope below (and enable test in break_on_framework_exceptions_test.dart),
-  //   https://github.com/flutter/flutter/issues/17007#issuecomment-818952818
-  // @pragma('vm:notify-debugger-on-exception')
   void _layout(ConstraintType constraints) {
+    // TODO(goderbauer): When https://github.com/dart-lang/sdk/issues/45710 is
+    //   fixed: refactor the anonymous closure below into a named one, apply the
+    //   @pragma('vm:notify-debugger-on-exception') to it and enable the
+    //   corresponding test in break_on_framework_exceptions_test.dart.
     owner!.buildScope(this, () {
       Widget built;
       try {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -114,7 +114,9 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     super.unmount();
   }
 
-  // TODO(goderbauer): The pragma should be applied to the buildScope closure, https://github.com/flutter/flutter/issues/17007#issuecomment-818952818
+  // TODO(goderbauer): Figure out how to apply the pragma to the closure passed
+  //   to buildScope below (and enable test in break_on_framework_exceptions_test.dart),
+  //   https://github.com/flutter/flutter/issues/17007#issuecomment-818952818
   // @pragma('vm:notify-debugger-on-exception')
   void _layout(ConstraintType constraints) {
     owner!.buildScope(this, () {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -114,6 +114,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     super.unmount();
   }
 
+  @pragma('vm:notify-debugger-on-exception')
   void _layout(ConstraintType constraints) {
     owner!.buildScope(this, () {
       Widget built;

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -114,7 +114,8 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     super.unmount();
   }
 
-  @pragma('vm:notify-debugger-on-exception')
+  // TODO(goderbauer): The pragma should be applied to the buildScope closure, https://github.com/flutter/flutter/issues/17007#issuecomment-818952818
+  // @pragma('vm:notify-debugger-on-exception')
   void _layout(ConstraintType constraints) {
     owner!.buildScope(this, () {
       Widget built;

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -774,7 +774,7 @@ class _CallbackHookProvider<T> {
         context: ErrorDescription('while invoking the callback for $runtimeType'),
         informationCollector: () sync* {
           yield DiagnosticsProperty<_CallbackHookProvider<T>>(
-            'The $runtimeType that invoked the callback was:',
+            'The $runtimeType that invoked the callback was',
             this,
             style: DiagnosticsTreeStyle.errorProperty,
           );

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -760,6 +760,7 @@ class _CallbackHookProvider<T> {
   /// Exceptions thrown by callbacks will be caught and reported using
   /// [FlutterError.reportError].
   @protected
+  @pragma('vm:notify-debugger-on-exception')
   T invokeCallback(T defaultValue) {
     if (_callbacks.isEmpty)
       return defaultValue;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -446,6 +446,7 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
   }
 
   @override
+  @pragma('vm:notify-debugger-on-exception')
   Widget? build(BuildContext context, int index) {
     assert(builder != null);
     if (index < 0 || (childCount != null && index >= childCount!))

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -37,7 +37,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'AnimationController listener';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'AnimationController listener';"));
   });
 
   testWithoutContext('breaks when AnimationController status listener throws', () async {
@@ -55,7 +56,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'AnimationController status listener';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'AnimationController status listener';"));
   });
 
   testWithoutContext('breaks when ChangeNotifier listener throws', () async {
@@ -73,7 +75,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'ValueNotifier listener';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'ValueNotifier listener';"));
   });
 
   testWithoutContext('breaks when handling a gesture throws', () async {
@@ -99,7 +102,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'while handling a gesture';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'while handling a gesture';"));
   });
 
   testWithoutContext('breaks when platform message callback throws', () async {
@@ -116,7 +120,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'platform message callback';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'platform message callback';"));
   }, skip: 'TODO(goderbauer): add pragma to _DefaultBinaryMessenger.handlePlatformMessage when async methods are supported (https://github.com/dart-lang/sdk/issues/45673) and enable this test');
 
   testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
@@ -136,7 +141,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'cannot build child';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'cannot build child';"));
   });
 
   testWithoutContext('breaks when EditableText.onChanged throws', () async {
@@ -159,7 +165,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onChanged';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'onChanged';"));
   });
 
   testWithoutContext('breaks when EditableText.onEditingComplete throws', () async {
@@ -184,7 +191,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onEditingComplete';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'onEditingComplete';"));
   });
 
   testWithoutContext('breaks when EditableText.onSelectionChanged throws', () async {
@@ -205,7 +213,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onSelectionChanged';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'onSelectionChanged';"));
   });
 
   testWithoutContext('breaks when Action listener throws', () async {
@@ -223,7 +232,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'action listener';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'action listener';"));
   });
 
   testWithoutContext('breaks when pointer route throws', () async {
@@ -241,7 +251,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'pointer route';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'pointer route';"));
   });
 
   testWithoutContext('breaks when PointerSignalResolver callback throws', () async {
@@ -260,7 +271,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'PointerSignalResolver callback';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'PointerSignalResolver callback';"));
   });
 
   testWithoutContext('breaks when PointerSignalResolver callback throws', () async {
@@ -279,7 +291,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'highlight mode listener';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'highlight mode listener';"));
   });
 
   testWithoutContext('breaks when GestureBinding.dispatchEvent throws', () async {
@@ -305,7 +318,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onHover';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'onHover';"));
   });
 
   testWithoutContext('breaks when ImageStreamListener.onImage throws', () async {
@@ -330,7 +344,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'setImage';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'setImage';"));
   });
 
   testWithoutContext('breaks when ImageStreamListener.onError throws', () async {
@@ -352,7 +367,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onError';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'onError';"));
   });
 
   testWithoutContext('breaks when LayoutBuilder.builder throws', () async {
@@ -370,7 +386,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'LayoutBuilder.builder';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'LayoutBuilder.builder';"));
   }, skip: 'TODO(goderbauer): Figure out how to apply pragma to anonymous closure in _LayoutBuilderElement._layout, https://github.com/flutter/flutter/issues/17007#issuecomment-818952818');
 
   testWithoutContext('breaks when _CallbackHookProvider callback throws', () async {
@@ -388,7 +405,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw '_CallbackHookProvider.callback';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw '_CallbackHookProvider.callback';"));
   });
 
   testWithoutContext('breaks when TimingsCallback throws', () async {
@@ -405,7 +423,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'TimingsCallback';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'TimingsCallback';"));
   });
 
   testWithoutContext('breaks when TimingsCallback throws', () async {
@@ -425,7 +444,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'scheduled task';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'scheduled task';"));
   }, skip: 'TODO(goderbauer): add pragma to SchedulerBinding.handleEventLoopCallback when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
 
   testWithoutContext('breaks when FrameCallback throws', () async {
@@ -442,7 +462,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'FrameCallback';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'FrameCallback';"));
   });
 
   testWithoutContext('breaks when attaching to render tree throws', () async {
@@ -467,7 +488,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'create element';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'create element';"));
   });
 
   testWithoutContext('breaks when RenderObject.performLayout throws', () async {
@@ -489,7 +511,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'performLayout';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'performLayout';"));
   });
 
   testWithoutContext('breaks when RenderObject.performResize throws', () async {
@@ -514,7 +537,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'performResize';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'performResize';"));
   });
 
   testWithoutContext('breaks when RenderObject.performLayout (without resize) throws', () async {
@@ -556,7 +580,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'performLayout without resize';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'performLayout without resize';"));
   });
 
   testWithoutContext('breaks when StatelessWidget.build throws', () async {
@@ -578,7 +603,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'StatelessWidget.build';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'StatelessWidget.build';"));
   });
 
   testWithoutContext('breaks when StatefulWidget.build throws', () async {
@@ -605,7 +631,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'StatefulWidget.build';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'StatefulWidget.build';"));
   });
 
   testWithoutContext('breaks when finalizing the tree throws', () async {
@@ -636,7 +663,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'dispose';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'dispose';"));
   }, skip: 'TODO(goderbauer): add pragma to BuildOwner.finalizeTree when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
 
   testWithoutContext('breaks when rebuilding dirty elements throws', () async {
@@ -683,7 +711,8 @@ void main() {
     await flutter.test(withDebugger: true, pauseOnExceptions: true);
     await flutter.waitForPause();
 
-    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'rebuild';")));
+    final int breakLine = (await flutter.getSourceLocation()).line;
+    expect(breakLine, project.lineContaining(project.test, "throw 'rebuild';"));
   });
 }
 

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -1,0 +1,325 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+
+import '../src/common.dart';
+import 'test_data/project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('break_on_framework_exceptions.');
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('breaks when AnimationController listener throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      AnimationController(vsync: TestVSync(), duration: Duration.zero)
+        ..addListener(() {
+          throw 'AnimationController listener';
+        })
+        ..forward();
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'AnimationController listener';")));
+  });
+
+  testWithoutContext('breaks when AnimationController status listener throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      AnimationController(vsync: TestVSync(), duration: Duration.zero)
+        ..addStatusListener((AnimationStatus _) {
+          throw 'AnimationController status listener';
+        })
+        ..forward();
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'AnimationController status listener';")));
+  });
+
+  testWithoutContext('breaks when ChangeNotifier listener throws', () async {
+    final TestProject project = TestProject(
+       r'''
+       ValueNotifier<int>(0)
+         ..addListener(() {
+           throw 'ValueNotifier listener';
+         })
+         ..value = 1;
+       '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'ValueNotifier listener';")));
+  });
+
+  testWithoutContext('breaks when handling a gesture throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: ElevatedButton(
+              child: const Text('foo'),
+              onPressed: () {
+                throw 'while handling a gesture';
+              },
+            ),
+          ),
+        )
+      );
+      await tester.tap(find.byType(ElevatedButton));
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'while handling a gesture';")));
+  });
+
+  testWithoutContext('breaks when platform message callback throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      BasicMessageChannel<String>('foo', const StringCodec()).setMessageHandler((_) {
+        throw 'platform message callback';
+      });
+      tester.binding.defaultBinaryMessenger.handlePlatformMessage('foo', const StringCodec().encodeMessage('Hello'), (_) {});
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'platform message callback';")));
+  }, skip: 'https://github.com/flutter/flutter/issues/17007#issuecomment-818318520');
+
+  testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      await tester.pumpWidget(MaterialApp(
+        home: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            throw 'cannot build child';
+          },
+        ),
+      ));
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'cannot build child';")));
+  });
+
+  testWithoutContext('breaks when EditableText.onChanged throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: TextField(
+            onChanged: (String t) {
+              throw 'onChanged';
+            },
+          ),
+        ),
+      ));
+      await tester.enterText(find.byType(TextField), 'foo');
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onChanged';")));
+  });
+
+  testWithoutContext('breaks when EditableText.onEditingComplete throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: TextField(
+            onEditingComplete: () {
+              throw 'onEditingComplete';
+            },
+          ),
+        ),
+      ));
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onEditingComplete';")));
+  });
+
+  testWithoutContext('breaks when EditableText.onSelectionChanged throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      await tester.pumpWidget(MaterialApp(
+        home: SelectableText('hello',
+          onSelectionChanged: (TextSelection selection, SelectionChangedCause? cause) {
+            throw 'onSelectionChanged';
+          },
+        ),
+      ));
+      await tester.tap(find.byType(SelectableText));
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'onSelectionChanged';")));
+  });
+
+  testWithoutContext('breaks when Action listener throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      CallbackAction<Intent>(onInvoke: (Intent _) { })
+        ..addActionListener((_) {
+          throw 'action listener';
+        })
+        ..notifyActionListeners();
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'action listener';")));
+  });
+
+  testWithoutContext('breaks when pointer route throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      PointerRouter()
+        ..addRoute(2, (PointerEvent event) {
+          throw 'pointer route';
+        })
+        ..route(TestPointer(2).down(Offset.zero));
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'pointer route';")));
+  });
+
+  testWithoutContext('breaks when PointerSignalResolver callback throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      const PointerScrollEvent originalEvent = PointerScrollEvent();
+      PointerSignalResolver()
+        ..register(originalEvent, (PointerSignalEvent event) {
+          throw 'PointerSignalResolver callback';
+        })
+        ..resolve(originalEvent);
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'PointerSignalResolver callback';")));
+  });
+
+  testWithoutContext('breaks when PointerSignalResolver callback throws', () async {
+    final TestProject project = TestProject(
+      r'''
+      FocusManager.instance
+        ..addHighlightModeListener((_) {
+          throw 'highlight mode listener';
+        })
+        ..highlightStrategy = FocusHighlightStrategy.alwaysTouch
+        ..highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+      '''
+    );
+    await project.setUpIn(tempDir);
+    final FlutterTestTestDriver flutter = FlutterTestTestDriver(tempDir);
+    await flutter.test(withDebugger: true, pauseOnExceptions: true);
+    await flutter.waitForPause();
+
+    expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'highlight mode listener';")));
+  });
+}
+
+class TestProject extends Project {
+  TestProject(this.testBody);
+
+  final String testBody;
+
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ">=2.12.0-0 <3.0.0"
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  dev_dependencies:
+    flutter_test:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = '';
+
+  @override
+  String get test => _test.replaceFirst('// TEST_BODY', testBody);
+
+  final String _test = r'''
+  import 'package:flutter_test/flutter_test.dart';
+  import 'package:flutter/animation.dart';
+  import 'package:flutter/foundation.dart';
+  import 'package:flutter/material.dart';
+  import 'package:flutter/services.dart';
+  import 'package:flutter/gestures.dart';
+
+  void main() {
+    testWidgets('test', (WidgetTester tester) async {
+      // TEST_BODY
+    });
+  }
+''';
+}

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -117,7 +117,7 @@ void main() {
     await flutter.waitForPause();
 
     expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'platform message callback';")));
-  }, skip: 'https://github.com/flutter/flutter/issues/17007#issuecomment-818318520');
+  }, skip: 'https://github.com/dart-lang/sdk/issues/45673');
 
   testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
     final TestProject project = TestProject(

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -650,14 +650,14 @@ void main() {
         class TestWidget extends StatelessWidget {
           @override
           StatelessElement createElement() => TestElement(this);
-        
+
           @override
           Widget build(BuildContext context) => Container();
         }
-        
+
         class TestElement extends StatelessElement {
           TestElement(StatelessWidget widget) : super(widget);
-        
+
           bool get throwOnRebuild => _throwOnRebuild;
           bool _throwOnRebuild = false;
           set throwOnRebuild(bool value) {
@@ -667,7 +667,7 @@ void main() {
             _throwOnRebuild = value;
             markNeedsBuild();
           }
-        
+
           @override
           void rebuild() {
             if (_throwOnRebuild) {
@@ -699,7 +699,7 @@ class TestProject extends Project {
     name: test
     environment:
       sdk: ">=2.12.0-0 <3.0.0"
-  
+
     dependencies:
       flutter:
         sdk: flutter
@@ -717,7 +717,7 @@ class TestProject extends Project {
   final String _test = r'''
     import 'dart:async';
     import 'dart:ui' as ui;
-  
+
     import 'package:flutter/animation.dart';
     import 'package:flutter/foundation.dart';
     import 'package:flutter/gestures.dart';
@@ -725,9 +725,9 @@ class TestProject extends Project {
     import 'package:flutter/scheduler.dart';
     import 'package:flutter/services.dart';
     import 'package:flutter_test/flutter_test.dart';
-  
+
     void main() {
-      // SETUP 
+      // SETUP
       testWidgets('test', (WidgetTester tester) async {
         // TEST_BODY
       });

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -309,12 +309,12 @@ class TestProject extends Project {
   String get test => _test.replaceFirst('// TEST_BODY', testBody);
 
   final String _test = r'''
-  import 'package:flutter_test/flutter_test.dart';
   import 'package:flutter/animation.dart';
   import 'package:flutter/foundation.dart';
+  import 'package:flutter/gestures.dart';
   import 'package:flutter/material.dart';
   import 'package:flutter/services.dart';
-  import 'package:flutter/gestures.dart';
+  import 'package:flutter_test/flutter_test.dart';
 
   void main() {
     testWidgets('test', (WidgetTester tester) async {

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -388,7 +388,7 @@ void main() {
 
     final int breakLine = (await flutter.getSourceLocation()).line;
     expect(breakLine, project.lineContaining(project.test, "throw 'LayoutBuilder.builder';"));
-  }, skip: 'TODO(goderbauer): Figure out how to apply pragma to anonymous closure in _LayoutBuilderElement._layout, https://github.com/flutter/flutter/issues/17007#issuecomment-818952818');
+  }, skip: 'TODO(goderbauer): Once https://github.com/dart-lang/sdk/issues/45710 is fixed, fix TODO in _LayoutBuilderElement._layout and enable this test');
 
   testWithoutContext('breaks when _CallbackHookProvider callback throws', () async {
     final TestProject project = TestProject(

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -117,7 +117,7 @@ void main() {
     await flutter.waitForPause();
 
     expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'platform message callback';")));
-  }, skip: 'https://github.com/dart-lang/sdk/issues/45673');
+  }, skip: 'TODO(goderbauer): add pragma to _DefaultBinaryMessenger.handlePlatformMessage when async methods are supported (https://github.com/dart-lang/sdk/issues/45673) and enable this test');
 
   testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
     final TestProject project = TestProject(
@@ -371,7 +371,7 @@ void main() {
     await flutter.waitForPause();
 
     expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'LayoutBuilder.builder';")));
-  }, skip: 'https://github.com/flutter/flutter/issues/17007#issuecomment-818952818');
+  }, skip: 'TODO(goderbauer): Figure out how to apply pragma to anonymous closure in _LayoutBuilderElement._layout, https://github.com/flutter/flutter/issues/17007#issuecomment-818952818');
 
   testWithoutContext('breaks when _CallbackHookProvider callback throws', () async {
     final TestProject project = TestProject(
@@ -426,7 +426,7 @@ void main() {
     await flutter.waitForPause();
 
     expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'scheduled task';")));
-  }, skip: 'TODO(goderbauer): figure out why the pragma does not work on SchedulerBinding.handleEventLoopCallback');
+  }, skip: 'TODO(goderbauer): add pragma to SchedulerBinding.handleEventLoopCallback when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
 
   testWithoutContext('breaks when FrameCallback throws', () async {
     final TestProject project = TestProject(
@@ -637,7 +637,7 @@ void main() {
     await flutter.waitForPause();
 
     expect((await flutter.getSourceLocation()).line, equals(project.lineContaining(project.test, "throw 'dispose';")));
-  }, skip: 'TODO(goderbauer): Figure out why the pragma on BuildOwner.finalizeTree does not work');
+  }, skip: 'TODO(goderbauer): add pragma to BuildOwner.finalizeTree when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
 
   testWithoutContext('breaks when rebuilding dirty elements throws', () async {
     final TestProject project = TestProject(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/17007

This does elevate the experience when using an interactive debugger.

The following bugs in the Dart SDK prevent us from using the `vm:notify-debugger-on-exception` in all possible instances. I've added TODOs in the code for those cases.
* https://github.com/dart-lang/sdk/issues/45673 (async methods)
* https://github.com/dart-lang/sdk/issues/45710 (named closures)
* https://github.com/dart-lang/sdk/issues/45684 (debugger not breaking on correct line)

/cc @devoncarew @DanTup 