### PR TITLE
Remove ignores that are not ignoring anything

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-// ignore: unused_import
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -67,7 +66,6 @@ import 'stock_strings_es.dart';
 abstract class StockStrings {
   StockStrings(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
-  // ignore: unused_field
   final String localeName;
 
   static StockStrings of(BuildContext context) {

--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings_en.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings_en.dart
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore: unused_import
-import 'package:intl/intl.dart' as intl;
 import 'stock_strings.dart';
-
-// ignore_for_file: unnecessary_brace_in_string_interps
 
 /// The translations for English (`en`).
 class StockStringsEn extends StockStrings {

--- a/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings_es.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/i18n/stock_strings_es.dart
@@ -2,11 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore: unused_import
-import 'package:intl/intl.dart' as intl;
 import 'stock_strings.dart';
-
-// ignore_for_file: unnecessary_brace_in_string_interps
 
 /// The translations for Spanish Castilian (`es`).
 class StockStringsEs extends StockStrings {

--- a/packages/flutter_tools/lib/src/test/test_wrapper.dart
+++ b/packages/flutter_tools/lib/src/test/test_wrapper.dart
@@ -11,7 +11,7 @@ import 'package:test_core/src/platform.dart' as hack show registerPlatformPlugin
 import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 
 export 'package:test_api/backend.dart' show Runtime; // ignore: deprecated_member_use
-export 'package:test_core/src/platform.dart' show PlatformPlugin; // ignore: implementation_imports
+export 'package:test_core/src/platform.dart' show PlatformPlugin;
 
 abstract class TestWrapper {
   const factory TestWrapper() = _DefaultTestWrapper;

--- a/packages/integration_test/example/lib/main.dart
+++ b/packages/integration_test/example/lib/main.dart
@@ -4,6 +4,4 @@
 
 import 'my_app.dart' if (dart.library.html) 'my_web_app.dart';
 
-// ignore_for_file: public_member_api_docs
-
 void main() => startApp();


### PR DESCRIPTION
@shihaohong To unblock https://github.com/dart-lang/sdk/issues/35234 I am removing the unnecessary `// ignore:`s from the generated i18n code. I've filed an issue to update the generator.