### PR TITLE
Fix socket leak by ensuring HttpClientResponse is properly consumed

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -96,7 +96,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
         // The network may be only temporarily unavailable, or the file will be
         // added on the server later. Avoid having future calls to resolve
         // fail to check the network again.
-        response.listen((_) {}).cancel();
+        response.listen(null, onError: (_) {}, cancelOnError: true);
         throw image_provider.NetworkImageLoadException(statusCode: response.statusCode, uri: resolved);
       }
 

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -96,6 +96,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
         // The network may be only temporarily unavailable, or the file will be
         // added on the server later. Avoid having future calls to resolve
         // fail to check the network again.
+        response.listen((_) {}).cancel();
         throw image_provider.NetworkImageLoadException(statusCode: response.statusCode, uri: resolved);
       }
 


### PR DESCRIPTION
This fix a socket leak in NetworkImage IO implementation, that happens when a non Ok http code is returned.
In that case the HttpClientResponse was left unconsumed, and a underlying socket opened.

https://github.com/flutter/flutter/issues/78741

This quick fix ensure the socket is properly closed, by listening to the response and cancelling the stream.
As an alternative we may want to consume (and ignore) the whole response, so that the socket can be reused if kept alive.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
