### PR TITLE
popCompleter for Page

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -561,7 +561,7 @@ abstract class Page<T> extends RouteSettings {
   /// Creates a page and initializes [key] for subclasses.
   ///
   /// The [arguments] argument must not be null.
-  const Page({
+  Page({
     this.key,
     String? name,
     Object? arguments,
@@ -583,6 +583,11 @@ abstract class Page<T> extends RouteSettings {
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
   final String? restorationId;
+
+  /// A completer which produce [Future] and completes when this page is popped off the navigator.
+  ///
+  /// The future completes with the value given to [Navigator.pop].
+  final Completer<T?> popCompleter = Completer<T?>();
 
   /// Whether this page can be updated with the [other] page.
   ///
@@ -5070,6 +5075,8 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
     final _RouteEntry entry = _history.lastWhere(_RouteEntry.isPresentPredicate);
     if (entry.hasPage) {
+      final Page<T> page = entry.route.settings as Page<T>;
+      page.popCompleter.complete(result);
       if (widget.onPopPage!(entry.route, result))
         entry.currentState = _RouteLifecycle.pop;
     } else {


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/74195

Exposing popCompleter may not be desirable, but I think that this is the simplest way to solve the issue.
I would like to get your feedback.

## Usage
```dart
Future<dynamic> pushPage() {
  final Page<dynamic> page = MaterialPage(
        key: ValueKey(_selectedBook),
        child: BookDetailsScreen(book: _selectedBook),
  );
  // ...
  return page.popCompleter.future;
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
