### PR TITLE
Migrate Gradle repo from jcenter to mavenCentral in dev projects

### DIFF
--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/macrobenchmarks/android/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/microbenchmarks/android/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/multiple_flutters/android/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/build.gradle
@@ -7,7 +7,13 @@ buildscript {
     ext.kotlin_version = "1.3.72"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.2"
@@ -21,7 +27,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/platform_views_layout/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/benchmarks/test_apps/stocks/android/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
@@ -6,7 +6,13 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -18,7 +24,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/android_custom_host_app/build.gradle
+++ b/dev/integration_tests/android_custom_host_app/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
@@ -15,7 +21,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
@@ -6,7 +6,13 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -18,7 +24,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/android_host_app_v2_embedding/build.gradle
+++ b/dev/integration_tests/android_host_app_v2_embedding/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
@@ -15,7 +21,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/android_semantics_testing/android/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/android_views/android/build.gradle
+++ b/dev/integration_tests/android_views/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/channels/android/build.gradle
+++ b/dev/integration_tests/channels/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/external_ui/android/build.gradle
+++ b/dev/integration_tests/external_ui/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/flavors/android/build.gradle
+++ b/dev/integration_tests/flavors/android/build.gradle
@@ -5,7 +5,14 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +23,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/flutter_gallery/android/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
         maven {
             url 'https://google.bintray.com/exoplayer/'
         }

--- a/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/hybrid_android_views/android/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
@@ -15,7 +21,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/non_nullable/android/build.gradle
+++ b/dev/integration_tests/non_nullable/android/build.gradle
@@ -6,7 +6,13 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -18,7 +24,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/platform_interaction/android/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/release_smoke_test/android/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/integration_tests/ui/android/build.gradle
+++ b/dev/integration_tests/ui/android/build.gradle
@@ -5,7 +5,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -16,7 +22,14 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 

--- a/dev/manual_tests/android/build.gradle
+++ b/dev/manual_tests/android/build.gradle
@@ -6,7 +6,13 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 
     dependencies {
@@ -18,7 +24,13 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // TODO(jmagman): Remove with https://github.com/flutter/flutter/issues/78338
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Replace sunsetting `jcenter` with `mavenCentral`, except for `trove4j` only in `dev` directory to work around `center.bintray.com` flakiness in CI.

This can be removed once `trove4j` is uploaded to Maven Central and we have a better migration story for Flutter apps, tracked with https://github.com/flutter/flutter/issues/78338

More context at https://youtrack.jetbrains.com/issue/IDEA-261387 and https://github.com/flutter/flutter/issues/78338#issuecomment-804328528.

Fixes https://github.com/flutter/flutter/issues/78354