### PR TITLE
Update Podfile.lock modified timestamp when pod install is run

### DIFF
--- a/dev/integration_tests/flutter_gallery/macos/Podfile.lock
+++ b/dev/integration_tests/flutter_gallery/macos/Podfile.lock
@@ -1,0 +1,35 @@
+PODS:
+  - connectivity_macos (0.0.1):
+    - FlutterMacOS
+    - Reachability
+  - FlutterMacOS (1.0.0)
+  - Reachability (3.2)
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - connectivity_macos (from `Flutter/ephemeral/.symlinks/plugins/connectivity_macos/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+EXTERNAL SOURCES:
+  connectivity_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_macos/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+
+SPEC CHECKSUMS:
+  connectivity_macos: 9f30e9d0e67a0bc08a0c563ee82310b51ca6e818
+  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
+  url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
+
+PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+
+COCOAPODS: 1.10.1

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -335,10 +335,18 @@ class CocoaPods {
         _logger.printStatus(stderr, indent: 4);
       }
     }
+
     if (result.exitCode != 0) {
       invalidatePodInstallOutput(xcodeProject);
       _diagnosePodInstallFailure(result);
       throwToolExit('Error running pod install');
+    } else if (xcodeProject.podfileLock.existsSync()) {
+      // Even if the Podfile.lock didn't change, update its modified date to now
+      // so Podfile.lock is newer than Podfile.
+      _processManager.runSync(
+        <String>['touch', xcodeProject.podfileLock.path],
+        workingDirectory: _fileSystem.path.dirname(xcodeProject.podfile.path),
+      );
     }
   }
 

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -351,8 +351,18 @@ void main() {
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testUsingContext('exits if Podfile creates the Flutter engine symlink', () async {
-      final FlutterProject projectUnderTest = setupProjectUnderTest();
+    testWithoutContext('exits if Podfile creates the Flutter engine symlink', () async {
+      pretendPodIsInstalled();
+      pretendPodVersionIs('1.10.0');
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
+          command: <String>['pod', 'install', '--verbose'],
+        ),
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
+
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -368,8 +378,18 @@ void main() {
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testUsingContext('exits if iOS Podfile parses .flutter-plugins', () async {
-      final FlutterProject projectUnderTest = setupProjectUnderTest();
+    testWithoutContext('exits if iOS Podfile parses .flutter-plugins', () async {
+      pretendPodIsInstalled();
+      pretendPodVersionIs('1.10.0');
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
+          command: <String>['pod', 'install', '--verbose'],
+        ),
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
+
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('plugin_pods = parse_KV_file(\'../.flutter-plugins\')');
@@ -385,11 +405,14 @@ void main() {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
       pretendPodVersionIs('1.10.0');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/macos/Podfile.lock'],
+        ),
+      ]);
 
       fileSystem.file(fileSystem.path.join('project', 'macos', 'Podfile'))
         ..createSync()
@@ -556,13 +579,13 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing lock file.');
 
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+      ]);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
@@ -582,13 +605,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       projectUnderTest.ios.podfileLock
         ..createSync()
         ..writeAsStringSync('Existing lock file.');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
@@ -608,13 +634,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       projectUnderTest.macos.podfileLock
         ..createSync()
         ..writeAsStringSync('Existing lock file.');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/macos',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/macos/Podfile.lock'],
+        ),
+      ]);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.macos,
         buildMode: BuildMode.debug,
@@ -637,13 +666,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       projectUnderTest.ios.podManifestLock
         ..createSync(recursive: true)
         ..writeAsStringSync('Different lock file.');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
@@ -666,13 +698,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       projectUnderTest.ios.podManifestLock
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing lock file.');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
       final bool didInstall = await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
@@ -698,13 +733,16 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       await Future<void>.delayed(const Duration(milliseconds: 10));
       projectUnderTest.ios.podfile
         .writeAsStringSync('Updated Podfile');
-      fakeProcessManager.addCommand(
-        const FakeCommand(
+      fakeProcessManager.addCommands(const <FakeCommand>[
+        FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
           workingDirectory: 'project/ios',
           environment: <String, String>{'COCOAPODS_DISABLE_STATS': 'true', 'LANG': 'en_US.UTF-8'},
         ),
-      );
+        FakeCommand(
+          command: <String>['touch', 'project/ios/Podfile.lock'],
+        ),
+      ]);
       await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -335,7 +335,7 @@ void main() {
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
       ), throwsToolExit(message: 'CocoaPods not installed or not in valid state'));
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
@@ -347,22 +347,12 @@ void main() {
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
       ), throwsToolExit(message: 'CocoaPods not installed or not in valid state'));
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testWithoutContext('exits if Podfile creates the Flutter engine symlink', () async {
-      pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
-      fakeProcessManager.addCommands(const <FakeCommand>[
-        FakeCommand(
-          command: <String>['pod', 'install', '--verbose'],
-        ),
-        FakeCommand(
-          command: <String>['touch', 'project/ios/Podfile.lock'],
-        ),
-      ]);
-
+    testUsingContext('exits if Podfile creates the Flutter engine symlink', () async {
+      final FlutterProject projectUnderTest = setupProjectUnderTest();
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -378,18 +368,8 @@ void main() {
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
-    testWithoutContext('exits if iOS Podfile parses .flutter-plugins', () async {
-      pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
-      fakeProcessManager.addCommands(const <FakeCommand>[
-        FakeCommand(
-          command: <String>['pod', 'install', '--verbose'],
-        ),
-        FakeCommand(
-          command: <String>['touch', 'project/ios/Podfile.lock'],
-        ),
-      ]);
-
+    testUsingContext('exits if iOS Podfile parses .flutter-plugins', () async {
+      final FlutterProject projectUnderTest = setupProjectUnderTest();
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('plugin_pods = parse_KV_file(\'../.flutter-plugins\')');
@@ -414,9 +394,12 @@ void main() {
         ),
       ]);
 
-      fileSystem.file(fileSystem.path.join('project', 'macos', 'Podfile'))
+      projectUnderTest.macos.podfile
         ..createSync()
         ..writeAsStringSync('plugin_pods = parse_KV_file(\'../.flutter-plugins\')');
+      projectUnderTest.macos.podfileLock
+        ..createSync()
+        ..writeAsStringSync('Existing lock file.');
 
       await cocoaPodsUnderTest.processPods(
         xcodeProject: projectUnderTest.macos,
@@ -434,7 +417,7 @@ void main() {
         xcodeProject: projectUnderTest.ios,
         buildMode: BuildMode.debug,
       ), throwsToolExit(message: 'Podfile missing'));
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('throws, if specs repo is outdated.', () async {
@@ -592,7 +575,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: false,
       );
       expect(didInstall, isTrue);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('runs iOS pod install, if Manifest.lock is missing', () async {
@@ -621,7 +604,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: false,
       );
       expect(didInstall, isTrue);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('runs macOS pod install, if Manifest.lock is missing', () async {
@@ -650,7 +633,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: false,
       );
       expect(didInstall, isTrue);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('runs pod install, if Manifest.lock different from Podspec.lock', () async {
@@ -682,7 +665,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: false,
       );
       expect(didInstall, isTrue);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('runs pod install, if flutter framework changed', () async {
@@ -714,7 +697,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: true,
       );
       expect(didInstall, isTrue);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('runs pod install, if Podfile.lock is older than Podfile', () async {
@@ -748,7 +731,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         buildMode: BuildMode.debug,
         dependenciesChanged: false,
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('skips pod install, if nothing changed', () async {
@@ -768,7 +751,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
         dependenciesChanged: false,
       );
       expect(didInstall, isFalse);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('a failed pod install deletes Pods/Manifest.lock', () async {


### PR DESCRIPTION
`pod install` takes ~1.6 seconds on my machine.  The tool tries to only run that command when it's needed:
https://github.com/flutter/flutter/blob/c3d0f60407f4fe556a73f9bef495aac352d4595b/packages/flutter_tools/lib/src/macos/cocoapods.dart#L292-L298

So `2. Podfile.lock is older than Podfile` is problematic when Flutter required `ios/Podfile` and `macos/Podfile` updates like https://github.com/flutter/flutter/pull/59044.  Our own `dev/integration_tests/flutter_gallery` had an older `Podfile.lock` than `Podfile`, so was getting run on every build.

`touch` the Podfile.lock after running `pod install` to make sure it's newer than the `Podfile` to no longer defeat that optimization.

Fixes https://github.com/flutter/flutter/issues/78677