### PR TITLE
Record deferred components assets in AssetManifest.json

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -530,17 +530,27 @@ class ManifestAssetBundle implements AssetBundle {
   }) {
     final Map<String, List<String>> jsonObject = <String, List<String>>{};
     final List<_Asset> assets = assetVariants.keys.toList();
-    if (deferredComponentsAssetVariants != null) {
-      for (Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values()) {
-        assets.addAll(componentAssets.keys.toList());
-      }
-    }
-    assets.sort((_Asset left, _Asset right) => left.entryUri.path.compareTo(right.entryUri.path));
+    final Map<_Asset, List<String>> jsonEntries = <_Asset, List<String>>{};
     for (final _Asset main in assets) {
-      jsonObject[main.entryUri.path] = <String>[
+      jsonEntries[main] = <String>[
         for (final _Asset variant in assetVariants[main])
           variant.entryUri.path,
       ];
+    }
+    if (deferredComponentsAssetVariants != null) {
+      for (Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values) {
+        for (final _Asset main in componentAssets.keys) {
+          jsonEntries[main] = <String>[
+            for (final _Asset variant in componentAssets[main])
+              variant.entryUri.path,
+          ];
+        }
+      }
+    }
+    final List<_Asset> sortedKeys = jsonEntries.keys.toList()
+        ..sort((_Asset left, _Asset right) => left.entryUri.path.compareTo(right.entryUri.path));
+    for (final _Asset main in sortedKeys) {
+      jsonObject[main.entryUri.path] = jsonEntries[main];
     }
     return DevFSStringContent(json.encode(jsonObject));
   }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -538,7 +538,7 @@ class ManifestAssetBundle implements AssetBundle {
       ];
     }
     if (deferredComponentsAssetVariants != null) {
-      for (Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values) {
+      for (final Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values) {
         for (final _Asset main in componentAssets.keys) {
           jsonEntries[main] = <String>[
             for (final _Asset variant in componentAssets[main])

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -399,7 +399,7 @@ class ManifestAssetBundle implements AssetBundle {
       _wildcardDirectories[uri] ??= _fileSystem.directory(uri);
     }
 
-    final DevFSStringContent assetManifest  = _createAssetManifest(assetVariants, deferredComponentsAssetVariants: deferredComponentsAssetVariants);
+    final DevFSStringContent assetManifest  = _createAssetManifest(assetVariants, deferredComponentsAssetVariants);
     final DevFSStringContent fontManifest = DevFSStringContent(json.encode(fonts));
     final LicenseResult licenseResult = _licenseCollector.obtainLicenses(packageConfig, additionalLicenseFiles);
     if (licenseResult.errorMessages.isNotEmpty) {
@@ -525,9 +525,9 @@ class ManifestAssetBundle implements AssetBundle {
   }
 
   DevFSStringContent _createAssetManifest(
-    Map<_Asset, List<_Asset>> assetVariants, {
+    Map<_Asset, List<_Asset>> assetVariants,
     Map<String, Map<_Asset, List<_Asset>>> deferredComponentsAssetVariants
-  }) {
+  ) {
     final Map<String, List<String>> jsonObject = <String, List<String>>{};
     final List<_Asset> assets = assetVariants.keys.toList();
     final Map<_Asset, List<String>> jsonEntries = <_Asset, List<String>>{};

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -399,7 +399,7 @@ class ManifestAssetBundle implements AssetBundle {
       _wildcardDirectories[uri] ??= _fileSystem.directory(uri);
     }
 
-    final DevFSStringContent assetManifest  = _createAssetManifest(assetVariants);
+    final DevFSStringContent assetManifest  = _createAssetManifest(assetVariants, deferredComponentsAssetVariants: deferredComponentsAssetVariants);
     final DevFSStringContent fontManifest = DevFSStringContent(json.encode(fonts));
     final LicenseResult licenseResult = _licenseCollector.obtainLicenses(packageConfig, additionalLicenseFiles);
     if (licenseResult.errorMessages.isNotEmpty) {
@@ -524,10 +524,18 @@ class ManifestAssetBundle implements AssetBundle {
     return deferredComponentsAssetVariants;
   }
 
-  DevFSStringContent _createAssetManifest(Map<_Asset, List<_Asset>> assetVariants) {
+  DevFSStringContent _createAssetManifest(
+    Map<_Asset, List<_Asset>> assetVariants, {
+    Map<String, Map<_Asset, List<_Asset>>> deferredComponentsAssetVariants
+  }) {
     final Map<String, List<String>> jsonObject = <String, List<String>>{};
-    final List<_Asset> assets = assetVariants.keys.toList()
-      ..sort((_Asset left, _Asset right) => left.entryUri.path.compareTo(right.entryUri.path));
+    final List<_Asset> assets = assetVariants.keys.toList();
+    if (deferredComponentsAssetVariants != null) {
+      for (Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values()) {
+        assets.addAll(componentAssets.keys.toList());
+      }
+    }
+    assets.sort((_Asset left, _Asset right) => left.entryUri.path.compareTo(right.entryUri.path));
     for (final _Asset main in assets) {
       jsonObject[main.entryUri.path] = <String>[
         for (final _Asset variant in assetVariants[main])

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -612,14 +612,10 @@ flutter:
         - assets/bar.jpg
         - assets/apple.jpg
 ''');
-    globals.fs.file('assets/foo.jpg')
-      ..createSync(recursive: true);
-    globals.fs.file('assets/bar.jpg')
-      ..createSync();
-    globals.fs.file('assets/apple.jpg')
-      ..createSync();
-    globals.fs.file('assets/zebra.jpg')
-      ..createSync();
+    globals.fs.file('assets/foo.jpg').createSync(recursive: true);
+    globals.fs.file('assets/bar.jpg').createSync();
+    globals.fs.file('assets/apple.jpg').createSync();
+    globals.fs.file('assets/zebra.jpg').createSync();
     final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
     expect(await bundle.build(manifestPath: 'pubspec.yaml', packagesPath: '.packages'), 0);

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -591,4 +591,45 @@ flutter:
     ProcessManager: () => FakeProcessManager.any(),
     Platform: () => FakePlatform(operatingSystem: 'linux'),
   });
+
+  testUsingContext('deferred and regular assets are included in manifest alphabetically', () async {
+    globals.fs.file('.packages').writeAsStringSync(r'''
+example:lib/
+''');
+    globals.fs.file('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync(r'''
+name: example
+
+flutter:
+  assets:
+    - assets/zebra.jpg
+    - assets/foo.jpg
+
+  deferred-components:
+    - name: component1
+      assets:
+        - assets/bar.jpg
+        - assets/apple.jpg
+''');
+    globals.fs.file('assets/foo.jpg')
+      ..createSync(recursive: true);
+    globals.fs.file('assets/bar.jpg')
+      ..createSync();
+    globals.fs.file('assets/apple.jpg')
+      ..createSync();
+    globals.fs.file('assets/zebra.jpg')
+      ..createSync();
+    final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
+
+    expect(await bundle.build(manifestPath: 'pubspec.yaml', packagesPath: '.packages'), 0);
+    expect((bundle.entries['FontManifest.json'] as DevFSStringContent).string, '[]');
+    // The assets from deferred components and regular assets
+    // are both included in alphabetical order
+    expect((bundle.entries['AssetManifest.json'] as DevFSStringContent).string, '{"assets/apple.jpg":["assets/apple.jpg"],"assets/bar.jpg":["assets/bar.jpg"],"assets/foo.jpg":["assets/foo.jpg"],"assets/zebra.jpg":["assets/zebra.jpg"]}');
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+    Platform: () => FakePlatform(operatingSystem: 'linux'),
+  });
 }


### PR DESCRIPTION
Some plugins and packages such as google fonts (https://pub.dev/packages/google_fonts) depend on reading `AssetManifest.json` to know what assets the app contains. This is reasonable behavior, and this PR adds support for tracking all assets in the manifest for use cases like this.

If the assets are contained in a deferred component, it must still be installed before accessing the assets. This only includes them in the manifest.

In particular, this allows fonts to be included in deferred components in Gallery: https://github.com/flutter/gallery/pull/461