### PR TITLE
Revert "Fixed Buttons with icon RenderFlex overflow"

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -468,7 +468,7 @@ class _ElevatedButtonWithIconChild extends StatelessWidget {
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child: label)],
+      children: <Widget>[icon, SizedBox(width: gap), label],
     );
   }
 }

--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -229,7 +229,7 @@ class _FlatButtonWithIcon extends FlatButton with MaterialButtonWithIconMixin {
            children: <Widget>[
              icon,
              const SizedBox(width: 8.0),
-             Flexible(child: label),
+             label,
            ],
          ),
          minWidth: minWidth,

--- a/packages/flutter/lib/src/material/outline_button.dart
+++ b/packages/flutter/lib/src/material/outline_button.dart
@@ -274,7 +274,7 @@ class _OutlineButtonWithIcon extends OutlineButton with MaterialButtonWithIconMi
            children: <Widget>[
              icon,
              const SizedBox(width: 8.0),
-             Flexible(child:label),
+             label,
            ],
          ),
        );

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -374,7 +374,7 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child:label)],
+      children: <Widget>[icon, SizedBox(width: gap), label],
     );
   }
 }

--- a/packages/flutter/lib/src/material/raised_button.dart
+++ b/packages/flutter/lib/src/material/raised_button.dart
@@ -265,7 +265,7 @@ class _RaisedButtonWithIcon extends RaisedButton with MaterialButtonWithIconMixi
            children: <Widget>[
              icon,
              const SizedBox(width: 8.0),
-             Flexible(child: label),
+             label,
            ],
          ),
        );

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -465,7 +465,7 @@ class _TextButtonWithIconChild extends StatelessWidget {
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[icon, SizedBox(width: gap), Flexible(child:label)],
+      children: <Widget>[icon, SizedBox(width: gap), label],
     );
   }
 }

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -1114,26 +1114,6 @@ void main() {
       await tester.pumpAndSettle();
     }
   });
-
-  testWidgets('Fixed ElevatedButton.icon RenderFlex overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 200,
-            child: ElevatedButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.takeException(), null);
-  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/flat_button_test.dart
+++ b/packages/flutter/test/material/flat_button_test.dart
@@ -882,26 +882,6 @@ void main() {
       await buildWidget(buttonMinWidth: buttonMinWidth);
       expect(tester.widget<RawMaterialButton>(rawMaterialButtonFinder).constraints.minWidth, buttonMinWidth);
     });
-
-    testWidgets('Fixed FlatButton.icon RenderFlex overflow', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SizedBox(
-              width: 200,
-              child: FlatButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.add),
-                label: const Text(
-                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-      expect(tester.takeException(), null);
-  });
 }
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -1222,26 +1222,6 @@ void main() {
     expect(box.size, equals(const Size(76, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
-
-  testWidgets('Fixed OutlineButton.icon RenderFlex overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 200,
-            child: OutlineButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.takeException(), null);
-  });
 }
 
 PhysicalModelLayer _findPhysicalLayer(Element element) {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1290,26 +1290,6 @@ void main() {
       await tester.pumpAndSettle();
     }
   });
-
-  testWidgets('Fixed OutlinedButton.icon RenderFlex overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 200,
-            child: OutlinedButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.takeException(), null);
-  });
 }
 
 PhysicalModelLayer _findPhysicalLayer(Element element) {

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -727,26 +727,6 @@ void main() {
     expect(paddingRect.top, tallerWidget.top - 5);
     expect(paddingRect.bottom, tallerWidget.bottom + 12);
   });
-
-  testWidgets('Fixed RaisedButton.icon RenderFlex overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 200,
-            child: RaisedButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.takeException(), null);
-  });
 }
 
 TextStyle _iconStyle(WidgetTester tester, IconData icon) {

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -1087,26 +1087,6 @@ void main() {
       await tester.pumpAndSettle();
     }
   });
-
-  testWidgets('Fixed TextButton.icon RenderFlex overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 200,
-            child: TextButton.icon(
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut a euismod nibh. Morbi laoreet purus.',
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.takeException(), null);
-  });
 }
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {


### PR DESCRIPTION
Reverts flutter/flutter#78018

This is a nice fix however it breaks existing apps that wrapped their label/icon in Flexible, knowing that the `.icon` button factories would wrap these widgets in a Row. In most cases, fixing the problem just meant removing the extra Flexible widget, however the cases that depend on Expanded aren't so easy.

Working on a fix that will enable relanding this PR now.
