### PR TITLE
Make version and time in flutter_tool null safe

### DIFF
--- a/packages/flutter_tools/lib/src/base/time.dart
+++ b/packages/flutter_tools/lib/src/base/time.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 /// A class for making time based operations testable.
 class SystemClock {
   /// A const constructor to allow subclasses to be const.

--- a/packages/flutter_tools/lib/src/base/version.dart
+++ b/packages/flutter_tools/lib/src/base/version.dart
@@ -2,14 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:meta/meta.dart';
 
 @immutable
 class Version implements Comparable<Version> {
   /// Creates a new [Version] object.
-  factory Version(int major, int minor, int patch, {String text}) {
+  factory Version(int? major, int? minor, int? patch, {String? text}) {
     if (text == null) {
       text = major == null ? '0' : '$major';
       if (minor != null) {
@@ -36,8 +34,8 @@ class Version implements Comparable<Version> {
   }
 
   /// Creates a new [Version] by parsing [text].
-  factory Version.parse(String text) {
-    final Match match = versionPattern.firstMatch(text ?? '');
+  static Version? parse(String? text) {
+    final Match? match = versionPattern.firstMatch(text ?? '');
     if (match == null) {
       return null;
     }
@@ -46,7 +44,7 @@ class Version implements Comparable<Version> {
       final int major = int.parse(match[1] ?? '0');
       final int minor = int.parse(match[3] ?? '0');
       final int patch = int.parse(match[5] ?? '0');
-      return Version._(major, minor, patch, text);
+      return Version._(major, minor, patch, text ?? '');
     } on FormatException {
       return null;
     }
@@ -55,8 +53,8 @@ class Version implements Comparable<Version> {
   /// Returns the primary version out of a list of candidates.
   ///
   /// This is the highest-numbered stable version.
-  static Version primary(List<Version> versions) {
-    Version primary;
+  static Version? primary(List<Version> versions) {
+    Version? primary;
     for (final Version version in versions) {
       if (primary == null || (version > primary)) {
         primary = version;


### PR DESCRIPTION
Migrate version.dart and time.dart to null safety.

Part of #71511