### PR TITLE
Make gesture recorgnizer allow more than one kind of device

### DIFF
--- a/packages/flutter/lib/src/gestures/eager.dart
+++ b/packages/flutter/lib/src/gestures/eager.dart
@@ -16,7 +16,10 @@ class EagerGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Create an eager gesture recognizer.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.kind}
-  EagerGestureRecognizer({ PointerDeviceKind? kind }) : super(kind: kind);
+  EagerGestureRecognizer({
+    PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(kind: kind, kindSet: kindSet);
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
@@ -30,8 +33,8 @@ class EagerGestureRecognizer extends OneSequenceGestureRecognizer {
   String get debugDescription => 'eager';
 
   @override
-  void didStopTrackingLastPointer(int pointer) { }
+  void didStopTrackingLastPointer(int pointer) {}
 
   @override
-  void handleEvent(PointerEvent event) { }
+  void handleEvent(PointerEvent event) {}
 }

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -123,11 +123,12 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     this.interpolation = _inverseLerp,
     Object? debugOwner,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
   }) : assert(startPressure != null),
        assert(peakPressure != null),
        assert(interpolation != null),
        assert(peakPressure > startPressure),
-       super(debugOwner: debugOwner, kind: kind);
+       super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   /// A pointer is in contact with the screen and has just pressed with a force
   /// exceeding the [startPressure]. Consequently, if there were other gesture

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -164,11 +164,13 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     Duration? duration,
     double? postAcceptSlopTolerance,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
     Object? debugOwner,
   }) : super(
           deadline: duration ?? kLongPressTimeout,
           postAcceptSlopTolerance: postAcceptSlopTolerance,
           kind: kind,
+          kindSet: kindSet,
           debugOwner: debugOwner,
         );
 

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -67,10 +67,11 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   DragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
   }) : assert(dragStartBehavior != null),
-       super(debugOwner: debugOwner, kind: kind);
+       super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker.withKind(event.kind);
   /// Configure the behavior of offsets sent to [onStart].
@@ -508,7 +509,8 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
@@ -549,7 +551,8 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -202,7 +202,8 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   MultiDragGestureRecognizer({
     required Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   /// Called when this class recognizes the start of a drag gesture.
   ///
@@ -351,7 +352,8 @@ class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Im
   ImmediateMultiDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   @override
   _ImmediatePointerState createNewPointerState(PointerDownEvent event) {
@@ -400,7 +402,8 @@ class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_H
   HorizontalMultiDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   @override
   _HorizontalPointerState createNewPointerState(PointerDownEvent event) {
@@ -449,7 +452,8 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Ver
   VerticalMultiDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   @override
   _VerticalPointerState createNewPointerState(PointerDownEvent event) {
@@ -552,8 +556,9 @@ class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Dela
     this.delay = kLongPressTimeout,
     Object? debugOwner,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
   }) : assert(delay != null),
-       super(debugOwner: debugOwner, kind: kind);
+       super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   /// The amount of time the pointer must remain in the same place for the drag
   /// to be recognized.

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -117,7 +117,8 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   DoubleTapGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   // Implementation notes:
   //
@@ -460,7 +461,8 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
     this.longTapDelay = Duration.zero,
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   /// A pointer that might cause a tap has contacted the screen at a particular
   /// location.

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -251,9 +251,10 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   ScaleGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
     this.dragStartBehavior = DragStartBehavior.down,
   }) : assert(dragStartBehavior != null),
-       super(debugOwner: debugOwner, kind: kind);
+       super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
 
   /// Determines what point is used as the starting point in all calculations
   /// involving this gesture.

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -423,7 +423,8 @@ class _UiKitViewGestureRecognizer extends OneSequenceGestureRecognizer {
     this.controller,
     this.gestureRecognizerFactories, {
     PointerDeviceKind? kind,
-  }) : super(kind: kind) {
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(kind: kind, kindSet: kindSet) {
     team = GestureArenaTeam()
       ..captain = this;
     _gestureRecognizers = gestureRecognizerFactories.map(
@@ -501,7 +502,8 @@ class _PlatformViewGestureRecognizer extends OneSequenceGestureRecognizer {
     _HandlePointerEvent handlePointerEvent,
     this.gestureRecognizerFactories, {
     PointerDeviceKind? kind,
-  }) : super(kind: kind) {
+    Set<PointerDeviceKind>? kindSet,
+  }) : super(kind: kind, kindSet: kindSet) {
     team = GestureArenaTeam()
       ..captain = this;
     _gestureRecognizers = gestureRecognizerFactories.map(

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1384,6 +1384,7 @@ class _ThumbPressGestureRecognizer extends LongPressGestureRecognizer {
   _ThumbPressGestureRecognizer({
     double? postAcceptSlopTolerance,
     PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
     required Object debugOwner,
     required GlobalKey customPaintKey,
     required Duration pressDuration,
@@ -1391,6 +1392,7 @@ class _ThumbPressGestureRecognizer extends LongPressGestureRecognizer {
        super(
          postAcceptSlopTolerance: postAcceptSlopTolerance,
          kind: kind,
+         kindSet: kindSet,
          debugOwner: debugOwner,
          duration: pressDuration,
        );

--- a/packages/flutter/test/gestures/recognizer_test.dart
+++ b/packages/flutter/test/gestures/recognizer_test.dart
@@ -2,28 +2,50 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'gesture_tester.dart';
+
 class TestGestureRecognizer extends GestureRecognizer {
-  TestGestureRecognizer({ Object? debugOwner }) : super(debugOwner: debugOwner);
+  TestGestureRecognizer({
+    Object? debugOwner,
+    PointerDeviceKind? kind,
+    Set<PointerDeviceKind>? kindSet,
+    this.onAllowedPointer,
+    this.onNotAllowedPointer,
+  }) : super(debugOwner: debugOwner, kind: kind, kindSet: kindSet);
+
+  final ValueChanged<PointerDownEvent>? onAllowedPointer;
+  final ValueChanged<PointerDownEvent>? onNotAllowedPointer;
 
   @override
   String get debugDescription => 'debugDescription content';
 
   @override
-  void addPointer(PointerDownEvent event) { }
-
-  @override
   void acceptGesture(int pointer) { }
 
   @override
-  void rejectGesture(int pointer) { }
+  void rejectGesture(int pointer) {}
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    onAllowedPointer?.call(event);
+  }
+
+  @override
+  void handleNonAllowedPointer(PointerDownEvent event) {
+    onNotAllowedPointer?.call(event);
+  }
 }
 
 void main() {
+  setUp(ensureGestureBinding);
+
   test('GestureRecognizer smoketest', () {
-    final TestGestureRecognizer recognizer = TestGestureRecognizer(debugOwner: 0);
+    final TestGestureRecognizer recognizer =
+        TestGestureRecognizer(debugOwner: 0);
     expect(recognizer, hasAGoodToStringDeep);
   });
 
@@ -48,6 +70,78 @@ void main() {
     final OffsetPair difference = offset2 - offset1;
     expect(difference.local, const Offset(40, 40));
     expect(difference.global, const Offset(40, 40));
+  });
 
+  group('GestureRecognizer', () {
+    test('isPointerAllowed for a single kind', () {
+      PointerDownEvent? lastAllowedEvent;
+      PointerDownEvent? lastNotAllowedEvent;
+
+      final TestGestureRecognizer stylusOnlyGestureRecognizer =
+          TestGestureRecognizer(
+        kind: PointerDeviceKind.stylus,
+        onAllowedPointer: (PointerDownEvent event) {
+          lastAllowedEvent = event;
+        },
+        onNotAllowedPointer: (PointerDownEvent event) {
+          lastNotAllowedEvent = event;
+        },
+      );
+
+      final PointerDownEvent stylusPointerEvent = TestPointer(
+        0,
+        PointerDeviceKind.stylus,
+      ).down(Offset.zero);
+      stylusOnlyGestureRecognizer.addPointer(stylusPointerEvent);
+      expect(lastAllowedEvent, stylusPointerEvent);
+
+      final PointerDownEvent mousePointerEvent = TestPointer(
+        0,
+        PointerDeviceKind.mouse,
+      ).down(Offset.zero);
+      stylusOnlyGestureRecognizer.addPointer(mousePointerEvent);
+      expect(lastAllowedEvent, stylusPointerEvent);
+      expect(lastNotAllowedEvent, mousePointerEvent);
+    });
+
+    test('isPointerAllowed for a set of kinds', () {
+      PointerDownEvent? lastAllowedEvent;
+      PointerDownEvent? lastNotAllowedEvent;
+
+      final TestGestureRecognizer stylusOnlyGestureRecognizer =
+          TestGestureRecognizer(
+        kindSet: <PointerDeviceKind>{
+          PointerDeviceKind.mouse,
+          PointerDeviceKind.touch,
+        },
+        onAllowedPointer: (PointerDownEvent event) {
+          lastAllowedEvent = event;
+        },
+        onNotAllowedPointer: (PointerDownEvent event) {
+          lastNotAllowedEvent = event;
+        },
+      );
+
+      final PointerDownEvent stylusPointerEvent =
+          TestPointer(0, PointerDeviceKind.stylus).down(Offset.zero);
+      stylusOnlyGestureRecognizer.addPointer(stylusPointerEvent);
+      expect(lastNotAllowedEvent, stylusPointerEvent);
+
+      final PointerDownEvent mousePointerEvent = TestPointer(
+        0,
+        PointerDeviceKind.mouse,
+      ).down(Offset.zero);
+      stylusOnlyGestureRecognizer.addPointer(mousePointerEvent);
+      expect(lastNotAllowedEvent, stylusPointerEvent);
+      expect(lastAllowedEvent, mousePointerEvent);
+
+      final PointerDownEvent touchPointerEvent = TestPointer(
+        0,
+        PointerDeviceKind.touch,
+      ).down(Offset.zero);
+      stylusOnlyGestureRecognizer.addPointer(touchPointerEvent);
+      expect(lastNotAllowedEvent, stylusPointerEvent);
+      expect(lastAllowedEvent, touchPointerEvent);
+    });
   });
 }


### PR DESCRIPTION
Today, to specify what  `PointerDeviceKind` a gesture recognizer should accept, we have the "one or all" option, where you either have to support just one device kind by specifying a `kind` or support all kinds by omitting this param.

This PR aims to add the option to make a recognizer accept more than one kind. The core change is to make `GestureRecognizer` store a set of `PointerDeviceKind` as `_kindFilter` instead of just one `PointerDeviceKind`. 

In order to make this not to be a breaking change, I decided to keep `kind` as an option. I am not sure if it is valid to deprecate this option. 

This addresses the proposal on #78547.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
