### PR TITLE
Fixed a comment on line 2347 of ...material/scaffold.dart

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2344,7 +2344,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   ///
   ///   * [ScaffoldMessenger], this should be used instead to manage [SnackBar]s.
   @Deprecated(
-    'Use ScaffoldMessenger.hideCurrentSnackBar. '
+    'Use ScaffoldMessenger.of(context).hideCurrentSnackBar'
     'This feature was deprecated after v1.23.0-14.0.pre.'
   )
   void hideCurrentSnackBar({ SnackBarClosedReason reason = SnackBarClosedReason.hide }) {


### PR DESCRIPTION
It says to use "ScaffoldMessenger.hideCurrentSnackBar" instead of "hideCurrentSnackBar", but this errors. The suggestion actually needs to be: "ScaffoldMessenger.of(context).hideCurrentSnackBar"

Fixes #78865
