### PR TITLE
Exclude CI from tool root check

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -190,8 +190,8 @@ function shared::execute() {
       ;;
   esac
 
-  # Test if running as superuser – but don't warn if running within Docker
-  if [[ "$EUID" == "0" && ! -f /.dockerenv ]]; then
+  # Test if running as superuser – but don't warn if running within Docker or CI.
+  if [[ "$EUID" == "0" && ! -f /.dockerenv && "$CI" != "true" && "$BOT" != "true" && "$CONTINUOUS_INTEGRATION" != "true" ]]; then
     >&2 echo "   Woah! You appear to be trying to run flutter as root."
     >&2 echo "   We strongly recommend running the flutter tool without superuser privileges."
     >&2 echo "  /"


### PR DESCRIPTION
The root warning was showing up on the VM clusters because `.dockerenv` was no longer present: https://github.com/flutter/flutter/issues/78758#issuecomment-805045104
> We updated the clusters to use the latest recommended versions of VMs which use containerd . When a task is running on a containerd pod is .dockerenv file does not exist. I reverted that change back to use the previous VM versions using docker.

Add a few CI checks to suppress that warning.  Confirmed `sudo flutter` still shows the warning, and setting `CI=true` does not show it.

https://github.com/flutter/flutter/issues/78758