### PR TITLE
Add split Linux docs jobs to prod builder json

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -121,10 +121,16 @@
       "flaky": false
     },
     {
-      "name": "Linux docs",
+      "name": "Linux docs_test",
       "repo": "flutter",
-      "task_name": "linux_docs",
-      "flaky": false
+      "task_name": "linux_docs_test",
+      "flaky": true
+    },
+    {
+      "name": "Linux docs_publish",
+      "repo": "flutter",
+      "task_name": "linux_docs_publish",
+      "flaky": true
     },
     {
       "name": "Linux build_tests_1_2",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -32,20 +32,6 @@
       "enabled": true
     },
     {
-      "name": "Linux docs",
-      "repo": "flutter",
-      "task_name": "linux_docs",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_test/",
-        "packages/flutter_drive/",
-        "packages/flutter_localizations/",
-        "bin/"
-      ]
-    },
-    {
       "name": "Linux framework_tests_libraries",
       "repo": "flutter",
       "task_name": "linux_framework_tests_libraries",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -32,6 +32,20 @@
       "enabled": true
     },
     {
+      "name": "Linux docs",
+      "repo": "flutter",
+      "task_name": "linux_docs",
+      "enabled": true,
+      "run_if": [
+        "dev/",
+        "packages/flutter/",
+        "packages/flutter_test/",
+        "packages/flutter_drive/",
+        "packages/flutter_localizations/",
+        "bin/"
+      ]
+    },
+    {
       "name": "Linux framework_tests_libraries",
       "repo": "flutter",
       "task_name": "linux_framework_tests_libraries",


### PR DESCRIPTION
The `Linux docs` prod builder was split into [`Linux docs_test`](https://ci.chromium.org/p/flutter/builders/prod/Linux%20docs_test) and [`Linux docs_publish`](https://ci.chromium.org/p/flutter/builders/prod/Linux%20docs_publish) in https://github.com/flutter/infra/pull/375.  Add them to the framework builders json file.

`Linux docs` was showing up as not running:
![Screen Shot 2021-03-23 at 11 19 00 AM](https://user-images.githubusercontent.com/682784/112197881-c8e3ed00-8bc9-11eb-96be-8b9d65721f11.png)

Note the try job is still called [`Linux docs`](https://ci.chromium.org/p/flutter/builders/try/Linux%20docs).

Fixes https://github.com/flutter/flutter/issues/78887