### PR TITLE
Migrate flutter_tools os.dart to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -16,7 +16,6 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/user_messages.dart' hide userMessages;
 import '../base/version.dart';
-import '../build_info.dart';
 import '../convert.dart';
 import '../doctor.dart';
 import '../features.dart';

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -2,15 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
-import '../build_info.dart';
-import '../globals.dart' as globals;
 import 'common.dart';
 import 'file_system.dart';
 import 'io.dart';
@@ -20,10 +16,10 @@ import 'process.dart';
 
 abstract class OperatingSystemUtils {
   factory OperatingSystemUtils({
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
   }) {
     if (platform.isWindows) {
       return _WindowsUtils(
@@ -50,10 +46,10 @@ abstract class OperatingSystemUtils {
   }
 
   OperatingSystemUtils._private({
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
   }) : _fileSystem = fileSystem,
        _logger = logger,
        _platform = platform,
@@ -85,7 +81,7 @@ abstract class OperatingSystemUtils {
 
   /// Return the path (with symlinks resolved) to the given executable, or null
   /// if `which` was not able to locate the binary.
-  File which(String execName) {
+  File? which(String execName) {
     final List<File> result = _which(execName);
     if (result == null || result.isEmpty) {
       return null;
@@ -119,7 +115,7 @@ abstract class OperatingSystemUtils {
       'windows': 'Windows',
     };
     final String osName = _platform.operatingSystem;
-    return osNames.containsKey(osName) ? osNames[osName] : osName;
+    return osNames[osName] ?? osName;
   }
 
   HostPlatform get hostPlatform;
@@ -137,7 +133,7 @@ abstract class OperatingSystemUtils {
   /// its intended user.
   Future<int> findFreePort({bool ipv6 = false}) async {
     int port = 0;
-    ServerSocket serverSocket;
+    ServerSocket? serverSocket;
     final InternetAddress loopback =
         ipv6 ? InternetAddress.loopbackIPv6 : InternetAddress.loopbackIPv4;
     try {
@@ -163,10 +159,10 @@ abstract class OperatingSystemUtils {
 
 class _PosixUtils extends OperatingSystemUtils {
   _PosixUtils({
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
   }) : super._private(
     fileSystem: fileSystem,
     logger: logger,
@@ -261,7 +257,7 @@ class _PosixUtils extends OperatingSystemUtils {
   @override
   String get pathVarSeparator => ':';
 
-  HostPlatform _hostPlatform;
+  HostPlatform? _hostPlatform;
 
   @override
   HostPlatform get hostPlatform {
@@ -283,16 +279,16 @@ class _PosixUtils extends OperatingSystemUtils {
         _hostPlatform = HostPlatform.linux_arm64;
       }
     }
-    return _hostPlatform;
+    return _hostPlatform!;
   }
 }
 
 class _MacOSUtils extends _PosixUtils {
   _MacOSUtils({
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
   }) : super(
           fileSystem: fileSystem,
           logger: logger,
@@ -300,7 +296,7 @@ class _MacOSUtils extends _PosixUtils {
           processManager: processManager,
         );
 
-  String _name;
+  String? _name;
 
   @override
   String get name {
@@ -316,14 +312,14 @@ class _MacOSUtils extends _PosixUtils {
       }
       _name ??= super.name;
     }
-    return _name;
+    return _name!;
   }
 
   // On ARM returns arm64, even when this process is running in Rosetta.
   @override
   HostPlatform get hostPlatform {
     if (_hostPlatform == null) {
-      String sysctlPath;
+      String? sysctlPath;
       if (which('sysctl') == null) {
         // Fallback to known install locations.
         for (final String path in <String>[
@@ -342,7 +338,7 @@ class _MacOSUtils extends _PosixUtils {
         throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
       }
       final RunResult arm64Check =
-          _processUtils.runSync(<String>[sysctlPath, 'hw.optional.arm64']);
+          _processUtils.runSync(<String>[sysctlPath!, 'hw.optional.arm64']);
       // On arm64 stdout is "sysctl hw.optional.arm64: 1"
       // On x86 hw.optional.arm64 is unavailable and exits with 1.
       if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
@@ -351,16 +347,16 @@ class _MacOSUtils extends _PosixUtils {
         _hostPlatform = HostPlatform.darwin_x64;
       }
     }
-    return _hostPlatform;
+    return _hostPlatform!;
   }
 }
 
 class _WindowsUtils extends OperatingSystemUtils {
   _WindowsUtils({
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
   }) : super._private(
     fileSystem: fileSystem,
     logger: logger,
@@ -380,7 +376,7 @@ class _WindowsUtils extends OperatingSystemUtils {
   @override
   List<File> _which(String execName, { bool all = false }) {
     // `where` always returns all matches, not just the first one.
-    ProcessResult result;
+    ProcessResult? result;
     try {
       result = _processManager.runSync(<String>['where', execName]);
     } on ArgumentError {
@@ -392,10 +388,10 @@ class _WindowsUtils extends OperatingSystemUtils {
         'the terminal and/or IDE.'
       );
     }
-    if (result.exitCode != 0) {
+    if (result?.exitCode != 0) {
       return const <File>[];
     }
-    final List<String> lines = (result.stdout as String).trim().split('\n');
+    final List<String> lines = (result!.stdout as String).trim().split('\n');
     if (all) {
       return lines.map<File>((String path) => _fileSystem.file(path.trim())).toList();
     }
@@ -439,7 +435,7 @@ class _WindowsUtils extends OperatingSystemUtils {
     throw UnsupportedError('makePipe is not implemented on Windows.');
   }
 
-  String _name;
+  String? _name;
 
   @override
   String get name {
@@ -452,7 +448,7 @@ class _WindowsUtils extends OperatingSystemUtils {
         _name = super.name;
       }
     }
-    return _name;
+    return _name!;
   }
 
   @override
@@ -463,17 +459,40 @@ class _WindowsUtils extends OperatingSystemUtils {
 /// directory or the current working directory if none specified.
 /// Return null if the project root could not be found
 /// or if the project root is the flutter repository root.
-String findProjectRoot([ String directory ]) {
+String? findProjectRoot(FileSystem fileSystem, [ String? directory ]) {
   const String kProjectRootSentinel = 'pubspec.yaml';
-  directory ??= globals.fs.currentDirectory.path;
+  directory ??= fileSystem.currentDirectory.path;
   while (true) {
-    if (globals.fs.isFileSync(globals.fs.path.join(directory, kProjectRootSentinel))) {
+    if (fileSystem.isFileSync(fileSystem.path.join(directory!, kProjectRootSentinel))) {
       return directory;
     }
-    final String parent = globals.fs.path.dirname(directory);
+    final String parent = fileSystem.path.dirname(directory);
     if (directory == parent) {
       return null;
     }
     directory = parent;
+  }
+}
+
+enum HostPlatform {
+  darwin_x64,
+  darwin_arm,
+  linux_x64,
+  linux_arm64,
+  windows_x64,
+}
+
+String getNameForHostPlatform(HostPlatform platform) {
+  switch (platform) {
+    case HostPlatform.darwin_x64:
+      return 'darwin-x64';
+    case HostPlatform.darwin_arm:
+      return 'darwin-arm';
+    case HostPlatform.linux_x64:
+      return 'linux-x64';
+    case HostPlatform.linux_arm64:
+      return 'linux-arm64';
+    case HostPlatform.windows_x64:
+      return 'windows-x64';
   }
 }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -11,6 +11,7 @@ import 'base/config.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
+import 'base/os.dart';
 import 'base/utils.dart';
 import 'build_system/targets/icon_tree_shaker.dart';
 import 'convert.dart';
@@ -450,31 +451,6 @@ bool isAotBuildMode(BuildMode mode) {
 // Returns true if the given build mode can be used on emulators / simulators.
 bool isEmulatorBuildMode(BuildMode mode) {
   return mode == BuildMode.debug;
-}
-
-enum HostPlatform {
-  darwin_x64,
-  darwin_arm,
-  linux_x64,
-  linux_arm64,
-  windows_x64,
-}
-
-String getNameForHostPlatform(HostPlatform platform) {
-  switch (platform) {
-    case HostPlatform.darwin_x64:
-      return 'darwin-x64';
-    case HostPlatform.darwin_arm:
-      return 'darwin-arm';
-    case HostPlatform.linux_x64:
-      return 'linux-x64';
-    case HostPlatform.linux_arm64:
-      return 'linux-arm64';
-    case HostPlatform.windows_x64:
-      return 'windows-x64';
-  }
-  assert(false);
-  return null;
 }
 
 enum TargetPlatform {

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -145,6 +145,6 @@ class BuildAarCommand extends BuildSubCommand {
     if (argResults.rest.isEmpty) {
       return FlutterProject.current();
     }
-    return FlutterProject.fromDirectory(globals.fs.directory(findProjectRoot(argResults.rest.first)));
+    return FlutterProject.fromDirectory(globals.fs.directory(findProjectRoot(globals.fs, argResults.rest.first)));
   }
 }

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -84,7 +84,7 @@ class PackagesGetCommand extends FlutterCommand {
   Future<Map<CustomDimensions, String>> get usageValues async {
     final Map<CustomDimensions, String> usageValues = <CustomDimensions, String>{};
     final String workingDirectory = argResults.rest.length == 1 ? argResults.rest[0] : null;
-    final String target = findProjectRoot(workingDirectory);
+    final String target = findProjectRoot(globals.fs, workingDirectory);
     if (target == null) {
       return usageValues;
     }
@@ -154,7 +154,7 @@ class PackagesGetCommand extends FlutterCommand {
     }
 
     final String workingDirectory = argResults.rest.length == 1 ? argResults.rest[0] : null;
-    final String target = findProjectRoot(workingDirectory);
+    final String target = findProjectRoot(globals.fs, workingDirectory);
     if (target == null) {
       throwToolExit(
        'Expected to find project root in '
@@ -303,10 +303,10 @@ class PackagesInteractiveGetCommand extends FlutterCommand {
             rest[0].contains(r'\'))) {
       // HACK: Supporting flutter specific behavior where you can pass a
       //       folder to the command.
-      target = findProjectRoot(rest[0]);
+      target = findProjectRoot(globals.fs, rest[0]);
       rest = <String>[];
     } else {
-      target = findProjectRoot();
+      target = findProjectRoot(globals.fs);
     }
     if (target == null) {
       throwToolExit('Expected to find project root in '

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -305,7 +305,7 @@ class UpgradeCommandRunner {
   Future<void> updatePackages(FlutterVersion flutterVersion) async {
     globals.printStatus('');
     globals.printStatus(flutterVersion.toString());
-    final String projectRoot = findProjectRoot();
+    final String projectRoot = findProjectRoot(globals.fs);
     if (projectRoot != null) {
       globals.printStatus('');
       await pub.get(

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/utils.dart';
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/cmake.dart';
 import 'package:flutter_tools/src/commands/build.dart';

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/base/version.dart';
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:mockito/mockito.dart';
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/build_info.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -18,7 +18,6 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';


### PR DESCRIPTION
Hoist `HostPlatform` out of build_info.dart and into base so `os` can be migrated and break the circular dependency.  Remove globals from `os`.

Part of #71511