### PR TITLE
[flutter_tools] handle concurrent modification in signal callback

### DIFF
--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -104,17 +104,14 @@ class LocalSignals implements Signals {
   Future<bool> removeHandler(ProcessSignal signal, Object token) async {
     // We don't know about this signal.
     if (!_handlersTable.containsKey(signal)) {
-      print('no signal');
       return false;
     }
     // We don't know about this token.
     if (!_handlersTable[signal]!.containsKey(token)) {
-       print('no token');
       return false;
     }
     final SignalHandler? handler = _handlersTable[signal]!.remove(token);
     if (handler == null) {
-       print('no handle');
       return false;
     }
     final bool removed = _handlersList[signal]!.remove(handler);

--- a/packages/flutter_tools/lib/src/base/signals.dart
+++ b/packages/flutter_tools/lib/src/base/signals.dart
@@ -104,14 +104,17 @@ class LocalSignals implements Signals {
   Future<bool> removeHandler(ProcessSignal signal, Object token) async {
     // We don't know about this signal.
     if (!_handlersTable.containsKey(signal)) {
+      print('no signal');
       return false;
     }
     // We don't know about this token.
     if (!_handlersTable[signal]!.containsKey(token)) {
+       print('no token');
       return false;
     }
     final SignalHandler? handler = _handlersTable[signal]!.remove(token);
     if (handler == null) {
+       print('no handle');
       return false;
     }
     final bool removed = _handlersList[signal]!.remove(handler);
@@ -128,12 +131,16 @@ class LocalSignals implements Signals {
   }
 
   Future<void> _handleSignal(ProcessSignal s) async {
-    for (final SignalHandler handler in _handlersList[s] ?? <SignalHandler>[]) {
-      try {
-        await asyncGuard<void>(() async => handler(s));
-      } on Exception catch (e) {
-        if (_errorStreamController.hasListener) {
-          _errorStreamController.add(e);
+    final List<SignalHandler>? handlers = _handlersList[s];
+    if (handlers != null) {
+      final List<SignalHandler> handlersCopy = handlers.toList();
+      for (final SignalHandler handler in handlersCopy) {
+        try {
+          await asyncGuard<void>(() async => handler(s));
+        } on Exception catch (e) {
+          if (_errorStreamController.hasListener) {
+            _errorStreamController.add(e);
+          }
         }
       }
     }

--- a/packages/flutter_tools/test/general.shard/base/signals_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/signals_test.dart
@@ -56,6 +56,21 @@ void main() {
       await completer.future;
     });
 
+    testWithoutContext('signal handlers do not cause concurrent modification errors when removing handlers in a signal callback', () async {
+      final Completer<void> completer = Completer<void>();
+      Object token;
+      Future<void> handle(ProcessSignal s) async {
+        expect(s, signalUnderTest);
+        expect(await signals.removeHandler(signalUnderTest, token), true);
+        completer.complete();
+      }
+
+      token = signals.addHandler(signalUnderTest, handle);
+
+      fakeSignal.controller.add(fakeSignal);
+      await completer.future;
+    });
+
     testWithoutContext('signal handler error goes on error stream', () async {
       final Exception exn = Exception('Error');
       signals.addHandler(signalUnderTest, (ProcessSignal s) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/78906

Copy the list before iterating, so that removing a signal in a callback does not cause concurrent modification
