### PR TITLE
Migrate flutter_tool net.dart to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -21,13 +19,14 @@ typedef HttpClientFactory = HttpClient Function();
 
 typedef UrlTunneller = Future<String> Function(String url);
 
+/// If [httpClientFactory] is null, a default [HttpClient] is used.
 class Net {
   Net({
-    HttpClientFactory httpClientFactory,
-    @required Logger logger,
-    @required Platform platform,
+    HttpClientFactory? httpClientFactory,
+    required Logger logger,
+    required Platform platform,
   }) :
-    _httpClientFactory = httpClientFactory,
+    _httpClientFactory = httpClientFactory ?? (() => HttpClient()),
     _logger = logger,
     _platform = platform;
 
@@ -45,16 +44,16 @@ class Net {
   /// returns an empty list.
   ///
   /// If [maxAttempts] is exceeded, returns null.
-  Future<List<int>> fetchUrl(Uri url, {
-    int maxAttempts,
-    File destFile,
-    @visibleForTesting Duration durationOverride,
+  Future<List<int>?> fetchUrl(Uri url, {
+    int? maxAttempts,
+    File? destFile,
+    @visibleForTesting Duration? durationOverride,
   }) async {
     int attempts = 0;
     int durationSeconds = 1;
     while (true) {
       attempts += 1;
-      _MemoryIOSink memorySink;
+      _MemoryIOSink? memorySink;
       IOSink sink;
       if (destFile == null) {
         memorySink = _MemoryIOSink();
@@ -68,7 +67,7 @@ class Net {
         destSink: sink,
       );
       if (result) {
-        return memorySink?.writes?.takeBytes() ?? <int>[];
+        return memorySink?.writes.takeBytes() ?? <int>[];
       }
 
       if (maxAttempts != null && attempts >= maxAttempts) {
@@ -91,19 +90,14 @@ class Net {
 
   // Returns true on success and false on failure.
   Future<bool> _attempt(Uri url, {
-    IOSink destSink,
+    IOSink? destSink,
     bool onlyHeaders = false,
   }) async {
     assert(onlyHeaders || destSink != null);
     _logger.printTrace('Downloading: $url');
-    HttpClient httpClient;
-    if (_httpClientFactory != null) {
-      httpClient = _httpClientFactory();
-    } else {
-      httpClient = HttpClient();
-    }
+    final HttpClient httpClient = _httpClientFactory();
     HttpClientRequest request;
-    HttpClientResponse response;
+    HttpClientResponse? response;
     try {
       if (onlyHeaders) {
         request = await httpClient.headUrl(url);
@@ -112,7 +106,7 @@ class Net {
       }
       response = await request.close();
     } on ArgumentError catch (error) {
-      final String overrideUrl = _platform.environment['FLUTTER_STORAGE_BASE_URL'];
+      final String? overrideUrl = _platform.environment['FLUTTER_STORAGE_BASE_URL'];
       if (overrideUrl != null && url.toString().contains(overrideUrl)) {
         _logger.printError(error.toString());
         throwToolExit(
@@ -144,9 +138,9 @@ class Net {
     // If we're making a HEAD request, we're only checking to see if the URL is
     // valid.
     if (onlyHeaders) {
-      return response.statusCode == HttpStatus.ok;
+      return response!.statusCode == HttpStatus.ok;
     }
-    if (response.statusCode != HttpStatus.ok) {
+    if (response!.statusCode != HttpStatus.ok) {
       if (response.statusCode > 0 && response.statusCode < 500) {
         throwToolExit(
           'Download failed.\n'
@@ -162,7 +156,7 @@ class Net {
     _logger.printTrace('Received response from server, collecting bytes...');
     try {
       assert(destSink != null);
-      await response.forEach(destSink.add);
+      await response.forEach(destSink!.add);
       return true;
     } on IOException catch (error) {
       _logger.printTrace('Download error: $error');
@@ -199,12 +193,12 @@ class _MemoryIOSink implements IOSink {
   }
 
   @override
-  void write(Object obj) {
+  void write(Object? obj) {
     add(encoding.encode('$obj'));
   }
 
   @override
-  void writeln([ Object obj = '' ]) {
+  void writeln([ Object? obj = '' ]) {
     add(encoding.encode('$obj\n'));
   }
 
@@ -221,7 +215,7 @@ class _MemoryIOSink implements IOSink {
   }
 
   @override
-  void addError(dynamic error, [ StackTrace stackTrace ]) {
+  void addError(dynamic error, [ StackTrace? stackTrace ]) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -8,7 +8,6 @@ import '../android/gradle_utils.dart' as gradle;
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../base/net.dart';
 import '../base/terminal.dart';
 import '../convert.dart';
@@ -91,7 +90,7 @@ class CreateCommand extends CreateBase {
   // Lazy-initialize the net utilities with values from the context.
   Net _cachedNet;
   Net get _net => _cachedNet ??= Net(
-    httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
+    httpClientFactory: context.get<HttpClientFactory>(),
     logger: globals.logger,
     platform: globals.platform,
   );

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -11,7 +11,6 @@ import 'package:meta/meta.dart';
 import '../base/common.dart';
 import '../base/context.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/net.dart';
 import '../cache.dart';
@@ -145,7 +144,7 @@ class UpdatePackagesCommand extends FlutterCommand {
   // Lazy-initialize the net utilities with values from the context.
   Net _cachedNet;
   Net get _net => _cachedNet ??= Net(
-    httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
+    httpClientFactory: context.get<HttpClientFactory>(),
     logger: globals.logger,
     platform: globals.platform,
   );


### PR DESCRIPTION
Push `HttpClient` default fallback into the initializer.

Part of #71511