### PR TITLE
[flutter_tools] throwToolExit should return Never

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -452,7 +452,6 @@ class AndroidLicenseValidator extends DoctorValidator {
         e.toString(),
         _platform,
       ));
-      return false;
     }
   }
 

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -1083,7 +1083,6 @@ String _getLocalArtifactVersion(String pomPath, FileSystem fileSystem) {
     }
   }
   throwToolExit('Error while parsing the <version> element from $pomPath');
-  return null;
 }
 
 /// Returns the local Maven repository for a local engine build.

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -65,7 +65,6 @@ class GradleUtils {
       'Unable to locate gradlew script. Please check that ${gradle.path} '
       'exists or that ${gradle.dirname} can be read.'
     );
-    return null;
   }
 
   /// Injects the Gradle wrapper files if any of these files don't exist in [directory].
@@ -180,7 +179,6 @@ String getGradleVersionFor(String androidPluginVersion) {
     return '6.7';
   }
   throwToolExit('Unsupported Android Plugin version: $androidPluginVersion.');
-  return '';
 }
 
 /// Overwrite local.properties in the specified Flutter project's Android

--- a/packages/flutter_tools/lib/src/base/common.dart
+++ b/packages/flutter_tools/lib/src/base/common.dart
@@ -6,7 +6,7 @@
 /// where the tool should exit with a clear message to the user
 /// and no stack trace unless the --verbose option is specified.
 /// For example: network errors.
-void throwToolExit(String message, { int? exitCode }) {
+Never throwToolExit(String message, { int? exitCode }) {
   throw ToolExit(message, exitCode: exitCode);
 }
 

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -76,7 +76,6 @@ class DartDevelopmentService {
         } on StateError {
           if (e.message.contains('Existing VM service clients prevent DDS from taking control.')) {
             throwToolExit('${e.message}. Please rebuild your application with a newer version of Flutter.');
-            return;
           }
           logger.printError(
             'DDS has failed to start and there is not an existing DDS instance '

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -338,7 +338,7 @@ class _MacOSUtils extends _PosixUtils {
         throwToolExit('sysctl not found. Try adding it to your PATH environment variable.');
       }
       final RunResult arm64Check =
-          _processUtils.runSync(<String>[sysctlPath!, 'hw.optional.arm64']);
+          _processUtils.runSync(<String>[sysctlPath, 'hw.optional.arm64']);
       // On arm64 stdout is "sysctl hw.optional.arm64: 1"
       // On x86 hw.optional.arm64 is unavailable and exits with 1.
       if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
@@ -376,7 +376,7 @@ class _WindowsUtils extends OperatingSystemUtils {
   @override
   List<File> _which(String execName, { bool all = false }) {
     // `where` always returns all matches, not just the first one.
-    ProcessResult? result;
+    ProcessResult result;
     try {
       result = _processManager.runSync(<String>['where', execName]);
     } on ArgumentError {
@@ -388,10 +388,10 @@ class _WindowsUtils extends OperatingSystemUtils {
         'the terminal and/or IDE.'
       );
     }
-    if (result?.exitCode != 0) {
+    if (result.exitCode != 0) {
       return const <File>[];
     }
-    final List<String> lines = (result!.stdout as String).trim().split('\n');
+    final List<String> lines = (result.stdout as String).trim().split('\n');
     if (all) {
       return lines.map<File>((String path) => _fileSystem.file(path.trim())).toList();
     }

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -149,7 +149,6 @@ known, it can be explicitly provided to attach via the command-line, e.g.
     } on Exception catch (error) {
       throwToolExit('Invalid port for `--debug-port`: $error');
     }
-    return null;
   }
 
   Uri get debugUri {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -220,7 +220,6 @@ class UpgradeCommandRunner {
         'Error: $error.'
       );
     }
-    return false;
   }
 
   /// Returns the remote HEAD flutter version.

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -622,13 +622,11 @@ class FuchsiaDevice extends Device {
     final RunResult findResult = await shell(findCommand);
     if (findResult.exitCode != 0) {
       throwToolExit("'$findCommand' on device $name failed. stderr: '${findResult.stderr}'");
-      return null;
     }
     final String findOutput = findResult.stdout;
     if (findOutput.trim() == '') {
       throwToolExit(
           'No Dart Observatories found. Are you running a debug build?');
-      return null;
     }
     final List<int> ports = <int>[];
     for (final String path in findOutput.split('\n')) {
@@ -639,7 +637,6 @@ class FuchsiaDevice extends Device {
       final RunResult lsResult = await shell(lsCommand);
       if (lsResult.exitCode != 0) {
         throwToolExit("'$lsCommand' on device $name failed");
-        return null;
       }
       final String lsOutput = lsResult.stdout;
       for (final String line in lsOutput.split('\n')) {
@@ -715,7 +712,6 @@ class FuchsiaDevice extends Device {
       }
     }
     throwToolExit('No ports found running $isolateName');
-    return null;
   }
 
   FuchsiaIsolateDiscoveryProtocol getIsolateDiscoveryProtocol(String isolateName) {

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -563,7 +563,6 @@ class ResidentWebRunner extends ResidentRunner {
       appFailedToStart();
       rethrow;
     }
-    return 0;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -392,7 +392,6 @@ class CocoaPods {
               'To regenerate the Podfile, run:\n'
               '$podfileIosMigrationInstructions\n',
         );
-        return;
       }
     }
     // Most of the pod and plugin parsing logic was moved from the Podfile

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -378,7 +378,6 @@ abstract class FlutterCommand extends Command<void> {
     } on FormatException catch (error) {
       throwToolExit('Invalid port for `--observatory-port/--host-vmservice-port`: $error');
     }
-    return null;
   }
 
   int get ddsPort {
@@ -440,7 +439,6 @@ abstract class FlutterCommand extends Command<void> {
     } on FormatException catch (error) {
       throwToolExit('Invalid port for `--device-vmservice-port`: $error');
     }
-    return null;
   }
 
   void addPublishPort({ bool enabledByDefault = true, bool verboseHelp = false }) {

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -112,7 +112,6 @@ class Template {
     } on FileSystemException catch (err) {
       _logger.printError(err.toString());
       throwToolExit('Failed to flutter create at ${destination.path}.');
-      return 0;
     }
     int fileCount = 0;
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -638,7 +638,6 @@ class BrowserManager {
     return completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
       chrome.close();
       throwToolExit('Timed out waiting for ${runtime.name} to connect.');
-      return;
     });
   }
 

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -81,7 +81,6 @@ String findChromeExecutable(Platform platform, FileSystem fileSystem) {
     return fileSystem.path.join(windowsPrefix, kWindowsExecutable);
   }
   throwToolExit('Platform ${platform.operatingSystem} is not supported.');
-  return null;
 }
 
 /// Find the Microsoft Edge executable on the current platform.

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -241,7 +241,6 @@ void main() {
       final DummyFlutterCommand flutterCommand = DummyFlutterCommand(
         commandFunction: () async {
           throwToolExit('fail');
-          return null; // unreachable
         }
       );
       try {
@@ -469,7 +468,6 @@ void main() {
       final DummyFlutterCommand flutterCommand = DummyFlutterCommand(
         commandFunction: () async {
           throwToolExit('fail');
-          return null; // unreachable
         },
       );
 


### PR DESCRIPTION
Minor cleanup, to make `throwToolExit` return `Never`, allowing better static analysis.