### PR TITLE
[SliverAppBar] Improve dartpad sample in documentation

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1306,9 +1306,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///               ),
 ///             ),
 ///             const SliverToBoxAdapter(
-///               child: Center(
-///                 child: SizedBox(
-///                   height: 20,
+///               child: SizedBox(
+///                 height: 20,
+///                 child: Center(
 ///                   child: const Text('Scroll to see the SliverAppBar in effect.'),
 ///                 ),
 ///               ),

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1308,11 +1308,25 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///             const SliverToBoxAdapter(
 ///               child: Center(
 ///                 child: SizedBox(
-///                   height: 2000,
+///                   height: 20,
 ///                   child: const Text('Scroll to see SliverAppBar in effect .'),
 ///                 ),
 ///               ),
 ///             ),
+///             SliverList(
+///              delegate: SliverChildBuilderDelegate(
+///                (BuildContext context, int index) {
+///                  return Container(
+///                    color: index % 2 == 0 ? Colors.white : Colors.black12,
+///                    height: 100.0,
+///                    child: Center(
+///                      child: Text('$index', textScaleFactor: 5),
+///                    ),
+///                  );
+///                },
+///                childCount: 20,
+///              ),
+///            ),
 ///           ],
 ///         ),
 ///         bottomNavigationBar: BottomAppBar(

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1288,7 +1288,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///   bool _floating = false;
 ///
 ///  // [SliverAppBar]s are typically used in [CustomScrollView.slivers], which in
-///  // turn is placed in [Scaffold.body]
+///  // turn can be placed in a [Scaffold.body].
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
@@ -1353,7 +1353,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                     onChanged: (bool val) {
 ///                       setState(() {
 ///                         _snap = val;
-///                         // Snapping only applies when the app bar is floating
+///                         // Snapping only applies when the app bar is floating.
 ///                         _floating = _floating || val;
 ///                       });
 ///                     },

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1287,8 +1287,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///   bool _snap = false;
 ///   bool _floating = false;
 ///
-///   // SliverAppBar is declared in Scaffold.body, in slivers of a
-///   // CustomScrollView.
+///  // [SliverAppBar]s are typically used in [CustomScrollView.slivers], which in
+///  // turn is placed in [Scaffold.body]
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return MaterialApp(
@@ -1309,7 +1309,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///               child: Center(
 ///                 child: SizedBox(
 ///                   height: 20,
-///                   child: const Text('Scroll to see SliverAppBar in effect .'),
+///                   child: const Text('Scroll to see the sliverAppBar in effect.'),
 ///                 ),
 ///               ),
 ///             ),
@@ -1353,7 +1353,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                     onChanged: (bool val) {
 ///                       setState(() {
 ///                         _snap = val;
-///                         //Snapping only applies when the app bar is floating.
+///                         // Snapping only applies when the app bar is floating
 ///                         _floating = _floating || val;
 ///                       });
 ///                     },

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1309,7 +1309,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///               child: Center(
 ///                 child: SizedBox(
 ///                   height: 20,
-///                   child: const Text('Scroll to see the sliverAppBar in effect.'),
+///                   child: const Text('Scroll to see the SliverAppBar in effect.'),
 ///                 ),
 ///               ),
 ///             ),
@@ -1317,7 +1317,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///              delegate: SliverChildBuilderDelegate(
 ///                (BuildContext context, int index) {
 ///                  return Container(
-///                    color: index % 2 == 0 ? Colors.white : Colors.black12,
+///                    color: index.isOdd ? Colors.white : Colors.black12,
 ///                    height: 100.0,
 ///                    child: Center(
 ///                      child: Text('$index', textScaleFactor: 5),

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1264,125 +1264,107 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// ```
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=freeform}
-///
-/// This sample shows a [SliverAppBar] and it's behaviors when using the [pinned], [snap] and [floating] parameters.
-///
-/// ```dart imports
-/// import 'package:flutter/material.dart';
-/// ```
+/// {@tool dartpad --template=stateful_widget_material}
+/// This sample shows a [SliverAppBar] and it's behavior when using the
+/// [pinned], [snap] and [floating] parameters.
 ///
 /// ```dart
-/// void main() => runApp(const MyApp());
+/// bool _pinned = true;
+/// bool _snap = false;
+/// bool _floating = false;
 ///
-/// class MyApp extends StatefulWidget {
-///   const MyApp({Key? key}) : super(key: key);
-///
-///   @override
-///   State<StatefulWidget> createState() => _MyAppState();
-/// }
-///
-/// class _MyAppState extends State<MyApp> {
-///   bool _pinned = true;
-///   bool _snap = false;
-///   bool _floating = false;
-///
-///  // [SliverAppBar]s are typically used in [CustomScrollView.slivers], which in
-///  // turn can be placed in a [Scaffold.body].
-///   @override
-///   Widget build(BuildContext context) {
-///     return MaterialApp(
-///       home: Scaffold(
-///         body: CustomScrollView(
-///           slivers: <Widget>[
-///             SliverAppBar(
-///               pinned: _pinned,
-///               snap: _snap,
-///               floating: _floating,
-///               expandedHeight: 160.0,
-///               flexibleSpace: const FlexibleSpaceBar(
-///                 title: Text('SliverAppBar'),
-///                 background: FlutterLogo(),
-///               ),
-///             ),
-///             const SliverToBoxAdapter(
-///               child: SizedBox(
-///                 height: 20,
-///                 child: Center(
-///                   child: const Text('Scroll to see the SliverAppBar in effect.'),
-///                 ),
-///               ),
-///             ),
-///             SliverList(
-///              delegate: SliverChildBuilderDelegate(
-///                (BuildContext context, int index) {
-///                  return Container(
-///                    color: index.isOdd ? Colors.white : Colors.black12,
-///                    height: 100.0,
-///                    child: Center(
-///                      child: Text('$index', textScaleFactor: 5),
-///                    ),
-///                  );
-///                },
-///                childCount: 20,
-///              ),
-///            ),
-///           ],
+/// // [SliverAppBar]s are typically used in [CustomScrollView.slivers], which in
+/// // turn can be placed in a [Scaffold.body].
+/// @override
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     body: CustomScrollView(
+///       slivers: <Widget>[
+///         SliverAppBar(
+///           pinned: _pinned,
+///           snap: _snap,
+///           floating: _floating,
+///           expandedHeight: 160.0,
+///           flexibleSpace: const FlexibleSpaceBar(
+///             title: Text('SliverAppBar'),
+///             background: FlutterLogo(),
+///           ),
 ///         ),
-///         bottomNavigationBar: BottomAppBar(
-///           child: ButtonBar(
-///             alignment: MainAxisAlignment.spaceEvenly,
+///         const SliverToBoxAdapter(
+///           child: SizedBox(
+///             height: 20,
+///             child: Center(
+///               child: const Text('Scroll to see the SliverAppBar in effect.'),
+///             ),
+///           ),
+///         ),
+///         SliverList(
+///          delegate: SliverChildBuilderDelegate(
+///            (BuildContext context, int index) {
+///              return Container(
+///                color: index.isOdd ? Colors.white : Colors.black12,
+///                height: 100.0,
+///                child: Center(
+///                  child: Text('$index', textScaleFactor: 5),
+///                ),
+///              );
+///            },
+///            childCount: 20,
+///          ),
+///        ),
+///       ],
+///     ),
+///     bottomNavigationBar: BottomAppBar(
+///       child: ButtonBar(
+///         alignment: MainAxisAlignment.spaceEvenly,
+///         children: <Widget>[
+///           Row(
 ///             children: <Widget>[
-///               Row(
-///                 children: <Widget>[
-///                   const Text('pinned'),
-///                   Switch(
-///                     onChanged: (bool val) {
-///                       setState(() {
-///                         _pinned = val;
-///                       });
-///                     },
-///                     value: _pinned,
-///                   ),
-///                 ],
-///               ),
-///               Row(
-///                 children: <Widget>[
-///                   const Text('snap'),
-///                   Switch(
-///                     onChanged: (bool val) {
-///                       setState(() {
-///                         _snap = val;
-///                         // Snapping only applies when the app bar is floating.
-///                         _floating = _floating || _snap;
-///                       });
-///                     },
-///                     value: _snap,
-///                   ),
-///                 ],
-///               ),
-///               Row(
-///                 children: <Widget>[
-///                   const Text('floating'),
-///                   Switch(
-///                     onChanged: (bool val) {
-///                       setState(() {
-///                         _floating = val;
-///                         _snap = _snap && _floating;
-///                       });
-///                     },
-///                     value: _floating,
-///                   ),
-///                 ],
+///               const Text('pinned'),
+///               Switch(
+///                 onChanged: (bool val) {
+///                   setState(() {
+///                     _pinned = val;
+///                   });
+///                 },
+///                 value: _pinned,
 ///               ),
 ///             ],
 ///           ),
-///         ),
+///           Row(
+///             children: <Widget>[
+///               const Text('snap'),
+///               Switch(
+///                 onChanged: (bool val) {
+///                   setState(() {
+///                     _snap = val;
+///                     // Snapping only applies when the app bar is floating.
+///                     _floating = _floating || _snap;
+///                   });
+///                 },
+///                 value: _snap,
+///               ),
+///             ],
+///           ),
+///           Row(
+///             children: <Widget>[
+///               const Text('floating'),
+///               Switch(
+///                 onChanged: (bool val) {
+///                   setState(() {
+///                     _floating = val;
+///                     _snap = _snap && _floating;
+///                   });
+///                 },
+///                 value: _floating,
+///               ),
+///             ],
+///           ),
+///         ],
 ///       ),
-///     );
-///   }
+///     ),
+///   );
 /// }
-///
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1354,7 +1354,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                       setState(() {
 ///                         _snap = val;
 ///                         // Snapping only applies when the app bar is floating.
-///                         _floating = _floating || val;
+///                         _floating = _floating || _snap;
 ///                       });
 ///                     },
 ///                     value: _snap,
@@ -1368,11 +1368,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///                     onChanged: (bool val) {
 ///                       setState(() {
 ///                         _floating = val;
-///                         if (_snap == true) {
-///                           if (_floating != true) {
-///                             _snap = false;
-///                           }
-///                         }
+///                         _snap = _snap && _floating;
 ///                       });
 ///                     },
 ///                     value: _floating,


### PR DESCRIPTION
This PR improves the [dartpad sample](https://master-api.flutter.dev/flutter/material/SliverAppBar-class.html#material.SliverAppBar.2) of `SliverAppBar` to include a `SliverList` to provide feedback that the inner scroll view is being scrolled.

|Before|After|
|-------|------|
|![dartpad_before](https://user-images.githubusercontent.com/44899587/112355593-d1384700-8cf3-11eb-9f66-18c55e3d2e4e.gif)|![after](https://user-images.githubusercontent.com/44899587/112355665-e2815380-8cf3-11eb-974f-064643a425d6.gif)|

## Related Issues
Fixes #78985.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
