### PR TITLE
InteractiveViewer should call onInteractionUpdate even when gesture is disabled

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -253,7 +253,8 @@ class InteractiveViewer extends StatefulWidget {
   /// Called when the user ends a pan or scale gesture on the widget.
   ///
   /// At the time this is called, the [TransformationController] will have
-  /// already been updated to reflect the change caused by the interaction.
+  /// already been updated to reflect the change caused by the interaction,
+  /// though a pan may cause an inertia animation after this is called as well.
   ///
   /// {@template flutter.widgets.InteractiveViewer.onInteractionEnd}
   /// Will be called even if the interaction is disabled with [panEnabled] or
@@ -781,12 +782,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // Handle an update to an ongoing gesture. All of pan, scale, and rotate are
   // handled with GestureDetector's scale gesture.
   void _onScaleUpdate(ScaleUpdateDetails details) {
-    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
-      focalPoint: details.focalPoint,
-      localFocalPoint: details.localFocalPoint,
-      scale: details.scale,
-      rotation: details.rotation,
-    ));
     final double scale = _transformationController!.value.getMaxScaleOnAxis();
     final Offset focalPointScene = _transformationController!.toScene(
       details.localFocalPoint,
@@ -802,6 +797,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       _gestureType ??= _getGestureType(details);
     }
     if (!_gestureIsSupported(_gestureType)) {
+      widget.onInteractionUpdate?.call(details);
       return;
     }
 
@@ -877,6 +873,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         );
         break;
     }
+    widget.onInteractionUpdate?.call(details);
   }
 
   // Handle the end of a gesture of _GestureType. All of pan, scale, and rotate

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -295,7 +295,8 @@ class InteractiveViewer extends StatefulWidget {
   /// Called when the user updates a pan or scale gesture on the widget.
   ///
   /// At the time this is called, the [TransformationController] will have
-  /// already been updated to reflect the change caused by the interaction.
+  /// already been updated to reflect the change caused by the interaction, if
+  /// the interation caused the matrix to change.
   ///
   /// {@macro flutter.widgets.InteractiveViewer.onInteractionEnd}
   ///
@@ -841,6 +842,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
 
       case _GestureType.rotate:
         if (details.rotation == 0.0) {
+          widget.onInteractionUpdate?.call(details);
           return;
         }
         final double desiredRotation = _rotationStart! + details.rotation;
@@ -858,6 +860,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         // In an effort to keep the behavior similar whether or not scaleEnabled
         // is true, these gestures are thrown away.
         if (details.scale != 1.0) {
+          widget.onInteractionUpdate?.call(details);
           return;
         }
         _panAxis ??= _getPanAxis(_referenceFocalPoint!, focalPointScene);

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -781,6 +781,12 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
   // Handle an update to an ongoing gesture. All of pan, scale, and rotate are
   // handled with GestureDetector's scale gesture.
   void _onScaleUpdate(ScaleUpdateDetails details) {
+    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
+      focalPoint: details.focalPoint,
+      localFocalPoint: details.localFocalPoint,
+      scale: details.scale,
+      rotation: details.rotation,
+    ));
     final double scale = _transformationController!.value.getMaxScaleOnAxis();
     final Offset focalPointScene = _transformationController!.toScene(
       details.localFocalPoint,
@@ -871,12 +877,6 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         );
         break;
     }
-    widget.onInteractionUpdate?.call(ScaleUpdateDetails(
-      focalPoint: details.focalPoint,
-      localFocalPoint: details.localFocalPoint,
-      scale: details.scale,
-      rotation: details.rotation,
-    ));
   }
 
   // Handle the end of a gesture of _GestureType. All of pan, scale, and rotate

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart' show Quad, Vector3, Matrix4;
@@ -758,7 +759,7 @@ void main() {
       expect(scenePoint.dy, greaterThan(0.0));
     });
 
-    testWidgets('onInteraction is called even when disabled', (WidgetTester tester) async{
+    testWidgets('onInteraction is called even when disabled (touch)', (WidgetTester tester) async {
       final TransformationController transformationController = TransformationController();
       bool calledStart = false;
       bool calledUpdate = false;
@@ -829,6 +830,55 @@ void main() {
       expect(calledStart, isTrue);
       expect(calledUpdate, isTrue);
       expect(calledEnd, isTrue);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }));
+
+    testWidgets('onInteraction is called even when disabled (mouse)', (WidgetTester tester) async {
+      final TransformationController transformationController = TransformationController();
+      bool calledStart = false;
+      bool calledUpdate = false;
+      bool calledEnd = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                transformationController: transformationController,
+                scaleEnabled: false,
+                onInteractionStart: (ScaleStartDetails details) {
+                  calledStart = true;
+                },
+                onInteractionUpdate: (ScaleUpdateDetails details) {
+                  calledUpdate = true;
+                },
+                onInteractionEnd: (ScaleEndDetails details) {
+                  calledEnd = true;
+                },
+                child: const SizedBox(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Offset childOffset = tester.getTopLeft(find.byType(SizedBox));
+      final Offset childInterior = Offset(
+        childOffset.dx + 20.0,
+        childOffset.dy + 20.0,
+      );
+      final TestGesture gesture = await tester.startGesture(childOffset, kind: PointerDeviceKind.mouse);
+
+      // Attempting to pan doesn't work because it's disabled, but the
+      // interaction methods are still called.
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.moveTo(childInterior);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(transformationController.value, equals(Matrix4.identity()));
+      expect(calledStart, isTrue);
+      expect(calledUpdate, isTrue);
+      expect(calledEnd, isTrue);
 
       // Attempting to scroll with a mouse to zoom doesn't work because it's
       // disabled, but the interaction methods are still called.
@@ -841,7 +891,7 @@ void main() {
       expect(calledStart, isTrue);
       expect(calledUpdate, isTrue);
       expect(calledEnd, isTrue);
-    });
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS, TargetPlatform.linux, TargetPlatform.windows }));
 
     testWidgets('viewport changes size', (WidgetTester tester) async {
       final TransformationController transformationController = TransformationController();

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -829,6 +829,18 @@ void main() {
       expect(calledStart, isTrue);
       expect(calledUpdate, isTrue);
       expect(calledEnd, isTrue);
+
+      // Attempting to scroll with a mouse to zoom doesn't work because it's
+      // disabled, but the interaction methods are still called.
+      calledStart = false;
+      calledUpdate = false;
+      calledEnd = false;
+      await scrollAt(childInterior, tester, const Offset(0.0, -20.0));
+      await tester.pumpAndSettle();
+      expect(transformationController.value, equals(Matrix4.identity()));
+      expect(calledStart, isTrue);
+      expect(calledUpdate, isTrue);
+      expect(calledEnd, isTrue);
     });
 
     testWidgets('viewport changes size', (WidgetTester tester) async {


### PR DESCRIPTION
InteractiveViewer provides onInteractionStart/Update/End events so that users can get information about gestures happening on the child without running into problems with overlapping GestureDetectors.  This information should be provided even when the gesture is disabled, and it is documented as such.  However, onInteractionUpdate wasn't being called.  This PR fixes it.

Closes https://github.com/flutter/flutter/issues/77455