### PR TITLE
Manually close the tree

### DIFF
--- a/dev/devicelab/bin/tasks/microbenchmarks_ios.dart
+++ b/dev/devicelab/bin/tasks/microbenchmarks_ios.dart
@@ -10,4 +10,6 @@ import 'package:flutter_devicelab/tasks/microbenchmarks.dart';
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(createMicrobenchmarkTask());
+  // TODO(jmagman): https://github.com/flutter/flutter/issues/78917
+  throw Exception('Tree closed, see https://github.com/flutter/flutter/issues/78917');
 }


### PR DESCRIPTION
GitHub quota problem is not running LUCI tasks in presubmit.  Manually close the tree until it's resolved.
https://github.com/flutter/flutter/issues/78917