### PR TITLE
[ci] Run same script to analyze plugins as flutter/plugins.

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -840,20 +840,8 @@ Future<void> _runFlutterPluginsTests() async {
       workingDirectory: checkout.path,
     );
     await runCommand(
-      pub,
+      './script/incremental_build.sh',
       <String>[
-        'global',
-        'activate',
-        'flutter_plugin_tools',
-      ],
-      workingDirectory: checkout.path,
-    );
-    await runCommand(
-      pub,
-      <String>[
-        'global',
-        'run',
-        'flutter_plugin_tools',
         'analyze',
       ],
       workingDirectory: checkout.path,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -845,6 +845,9 @@ Future<void> _runFlutterPluginsTests() async {
         'analyze',
       ],
       workingDirectory: checkout.path,
+      environment: <String, String>{
+        'BRANCH_NAME': 'master',
+      },
     );
   }
   await selectSubshard(<String, ShardRunner>{


### PR DESCRIPTION
This change runs flutter/plugins tests with the same code that is used in flutter/plugins.

The current method (flutter_plugin_tools) is being deprecated.

Fixes https://github.com/flutter/flutter/issues/78994

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
