### PR TITLE
Updated TimePickerThemeData API doc

### DIFF
--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -126,8 +126,8 @@ class TimePickerThemeData with Diagnosticable {
   /// text color can depend on the [MaterialState.selected] state, i.e. if the
   /// text is selected or not.
   ///
-  /// By default the overall theme's `textTheme` color is used when the text is
-  /// selected and `accentTextTheme` color is used when it's not selected.
+  /// If this color is null then the dial's text colors are based on the
+  /// theme's [ThemeData.colorScheme].
   final Color? dialTextColor;
 
   /// The color of the entry mode [IconButton].


### PR DESCRIPTION
Removed a vestigial reference to accentTextTheme in TimePickerThemeData.dialTextColor's API doc per https://github.com/flutter/flutter/issues/56918.

The new doc doesn't make the ColorScheme dependency explicit, i.e. it doesn't explain how the TimePicker uses the derived primary and secondary label colors or which ColorScheme colors they're based on, because doing so seemed to be of marginal value.