### PR TITLE
Removed unnecessary ! in net.dart

### DIFF
--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -138,9 +138,9 @@ class Net {
     // If we're making a HEAD request, we're only checking to see if the URL is
     // valid.
     if (onlyHeaders) {
-      return response!.statusCode == HttpStatus.ok;
+      return response.statusCode == HttpStatus.ok;
     }
-    if (response!.statusCode != HttpStatus.ok) {
+    if (response.statusCode != HttpStatus.ok) {
       if (response.statusCode > 0 && response.statusCode < 500) {
         throwToolExit(
           'Download failed.\n'


### PR DESCRIPTION
Not sure how this slipped through the analyzer in #78922.

```
warning • The '!' will have no effect because the receiver can't be null • packages/flutter_tools/lib/src/base/net.dart:141:22 • unnecessary_non_null_assertion
warning • The '!' will have no effect because the receiver can't be null • packages/flutter_tools/lib/src/base/net.dart:143:17 • unnecessary_non_null_assertion
```