### PR TITLE
Split globals.dart into null safe and unsafe libraries

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/bundle.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/reporting/reporting.dart';
 
 const String _kOptionPackages = 'packages';

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -10,7 +10,7 @@ import '../base/io.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
 import '../base/version.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../ios/plist_parser.dart';
 
 AndroidStudio get androidStudio => context.get<AndroidStudio>();

--- a/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
@@ -12,7 +12,7 @@ import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../template.dart';
 import 'deferred_components_validator.dart';

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -113,7 +113,7 @@ class AppContext {
 
   /// Gets the value associated with the specified [type], or `null` if no
   /// such value has been associated.
-  T get<T>() {
+  T? get<T>() {
     dynamic value = _generateIfNecessary(T, _overrides);
     if (value == null && _parent != null) {
       value = _parent!.get<T>();

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -5,7 +5,7 @@
 import 'context.dart';
 import 'platform.dart';
 
-UserMessages get userMessages => context.get<UserMessages>();
+UserMessages get userMessages => context.get<UserMessages>()!;
 
 /// Class containing message strings that can be produced by Flutter tools.
 class UserMessages {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -15,7 +15,7 @@ import 'base/os.dart';
 import 'base/utils.dart';
 import 'build_system/targets/icon_tree_shaker.dart';
 import 'convert.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 
 /// Information about a build to be performed or used.
 class BuildInfo {

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -9,7 +9,7 @@ import '../../base/build.dart';
 import '../../base/deferred_component.dart';
 import '../../base/file_system.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals hide fs, artifacts, logger, processManager;
+import '../../globals.dart' as globals show platform, printError, xcode;
 import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -12,7 +12,7 @@ import '../../base/file_system.dart';
 import '../../build_info.dart';
 import '../../compile.dart';
 import '../../dart/package_map.dart';
-import '../../globals.dart' as globals hide fs, processManager, artifacts, logger;
+import '../../globals.dart' as globals show xcode;
 import '../build_system.dart';
 import '../depfile.dart';
 import '../exceptions.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -12,7 +12,7 @@ import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals hide fs, logger, processManager, artifacts;
+import '../../globals.dart' as globals show xcode;
 import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../build_system.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -10,7 +10,7 @@ import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/process.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals hide fs, logger, artifacts, processManager;
+import '../../globals.dart' as globals show xcode;
 import '../build_system.dart';
 import '../depfile.dart';
 import '../exceptions.dart';

--- a/packages/flutter_tools/lib/src/commands/analyze_base.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_base.dart
@@ -18,7 +18,7 @@ import '../base/terminal.dart';
 import '../base/utils.dart';
 import '../cache.dart';
 import '../dart/analysis.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 
 /// Common behavior for `flutter analyze` and `flutter analyze --watch`
 abstract class AnalyzeBase {

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -8,7 +8,7 @@ import '../base/common.dart';
 import '../build_info.dart';
 import '../bundle.dart';
 import '../features.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -12,7 +12,7 @@ import '../cache.dart';
 import '../features.dart';
 import '../fuchsia/fuchsia_build.dart';
 import '../fuchsia/fuchsia_pm.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
 import 'build.dart';

--- a/packages/flutter_tools/lib/src/commands/build_winuwp.dart
+++ b/packages/flutter_tools/lib/src/commands/build_winuwp.dart
@@ -10,7 +10,7 @@ import '../base/common.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../features.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;
 import '../windows/build_windows.dart';

--- a/packages/flutter_tools/lib/src/commands/generate.dart
+++ b/packages/flutter_tools/lib/src/commands/generate.dart
@@ -4,7 +4,7 @@
 
 // @dart = 2.8
 
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class GenerateCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -7,7 +7,7 @@
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../localizations/gen_l10n.dart';
 import '../localizations/gen_l10n_types.dart';
 import '../localizations/localizations_utils.dart';

--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -7,7 +7,7 @@
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../template.dart';
 

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -9,7 +9,7 @@ import '../application_package.dart';
 import '../base/common.dart';
 import '../base/io.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -10,7 +10,7 @@ import '../base/common.dart';
 import '../base/io.dart';
 import '../cache.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class LogsCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -10,7 +10,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../convert.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -8,7 +8,7 @@ import 'package:completion/completion.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class ShellCompletionCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -16,7 +16,7 @@ import '../bundle.dart';
 import '../cache.dart';
 import '../devfs.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart';
 import '../test/coverage_collector.dart';

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -15,7 +15,7 @@ import '../base/logger.dart';
 import '../base/net.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 /// Map from package name to package version, used to artificially pin a pub

--- a/packages/flutter_tools/lib/src/fuchsia/application_package.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/application_package.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 
 abstract class FuchsiaApp extends ApplicationPackage {

--- a/packages/flutter_tools/lib/src/fuchsia/tiles_ctl.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/tiles_ctl.dart
@@ -5,7 +5,7 @@
 // @dart = 2.8
 
 import '../base/process.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 
 import 'fuchsia_device.dart';
 

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -4,35 +4,21 @@
 
 // @dart = 2.8
 
-import 'package:process/process.dart';
-
 import 'android/android_sdk.dart';
 import 'android/android_studio.dart';
 import 'android/gradle_utils.dart';
 import 'artifacts.dart';
 import 'base/bot_detector.dart';
-import 'base/config.dart';
 import 'base/context.dart';
-import 'base/error_handling_io.dart';
-import 'base/file_system.dart';
 import 'base/io.dart';
-import 'base/logger.dart';
 import 'base/net.dart';
-import 'base/os.dart';
-import 'base/platform.dart';
-import 'base/process.dart';
-import 'base/signals.dart';
-import 'base/template.dart';
-import 'base/terminal.dart';
-import 'base/time.dart';
-import 'base/user_messages.dart';
 import 'build_system/build_system.dart';
 import 'cache.dart';
 import 'device.dart';
 import 'doctor.dart';
 import 'fuchsia/fuchsia_sdk.dart';
+import 'globals_null_migrated.dart' as globals;
 import 'ios/ios_workflow.dart';
-import 'ios/plist_parser.dart';
 import 'ios/simulators.dart';
 import 'ios/xcodeproj.dart';
 import 'macos/cocoapods.dart';
@@ -44,54 +30,27 @@ import 'reporting/reporting.dart';
 import 'runner/local_engine.dart';
 import 'version.dart';
 
+export 'globals_null_migrated.dart';
+
 Artifacts get artifacts => context.get<Artifacts>();
 BuildSystem get buildSystem => context.get<BuildSystem>();
 Cache get cache => context.get<Cache>();
-Config get config => context.get<Config>();
 CrashReporter get crashReporter => context.get<CrashReporter>();
 Doctor get doctor => context.get<Doctor>();
-HttpClientFactory get httpClientFactory => context.get<HttpClientFactory>();
-Logger get logger => context.get<Logger>();
-OperatingSystemUtils get os => context.get<OperatingSystemUtils>();
 PersistentToolState get persistentToolState => PersistentToolState.instance;
-Signals get signals => context.get<Signals>() ?? LocalSignals.instance;
 Usage get flutterUsage => context.get<Usage>();
 DeviceManager get deviceManager => context.get<DeviceManager>();
 
 FlutterProjectFactory get projectFactory {
   return context.get<FlutterProjectFactory>() ?? FlutterProjectFactory(
-    logger: logger,
-    fileSystem: fs,
+    logger: globals.logger,
+    fileSystem: globals.fs,
   );
 }
 
 CocoaPodsValidator get cocoapodsValidator => context.get<CocoaPodsValidator>();
 
 LocalEngineLocator get localEngineLocator => context.get<LocalEngineLocator>();
-
-/// Currently active implementation of the file system.
-///
-/// By default it uses local disk-based implementation. Override this in tests
-/// with [MemoryFileSystem].
-FileSystem get fs => ErrorHandlingFileSystem(
-  delegate: context.get<FileSystem>() ?? localFileSystem,
-  platform: platform,
-);
-
-FileSystemUtils get fsUtils => context.get<FileSystemUtils>() ?? FileSystemUtils(
-  fileSystem: fs,
-  platform: platform,
-);
-
-const ProcessManager _kLocalProcessManager = LocalProcessManager();
-
-/// The active process manager.
-ProcessManager get processManager => context.get<ProcessManager>() ?? _kLocalProcessManager;
-ProcessUtils get processUtils => context.get<ProcessUtils>();
-
-const Platform _kLocalPlatform = LocalPlatform();
-
-Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
 
 AndroidStudio get androidStudio => context.get<AndroidStudio>();
 AndroidSdk get androidSdk => context.get<AndroidSdk>();
@@ -100,22 +59,14 @@ FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 FuchsiaArtifacts get fuchsiaArtifacts => context.get<FuchsiaArtifacts>();
 IOSSimulatorUtils get iosSimulatorUtils => context.get<IOSSimulatorUtils>();
 IOSWorkflow get iosWorkflow => context.get<IOSWorkflow>();
-UserMessages get userMessages => context.get<UserMessages>();
 Xcode get xcode => context.get<Xcode>();
 XcodeProjectInterpreter get xcodeProjectInterpreter => context.get<XcodeProjectInterpreter>();
 
 XCDevice get xcdevice => context.get<XCDevice>();
 
-final OutputPreferences _default = OutputPreferences(
-  wrapText: stdio.hasTerminal ?? false,
-  showColor:  platform.stdoutSupportsAnsi,
-  stdio: stdio,
-);
-OutputPreferences get outputPreferences => context.get<OutputPreferences>() ?? _default;
-
 final BotDetector _defaultBotDetector = BotDetector(
   httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
-  platform: platform,
+  platform: globals.platform,
   persistentToolState: persistentToolState,
 );
 
@@ -123,105 +74,5 @@ BotDetector get botDetector => context.get<BotDetector>() ?? _defaultBotDetector
 
 Future<bool> get isRunningOnBot => botDetector.isRunningOnBot;
 
-/// The current system clock instance.
-SystemClock get systemClock => context.get<SystemClock>();
-
-ProcessInfo get processInfo => context.get<ProcessInfo>();
-
-/// Display an error level message to the user. Commands should use this if they
-/// fail in some way.
-///
-/// Set [emphasis] to true to make the output bold if it's supported.
-/// Set [color] to a [TerminalColor] to color the output, if the logger
-/// supports it. The [color] defaults to [TerminalColor.red].
-void printError(
-  String message, {
-  StackTrace stackTrace,
-  bool emphasis,
-  TerminalColor color,
-  int indent,
-  int hangingIndent,
-  bool wrap,
-}) {
-  logger.printError(
-    message,
-    stackTrace: stackTrace,
-    emphasis: emphasis ?? false,
-    color: color,
-    indent: indent,
-    hangingIndent: hangingIndent,
-    wrap: wrap,
-  );
-}
-
-/// Display normal output of the command. This should be used for things like
-/// progress messages, success messages, or just normal command output.
-///
-/// Set `emphasis` to true to make the output bold if it's supported.
-///
-/// Set `newline` to false to skip the trailing linefeed.
-///
-/// If `indent` is provided, each line of the message will be prepended by the
-/// specified number of whitespaces.
-void printStatus(
-  String message, {
-  bool emphasis,
-  bool newline,
-  TerminalColor color,
-  int indent,
-  int hangingIndent,
-  bool wrap,
-}) {
-  logger.printStatus(
-    message,
-    emphasis: emphasis ?? false,
-    color: color,
-    newline: newline ?? true,
-    indent: indent,
-    hangingIndent: hangingIndent,
-    wrap: wrap,
-  );
-}
-
-/// Use this for verbose tracing output. Users can turn this output on in order
-/// to help diagnose issues with the toolchain or with their setup.
-void printTrace(String message) => logger.printTrace(message);
-
-AnsiTerminal get terminal {
-  return context?.get<AnsiTerminal>() ?? _defaultAnsiTerminal;
-}
-
-final AnsiTerminal _defaultAnsiTerminal = AnsiTerminal(
-  stdio: stdio,
-  platform: platform,
-);
-
-/// The global Stdio wrapper.
-Stdio get stdio => context.get<Stdio>() ?? (_stdioInstance ??= Stdio());
-Stdio _stdioInstance;
-
-PlistParser get plistParser => context.get<PlistParser>() ?? (
-  _plistInstance ??= PlistParser(
-    fileSystem: fs,
-    processManager: processManager,
-    logger: logger,
-));
-PlistParser _plistInstance;
-
-/// The global template renderer.
-TemplateRenderer get templateRenderer => context.get<TemplateRenderer>();
-
 /// Gradle utils in the current [AppContext].
 GradleUtils get gradleUtils => context.get<GradleUtils>();
-
-ShutdownHooks get shutdownHooks => context.get<ShutdownHooks>();
-
-// Unless we're in a test of this class's signal handling features, we must
-// have only one instance created with the singleton LocalSignals instance
-// and the catchable signals it considers to be fatal.
-LocalFileSystem _instance;
-LocalFileSystem get localFileSystem => _instance ??= LocalFileSystem(
-  LocalSignals.instance,
-  Signals.defaultExitSignals,
-  shutdownHooks,
-);

--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -1,0 +1,161 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:process/process.dart';
+
+import 'base/config.dart';
+import 'base/context.dart';
+import 'base/error_handling_io.dart';
+import 'base/file_system.dart';
+import 'base/io.dart';
+import 'base/logger.dart';
+import 'base/net.dart';
+import 'base/os.dart';
+import 'base/platform.dart';
+import 'base/process.dart';
+import 'base/signals.dart';
+import 'base/template.dart';
+import 'base/terminal.dart';
+import 'base/time.dart';
+import 'base/user_messages.dart';
+import 'ios/plist_parser.dart';
+
+Config get config => context.get<Config>()!;
+HttpClientFactory get httpClientFactory => context.get<HttpClientFactory>()!;
+Logger get logger => context.get<Logger>()!;
+OperatingSystemUtils get os => context.get<OperatingSystemUtils>()!;
+Signals get signals => context.get<Signals>() ?? LocalSignals.instance;
+
+/// Currently active implementation of the file system.
+///
+/// By default it uses local disk-based implementation. Override this in tests
+/// with [MemoryFileSystem].
+FileSystem get fs => ErrorHandlingFileSystem(
+  delegate: context.get<FileSystem>() ?? localFileSystem,
+  platform: platform,
+);
+
+FileSystemUtils get fsUtils => context.get<FileSystemUtils>() ?? FileSystemUtils(
+  fileSystem: fs,
+  platform: platform,
+);
+
+const ProcessManager _kLocalProcessManager = LocalProcessManager();
+
+/// The active process manager.
+ProcessManager get processManager => context.get<ProcessManager>() ?? _kLocalProcessManager;
+ProcessUtils get processUtils => context.get<ProcessUtils>()!;
+
+const Platform _kLocalPlatform = LocalPlatform();
+Platform get platform => context.get<Platform>() ?? _kLocalPlatform;
+
+UserMessages get userMessages => context.get<UserMessages>()!;
+
+final OutputPreferences _default = OutputPreferences(
+  wrapText: stdio.hasTerminal,
+  showColor:  platform.stdoutSupportsAnsi,
+  stdio: stdio,
+);
+OutputPreferences get outputPreferences => context.get<OutputPreferences>() ?? _default;
+
+/// The current system clock instance.
+SystemClock get systemClock => context.get<SystemClock>() ?? _systemClock;
+SystemClock _systemClock = const SystemClock();
+
+ProcessInfo get processInfo => context.get<ProcessInfo>()!;
+
+/// Display an error level message to the user. Commands should use this if they
+/// fail in some way.
+///
+/// Set [emphasis] to true to make the output bold if it's supported.
+/// Set [color] to a [TerminalColor] to color the output, if the logger
+/// supports it. The [color] defaults to [TerminalColor.red].
+void printError(
+  String message, {
+  StackTrace? stackTrace,
+  bool? emphasis,
+  TerminalColor? color,
+  int? indent,
+  int? hangingIndent,
+  bool? wrap,
+}) {
+  logger.printError(
+    message,
+    stackTrace: stackTrace,
+    emphasis: emphasis ?? false,
+    color: color,
+    indent: indent,
+    hangingIndent: hangingIndent,
+    wrap: wrap,
+  );
+}
+
+/// Display normal output of the command. This should be used for things like
+/// progress messages, success messages, or just normal command output.
+///
+/// Set `emphasis` to true to make the output bold if it's supported.
+///
+/// Set `newline` to false to skip the trailing linefeed.
+///
+/// If `indent` is provided, each line of the message will be prepended by the
+/// specified number of whitespaces.
+void printStatus(
+  String message, {
+  bool? emphasis,
+  bool? newline,
+  TerminalColor? color,
+  int? indent,
+  int? hangingIndent,
+  bool? wrap,
+}) {
+  logger.printStatus(
+    message,
+    emphasis: emphasis ?? false,
+    color: color,
+    newline: newline ?? true,
+    indent: indent,
+    hangingIndent: hangingIndent,
+    wrap: wrap,
+  );
+}
+
+/// Use this for verbose tracing output. Users can turn this output on in order
+/// to help diagnose issues with the toolchain or with their setup.
+void printTrace(String message) => logger.printTrace(message);
+
+AnsiTerminal get terminal {
+  return context.get<AnsiTerminal>() ?? _defaultAnsiTerminal;
+}
+
+final AnsiTerminal _defaultAnsiTerminal = AnsiTerminal(
+  stdio: stdio,
+  platform: platform,
+);
+
+/// The global Stdio wrapper.
+Stdio get stdio => context.get<Stdio>() ?? (_stdioInstance ??= Stdio());
+Stdio? _stdioInstance;
+
+PlistParser get plistParser => context.get<PlistParser>() ?? (
+  _plistInstance ??= PlistParser(
+    fileSystem: fs,
+    processManager: processManager,
+    logger: logger,
+));
+PlistParser? _plistInstance;
+
+/// The global template renderer.
+TemplateRenderer get templateRenderer => context.get<TemplateRenderer>()!;
+
+ShutdownHooks? get shutdownHooks => context.get<ShutdownHooks>();
+
+// Unless we're in a test of this class's signal handling features, we must
+// have only one instance created with the singleton LocalSignals instance
+// and the catchable signals it considers to be fatal.
+LocalFileSystem? _instance;
+LocalFileSystem get localFileSystem => _instance ??= LocalFileSystem(
+  LocalSignals.instance,
+  Signals.defaultExitSignals,
+  shutdownHooks,
+);

--- a/packages/flutter_tools/lib/src/linux/application_package.dart
+++ b/packages/flutter_tools/lib/src/linux/application_package.dart
@@ -10,7 +10,7 @@ import '../application_package.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../cmake.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 
 abstract class LinuxApp extends ApplicationPackage {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -10,7 +10,7 @@ import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../convert.dart';
 import '../flutter_manifest.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 
 import 'gen_l10n_templates.dart';
 import 'gen_l10n_types.dart';

--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -11,7 +11,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../ios/plist_parser.dart';
 import '../project.dart';
 

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -12,7 +12,7 @@ import 'base/common.dart';
 import 'base/file_system.dart';
 import 'build_info.dart';
 import 'device.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 import 'resident_devtools_handler.dart';
 import 'resident_runner.dart';
 import 'tracing.dart';

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -12,7 +12,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/process.dart';
 import '../base/utils.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../vmservice.dart';
 
 import 'test_device.dart';

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -19,7 +19,7 @@ import '../compile.dart';
 import '../convert.dart';
 import '../dart/language_version.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../test/test_wrapper.dart';
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
@@ -12,7 +12,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../convert.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import 'test_compiler.dart';
 import 'test_config.dart';
 

--- a/packages/flutter_tools/lib/src/windows/application_package.dart
+++ b/packages/flutter_tools/lib/src/windows/application_package.dart
@@ -11,7 +11,7 @@ import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../cmake.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 
 abstract class WindowsApp extends ApplicationPackage {

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/assemble.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -18,7 +18,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwader.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/resident_runner.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -35,16 +35,10 @@ void main() {
     group('general', () {
       MemoryFileSystem fs;
       Directory buildDirectory;
-      FlutterProject projectUnderTest;
 
-      setUp(() {
-        fs = MemoryFileSystem.test();
-
-        final Directory currentDirectory = fs.currentDirectory;
-        buildDirectory = currentDirectory.childDirectory('build');
-        buildDirectory.createSync(recursive: true);
-
-        projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
+      FlutterProject setupProjectUnderTest(Directory currentDirectory) {
+        // This needs to be run within testWithoutContext and not setUp since FlutterProject uses context.
+        final FlutterProject projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
         projectUnderTest.ios.xcodeWorkspace.createSync(recursive: true);
         projectUnderTest.macos.xcodeWorkspace.createSync(recursive: true);
 
@@ -65,9 +59,20 @@ void main() {
         projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
         projectUnderTest.flutterPluginsFile.createSync(recursive: true);
         projectUnderTest.flutterPluginsDependenciesFile.createSync(recursive: true);
+
+        return projectUnderTest;
+      }
+
+      setUp(() {
+        fs = MemoryFileSystem.test();
+
+        final Directory currentDirectory = fs.currentDirectory;
+        buildDirectory = currentDirectory.childDirectory('build');
+        buildDirectory.createSync(recursive: true);
       });
 
       testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode', () async {
+        final FlutterProject projectUnderTest = setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
         when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
         when(mockXcodeProjectInterpreter.majorVersion).thenReturn(1000);
@@ -102,6 +107,7 @@ void main() {
       });
 
       testUsingContext('$CleanCommand cleans Xcode verbosely', () async {
+        setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
         when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
         when(mockXcodeProjectInterpreter.majorVersion).thenReturn(1000);

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/config.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:test/fake.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/create_usage_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -66,7 +66,7 @@ void main() {
       });
     });
 
-    test('set template type as usage value', () => testbed.run(() async {
+    testUsingContext('set template type as usage value', () => testbed.run(() async {
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -83,7 +83,7 @@ void main() {
       expect(await command.usageValues, containsPair(CustomDimensions.commandCreateProjectType, 'plugin'));
     }));
 
-    test('set iOS host language type as usage value', () => testbed.run(() async {
+    testUsingContext('set iOS host language type as usage value', () => testbed.run(() async {
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
@@ -104,7 +104,7 @@ void main() {
 
     }));
 
-    test('set Android host language type as usage value', () => testbed.run(() async {
+    testUsingContext('set Android host language type as usage value', () => testbed.run(() async {
       final CreateCommand command = CreateCommand();
       final CommandRunner<void> runner = createTestCommandRunner(command);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/ios_workflow.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -22,7 +22,7 @@ import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vscode/vscode.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/ide_config_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/template.dart';
 import 'package:flutter_tools/src/commands/ide_config.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/shell_completion.dart';
 import 'package:process/process.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_aar.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:test/fake.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_apk.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 

--- a/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_appbundle.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:process/process.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
@@ -8,7 +8,7 @@ import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/format.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/upgrade.dart';
 import 'package:flutter_tools/src/convert.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/version.dart';

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/android/android_studio.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:test/fake.dart';
 

--- a/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/doctor.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/android/gradle_errors.dart';
 import 'package:flutter_tools/src/android/gradle_utils.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/fuchsia/application_package.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/project.dart';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
@@ -12,7 +12,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -12,7 +12,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/devfs.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -12,7 +12,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -6,7 +6,7 @@
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
@@ -7,7 +7,7 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:process/process.dart';
 
 import '../../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/devtools_launcher.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -32,7 +32,7 @@ import 'package:flutter_tools/src/fuchsia/fuchsia_pm.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
 import 'package:flutter_tools/src/fuchsia/tiles_ctl.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/ios/code_signing.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwader.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/simulators.dart';

--- a/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/macos/application_package.dart';
 import 'package:mockito/mockito.dart';
 

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/features.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/plugins.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -1307,7 +1307,7 @@ flutter:
         projectDir.childFile('pubspec.yaml')..createSync(recursive: true)..writeAsStringSync(yamlString);
       }
 
-      test('validatePubspecForPlugin works', () async {
+      testUsingContext('validatePubspecForPlugin works', () async {
         const String pluginYaml = '''
   flutter:
     plugin:
@@ -1333,7 +1333,7 @@ flutter:
         ], androidIdentifier: 'AndroidPackage', webFileName: 'lib/SomeFile.dart');
       });
 
-      test('createPlatformsYamlMap should create the correct map', () async {
+      testUsingContext('createPlatformsYamlMap should create the correct map', () async {
         final YamlMap map = Plugin.createPlatformsYamlMap(<String>['ios', 'android', 'linux'], 'PluginClass', 'some.android.package');
         expect(map['ios'], <String, String> {
           'pluginClass' : 'PluginClass'
@@ -1347,7 +1347,7 @@ flutter:
         });
       });
 
-      test('createPlatformsYamlMap should create empty map', () async {
+      testUsingContext('createPlatformsYamlMap should create empty map', () async {
         final YamlMap map = Plugin.createPlatformsYamlMap(<String>[], null, null);
         expect(map.isEmpty, true);
       });

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -8,6 +8,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -16,7 +17,7 @@ import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
@@ -809,10 +810,16 @@ void _testInMemory(String description, Future<void> Function() testMethod) {
     ..writeAsStringSync('{"configVersion":2,"packages":[]}');
   // Transfer needed parts of the Flutter installation folder
   // to the in-memory file system used during testing.
+  final Logger logger = BufferLogger.test();
   transfer(Cache(
     fileSystem: globals.fs,
-    logger: globals.logger,
-    osUtils: globals.os,
+    logger: logger,
+    osUtils: OperatingSystemUtils(
+      fileSystem: globals.fs,
+      logger: logger,
+      platform: globals.platform,
+      processManager: globals.processManager,
+    ),
     platform: globals.platform,
   ).getArtifactDirectory('gradle_wrapper'), testFileSystem);
   transfer(globals.fs.directory(Cache.flutterRoot)
@@ -840,11 +847,6 @@ void _testInMemory(String description, Future<void> Function() testMethod) {
     ],
   }));
 
-  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(
-    fileSystem: testFileSystem,
-    logger: globals.logger ?? BufferLogger.test(),
-  );
-
   testUsingContext(
     description,
     testMethod,
@@ -853,11 +855,14 @@ void _testInMemory(String description, Future<void> Function() testMethod) {
       ProcessManager: () => FakeProcessManager.any(),
       Cache: () => Cache(
         logger: globals.logger,
-        fileSystem: globals.fs,
+        fileSystem: testFileSystem,
         osUtils: globals.os,
         platform: globals.platform,
       ),
-      FlutterProjectFactory: () => flutterProjectFactory,
+      FlutterProjectFactory: () => FlutterProjectFactory(
+        fileSystem: testFileSystem,
+        logger: globals.logger ?? BufferLogger.test(),
+      ),
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/testbed_test.dart
+++ b/packages/flutter_tools/test/general.shard/testbed_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
 import 'package:flutter_tools/src/base/process.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/testbed.dart';

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
@@ -7,7 +7,7 @@
 import 'dart:convert';
 
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/test/flutter_web_goldens.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
@@ -9,7 +9,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_tools/src/test/flutter_web_goldens.dart';
 import 'package:flutter_tools/src/test/test_compiler.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
 

--- a/packages/flutter_tools/test/general.shard/web/web_expression_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_expression_compiler_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/isolated/devfs_web.dart';
 import 'package:matcher/matcher.dart';
 import 'package:mockito/mockito.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/testbed.dart';

--- a/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
@@ -51,10 +51,11 @@ void main() {
       .map(_asFile);
     for (final File file in files) {
       for (final String line in file.readAsLinesSync()) {
-        if (line.startsWith(RegExp(r'import.*globals.dart'))
-         && !line.contains(r'as globals')) {
+        if ((line.startsWith(RegExp(r'import.*globals.dart')) ||
+                line.startsWith(RegExp(r'import.*globals_null_migrated.dart'))) &&
+            !line.contains(r'as globals')) {
           final String relativePath = fileSystem.path.relative(file.path, from:flutterTools);
-          fail('$relativePath imports globals.dart without a globals prefix.');
+          fail('$relativePath imports globals_null_migrated.dart or globals.dart without a globals prefix.');
         }
       }
     }

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -8,7 +8,7 @@ import 'dart:io' as io;
 
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -6,7 +6,7 @@
 
 import 'package:meta/meta.dart';
 
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/android/android_builder.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -21,7 +21,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/doctor.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:flutter_tools/src/vmservice.dart';

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -31,7 +31,7 @@ import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/android/android_sdk.dart' show AndroidSdk;
 import 'package:flutter_tools/src/base/file_system.dart' hide IOSink;
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/flutter_tools/test/src/pubspec_schema.dart
+++ b/packages/flutter_tools/test/src/pubspec_schema.dart
@@ -6,7 +6,7 @@
 
 import 'package:flutter_tools/src/flutter_manifest.dart';
 import 'package:meta/meta.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:yaml/yaml.dart';
 import 'common.dart';
 

--- a/packages/flutter_tools/test/src/testbed.dart
+++ b/packages/flutter_tools/test/src/testbed.dart
@@ -21,7 +21,7 @@ import 'package:flutter_tools/src/context_runner.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:process/process.dart';
 
 import 'context.dart';

--- a/packages/flutter_tools/tool/global_count.dart
+++ b/packages/flutter_tools/tool/global_count.dart
@@ -5,32 +5,39 @@
 import 'dart:io';
 import 'package:path/path.dart' as path;
 
-/// Count the number of libraries that import globals.dart in lib and test.
+/// Count the number of libraries that import globals_null_migrated.dart and globals.dart in lib and test.
 ///
 /// This must be run from the flutter_tools project root directory.
 void main() {
   final Directory sources = Directory(path.join(Directory.current.path, 'lib'));
   final Directory tests = Directory(path.join(Directory.current.path, 'test'));
-  final int sourceGlobals = countGlobalImports(sources);
-  final int testGlobals = countGlobalImports(tests);
-  print('lib/ contains $sourceGlobals libraries with global usage');
-  print('test/ contains $testGlobals libraries with global usage');
+  countGlobalImports(sources);
+  countGlobalImports(tests);
 }
 
-final RegExp globalImport = RegExp('import.*globals.dart\' as globals;');
+final RegExp globalImport = RegExp(r"import.*(?:globals|globals_null_migrated)\.dart' as globals;");
+final RegExp globalNullUnsafeImport = RegExp('import.*globals.dart\' as globals;');
 
-int countGlobalImports(Directory directory) {
+void countGlobalImports(Directory directory) {
   int count = 0;
+  int nullUnsafeImportCount = 0;
   for (final FileSystemEntity file in directory.listSync(recursive: true)) {
     if (!file.path.endsWith('.dart') || file is! File) {
       continue;
     }
-    final bool hasImport = file.readAsLinesSync().any((String line) {
+    final List<String> fileLines = file.readAsLinesSync();
+    final bool hasImport = fileLines.any((String line) {
       return globalImport.hasMatch(line);
     });
     if (hasImport) {
       count += 1;
     }
+    final bool hasUnsafeImport = fileLines.any((String line) {
+      return globalNullUnsafeImport.hasMatch(line);
+    });
+    if (hasUnsafeImport) {
+      nullUnsafeImportCount += 1;
+    }
   }
-  return count;
+  print('${path.basename(directory.path)} contains $count libraries with global usage ($nullUnsafeImportCount unsafe)');
 }


### PR DESCRIPTION
The globals library imports lots of still-null unsafe libraries, and is imported from 103 flutter_tool libraries, some of which would otherwise be null safe migratable.

Split globals.dart into two libraries: a `globals_null_migrated.dart` null safe migrated library and `globals.dart` null unsafe library.  Update imports to `globals.dart` -> `globals_null_migrated.dart` where possible.  Export `globals_null_migrated` in `globals` to avoid g3 breakage.

Update globals_count script to also count how many imports are null unsafe.
```
lib contains 103 libraries with global usage (68 unsafe)
test contains 66 libraries with global usage (21 unsafe)
```

Part of #71511