### PR TITLE
[flutter_test] make showKeyboard respect finder's skipOffstage value

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -1031,7 +1031,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
       final EditableTextState editable = state<EditableTextState>(
         find.descendant(
           of: finder,
-          matching: find.byType(EditableText),
+          matching: find.byType(EditableText, skipOffstage: finder.skipOffstage),
           matchRoot: true,
         ),
       );

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -611,25 +611,42 @@ void main() {
     });
   });
 
-  testWidgets('showKeyboard can be called twice', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Center(
-            child: TextFormField(),
+  group('showKeyboard', () {
+    testWidgets('can be called twice', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: TextFormField(),
+            ),
           ),
         ),
-      ),
-    );
-    await tester.showKeyboard(find.byType(TextField));
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pump();
-    await tester.showKeyboard(find.byType(TextField));
-    await tester.testTextInput.receiveAction(TextInputAction.done);
-    await tester.pump();
-    await tester.showKeyboard(find.byType(TextField));
-    await tester.showKeyboard(find.byType(TextField));
-    await tester.pump();
+      );
+      await tester.showKeyboard(find.byType(TextField));
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      await tester.showKeyboard(find.byType(TextField));
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      await tester.showKeyboard(find.byType(TextField));
+      await tester.showKeyboard(find.byType(TextField));
+      await tester.pump();
+    });
+
+    testWidgets(
+      'can focus on offstage text input field if finder says not to skip offstage nodes',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Offstage(
+                child: TextFormField(),
+              ),
+            ),
+          ),
+        );
+        await tester.showKeyboard(find.byType(TextField, skipOffstage: false));
+      });
   });
 
   testWidgets('verifyTickersWereDisposed control test', (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixes an issue where during widget tests, offstage input text fields can be located but can't be focused on (via [`showKeyboard()`](https://api.flutter.dev/flutter/flutter_test/WidgetTester/showKeyboard.html) or [`enterText()`](https://api.flutter.dev/flutter/flutter_test/WidgetTester/enterText.html), whose implementation calls `showKeyboard()`.

This would close https://github.com/flutter/flutter/issues/79033 and fix involves having the implementation of `showKeyboard()` respect the value of `skipOffstage` property of the finder that is passed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
