### PR TITLE
[flutter_tools] separate concept of null safe language version from current language version

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -14,6 +14,7 @@ import '../../artifacts.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../build_info.dart';
+import '../../cache.dart';
 import '../../dart/language_version.dart';
 import '../../dart/package_map.dart';
 import '../../globals.dart' as globals;
@@ -103,6 +104,7 @@ class WebEntrypointTarget extends Target {
     final LanguageVersion languageVersion = determineLanguageVersion(
       environment.fileSystem.file(targetFile),
       packageConfig[flutterProject.manifest.appName],
+      Cache.flutterRoot,
     );
 
     // Use the PackageConfig to find the correct package-scheme import path

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:file/file.dart';
 import 'package:package_config/package_config.dart';
 
@@ -25,8 +27,16 @@ LanguageVersion currentLanguageVersion(FileSystem fileSystem, String flutterRoot
   // Either reading the file or parsing the version could fail on a corrupt Dart SDK.
   // let it crash so it shows up in crash logging.
   final File versionFile = fileSystem.file(fileSystem.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'version'));
+  if (!versionFile.existsSync() && _inUnitTest()) {
+    return LanguageVersion(2, 12);
+  }
   final Version version = Version.parse(versionFile.readAsStringSync())!;
   return _currentLanguageVersion = LanguageVersion(version.major, version.minor);
+}
+
+// Whether the tool is executing in a unit test.
+bool _inUnitTest() {
+  return Zone.current[#test.declarer] != null;
 }
 
 /// Attempts to read the language version of a dart [file].

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -13,6 +13,9 @@ const String _blockCommentEnd = '*/';
 /// The first language version where null safety was available by default.
 final LanguageVersion nullSafeVersion = LanguageVersion(2, 12);
 
+/// The current dart language version.
+final LanguageVersion currentLanguageVersion = LanguageVersion(2, 13);
+
 /// Attempts to read the language version of a dart [file].
 ///
 /// If this is not present, falls back to the language version defined in
@@ -31,7 +34,7 @@ LanguageVersion determineLanguageVersion(File file, Package package) {
   try {
     lines = file.readAsLinesSync();
   } on FileSystemException {
-    return nullSafeVersion;
+    return currentLanguageVersion;
   }
 
   for (final String line in lines) {
@@ -84,8 +87,8 @@ LanguageVersion determineLanguageVersion(File file, Package package) {
 
   // If the language version cannot be found, use the package version.
   if (package != null) {
-    return package.languageVersion ?? nullSafeVersion;
+    return package.languageVersion ?? currentLanguageVersion;
   }
-  // Default to 2.12
-  return nullSafeVersion;
+  // Default to current version.
+  return currentLanguageVersion;
 }

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/version.dart';
 import 'package:package_config/package_config.dart';
+
+import '../base/version.dart';
 
 final RegExp _languageVersion = RegExp(r'\/\/\s*@dart\s*=\s*([0-9])\.([0-9]+)');
 final RegExp _declarationEnd = RegExp('(import)|(library)|(part)');

--- a/packages/flutter_tools/lib/src/dart/language_version.dart
+++ b/packages/flutter_tools/lib/src/dart/language_version.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:package_config/package_config.dart';
 
 final RegExp _languageVersion = RegExp(r'\/\/\s*@dart\s*=\s*([0-9])\.([0-9]+)');
@@ -13,8 +14,19 @@ const String _blockCommentEnd = '*/';
 /// The first language version where null safety was available by default.
 final LanguageVersion nullSafeVersion = LanguageVersion(2, 12);
 
-/// The current dart language version.
-final LanguageVersion currentLanguageVersion = LanguageVersion(2, 13);
+LanguageVersion? _currentLanguageVersion;
+
+/// Lookup the current Dart language version.
+LanguageVersion currentLanguageVersion(FileSystem fileSystem, String flutterRoot) {
+  if (_currentLanguageVersion != null) {
+    return _currentLanguageVersion!;
+  }
+  // Either reading the file or parsing the version could fail on a corrupt Dart SDK.
+  // let it crash so it shows up in crash logging.
+  final File versionFile = fileSystem.file(fileSystem.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'version'));
+  final Version version = Version.parse(versionFile.readAsStringSync())!;
+  return _currentLanguageVersion = LanguageVersion(version.major, version.minor);
+}
 
 /// Attempts to read the language version of a dart [file].
 ///
@@ -25,7 +37,7 @@ final LanguageVersion currentLanguageVersion = LanguageVersion(2, 13);
 ///
 /// The specification for the language version tag is defined at:
 /// https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/feature-specification.md#individual-library-language-version-override
-LanguageVersion determineLanguageVersion(File file, Package package) {
+LanguageVersion determineLanguageVersion(File file, Package package, String flutterRoot) {
   int blockCommentDepth = 0;
   // If reading the file fails, default to a null-safe version. The
   // command will likely fail later in the process with a better error
@@ -34,7 +46,7 @@ LanguageVersion determineLanguageVersion(File file, Package package) {
   try {
     lines = file.readAsLinesSync();
   } on FileSystemException {
-    return currentLanguageVersion;
+    return currentLanguageVersion(file.fileSystem, flutterRoot);
   }
 
   for (final String line in lines) {
@@ -87,8 +99,8 @@ LanguageVersion determineLanguageVersion(File file, Package package) {
 
   // If the language version cannot be found, use the package version.
   if (package != null) {
-    return package.languageVersion ?? currentLanguageVersion;
+    return package.languageVersion ?? currentLanguageVersion(file.fileSystem, flutterRoot);
   }
   // Default to current version.
-  return currentLanguageVersion;
+  return currentLanguageVersion(file.fileSystem, flutterRoot);
 }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -25,6 +25,7 @@ import '../base/time.dart';
 import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/targets/web.dart';
+import '../cache.dart';
 import '../dart/language_version.dart';
 import '../devfs.dart';
 import '../device.dart';
@@ -678,6 +679,7 @@ class ResidentWebRunner extends ResidentRunner {
       final LanguageVersion languageVersion =  determineLanguageVersion(
         _fileSystem.file(mainUri),
         packageConfig[flutterProject.manifest.appName],
+        Cache.flutterRoot,
       );
 
       final String entrypoint = <String>[

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -885,6 +885,7 @@ abstract class FlutterCommand extends Command<void> {
         final LanguageVersion languageVersion = determineLanguageVersion(
           entrypointFile,
           packageConfig.packageOf(entrypointFile.absolute.uri),
+          Cache.flutterRoot,
         );
         // Extra frontend options are only provided if explicitly
         // requested.

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -14,6 +14,7 @@ import 'package:test_core/src/platform.dart'; // ignore: implementation_imports
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../cache.dart';
 import '../compile.dart';
 import '../convert.dart';
 import '../dart/language_version.dart';
@@ -512,6 +513,7 @@ class FlutterPlatform extends PlatformPlugin {
     final LanguageVersion languageVersion = determineLanguageVersion(
       file,
       packageConfig[flutterProject?.manifest?.appName],
+      Cache.flutterRoot,
     );
     return generateTestBootstrap(
       testUrl: testUrl,

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -63,7 +63,7 @@ class WebTestCompiler {
       }
     } else if (buildInfo.nullSafetyMode == NullSafetyMode.sound) {
       platformDillArtifact = Artifact.webPlatformSoundKernelDill;
-      languageVersion = nullSafeVersion;
+      languageVersion = currentLanguageVersion;
       if (!extraFrontEndOptions.contains('--sound-null-safety')) {
         extraFrontEndOptions.add('--sound-null-safety');
       }

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -16,6 +16,7 @@ import '../base/logger.dart';
 import '../base/platform.dart';
 import '../build_info.dart';
 import '../bundle.dart';
+import '../cache.dart';
 import '../compile.dart';
 import '../dart/language_version.dart';
 import '../web/bootstrap.dart';
@@ -63,7 +64,7 @@ class WebTestCompiler {
       }
     } else if (buildInfo.nullSafetyMode == NullSafetyMode.sound) {
       platformDillArtifact = Artifact.webPlatformSoundKernelDill;
-      languageVersion = currentLanguageVersion;
+      languageVersion = currentLanguageVersion(_fileSystem, Cache.flutterRoot);
       if (!extraFrontEndOptions.contains('--sound-null-safety')) {
         extraFrontEndOptions.add('--sound-null-safety');
       }

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -6,16 +6,25 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/dart/language_version.dart';
 import 'package:package_config/package_config.dart';
-import 'package:test/fake.dart';
 
 import '../../src/common.dart';
+
+const String flutterRoot = '';
+const String testVersionString = '2.13';
+final LanguageVersion testCurrentLanguageVersion = LanguageVersion(2, 13);
+
+void setUpLanguageVersion(FileSystem fileSystem, [String version = testVersionString]) {
+  fileSystem.file(fileSystem.path.join('bin', 'cache', 'dart-sdk', 'version'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(version);
+}
 
 void main() {
   testWithoutContext('detects language version in comment', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -23,11 +32,12 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 9));
+    expect(determineLanguageVersion(file, null, flutterRoot), LanguageVersion(2, 9));
   });
 
   testWithoutContext('detects language version in comment without spacing', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -35,11 +45,12 @@ void main() {
 // @dart=2.9
 ''');
 
-    expect(determineLanguageVersion(file, null),  LanguageVersion(2, 9));
+    expect(determineLanguageVersion(file, null, flutterRoot),  LanguageVersion(2, 9));
   });
 
   testWithoutContext('detects language version in comment with more numbers', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -47,11 +58,12 @@ void main() {
 // @dart=2.12
 ''');
 
-    expect(determineLanguageVersion(file, null), nullSafeVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), nullSafeVersion);
   });
 
   testWithoutContext('does not detect invalid language version', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -59,7 +71,7 @@ void main() {
 // @dart
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('detects language version with leading whitespace', () {
@@ -71,7 +83,7 @@ void main() {
     // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 9));
+    expect(determineLanguageVersion(file, null, flutterRoot), LanguageVersion(2, 9));
   });
 
   testWithoutContext('detects language version with tabs', () {
@@ -83,7 +95,7 @@ void main() {
 //\t@dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 9));
+    expect(determineLanguageVersion(file, null, flutterRoot), LanguageVersion(2, 9));
   });
 
   testWithoutContext('detects language version with tons of whitespace', () {
@@ -95,11 +107,12 @@ void main() {
 //        @dart       = 2.23
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 23));
+    expect(determineLanguageVersion(file, null, flutterRoot), LanguageVersion(2, 23));
   });
 
   testWithoutContext('does not detect language version in dartdoc', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -107,11 +120,12 @@ void main() {
 /// @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in block comment', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -121,11 +135,12 @@ void main() {
 */
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in nested block comment', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -137,7 +152,7 @@ void main() {
 */
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('detects language version after nested block comment', () {
@@ -152,11 +167,12 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 9));
+    expect(determineLanguageVersion(file, null, flutterRoot), LanguageVersion(2, 9));
   });
 
   testWithoutContext('does not crash with unbalanced opening block comments', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -167,11 +183,12 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not crash with unbalanced closing block comments', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -182,11 +199,12 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in single line block comment', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -194,11 +212,12 @@ void main() {
 /* // @dart = 2.9 */
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after import declaration', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -208,11 +227,12 @@ import 'dart:ui' as ui;
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after part declaration', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem);
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
 // Some license
@@ -222,7 +242,7 @@ part of 'foo.dart';
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after library declaration', () {
@@ -236,7 +256,7 @@ library funstuff;
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), currentLanguageVersion);
+    expect(determineLanguageVersion(file, null, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('looks up language version from package if not found in file', () {
@@ -251,7 +271,7 @@ library funstuff;
       languageVersion: LanguageVersion(2, 7),
     );
 
-    expect(determineLanguageVersion(file, package), LanguageVersion(2, 7));
+    expect(determineLanguageVersion(file, package, flutterRoot), LanguageVersion(2, 7));
   });
 
   testWithoutContext('defaults to current version if package lookup returns null', () {
@@ -266,23 +286,30 @@ library funstuff;
       languageVersion: null,
     );
 
-    expect(determineLanguageVersion(file, package), currentLanguageVersion);
+    expect(determineLanguageVersion(file, package, flutterRoot), testCurrentLanguageVersion);
   });
 
   testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
+    final FileExceptionHandler handler = FileExceptionHandler();
+    final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+    setUpLanguageVersion(fileSystem);
+    final File errorFile = fileSystem.file('foo');
+    handler.addError(errorFile, FileSystemOp.read, const FileSystemException());
+
     final Package package = Package(
       'foo',
       Uri.parse('file://foo/'),
       languageVersion: LanguageVersion(2, 7),
     );
 
-    expect(determineLanguageVersion(FakeFile(), package), currentLanguageVersion);
+    expect(determineLanguageVersion(errorFile, package, flutterRoot), testCurrentLanguageVersion);
+  });
+
+  testWithoutContext('Can parse Dart language version with pre/post suffix', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    setUpLanguageVersion(fileSystem, '2.13.0-150.0.dev');
+
+    expect(currentLanguageVersion(fileSystem, flutterRoot), LanguageVersion(2, 13));
   });
 }
 
-class FakeFile extends Fake implements File {
-  @override
-  List<String> readAsLinesSync({ Encoding encoding = utf8ForTesting }) {
-    throw const FileSystemException();
-  }
-}

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -47,7 +47,7 @@ void main() {
 // @dart=2.12
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), nullSafeVersion);
   });
 
   testWithoutContext('does not detect invalid language version', () {
@@ -59,7 +59,7 @@ void main() {
 // @dart
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('detects language version with leading whitespace', () {
@@ -107,7 +107,7 @@ void main() {
 /// @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in block comment', () {
@@ -121,7 +121,7 @@ void main() {
 */
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in nested block comment', () {
@@ -137,7 +137,7 @@ void main() {
 */
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('detects language version after nested block comment', () {
@@ -167,7 +167,7 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not crash with unbalanced closing block comments', () {
@@ -182,7 +182,7 @@ void main() {
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version in single line block comment', () {
@@ -194,7 +194,7 @@ void main() {
 /* // @dart = 2.9 */
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after import declaration', () {
@@ -208,7 +208,7 @@ import 'dart:ui' as ui;
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after part declaration', () {
@@ -222,7 +222,7 @@ part of 'foo.dart';
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('does not detect language version after library declaration', () {
@@ -236,7 +236,7 @@ library funstuff;
 // @dart = 2.9
 ''');
 
-    expect(determineLanguageVersion(file, null), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, null), currentLanguageVersion);
   });
 
   testWithoutContext('looks up language version from package if not found in file', () {
@@ -254,7 +254,7 @@ library funstuff;
     expect(determineLanguageVersion(file, package), LanguageVersion(2, 7));
   });
 
-  testWithoutContext('defaults to null safe version if package lookup returns null', () {
+  testWithoutContext('defaults to current version if package lookup returns null', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final File file = fileSystem.file('example.dart')
       ..writeAsStringSync('''
@@ -266,7 +266,7 @@ library funstuff;
       languageVersion: null,
     );
 
-    expect(determineLanguageVersion(file, package), LanguageVersion(2, 12));
+    expect(determineLanguageVersion(file, package), currentLanguageVersion);
   });
 
   testWithoutContext('Returns null safe error if reading the file throws a FileSystemException', () {
@@ -276,7 +276,7 @@ library funstuff;
       languageVersion: LanguageVersion(2, 7),
     );
 
-    expect(determineLanguageVersion(FakeFile(), package), nullSafeVersion);
+    expect(determineLanguageVersion(FakeFile(), package), currentLanguageVersion);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -312,4 +312,3 @@ library funstuff;
     expect(currentLanguageVersion(fileSystem, flutterRoot), LanguageVersion(2, 13));
   });
 }
-


### PR DESCRIPTION
The tool currently treats a missing language version as 2.12, the null safe version. This needs to be bumped to 2.13 for the next dart release. In general, we should find a way to automate this, without doing any runtime reading of the Dart SDK.


