### PR TITLE
Refactor text editing test APIs

### DIFF
--- a/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 // @dart = 2.9
+
 import 'dart:html';
 import 'dart:js_util' as js_util;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -20,9 +22,6 @@ void main() {
       (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();
-
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
 
     // Focus on a TextFormField.
     final Finder finder = find.byKey(const Key('input'));
@@ -49,9 +48,6 @@ void main() {
     app.main();
     await tester.pumpAndSettle();
 
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
-
     // Focus on a TextFormField.
     final Finder finder = find.byKey(const Key('empty-input'));
     expect(finder, findsOneWidget);
@@ -76,9 +72,6 @@ void main() {
       (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();
-
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
 
     // This text will show no-enter initially. It will have 'enter-pressed'
     // after `onFieldSubmitted` of TextField is triggered.
@@ -113,9 +106,6 @@ void main() {
     app.main();
     await tester.pumpAndSettle();
 
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
-
     // Focus on a TextFormField.
     final Finder finder = find.byKey(const Key('input'));
     expect(finder, findsOneWidget);
@@ -147,9 +137,6 @@ void main() {
   testWidgets('Jump between TextFormFields with tab key after CapsLock is activated', (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();
-
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
 
     // Focus on a TextFormField.
     final Finder finder = find.byKey(const Key('input'));
@@ -197,9 +184,6 @@ void main() {
     const String text = 'Lorem ipsum dolor sit amet';
     app.main();
     await tester.pumpAndSettle();
-
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
-    SystemChannels.textInput.setMockMethodCallHandler(null);
 
     // Select something from the selectable text.
     final Finder finder = find.byKey(const Key('selectable'));

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -120,6 +120,11 @@ class SystemChannels {
   /// they apply, so that stale messages referencing past transactions can be
   /// ignored.
   ///
+  /// In debug builds, messages sent with a client ID of -1 are always accepted.
+  /// This allows tests to smuggle messages without having to mock the engine's
+  /// text handling (for example, allowing the engine to still handle the text
+  /// input messages in an integration test).
+  ///
   /// The methods described below are wrapped in a more convenient form by the
   /// [TextInput] and [TextInputConnection] class.
   ///
@@ -152,9 +157,15 @@ class SystemChannels {
   /// is a transaction identifier. Calls for stale transactions should be ignored.
   ///
   ///  * `TextInputClient.updateEditingState`: The user has changed the contents
-  ///    of the text control. The second argument is a [String] containing a
-  ///    JSON-encoded object with seven keys, in the form expected by
-  ///    [TextEditingValue.fromJSON].
+  ///    of the text control. The second argument is an object with seven keys,
+  ///    in the form expected by [TextEditingValue.fromJSON].
+  ///
+  ///  * `TextInputClient.updateEditingStateWithTag`: One or more text controls
+  ///    were autofilled by the platform's autofill service. The first argument
+  ///    (the client ID) is ignored, the second argument is a map of tags to
+  ///    objects in the form expected by [TextEditingValue.fromJSON]. See
+  ///    [AutofillScope.getAutofillClient] for details on the interpretation of
+  ///    the tag.
   ///
   ///  * `TextInputClient.performAction`: The user has triggered an action. The
   ///    second argument is a [String] consisting of the stringification of one
@@ -165,7 +176,8 @@ class SystemChannels {
   ///    one. The framework should call `TextInput.setClient` and
   ///    `TextInput.setEditingState` again with its most recent information. If
   ///    there is no existing state on the framework side, the call should
-  ///    fizzle.
+  ///    fizzle. (This call is made without a client ID; indeed, without any
+  ///    arguments at all.)
   ///
   ///  * `TextInputClient.onConnectionClosed`: The text input connection closed
   ///    on the platform side. For example the application is moved to

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1327,9 +1327,11 @@ class TextInput {
 
     final List<dynamic> args = methodCall.arguments as List<dynamic>;
 
+    // The updateEditingStateWithTag request (autofill) can come up even to a
+    // text field that doesn't have a connection.
     if (method == 'TextInputClient.updateEditingStateWithTag') {
+      assert(_currentConnection!._client != null);
       final TextInputClient client = _currentConnection!._client;
-      assert(client != null);
       final AutofillScope? scope = client.currentAutofillScope;
       final Map<String, dynamic> editingValue = args[1] as Map<String, dynamic>;
       for (final String tag in editingValue.keys) {
@@ -1343,9 +1345,22 @@ class TextInput {
     }
 
     final int client = args[0] as int;
-    // The incoming message was for a different client.
-    if (client != _currentConnection!._id)
-      return;
+    if (client != _currentConnection!._id) {
+      // If the client IDs don't match, the incoming message was for a different
+      // client.
+      bool debugAllowAnyway = false;
+      assert(() {
+        // In debug builds we allow "-1" as a magical client ID that ignores
+        // this verification step so that tests can always get through, even
+        // when they are not mocking the engine side of text input.
+        if (client == -1)
+          debugAllowAnyway = true;
+        return true;
+      }());
+      if (!debugAllowAnyway)
+        return;
+    }
+
     switch (method) {
       case 'TextInputClient.updateEditingState':
         _currentConnection!._client.updateEditingValue(TextEditingValue.fromJSON(args[1] as Map<String, dynamic>));

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2111,7 +2111,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (_hasFocus) {
       _openInputConnection();
     } else {
-      widget.focusNode.requestFocus();
+      widget.focusNode.requestFocus(); // This eventually calls _openInputConnection also, see _handleFocusChanged.
     }
   }
 

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -15,6 +15,18 @@ export 'package:flutter/services.dart' show TextEditingValue, TextInputAction;
 ///
 /// Typical app tests will not need to use this class directly.
 ///
+/// The [TestWidgetsFlutterBinding] class registers a [TestTextInput] instance
+/// ([TestWidgetsFlutterBinding.testTextInput]) as a stub keyboard
+/// implementation if its [TestWidgetsFlutterBinding.registerTestTextInput]
+/// property returns true when a test starts, and unregisters it when the test
+/// ends (unless it ends with a failure).
+///
+/// See [register], [unregister], and [isRegistered] for details.
+///
+/// The [enterText], [updateEditingValue], [receiveAction], and
+/// [closeConnection] methods can be used even when the [TestTextInput] is not
+/// registered. All other methods will assert if [isRegistered] is false.
+///
 /// See also:
 ///
 /// * [WidgetTester.enterText], which uses this class to simulate keyboard input.
@@ -37,57 +49,75 @@ class TestTextInput {
   /// The messenger which sends the bytes for this channel, not null.
   BinaryMessenger get _binaryMessenger => ServicesBinding.instance!.defaultBinaryMessenger;
 
-  /// Resets any internal state of this object and calls [register].
-  ///
-  /// This method is invoked by the testing framework between tests. It should
-  /// not ordinarily be called by tests directly.
-  void resetAndRegister() {
-    log.clear();
-    editingState = null;
-    setClientArgs = null;
-    _client = 0;
-    _isVisible = false;
-    register();
-  }
-  /// Installs this object as a mock handler for [SystemChannels.textInput].
-  void register() => SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
-
-  /// Removes this object as a mock handler for [SystemChannels.textInput].
-  ///
-  /// After calling this method, the channel will exchange messages with the
-  /// Flutter engine. Use this with [FlutterDriver] tests that need to display
-  /// on-screen keyboard provided by the operating system.
-  void unregister() => SystemChannels.textInput.setMockMethodCallHandler(null);
-
   /// Log for method calls.
   ///
   /// For all registered channels, handled calls are added to the list. Can
   /// be cleaned using `log.clear()`.
   final List<MethodCall> log = <MethodCall>[];
 
+  /// Installs this object as a mock handler for [SystemChannels.textInput].
+  ///
+  /// Called by the binding at the top of a test when
+  /// [TestWidgetsFlutterBinding.registerTestTextInput] is true.
+  void register() => SystemChannels.textInput.setMockMethodCallHandler(_handleTextInputCall);
+
+  /// Removes this object as a mock handler for [SystemChannels.textInput].
+  ///
+  /// After calling this method, the channel will exchange messages with the
+  /// Flutter engine instead of the stub.
+  ///
+  /// Called by the binding at the end of a (successful) test when
+  /// [TestWidgetsFlutterBinding.registerTestTextInput] is true.
+  void unregister() => SystemChannels.textInput.setMockMethodCallHandler(null);
+
   /// Whether this [TestTextInput] is registered with [SystemChannels.textInput].
   ///
-  /// Use [register] and [unregister] methods to control this value.
+  /// The binding uses the [register] and [unregister] methods to control this
+  /// value when [TestWidgetsFlutterBinding.registerTestTextInput] is true.
   bool get isRegistered => SystemChannels.textInput.checkMockMethodCallHandler(_handleTextInputCall);
+
+  int? _client;
 
   /// Whether there are any active clients listening to text input.
   bool get hasAnyClients {
     assert(isRegistered);
-    return _client > 0;
+    return _client != null && _client! > 0;
   }
 
-  int _client = 0;
-
-  /// Arguments supplied to the TextInput.setClient method call.
+  /// The last set of arguments supplied to the `TextInput.setClient` and
+  /// `TextInput.updateConfig` methods of this stub implementation.
   Map<String, dynamic>? setClientArgs;
 
   /// The last set of arguments that [TextInputConnection.setEditingState] sent
-  /// to the embedder.
+  /// to this stub implementation (i.e. the arguments set to
+  /// `TextInput.setEditingState`).
   ///
   /// This is a map representation of a [TextEditingValue] object. For example,
   /// it will have a `text` entry whose value matches the most recent
   /// [TextEditingValue.text] that was sent to the embedder.
   Map<String, dynamic>? editingState;
+
+  /// Whether the onscreen keyboard is visible to the user.
+  ///
+  /// Specifically, this reflects the last call to `TextInput.show` or
+  /// `TextInput.hide` received by the stub implementation.
+  bool get isVisible {
+    assert(isRegistered);
+    return _isVisible;
+  }
+  bool _isVisible = false;
+
+  /// Resets any internal state of this object.
+  ///
+  /// This method is invoked by the testing framework between tests. It should
+  /// not ordinarily be called by tests directly.
+  void reset() {
+    log.clear();
+    _client = null;
+    setClientArgs = null;
+    editingState = null;
+    _isVisible = false;
+  }
 
   Future<dynamic> _handleTextInputCall(MethodCall methodCall) async {
     log.add(methodCall);
@@ -100,7 +130,7 @@ class TestTextInput {
         setClientArgs = methodCall.arguments as Map<String, dynamic>;
         break;
       case 'TextInput.clearClient':
-        _client = 0;
+        _client = null;
         _isVisible = false;
         onCleared?.call();
         break;
@@ -116,87 +146,69 @@ class TestTextInput {
     }
   }
 
-  /// Whether the onscreen keyboard is visible to the user.
-  bool get isVisible {
-    assert(isRegistered);
-    return _isVisible;
-  }
-  bool _isVisible = false;
-
-  /// Simulates the user changing the [TextEditingValue] to the given value.
-  void updateEditingValue(TextEditingValue value) {
-    assert(isRegistered);
-    // Not using the `expect` function because in the case of a FlutterDriver
-    // test this code does not run in a package:test test zone.
-    if (_client == 0)
-      throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
-    _binaryMessenger.handlePlatformMessage(
-      SystemChannels.textInput.name,
-      SystemChannels.textInput.codec.encodeMethodCall(
-        MethodCall(
-          'TextInputClient.updateEditingState',
-          <dynamic>[_client, value.toJSON()],
-        ),
-      ),
-      (ByteData? data) { /* response from framework is discarded */ },
-    );
-  }
-
-  /// Simulates the user closing the text input connection.
+  /// Simulates the user hiding the onscreen keyboard.
   ///
-  /// For example:
-  /// - User pressed the home button and sent the application to background.
-  /// - User closed the virtual keyboard.
-  void closeConnection() {
+  /// This does nothing but set the internal flag.
+  void hide() {
     assert(isRegistered);
-    // Not using the `expect` function because in the case of a FlutterDriver
-    // test this code does not run in a package:test test zone.
-    if (_client == 0)
-      throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
-    _binaryMessenger.handlePlatformMessage(
-      SystemChannels.textInput.name,
-      SystemChannels.textInput.codec.encodeMethodCall(
-        MethodCall(
-          'TextInputClient.onConnectionClosed',
-           <dynamic>[_client,]
-        ),
-      ),
-      (ByteData? data) { /* response from framework is discarded */ },
-    );
+    _isVisible = false;
   }
 
   /// Simulates the user typing the given text.
   ///
   /// Calling this method replaces the content of the connected input field with
   /// `text`, and places the caret at the end of the text.
+  ///
+  /// This can be called even if the [TestTextInput] has not been [register]ed.
+  ///
+  /// If this is used to inject text when there is a real IME connection, for
+  /// example when using the [integration_test] library, there is a risk that
+  /// the real IME will become confused as to the current state of input.
   void enterText(String text) {
-    assert(isRegistered);
     updateEditingValue(TextEditingValue(
       text: text,
       selection: TextSelection.collapsed(offset: text.length),
     ));
   }
 
+  /// Simulates the user changing the [TextEditingValue] to the given value.
+  ///
+  /// This can be called even if the [TestTextInput] has not been [register]ed.
+  ///
+  /// If this is used to inject text when there is a real IME connection, for
+  /// example when using the [integration_test] library, there is a risk that
+  /// the real IME will become confused as to the current state of input.
+  void updateEditingValue(TextEditingValue value) {
+    _binaryMessenger.handlePlatformMessage(
+      SystemChannels.textInput.name,
+      SystemChannels.textInput.codec.encodeMethodCall(
+        MethodCall(
+          'TextInputClient.updateEditingState',
+          <dynamic>[_client ?? -1, value.toJSON()],
+        ),
+      ),
+      (ByteData? data) { /* response from framework is discarded */ },
+    );
+  }
+
   /// Simulates the user pressing one of the [TextInputAction] buttons.
   /// Does not check that the [TextInputAction] performed is an acceptable one
   /// based on the `inputAction` [setClientArgs].
+  ///
+  /// This can be called even if the [TestTextInput] has not been [register]ed.
+  ///
+  /// If this is used to inject an action when there is a real IME connection,
+  /// for example when using the [integration_test] library, there is a risk
+  /// that the real IME will become confused as to the current state of input.
   Future<void> receiveAction(TextInputAction action) async {
-    assert(isRegistered);
     return TestAsyncUtils.guard(() {
-      // Not using the `expect` function because in the case of a FlutterDriver
-      // test this code does not run in a package:test test zone.
-      if (_client == 0) {
-        throw TestFailure('Tried to use TestTextInput with no keyboard attached. You must use WidgetTester.showKeyboard() first.');
-      }
-
       final Completer<void> completer = Completer<void>();
-
       _binaryMessenger.handlePlatformMessage(
         SystemChannels.textInput.name,
         SystemChannels.textInput.codec.encodeMethodCall(
           MethodCall(
             'TextInputClient.performAction',
-            <dynamic>[_client, action.toString()],
+            <dynamic>[_client ?? -1, action.toString()],
           ),
         ),
         (ByteData? data) {
@@ -220,9 +232,28 @@ class TestTextInput {
     });
   }
 
-  /// Simulates the user hiding the onscreen keyboard.
-  void hide() {
-    assert(isRegistered);
-    _isVisible = false;
+  /// Simulates the user closing the text input connection.
+  ///
+  /// For example:
+  ///
+  ///  * User pressed the home button and sent the application to background.
+  ///  * User closed the virtual keyboard.
+  ///
+  /// This can be called even if the [TestTextInput] has not been [register]ed.
+  ///
+  /// If this is used to inject text when there is a real IME connection, for
+  /// example when using the [integration_test] library, there is a risk that
+  /// the real IME will become confused as to the current state of input.
+  void closeConnection() {
+    _binaryMessenger.handlePlatformMessage(
+      SystemChannels.textInput.name,
+      SystemChannels.textInput.codec.encodeMethodCall(
+        MethodCall(
+          'TextInputClient.onConnectionClosed',
+           <dynamic>[_client ?? -1],
+        ),
+      ),
+      (ByteData? data) { /* response from framework is discarded */ },
+    );
   }
 }

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:test_api/test_api.dart' as test_package;
 
 void main() {
+  final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+
   group(TestViewConfiguration, () {
     test('is initialized with top-level window if one is not provided', () {
       // The code below will throw without the default.
@@ -20,15 +22,32 @@ void main() {
 
   group(AutomatedTestWidgetsFlutterBinding, () {
     test('allows setting defaultTestTimeout to 5 minutes', () {
-      final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
       binding.defaultTestTimeout = const test_package.Timeout(Duration(minutes: 5));
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
   });
 
+  // The next three tests must run in order -- first using `test`, then `testWidgets`, then `test` again.
+
+  int order = 0;
+
   test('Initializes httpOverrides and testTextInput', () async {
-    final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
-    expect(binding.testTextInput.isRegistered, true);
+    assert(order == 0);
+    expect(binding.testTextInput, isNotNull);
+    expect(binding.testTextInput.isRegistered, isFalse);
     expect(HttpOverrides.current, isNotNull);
+    order += 1;
+  });
+
+  testWidgets('Registers testTextInput', (WidgetTester tester) async {
+    assert(order == 1);
+    expect(tester.testTextInput.isRegistered, isTrue);
+    order += 1;
+  });
+
+  test('Unregisters testTextInput', () async {
+    assert(order == 2);
+    expect(binding.testTextInput.isRegistered, isFalse);
+    order += 1;
   });
 }


### PR DESCRIPTION
...and remove a legacy TODO whose referenced issue (#51885) is now closed.

To actually fix this required some refactoring of the text editing test APIs.

See #77454 for original discussion.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
