### PR TITLE
Keep original start baseOffset on drag update in RenderEditable

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2129,6 +2129,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     markNeedsSemanticsUpdate();
   }
 
+  // Holds the text position at the last drag start.
+  TextPosition? _lastDragStartPosition;
+
   /// The offset at which the text should be painted.
   ///
   /// If the text content is larger than the editable line itself, the editable
@@ -2973,7 +2976,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       ? null
       : _textPainter.getPositionForOffset(globalToLocal(to - _paintOffset));
 
-    final int baseOffset = fromPosition.offset;
+    // If it's a drag update, keep the original baseOffset from drag start
+    // since the scroll offset may have changed.
+    if (cause == SelectionChangedCause.drag && to == null) {
+      _lastDragStartPosition = fromPosition;
+    }
+
+    final int baseOffset = (cause == SelectionChangedCause.drag && to != null)
+      ? _lastDragStartPosition?.offset ?? fromPosition.offset
+      : fromPosition.offset;
     final int extentOffset = toPosition?.offset ?? fromPosition.offset;
 
     final TextSelection newSelection = TextSelection(


### PR DESCRIPTION
## Description
Currently when selecting by dragging, both baseOffset and extentOffset are updated on each call to selectPositionAt() i.e. on each pointer update. If the viewport offset changes in the meantime on a scroll, this causes the baseOffset to move incorrectly:

![before](https://user-images.githubusercontent.com/72562119/112641312-8c6ef600-8e42-11eb-8be6-28dc7cddc7ff.gif)

This PR keeps the original baseOffset from the drag start call to selectPositionAt() to fix this behaviour:

![after](https://user-images.githubusercontent.com/72562119/112641330-93960400-8e42-11eb-872b-f8d8c5e12e73.gif)

## Related issues
https://github.com/flutter/flutter/issues/69296

## Tests

I added the following tests:
```
packages/flutter/test/rendering/editable_test.dart:
 test('selection baseOffset does not move when scrolling while dragging', () {
```

Relevant tests passing:
```
% ../../bin/flutter test test/rendering/editable_test.dart
00:04 +54: All tests passed!                                                                                                                                       
% ../../bin/flutter test test/widgets/editable_text_cursor_test.dart
00:07 +24: All tests passed!                                                                                                                                       
% ../../bin/flutter test test/widgets/editable_text_show_on_screen_test.dart
00:05 +17: All tests passed!                                                                                                                                       
% ../../bin/flutter test test/widgets/editable_text_test.dart
00:13 +168: All tests passed!                                                                                                                                      
% ../../bin/flutter test test/widgets/text_selection_test.dart 
00:04 +23: All tests passed!                                                                                                                                       
% ../../bin/flutter test test/widgets/selectable_text_test.dart
00:14 +143 ~2: All tests passed!                                                                                                                                   
% ../../bin/flutter test test/material/text_field_test.dart
00:30 +301: All tests passed!                      
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
