### PR TITLE
[flutter_test] allow hot reload during test run execution

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -332,6 +332,12 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }
 
   @override
+  Future<void> reassembleApplication() async {
+    // The super.reassembleApplication method assumes that it can schedule frames which may
+    // or may not be the case in tests. No-op instead to avoid modifying any test state.
+  }
+
+  @override
   BinaryMessenger createBinaryMessenger() {
     return TestDefaultBinaryMessenger(super.createBinaryMessenger());
   }
@@ -918,8 +924,8 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
 /// This binding controls time, allowing tests to verify long
 /// animation sequences without having to execute them in real time.
 ///
-/// This class assumes it is always run in checked mode (since tests are always
-/// run in checked mode).
+/// This class assumes it is always run in debug mode (since tests are always
+/// run in debug mode).
 class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   @override
   void initInstances() {

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -31,4 +31,11 @@ void main() {
     expect(binding.testTextInput.isRegistered, true);
     expect(HttpOverrides.current, isNotNull);
   });
+
+  test('Returns a no-op future for ReassembleApplication', () async {
+    final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+
+    // If the binding was waiting for frames this future would never complete.
+    await expectLater(binding.reassembleApplication(), completes);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/79150

reassembleApplication schedules a frame and then waits for the end of this frame. This does not work in test modes where the frame policy is tightly controlled. Instead, no-op to avoid interacting with the test state.