### PR TITLE
docs: add an example to ReorderableListView.builder

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -121,11 +121,11 @@ class ReorderableListView extends StatefulWidget {
   /// constructor. Even more efficient, however, is to create the instances
   /// on demand using this constructor's `itemBuilder` callback.
   ///
-  /// This example mirrors the previous one, creating the same list using the
+  /// This example creates a list using the
   /// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], The
   /// list items are built lazily on demand.
   /// {@tool dartpad --template=stateful_widget_material}
-  /// 
+  ///
   /// ```dart
   /// final List<int> _items = List<int>.generate(50, (int index) => index);
   ///

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -65,43 +65,6 @@ import 'theme.dart';
 /// ```
 ///
 ///{@end-tool}
-///
-/// {@tool snippet}
-/// This example mirrors the previous one, creating the same list using the
-/// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], The
-/// list items are built lazily on demand.
-/// ```dart
-/// final List<int> _items = List<int>.generate(50, (int index) => index);
-///
-/// @override
-/// Widget build(BuildContext context){
-///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
-///   final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
-///   final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
-///
-/// return ReorderableListView.builder(
-///   padding: const EdgeInsets.symmetric(horizontal: 40),
-///   itemCount:_items.length,
-///   itemBuilder: (BuildContext _, int index) {
-///     return ListTile(
-///       key: Key('$index'),
-///       tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,
-///       title: Text('Item ${_items[index]}'),
-///     );
-///   },
-///   onReorder: (int oldIndex, int newIndex) {
-///     setState(() {
-///       if (oldIndex < newIndex) {
-///         newIndex -= 1;
-///       }
-///       final int item = _items.removeAt(oldIndex);
-///       _items.insert(newIndex, item);
-///     });
-///   },
-///  );
-/// }
-/// ```
-/// {@end-tool}
 class ReorderableListView extends StatefulWidget {
   /// Creates a reorderable list from a pre-built list of widgets.
   ///
@@ -158,6 +121,44 @@ class ReorderableListView extends StatefulWidget {
   /// constructor. Even more efficient, however, is to create the instances
   /// on demand using this constructor's `itemBuilder` callback.
   ///
+  /// This example mirrors the previous one, creating the same list using the
+  /// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], The
+  /// list items are built lazily on demand.
+  /// {@tool dartpad --template=stateful_widget_material}
+  /// 
+  /// ```dart
+  /// final List<int> _items = List<int>.generate(50, (int index) => index);
+  ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
+  ///   final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
+  ///   final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
+  ///
+  ///   return ReorderableListView.builder(
+  ///     padding: const EdgeInsets.symmetric(horizontal: 40),
+  ///     itemCount:_items.length,
+  ///     itemBuilder: (BuildContext context, int index) {
+  ///       return ListTile(
+  ///         key: Key('$index'),
+  ///         tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,
+  ///         title: Text('Item ${_items[index]}'),
+  ///         );
+  ///     },
+  ///     onReorder: (int oldIndex, int newIndex) {
+  ///       setState(() {
+  ///         if (oldIndex < newIndex) {
+  ///           newIndex -= 1;
+  ///         }
+  ///         final int item = _items.removeAt(oldIndex);
+  ///         _items.insert(newIndex, item);
+  ///       });
+  ///     },
+  ///   );
+  /// }
+  ///
+  /// ```
+  /// {@end-tool}
   /// See also:
   ///
   ///   * [ReorderableListView], which allows you to build a reorderable

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -98,7 +98,8 @@ import 'theme.dart';
 ///       _items.insert(newIndex, item);
 ///     });
 ///   },
-/// );
+///  );
+/// }
 /// ```
 /// {@end-tool}
 class ReorderableListView extends StatefulWidget {

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -68,8 +68,8 @@ import 'theme.dart';
 ///
 /// {@tool snippet}
 /// This example mirrors the previous one, creating the same list using the
-/// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], children
-/// are built lazily on demand.
+/// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], The
+/// list items are built lazily on demand.
 /// ```dart
 /// final List<int> _items = List<int>.generate(50, (int index) => index);
 ///

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -65,6 +65,42 @@ import 'theme.dart';
 /// ```
 ///
 ///{@end-tool}
+///
+/// {@tool snippet}
+/// This example mirrors the previous one, creating the same list using the
+/// [ReorderableListView.builder] constructor. Using the [IndexedWidgetBuilder], children
+/// are built lazily on demand.
+/// ```dart
+/// final List<int> _items = List<int>.generate(50, (int index) => index);
+///
+/// @override
+/// Widget build(BuildContext context){
+///   final ColorScheme colorScheme = Theme.of(context).colorScheme;
+///   final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
+///   final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
+///
+/// return ReorderableListView.builder(
+///   padding: const EdgeInsets.symmetric(horizontal: 40),
+///   itemCount:_items.length,
+///   itemBuilder: (BuildContext _, int index) {
+///     return ListTile(
+///       key: Key('$index'),
+///       tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,
+///       title: Text('Item ${_items[index]}'),
+///     );
+///   },
+///   onReorder: (int oldIndex, int newIndex) {
+///     setState(() {
+///       if (oldIndex < newIndex) {
+///         newIndex -= 1;
+///       }
+///       final int item = _items.removeAt(oldIndex);
+///       _items.insert(newIndex, item);
+///     });
+///   },
+/// );
+/// ```
+/// {@end-tool}
 class ReorderableListView extends StatefulWidget {
   /// Creates a reorderable list from a pre-built list of widgets.
   ///


### PR DESCRIPTION
I added a sample example to the docs of [ReorderableListView.builder](https://api.flutter.dev/flutter/material/ReorderableListView/ReorderableListView.builder.html) with reference to the issue mentioned here https://github.com/flutter/flutter/issues/78752


