### PR TITLE
[gen-l10n] Add `nullable-getter` flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -174,7 +174,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
     );
     argParser.addFlag(
       'nullable-getter',
-      help: 'Whether or not the localizations class getter is non-nullable.\n'
+      help: 'Whether or not the localizations class getter is nullable.\n'
             '\n'
             'By default, this value is set to true so that '
             'Localizations.of(context) returns a nullable value '

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -220,6 +220,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
     final bool useSyntheticPackage = boolArg('synthetic-package');
     final String projectPathString = stringArg('project-dir');
     final bool areResourceAttributesRequired = boolArg('required-resource-attributes');
+    final bool usesNullableGetter = boolArg('nullable-getter');
 
     final LocalizationsGenerator localizationsGenerator = LocalizationsGenerator(_fileSystem);
 
@@ -242,6 +243,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
           projectPathString: projectPathString,
           areResourceAttributesRequired: areResourceAttributesRequired,
           untranslatedMessagesFile: untranslatedMessagesFile,
+          usesNullableGetter: usesNullableGetter,
         )
         ..loadResources()
         ..writeOutputFiles(_logger);

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -172,6 +172,17 @@ class GenerateLocalizationsCommand extends FlutterCommand {
             '\n'
             'Resource attributes are still required for plural messages.'
     );
+    argParser.addFlag(
+      'nullable-getter',
+      help: 'Whether or not the localizations class getter is non-nullable.\n'
+            '\n'
+            'By default, this value is set to true so that '
+            'Localizations.of(context) returns a nullable value '
+            'for backwards compatibility. If this value is set to true, then '
+            'a null check is performed on the returned value of '
+            'Localizations.of(context), removing the need for null checking in '
+            'user code.'
+    );
   }
 
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -66,6 +66,7 @@ void generateLocalizations({
         useSyntheticPackage: options.useSyntheticPackage ?? true,
         areResourceAttributesRequired: options.areResourceAttributesRequired ?? false,
         untranslatedMessagesFile: options?.untranslatedMessagesFile?.toFilePath(),
+        usesNullableGetter: options?.usesNullableGetter ?? true,
       )
       ..loadResources()
       ..writeOutputFiles(logger, isFromYaml: true);

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1028,8 +1028,7 @@ class LocalizationsGenerator {
       .replaceAll('@(class)', '$className${locale.camelCase()}')
       .replaceAll('@(localeName)', locale.toString())
       .replaceAll('@(methods)', methods.join('\n\n'))
-      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '')
-      .replaceAll('@(isNullable)', _usesNullableGetter ? '?' : '');
+      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '');
   }
 
   String _generateSubclass(
@@ -1169,7 +1168,9 @@ class LocalizationsGenerator {
       .replaceAll('@(supportedLanguageCodes)', supportedLanguageCodes.join(', '))
       .replaceAll('@(messageClassImports)', sortedClassImports.join('\n'))
       .replaceAll('@(delegateClass)', delegateClass)
-      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '');
+      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '')
+      .replaceAll('@(canBeNullable)', _usesNullableGetter ? '?' : '')
+      .replaceAll('@(needsNullCheck)', _usesNullableGetter ? '' : '!');
   }
 
   bool _containsPluralMessage() => _allMessages.any((Message message) => message.isPlural);

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -545,6 +545,10 @@ class LocalizationsGenerator {
   AppResourceBundleCollection _allBundles;
   LocaleInfo _templateArbLocale;
   bool _useSyntheticPackage = true;
+  // Used to decide if the generated code is nullable or not
+  // (whether AppLocalizations? or AppLocalizations is returned from
+  // `static {name}Localizations{?} of (BuildContext context))`
+  bool _usesNullableGetter = true;
 
   /// The directory that contains the project's arb files, as well as the
   /// header file, if specified.
@@ -689,8 +693,10 @@ class LocalizationsGenerator {
     String projectPathString,
     bool areResourceAttributesRequired = false,
     String untranslatedMessagesFile,
+    bool usesNullableGetter = true,
   }) {
     _useSyntheticPackage = useSyntheticPackage;
+    _usesNullableGetter = usesNullableGetter;
     setProjectDir(projectPathString);
     setInputDirectory(inputPathString);
     setOutputDirectory(outputPathString ?? inputPathString);
@@ -1022,7 +1028,8 @@ class LocalizationsGenerator {
       .replaceAll('@(class)', '$className${locale.camelCase()}')
       .replaceAll('@(localeName)', locale.toString())
       .replaceAll('@(methods)', methods.join('\n\n'))
-      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '');
+      .replaceAll('@(requiresIntlImport)', _containsPluralMessage() ? "import 'package:intl/intl.dart' as intl;" : '')
+      .replaceAll('@(isNullable)', _usesNullableGetter ? '?' : '');
   }
 
   String _generateSubclass(

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -77,8 +77,8 @@ abstract class @(class) {
   // ignore: unused_field
   final String localeName;
 
-  static @(class)@(isNullable) of(BuildContext context) {
-    return Localizations.of<@(class)>(context, @(class));
+  static @(class)@(canBeNullable) of(BuildContext context) {
+    return Localizations.of<@(class)>(context, @(class))@(needsNullCheck);
   }
 
   static const LocalizationsDelegate<@(class)> delegate = _@(class)Delegate();

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -77,7 +77,7 @@ abstract class @(class) {
   // ignore: unused_field
   final String localeName;
 
-  static @(class)? of(BuildContext context) {
+  static @(class)@(isNullable) of(BuildContext context) {
     return Localizations.of<@(class)>(context, @(class));
   }
 

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -369,7 +369,7 @@ class LocalizationOptions {
 
   /// The `nullable-getter` argument.
   ///
-  /// Whether or not the localizations class getter is non-nullable.
+  /// Whether or not the localizations class getter is nullable.
   final bool usesNullableGetter;
 }
 

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -304,6 +304,7 @@ class LocalizationOptions {
     this.deferredLoading,
     this.useSyntheticPackage = true,
     this.areResourceAttributesRequired = false,
+    this.usesNullableGetter = true,
   }) : assert(useSyntheticPackage != null);
 
   /// The `--arb-dir` argument.
@@ -365,6 +366,11 @@ class LocalizationOptions {
   /// Whether to require all resource ids to contain a corresponding
   /// resource attribute.
   final bool areResourceAttributesRequired;
+
+  /// The `nullable-getter` argument.
+  ///
+  /// Whether or not the localizations class getter is non-nullable.
+  final bool usesNullableGetter;
 }
 
 /// Parse the localizations configuration options from [file].

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -404,6 +404,7 @@ LocalizationOptions parseLocalizationsOptions({
     deferredLoading: _tryReadBool(yamlNode, 'use-deferred-loading', logger),
     useSyntheticPackage: _tryReadBool(yamlNode, 'synthetic-package', logger) ?? true,
     areResourceAttributesRequired: _tryReadBool(yamlNode, 'required-resource-attributes', logger) ?? false,
+    usesNullableGetter: _tryReadBool(yamlNode, 'nullable-getter', logger) ?? true,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -153,6 +153,9 @@ header-file: header
 header: HEADER
 use-deferred-loading: true
 preferred-supported-locales: en_US
+synthetic-package: false
+required-resource-attributes: false
+nullable-getter: false
 ''');
 
     final LocalizationOptions options = parseLocalizationsOptions(
@@ -169,6 +172,9 @@ preferred-supported-locales: en_US
     expect(options.header, 'HEADER');
     expect(options.deferredLoading, true);
     expect(options.preferredSupportedLocales, <String>['en_US']);
+    expect(options.useSyntheticPackage, false);
+    expect(options.areResourceAttributesRequired, false);
+    expect(options.usesNullableGetter, false);
   });
 
   testWithoutContext('parseLocalizationsOptions handles preferredSupportedLocales as list', () async {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -44,6 +44,7 @@ void main() {
       untranslatedMessagesFile: Uri.file('untranslated'),
       useSyntheticPackage: false,
       areResourceAttributesRequired: true,
+      usesNullableGetter: false,
     );
 
     final LocalizationsGenerator mockLocalizationsGenerator = MockLocalizationsGenerator();
@@ -70,6 +71,7 @@ void main() {
         projectPathString: '/',
         areResourceAttributesRequired: true,
         untranslatedMessagesFile: 'untranslated',
+        usesNullableGetter: false,
       ),
     ).called(1);
     verify(mockLocalizationsGenerator.loadResources()).called(1);

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -800,6 +800,82 @@ void main() {
     },
   );
 
+  testUsingContext(
+    'generates nullable localizations class getter via static `of` method '
+    'by default',
+    () {
+      _standardFlutterDirectoryL10nSetup(fs);
+
+      LocalizationsGenerator generator;
+      try {
+        generator = LocalizationsGenerator(fs);
+        generator
+          ..initialize(
+            inputPathString: defaultL10nPathString,
+            outputPathString: fs.path.join('lib', 'l10n', 'output'),
+            templateArbFileName: defaultTemplateArbFileName,
+            outputFileString: defaultOutputFileString,
+            classNameString: defaultClassNameString,
+            useSyntheticPackage: false,
+          )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+      } on L10nException catch (e) {
+        fail('Generating output should not fail: \n${e.message}');
+      }
+
+      final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
+      expect(outputDirectory.existsSync(), isTrue);
+      expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
+      expect(
+        outputDirectory.childFile('output-localization-file.dart').readAsStringSync(),
+        contains('static AppLocalizations? of(BuildContext context)'),
+      );
+      expect(
+        outputDirectory.childFile('output-localization-file.dart').readAsStringSync(),
+        contains('return Localizations.of<AppLocalizations>(context, AppLocalizations);'),
+      );
+    },
+  );
+
+  testUsingContext(
+    'can generate non-nullable localizations class getter via static `of` method ',
+    () {
+      _standardFlutterDirectoryL10nSetup(fs);
+
+      LocalizationsGenerator generator;
+      try {
+        generator = LocalizationsGenerator(fs);
+        generator
+          ..initialize(
+            inputPathString: defaultL10nPathString,
+            outputPathString: fs.path.join('lib', 'l10n', 'output'),
+            templateArbFileName: defaultTemplateArbFileName,
+            outputFileString: defaultOutputFileString,
+            classNameString: defaultClassNameString,
+            useSyntheticPackage: false,
+            usesNullableGetter: false,
+          )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+      } on L10nException catch (e) {
+        fail('Generating output should not fail: \n${e.message}');
+      }
+
+      final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
+      expect(outputDirectory.existsSync(), isTrue);
+      expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
+      expect(
+        outputDirectory.childFile('output-localization-file.dart').readAsStringSync(),
+        contains('static AppLocalizations of(BuildContext context)'),
+      );
+      expect(
+        outputDirectory.childFile('output-localization-file.dart').readAsStringSync(),
+        contains('return Localizations.of<AppLocalizations>(context, AppLocalizations)!;'),
+      );
+    },
+  );
+
   testUsingContext('creates list of inputs and outputs when file path is specified', () {
     _standardFlutterDirectoryL10nSetup(fs);
 


### PR DESCRIPTION
Adds a `nullable-getter` flag. It is `true` by default. However, when it is set to false, it reduces the instances for which developers need to set a null-check `!` in their code by generating the class getter as follows:

```dart
  static AppLocalizations of(BuildContext context) {
    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
  }
```

instead of
```dart
  static AppLocalizations? of(BuildContext context) {
    return Localizations.of<AppLocalizations>(context, AppLocalizations);
  }
```

Fixes https://github.com/flutter/flutter/issues/78947.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
