### PR TITLE
Drain socket before throwing

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -96,6 +96,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
         // The network may be only temporarily unavailable, or the file will be
         // added on the server later. Avoid having future calls to resolve
         // fail to check the network again.
+        await response.drain<List<int>>();
         throw image_provider.NetworkImageLoadException(statusCode: response.statusCode, uri: resolved);
       }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/78741
Similar to https://github.com/flutter/flutter/pull/78742

This makes it so that when a network image fails with a non-OK status code, we drain the socket to avoid keeping it open longer than necessary. Updates an existing test with this expectation.

Note that `drain` is documented as doing the same as what `listen` did in #78742, but just seems a bit more idiomatic to me.

Rather than creating a completely new test, I added an expectation to an existing test that exercised this code branch.

/cc @alexd6631
