### PR TITLE
Update dartdoc to 0.41.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.40.0
+    "$PUB" global activate dartdoc 0.41.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
This updates flutter to use the new version of dartdoc.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.41.0

The TL;DR is that dartdoc is slightly faster, has some bugs fixed, and will now support non-function typedefs.