### PR TITLE
[WIP] Restrict DropdownButton generic to not allow nullable type T

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -802,7 +802,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 ///    from displaying their underlines.
 ///  * [ElevatedButton], [TextButton], ordinary buttons that trigger a single action.
 ///  * <https://material.io/design/components/menus.html#dropdown-menu>
-class DropdownButton<T> extends StatefulWidget {
+class DropdownButton<T extends Object> extends StatefulWidget {
   /// Creates a dropdown button.
   ///
   /// The [items] must have distinct values. If [value] isn't null then it
@@ -1114,7 +1114,7 @@ class DropdownButton<T> extends StatefulWidget {
   _DropdownButtonState<T> createState() => _DropdownButtonState<T>();
 }
 
-class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindingObserver {
+class _DropdownButtonState<T extends Object> extends State<DropdownButton<T>> with WidgetsBindingObserver {
   int? _selectedIndex;
   _DropdownRoute<T>? _dropdownRoute;
   Orientation? _lastOrientation;
@@ -1465,7 +1465,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 }
 
 /// A convenience widget that makes a [DropdownButton] into a [FormField].
-class DropdownButtonFormField<T> extends FormField<T> {
+class DropdownButtonFormField<T extends Object> extends FormField<T> {
   /// Creates a [DropdownButton] widget that is a [FormField], wrapped in an
   /// [InputDecorator].
   ///
@@ -1601,7 +1601,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
   FormFieldState<T> createState() => _DropdownButtonFormFieldState<T>();
 }
 
-class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
+class _DropdownButtonFormFieldState<T extends Object> extends FormFieldState<T> {
   @override
   DropdownButtonFormField<T> get widget => super.widget as DropdownButtonFormField<T>;
 


### PR DESCRIPTION
Currently, if you try to set `DropdownButton`'s generic type to a nullable value, it causes issues at runtime for tests (see [this comment](https://github.com/flutter/flutter/issues/74389#issuecomment-764602195) for a reproducible sample). This PR simply restricts `T` to be an extension of `Object`, which prevents it from being a nullable type. I think that this is needed because the null-safe implementation of `DropdownButton` needs to be backwards compatible for Flutter apps that have not migrated to null safety yet, but we also want those who have migrated to null-safe applications to not be confused by `DropdownButton`'s behavior.

May address https://github.com/flutter/flutter/issues/74389.

Edit: Also, not sure how this can be tested

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
