### PR TITLE
[WIP] Add DeferredWidget

### DIFF
--- a/packages/flutter/lib/src/widgets/deferred_widget.dart
+++ b/packages/flutter/lib/src/widgets/deferred_widget.dart
@@ -1,0 +1,77 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'container.dart';
+
+typedef LibraryLoader = Future<void> Function();
+typedef DeferredWidgetBuilder = Widget Function();
+
+/// Wraps the child inside a deferred module loader.
+///
+/// The child is created and a single instance of the Widget is maintained in
+/// state as long as closure to create widget stays the same.
+///
+class DeferredWidget extends StatefulWidget {
+  DeferredWidget(this.libraryLoader, this.createWidget,
+      {Key key, Widget placeholder})
+      : placeholder = placeholder ?? Container(),
+        super(key: key);
+
+  final LibraryLoader libraryLoader;
+  final DeferredWidgetBuilder createWidget;
+  final Widget placeholder;
+  static final Map<LibraryLoader, Future<void>> _moduleLoaders = {};
+  static final Set<LibraryLoader> _loadedModules = {};
+
+  static Future<void> preload(LibraryLoader loader) {
+    if (!_moduleLoaders.containsKey(loader)) {
+      _moduleLoaders[loader] = loader().then((dynamic _) {
+        _loadedModules.add(loader);
+      });
+    }
+    return _moduleLoaders[loader];
+  }
+
+  @override
+  _DeferredWidgetState createState() => _DeferredWidgetState();
+}
+
+class _DeferredWidgetState extends State<DeferredWidget> {
+  _DeferredWidgetState();
+  Widget _loadedChild;
+  DeferredWidgetBuilder _loadedCreator;
+
+  @override
+  void initState() {
+    /// If module was already loaded immediately create widget instead of
+    /// waiting for future or zone turn.
+    if (DeferredWidget._loadedModules.contains(widget.libraryLoader)) {
+      _onLibraryLoaded();
+    } else {
+      DeferredWidget.preload(widget.libraryLoader)
+          .then((dynamic _) => _onLibraryLoaded());
+    }
+    super.initState();
+  }
+
+  void _onLibraryLoaded() {
+    setState(() {
+      _loadedCreator = widget.createWidget;
+      _loadedChild = _loadedCreator();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    /// If closure to create widget changed, create new instance, otherwise
+    /// treat as const Widget.
+    if (_loadedCreator != widget.createWidget && _loadedCreator != null) {
+      _loadedCreator = widget.createWidget;
+      _loadedChild = _loadedCreator();
+    }
+    return _loadedChild ?? widget.placeholder;
+  }
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -35,6 +35,7 @@ export 'src/widgets/container.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/default_text_editing_actions.dart';
 export 'src/widgets/default_text_editing_shortcuts.dart';
+export 'src/widgets/deferred_widget.dart';
 export 'src/widgets/desktop_text_selection_toolbar_layout_delegate.dart';
 export 'src/widgets/dismissible.dart';
 export 'src/widgets/disposable_build_context.dart';


### PR DESCRIPTION
This widget is originally from Flutter Gallery https://github.com/flutter/gallery/blob/master/lib/deferred_widget.dart

This elevates this widget to the framework in order to create a default safe way to handle loading deferred libs. Manually handling `loadLibrary` calls has potential to attempt to access a widget before it is loaded, whereas this widget prevents this from happening.