### PR TITLE
Migrate event_printer and test_config to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -248,7 +248,6 @@ class Stdio {
 
   Stream<List<int>> get stdin => io.stdin;
 
-  @visibleForTesting
   io.Stdout get stdout {
     if (_stdout != null) {
       return _stdout!;

--- a/packages/flutter_tools/lib/src/build_system/targets/desktop.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/desktop.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:meta/meta.dart';
-
 import '../../base/file_system.dart';
 import '../depfile.dart';
 
@@ -18,12 +14,12 @@ import '../depfile.dart';
 /// Throws an [Exception] if [artifacts] includes missing files, directories,
 /// or links.
 Depfile unpackDesktopArtifacts({
-  @required FileSystem fileSystem,
-  @required List<String> artifacts,
-  @required Directory outputDirectory,
-  @required String engineSourcePath,
-  List<String> clientSourcePaths,
-  String icuDataPath,
+  required FileSystem fileSystem,
+  required List<String> artifacts,
+  required Directory outputDirectory,
+  required String engineSourcePath,
+  List<String>? clientSourcePaths,
+  String? icuDataPath,
 }) {
   final List<File> inputs = <File>[];
   final List<File> outputs = <File>[];

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -310,7 +310,7 @@ class TestCommand extends FlutterCommand {
 
     TestWatcher watcher;
     if (machine) {
-      watcher = EventPrinter(parent: collector);
+      watcher = EventPrinter(parent: collector, out: globals.stdio.stdout);
     } else if (collector != null) {
       watcher = collector;
     }

--- a/packages/flutter_tools/lib/src/test/event_printer.dart
+++ b/packages/flutter_tools/lib/src/test/event_printer.dart
@@ -2,25 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import '../convert.dart';
-import '../globals.dart' as globals;
 
 import 'test_device.dart';
 import 'watcher.dart';
 
 /// Prints JSON events when running a test in --machine mode.
 class EventPrinter extends TestWatcher {
-  EventPrinter({StringSink out, TestWatcher parent})
-    : _out = out ?? globals.stdio.stdout,
+  EventPrinter({required StringSink out, TestWatcher? parent})
+    : _out = out,
       _parent = parent;
 
   final StringSink _out;
-  final TestWatcher _parent;
+  final TestWatcher? _parent;
 
   @override
-  void handleStartedDevice(Uri observatoryUri) {
+  void handleStartedDevice(Uri? observatoryUri) {
     _sendEvent('test.startedProcess',
         <String, dynamic>{'observatoryUri': observatoryUri?.toString()});
     _parent?.handleStartedDevice(observatoryUri);

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -517,7 +517,7 @@ class FlutterPlatform extends PlatformPlugin {
     );
     return generateTestBootstrap(
       testUrl: testUrl,
-      testConfigFile: findTestConfigFile(globals.fs.file(testUrl)),
+      testConfigFile: findTestConfigFile(globals.fs.file(testUrl), globals.logger),
       host: host,
       updateGoldens: updateGoldens,
       flutterTestDep: packageConfig['flutter_test'] != null,

--- a/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
@@ -147,7 +147,7 @@ class TestGoldenComparatorProcess {
   }
 
   static String generateBootstrap(Uri testUri) {
-    final File testConfigFile = findTestConfigFile(globals.fs.file(testUri));
+    final File testConfigFile = findTestConfigFile(globals.fs.file(testUri), globals.logger);
     // Generate comparator process for the file.
     return '''
 import 'dart:convert'; // flutter_ignore: dart_convert_import

--- a/packages/flutter_tools/lib/src/test/test_config.dart
+++ b/packages/flutter_tools/lib/src/test/test_config.dart
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import '../base/file_system.dart';
-import '../globals.dart' as globals;
+import '../base/logger.dart';
 
 /// The name of the test configuration file that will be discovered by the
 /// test harness if it exists in the project directory hierarchy.
@@ -16,18 +14,18 @@ const String _kTestConfigFileName = 'flutter_test_config.dart';
 const String _kProjectRootSentinel = 'pubspec.yaml';
 
 /// Find the `flutter_test_config.dart` file for a specific test file.
-File findTestConfigFile(File testFile) {
-  File testConfigFile;
+File? findTestConfigFile(File testFile, Logger logger) {
+  File? testConfigFile;
   Directory directory = testFile.parent;
   while (directory.path != directory.parent.path) {
     final File configFile = directory.childFile(_kTestConfigFileName);
     if (configFile.existsSync()) {
-      globals.printTrace('Discovered $_kTestConfigFileName in ${directory.path}');
+      logger.printTrace('Discovered $_kTestConfigFileName in ${directory.path}');
       testConfigFile = configFile;
       break;
     }
     if (directory.childFile(_kProjectRootSentinel).existsSync()) {
-      globals.printTrace('Stopping scan for $_kTestConfigFileName; '
+      logger.printTrace('Stopping scan for $_kTestConfigFileName; '
           'found project root at ${directory.path}');
       break;
     }

--- a/packages/flutter_tools/lib/src/test/watcher.dart
+++ b/packages/flutter_tools/lib/src/test/watcher.dart
@@ -10,7 +10,7 @@ abstract class TestWatcher {
   ///
   /// If startPaused was true, the caller needs to resume in Observatory to
   /// start running the tests.
-  void handleStartedDevice(Uri observatoryUri) { }
+  void handleStartedDevice(Uri? observatoryUri) { }
 
   /// Called after the tests finish but before the test device exits.
   ///

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -83,7 +83,7 @@ class WebTestCompiler {
         ..writeAsStringSync(generateTestEntrypoint(
             relativeTestPath: relativeTestSegments.join('/'),
             absolutePath: testFilePath,
-            testConfigPath: findTestConfigFile(_fileSystem.file(testFilePath))?.path,
+            testConfigPath: findTestConfigFile(_fileSystem.file(testFilePath), _logger)?.path,
             languageVersion: languageVersion,
         ));
       generatedFiles.add(generatedFile);


### PR DESCRIPTION
Swap a few easy files to null safety.  Remove `globals` from event_printer and test_config.

Part of #71511