### PR TITLE
Indicate that only physical iOS devices are supported

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -794,7 +794,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     }
 
     if (deviceIds.isEmpty) {
-      throw const DeviceException('No connected iOS devices found.');
+      throw const DeviceException('No connected physical iOS devices found.');
     }
     return deviceIds;
   }


### PR DESCRIPTION
Since emulators on Android works for running devicelab tests locally, I thought iOS simulators would work as well. Turns out they don't, because of the `emulators != true` check a few lines before. I think the error message could better indicate this though 🙂 


https://github.com/flutter/flutter/blob/e93590474d84df6dbc63a0ff735cef9c98b56ad7/dev/devicelab/lib/framework/adb.dart#L730