### PR TITLE
[flutter_tools] Make `flutter upgrade` only work with standard remotes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -17,6 +17,9 @@ import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../version.dart';
 
+/// The flutter GitHub repository.
+String get _flutterGit => globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
+
 class UpgradeCommand extends FlutterCommand {
   UpgradeCommand({
     @required bool verboseHelp,
@@ -231,8 +234,6 @@ class UpgradeCommandRunner {
   /// upstream updates from the latter, which is used for version check and
   /// inform users about the update in the first place.
   void checkSupportedRemote(FlutterVersion localVersion) {
-    /// The flutter GitHub repository.
-    final String _flutterGit = globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
     if (localVersion.repositoryUrl != _flutterGit) {
       throwToolExit(
         'Your local copy of Flutter is tracking an unsupported remote '

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -252,7 +252,9 @@ class UpgradeCommandRunner {
   /// Returns the remote HEAD flutter version.
   ///
   /// Exits tool if HEAD isn't pointing to a branch, or there is no upstream.
-  Future<FlutterVersion> fetchLatestVersion({@required FlutterVersion localVersion}) async {
+  Future<FlutterVersion> fetchLatestVersion({
+    @required FlutterVersion localVersion,
+  }) async {
     String revision;
     try {
       // Fetch upstream branch's commits and tags

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -238,18 +238,35 @@ class UpgradeCommandRunner {
     final String flutterGitUrl = _stripDotGit(_flutterGit);
 
     if (trackingUrl != flutterGitUrl) {
-      throwToolExit(
-        'Unable to upgrade Flutter: Your local copy of Flutter is tracking a '
-        'nonstandard remote "${localVersion.repositoryUrl}".\n'
-        'To use the unofficial remote, set the environment variable '
-        '"FLUTTER_GIT_URL" to "${localVersion.repositoryUrl}",\n'
-        'or to use the official remote, run '
-        '"git remote add origin https://github.com/flutter/flutter" and '
-        '"git branch --set-upstream-to=origin/${localVersion.channel}" if remote "origin" '
-        'exists in $workingDirectory.\n\n'
-        'If you are okay with losing local changes you made to the SDK, re-install '
-        'Flutter by going to https://flutter.dev/docs/get-started/install.'
-      );
+      if (globals.platform.environment.containsKey('FLUTTER_GIT_URL')) {
+        // If `FLUTTER_GIT_URL` is set, inform the user to either remove the
+        // `FLUTTER_GIT_URL` environment variable or set it to the current
+        // tracking remote to continue.
+        throwToolExit(
+          'Unable to upgrade Flutter: The Flutter SDK is tracking '
+          '"${localVersion.repositoryUrl}" but "FLUTTER_GIT_URL" is set to "$_flutterGit."\n'
+          'Either remove "FLUTTER_GIT_URL from the environment or set "FLUTTER_GIT_URL" '
+          'to "${localVersion.repositoryUrl}", and retry.\n\n'
+          'If you are okay with losing local changes you made to the SDK, re-install '
+          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+        );
+      } else {
+        // Inform that the user has to either set the environment variable, or
+        // change the url of the tracking remote to the Flutter GitHub repository
+        // to continue.
+        throwToolExit(
+          'Unable to upgrade Flutter: The Flutter SDK is tracking a non-standard '
+          'remote "${localVersion.repositoryUrl}".\n'
+          '  - To use the current remote, set the environment variable "FLUTTER_GIT_URL" '
+          'to "${localVersion.repositoryUrl}", and retry.\n'
+          '  - To use the standard remote, change the url of the tracking remote to '
+          '"https://github.com/flutter/flutter.git", and retry, for example, to change '
+          'the url of the remote "origin", run:\n\n'
+          '      git remote set-url origin https://github.com/flutter/flutter.git\n\n'
+          'If you are okay with losing local changes you made to the SDK, re-install '
+          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+        );
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -233,7 +233,11 @@ class UpgradeCommandRunner {
   ///
   /// Exits tool if the tracking remote is not standard.
   void verifyStandardRemote(FlutterVersion localVersion) {
-    if (localVersion.repositoryUrl != _flutterGit) {
+    // Strip `.git` suffix from repository url and _flutterGit
+    final String trackingUrl = _stripDotGit(localVersion.repositoryUrl);
+    final String flutterGitUrl = _stripDotGit(_flutterGit);
+
+    if (trackingUrl != flutterGitUrl) {
       throwToolExit(
         'Unable to upgrade Flutter: Your local copy of Flutter is tracking a '
         'nonstandard remote "${localVersion.repositoryUrl}".\n'
@@ -247,6 +251,15 @@ class UpgradeCommandRunner {
         'Flutter by going to https://flutter.dev/docs/get-started/install.'
       );
     }
+  }
+
+  String _stripDotGit(String url) {
+    final RegExp pattern = RegExp(r'(.*)(\.git)$');
+    final RegExpMatch match = pattern.firstMatch(url);
+    if (match == null) {
+      return url;
+    }
+    return match.group(1);
   }
 
   /// Returns the remote HEAD flutter version.

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -113,8 +113,7 @@ class UpgradeCommandRunner {
     @required bool testFlow,
     @required bool verifyOnly,
   }) async {
-    final FlutterVersion upstreamVersion = await fetchLatestVersion();
-    checkSupportedRemote(flutterVersion);
+    final FlutterVersion upstreamVersion = await fetchLatestVersion(localVersion: flutterVersion);
     if (flutterVersion.frameworkRevision == upstreamVersion.frameworkRevision) {
       globals.printStatus('Flutter is already up to date on channel ${flutterVersion.channel}');
       globals.printStatus('$flutterVersion');
@@ -251,7 +250,7 @@ class UpgradeCommandRunner {
   /// Returns the remote HEAD flutter version.
   ///
   /// Exits tool if HEAD isn't pointing to a branch, or there is no upstream.
-  Future<FlutterVersion> fetchLatestVersion() async {
+  Future<FlutterVersion> fetchLatestVersion({@required FlutterVersion localVersion}) async {
     String revision;
     try {
       // Fetch upstream branch's commits and tags
@@ -280,12 +279,7 @@ class UpgradeCommandRunner {
         // Get the name of local branch to show in error message
         String localBranch;
         try {
-          final RunResult result = await globals.processUtils.run(
-            <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-            throwOnError: true,
-            workingDirectory: workingDirectory,
-          );
-          localBranch = result.stdout.trim();
+          localBranch = localVersion.getBranchName();
         } on Exception catch (e) {
           throwToolExit(e.toString());
         }
@@ -299,6 +293,7 @@ class UpgradeCommandRunner {
         throwToolExit(errorString);
       }
     }
+    checkSupportedRemote(localVersion);
     return FlutterVersion(workingDirectory: workingDirectory, frameworkRevision: revision);
   }
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -236,8 +236,8 @@ class UpgradeCommandRunner {
   void checkSupportedRemote(FlutterVersion localVersion) {
     if (localVersion.repositoryUrl != _flutterGit) {
       throwToolExit(
-        'Your local copy of Flutter is tracking an unsupported remote '
-        '"${localVersion.repositoryUrl}".\n'
+        'Unable to upgrade Flutter: Your local copy of Flutter is tracking a '
+        'nonstandard remote "${localVersion.repositoryUrl}".\n'
         'To use the unofficial remote, set the environment variable '
         '"FLUTTER_GIT_URL" to "${localVersion.repositoryUrl}",\n'
         'or to use the official remote, run '
@@ -271,9 +271,10 @@ class UpgradeCommandRunner {
       final String errorString = e.toString();
       if (errorString.contains('fatal: HEAD does not point to a branch')) {
         throwToolExit(
-          'You are not currently on a release branch. Use git to '
-          "check out an official branch ('stable', 'beta', 'dev', or 'master') "
-          'and retry, for example:\n'
+          'Unable to upgrade Flutter: HEAD does not point to a branch(Are you '
+          'in a detached HEAD state?).\n'
+          'Use "git" to checkout an official branch '
+          '("stable", "beta", "dev", or "master") and retry, for example:\n'
           '  git checkout stable'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
@@ -285,9 +286,8 @@ class UpgradeCommandRunner {
           throwToolExit(e.toString());
         }
         throwToolExit(
-          'Unable to upgrade Flutter: no origin repository configured. '
-          'Run "git remote add origin '
-          'https://github.com/flutter/flutter" and '
+          'Unable to upgrade Flutter: no upstream repository configured for branch.\n'
+          'Run "git remote add origin https://github.com/flutter/flutter" and '
           '"git branch --set-upstream-to=origin/$localBranch" if remote '
           '"origin" exists in $workingDirectory');
       } else {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -239,10 +239,9 @@ class UpgradeCommandRunner {
     // If localVersion.repositoryUrl is null, exit
     if (localVersion.repositoryUrl == null) {
       throwToolExit(
-        'Unable to upgrade Flutter: The Flutter SDK is tracking an "unknown" '
-        'remote.\n'
-        'Re-install Flutter by going to $_flutterInstallDocs. Alternatively, use '
-        '"git" directly to configure a valid upstream for the branch and retry.'
+        'Unable to upgrade Flutter: The tool could not determine the url of '
+        'the remote upstream which is currently being tracked by the SDK.\n'
+        'Re-install Flutter by going to $_flutterInstallDocs.'
       );
     }
 
@@ -329,9 +328,9 @@ class UpgradeCommandRunner {
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         throwToolExit(
-          'Unable to upgrade Flutter: No upstream repository configured for branch.\n'
-          'Re-install Flutter by going to $_flutterInstallDocs. Alternatively, use '
-          '"git" directly to configure an upstream for the branch and retry.'
+          'Unable to upgrade Flutter: No upstream repository configured for '
+          'current branch.\n'
+          'Re-install Flutter by going to $_flutterInstallDocs.'
         );
       } else {
         throwToolExit(errorString);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -259,12 +259,10 @@ class UpgradeCommandRunner {
           'remote "${localVersion.repositoryUrl}".\n'
           '  - To use the current remote, set the environment variable "FLUTTER_GIT_URL" '
           'to "${localVersion.repositoryUrl}", and retry.\n'
-          '  - To use the standard remote, change the url of the tracking remote to '
-          '"https://github.com/flutter/flutter.git", and retry, for example, to change '
-          'the url of the remote "origin", run:\n\n'
-          '      git remote set-url origin https://github.com/flutter/flutter.git\n\n'
-          'If you are okay with losing local changes you made to the SDK, re-install '
-          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+          '  - To use the standard remote, change the url of the tracking remote via '
+          '"git remote" to "https://github.com/flutter/flutter.git", and retry.\n\n'
+          'As an alternative, if you are okay with losing local changes you made '
+          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
         );
       }
     }
@@ -306,27 +304,16 @@ class UpgradeCommandRunner {
         throwToolExit(
           'Unable to upgrade Flutter: HEAD does not point to a branch(Are you '
           'in a detached HEAD state?).\n'
-          'Use "git" to checkout an official branch '
-          '("stable", "beta", "dev", or "master") and retry, for example:\n'
-          '  flutter channel stable\n\n'
-          'If you are okay with losing local changes you made to the SDK, re-install '
-          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+          'Use "flutter channel" to switch to an official channel, and retry.\n\n'
+          'As an alternative, if you are okay with losing local changes you made '
+          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
-        // Get the name of local branch to show in error message
-        String localBranch;
-        try {
-          localBranch = localVersion.getBranchName();
-        } on Exception catch (e) {
-          throwToolExit(e.toString());
-        }
         throwToolExit(
-          'Unable to upgrade Flutter: no upstream repository configured for branch.\n'
-          'Run "git remote add origin https://github.com/flutter/flutter" and '
-          '"git branch --set-upstream-to=origin/$localBranch" if remote '
-          '"origin" exists in $workingDirectory.\n\n'
-          'If you are okay with losing local changes you made to the SDK, re-install '
-          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+          'Unable to upgrade Flutter: No upstream repository configured for branch.\n'
+          'Use "git remote" to set an upstream remote for the current branch, and retry.\n\n'
+          'As an alternative, if you are okay with losing local changes you made '
+          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
         );
       } else {
         throwToolExit(errorString);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -225,15 +225,14 @@ class UpgradeCommandRunner {
     }
   }
 
-  /// Checks to see if the local copy of Flutter is tracking a "standard remote",
-  /// that is, either "https://github.com/flutter/flutter.git" or the one set as
-  /// `FLUTTER_GIT_URL` environment variable.
+  /// Checks if the Flutter git repository is tracking a "standard remote".
   ///
-  /// If the upstream remote url is configured to track a remote different
-  /// from `_flutterGit`, upgrading would not necessarily fetch the actual
-  /// upstream updates from the latter, which is used for version check and
-  /// inform users about the update in the first place.
-  void checkSupportedRemote(FlutterVersion localVersion) {
+  /// Using `flutter upgrade` is not supported from a non-standard remote. A git
+  /// remote should have the same url as [_flutterGit] to be considered as a
+  /// "standard" remote.
+  ///
+  /// Exits tool if the tracking remote is not standard.
+  void verifyStandardRemote(FlutterVersion localVersion) {
     if (localVersion.repositoryUrl != _flutterGit) {
       throwToolExit(
         'Unable to upgrade Flutter: Your local copy of Flutter is tracking a '
@@ -243,7 +242,9 @@ class UpgradeCommandRunner {
         'or to use the official remote, run '
         '"git remote add origin https://github.com/flutter/flutter" and '
         '"git branch --set-upstream-to=origin/${localVersion.channel}" if remote "origin" '
-        'exists in $workingDirectory.\n'
+        'exists in $workingDirectory.\n\n'
+        'If you are okay with losing local changes you made to the SDK, re-install '
+        'Flutter by going to https://flutter.dev/docs/get-started/install.'
       );
     }
   }
@@ -294,7 +295,7 @@ class UpgradeCommandRunner {
         throwToolExit(errorString);
       }
     }
-    checkSupportedRemote(localVersion);
+    verifyStandardRemote(localVersion);
     return FlutterVersion(workingDirectory: workingDirectory, frameworkRevision: revision);
   }
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -278,7 +278,9 @@ class UpgradeCommandRunner {
           'in a detached HEAD state?).\n'
           'Use "git" to checkout an official branch '
           '("stable", "beta", "dev", or "master") and retry, for example:\n'
-          '  git checkout stable'
+          '  flutter channel stable\n\n'
+          'If you are okay with losing local changes you made to the SDK, re-install '
+          'Flutter by going to https://flutter.dev/docs/get-started/install.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         // Get the name of local branch to show in error message
@@ -292,7 +294,10 @@ class UpgradeCommandRunner {
           'Unable to upgrade Flutter: no upstream repository configured for branch.\n'
           'Run "git remote add origin https://github.com/flutter/flutter" and '
           '"git branch --set-upstream-to=origin/$localBranch" if remote '
-          '"origin" exists in $workingDirectory');
+          '"origin" exists in $workingDirectory.\n\n'
+          'If you are okay with losing local changes you made to the SDK, re-install '
+          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+        );
       } else {
         throwToolExit(errorString);
       }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -20,6 +20,9 @@ import '../version.dart';
 /// The flutter GitHub repository.
 String get _flutterGit => globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
 
+/// The official docs to install Flutter.
+String get _flutterInstallDocs => 'https://flutter.dev/docs/get-started/install';
+
 class UpgradeCommand extends FlutterCommand {
   UpgradeCommand({
     @required bool verboseHelp,
@@ -238,9 +241,8 @@ class UpgradeCommandRunner {
       throwToolExit(
         'Unable to upgrade Flutter: The Flutter SDK is tracking an "unknown" '
         'remote.\n'
-        'Re-install Flutter by going to '
-        'https://flutter.dev/docs/get-started/install. Alternatively, use "git" '
-        'directly to configure a valid upstream for the branch and retry.'
+        'Re-install Flutter by going to $_flutterInstallDocs. Alternatively, use '
+        '"git" directly to configure a valid upstream for the branch and retry.'
       );
     }
 
@@ -264,27 +266,28 @@ class UpgradeCommandRunner {
           '"$_flutterGit".\n'
           'Either remove "FLUTTER_GIT_URL" from the environment or set '
           '"FLUTTER_GIT_URL" to "${localVersion.repositoryUrl}", and retry. '
-          'Alternatively, re-install Flutter by going to '
-          'https://flutter.dev/docs/get-started/install.\n'
-          'If this is intentional, it is recommended to use "git" directly to '
-          'keep Flutter SDK up-to date.'
-        );
-      } else {
-        // Inform that the user has to set the environment variable to continue.
-        throwToolExit(
-          'Unable to upgrade Flutter: The Flutter SDK is tracking a non-standard '
-          'remote "${localVersion.repositoryUrl}".\n'
-          'Set the environment variable "FLUTTER_GIT_URL" to '
-          '"${localVersion.repositoryUrl}", and retry. '
-          'Alternatively, re-install Flutter by going to '
-          'https://flutter.dev/docs/get-started/install.\n'
+          'Alternatively, re-install Flutter by going to $_flutterInstallDocs.\n'
           'If this is intentional, it is recommended to use "git" directly to '
           'keep Flutter SDK up-to date.'
         );
       }
+      // If `FLUTTER_GIT_URL` is unset, inform that the user has to set the
+      // environment variable to continue.
+      throwToolExit(
+        'Unable to upgrade Flutter: The Flutter SDK is tracking a non-standard '
+        'remote "${localVersion.repositoryUrl}".\n'
+        'Set the environment variable "FLUTTER_GIT_URL" to '
+        '"${localVersion.repositoryUrl}", and retry. '
+        'Alternatively, re-install Flutter by going to $_flutterInstallDocs.\n'
+        'If this is intentional, it is recommended to use "git" directly to '
+        'keep Flutter SDK up-to date.'
+      );
     }
   }
 
+  // Strips ".git" suffix from a given string, preferably an url.
+  // For example, changes 'https://github.com/flutter/flutter.git' to 'https://github.com/flutter/flutter'.
+  // URLs without ".git" suffix will be unaffected.
   String _stripDotGit(String url) {
     final RegExp pattern = RegExp(r'(.*)(\.git)$');
     final RegExpMatch match = pattern.firstMatch(url);
@@ -319,18 +322,16 @@ class UpgradeCommandRunner {
       final String errorString = e.toString();
       if (errorString.contains('fatal: HEAD does not point to a branch')) {
         throwToolExit(
-          'Unable to upgrade Flutter: HEAD does not point to a branch(Are you '
+          'Unable to upgrade Flutter: HEAD does not point to a branch (Are you '
           'in a detached HEAD state?).\n'
           'Use "flutter channel" to switch to an official channel, and retry. '
-          'Alternatively, re-install Flutter by going to '
-          'https://flutter.dev/docs/get-started/install.'
+          'Alternatively, re-install Flutter by going to $_flutterInstallDocs.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         throwToolExit(
           'Unable to upgrade Flutter: No upstream repository configured for branch.\n'
-          'Re-install Flutter by going to '
-          'https://flutter.dev/docs/get-started/install. Alternatively, use "git" '
-          'directly to configure an upstream for the branch and retry.'
+          'Re-install Flutter by going to $_flutterInstallDocs. Alternatively, use '
+          '"git" directly to configure an upstream for the branch and retry.'
         );
       } else {
         throwToolExit(errorString);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -244,25 +244,26 @@ class UpgradeCommandRunner {
         // tracking remote to continue.
         throwToolExit(
           'Unable to upgrade Flutter: The Flutter SDK is tracking '
-          '"${localVersion.repositoryUrl}" but "FLUTTER_GIT_URL" is set to "$_flutterGit."\n'
-          'Either remove "FLUTTER_GIT_URL from the environment or set "FLUTTER_GIT_URL" '
-          'to "${localVersion.repositoryUrl}", and retry.\n\n'
-          'If you are okay with losing local changes you made to the SDK, re-install '
-          'Flutter by going to https://flutter.dev/docs/get-started/install.'
+          '"${localVersion.repositoryUrl}" but "FLUTTER_GIT_URL" is set to '
+          '"$_flutterGit".\n'
+          'Either remove "FLUTTER_GIT_URL" from the environment or set '
+          '"FLUTTER_GIT_URL" to "${localVersion.repositoryUrl}", and retry. '
+          'Alternatively, re-install Flutter by going to '
+          'https://flutter.dev/docs/get-started/install.\n'
+          'If this is intentional, it is recommended to use "git" directly to '
+          'keep Flutter SDK up-to date.'
         );
       } else {
-        // Inform that the user has to either set the environment variable, or
-        // change the url of the tracking remote to the Flutter GitHub repository
-        // to continue.
+        // Inform that the user has to set the environment variable to continue.
         throwToolExit(
           'Unable to upgrade Flutter: The Flutter SDK is tracking a non-standard '
           'remote "${localVersion.repositoryUrl}".\n'
-          '  - To use the current remote, set the environment variable "FLUTTER_GIT_URL" '
-          'to "${localVersion.repositoryUrl}", and retry.\n'
-          '  - To use the standard remote, change the url of the tracking remote via '
-          '"git remote" to "https://github.com/flutter/flutter.git", and retry.\n\n'
-          'As an alternative, if you are okay with losing local changes you made '
-          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
+          'Set the environment variable "FLUTTER_GIT_URL" to '
+          '"${localVersion.repositoryUrl}", and retry. '
+          'Alternatively, re-install Flutter by going to '
+          'https://flutter.dev/docs/get-started/install.\n'
+          'If this is intentional, it is recommended to use "git" directly to '
+          'keep Flutter SDK up-to date.'
         );
       }
     }
@@ -304,16 +305,16 @@ class UpgradeCommandRunner {
         throwToolExit(
           'Unable to upgrade Flutter: HEAD does not point to a branch(Are you '
           'in a detached HEAD state?).\n'
-          'Use "flutter channel" to switch to an official channel, and retry.\n\n'
-          'As an alternative, if you are okay with losing local changes you made '
-          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
+          'Use "flutter channel" to switch to an official channel, and retry. '
+          'Alternatively, re-install Flutter by going to '
+          'https://flutter.dev/docs/get-started/install.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         throwToolExit(
           'Unable to upgrade Flutter: No upstream repository configured for branch.\n'
-          'Use "git remote" to set an upstream remote for the current branch, and retry.\n\n'
-          'As an alternative, if you are okay with losing local changes you made '
-          'to the SDK, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
+          'Re-install Flutter by going to '
+          'https://flutter.dev/docs/get-started/install. Alternatively, use "git" '
+          'directly to configure an upstream for the branch and retry.'
         );
       } else {
         throwToolExit(errorString);

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -237,6 +237,11 @@ class UpgradeCommandRunner {
     final String trackingUrl = _stripDotGit(localVersion.repositoryUrl);
     final String flutterGitUrl = _stripDotGit(_flutterGit);
 
+    // Exempt the flutter GitHub git SSH remote from this check
+    if (trackingUrl == 'git@github.com:flutter/flutter') {
+      return;
+    }
+
     if (trackingUrl != flutterGitUrl) {
       if (globals.platform.environment.containsKey('FLUTTER_GIT_URL')) {
         // If `FLUTTER_GIT_URL` is set, inform the user to either remove the

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -233,6 +233,17 @@ class UpgradeCommandRunner {
   ///
   /// Exits tool if the tracking remote is not standard.
   void verifyStandardRemote(FlutterVersion localVersion) {
+    // If localVersion.repositoryUrl is null, exit
+    if (localVersion.repositoryUrl == null) {
+      throwToolExit(
+        'Unable to upgrade Flutter: The Flutter SDK is tracking an "unknown" '
+        'remote.\n'
+        'Re-install Flutter by going to '
+        'https://flutter.dev/docs/get-started/install. Alternatively, use "git" '
+        'directly to configure a valid upstream for the branch and retry.'
+      );
+    }
+
     // Strip `.git` suffix from repository url and _flutterGit
     final String trackingUrl = _stripDotGit(localVersion.repositoryUrl);
     final String flutterGitUrl = _stripDotGit(_flutterGit);

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -201,7 +201,7 @@ void main() {
 
       await expectLater(
             () async => realCommandRunner.fetchLatestVersion(localVersion: FakeFlutterVersion()),
-        throwsToolExit(message: 'You are not currently on a release branch.'),
+        throwsToolExit(message: 'Unable to upgrade Flutter: HEAD does not point to a branch'),
       );
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
@@ -211,6 +211,7 @@ void main() {
 
     testUsingContext('fetchLatestVersion throws toolExit if no upstream configured', () async {
       realCommandRunner.workingDirectory = '/src/flutter';
+
       processManager.addCommands(const <FakeCommand>[
         FakeCommand(command: <String>[
           'git', 'fetch', '--tags'
@@ -232,7 +233,7 @@ void main() {
         err = e;
       }
       expect(err, isNotNull);
-      expect(err.toString(), contains('Unable to upgrade Flutter: no origin repository configured.'));
+      expect(err.toString(), contains('Unable to upgrade Flutter: no upstream repository configured for branch.'));
       // FakeFlutterVersion.getBranchName is hardcoded to 'master'
       expect(err.toString(), contains('git branch --set-upstream-to=origin/master'));
       expect(err.toString(), contains('if remote "origin" exists in /src/flutter'));

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -237,9 +237,8 @@ void main() {
         err = e;
       }
       expect(err, isNotNull);
-      expect(err.toString(), contains('Unable to upgrade Flutter: No upstream repository configured for branch.'));
+      expect(err.toString(), contains('Unable to upgrade Flutter: No upstream repository configured for current branch.'));
       expect(err.toString(), contains('Re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
-      expect(err.toString(), contains('use "git" directly to configure an upstream for the branch and retry.'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
@@ -265,9 +264,8 @@ void main() {
           err = e;
         }
         expect(err, isNotNull);
-        expect(err.toString(), contains('The Flutter SDK is tracking an "unknown" remote.'));
+        expect(err.toString(), contains('could not determine the url of the remote upstream which is currently being tracked by the SDK'));
         expect(err.toString(), contains('Re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
-        expect(err.toString(), contains('use "git" directly to configure a valid upstream for the branch and retry.'));
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -216,8 +216,6 @@ void main() {
     });
 
     testUsingContext('fetchLatestVersion throws toolExit if no upstream configured', () async {
-      realCommandRunner.workingDirectory = '/src/flutter';
-
       processManager.addCommands(const <FakeCommand>[
         FakeCommand(command: <String>[
           'git', 'fetch', '--tags'
@@ -254,7 +252,7 @@ void main() {
       const String flutterStandardUrl = 'https://github.com/flutter/flutter';
       const String flutterStandardSshUrlDotGit = 'git@github.com:flutter/flutter.git';
 
-      testUsingContext('throws toolExit if upstreamUrl is null', () async {
+      testUsingContext('throws toolExit if repository url is null', () async {
         final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
           channel: 'dev',
           repositoryUrl: null,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -207,9 +207,7 @@ void main() {
       }
       expect(err, isNotNull);
       expect(err.toString(), contains('Unable to upgrade Flutter: HEAD does not point to a branch'));
-      expect(err.toString(), contains('Use "flutter channel" to switch to an official channel ("stable", "beta", "dev", or "master") and retry'));
-      // FakeFlutterVersion.getBranchName is hardcoded to 'master'
-      expect(err.toString(), contains('flutter channel stable'));
+      expect(err.toString(), contains('Use "flutter channel" to switch to an official channel, and retry'));
       expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
@@ -242,10 +240,7 @@ void main() {
       }
       expect(err, isNotNull);
       expect(err.toString(), contains('Unable to upgrade Flutter: No upstream repository configured for branch.'));
-      expect(err.toString(), contains('Run "git remote add origin https://github.com/flutter/flutter.git"'));
-      // FakeFlutterVersion.getBranchName is hardcoded to 'master'
-      expect(err.toString(), contains('and "git branch --set-upstream-to=origin/master"'));
-      expect(err.toString(), contains('if remote "origin" exists in /src/flutter'));
+      expect(err.toString(), contains('Use "git remote" to set an upstream remote for the current branch, and retry'));
       expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
@@ -311,8 +306,7 @@ void main() {
         expect(err, isNotNull);
         expect(err.toString(), contains('The Flutter SDK is tracking a non-standard remote "$flutterNonStandardUrlDotGit"'));
         expect(err.toString(), contains('set the environment variable "FLUTTER_GIT_URL" to "$flutterNonStandardUrlDotGit", and retry.'));
-        expect(err.toString(), contains('change the url of the tracking remote to "https://github.com/flutter/flutter.git", and retry,'));
-        expect(err.toString(), contains('git remote set-url origin https://github.com/flutter/flutter.git'));
+        expect(err.toString(), contains('change the url of the tracking remote via "git remote" to "https://github.com/flutter/flutter.git", and retry'));
         expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -254,6 +254,28 @@ void main() {
       const String flutterStandardUrl = 'https://github.com/flutter/flutter';
       const String flutterStandardSshUrlDotGit = 'git@github.com:flutter/flutter.git';
 
+      testUsingContext('throws toolExit if upstreamUrl is null', () async {
+        final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+          channel: 'dev',
+          repositoryUrl: null,
+        );
+
+        ToolExit err;
+        try {
+         realCommandRunner.verifyStandardRemote(flutterVersion);
+        } on ToolExit catch (e) {
+          err = e;
+        }
+        expect(err, isNotNull);
+        expect(err.toString(), contains('The Flutter SDK is tracking an "unknown" remote.'));
+        expect(err.toString(), contains('Re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+        expect(err.toString(), contains('use "git" directly to configure a valid upstream for the branch and retry.'));
+        expect(processManager, hasNoRemainingExpectations);
+      }, overrides: <Type, Generator> {
+        ProcessManager: () => processManager,
+        Platform: () => fakePlatform,
+      });
+
       testUsingContext('does not throw toolExit at standard remote url with .git suffix and FLUTTER_GIT_URL unset', () async {
         final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
           channel: 'dev',

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -280,13 +280,7 @@ void main() {
           repositoryUrl: flutterStandardUrlDotGit,
         );
 
-        ToolExit err;
-        try {
-         realCommandRunner.verifyStandardRemote(flutterVersion);
-        } on ToolExit catch (e) {
-          err = e;
-        }
-        expect(err, isNull);
+        expect(() => realCommandRunner.verifyStandardRemote(flutterVersion), returnsNormally);
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,
@@ -299,13 +293,7 @@ void main() {
           repositoryUrl: flutterStandardUrl,
         );
 
-        ToolExit err;
-        try {
-         realCommandRunner.verifyStandardRemote(flutterVersion);
-        } on ToolExit catch (e) {
-          err = e;
-        }
-        expect(err, isNull);
+        expect(() => realCommandRunner.verifyStandardRemote(flutterVersion), returnsNormally);
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,
@@ -341,13 +329,7 @@ void main() {
           repositoryUrl: flutterNonStandardUrlDotGit,
         );
 
-        ToolExit err;
-        try {
-         realCommandRunner.verifyStandardRemote(flutterVersion);
-        } on ToolExit catch (e) {
-          err = e;
-        }
-        expect(err, isNull);
+        expect(() => realCommandRunner.verifyStandardRemote(flutterVersion), returnsNormally);
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,
@@ -388,13 +370,7 @@ void main() {
           repositoryUrl: flutterStandardSshUrlDotGit,
         );
 
-        ToolExit err;
-        try {
-         realCommandRunner.verifyStandardRemote(flutterVersion);
-        } on ToolExit catch (e) {
-          err = e;
-        }
-        expect(err, isNull);
+        expect(() => realCommandRunner.verifyStandardRemote(flutterVersion), returnsNormally);
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -240,8 +240,8 @@ void main() {
       }
       expect(err, isNotNull);
       expect(err.toString(), contains('Unable to upgrade Flutter: No upstream repository configured for branch.'));
-      expect(err.toString(), contains('Use "git remote" to set an upstream remote for the current branch, and retry'));
-      expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+      expect(err.toString(), contains('Re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+      expect(err.toString(), contains('use "git" directly to configure an upstream for the branch and retry.'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
@@ -305,9 +305,9 @@ void main() {
         }
         expect(err, isNotNull);
         expect(err.toString(), contains('The Flutter SDK is tracking a non-standard remote "$flutterNonStandardUrlDotGit"'));
-        expect(err.toString(), contains('set the environment variable "FLUTTER_GIT_URL" to "$flutterNonStandardUrlDotGit", and retry.'));
-        expect(err.toString(), contains('change the url of the tracking remote via "git remote" to "https://github.com/flutter/flutter.git", and retry'));
+        expect(err.toString(), contains('Set the environment variable "FLUTTER_GIT_URL" to "$flutterNonStandardUrlDotGit", and retry.'));
         expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+        expect(err.toString(), contains('it is recommended to use "git" directly to keep Flutter SDK up-to date.'));
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,
@@ -352,6 +352,7 @@ void main() {
         expect(err.toString(), contains('but "FLUTTER_GIT_URL" is set to "$flutterStandardUrl"'));
         expect(err.toString(), contains('remove "FLUTTER_GIT_URL" from the environment or set "FLUTTER_GIT_URL" to "$flutterNonStandardUrlDotGit"'));
         expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+        expect(err.toString(), contains('it is recommended to use "git" directly to keep Flutter SDK up-to date.'));
         expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator> {
         ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -252,6 +252,7 @@ void main() {
       const String flutterStandardUrlDotGit = 'https://github.com/flutter/flutter.git';
       const String flutterNonStandardUrlDotGit = 'https://githubmirror.com/flutter/flutter.git';
       const String flutterStandardUrl = 'https://github.com/flutter/flutter';
+      const String flutterStandardSshUrlDotGit = 'git@github.com:flutter/flutter.git';
 
       testUsingContext('does not throw toolExit at standard remote url with .git suffix and FLUTTER_GIT_URL unset', () async {
         final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
@@ -359,6 +360,25 @@ void main() {
         Platform: () => fakePlatform..environment = Map<String, String>.unmodifiable(<String, String> {
           'FLUTTER_GIT_URL': flutterStandardUrl,
         }),
+      });
+
+      testUsingContext('exempts standard ssh url from check with FLUTTER_GIT_URL unset', () async {
+        final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
+          channel: 'dev',
+          repositoryUrl: flutterStandardSshUrlDotGit,
+        );
+
+        ToolExit err;
+        try {
+         realCommandRunner.verifyStandardRemote(flutterVersion);
+        } on ToolExit catch (e) {
+          err = e;
+        }
+        expect(err, isNull);
+        expect(processManager, hasNoRemainingExpectations);
+      }, overrides: <Type, Generator> {
+        ProcessManager: () => processManager,
+        Platform: () => fakePlatform,
       });
     });
 

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -210,6 +210,7 @@ void main() {
     });
 
     testUsingContext('fetchLatestVersion throws toolExit if no upstream configured', () async {
+      realCommandRunner.workingDirectory = '/src/flutter';
       processManager.addCommands(const <FakeCommand>[
         FakeCommand(command: <String>[
           'git', 'fetch', '--tags'
@@ -234,20 +235,30 @@ void main() {
       expect(err.toString(), contains('Unable to upgrade Flutter: no origin repository configured.'));
       // FakeFlutterVersion.getBranchName is hardcoded to 'master'
       expect(err.toString(), contains('git branch --set-upstream-to=origin/master'));
-      expect(err.toString(), contains('if remote "origin" exists in src/flutter'));
+      expect(err.toString(), contains('if remote "origin" exists in /src/flutter'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
       Platform: () => fakePlatform,
     });
 
-    testUsingContext('fetchLatestVersion throws on unsupported upstream remote with FLUTTER_GIT_URL unset', () async {
+    testUsingContext('fetchLatestVersion throws toolExit on nonstandard upstream remote with FLUTTER_GIT_URL unset', () async {
+      realCommandRunner.workingDirectory = '/src/flutter';
       final FakeFlutterVersion flutterVersion = FakeFlutterVersion(
         channel: 'dev',
         repositoryUrl: 'https://githubmirror.com/flutter',
       );
 
-      realCommandRunner.workingDirectory = './src/flutter';
+      processManager.addCommands(const <FakeCommand>[
+        FakeCommand(command: <String>[
+          'git', 'fetch', '--tags'
+        ]),
+        FakeCommand(command: <String>[
+          'git', 'rev-parse', '--verify', '@{u}',
+        ],
+        stdout: ''),
+      ]);
+
       ToolExit err;
       try {
        await realCommandRunner.fetchLatestVersion(localVersion: flutterVersion);
@@ -258,18 +269,39 @@ void main() {
       expect(err.toString(), contains('Your local copy of Flutter is tracking an unsupported remote'));
       expect(err.toString(), contains('"FLUTTER_GIT_URL" to "https://githubmirror.com/flutter"'));
       expect(err.toString(), contains('git branch --set-upstream-to=origin/dev'));
-      expect(err.toString(), contains('if remote "origin" exists in flutter'));
+      expect(err.toString(), contains('if remote "origin" exists in /src/flutter'));
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator> {
+      ProcessManager: () => processManager,
       Platform: () => fakePlatform,
     });
 
     testUsingContext('fetchLatestVersion does not throw on unsupported upstream remote with FLUTTER_GIT_URL set', () async {
       final FakeFlutterVersion flutterVersion = FakeFlutterVersion(repositoryUrl: 'https://githubmirror.com/flutter');
+      const String upstreamRevision = '22222222222222222222';
+
+      processManager.addCommands(const <FakeCommand>[
+        FakeCommand(command: <String>[
+          'git', 'fetch', '--tags'
+        ]),
+        FakeCommand(command: <String>[
+          'git', 'rev-parse', '--verify', '@{u}',
+        ],
+        stdout: upstreamRevision),
+        FakeCommand(command: <String>[
+          'git', 'tag', '--points-at', upstreamRevision,
+        ],
+        stdout: ''),
+        FakeCommand(command: <String>[
+          'git', 'describe', '--match', '*.*.*', '--long', '--tags', upstreamRevision,
+        ],
+        stdout: ''),
+      ]);
 
       await realCommandRunner.fetchLatestVersion(localVersion: flutterVersion);
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator> {
+      ProcessManager: () => processManager,
       Platform: () => fakePlatform..environment = Map<String, String>.unmodifiable(<String, String> {
         'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter',
       }),


### PR DESCRIPTION
This PR makes `flutter upgrade` to only work with "standard remotes", i.e., either `https://github.com/flutter/flutter.git`(or the SSH remote `git@github.com:flutter/flutter.git`) or the one set as the `FLUTTER_GIT_URL` environment variable.

Otherwise running `flutter upgrade` makes the tool throw an error and exit(The `.git` suffix of either of the standard URLs can be used without).

### Error messages
The tool will display different error messages on different non-ideal user setups:

- The user is tracking a different remote other than `https://github.com/flutter/flutter.git` or `git@github.com:flutter/flutter.git` and having `FLUTTER_GIT_URL` unset:
```
Unable to upgrade Flutter: The Flutter SDK is tracking a non-standard remote
"git@github.com:RoyARG02/flutter.git".
Set the environment variable "FLUTTER_GIT_URL" to "git@github.com:RoyARG02/flutter.git", and retry. Alternatively,
re-install Flutter by going to https://flutter.dev/docs/get-started/install.
If this is intentional, it is recommended to use "git" directly to keep Flutter SDK up-to date.
```

- `FLUTTER_GIT_URL` is set to different url than the tracking remote:
```
Unable to upgrade Flutter: The Flutter SDK is tracking "git@github.com:RoyARG02/flutter.git" but "FLUTTER_GIT_URL"
is set to "https://github.com/flutter/flutter.git".
Either remove "FLUTTER_GIT_URL" from the environment or set "FLUTTER_GIT_URL" to
"git@github.com:RoyARG02/flutter.git", and retry. Alternatively, re-install Flutter by going to
https://flutter.dev/docs/get-started/install.
If this is intentional, it is recommended to use "git" directly to keep Flutter SDK up-to date.
```

- `FlutterVersion.repositoryUrl` is null (The Flutter tool couldn't determine the upstream repository):
```
Unable to upgrade Flutter: The tool could not determine the url of the remote upstream which is currently being
tracked by the SDK.
Re-install Flutter by going to https://flutter.dev/docs/get-started/install.
```

### Additional fixes
Additionally, replaces the git commands with `flutter channel` upon detached HEAD state and clarifies the error message upon missing upstream for current branch.

## Related Issues

Fixes #78591.
Fixes #49713.
Fixes #79366.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
