### PR TITLE
Apply carriedVelocity unless substantially different

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -275,10 +275,10 @@ class ScrollDragController implements Drag {
       Duration(milliseconds: 20);
 
   /// The minimum amount of velocity needed to apply the [carriedVelocity] at
-  /// the end of a drag. Expressed as a factor. For example with a 
+  /// the end of a drag. Expressed as a factor. For example with a
   /// [carriedVelocity] of 2000, we will need a velocity of at least 1000 to 
-  /// apply the [carriedVelocity] as well. If the velocity does not meet the 
-  /// threshold the the [carriedVelocity] is lost. Decided by fair eyeballing 
+  /// apply the [carriedVelocity] as well. If the velocity does not meet the
+  /// threshold the the [carriedVelocity] is lost. Decided by fair eyeballing
   /// with the scroll_overlay platform test.
   static const double momentumRetainVelocityThresholdFactor = 0.5;
 
@@ -401,9 +401,9 @@ class ScrollDragController implements Drag {
     if (_retainMomentum) {
       // Build momentum only if dragging in the same direction.
       final bool isFlingingInSameDirection = velocity.sign == carriedVelocity!.sign;
-      // Build momentum only if the velocity of the last drag was not 
+      // Build momentum only if the velocity of the last drag was not
       // substantially lower than the carried momentum.
-      final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = 
+      final bool isVelocityNotSubstantiallyLessThanCarriedMomentum =
         velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
       if(isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
         velocity += carriedVelocity!;

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -274,9 +274,10 @@ class ScrollDragController implements Drag {
   static const Duration momentumRetainStationaryDurationThreshold =
       Duration(milliseconds: 20);
 
-  /// The factor multiplied with the carriedVelocity to check if it should be
-  /// added to added to the velocity of an ended scroll gesture.
-  /// Decided by fair eyeballing with the scroll_overlay platform test
+  /// The minimum amount of velocity needed to apply the [carriedVelocity] at
+  /// the end of a drag. Expressed as a factor. For example with a [carriedVelocity]
+  /// of 2000, we will need a velocity of at least 1000 to apply the [carriedVelocity]
+  /// as well. Decided by fair eyeballing with the scroll_overlay platform test.
   static const double momentumRetainVelocityThresholdFactor = 0.5;
 
   /// Maximum amount of time interval the drag can have consecutive stationary
@@ -396,15 +397,10 @@ class ScrollDragController implements Drag {
     _lastDetails = details;
 
     // Build momentum only if dragging in the same direction.
-    // Check that the incomming velocity is more than
-    // a [momentumRetainVelocityThresholdFactor]'th of the carriedVelocity to
-    // avoid adding the carriedVelocity to the current velocity if the finger
-    // left the screen with a substantially smaller speed giving the effect of
-    // the scrollview carrying on in a much larger speed than the finger left with
-    if (_retainMomentum &&
-        velocity.sign == carriedVelocity!.sign &&
-        (carriedVelocity! == 0 || velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor)
-    ) {
+    final bool isFlingingInSameDirection = velocity.sign == carriedVelocity!.sign;
+    // Build momentum only if the velocity of the last drag was not substantially lower than the carried momentum.
+    final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
+    if (_retainMomentum && isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
       velocity += carriedVelocity!;
     }
     delegate.goBallistic(velocity);

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -275,9 +275,11 @@ class ScrollDragController implements Drag {
       Duration(milliseconds: 20);
 
   /// The minimum amount of velocity needed to apply the [carriedVelocity] at
-  /// the end of a drag. Expressed as a factor. For example with a [carriedVelocity]
-  /// of 2000, we will need a velocity of at least 1000 to apply the [carriedVelocity]
-  /// as well. Decided by fair eyeballing with the scroll_overlay platform test.
+  /// the end of a drag. Expressed as a factor. For example with a 
+  /// [carriedVelocity] of 2000, we will need a velocity of at least 1000 to 
+  /// apply the [carriedVelocity] as well. If the velocity does not meet the 
+  /// threshold the the [carriedVelocity] is lost. Decided by fair eyeballing 
+  /// with the scroll_overlay platform test.
   static const double momentumRetainVelocityThresholdFactor = 0.5;
 
   /// Maximum amount of time interval the drag can have consecutive stationary
@@ -399,8 +401,10 @@ class ScrollDragController implements Drag {
     if (_retainMomentum) {
       // Build momentum only if dragging in the same direction.
       final bool isFlingingInSameDirection = velocity.sign == carriedVelocity!.sign;
-      // Build momentum only if the velocity of the last drag was not substantially lower than the carried momentum.
-      final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
+      // Build momentum only if the velocity of the last drag was not 
+      // substantially lower than the carried momentum.
+      final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = 
+        velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
       if(isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
         velocity += carriedVelocity!;
       }

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -396,12 +396,12 @@ class ScrollDragController implements Drag {
     _lastDetails = details;
 
     // Build momentum only if dragging in the same direction.
-    // Check that the incomming velocity is more than 
+    // Check that the incomming velocity is more than
     // a [momentumRetainVelocityThresholdFactor]'th of the carriedVelocity to
-    // avoid adding the carriedVelocity to the current velocity if the finger 
+    // avoid adding the carriedVelocity to the current velocity if the finger
     // left the screen with a substantially smaller speed giving the effect of
     // the scrollview carrying on in a much larger speed than the finger left with
-    if (_retainMomentum && 
+    if (_retainMomentum &&
         velocity.sign == carriedVelocity!.sign &&
         (carriedVelocity! == 0 || velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor)
     ) {

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -402,7 +402,7 @@ class ScrollDragController implements Drag {
       // Build momentum only if the velocity of the last drag was not substantially lower than the carried momentum.
       final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
       if(isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
-        velocity += carriedVelocity!;      
+        velocity += carriedVelocity!;
       }
     }
     delegate.goBallistic(velocity);

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -396,12 +396,14 @@ class ScrollDragController implements Drag {
       velocity = -velocity;
     _lastDetails = details;
 
-    // Build momentum only if dragging in the same direction.
-    final bool isFlingingInSameDirection = velocity.sign == carriedVelocity!.sign;
-    // Build momentum only if the velocity of the last drag was not substantially lower than the carried momentum.
-    final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
-    if (_retainMomentum && isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
-      velocity += carriedVelocity!;
+    if (_retainMomentum) {
+      // Build momentum only if dragging in the same direction.
+      final bool isFlingingInSameDirection = velocity.sign == carriedVelocity!.sign;
+      // Build momentum only if the velocity of the last drag was not substantially lower than the carried momentum.
+      final bool isVelocityNotSubstantiallyLessThanCarriedMomentum = velocity.abs() > carriedVelocity!.abs() * momentumRetainVelocityThresholdFactor;
+      if(isFlingingInSameDirection && isVelocityNotSubstantiallyLessThanCarriedMomentum) {
+        velocity += carriedVelocity!;      
+      }
     }
     delegate.goBallistic(velocity);
   }

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -276,7 +276,7 @@ class ScrollDragController implements Drag {
 
   /// The minimum amount of velocity needed to apply the [carriedVelocity] at
   /// the end of a drag. Expressed as a factor. For example with a
-  /// [carriedVelocity] of 2000, we will need a velocity of at least 1000 to 
+  /// [carriedVelocity] of 2000, we will need a velocity of at least 1000 to
   /// apply the [carriedVelocity] as well. If the velocity does not meet the
   /// threshold the the [carriedVelocity] is lost. Decided by fair eyeballing
   /// with the scroll_overlay platform test.

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -171,7 +171,6 @@ void main() {
   });
 
   testWidgets('A slower final fling does not apply carried momentum', (WidgetTester tester) async {
-    const double finalFlingSpeed = 200.0;
     await pumpTest(tester, debugDefaultTargetPlatformOverride);
     await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);
     await tester.pump(); // trigger fling
@@ -181,11 +180,11 @@ void main() {
     await tester.pump(); // trigger the second fling
     await tester.pump(const Duration(milliseconds: 10));
     // Make a final fling that is much slower.
-    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), finalFlingSpeed);
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 200.0);
     await tester.pump(); // trigger the third fling
     await tester.pump(const Duration(milliseconds: 10));
     // expect that there is no carried velocity
-    expect(getScrollVelocity(tester), lessThan(finalFlingSpeed));
+    expect(getScrollVelocity(tester), lessThan(200.0));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('No iOS/macOS momentum build with flings in opposite directions', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -170,6 +170,24 @@ void main() {
     expect(getScrollVelocity(tester), moreOrLessEquals(1000.0));
   });
 
+  testWidgets('A slower final fling does not apply carried momentum', (WidgetTester tester) async {
+    const double finalFlingSpeed = 200.0;
+    await pumpTest(tester, debugDefaultTargetPlatformOverride);
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.pump(); // trigger fling
+    await tester.pump(const Duration(milliseconds: 10));
+    // Repeat the exact same motion to build momentum.
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);
+    await tester.pump(); // trigger the second fling
+    await tester.pump(const Duration(milliseconds: 10));
+    // Make a final fling that is much slower.
+    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), finalFlingSpeed);
+    await tester.pump(); // trigger the third fling
+    await tester.pump(const Duration(milliseconds: 10));
+    // expect that there is no carried velocity
+    expect(getScrollVelocity(tester), lessThan(finalFlingSpeed));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+
   testWidgets('No iOS/macOS momentum build with flings in opposite directions', (WidgetTester tester) async {
     await pumpTest(tester, debugDefaultTargetPlatformOverride);
     await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);


### PR DESCRIPTION
On iOS the `carriedVelocity` (if it should be retained) is always added when a drag is ended. This can cause the unexpected behaviour of the scrollview speeding up after a fling, something that is not the expected behaviour in a native iOS app. This PR seeks to fix this issue by adding a check that the incoming velocity is larger than a factor of the carried velocity before applying it.

Attached two videos show the before and after behaviour

https://user-images.githubusercontent.com/1550685/113015889-3f5e8d00-917e-11eb-92be-6f8d2278c714.mp4

https://user-images.githubusercontent.com/1550685/113015759-2655dc00-917e-11eb-8a7a-0e3df19b28e6.mp4

Related Issues
Fixes #77043
Fixes #79277

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.




I intend to add a test for this as well, but I wanted to get some feedback on the suggested solution first, seeing as this is my first contribution to flutter.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
