### PR TITLE
Do not run version check if generating shell completion and stdout isn't terminal

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -253,11 +253,14 @@ class FlutterCommandRunner extends CommandRunner<void> {
         globals.flutterVersion.ensureVersionFile();
         final bool machineFlag = topLevelResults['machine'] as bool;
         final bool ci = await globals.botDetector.isRunningOnBot;
+        final bool redirectedCompletion = !globals.stdio.hasTerminal &&
+            (topLevelResults.command?.name ?? '').endsWith('-completion');
+        final bool isMachine = machineFlag || ci || redirectedCompletion;
         final bool versionCheckFlag = topLevelResults['version-check'] as bool;
         final bool explicitVersionCheckPassed = topLevelResults.wasParsed('version-check') && versionCheckFlag;
 
         if (topLevelResults.command?.name != 'upgrade' &&
-            (explicitVersionCheckPassed || (versionCheckFlag && !ci && !machineFlag))) {
+            (explicitVersionCheckPassed || (versionCheckFlag && !isMachine))) {
           await globals.flutterVersion.checkFlutterVersionFreshness();
         }
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -108,6 +108,40 @@ void main() {
         BotDetector: () => const FakeBotDetector(true),
       }, initializeFlutterRoot: false);
 
+      testUsingContext('checks that Flutter installation is up-to-date if shell completion to terminal', () async {
+        final FlutterCommand command = DummyFlutterCommand(name: 'bash-completion');
+        final FlutterCommandRunner runner = createTestCommandRunner(command) as FlutterCommandRunner;
+        final FakeFlutterVersion version = globals.flutterVersion as FakeFlutterVersion;
+
+        await runner.run(<String>['bash-completion']);
+
+        expect(version.didCheckFlutterVersionFreshness, true);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Platform: () => platform,
+        FlutterVersion: () => FakeFlutterVersion(),
+        BotDetector: () => const FakeBotDetector(false),
+        Stdio: () => FakeStdio(hasFakeTerminal: true),
+      });
+
+      testUsingContext('does not check that Flutter installation is up-to-date if redirecting shell completion', () async {
+        final FlutterCommand command = DummyFlutterCommand(name: 'bash-completion');
+        final FlutterCommandRunner runner = createTestCommandRunner(command) as FlutterCommandRunner;
+        final FakeFlutterVersion version = globals.flutterVersion as FakeFlutterVersion;
+
+        await runner.run(<String>['bash-completion']);
+
+        expect(version.didCheckFlutterVersionFreshness, false);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => FakeProcessManager.any(),
+        Platform: () => platform,
+        FlutterVersion: () => FakeFlutterVersion(),
+        BotDetector: () => const FakeBotDetector(false),
+        Stdio: () => FakeStdio(hasFakeTerminal: false),
+      });
+
       testUsingContext('Fetches tags when --version is used', () async {
         final FlutterCommandRunner runner = createTestCommandRunner(DummyFlutterCommand()) as FlutterCommandRunner;
         final FakeFlutterVersion version = globals.flutterVersion as FakeFlutterVersion;

--- a/packages/flutter_tools/test/general.shard/runner/utils.dart
+++ b/packages/flutter_tools/test/general.shard/runner/utils.dart
@@ -13,6 +13,7 @@ class DummyFlutterCommand extends FlutterCommand {
   DummyFlutterCommand({
     this.shouldUpdateCache = false,
     this.noUsagePath  = false,
+    this.name = 'dummy',
     this.commandFunction,
   });
 
@@ -29,7 +30,7 @@ class DummyFlutterCommand extends FlutterCommand {
   Future<String> get usagePath => noUsagePath ? null : super.usagePath;
 
   @override
-  String get name => 'dummy';
+  final String name;
 
   @override
   Future<FlutterCommandResult> runCommand() async {


### PR DESCRIPTION
In addition to suppressing the version check if running in CI or with the machine flag, suppress it if stdout is being piped or redirected while using one of the shell completion commands.

Fixes #79202.

Happy to amend this to use one of the other ways proposed in the original issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], ~~including [Features we expect every widget to implement].~~
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] ~~I updated/added relevant documentation (doc comments with `///`).~~
- [x] I added new tests to check the change I am making or feature I am adding, ~~or Hixie said the PR is test-exempt.~~
- [x] All existing and new tests are passing

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
