### PR TITLE
Add missing io import to complex_layout_semantics_perf

### DIFF
--- a/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/host_agent.dart';


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/79419 is missing an import
```
  error • A value of type 'dynamic' can't be assigned to a variable of type 'String' • dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart:38:31 • invalid_assignment
  error • Undefined name 'Platform' • dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart:38:31 • undefined_identifier
```