### PR TITLE
add http access support with flutter module on android or iOS example

### DIFF
--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/AndroidManifest.xml.tmpl
@@ -10,7 +10,8 @@
 
     <application
         android:label="{{projectName}}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/res/xml/network_security_config.xml
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.tmpl/Info.plist.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Runner.tmpl/Info.plist.tmpl
@@ -22,6 +22,11 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
fix issue
#79433

this PR
some time we will debug on flutter module with http access，on android and ios ，the higher version is not http access by defalut
In a test environment with http, we need to change the templates code to achieve the debug status, which is too cumbersome
