### PR TITLE
[flutter_tools] remove globals from Device and separate FlutterDeviceManager

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -24,9 +24,6 @@ Future<dds.DartDevelopmentService> Function(
 /// Helper class to launch a [dds.DartDevelopmentService]. Allows for us to
 /// mock out this functionality for testing purposes.
 class DartDevelopmentService {
-  DartDevelopmentService({@required this.logger});
-
-  final Logger logger;
   dds.DartDevelopmentService _ddsInstance;
 
   Uri get uri => _ddsInstance?.uri ?? _existingDdsUri;
@@ -39,8 +36,9 @@ class DartDevelopmentService {
     Uri observatoryUri,
     int hostPort,
     bool ipv6,
-    bool disableServiceAuthCodes,
-  ) async {
+    bool disableServiceAuthCodes, {
+    @required Logger logger,
+  }) async {
     final Uri ddsUri = Uri(
       scheme: 'http',
       host: (ipv6 ?

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -37,6 +37,7 @@ import 'devtools_launcher.dart';
 import 'doctor.dart';
 import 'emulator.dart';
 import 'features.dart';
+import 'flutter_device_manager.dart';
 import 'fuchsia/fuchsia_device.dart' show FuchsiaDeviceTools;
 import 'fuchsia/fuchsia_sdk.dart' show FuchsiaSdk, FuchsiaArtifacts;
 import 'fuchsia/fuchsia_workflow.dart' show FuchsiaWorkflow, fuchsiaWorkflow;

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -8,46 +8,22 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
-import 'package:process/process.dart';
 
-import 'android/android_device_discovery.dart';
-import 'android/android_sdk.dart';
-import 'android/android_workflow.dart';
 import 'application_package.dart';
 import 'artifacts.dart';
 import 'base/common.dart';
-import 'base/config.dart';
 import 'base/context.dart';
 import 'base/dds.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
-import 'base/os.dart';
-import 'base/platform.dart';
 import 'base/terminal.dart';
 import 'base/user_messages.dart' hide userMessages;
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'devfs.dart';
 import 'device_port_forwader.dart';
-import 'features.dart';
-import 'fuchsia/fuchsia_device.dart';
-import 'fuchsia/fuchsia_sdk.dart';
-import 'fuchsia/fuchsia_workflow.dart';
-import 'globals.dart' as globals show logger;
-import 'ios/devices.dart';
-import 'ios/ios_workflow.dart';
-import 'ios/simulators.dart';
-import 'linux/linux_device.dart';
-import 'macos/macos_device.dart';
-import 'macos/macos_workflow.dart';
-import 'macos/xcode.dart';
 import 'project.dart';
-import 'tester/flutter_tester.dart';
-import 'version.dart';
 import 'vmservice.dart';
-import 'web/web_device.dart';
-import 'windows/windows_device.dart';
-import 'windows/windows_workflow.dart';
 
 DeviceManager get deviceManager => context.get<DeviceManager>();
 
@@ -341,101 +317,6 @@ abstract class DeviceManager {
   }
 }
 
-class FlutterDeviceManager extends DeviceManager {
-  FlutterDeviceManager({
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
-    @required FileSystem fileSystem,
-    @required AndroidSdk androidSdk,
-    @required FeatureFlags featureFlags,
-    @required IOSSimulatorUtils iosSimulatorUtils,
-    @required XCDevice xcDevice,
-    @required AndroidWorkflow androidWorkflow,
-    @required IOSWorkflow iosWorkflow,
-    @required FuchsiaWorkflow fuchsiaWorkflow,
-    @required FlutterVersion flutterVersion,
-    @required Config config,
-    @required Artifacts artifacts,
-    @required MacOSWorkflow macOSWorkflow,
-    @required UserMessages userMessages,
-    @required OperatingSystemUtils operatingSystemUtils,
-    @required WindowsWorkflow windowsWorkflow,
-    @required Terminal terminal,
-  }) : deviceDiscoverers =  <DeviceDiscovery>[
-    AndroidDevices(
-      logger: logger,
-      androidSdk: androidSdk,
-      androidWorkflow: androidWorkflow,
-      processManager: processManager,
-      fileSystem: fileSystem,
-      platform: platform,
-      userMessages: userMessages,
-    ),
-    IOSDevices(
-      platform: platform,
-      xcdevice: xcDevice,
-      iosWorkflow: iosWorkflow,
-      logger: logger,
-    ),
-    IOSSimulators(
-      iosSimulatorUtils: iosSimulatorUtils,
-    ),
-    FuchsiaDevices(
-      fuchsiaSdk: fuchsiaSdk,
-      logger: logger,
-      fuchsiaWorkflow: fuchsiaWorkflow,
-      platform: platform,
-    ),
-    FlutterTesterDevices(
-      fileSystem: fileSystem,
-      flutterVersion: flutterVersion,
-      processManager: processManager,
-      config: config,
-      logger: logger,
-      artifacts: artifacts,
-      operatingSystemUtils: operatingSystemUtils,
-    ),
-    MacOSDevices(
-      processManager: processManager,
-      macOSWorkflow: macOSWorkflow,
-      logger: logger,
-      platform: platform,
-      fileSystem: fileSystem,
-      operatingSystemUtils: operatingSystemUtils,
-    ),
-    LinuxDevices(
-      platform: platform,
-      featureFlags: featureFlags,
-      processManager: processManager,
-      logger: logger,
-      fileSystem: fileSystem,
-      operatingSystemUtils: operatingSystemUtils,
-    ),
-    WindowsDevices(
-      processManager: processManager,
-      operatingSystemUtils: operatingSystemUtils,
-      logger: logger,
-      fileSystem: fileSystem,
-      windowsWorkflow: windowsWorkflow,
-      featureFlags: featureFlags,
-    ),
-    WebDevices(
-      featureFlags: featureFlags,
-      fileSystem: fileSystem,
-      platform: platform,
-      processManager: processManager,
-      logger: logger,
-    ),
-  ], super(
-      logger: logger,
-      terminal: terminal,
-      userMessages: userMessages,
-    );
-
-  @override
-  final List<DeviceDiscovery> deviceDiscoverers;
-}
 
 /// An abstract class to discover and enumerate a specific type of devices.
 abstract class DeviceDiscovery {
@@ -660,10 +541,7 @@ abstract class Device {
   DevicePortForwarder get portForwarder;
 
   /// Get the DDS instance for this device.
-  DartDevelopmentService get dds => _dds ??= DartDevelopmentService(
-    logger: globals.logger,
-  );
-  DartDevelopmentService _dds;
+  final DartDevelopmentService dds = DartDevelopmentService();
 
   /// Clear the device's logs.
   void clearLogs();

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -209,6 +209,7 @@ class FlutterDriverService extends DriverService {
         debuggingOptions.ddsPort,
         ipv6,
         debuggingOptions.disableServiceAuthCodes,
+        logger: _logger,
       );
       _vmServiceUri = device.dds.uri.toString();
     } on dds.DartDevelopmentServiceException {

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -1,0 +1,134 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:meta/meta.dart';
+import 'package:process/process.dart';
+
+import 'android/android_device_discovery.dart';
+import 'android/android_sdk.dart';
+import 'android/android_workflow.dart';
+import 'artifacts.dart';
+import 'base/config.dart';
+import 'base/file_system.dart';
+import 'base/logger.dart';
+import 'base/os.dart';
+import 'base/platform.dart';
+import 'base/terminal.dart';
+import 'base/user_messages.dart' hide userMessages;
+import 'device.dart';
+import 'features.dart';
+import 'fuchsia/fuchsia_device.dart';
+import 'fuchsia/fuchsia_sdk.dart';
+import 'fuchsia/fuchsia_workflow.dart';
+import 'ios/devices.dart';
+import 'ios/ios_workflow.dart';
+import 'ios/simulators.dart';
+import 'linux/linux_device.dart';
+import 'macos/macos_device.dart';
+import 'macos/macos_workflow.dart';
+import 'macos/xcode.dart';
+import 'tester/flutter_tester.dart';
+import 'version.dart';
+import 'web/web_device.dart';
+import 'windows/windows_device.dart';
+import 'windows/windows_workflow.dart';
+
+
+class FlutterDeviceManager extends DeviceManager {
+  FlutterDeviceManager({
+    @required Logger logger,
+    @required Platform platform,
+    @required ProcessManager processManager,
+    @required FileSystem fileSystem,
+    @required AndroidSdk androidSdk,
+    @required FeatureFlags featureFlags,
+    @required IOSSimulatorUtils iosSimulatorUtils,
+    @required XCDevice xcDevice,
+    @required AndroidWorkflow androidWorkflow,
+    @required IOSWorkflow iosWorkflow,
+    @required FuchsiaWorkflow fuchsiaWorkflow,
+    @required FlutterVersion flutterVersion,
+    @required Config config,
+    @required Artifacts artifacts,
+    @required MacOSWorkflow macOSWorkflow,
+    @required UserMessages userMessages,
+    @required OperatingSystemUtils operatingSystemUtils,
+    @required WindowsWorkflow windowsWorkflow,
+    @required Terminal terminal,
+  }) : deviceDiscoverers =  <DeviceDiscovery>[
+    AndroidDevices(
+      logger: logger,
+      androidSdk: androidSdk,
+      androidWorkflow: androidWorkflow,
+      processManager: processManager,
+      fileSystem: fileSystem,
+      platform: platform,
+      userMessages: userMessages,
+    ),
+    IOSDevices(
+      platform: platform,
+      xcdevice: xcDevice,
+      iosWorkflow: iosWorkflow,
+      logger: logger,
+    ),
+    IOSSimulators(
+      iosSimulatorUtils: iosSimulatorUtils,
+    ),
+    FuchsiaDevices(
+      fuchsiaSdk: fuchsiaSdk,
+      logger: logger,
+      fuchsiaWorkflow: fuchsiaWorkflow,
+      platform: platform,
+    ),
+    FlutterTesterDevices(
+      fileSystem: fileSystem,
+      flutterVersion: flutterVersion,
+      processManager: processManager,
+      config: config,
+      logger: logger,
+      artifacts: artifacts,
+      operatingSystemUtils: operatingSystemUtils,
+    ),
+    MacOSDevices(
+      processManager: processManager,
+      macOSWorkflow: macOSWorkflow,
+      logger: logger,
+      platform: platform,
+      fileSystem: fileSystem,
+      operatingSystemUtils: operatingSystemUtils,
+    ),
+    LinuxDevices(
+      platform: platform,
+      featureFlags: featureFlags,
+      processManager: processManager,
+      logger: logger,
+      fileSystem: fileSystem,
+      operatingSystemUtils: operatingSystemUtils,
+    ),
+    WindowsDevices(
+      processManager: processManager,
+      operatingSystemUtils: operatingSystemUtils,
+      logger: logger,
+      fileSystem: fileSystem,
+      windowsWorkflow: windowsWorkflow,
+      featureFlags: featureFlags,
+    ),
+    WebDevices(
+      featureFlags: featureFlags,
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      logger: logger,
+    ),
+  ], super(
+      logger: logger,
+      terminal: terminal,
+      userMessages: userMessages,
+    );
+
+  @override
+  final List<DeviceDiscovery> deviceDiscoverers;
+}

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -36,7 +36,7 @@ import 'web/web_device.dart';
 import 'windows/windows_device.dart';
 import 'windows/windows_workflow.dart';
 
-
+/// A provider for all of the device discovery instances.
 class FlutterDeviceManager extends DeviceManager {
   FlutterDeviceManager({
     @required Logger logger,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -64,6 +64,7 @@ Future<void> _kDefaultDartDevelopmentServiceStarter(
     0,
     true,
     disableServiceAuthCodes,
+    logger: globals.logger,
   );
 }
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -271,6 +271,7 @@ class FlutterDevice {
             ddsPort,
             ipv6,
             disableServiceAuthCodes,
+            logger: globals.logger,
           );
         } on dds.DartDevelopmentServiceException catch (e, st) {
           if (!allowExistingDdsInstance ||

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -94,7 +94,7 @@ void main() {
           .thenAnswer((_) async {});
         when(device.dds).thenReturn(mockDds);
         final Completer<void> noopCompleter = Completer<void>();
-        when(mockDds.startDartDevelopmentService(any, any, false, any)).thenReturn(null);
+        when(mockDds.startDartDevelopmentService(any, any, false, any, logger: anyNamed('logger'))).thenReturn(null);
         when(mockDds.uri).thenReturn(Uri.parse('http://localhost:8181'));
         when(mockDds.done).thenAnswer((_) => noopCompleter.future);
 
@@ -323,7 +323,7 @@ void main() {
       )).thenReturn(mockHotRunner);
       when(mockHotRunner.exited).thenReturn(false);
       when(mockHotRunner.isWaitingForObservatory).thenReturn(false);
-      when(mockDds.startDartDevelopmentService(any, any, false, any)).thenReturn(null);
+      when(mockDds.startDartDevelopmentService(any, any, false, any, logger: anyNamed('logger'))).thenReturn(null);
       when(mockDds.uri).thenReturn(Uri.parse('http://localhost:8181'));
 
       testDeviceManager.addDevice(device);
@@ -410,7 +410,7 @@ void main() {
       )).thenReturn(mockHotRunner);
       when(mockHotRunner.exited).thenReturn(false);
       when(mockHotRunner.isWaitingForObservatory).thenReturn(false);
-      when(mockDds.startDartDevelopmentService(any, any, false, any)).thenReturn(null);
+      when(mockDds.startDartDevelopmentService(any, any, false, any, logger: anyNamed('logger'))).thenReturn(null);
       when(mockDds.uri).thenReturn(Uri.parse('http://localhost:8181'));
 
       testDeviceManager.addDevice(device);
@@ -457,7 +457,7 @@ void main() {
           .thenAnswer((_) async {});
         when(device.dds)
           .thenReturn(mockDds);
-        when(mockDds.startDartDevelopmentService(any, any, any, any))
+        when(mockDds.startDartDevelopmentService(any, any, any, any, logger: anyNamed('logger')))
           .thenReturn(null);
         when(mockDds.uri).thenReturn(Uri.parse('http://localhost:8181'));
         final Completer<void> noopCompleter = Completer<void>();

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/drive/drive_service.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
+import 'package:meta/meta.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -487,8 +488,9 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
     Uri observatoryUri,
     int hostPort,
     bool ipv6,
-    bool disableServiceAuthCodes,
-  ) async {
+    bool disableServiceAuthCodes, {
+    @required Logger logger,
+  }) async {
     started = true;
   }
 

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -834,7 +834,7 @@ void main() {
       );
       final MockDartDevelopmentService mockDds = MockDartDevelopmentService();
       when(fuchsiaDevice.dds).thenReturn(mockDds);
-      when(mockDds.startDartDevelopmentService(any, any, any, any)).thenReturn(null);
+      when(mockDds.startDartDevelopmentService(any, any, any, any, logger: anyNamed('logger'))).thenReturn(null);
       when(mockDds.uri).thenReturn(Uri.parse('example'));
       when(fuchsiaDevice.servicePorts())
           .thenAnswer((Invocation invocation) async => <int>[1]);

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2671,7 +2671,7 @@ void main() {
     final Completer<void> noopCompleter = Completer<void>();
     when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(mockLogReader);
     when(mockDevice.dds).thenReturn(mockDds);
-    when(mockDds.startDartDevelopmentService(any, any, any, any)).thenReturn(null);
+    when(mockDds.startDartDevelopmentService(any, any, any, any, logger: anyNamed('logger'))).thenReturn(null);
     when(mockDds.uri).thenReturn(Uri.parse('http://localhost:8181'));
     when(mockDds.done).thenAnswer((_) => noopCompleter.future);
 
@@ -2702,7 +2702,7 @@ void main() {
     final Completer<void> noopCompleter = Completer<void>();
     when(mockDevice.getLogReader(app: anyNamed('app'))).thenReturn(mockLogReader);
     when(mockDevice.dds).thenReturn(mockDds);
-    when(mockDds.startDartDevelopmentService(any, any, any, any)).thenThrow(FakeDartDevelopmentServiceException());
+    when(mockDds.startDartDevelopmentService(any, any, any, any, logger: anyNamed('logger'))).thenThrow(FakeDartDevelopmentServiceException());
     when(mockDds.uri).thenReturn(Uri.parse('http://localhost:1234'));
     when(mockDds.done).thenAnswer((_) => noopCompleter.future);
 
@@ -2727,7 +2727,7 @@ void main() {
   testUsingContext('Handle existing VM service clients DDS error', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice mockDevice = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
+      ..dds = DartDevelopmentService();
     ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) {
       throw FakeDartDevelopmentServiceException(message:
         'Existing VM service clients prevent DDS from taking control.',
@@ -2769,7 +2769,7 @@ void main() {
     // See https://github.com/flutter/flutter/issues/72385 for context.
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice mockDevice = FakeDevice()
-      ..dds = DartDevelopmentService(logger: testLogger);
+      ..dds = DartDevelopmentService();
     ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) {
       throw FakeDartDevelopmentServiceException(message: 'No URI');
     };


### PR DESCRIPTION
To make this easier to migrate to null safety, remove the globals dependencies and then move the instantiation of all of the device discovery classes into a new library.

https://github.com/flutter/flutter/issues/71511