### PR TITLE
roll gallery version to fix build

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'e2cfe22e9fa0b585b719cd911439fc80a3c27f39';
+const String galleryVersion = 'bc7b2bba0bbcb54f30ffc0042120253c261aadeb';


### PR DESCRIPTION
There is another place where we version solve for flutter/gallery, make sure the hash is updated to latest. This is the same version that successfully version solved on the customer tests, however the framework devicelab had the hash pinned in a second place which I missed on presubmit
