### PR TITLE
Properly position the built-in drag handles on horizontal ReorderableListViews.

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -369,25 +369,48 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         case TargetPlatform.linux:
         case TargetPlatform.windows:
         case TargetPlatform.macOS:
-          return Stack(
-            key: itemGlobalKey,
-            children: <Widget>[
-              itemWithSemantics,
-              Positioned.directional(
-                textDirection: Directionality.of(context),
-                top: 0,
-                bottom: 0,
-                end: 8,
-                child: Align(
-                  alignment: AlignmentDirectional.centerEnd,
-                  child: ReorderableDragStartListener(
-                    index: index,
-                    child: const Icon(Icons.drag_handle),
+          switch (widget.scrollDirection) {
+            case Axis.horizontal:
+              return Stack(
+                key: itemGlobalKey,
+                children: <Widget>[
+                  itemWithSemantics,
+                  Positioned.directional(
+                    textDirection: Directionality.of(context),
+                    start: 0,
+                    end: 0,
+                    bottom: 8,
+                    child: Align(
+                      alignment: AlignmentDirectional.bottomCenter,
+                      child: ReorderableDragStartListener(
+                        index: index,
+                        child: const Icon(Icons.drag_handle),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-            ],
-          );
+                ],
+              );
+            case Axis.vertical:
+              return Stack(
+                key: itemGlobalKey,
+                children: <Widget>[
+                  itemWithSemantics,
+                  Positioned.directional(
+                    textDirection: Directionality.of(context),
+                    top: 0,
+                    bottom: 0,
+                    end: 8,
+                    child: Align(
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: ReorderableDragStartListener(
+                        index: index,
+                        child: const Icon(Icons.drag_handle),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+          }
 
         case TargetPlatform.iOS:
         case TargetPlatform.android:

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -30,8 +30,14 @@ void main() {
       );
     }
 
-    Widget build({ Widget? header, Axis scrollDirection = Axis.vertical, TextDirection textDirection = TextDirection.ltr }) {
+    Widget build({
+      Widget? header,
+      Axis scrollDirection = Axis.vertical,
+      TextDirection textDirection = TextDirection.ltr,
+      TargetPlatform? platform,
+    }) {
       return MaterialApp(
+        theme: ThemeData(platform: platform),
         home: Directionality(
           textDirection: textDirection,
           child: SizedBox(
@@ -1309,6 +1315,28 @@ void main() {
       expect(getTestItemPosition(), startPosition);
     });
     // TODO(djshuckerow): figure out how to write a test for scrolling the list.
+
+    testWidgets('Vertical list renders drag handle in correct position', (WidgetTester tester) async {
+      await tester.pumpWidget(build(platform: TargetPlatform.macOS));
+      final Finder listView = find.byType(ReorderableListView);
+      final Finder item1 = find.byKey(const Key('Item 1'));
+      final Finder dragHandle = find.byIcon(Icons.drag_handle).first;
+
+      // Should be centered vertically within the item and 8 pixels from the right edge of the list.
+      expect(tester.getCenter(dragHandle).dy, tester.getCenter(item1).dy);
+      expect(tester.getTopRight(dragHandle).dx, tester.getSize(listView).width - 8);
+    });
+
+    testWidgets('Horizontal list renders drag handle in correct position', (WidgetTester tester) async {
+      await tester.pumpWidget(build(scrollDirection: Axis.horizontal, platform: TargetPlatform.macOS));
+      final Finder listView = find.byType(ReorderableListView);
+      final Finder item1 = find.byKey(const Key('Item 1'));
+      final Finder dragHandle = find.byIcon(Icons.drag_handle).first;
+
+      // Should be centered horizontally within the item and 8 pixels from the bottom of the list.
+      expect(tester.getCenter(dragHandle).dx, tester.getCenter(item1).dx);
+      expect(tester.getBottomRight(dragHandle).dy, tester.getSize(listView).height - 8);
+    });
   });
 
   testWidgets('ReorderableListView, can deal with the dragged item getting unmounted and rebuilt during drag', (WidgetTester tester) async {


### PR DESCRIPTION
The positioning of the drag handles in `ReorderableListView` is incorrect for horizontal lists. This PR moves them to the correct location.

Fixes: #79453

Added tests to verify the position of the drag handle for both vertical and horizontal lists.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
