### PR TITLE
Mark ios32 device tests flaky to reopen build.

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1006,7 +1006,7 @@
       "name": "Mac_ios flutter_gallery__transition_perf_e2e_ios32",
       "repo": "flutter",
       "task_name": "mac_ios_flutter_gallery__transition_perf_e2e_ios32",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Mac_ios flutter_gallery_ios__compile",
@@ -1120,7 +1120,7 @@
       "name": "Mac_ios native_ui_tests_ios32",
       "repo": "flutter",
       "task_name": "mac_ios_native_ui_tests_ios32",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Mac_ios new_gallery_ios__transition_perf",


### PR DESCRIPTION
Marking mac_ios_native_ui_tests_ios32 and mac_ios_flutter_gallery__transition_perf_e2e_ios32 flaky to open the build while https://github.com/flutter/flutter/issues/79493 is being addressed.