### PR TITLE
Correct misspellings throughout the codebase

### DIFF
--- a/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
+++ b/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
@@ -53,7 +53,7 @@ task printEngineMavenUrl() {
           '$mavenUrl instead');
         }
 
-        section('Checking overriden maven URL');
+        section('Checking overridden maven URL');
         mavenUrl = await eval(
           gradlewExecutable,
           <String>['printEngineMavenUrl', '-q'],
@@ -63,7 +63,7 @@ task printEngineMavenUrl() {
         );
 
         if (mavenUrl != 'https://my.special.proxy/download.flutter.io') {
-          throw TaskResult.failure('Expected overriden Android engine maven '
+          throw TaskResult.failure('Expected overridden Android engine maven '
           'dependency URL to resolve to proxy location '
           'https://my.special.proxy/download.flutter.io. Got '
           '$mavenUrl instead');

--- a/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
@@ -31,7 +31,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   String infoText = 'no-enter';
 
-  // Controller with no inital value;
+  // Controller with no initial value;
   final TextEditingController _emptyController = TextEditingController();
 
   final TextEditingController _controller =

--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -30,7 +30,7 @@ const EdgeInsetsGeometry _kDefaultPadding =
 /// The [helper] and [error] parameters are both optional widgets targeted at
 /// displaying more information about the row. Both widgets are placed
 /// underneath the [prefix] and [child], and will expand the row's height to
-/// accomodate for their presence. When a [Text] is given to [error], it will
+/// accommodate for their presence. When a [Text] is given to [error], it will
 /// be shown in [CupertinoColors.destructiveRed] coloring and
 /// medium-weighted font.
 ///
@@ -96,7 +96,7 @@ class CupertinoFormRow extends StatelessWidget {
   /// The [helper] and [error] parameters are both optional widgets targeted at
   /// displaying more information about the row. Both widgets are placed
   /// underneath the [prefix] and [child], and will expand the row's height to
-  /// accomodate for their presence. When a [Text] is given to [error], it will
+  /// accommodate for their presence. When a [Text] is given to [error], it will
   /// be shown in [CupertinoColors.destructiveRed] coloring and
   /// medium-weighted font.
   const CupertinoFormRow({

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -218,7 +218,7 @@ class _RenderCupertinoTextSelectionToolbarShape extends RenderShiftedBox {
   // top and bottom. Since _kToolbarHeight includes the height of one arrow, the
   // total height that the child is given is that plus one more arrow height.
   // The extra height on the opposite side of the arrow will be clipped out. By
-  // using this appraoch, the buttons don't need any special padding that
+  // using this approach, the buttons don't need any special padding that
   // depends on isAbove.
   final BoxConstraints _heightConstraint = BoxConstraints.tightFor(
     height: _kToolbarHeight + _kToolbarArrowSize.height,

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -311,7 +311,7 @@ class IOSScrollViewFlingVelocityTracker extends VelocityTracker {
 
   // Computes the velocity using 2 adjacent points in history. When index = 0,
   // it uses the latest point recorded and the point recorded immediately before
-  // it. The smaller index is, the ealier in history the points used are.
+  // it. The smaller index is, the earlier in history the points used are.
   Offset _previousVelocityAt(int index) {
     final int endIndex = (_index + index) % _sampleSize;
     final int startIndex = (_index + index - 1) % _sampleSize;

--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -69,7 +69,7 @@ Future<T?> showSearch<T>({
 /// The search page always shows an [AppBar] at the top where users can
 /// enter their search queries. The buttons shown before and after the search
 /// query text field can be customized via [SearchDelegate.buildLeading]
-/// and [SearchDelegate.buildActions]. Additonally, a widget can be placed
+/// and [SearchDelegate.buildActions]. Additionally, a widget can be placed
 /// across the bottom of the [AppBar] via [SearchDelegate.buildBottom].
 ///
 /// The body below the [AppBar] can either show suggested queries (returned by

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -281,7 +281,7 @@ class AssetImage extends AssetBundleImageProvider {
     return _findBestVariant(mapping, config.devicePixelRatio!);
   }
 
-  // Returns the "best" asset variant amongst the availabe `candidates`.
+  // Returns the "best" asset variant amongst the available `candidates`.
   //
   // The best variant is chosen as follows:
   // - Choose a variant whose key matches `value` exactly, if available.

--- a/packages/flutter/lib/src/painting/shader_warm_up.dart
+++ b/packages/flutter/lib/src/painting/shader_warm_up.dart
@@ -127,7 +127,7 @@ class DefaultShaderWarmUp extends ShaderWarmUp {
   /// Defaults to 0.0.
   ///
   /// When changing this value, the [canvasSize] must also be changed to
-  /// accomodate the bigger canvas.
+  /// accommodate the bigger canvas.
   final double drawCallSpacing;
 
   /// The [size] of the canvas required to paint the shapes in [warmUpOnCanvas].

--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -21,7 +21,7 @@ class ChildLayoutHelper {
   const ChildLayoutHelper._();
 
   /// Returns the [Size] that the [RenderBox] would have if it were to
-  /// be layed out with the given [BoxConstraints].
+  /// be laid out with the given [BoxConstraints].
   ///
   /// This method calls [RenderBox.getDryLayout] on the given [RenderBox].
   ///

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -654,7 +654,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 /// When [child] is null, this [RenderBox] takes the smallest possible size and
 /// never overflows.
 ///
-/// This [RenderBox] can be used to ensure some of [child]'s natrual dimensions
+/// This [RenderBox] can be used to ensure some of [child]'s natural dimensions
 /// are honored, and get an early warning during development otherwise. For
 /// instance, if [child] requires a minimum height to fully display its content,
 /// [constraintsTransform] can be set to a function that removes the `maxHeight`

--- a/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/rendering/sliver_persistent_header.dart
@@ -754,7 +754,7 @@ abstract class RenderSliverFloatingPersistentHeader extends RenderSliverPersiste
         showOnScreen.maxShowOnScreenExtent,
       )
       // Clamp the value back to the valid range after applying additional
-      // constriants. Contracting is not allowed.
+      // constraints. Contracting is not allowed.
       .clamp(childExtent, effectiveMaxExtent);
 
     // Expands the header if needed, with animation.

--- a/packages/flutter/lib/src/services/deferred_component.dart
+++ b/packages/flutter/lib/src/services/deferred_component.dart
@@ -10,7 +10,7 @@ import 'system_channels.dart';
 ///
 /// Deferred components allow Flutter applications to download precompiled AOT
 /// dart code and assets at runtime, reducing the install size of apps and
-/// avoiding installing unnessecary code/assets on end user devices. Common
+/// avoiding installing unnecessary code/assets on end user devices. Common
 /// use cases include deferring installation of advanced or infrequently
 /// used features and limiting locale specific features to users of matching
 /// locales. Deferred components can only deliver split off parts of the same

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2336,7 +2336,7 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 /// When [child] is null, this widget becomes as small as possible and never
 /// overflows
 ///
-/// This widget can be used to ensure some of [child]'s natrual dimensions are
+/// This widget can be used to ensure some of [child]'s natural dimensions are
 /// honored, and get an early warning otherwise during development. For
 /// instance, if [child] requires a minimum height to fully display its content,
 /// [constraintsTransform] can be set to [maxHeightUnconstrained], so that if
@@ -2346,8 +2346,8 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 ///
 /// {@tool snippet}
 /// In the following snippet, the [Card] is guaranteed to be at least as tall as
-/// its "natrual" height. Unlike [UnconstrainedBox], it will become taller if
-/// its "natrual" height is smaller than 40 px. If the [Container] isn't high
+/// its "natural" height. Unlike [UnconstrainedBox], it will become taller if
+/// its "natural" height is smaller than 40 px. If the [Container] isn't high
 /// enough to show the full content of the [Card], in debug mode a warning will
 /// be given.
 ///

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -68,7 +68,7 @@ typedef DragTargetMove<T> = void Function(DragTargetDetails<T> details);
 
 /// Signature for the strategy that determines the drag start point.
 ///
-/// Used for the built-in strategies switched via [DragAnchor] and the optinally
+/// Used for the built-in strategies switched via [DragAnchor] and the optimally
 /// injectable [Draggable.dragAnchorStrategy]
 typedef DragAnchorStrategy = Offset Function(Draggable<Object> draggable, BuildContext context, Offset position);
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2240,9 +2240,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // send unrecognized exceptions to the engine/platform. Make sure the
   // exceptions that user callbacks throw are handled within this method.
   void _formatAndSetValue(TextEditingValue newTextEditingValue, SelectionChangedCause? cause, {bool userInteraction = false}) {
-    // Only apply input formatters if the text has changed (including uncommited
-    // text in the composing region), or when the user committed the composing
-    // text.
+    // Only apply input formatters if the text has changed (including
+    // uncommitted text in the composing region), or when the user committed
+    // the composing text.
     // Gboard is very persistent in restoring the composing region. Applying
     // input formatters on composing-region-only changes (except clearing the
     // current composing region) is very infinite-loop-prone: the formatters

--- a/packages/flutter/test/cupertino/text_selection_toolbar_button_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_button_test.dart
@@ -41,7 +41,7 @@ void main() {
       ),
     );
 
-    // Originall at full opacity.
+    // Original at full opacity.
     FadeTransition opacity = tester.widget(find.descendant(
       of: find.byType(CupertinoTextSelectionToolbarButton),
       matching: find.byType(FadeTransition),

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -98,7 +98,7 @@ void main() {
       expect(actual, 5);
     });
 
-    test('should be 0 when offset is 0.00000001 times greater than item extent where the divison will return more than 13 zero decimals', () {
+    test('should be 0 when offset is 0.00000001 times greater than item extent where the division will return more than 13 zero decimals', () {
       final int actual = testGetMaxChildIndexForScrollOffset(
         genericItemExtent + extraValueToHaveRoundingIssues, genericItemExtent);
       expect(actual, 0);

--- a/packages/flutter/test/widgets/scroll_position_test.dart
+++ b/packages/flutter/test/widgets/scroll_position_test.dart
@@ -224,7 +224,7 @@ void main() {
     expect(controller.position.pixels, equals(0.0));
   });
 
-  testWidgets('jumpTo recomends deferred loading', (WidgetTester tester) async {
+  testWidgets('jumpTo recommends deferred loading', (WidgetTester tester) async {
     int loadedWithDeferral = 0;
     int buildCount = 0;
     const double height = 500;

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -565,7 +565,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           child: Checkbox(value: false, onChanged: null),
                         ),
@@ -837,7 +837,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           alignment: PlaceholderAlignment.baseline,
                           baseline: TextBaseline.alphabetic,
@@ -944,7 +944,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           alignment: PlaceholderAlignment.aboveBaseline,
                           baseline: TextBaseline.alphabetic,
@@ -1051,7 +1051,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           alignment: PlaceholderAlignment.belowBaseline,
                           baseline: TextBaseline.alphabetic,
@@ -1158,7 +1158,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           alignment: PlaceholderAlignment.top,
                           baseline: TextBaseline.alphabetic,
@@ -1265,7 +1265,7 @@ void main() {
                             ),
                           ),
                         ),
-                        TextSpan(text: 'hello world! sieze the day!'),
+                        TextSpan(text: 'hello world! seize the day!'),
                         WidgetSpan(
                           alignment: PlaceholderAlignment.middle,
                           baseline: TextBaseline.alphabetic,

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -227,13 +227,13 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   @protected
   bool get disableShadows => false;
 
-  /// Determines whether the Dart [HttpClient] class should be overriden to
+  /// Determines whether the Dart [HttpClient] class should be overridden to
   /// always return a failure response.
   ///
   /// By default, this value is true, so that unit tests will not become flaky
-  /// due to intermitten network errors. The value may be overriden by a binding
-  /// intended for use in integration tests that do end to end application
-  /// testing, including working with real network responses.
+  /// due to intermittent network errors. The value may be overridden by a
+  /// binding intended for use in integration tests that do end to end
+  /// application testing, including working with real network responses.
   @protected
   bool get overrideHttpClient => true;
 
@@ -284,7 +284,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// typically used in `flutter test`), this advances the fake [clock] for the
   /// period and also increases timeout (see [addTime]).
   ///
-  /// In the live test environemnt ([LiveTestWidgetsFlutterBinding], typically
+  /// In the live test environment ([LiveTestWidgetsFlutterBinding], typically
   /// used for `flutter run` and for [e2e](https://pub.dev/packages/e2e)), it is
   /// equivalent as [Future.delayed].
   Future<void> delayed(Duration duration);
@@ -1293,7 +1293,7 @@ enum LiveTestWidgetsFlutterBindingFramePolicy {
   /// Strictly show only frames that are explicitly pumped.
   ///
   /// This most closely matches the [AutomatedTestWidgetsFlutterBinding]
-  /// (the defualt binding for `flutter test`) behavior.
+  /// (the default binding for `flutter test`) behavior.
   onlyPumps,
 
   /// Show pumped frames, and additionally schedule and run frames to fade

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -910,7 +910,7 @@ abstract class WidgetController {
     if (renderObject is! RenderBox) {
       throw FlutterError(
         'The finder "$finder" (used in a call to "$callee()") found an element whose corresponding render object is not a RenderBox (it is a ${renderObject.runtimeType}: "$renderObject"). '
-        'Unfortunately "$callee()" only supports targetting widgets that correspond to RenderBox objects in the rendering.'
+        'Unfortunately "$callee()" only supports targeting widgets that correspond to RenderBox objects in the rendering.'
       );
     }
     final RenderBox box = element.renderObject! as RenderBox;

--- a/packages/flutter_tools/gradle/aar_init_script.gradle
+++ b/packages/flutter_tools/gradle/aar_init_script.gradle
@@ -110,7 +110,7 @@ void addAarTask(Project project, variant) {
 // This method mimics the logic in AGP when `android.defaultPublishConfig` is set in `build.gradle`:
 // https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/variant/VariantHelper.java
 //
-// Unfortunately, `android.defaultPublishConfig` cannot be overriden at this point since
+// Unfortunately, `android.defaultPublishConfig` cannot be overridden at this point since
 // AGP already run this code.
 void overrideDefaultPublishConfig(Project project, variant) {
     String variantName = variant.name.capitalize()

--- a/packages/flutter_tools/lib/src/android/deferred_components_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_validator.dart
@@ -84,7 +84,7 @@ abstract class DeferredComponentsValidator {
   /// Returns true if there were any recommended changes that should
   /// be applied.
   ///
-  /// Retuns false if no problems or recommendations were detected.
+  /// Returns false if no problems or recommendations were detected.
   ///
   /// If no checks are run, then this will default to false and will remain so
   /// until a failing check finishes running.

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -768,7 +768,7 @@ final Converter<String, String> _defineDecoder = base64.decoder.fuse(utf8.decode
 /// control character on windows command lines.
 ///
 /// When decoding this string, it can be safely split on commas, since any
-/// user provided commans will still be encoded.
+/// user provided commands will still be encoded.
 ///
 /// If the presence of the `/` character ends up being an issue, this can
 /// be changed to use base32 instead.

--- a/packages/flutter_tools/lib/src/build_system/depfile.dart
+++ b/packages/flutter_tools/lib/src/build_system/depfile.dart
@@ -22,7 +22,7 @@ class DepfileService {
   /// Given an [depfile] File, write the depfile contents.
   ///
   /// If both [inputs] and [outputs] are empty, ensures the file does not
-  /// exist. This can be overriden with the [writeEmpty] parameter when
+  /// exist. This can be overridden with the [writeEmpty] parameter when
   /// both static and runtime dependencies exist and it is not desired
   /// to force a rerun due to no depfile.
   void writeToFile(Depfile depfile, File output, {bool writeEmpty = false}) {

--- a/packages/flutter_tools/lib/src/web/memory_fs.dart
+++ b/packages/flutter_tools/lib/src/web/memory_fs.dart
@@ -8,7 +8,7 @@ import '../base/file_system.dart';
 import '../base/utils.dart';
 import '../convert.dart';
 
-/// A psuedo-filesystem stored in memory.
+/// A pseudo-filesystem stored in memory.
 ///
 /// To support output to arbitrary multi-root file schemes, the frontend server
 /// will output web sources, sourcemaps, and metadata to concatenated single files

--- a/packages/flutter_tools/test/general.shard/build_system/source_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/source_test.dart
@@ -44,7 +44,7 @@ void main() {
     });
   });
 
-  test('configures implicit vs explict correctly', () => testbed.run(() {
+  test('configures implicit vs explicit correctly', () => testbed.run(() {
     expect(const Source.pattern('{PROJECT_DIR}/foo').implicit, false);
     expect(const Source.pattern('{PROJECT_DIR}/*foo').implicit, true);
   }));

--- a/packages/flutter_tools/test/general.shard/build_system/targets/desktop_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/desktop_test.dart
@@ -20,7 +20,7 @@ void main() {
     fileSystem.file('inputs/a.txt').createSync();
     fileSystem.file('inputs/b.txt').createSync();
     fileSystem.file('foo/c.txt').createSync(recursive: true);
-    // Sould not be copied.
+    // Should not be copied.
     fileSystem.file('inputs/d.txt').createSync();
 
     final Depfile depfile = unpackDesktopArtifacts(

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -129,7 +129,7 @@ void main() {
     expect(environment.outputDir.childDirectory('assets')
       .childFile('AssetManifest.json').existsSync(), true);
 
-    // Update to arbitary resource file triggers rebuild.
+    // Update to arbitrary resource file triggers rebuild.
     webResources.childFile('foo.txt').writeAsStringSync('B');
 
     await const WebReleaseBundle().build(environment);

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -1233,7 +1233,7 @@ void main() {
       when<String>(emptyStdoutProcessResult.stderr as String).thenReturn('');
     });
 
-    testUsingContext('does not throw on non-existant ssh config', () async {
+    testUsingContext('does not throw on non-existent ssh config', () async {
       final FuchsiaDevice device = FuchsiaDevice('123');
       expect(await device.sdkNameAndVersion, equals('Fuchsia'));
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -534,7 +534,7 @@ void main() {
     expect(gitTagVersion.frameworkVersionFor('abcd1234'), stableTag);
   });
 
-  testUsingContext('determine favors stable tag over dev tag if both idenitfy HEAD', () {
+  testUsingContext('determine favors stable tag over dev tag if both identify HEAD', () {
     const String stableTag = '1.2.3';
     final FakeProcessManager fakeProcessManager = FakeProcessManager.list(
       <FakeCommand>[

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -259,7 +259,7 @@ void setMockEncodedAnyVisualStudioInstallation(
 // Sets up the mock environment for a Windows 10 SDK query.
 //
 // registryPresent controls whether or not the registry key is found.
-// filesPresent controles where or not there are any SDK folders at the location
+// filesPresent controls where or not there are any SDK folders at the location
 // returned by the registry query.
 void setMockSdkRegResponse(
   FileSystem fileSystem,

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -241,7 +241,7 @@ zip -r "ios_tests.zip" "Release-iphoneos" "Runner_iphoneos$dev_target-arm64.xcte
 popd
 ```
 
-You can verify locally that your tests are succesful by running the following command:
+You can verify locally that your tests are successful by running the following command:
 
 ```sh
 xcodebuild test-without-building -xctestrun "build/ios_integ/Build/Products/Runner_iphoneos14.3-arm64.xctestrun" -destination id=<YOUR_DEVICE_ID>

--- a/packages/integration_test/lib/common.dart
+++ b/packages/integration_test/lib/common.dart
@@ -293,6 +293,6 @@ abstract class IntegrationTestResults {
   /// The extra data for the reported result.
   Map<String, dynamic>? get reportData;
 
-  /// Whether all the test methods completed succesfully.
+  /// Whether all the test methods completed successfully.
   Completer<bool> get allTestsPassed;
 }

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -104,7 +104,7 @@ Future<void> main() async {
 
   tearDownAll(() async {
     // This part is outside the group so that `request` has been compeleted as
-    // part of the `tearDownAll` registerred in the group during
+    // part of the `tearDownAll` registered in the group during
     // `IntegrationTestWidgetsFlutterBinding` initialization.
     final Map<String, dynamic> response =
         (await request)!['response'] as Map<String, dynamic>;


### PR DESCRIPTION
Did a once-every-couple-years-ly pass using the the misspell tool
available at https://github.com/client9/misspell, then applied
hand-corrections. It's possible we could adopt this as a presubmit, but
there are still enough false positives that it may not be worth the
effort.

No logical changes; covered by existing tests.

Filed https://github.com/flutter/flutter/issues/79502 for an issue with Material icons

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
