### PR TITLE
Take screenshot when startup perf test fails to run

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -580,6 +580,16 @@ class StartupTest {
           results.add(data);
         } else {
           currentFailures += 1;
+          await flutter(
+            'screenshot',
+            options: <String>[
+              '-d',
+              device.deviceId,
+              '--out',
+              hostAgent.dumpDirectory.childFile('screenshot_startup_failure_$currentFailures.png').path,
+            ],
+            canFail: true,
+          );
           i -= 1;
           if (currentFailures == maxFailures) {
             return TaskResult.failure('Application failed to start $maxFailures times');


### PR DESCRIPTION
Would be helpful to diagnose test failures like https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8851188397933725328/+/steps/run_flutter_gallery_ios__start_up/0/stdout

