### PR TITLE
[flutter_tools] Normalize test file paths before using them

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -273,7 +273,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           if (globals.fs.isDirectorySync(path))
             ..._findTests(globals.fs.directory(path))
           else
-            globals.fs.path.absolute(path)
+            globals.fs.path.normalize(globals.fs.path.absolute(path))
       ];
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -446,6 +446,27 @@ dev_dependencies:
       ]),
     });
 
+    testUsingContext('when absolute unnormalized path to integration test is passed', () async {
+      final FakePackageTest fakePackageTest = FakePackageTest();
+
+      final TestCommand testCommand = TestCommand(testWrapper: fakePackageTest);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '/package/../package/integration_test/some_integration_test.dart',
+      ]);
+
+      expect(testCommand.isIntegrationTest, true);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => _FakeDeviceManager(<Device>[
+        FakeDevice('ephemeral', 'ephemeral', type: PlatformType.android),
+      ]),
+    });
+
     testUsingContext('when both test and integration test are passed', () async {
       final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
 


### PR DESCRIPTION
Turns out that the tests for Integration Tests in such as https://github.com/flutter/flutter/blob/1f19fd71086c8db573b8c9b299850d484c1e2321/packages/flutter_tools/test/integration.shard/test_test.dart#L52-L54
were not actually running as Integration Tests, since the path to the test is passed as a relative path, which confuses the detection logic. This PR normalizes all paths after making them absolute to make the check for Integration Tests more robust.

Manually tested debugging in VSCode on windows again for this.