### PR TITLE
[flutter_tools] use Url path.Context for joining URI

### DIFF
--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -7,8 +7,12 @@ import 'dart:math' as math;
 
 import 'package:intl/intl.dart';
 import 'package:file/file.dart';
+import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 
 import '../convert.dart';
+
+/// A path jointer for URL paths.
+final path.Context urlContext = path.url;
 
 /// Convert `foo_bar` to `fooBar`.
 String camelCase(String str) {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -14,6 +14,7 @@ import 'base/common.dart';
 import 'base/context.dart';
 import 'base/io.dart' as io;
 import 'base/logger.dart';
+import 'base/utils.dart';
 import 'build_info.dart';
 import 'convert.dart';
 import 'device.dart';
@@ -322,7 +323,7 @@ Future<FlutterVmService> _connect(
   io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
   Device device,
 }) async {
-  final Uri wsUri = httpUri.replace(scheme: 'ws', path: globals.fs.path.join(httpUri.path, 'ws'));
+  final Uri wsUri = httpUri.replace(scheme: 'ws', path: urlContext.join(httpUri.path, 'ws'));
   final io.WebSocket channel = await _openChannel(wsUri.toString(), compression: compression);
   final vm_service.VmService delegateService = vm_service.VmService(
     channel,

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:meta/meta.dart' show required;
+import 'package:meta/meta.dart' show required, visibleForTesting;
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import 'base/common.dart';
@@ -39,6 +39,14 @@ typedef WebSocketConnector = Future<io.WebSocket> Function(String url, {io.Compr
 typedef PrintStructuredErrorLogMethod = void Function(vm_service.Event);
 
 WebSocketConnector _openChannel = _defaultOpenChannel;
+
+/// A testing only override of the WebSocket connector.
+///
+/// Provide a `null` value to restore the original connector.
+@visibleForTesting
+set openChannelForTesting(WebSocketConnector connector) {
+  _openChannel = connector ?? _defaultOpenChannel;
+}
 
 /// The error codes for the JSON-RPC standard, including VM service specific
 /// error codes.

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -643,6 +643,19 @@ void main() {
 
     expect(processVmServiceMessage(event), 'Hello There');
   });
+
+  testUsingContext('WebSocket URL construction uses correct URI join primitives', () async {
+    final Completer<String> completer = Completer<String>();
+    openChannelForTesting = (String url, {io.CompressionOptions compression}) async {
+      completer.complete(url);
+      throw Exception('');
+    };
+
+    // Construct a URL that does not end in a `/`.
+    await expectLater(() => connectToVmService(Uri.parse('http://localhost:8181/foo')), throwsException);
+    expect(await completer.future, 'ws://localhost:8181/foo/ws');
+    openChannelForTesting = null;
+  });
 }
 
 class MockVMService extends Fake implements vm_service.VmService {


### PR DESCRIPTION
This just happens to work on windows, since `/` is treated as a path joiner as well and the URL always ends with a `/` so a `\` is never appended. Switch to path's URL context to be technically correct.