### PR TITLE
[flutter_tools] Move `_flutterGit` to globals

### DIFF
--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -37,6 +37,9 @@ import 'project.dart';
 import 'reporting/reporting.dart';
 import 'version.dart';
 
+/// The flutter GitHub repository.
+String get flutterGit => platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
+
 Artifacts? get artifacts => context.get<Artifacts>();
 BuildSystem? get buildSystem => context.get<BuildSystem>();
 Cache get cache => context.get<Cache>()!;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -14,9 +14,6 @@ import 'cache.dart';
 import 'convert.dart';
 import 'globals_null_migrated.dart' as globals;
 
-/// The flutter GitHub repository.
-String get _flutterGit => globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
-
 const String _unknownFrameworkVersion = '0.0.0-unknown';
 
 /// The names of each channel/branch in order of increasing stability.
@@ -274,7 +271,7 @@ class FlutterVersion {
         'remote',
         'add',
         _versionCheckRemote,
-        _flutterGit,
+        globals.flutterGit,
       ]);
       await _run(<String>['git', 'fetch', _versionCheckRemote, branch]);
       return _latestGitCommitDate(
@@ -284,7 +281,7 @@ class FlutterVersion {
     } on VersionCheckError catch (error) {
       if (globals.platform.environment.containsKey('FLUTTER_GIT_URL')) {
         globals.logger.printError('Warning: the Flutter git upstream was overridden '
-        'by the environment variable FLUTTER_GIT_URL = $_flutterGit');
+        'by the environment variable FLUTTER_GIT_URL = ${globals.flutterGit}');
       }
       globals.logger.printError(error.toString());
       rethrow;
@@ -632,7 +629,7 @@ class GitTagVersion {
       if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
         globals.printTrace('Skipping request to fetchTags - on well known channel $channel.');
       } else {
-        _runGit('git fetch $_flutterGit --tags -f', processUtils, workingDirectory);
+        _runGit('git fetch ${globals.flutterGit} --tags -f', processUtils, workingDirectory);
       }
     }
     final List<String> tags = _runGit(


### PR DESCRIPTION
As stated, moves `_flutterGit` from `flutter_tools/lib/src/version.dart` to `flutter_tools/lib/src/globals_null_migrated.dart`.

~Should only be merged after #79372 lands.~
~More context at https://github.com/flutter/flutter/pull/79372#discussion_r605062034.~

Edit: #79372 was reverted due to the change breaking the plugins tree: #83373

cc @christopherfujino should this require any tests?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
