### PR TITLE
Recommend an SDK dependency in integration_test README

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -8,7 +8,12 @@ and native Android instrumentation testing.
 
 Add a dependency on the `integration_test` and `flutter_test` package in the
 `dev_dependencies` section of `pubspec.yaml`. For plugins, do this in the
-`pubspec.yaml` of the example app.
+`pubspec.yaml` of the example app:
+
+```yaml
+integration_test:
+  sdk: flutter
+```
 
 Create a `integration_test/` directory for your package. In this directory,
 create a `<name>_test.dart`, using the following as a starting point to make


### PR DESCRIPTION
Now that `integration_test` is included as part of the SDK, we should recommend using an SDK dependency in the pubspec.

Realted to https://github.com/flutter/website/pull/5550 and https://github.com/flutter/website/pull/5575

closes #79405