### PR TITLE
Remove "unnecessary" imports in misc libraries

### DIFF
--- a/dev/tools/test/common.dart
+++ b/dev/tools/test/common.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dev_tools/stdio.dart';

--- a/dev/tracing_tests/test/image_painting_event_test.dart
+++ b/dev/tracing_tests/test/image_painting_event_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert' show jsonEncode;
 import 'dart:developer' as developer;
 import 'dart:ui' as ui;
 
-import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';

--- a/packages/flutter/lib/src/widgets/text_editing_action.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_action.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart' show RenderEditable;
 
 import 'actions.dart';

--- a/packages/flutter/test/material/elevated_button_theme_test.dart
+++ b/packages/flutter/test/material/elevated_button_theme_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
In each library where an import is removed, the library uses some elements
provided by the import, BUT there is another import which provides all of the
same elements, and at least one more which the library uses.

In this change, we remove the imports which can be simply removed in favor of
the other already present imports.

See https://github.com/dart-lang/sdk/issues/44569 for more information.

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/74381 is _improved_ by this issue. Not fixed.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat