### PR TITLE
ReorderableListView top padding causes clipping of content #79595

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -449,9 +449,9 @@ class _ReorderableListViewState extends State<ReorderableListView> {
     assert(debugCheckHasOverlay(context));
 
     // If there is a header we can't just apply the padding to the list,
-    // so we wrap the CustomScrollView in the padding for the top, left and right
-    // and only add the padding from the bottom to the sliver list (or the equivalent
-    // for other axis directions).
+    // so if header is not present, we wrap the CustomScrollView in the padding form the left and right
+    // and add the padding from the bottom and top to the sliver list. If header if present
+    // we only padd top of the header and bottom of the sliver list (or the equivalent for other axis directions).
     final EdgeInsets padding = widget.padding ?? EdgeInsets.zero;
     late EdgeInsets outerPadding;
     late EdgeInsets listPadding;
@@ -469,10 +469,10 @@ class _ReorderableListViewState extends State<ReorderableListView> {
       case Axis.vertical:
         if (widget.reverse) {
           outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, 0);
-          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, padding.bottom);
+          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, widget.header != null ? 0 : padding.bottom);
         } else {
           outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, 0);
-          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, padding.bottom);
+          listPadding = EdgeInsets.fromLTRB(0, widget.header != null ? 0 : padding.top, 0, padding.bottom);
         }
         break;
     }
@@ -494,7 +494,10 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         clipBehavior: widget.clipBehavior,
         slivers: <Widget>[
           if (widget.header != null)
-            SliverToBoxAdapter(child: widget.header!),
+            SliverPadding(
+              padding: EdgeInsets.fromLTRB(0, widget.reverse ? 0 : padding.top, 0, widget.reverse ? padding.bottom : 0),
+              sliver: SliverToBoxAdapter(child: widget.header!),
+            ),
           SliverPadding(
             padding: listPadding,
             sliver: SliverReorderableList(

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -468,8 +468,8 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         break;
       case Axis.vertical:
         if (widget.reverse) {
-          outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, padding.bottom);
-          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, 0);
+          outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, 0);
+          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, padding.bottom);
         } else {
           outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, 0);
           listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, padding.bottom);

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -471,8 +471,8 @@ class _ReorderableListViewState extends State<ReorderableListView> {
           outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, padding.bottom);
           listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, 0);
         } else {
-          outerPadding = EdgeInsets.fromLTRB(padding.left, padding.top, padding.right, 0);
-          listPadding = EdgeInsets.fromLTRB(0, 0, 0, padding.bottom);
+          outerPadding = EdgeInsets.fromLTRB(padding.left, 0, padding.right, 0);
+          listPadding = EdgeInsets.fromLTRB(0, padding.top, 0, padding.bottom);
         }
         break;
     }

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -35,6 +35,7 @@ void main() {
       Axis scrollDirection = Axis.vertical,
       TextDirection textDirection = TextDirection.ltr,
       TargetPlatform? platform,
+      EdgeInsets padding = const EdgeInsets.all(0.0),
     }) {
       return MaterialApp(
         theme: ThemeData(platform: platform),
@@ -48,6 +49,7 @@ void main() {
               children: listItems.map<Widget>(listItemToWidget).toList(),
               scrollDirection: scrollDirection,
               onReorder: onReorder,
+              padding: padding,
             ),
           ),
         ),
@@ -60,6 +62,12 @@ void main() {
     });
 
     group('in vertical mode', () {
+      testWidgets('when additional padding applied', (WidgetTester tester) async {
+        await tester.pumpWidget(build(padding: const EdgeInsets.all(10.0)));
+        final actualPadding = tester.widget<SliverPadding>(find.byType(SliverPadding));
+        expect((actualPadding).padding,EdgeInsets.only(top: 10.0, bottom: 10.0));
+      });
+      
       testWidgets('reorder is not triggered when children length is less or equals to 1', (WidgetTester tester) async {
         bool onReorderWasCalled = false;
         final List<String> currentListItems = listItems.take(1).toList();

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -36,6 +36,7 @@ void main() {
       TextDirection textDirection = TextDirection.ltr,
       TargetPlatform? platform,
       EdgeInsets padding = const EdgeInsets.all(0.0),
+      bool reverse = false,
     }) {
       return MaterialApp(
         theme: ThemeData(platform: platform),
@@ -50,6 +51,7 @@ void main() {
               scrollDirection: scrollDirection,
               onReorder: onReorder,
               padding: padding,
+              reverse: reverse,
             ),
           ),
         ),
@@ -64,8 +66,21 @@ void main() {
     group('in vertical mode', () {
       testWidgets('when additional padding applied', (WidgetTester tester) async {
         await tester.pumpWidget(build(padding: const EdgeInsets.all(10.0)));
-        final actualPadding = tester.widget<SliverPadding>(find.byType(SliverPadding));
-        expect((actualPadding).padding,EdgeInsets.only(top: 10.0, bottom: 10.0));
+        final SliverPadding actualPadding = tester.widget<SliverPadding>(find.byType(SliverPadding));
+        expect(actualPadding.padding,const EdgeInsets.only(top: 10.0, bottom: 10.0));
+      });
+
+      testWidgets('when additional padding applied with header', (WidgetTester tester) async {
+        await tester.pumpWidget(build(padding: const EdgeInsets.all(10.0), header: Container(height: 10.0,)));
+        final SliverPadding headerPadding = tester.widget<SliverPadding>(find.byType(SliverPadding).first);
+        expect(headerPadding.padding, const EdgeInsets.only(top: 10.0));
+        final SliverPadding listPadding = tester.widget<SliverPadding>(find.byType(SliverPadding).last);
+        expect(listPadding.padding, const EdgeInsets.only(bottom: 10.0));
+        await tester.pumpWidget(build(padding: const EdgeInsets.all(10.0), header: Container(height: 10.0,),reverse: true));
+        final SliverPadding headerPaddingReverse = tester.widget<SliverPadding>(find.byType(SliverPadding).first);
+        expect(headerPaddingReverse.padding, const EdgeInsets.only(bottom: 10.0));
+        final SliverPadding listPaddingReverse = tester.widget<SliverPadding>(find.byType(SliverPadding).last);
+        expect(listPaddingReverse.padding, const EdgeInsets.only(top: 10.0));
       });
       
       testWidgets('reorder is not triggered when children length is less or equals to 1', (WidgetTester tester) async {


### PR DESCRIPTION
ReorderableListView, when using the padding parameter, does not pad the content of the list, but instead pads the entire list itself. This is not the expected result, and does not occur when padding the bottom either. It only occurs with top padding.

fix for this issue #79595 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
