### PR TITLE
[flutter_tools] Remove special cased --no-chain-stack-traces

### DIFF
--- a/dev/automated_tests/integration_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/integration_test/exception_handling_expectation.txt
@@ -30,7 +30,7 @@ The following message was thrown running a test:
 Who lives, who dies, who tells your story\?
 
 When the exception was thrown, this was the stack:
-.*(TODO\(jiahaog\): Remove --no-chain-stack-traces and replace this with the actual stack once https://github.com/dart-lang/stack_trace/issues/106 is fixed)?
+#2      main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]integration_test[/\\]exception_handling_test\.dart:16:5\)
 <<skip until matching line>>
 The test description was:
 Exception handling in test harness - uncaught Future error

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -183,13 +183,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       return exitCode;
     }
 
-    if (integrationTestDevice != null) {
-      // Without this, some async exceptions which are caught will surface when
-      // debugging tests.
-      // TODO(jiahaog): Remove this once https://github.com/dart-lang/stack_trace/issues/106 is fixed.
-      testArgs.add('--no-chain-stack-traces');
-    }
-
     testArgs
       ..add('--')
       ..addAll(testFiles);

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -331,7 +331,6 @@ dev_dependencies:
     ]);
 
     expect(fakePackageTest.lastArgs, contains('--concurrency=1'));
-    expect(fakePackageTest.lastArgs, contains('--no-chain-stack-traces'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fs,
     ProcessManager: () => FakeProcessManager.any(),


### PR DESCRIPTION
Now that the try-catch that caused the bug is no longer triggered for Integration Tests after #79520, we no longer need to special case this.

Tested: Debugging locally in VSCode, the problematic `MissingPluginException` does not surface