### PR TITLE
Add back button listener widget

### DIFF
--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1001,6 +1001,8 @@ class ChildBackButtonDispatcher extends BackButtonDispatcher {
 /// A convenience widget that registers a callback when the back button is pressed
 /// by using [BackButtonDispatcher].
 ///
+/// It's required to have a [Router] widget ancestor on the tree.
+///
 /// It only applies to platforms that accept back button clicks, such as Android.
 ///
 /// It can be useful for scenarios, in which you create a different state in your
@@ -1015,10 +1017,11 @@ class BackButtonListener extends StatefulWidget {
     required this.onBackPressed,
   }) : super(key: key);
 
-  /// The child Widget that will be drawn and usually a page that will
+  /// The [child] Widget contained by the BackButtonListener.
   final Widget child;
 
   /// The callback function that will be called when the back button is pressed.
+  ///
   /// It must return a boolean future with true if this child will handle the request;
   /// otherwise, return a boolean future with false.
   final ValueGetter<Future<bool>> onBackPressed;

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -998,6 +998,63 @@ class ChildBackButtonDispatcher extends BackButtonDispatcher {
   }
 }
 
+/// A convenience widget that registers a callback when the back button is pressed
+/// by using [BackButtonDispatcher].
+///
+/// It only applies to platforms that accept back button clicks, such as Android.
+///
+/// It can be useful for scenarios, in which you create a different state in your
+/// screen but don't want to use a new page for that.
+class BackButtonListener extends StatefulWidget {
+  /// Creates a BackButtonListener widget .
+  ///
+  /// The [child] and [onBackPressed] arguments must not be null.
+  const BackButtonListener({
+    Key? key,
+    required this.child,
+    required this.onBackPressed,
+  }) : super(key: key);
+
+  /// The child Widget that will be drawn and usually a page that will
+  final Widget child;
+
+  /// The callback function that will be called when the back button is pressed.
+  /// It must return a boolean future with true if this child will handle the request;
+  /// otherwise, return a boolean future with false.
+  final ValueGetter<Future<bool>> onBackPressed;
+
+  @override
+  _BackButtonListenerState createState() => _BackButtonListenerState();
+}
+
+class _BackButtonListenerState extends State<BackButtonListener> {
+  BackButtonDispatcher? dispatcher;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    dispatcher?.removeCallback(widget.onBackPressed);
+
+    final BackButtonDispatcher? rootBackDispatcher = Router.of(context).backButtonDispatcher;
+    assert(rootBackDispatcher != null, 'make sure to have a Router object with a backButtonDispatcher registered');
+
+    dispatcher = rootBackDispatcher!.createChildBackButtonDispatcher()
+      ..addCallback(widget.onBackPressed)
+      ..takePriority();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    dispatcher?.removeCallback(widget.onBackPressed);
+    super.dispose();
+  }
+}
+
 /// A delegate that is used by the [Router] widget to parse a route information
 /// into a configuration of type T.
 ///

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1035,15 +1035,20 @@ class _BackButtonListenerState extends State<BackButtonListener> {
 
   @override
   void didChangeDependencies() {
+    _updateCallback(widget.onBackPressed);
     super.didChangeDependencies();
+  }
+
+  @override
+  void didUpdateWidget(covariant BackButtonListener oldWidget) {
+    _updateCallback(oldWidget.onBackPressed);
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  void dispose() {
     dispatcher?.removeCallback(widget.onBackPressed);
-
-    final BackButtonDispatcher? rootBackDispatcher = Router.of(context).backButtonDispatcher;
-    assert(rootBackDispatcher != null, 'make sure to have a Router object with a backButtonDispatcher registered');
-
-    dispatcher = rootBackDispatcher!.createChildBackButtonDispatcher()
-      ..addCallback(widget.onBackPressed)
-      ..takePriority();
+    super.dispose();
   }
 
   @override
@@ -1051,10 +1056,15 @@ class _BackButtonListenerState extends State<BackButtonListener> {
     return widget.child;
   }
 
-  @override
-  void dispose() {
-    dispatcher?.removeCallback(widget.onBackPressed);
-    super.dispose();
+  void _updateCallback(ValueGetter<Future<bool>> previousCallback) {
+    dispatcher?.removeCallback(previousCallback);
+
+    final BackButtonDispatcher? rootBackDispatcher = Router.of(context).backButtonDispatcher;
+    assert(rootBackDispatcher != null, 'The parent router must have a backButtonDispatcher to use this widget');
+
+    dispatcher = rootBackDispatcher!.createChildBackButtonDispatcher()
+      ..addCallback(widget.onBackPressed)
+      ..takePriority();
   }
 }
 

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -774,7 +774,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     expect(find.text('popped inner1'), findsOneWidget);
   });
 
-  testWidgets('BackButtonListener updates callback if it has been changed', (WidgetTester tester) async {  
+  testWidgets('BackButtonListener updates callback if it has been changed', (WidgetTester tester) async {
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
     provider.value = const RouteInformation(
       location: 'initial',
@@ -853,7 +853,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     expect(find.text('second callback'), findsOneWidget);
   });
 
-  testWidgets('BackButtonListener clears callback if it is disposed', (WidgetTester tester) async {  
+  testWidgets('BackButtonListener clears callback if it is disposed', (WidgetTester tester) async {
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
     provider.value = const RouteInformation(
       location: 'initial',

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -774,6 +774,154 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     expect(find.text('popped inner1'), findsOneWidget);
   });
 
+  testWidgets('BackButtonListener updates callback if it has been changed', (WidgetTester tester) async {  
+    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
+    provider.value = const RouteInformation(
+      location: 'initial',
+    );
+    final BackButtonDispatcher outerDispatcher = RootBackButtonDispatcher();
+    final SimpleRouterDelegate routerDelegate = SimpleRouterDelegate()
+      ..builder = (BuildContext context, RouteInformation? information) {
+            // Creates the sub-router.
+            return Column(
+              children: <Widget>[
+                Text(information!.location!),
+                BackButtonListener(
+                  child: Container(),
+                  onBackPressed: () {
+                      provider.value = const RouteInformation(
+                        location: 'first callback',
+                      );
+                      return SynchronousFuture<bool>(true);
+                    },
+                ),
+              ],
+            );
+          }
+        ..onPopRoute = () {
+            provider.value = const RouteInformation(
+              location: 'popped outter',
+            );
+            return SynchronousFuture<bool>(true);
+          };
+
+    await tester.pumpWidget(buildBoilerPlate(
+      Router<RouteInformation>(
+        backButtonDispatcher: outerDispatcher,
+        routeInformationProvider: provider,
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: routerDelegate
+      )
+    ));
+
+    routerDelegate
+      ..builder = (BuildContext context, RouteInformation? information) {
+        // Creates the sub-router.
+        return Column(
+          children: <Widget>[
+            Text(information!.location!),
+            BackButtonListener(
+              child: Container(),
+              onBackPressed: () {
+                  provider.value = const RouteInformation(
+                    location: 'second callback',
+                  );
+                  return SynchronousFuture<bool>(true);
+                },
+            ),
+          ],
+        );
+      }
+      ..onPopRoute = () {
+        provider.value = const RouteInformation(
+          location: 'popped outter',
+        );
+        return SynchronousFuture<bool>(true);
+      };
+
+    await tester.pumpWidget(buildBoilerPlate(
+      Router<RouteInformation>(
+        backButtonDispatcher: outerDispatcher,
+        routeInformationProvider: provider,
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: routerDelegate,
+      )
+    ));
+    await tester.pump();
+    await outerDispatcher.invokeCallback(SynchronousFuture<bool>(false));
+    await tester.pump();
+    expect(find.text('second callback'), findsOneWidget);
+  });
+
+  testWidgets('BackButtonListener clears callback if it is disposed', (WidgetTester tester) async {  
+    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();
+    provider.value = const RouteInformation(
+      location: 'initial',
+    );
+    final BackButtonDispatcher outerDispatcher = RootBackButtonDispatcher();
+    final SimpleRouterDelegate routerDelegate = SimpleRouterDelegate()
+      ..builder = (BuildContext context, RouteInformation? information) {
+            // Creates the sub-router.
+            return Column(
+              children: <Widget>[
+                Text(information!.location!),
+                BackButtonListener(
+                  child: Container(),
+                  onBackPressed: () {
+                      provider.value = const RouteInformation(
+                        location: 'first callback',
+                      );
+                      return SynchronousFuture<bool>(true);
+                    },
+                ),
+              ],
+            );
+          }
+        ..onPopRoute = () {
+            provider.value = const RouteInformation(
+              location: 'popped outter',
+            );
+            return SynchronousFuture<bool>(true);
+          };
+
+    await tester.pumpWidget(buildBoilerPlate(
+      Router<RouteInformation>(
+        backButtonDispatcher: outerDispatcher,
+        routeInformationProvider: provider,
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: routerDelegate
+      )
+    ));
+
+    routerDelegate
+      ..builder = (BuildContext context, RouteInformation? information) {
+        // Creates the sub-router.
+        return Column(
+          children: <Widget>[
+            Text(information!.location!),
+          ],
+        );
+      }
+      ..onPopRoute = () {
+        provider.value = const RouteInformation(
+          location: 'popped outter',
+        );
+        return SynchronousFuture<bool>(true);
+      };
+
+    await tester.pumpWidget(buildBoilerPlate(
+      Router<RouteInformation>(
+        backButtonDispatcher: outerDispatcher,
+        routeInformationProvider: provider,
+        routeInformationParser: SimpleRouteInformationParser(),
+        routerDelegate: routerDelegate,
+      )
+    ));
+    await tester.pump();
+    await outerDispatcher.invokeCallback(SynchronousFuture<bool>(false));
+    await tester.pump();
+    expect(find.text('popped outter'), findsOneWidget);
+  });
 
   testWidgets('Nested backButtonListener should take priority', (WidgetTester tester) async {
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider();

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -746,7 +746,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
                 Text(information!.location!),
                 BackButtonListener(
                   child: Container(),
-                  onBackPressed: () {
+                  onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'popped inner1',
                       );
@@ -788,7 +788,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
                 Text(information!.location!),
                 BackButtonListener(
                   child: Container(),
-                  onBackPressed: () {
+                  onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'first callback',
                       );
@@ -822,7 +822,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
             Text(information!.location!),
             BackButtonListener(
               child: Container(),
-              onBackPressed: () {
+              onBackButtonPressed: () {
                   provider.value = const RouteInformation(
                     location: 'second callback',
                   );
@@ -867,7 +867,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
                 Text(information!.location!),
                 BackButtonListener(
                   child: Container(),
-                  onBackPressed: () {
+                  onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'first callback',
                       );
@@ -943,14 +943,14 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
                 BackButtonListener(
                   child: BackButtonListener(
                     child: Container(),
-                    onBackPressed: () {
+                    onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'popped inner2',
                       );
                       return SynchronousFuture<bool>(true);
                     },
                   ),
-                  onBackPressed: () {
+                  onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'popped inner1',
                       );
@@ -998,14 +998,14 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
                 BackButtonListener(
                   child: BackButtonListener(
                     child: Container(),
-                    onBackPressed: () {
+                    onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'popped inner2',
                       );
                       return SynchronousFuture<bool>(false);
                     },
                   ),
-                  onBackPressed: () {
+                  onBackButtonPressed: () {
                       provider.value = const RouteInformation(
                         location: 'popped inner1',
                       );


### PR DESCRIPTION
This widget is a back button listener so apps using Router API can intercept the back button pressed event in a friendly way.

It fixes the issue #74437 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

PS: I'm not so sure about the tests. Would you be able to help @chunhtai? I feel like I should be testing the dispose method that it is indeed removing the callback, but I couldn't find any examples on how to do that. 

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
