### PR TITLE
[flutter_tools] allow winuwp build to setup generated cmake file

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -741,6 +741,11 @@ String getWindowsBuildDirectory() {
   return globals.fs.path.join(getBuildDirectory(), 'windows');
 }
 
+/// Returns the Windows UWP build output directory.
+String getWindowsBuildUwpDirectory() {
+  return globals.fs.path.join(getBuildDirectory(), 'winuwp');
+}
+
 /// Returns the Fuchsia build output directory.
 String getFuchsiaBuildDirectory() {
   return globals.fs.path.join(getBuildDirectory(), 'fuchsia');

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -108,7 +108,9 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
             ? FuchsiaApp.fromFuchsiaProject(FlutterProject.current().fuchsia)
             : FuchsiaApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.windows_uwp_x64:
-        throw UnsupportedError('Cannot build for windows_uwp_x64');
+        return applicationBinary == null
+            ? WindowsApp.fromWindowsProject(FlutterProject.current().windowsUwp)
+            : WindowsApp.fromPrebuiltApp(applicationBinary);
     }
     assert(platform != null);
     return null;

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -78,7 +78,7 @@ class WindowsUWPDevice extends DesktopDevice {
     @required FileSystem fileSystem,
     @required OperatingSystemUtils operatingSystemUtils,
   }) : super(
-      'windows-uwp',
+      'winuwp',
       platformType: PlatformType.windows,
       ephemeral: false,
       processManager: processManager,
@@ -88,7 +88,7 @@ class WindowsUWPDevice extends DesktopDevice {
   );
 
   @override
-  bool isSupported() => false;
+  bool isSupported() => true;
 
   @override
   String get name => 'Windows (UWP)';
@@ -100,7 +100,7 @@ class WindowsUWPDevice extends DesktopDevice {
   bool isSupportedForProject(FlutterProject flutterProject) {
     // TODO(flutter): update with detection once FlutterProject knows
     // about the UWP structure.
-    return false;
+    return true;
   }
 
   @override
@@ -109,8 +109,8 @@ class WindowsUWPDevice extends DesktopDevice {
     String mainPath,
     BuildInfo buildInfo,
   }) async {
-    await buildWindows(
-      FlutterProject.current().windows,
+    await buildWindowsUwp(
+      FlutterProject.current().windowsUwp,
       buildInfo,
       target: mainPath,
     );

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -40,6 +40,24 @@ void main() {
     expect(windowsDevice.supportsRuntimeMode(BuildMode.jitRelease), false);
   });
 
+  testWithoutContext('WindowsUwpDevice defaults', () async {
+    final WindowsUWPDevice windowsDevice = setUpWindowsUwpDevice();
+    final PrebuiltWindowsApp windowsApp = PrebuiltWindowsApp(executable: 'foo');
+
+    expect(await windowsDevice.targetPlatform, TargetPlatform.windows_uwp_x64);
+    expect(windowsDevice.name, 'Windows (UWP)');
+    expect(await windowsDevice.installApp(windowsApp), true);
+    expect(await windowsDevice.uninstallApp(windowsApp), true);
+    expect(await windowsDevice.isLatestBuildInstalled(windowsApp), true);
+    expect(await windowsDevice.isAppInstalled(windowsApp), true);
+    expect(windowsDevice.category, Category.desktop);
+
+    expect(windowsDevice.supportsRuntimeMode(BuildMode.debug), true);
+    expect(windowsDevice.supportsRuntimeMode(BuildMode.profile), true);
+    expect(windowsDevice.supportsRuntimeMode(BuildMode.release), true);
+    expect(windowsDevice.supportsRuntimeMode(BuildMode.jitRelease), false);
+  });
+
   testWithoutContext('WindowsDevices does not list devices if the workflow is unsupported', () async {
     expect(await WindowsDevices(
       windowsWorkflow: WindowsWorkflow(
@@ -157,6 +175,19 @@ WindowsDevice setUpWindowsDevice({
   ProcessManager processManager,
 }) {
   return WindowsDevice(
+    fileSystem: fileSystem ?? MemoryFileSystem.test(),
+    logger: logger ?? BufferLogger.test(),
+    processManager: processManager ?? FakeProcessManager.any(),
+    operatingSystemUtils: FakeOperatingSystemUtils(),
+  );
+}
+
+WindowsUWPDevice setUpWindowsUwpDevice({
+  FileSystem fileSystem,
+  Logger logger,
+  ProcessManager processManager,
+}) {
+  return WindowsUWPDevice(
     fileSystem: fileSystem ?? MemoryFileSystem.test(),
     logger: logger ?? BufferLogger.test(),
     processManager: processManager ?? FakeProcessManager.any(),


### PR DESCRIPTION
Allows a flutter run or flutter build winuwp to proceed far enough to output the generated cmake file. No further additions to the current workflow.

Also renames the windows-uwp device name to `winuwp` to better reflect the short name convention.