### PR TITLE
VisualDensity should not reduce ButtonStyleButton horizontal padding

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -309,14 +309,15 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
       }
     }
 
-    final EdgeInsetsGeometry padding = resolvedPadding!.add(
-      EdgeInsets.only(
-        left: densityAdjustment.dx,
-        top: densityAdjustment.dy,
-        right: densityAdjustment.dx,
-        bottom: densityAdjustment.dy,
-      ),
-    ).clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity);
+    // Per the Material Design team: don't allow the VisualDensity
+    // adjustment to reduce the width of the left/right padding. If we
+    // did, VisualDensity.compact, the default for desktop/web, would
+    // reduce the horizontal padding to zero.
+    final double dy = densityAdjustment.dy;
+    final double dx = math.max(0, densityAdjustment.dx);
+    final EdgeInsetsGeometry padding = resolvedPadding!
+      .add(EdgeInsets.fromLTRB(dx, dy, dx, dy))
+      .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity);
 
     // If an opaque button's background is becoming translucent while its
     // elevation is changing, change the elevation first. Material implicitly

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -649,7 +649,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(108, 100)));
+    expect(box.size, equals(const Size(132, 100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(VisualDensity.standard, useText: true);
@@ -667,7 +667,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(76, 36)));
+    expect(box.size, equals(const Size(88, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -956,7 +956,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(108, 100)));
+    expect(box.size, equals(const Size(132, 100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(VisualDensity.standard, useText: true);
@@ -974,7 +974,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(64, 36)));
+    expect(box.size, equals(const Size(88, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -739,7 +739,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(100, 100)));
+    expect(box.size, equals(const Size(116, 100)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(VisualDensity.standard, useText: true);
@@ -757,7 +757,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0), useText: true);
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(56, 36)));
+    expect(box.size, equals(const Size(72, 36)));
     expect(childRect, equals(const Rect.fromLTRB(372.0, 293.0, 428.0, 307.0)));
   });
 

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 
@@ -322,10 +324,11 @@ void main() {
         expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
 
         // Also check that the button alignment is true to expectations
+        // Buttons do not decrease their horizontal padding per the VisualDensity.
         final Finder button = find.byType(ElevatedButton);
         expect(
           tester.renderObject<RenderBox>(button).size,
-          Size(116.0 + density.horizontal * 8.0, 48.0 + density.vertical * 4.0),
+          Size(116.0 + math.max(0, density.horizontal) * 8.0, 48.0 + density.vertical * 4.0),
         );
         expect(tester.getBottomLeft(button).dy, equals(600.0));
         expect(tester.getCenter(button).dx, equals(400.0));
@@ -344,7 +347,8 @@ void main() {
         expect(tester.getCenter(logo).dy, lessThan(351.0));
         expect(
           tester.renderObject<RenderBox>(button).size,
-          Size(116.0 + density.horizontal * 8.0, 48.0 + density.vertical * 4.0),
+          // Buttons do not decrease their horizontal padding per the VisualDensity.
+          Size(116.0 + math.max(0, density.horizontal) * 8.0, 48.0 + density.vertical * 4.0),
         );
         expect(tester.getBottomLeft(button).dy, lessThan(600.0));
         expect(tester.getCenter(button).dx, equals(400.0));
@@ -592,10 +596,11 @@ void main() {
           expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
 
           // Also check that the button alignment is true to expectations.
+          // Buttons do not decrease their horizontal padding per the VisualDensity.
           final Finder button = find.byType(ElevatedButton);
           expect(
             tester.renderObject<RenderBox>(button).size,
-            Size(116.0 + density.horizontal * 8.0, 48.0 + density.vertical * 4.0),
+            Size(116.0 + math.max(0, density.horizontal) * 8.0, 48.0 + density.vertical * 4.0),
           );
           expect(tester.getBottomLeft(button).dy, equals(600.0));
           expect(tester.getCenter(button).dx, equals(400.0));
@@ -616,7 +621,8 @@ void main() {
           expect(tester.getCenter(logo).dy, lessThan(351.0));
           expect(
             tester.renderObject<RenderBox>(button).size,
-            Size(116.0 + density.horizontal * 8.0, 48.0 + density.vertical * 4.0),
+            // Buttons do not decrease their horizontal padding per the VisualDensity.
+            Size(116.0 + math.max(0, density.horizontal) * 8.0, 48.0 + density.vertical * 4.0),
           );
           expect(tester.getBottomLeft(button).dy, equals(600.0));
           expect(tester.getCenter(button).dx, equals(400.0));
@@ -635,7 +641,8 @@ void main() {
           expect(tester.getCenter(logo), Offset(400.0, 351.0 - density.vertical * 2.0));
           expect(
             tester.renderObject<RenderBox>(button).size,
-            Size(116.0 + density.horizontal * 8.0, 48.0 + density.vertical * 4.0),
+            // Buttons do not decrease their horizontal padding per the VisualDensity.
+            Size(116.0 + math.max(0, density.horizontal) * 8.0, 48.0 + density.vertical * 4.0),
           );
           expect(tester.getBottomLeft(button).dy, equals(600.0));
           expect(tester.getCenter(button).dx, equals(400.0));


### PR DESCRIPTION
VisualDensity should not reduce ButtonStyleButton horizontal padding. 

Fixes https://github.com/flutter/flutter/issues/78739
This PR depends on an internal CL: cl/369556372

Here's a screenshot with all 3 button types side-by-side, where the textScaleFactor is 0.5 for the first row and increases to 3 in the last row. The TextButtons have their background color set to blue, so that it's easy to see their boundaries. The visual density for the app is VisualDensity.compact, which has become the default for web/desktop.

<img width="1101" alt="Screen Shot 2021-04-02 at 4 59 47 PM" src="https://user-images.githubusercontent.com/1377460/113462287-066c2580-93d5-11eb-95ec-544b024998db.png">

The same app without the changes from this PR. You can see that that the horizontal padding quickly shrinks to zero because it's small to begin with(8 left and right per the Material Design spec) and VisualDensity.compact.dx is -2, which is typically interpreted as a -8 adjustment for padding and sizes.

<img width="1102" alt="Screen Shot 2021-04-02 at 4 58 49 PM" src="https://user-images.githubusercontent.com/1377460/113462328-2dc2f280-93d5-11eb-98b4-df6848702cd7.png">
