### PR TITLE
add editableTextId - a stable unique TextEditable identifier

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2335,7 +2335,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     assert(value != null);
     if (value != _editableTextId) {
       _editableTextId = value;
-      markNeedsPaint();
       markNeedsSemanticsUpdate();
     }
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -199,6 +199,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required this.textSelectionDelegate,
     RenderEditablePainter? painter,
     RenderEditablePainter? foregroundPainter,
+    required int editableTextId,
   }) : assert(textAlign != null),
        assert(textDirection != null, 'RenderEditable created without a textDirection.'),
        assert(maxLines == null || maxLines > 0),
@@ -257,7 +258,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
        _obscureText = obscureText,
        _readOnly = readOnly,
        _forceLine = forceLine,
-       _clipBehavior = clipBehavior {
+       _clipBehavior = clipBehavior,
+       _editableTextId = editableTextId {
     assert(_showCursor != null);
     assert(!_showCursor.value || cursorColor != null);
     this.hasFocus = hasFocus ?? false;
@@ -2327,6 +2329,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
   }
 
+  int get editableTextId => _editableTextId;
+  int _editableTextId;
+  set editableTextId(int value) {
+    assert(value != null);
+    if (value != _editableTextId) {
+      _editableTextId = value;
+      markNeedsPaint();
+      markNeedsSemanticsUpdate();
+    }
+  }
+
   /// Collected during [describeSemanticsConfiguration], used by
   /// [assembleSemanticsNode] and [_combineSemanticsInfo].
   List<InlineSpanSemanticsInformation>? _semanticsInfo;
@@ -2364,7 +2377,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       ..textDirection = textDirection
       ..isFocused = hasFocus
       ..isTextField = true
-      ..isReadOnly = readOnly;
+      ..isReadOnly = readOnly
+      ..editableTextId = _editableTextId;
 
     if (hasFocus && selectionEnabled)
       config.onSetSelection = _handleSetSelection;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3896,12 +3896,15 @@ class SemanticsConfiguration {
   /// Two configurations are said to be compatible if they can be added to the
   /// same [SemanticsNode] without losing any semantics information.
   bool isCompatibleWith(SemanticsConfiguration? other) {
-    if (other == null || !other.hasBeenAnnotated || !hasBeenAnnotated)
+    if (other == null || !other.hasBeenAnnotated || !hasBeenAnnotated) {
       return true;
-    if (_actionsAsBits & other._actionsAsBits != 0)
+    }
+    if (_actionsAsBits & other._actionsAsBits != 0) {
       return false;
-    if ((_flags & other._flags) != 0)
+    }
+    if ((_flags & other._flags) != 0) {
       return false;
+    }
     if (_platformViewId != null && other._platformViewId != null) {
       return false;
     }
@@ -3911,8 +3914,12 @@ class SemanticsConfiguration {
     if (_currentValueLength != null && other._currentValueLength != null) {
       return false;
     }
-    if (_value != null && _value.isNotEmpty && other._value != null && other._value.isNotEmpty)
+    if (_value != null && _value.isNotEmpty && other._value != null && other._value.isNotEmpty) {
       return false;
+    }
+    if (isTextField && other.isTextField && (_editableTextId != other._editableTextId)) {
+      return false;
+    }
     return true;
   }
 
@@ -3929,11 +3936,6 @@ class SemanticsConfiguration {
   /// configurations as determined by [isCompatibleWith].
   void absorb(SemanticsConfiguration child) {
     assert(!explicitChildNodes);
-    assert(
-      !isTextField || !child.isTextField,
-      'Both parent and child semantics configurations cannot be text fields.\n'
-      'Parent editableTextId was $_editableTextId. Child editableTextId was ${child._editableTextId}.',
-    );
 
     if (!child.hasBeenAnnotated)
       return;

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -771,7 +771,9 @@ class _AutofillScopeTextInputConfiguration extends TextInputConfiguration {
     required TextInputConfiguration currentClientConfiguration,
   }) : assert(allConfigurations != null),
        assert(currentClientConfiguration != null),
-       super(inputType: currentClientConfiguration.inputType,
+       super(
+         editableTextId: currentClientConfiguration.editableTextId,
+         inputType: currentClientConfiguration.inputType,
          obscureText: currentClientConfiguration.obscureText,
          autocorrect: currentClientConfiguration.autocorrect,
          smartDashesType: currentClientConfiguration.smartDashesType,

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -451,6 +451,7 @@ class TextInputConfiguration {
   /// All arguments have default values, except [actionLabel]. Only
   /// [actionLabel] may be null.
   const TextInputConfiguration({
+    required this.editableTextId,
     this.inputType = TextInputType.text,
     this.readOnly = false,
     this.obscureText = false,
@@ -472,6 +473,8 @@ class TextInputConfiguration {
        assert(keyboardAppearance != null),
        assert(inputAction != null),
        assert(textCapitalization != null);
+
+  final int editableTextId;
 
   /// The type of information for which to optimize the text input control.
   final TextInputType inputType;
@@ -590,6 +593,7 @@ class TextInputConfiguration {
   /// Returns a representation of this object as a JSON object.
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
+      'editableTextId': editableTextId,
       'inputType': inputType.toJson(),
       'readOnly': readOnly,
       'obscureText': obscureText,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1491,6 +1491,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   final GlobalKey _editableKey = GlobalKey();
   final ClipboardStatusNotifier? _clipboardStatus = kIsWeb ? null : ClipboardStatusNotifier();
 
+  static int _editableTextIdCounter = 0;
+  final int _editableTextId = ++_editableTextIdCounter;
+
   TextInputConnection? _textInputConnection;
   TextSelectionOverlay? _selectionOverlay;
 
@@ -2543,6 +2546,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   TextInputConfiguration _createTextInputConfiguration(bool needsAutofillConfiguration) {
     assert(needsAutofillConfiguration != null);
     return TextInputConfiguration(
+      editableTextId: _editableTextId,
       inputType: widget.keyboardType,
       readOnly: widget.readOnly,
       obscureText: widget.obscureText,
@@ -2667,6 +2671,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                 promptRectRange: _currentPromptRectRange,
                 promptRectColor: widget.autocorrectionTextRectColor,
                 clipBehavior: widget.clipBehavior,
+                editableTextId: _editableTextId,
               ),
             ),
           );
@@ -2750,6 +2755,7 @@ class _Editable extends LeafRenderObjectWidget {
     this.promptRectRange,
     this.promptRectColor,
     required this.clipBehavior,
+    required this.editableTextId,
   }) : assert(textDirection != null),
        assert(rendererIgnoresPointer != null),
        super(key: key);
@@ -2797,6 +2803,7 @@ class _Editable extends LeafRenderObjectWidget {
   final TextRange? promptRectRange;
   final Color? promptRectColor;
   final Clip clipBehavior;
+  final int editableTextId;
 
   @override
   RenderEditable createRenderObject(BuildContext context) {
@@ -2840,6 +2847,7 @@ class _Editable extends LeafRenderObjectWidget {
       promptRectRange: promptRectRange,
       promptRectColor: promptRectColor,
       clipBehavior: clipBehavior,
+      editableTextId: editableTextId,
     );
   }
 
@@ -2882,7 +2890,8 @@ class _Editable extends LeafRenderObjectWidget {
       ..paintCursorAboveText = paintCursorAboveText
       ..promptRectColor = promptRectColor
       ..clipBehavior = clipBehavior
-      ..setPromptRectRange(promptRectRange);
+      ..setPromptRectRange(promptRectRange)
+      ..editableTextId = editableTextId;
   }
 }
 

--- a/packages/flutter/test/services/autofill_test.dart
+++ b/packages/flutter/test/services/autofill_test.dart
@@ -49,6 +49,7 @@ void main() {
         final FakeAutofillClient client2 = FakeAutofillClient(const TextEditingValue(text: 'test2'));
 
         client1.textInputConfiguration = TextInputConfiguration(
+          editableTextId: 1,
           autofillConfiguration: AutofillConfiguration(
             uniqueIdentifier: client1.autofillId,
             autofillHints: const <String>['client1'],
@@ -57,6 +58,7 @@ void main() {
         );
 
         client2.textInputConfiguration = TextInputConfiguration(
+          editableTextId: 2,
           autofillConfiguration: AutofillConfiguration(
             uniqueIdentifier: client2.autofillId,
             autofillHints: const <String>['client2'],

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -81,7 +81,9 @@ void main() {
     });
 
     test('sets expected defaults', () {
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       expect(configuration.inputType, TextInputType.text);
       expect(configuration.readOnly, false);
       expect(configuration.obscureText, false);
@@ -93,6 +95,7 @@ void main() {
 
     test('text serializes to JSON', () async {
       const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
         inputType: TextInputType.text,
         readOnly: true,
         obscureText: true,
@@ -113,6 +116,7 @@ void main() {
 
     test('number serializes to JSON', () async {
       const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
         inputType: TextInputType.numberWithOptions(decimal: true),
         obscureText: true,
         autocorrect: false,
@@ -166,7 +170,9 @@ void main() {
     test('TextInputClient onConnectionClosed method is called', () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(const TextEditingValue(text: 'test3'));
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -188,7 +194,9 @@ void main() {
     test('TextInputClient performPrivateCommand method is called', () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -215,7 +223,9 @@ void main() {
         () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -243,7 +253,9 @@ void main() {
         () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -271,7 +283,9 @@ void main() {
         () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -300,7 +314,9 @@ void main() {
         () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -328,7 +344,9 @@ void main() {
         () async {
       // Assemble a TextInputConnection so we can verify its change in state.
       final FakeTextInputClient client = FakeTextInputClient(TextEditingValue.empty);
-      const TextInputConfiguration configuration = TextInputConfiguration();
+      const TextInputConfiguration configuration = TextInputConfiguration(
+        editableTextId: 1,
+      );
       TextInput.attach(client, configuration);
 
       expect(client.latestMethodCall, isEmpty);
@@ -418,7 +436,9 @@ class FakeTextInputClient implements TextInputClient {
     latestMethodCall = 'showAutocorrectionPromptRect';
   }
 
-  TextInputConfiguration get configuration => const TextInputConfiguration();
+  TextInputConfiguration get configuration => const TextInputConfiguration(
+    editableTextId: 1,
+  );
 }
 
 class FakeTextChannel implements MethodChannel {


### PR DESCRIPTION
Attach an `editableTextId` value to the `EditableTextState` that uniquely identifies the text field and pass it to the engine via text input channel and semantics nodes. This field will be used to fix a race between the `flutter/textinput` channel and semantics.

This makes progress towards fixing https://github.com/flutter/flutter/issues/52106 (engine changes are required to fully fix this).

## Background

On the web, the semantics tree is responsible for hosting the `<input>` elements. The semantics update happens after the `TextInputConnection` is established. Conversely, the semantics tree can create `<input>` elements before text input connection is established. This leads to the following bad situations leading to various bugs:

- A text input command is sent to the engine, but there's no `<input>` element to sync to.
- Text input command is routed to a wrong `<input>` element.
- `<input>` is removed (due to lazy rendering) while a text input connection is still alive.

## Solution

`editableTextId` outlives `clientId` (which is unique to a single `TextInputConfiguration`), and it is the single source of truth for both semantics and the text input channel. Whether one or the other initiates the creation of an `<input>` element, they can connect by matching on the `editableTextId`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
