### PR TITLE
[flutter] optimize an inherited widget lookup with is

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3995,7 +3995,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   T? findAncestorWidgetOfExactType<T extends Widget>() {
     assert(_debugCheckStateIsActiveForAncestorLookup());
     Element? ancestor = _parent;
-    while (ancestor != null && ancestor.widget.runtimeType != T)
+    while (ancestor != null && ancestor.widget is! T)
       ancestor = ancestor._parent;
     return ancestor?.widget as T?;
   }


### PR DESCRIPTION
When the RHS of a `object.runtimeType ==/!= X` expression is a statically known type, it can safely be replaced with `object is/is! X` expression. This is generally more performant, though if not on a critical path it is unlikely to matter.

There are no reasonable scenarios where this change should be visible, and it is small enough that it is unlikely to show up in size or performance benchmarks.
