### PR TITLE
Fix samples of ExactAssetImage

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1007,7 +1007,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// Then, to fetch the image and associate it with scale `1.5`, use:
 ///
 /// ```dart
-/// AssetImage('icons/heart.png', scale: 1.5)
+/// ExactAssetImage('icons/heart.png', scale: 1.5)
 /// ```
 ///
 /// ## Assets in packages
@@ -1017,7 +1017,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// `my_icons`. Then to fetch the image, use:
 ///
 /// ```dart
-/// AssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
+/// ExactAssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
 /// ```
 ///
 /// Assets used by the package itself should also be fetched using the [package]

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1008,7 +1008,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 ///
 /// {@tool snippet}
 /// ```dart
-/// ExactAssetImage('icons/heart.png', scale: 1.5)
+/// const ExactAssetImage('icons/heart.png', scale: 1.5)
 /// ```
 /// {@end-tool}
 ///
@@ -1020,7 +1020,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 ///
 /// {@tool snippet}
 /// ```dart
-/// ExactAssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
+/// const ExactAssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1006,9 +1006,9 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 ///
 /// Then, to fetch the image and associate it with scale `1.5`, use:
 ///
-/// ```dart
+/// {@tool snippet}
 /// ExactAssetImage('icons/heart.png', scale: 1.5)
-/// ```
+/// {@end-tool}
 ///
 /// ## Assets in packages
 ///
@@ -1016,9 +1016,9 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// For instance, suppose the structure above is inside a package called
 /// `my_icons`. Then to fetch the image, use:
 ///
-/// ```dart
+/// {@tool snippet}
 /// ExactAssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
-/// ```
+/// {@end-tool}
 ///
 /// Assets used by the package itself should also be fetched using the [package]
 /// argument as above.

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1007,7 +1007,9 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// Then, to fetch the image and associate it with scale `1.5`, use:
 ///
 /// {@tool snippet}
+/// ```dart
 /// ExactAssetImage('icons/heart.png', scale: 1.5)
+/// ```
 /// {@end-tool}
 ///
 /// ## Assets in packages
@@ -1017,7 +1019,9 @@ class MemoryImage extends ImageProvider<MemoryImage> {
 /// `my_icons`. Then to fetch the image, use:
 ///
 /// {@tool snippet}
+/// ```dart
 /// ExactAssetImage('icons/heart.png', scale: 1.5, package: 'my_icons')
+/// ```
 /// {@end-tool}
 ///
 /// Assets used by the package itself should also be fetched using the [package]


### PR DESCRIPTION
Fixed two samples of `ExactAssetImage` where, instead of `ExactAssetImage`, they used `AssetImage`.

Fixes #79720.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.