### PR TITLE
Fixes modifier keys blocking Backspace/Delete on physical keyboards (Issue #78769)

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -626,6 +626,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     LogicalKeyboardKey.shift,
     LogicalKeyboardKey.control,
     LogicalKeyboardKey.alt,
+    LogicalKeyboardKey.capsLock,
+    LogicalKeyboardKey.numLock,
   };
 
   static final Set<LogicalKeyboardKey> _macOsModifierKeys = <LogicalKeyboardKey>{

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -23,7 +23,8 @@ const double _kCaretHeightOffset = 2.0; // pixels
 
 // The additional size on the x and y axis with which to expand the prototype
 // cursor to render the floating cursor in pixels.
-const EdgeInsets _kFloatingCaretSizeIncrease = EdgeInsets.symmetric(horizontal: 0.5, vertical: 1.0);
+const EdgeInsets _kFloatingCaretSizeIncrease =
+    EdgeInsets.symmetric(horizontal: 0.5, vertical: 1.0);
 
 // The corner radius of the floating cursor in pixels.
 const Radius _kFloatingCaretRadius = Radius.circular(1.0);
@@ -37,7 +38,8 @@ const Radius _kFloatingCaretRadius = Radius.circular(1.0);
   'textSelectionDelegate.userUpdateTextEditingValue. '
   'This feature was deprecated after v1.26.0-17.2.pre.',
 )
-typedef SelectionChangedHandler = void Function(TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause);
+typedef SelectionChangedHandler = void Function(TextSelection selection,
+    RenderEditable renderObject, SelectionChangedCause cause);
 
 /// Signature for the callback that reports when the caret location changes.
 ///
@@ -52,8 +54,7 @@ class TextSelectionPoint {
   /// Creates a description of a point in a text selection.
   ///
   /// The [point] argument must not be null.
-  const TextSelectionPoint(this.point, this.direction)
-    : assert(point != null);
+  const TextSelectionPoint(this.point, this.direction) : assert(point != null);
 
   /// Coordinates of the lower left or lower right corner of the selection,
   /// relative to the top left of the [RenderEditable] object.
@@ -173,7 +174,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       'Uses the textSelectionDelegate.userUpdateTextEditingValue instead. '
       'This feature was deprecated after v1.26.0-17.2.pre.',
     )
-    this.onSelectionChanged,
+        this.onSelectionChanged,
     this.onCaretChanged,
     this.ignorePointer = false,
     bool readOnly = false,
@@ -199,65 +200,67 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     required this.textSelectionDelegate,
     RenderEditablePainter? painter,
     RenderEditablePainter? foregroundPainter,
-  }) : assert(textAlign != null),
-       assert(textDirection != null, 'RenderEditable created without a textDirection.'),
-       assert(maxLines == null || maxLines > 0),
-       assert(minLines == null || minLines > 0),
-       assert(startHandleLayerLink != null),
-       assert(endHandleLayerLink != null),
-       assert(
-         (maxLines == null) || (minLines == null) || (maxLines >= minLines),
-         "minLines can't be greater than maxLines",
-       ),
-       assert(expands != null),
-       assert(
-         !expands || (maxLines == null && minLines == null),
-         'minLines and maxLines must be null when expands is true.',
-       ),
-       assert(textScaleFactor != null),
-       assert(offset != null),
-       assert(ignorePointer != null),
-       assert(textWidthBasis != null),
-       assert(paintCursorAboveText != null),
-       assert(obscuringCharacter != null && obscuringCharacter.characters.length == 1),
-       assert(obscureText != null),
-       assert(textSelectionDelegate != null),
-       assert(cursorWidth != null && cursorWidth >= 0.0),
-       assert(cursorHeight == null || cursorHeight >= 0.0),
-       assert(readOnly != null),
-       assert(forceLine != null),
-       assert(devicePixelRatio != null),
-       assert(selectionHeightStyle != null),
-       assert(selectionWidthStyle != null),
-       assert(clipBehavior != null),
-       _textPainter = TextPainter(
-         text: text,
-         textAlign: textAlign,
-         textDirection: textDirection,
-         textScaleFactor: textScaleFactor,
-         locale: locale,
-         strutStyle: strutStyle,
-         textHeightBehavior: textHeightBehavior,
-         textWidthBasis: textWidthBasis,
-       ),
-       _showCursor = showCursor ?? ValueNotifier<bool>(false),
-       _maxLines = maxLines,
-       _minLines = minLines,
-       _expands = expands,
-       _selection = selection,
-       _offset = offset,
-       _cursorWidth = cursorWidth,
-       _cursorHeight = cursorHeight,
-       _paintCursorOnTop = paintCursorAboveText,
-       _enableInteractiveSelection = enableInteractiveSelection,
-       _devicePixelRatio = devicePixelRatio,
-       _startHandleLayerLink = startHandleLayerLink,
-       _endHandleLayerLink = endHandleLayerLink,
-       _obscuringCharacter = obscuringCharacter,
-       _obscureText = obscureText,
-       _readOnly = readOnly,
-       _forceLine = forceLine,
-       _clipBehavior = clipBehavior {
+  })  : assert(textAlign != null),
+        assert(textDirection != null,
+            'RenderEditable created without a textDirection.'),
+        assert(maxLines == null || maxLines > 0),
+        assert(minLines == null || minLines > 0),
+        assert(startHandleLayerLink != null),
+        assert(endHandleLayerLink != null),
+        assert(
+          (maxLines == null) || (minLines == null) || (maxLines >= minLines),
+          "minLines can't be greater than maxLines",
+        ),
+        assert(expands != null),
+        assert(
+          !expands || (maxLines == null && minLines == null),
+          'minLines and maxLines must be null when expands is true.',
+        ),
+        assert(textScaleFactor != null),
+        assert(offset != null),
+        assert(ignorePointer != null),
+        assert(textWidthBasis != null),
+        assert(paintCursorAboveText != null),
+        assert(obscuringCharacter != null &&
+            obscuringCharacter.characters.length == 1),
+        assert(obscureText != null),
+        assert(textSelectionDelegate != null),
+        assert(cursorWidth != null && cursorWidth >= 0.0),
+        assert(cursorHeight == null || cursorHeight >= 0.0),
+        assert(readOnly != null),
+        assert(forceLine != null),
+        assert(devicePixelRatio != null),
+        assert(selectionHeightStyle != null),
+        assert(selectionWidthStyle != null),
+        assert(clipBehavior != null),
+        _textPainter = TextPainter(
+          text: text,
+          textAlign: textAlign,
+          textDirection: textDirection,
+          textScaleFactor: textScaleFactor,
+          locale: locale,
+          strutStyle: strutStyle,
+          textHeightBehavior: textHeightBehavior,
+          textWidthBasis: textWidthBasis,
+        ),
+        _showCursor = showCursor ?? ValueNotifier<bool>(false),
+        _maxLines = maxLines,
+        _minLines = minLines,
+        _expands = expands,
+        _selection = selection,
+        _offset = offset,
+        _cursorWidth = cursorWidth,
+        _cursorHeight = cursorHeight,
+        _paintCursorOnTop = paintCursorAboveText,
+        _enableInteractiveSelection = enableInteractiveSelection,
+        _devicePixelRatio = devicePixelRatio,
+        _startHandleLayerLink = startHandleLayerLink,
+        _endHandleLayerLink = endHandleLayerLink,
+        _obscuringCharacter = obscuringCharacter,
+        _obscureText = obscureText,
+        _readOnly = readOnly,
+        _forceLine = forceLine,
+        _clipBehavior = clipBehavior {
     assert(_showCursor != null);
     assert(!_showCursor.value || cursorColor != null);
     this.hasFocus = hasFocus ?? false;
@@ -285,14 +288,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _updateForegroundPainter(RenderEditablePainter? newPainter) {
     final _CompositeRenderEditablePainter effectivePainter = newPainter == null
-      ? _builtInForegroundPainters
-      : _CompositeRenderEditablePainter(painters: <RenderEditablePainter>[
-         _builtInForegroundPainters,
-         newPainter,
-      ]);
+        ? _builtInForegroundPainters
+        : _CompositeRenderEditablePainter(painters: <RenderEditablePainter>[
+            _builtInForegroundPainters,
+            newPainter,
+          ]);
 
     if (_foregroundRenderObject == null) {
-      final _RenderEditableCustomPaint foregroundRenderObject = _RenderEditableCustomPaint(painter: effectivePainter);
+      final _RenderEditableCustomPaint foregroundRenderObject =
+          _RenderEditableCustomPaint(painter: effectivePainter);
       adoptChild(foregroundRenderObject);
       _foregroundRenderObject = foregroundRenderObject;
     } else {
@@ -310,18 +314,19 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   RenderEditablePainter? get foregroundPainter => _foregroundPainter;
   RenderEditablePainter? _foregroundPainter;
   set foregroundPainter(RenderEditablePainter? newPainter) {
-    if (newPainter == _foregroundPainter)
-      return;
+    if (newPainter == _foregroundPainter) return;
     _updateForegroundPainter(newPainter);
   }
 
   void _updatePainter(RenderEditablePainter? newPainter) {
     final _CompositeRenderEditablePainter effectivePainter = newPainter == null
-      ? _builtInPainters
-      : _CompositeRenderEditablePainter(painters: <RenderEditablePainter>[_builtInPainters, newPainter]);
+        ? _builtInPainters
+        : _CompositeRenderEditablePainter(
+            painters: <RenderEditablePainter>[_builtInPainters, newPainter]);
 
     if (_backgroundRenderObject == null) {
-      final _RenderEditableCustomPaint backgroundRenderObject = _RenderEditableCustomPaint(painter: effectivePainter);
+      final _RenderEditableCustomPaint backgroundRenderObject =
+          _RenderEditableCustomPaint(painter: effectivePainter);
       adoptChild(backgroundRenderObject);
       _backgroundRenderObject = backgroundRenderObject;
     } else {
@@ -339,20 +344,22 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   RenderEditablePainter? get painter => _painter;
   RenderEditablePainter? _painter;
   set painter(RenderEditablePainter? newPainter) {
-    if (newPainter == _painter)
-      return;
+    if (newPainter == _painter) return;
     _updatePainter(newPainter);
   }
 
   // Caret Painters:
   // The floating painter. This painter paints the regular caret as well.
-  late final _FloatingCursorPainter _caretPainter = _FloatingCursorPainter(_onCaretChanged);
+  late final _FloatingCursorPainter _caretPainter =
+      _FloatingCursorPainter(_onCaretChanged);
 
   // Text Highlight painters:
   final _TextHighlightPainter _selectionPainter = _TextHighlightPainter();
-  final _TextHighlightPainter _autocorrectHighlightPainter = _TextHighlightPainter();
+  final _TextHighlightPainter _autocorrectHighlightPainter =
+      _TextHighlightPainter();
 
-  _CompositeRenderEditablePainter get _builtInForegroundPainters => _cachedBuiltInForegroundPainters ??= _createBuiltInForegroundPainters();
+  _CompositeRenderEditablePainter get _builtInForegroundPainters =>
+      _cachedBuiltInForegroundPainters ??= _createBuiltInForegroundPainters();
   _CompositeRenderEditablePainter? _cachedBuiltInForegroundPainters;
   _CompositeRenderEditablePainter _createBuiltInForegroundPainters() {
     return _CompositeRenderEditablePainter(
@@ -362,7 +369,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  _CompositeRenderEditablePainter get _builtInPainters => _cachedBuiltInPainters ??= _createBuiltInPainters();
+  _CompositeRenderEditablePainter get _builtInPainters =>
+      _cachedBuiltInPainters ??= _createBuiltInPainters();
   _CompositeRenderEditablePainter? _cachedBuiltInPainters;
   _CompositeRenderEditablePainter _createBuiltInPainters() {
     return _CompositeRenderEditablePainter(
@@ -373,6 +381,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       ],
     );
   }
+
   /// Called when the selection changes.
   ///
   /// If this is null, then selection changes will be ignored.
@@ -392,8 +401,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Called during the paint phase when the caret location changes.
   CaretChangedHandler? onCaretChanged;
   void _onCaretChanged(Rect caretRect) {
-    if (_lastCaretRect != caretRect)
-      onCaretChanged?.call(caretRect);
+    if (_lastCaretRect != caretRect) onCaretChanged?.call(caretRect);
     _lastCaretRect = onCaretChanged == null ? null : caretRect;
   }
 
@@ -413,8 +421,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// {@macro flutter.dart:ui.textHeightBehavior}
   TextHeightBehavior? get textHeightBehavior => _textPainter.textHeightBehavior;
   set textHeightBehavior(TextHeightBehavior? value) {
-    if (_textPainter.textHeightBehavior == value)
-      return;
+    if (_textPainter.textHeightBehavior == value) return;
     _textPainter.textHeightBehavior = value;
     markNeedsTextLayout();
   }
@@ -423,8 +430,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextWidthBasis get textWidthBasis => _textPainter.textWidthBasis;
   set textWidthBasis(TextWidthBasis value) {
     assert(value != null);
-    if (_textPainter.textWidthBasis == value)
-      return;
+    if (_textPainter.textWidthBasis == value) return;
     _textPainter.textWidthBasis = value;
     markNeedsTextLayout();
   }
@@ -435,8 +441,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   double get devicePixelRatio => _devicePixelRatio;
   double _devicePixelRatio;
   set devicePixelRatio(double value) {
-    if (devicePixelRatio == value)
-      return;
+    if (devicePixelRatio == value) return;
     _devicePixelRatio = value;
     markNeedsTextLayout();
   }
@@ -459,8 +464,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool get obscureText => _obscureText;
   bool _obscureText;
   set obscureText(bool value) {
-    if (_obscureText == value)
-      return;
+    if (_obscureText == value) return;
     _obscureText = value;
     markNeedsSemanticsUpdate();
   }
@@ -468,7 +472,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Controls how tall the selection highlight boxes are computed to be.
   ///
   /// See [ui.BoxHeightStyle] for details on available styles.
-  ui.BoxHeightStyle get selectionHeightStyle => _selectionPainter.selectionHeightStyle;
+  ui.BoxHeightStyle get selectionHeightStyle =>
+      _selectionPainter.selectionHeightStyle;
   set selectionHeightStyle(ui.BoxHeightStyle value) {
     _selectionPainter.selectionHeightStyle = value;
   }
@@ -476,11 +481,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Controls how wide the selection highlight boxes are computed to be.
   ///
   /// See [ui.BoxWidthStyle] for details on available styles.
-  ui.BoxWidthStyle get selectionWidthStyle => _selectionPainter.selectionWidthStyle;
+  ui.BoxWidthStyle get selectionWidthStyle =>
+      _selectionPainter.selectionWidthStyle;
   set selectionWidthStyle(ui.BoxWidthStyle value) {
     _selectionPainter.selectionWidthStyle = value;
   }
-
 
   /// The object that controls the text selection, used by this render object
   /// for implementing cut, copy, and paste keyboard shortcuts.
@@ -499,8 +504,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// This bool indicates whether the text is scrolled so that the handle is
   /// inside the text field viewport, as opposed to whether it is actually
   /// visible on the screen.
-  ValueListenable<bool> get selectionStartInViewport => _selectionStartInViewport;
-  final ValueNotifier<bool> _selectionStartInViewport = ValueNotifier<bool>(true);
+  ValueListenable<bool> get selectionStartInViewport =>
+      _selectionStartInViewport;
+  final ValueNotifier<bool> _selectionStartInViewport =
+      ValueNotifier<bool>(true);
 
   /// Track whether position of the end of the selected text is within the viewport.
   ///
@@ -532,16 +539,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // this can be changed to be a strict check instead of an approximation.
     const double visibleRegionSlop = 0.5;
     _selectionStartInViewport.value = visibleRegion
-      .inflate(visibleRegionSlop)
-      .contains(startOffset + effectiveOffset);
+        .inflate(visibleRegionSlop)
+        .contains(startOffset + effectiveOffset);
 
-    final Offset endOffset =  _textPainter.getOffsetForCaret(
+    final Offset endOffset = _textPainter.getOffsetForCaret(
       TextPosition(offset: selection!.end, affinity: selection!.affinity),
       _caretPrototype,
     );
     _selectionEndInViewport.value = visibleRegion
-      .inflate(visibleRegionSlop)
-      .contains(endOffset + effectiveOffset);
+        .inflate(visibleRegionSlop)
+        .contains(endOffset + effectiveOffset);
   }
 
   // Holds the last cursor location the user selected in the case the user tries
@@ -558,7 +565,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // down in a multiline text field when selecting using the keyboard.
   bool _wasSelectingVerticallyWithKeyboard = false;
 
-  void _setTextEditingValue(TextEditingValue newValue, SelectionChangedCause cause) {
+  void _setTextEditingValue(
+      TextEditingValue newValue, SelectionChangedCause cause) {
     textSelectionDelegate.textEditingValue = newValue;
     textSelectionDelegate.userUpdateTextEditingValue(newValue, cause);
   }
@@ -594,8 +602,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // components, so always send those events, even if we didn't think it
     // changed. Also, focusing an empty field is sent as a selection change even
     // if the selection offset didn't change.
-    final bool focusingEmpty = nextSelection.baseOffset == 0 && nextSelection.extentOffset == 0 && !hasFocus;
-    if (nextSelection == selection && cause != SelectionChangedCause.keyboard && !focusingEmpty) {
+    final bool focusingEmpty = nextSelection.baseOffset == 0 &&
+        nextSelection.extentOffset == 0 &&
+        !hasFocus;
+    if (nextSelection == selection &&
+        cause != SelectionChangedCause.keyboard &&
+        !focusingEmpty) {
       return;
     }
     onSelectionChanged?.call(nextSelection, this, cause);
@@ -626,9 +638,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     LogicalKeyboardKey.shift,
     LogicalKeyboardKey.control,
     LogicalKeyboardKey.alt,
+    LogicalKeyboardKey.capsLock,
+    LogicalKeyboardKey.numLock,
   };
 
-  static final Set<LogicalKeyboardKey> _macOsModifierKeys = <LogicalKeyboardKey>{
+  static final Set<LogicalKeyboardKey> _macOsModifierKeys =
+      <LogicalKeyboardKey>{
     LogicalKeyboardKey.shift,
     LogicalKeyboardKey.meta,
     LogicalKeyboardKey.alt,
@@ -646,14 +661,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    if (keyEvent is! RawKeyDownEvent)
-      return;
-    final Set<LogicalKeyboardKey> keysPressed = LogicalKeyboardKey.collapseSynonyms(RawKeyboard.instance.keysPressed);
+    if (keyEvent is! RawKeyDownEvent) return;
+    final Set<LogicalKeyboardKey> keysPressed =
+        LogicalKeyboardKey.collapseSynonyms(RawKeyboard.instance.keysPressed);
     final LogicalKeyboardKey key = keyEvent.logicalKey;
 
     final bool isMacOS = keyEvent.data is RawKeyEventDataMacOs;
     if (!_nonModifierKeys.contains(key) ||
-        keysPressed.difference(isMacOS ? _macOsModifierKeys : _modifierKeys).length > 1 ||
+        keysPressed
+                .difference(isMacOS ? _macOsModifierKeys : _modifierKeys)
+                .length >
+            1 ||
         keysPressed.difference(_interestingKeys).isNotEmpty) {
       // If the most recently pressed key isn't a non-modifier key, or more than
       // one non-modifier key is down, or keys other than the ones we're interested in
@@ -665,7 +683,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // all the keyboard handling functions assume it is not.
     assert(selection != null);
 
-    final bool isShortcutModifierPressed = isMacOS ? keyEvent.isMetaPressed : keyEvent.isControlPressed;
+    final bool isShortcutModifierPressed =
+        isMacOS ? keyEvent.isMetaPressed : keyEvent.isControlPressed;
     if (isShortcutModifierPressed && _shortcutKeys.contains(key)) {
       // _handleShortcuts depends on being started in the same stack invocation
       // as the _handleKeyEvent method
@@ -689,14 +708,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Setting includeWhitespace to false will only return the index of non-space
   /// characters.
   @visibleForTesting
-  static int nextCharacter(int index, String string, [bool includeWhitespace = true]) {
+  static int nextCharacter(int index, String string,
+      [bool includeWhitespace = true]) {
     assert(index >= 0 && index <= string.length);
     if (index == string.length) {
       return string.length;
     }
 
     int count = 0;
-    final Characters remaining = string.characters.skipWhile((String currentString) {
+    final Characters remaining =
+        string.characters.skipWhile((String currentString) {
       if (count <= index) {
         count += currentString.length;
         return true;
@@ -721,7 +742,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Setting includeWhitespace to false will only return the index of non-space
   /// characters.
   @visibleForTesting
-  static int previousCharacter(int index, String string, [bool includeWhitespace = true]) {
+  static int previousCharacter(int index, String string,
+      [bool includeWhitespace = true]) {
     assert(index >= 0 && index <= string.length);
     if (index == 0) {
       return 0;
@@ -731,7 +753,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     int? lastNonWhitespace;
     for (final String currentString in string.characters) {
       if (!includeWhitespace &&
-          !_isWhitespace(currentString.characters.first.toString().codeUnitAt(0))) {
+          !_isWhitespace(
+              currentString.characters.first.toString().codeUnitAt(0))) {
         lastNonWhitespace = count;
       }
       if (count + currentString.length >= index) {
@@ -745,7 +768,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Return a new selection that has been moved left once.
   //
   // If it can't be moved left, the original TextSelection is returned.
-  static TextSelection _moveGivenSelectionLeft(TextSelection selection, String text) {
+  static TextSelection _moveGivenSelectionLeft(
+      TextSelection selection, String text) {
     // If the selection is already all the way left, there is nothing to do.
     if (selection.isCollapsed && selection.extentOffset <= 0) {
       return selection;
@@ -768,7 +792,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Return a new selection that has been moved right once.
   //
   // If it can't be moved right, the original TextSelection is returned.
-  static TextSelection _moveGivenSelectionRight(TextSelection selection, String text) {
+  static TextSelection _moveGivenSelectionRight(
+      TextSelection selection, String text) {
     // If the selection is already all the way right, there is nothing to do.
     if (selection.isCollapsed && selection.extentOffset >= text.length) {
       return selection;
@@ -780,17 +805,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     } else {
       nextExtent = nextCharacter(selection.extentOffset, text);
     }
-    final TextSelection nextSelection = selection.copyWith(extentOffset: nextExtent);
+    final TextSelection nextSelection =
+        selection.copyWith(extentOffset: nextExtent);
 
     int newOffset = nextSelection.extentOffset;
     newOffset = nextSelection.baseOffset > nextSelection.extentOffset
-        ? nextSelection.baseOffset : nextSelection.extentOffset;
+        ? nextSelection.baseOffset
+        : nextSelection.extentOffset;
     return TextSelection.fromPosition(TextPosition(offset: newOffset));
   }
 
   // Return the offset at the start of the nearest word to the left of the given
   // offset.
-  static int _getLeftByWord(TextPainter textPainter, int offset, [bool includeWhitespace = true]) {
+  static int _getLeftByWord(TextPainter textPainter, int offset,
+      [bool includeWhitespace = true]) {
     // If the offset is already all the way left, there is nothing to do.
     if (offset <= 0) {
       return offset;
@@ -803,13 +831,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     final String text = textPainter.text!.toPlainText();
     final int startPoint = previousCharacter(offset, text, includeWhitespace);
-    final TextRange word = textPainter.getWordBoundary(TextPosition(offset: startPoint));
+    final TextRange word =
+        textPainter.getWordBoundary(TextPosition(offset: startPoint));
     return word.start;
   }
 
   // Return the offset at the end of the nearest word to the right of the given
   // offset.
-  static int _getRightByWord(TextPainter textPainter, int offset, [bool includeWhitespace = true]) {
+  static int _getRightByWord(TextPainter textPainter, int offset,
+      [bool includeWhitespace = true]) {
     // If the selection is already all the way right, there is nothing to do.
     final String text = textPainter.text!.toPlainText();
     if (offset == text.length) {
@@ -821,10 +851,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return text.length;
     }
 
-    final int startPoint = includeWhitespace || !_isWhitespace(text.codeUnitAt(offset))
-        ? offset
-        : nextCharacter(offset, text, includeWhitespace);
-    final TextRange nextWord = textPainter.getWordBoundary(TextPosition(offset: startPoint));
+    final int startPoint =
+        includeWhitespace || !_isWhitespace(text.codeUnitAt(offset))
+            ? offset
+            : nextCharacter(offset, text, includeWhitespace);
+    final TextRange nextWord =
+        textPainter.getWordBoundary(TextPosition(offset: startPoint));
     return nextWord.end;
   }
 
@@ -833,16 +865,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // See extendSelectionLeftByWord for a detailed explanation of the two
   // optional parameters.
-  static TextSelection _extendGivenSelectionLeftByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true, bool stopAtReversal = false]) {
+  static TextSelection _extendGivenSelectionLeftByWord(
+      TextPainter textPainter, TextSelection selection,
+      [bool includeWhitespace = true, bool stopAtReversal = false]) {
     // If the selection is already all the way left, there is nothing to do.
     if (selection.isCollapsed && selection.extentOffset <= 0) {
       return selection;
     }
 
-    final int leftOffset = _getLeftByWord(textPainter, selection.extentOffset, includeWhitespace);
+    final int leftOffset =
+        _getLeftByWord(textPainter, selection.extentOffset, includeWhitespace);
 
-    if (stopAtReversal && selection.extentOffset > selection.baseOffset
-        && leftOffset < selection.baseOffset) {
+    if (stopAtReversal &&
+        selection.extentOffset > selection.baseOffset &&
+        leftOffset < selection.baseOffset) {
       return selection.copyWith(
         extentOffset: selection.baseOffset,
       );
@@ -858,17 +894,21 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // See extendSelectionRightByWord for a detailed explanation of the two
   // optional parameters.
-  static TextSelection _extendGivenSelectionRightByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true, bool stopAtReversal = false]) {
+  static TextSelection _extendGivenSelectionRightByWord(
+      TextPainter textPainter, TextSelection selection,
+      [bool includeWhitespace = true, bool stopAtReversal = false]) {
     // If the selection is already all the way right, there is nothing to do.
     final String text = textPainter.text!.toPlainText();
     if (selection.isCollapsed && selection.extentOffset == text.length) {
       return selection;
     }
 
-    final int rightOffset = _getRightByWord(textPainter, selection.extentOffset, includeWhitespace);
+    final int rightOffset =
+        _getRightByWord(textPainter, selection.extentOffset, includeWhitespace);
 
-    if (stopAtReversal && selection.baseOffset > selection.extentOffset
-        && rightOffset > selection.baseOffset) {
+    if (stopAtReversal &&
+        selection.baseOffset > selection.extentOffset &&
+        rightOffset > selection.baseOffset) {
       return selection.copyWith(
         extentOffset: selection.baseOffset,
       );
@@ -883,13 +923,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // A TextSelection that isn't collapsed will be collapsed and moved from the
   // extentOffset.
-  static TextSelection _moveGivenSelectionLeftByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true]) {
+  static TextSelection _moveGivenSelectionLeftByWord(
+      TextPainter textPainter, TextSelection selection,
+      [bool includeWhitespace = true]) {
     // If the selection is already all the way left, there is nothing to do.
     if (selection.isCollapsed && selection.extentOffset <= 0) {
       return selection;
     }
 
-    final int leftOffset = _getLeftByWord(textPainter, selection.extentOffset, includeWhitespace);
+    final int leftOffset =
+        _getLeftByWord(textPainter, selection.extentOffset, includeWhitespace);
     return selection.copyWith(
       baseOffset: leftOffset,
       extentOffset: leftOffset,
@@ -900,35 +943,44 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // A TextSelection that isn't collapsed will be collapsed and moved from the
   // extentOffset.
-  static TextSelection _moveGivenSelectionRightByWord(TextPainter textPainter, TextSelection selection, [bool includeWhitespace = true]) {
+  static TextSelection _moveGivenSelectionRightByWord(
+      TextPainter textPainter, TextSelection selection,
+      [bool includeWhitespace = true]) {
     // If the selection is already all the way right, there is nothing to do.
     final String text = textPainter.text!.toPlainText();
     if (selection.isCollapsed && selection.extentOffset == text.length) {
       return selection;
     }
 
-    final int rightOffset = _getRightByWord(textPainter, selection.extentOffset, includeWhitespace);
+    final int rightOffset =
+        _getRightByWord(textPainter, selection.extentOffset, includeWhitespace);
     return selection.copyWith(
       baseOffset: rightOffset,
       extentOffset: rightOffset,
     );
   }
 
-  static TextSelection _extendGivenSelectionLeft(TextSelection selection, String text, [bool includeWhitespace = true]) {
+  static TextSelection _extendGivenSelectionLeft(
+      TextSelection selection, String text,
+      [bool includeWhitespace = true]) {
     // If the selection is already all the way left, there is nothing to do.
     if (selection.extentOffset <= 0) {
       return selection;
     }
-    final int previousExtent = previousCharacter(selection.extentOffset, text, includeWhitespace);
+    final int previousExtent =
+        previousCharacter(selection.extentOffset, text, includeWhitespace);
     return selection.copyWith(extentOffset: previousExtent);
   }
 
-  static TextSelection _extendGivenSelectionRight(TextSelection selection, String text, [bool includeWhitespace = true]) {
+  static TextSelection _extendGivenSelectionRight(
+      TextSelection selection, String text,
+      [bool includeWhitespace = true]) {
     // If the selection is already all the way right, there is nothing to do.
     if (selection.extentOffset >= text.length) {
       return selection;
     }
-    final int nextExtent = nextCharacter(selection.extentOffset, text, includeWhitespace);
+    final int nextExtent =
+        nextCharacter(selection.extentOffset, text, includeWhitespace);
     return selection.copyWith(extentOffset: nextExtent);
   }
 
@@ -984,8 +1036,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   // Returns the TextPosition above or below the given offset.
   TextPosition _getTextPositionVertical(int textOffset, double verticalOffset) {
-    final Offset caretOffset = _textPainter.getOffsetForCaret(TextPosition(offset: textOffset), _caretPrototype);
-    final Offset caretOffsetTranslated = caretOffset.translate(0.0, verticalOffset);
+    final Offset caretOffset = _textPainter.getOffsetForCaret(
+        TextPosition(offset: textOffset), _caretPrototype);
+    final Offset caretOffsetTranslated =
+        caretOffset.translate(0.0, verticalOffset);
     return _textPainter.getPositionForOffset(caretOffsetTranslated);
   }
 
@@ -1034,14 +1088,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // If the selection is collapsed at the end of the field already, then
     // nothing happens.
-    if (selection!.isCollapsed && selection!.extentOffset >= _plainText.length) {
+    if (selection!.isCollapsed &&
+        selection!.extentOffset >= _plainText.length) {
       return;
     }
     if (!selectionEnabled) {
       return moveSelectionDown(cause);
     }
 
-    final TextPosition positionBelow = _getTextPositionBelow(selection!.extentOffset);
+    final TextPosition positionBelow =
+        _getTextPositionBelow(selection!.extentOffset);
     late final TextSelection nextSelection;
     if (positionBelow.offset == selection!.extentOffset) {
       nextSelection = selection!.copyWith(
@@ -1087,10 +1143,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionToEnd(cause);
     }
 
-    final int firstOffset = math.max(0, math.min(
-      selection!.baseOffset,
-      selection!.extentOffset,
-    ));
+    final int firstOffset = math.max(
+        0,
+        math.min(
+          selection!.baseOffset,
+          selection!.extentOffset,
+        ));
     final TextSelection nextSelection = TextSelection(
       baseOffset: firstOffset,
       extentOffset: _plainText.length,
@@ -1157,8 +1215,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // so we go back to the first non-whitespace before asking for the line
     // bounds, since _getLineAtOffset finds the line boundaries without
     // including whitespace (like the newline).
-    final int startPoint = previousCharacter(selection!.extentOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final int startPoint =
+        previousCharacter(selection!.extentOffset, _plainText, false);
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
 
     late final TextSelection nextSelection;
     if (selection!.extentOffset > selection!.baseOffset) {
@@ -1229,8 +1289,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionRightByLine(cause);
     }
 
-    final int startPoint = nextCharacter(selection!.extentOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final int startPoint =
+        nextCharacter(selection!.extentOffset, _plainText, false);
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
 
     late final TextSelection nextSelection;
     if (selection!.extentOffset < selection!.baseOffset) {
@@ -1271,7 +1333,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionUp(cause);
     }
 
-    final TextPosition positionAbove = _getTextPositionAbove(selection!.extentOffset);
+    final TextPosition positionAbove =
+        _getTextPositionAbove(selection!.extentOffset);
     late final TextSelection nextSelection;
     if (positionAbove.offset == selection!.extentOffset) {
       nextSelection = selection!.copyWith(
@@ -1320,10 +1383,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionToStart(cause);
     }
 
-    final int lastOffset = math.max(0, math.max(
-      selection!.baseOffset,
-      selection!.extentOffset,
-    ));
+    final int lastOffset = math.max(
+        0,
+        math.max(
+          selection!.baseOffset,
+          selection!.extentOffset,
+        ));
     final TextSelection nextSelection = TextSelection(
       baseOffset: lastOffset,
       extentOffset: 0,
@@ -1353,9 +1418,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionLeftByLine(cause);
     }
 
-    final int firstOffset = math.min(selection!.baseOffset, selection!.extentOffset);
+    final int firstOffset =
+        math.min(selection!.baseOffset, selection!.extentOffset);
     final int startPoint = previousCharacter(firstOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
 
     late final TextSelection nextSelection;
     if (selection!.extentOffset <= selection!.baseOffset) {
@@ -1391,7 +1458,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   ///   * [extendSelectionRightByWord], which is the same but in the opposite
   ///     direction.
-  void extendSelectionLeftByWord(SelectionChangedCause cause, [bool includeWhitespace = true, bool stopAtReversal = false]) {
+  void extendSelectionLeftByWord(SelectionChangedCause cause,
+      [bool includeWhitespace = true, bool stopAtReversal = false]) {
     assert(selection != null);
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1401,7 +1469,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextSelection nextSelection = _extendGivenSelectionLeftByWord(
@@ -1431,7 +1499,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   ///   * [extendSelectionLeftByWord], which is the same but in the opposite
   ///     direction.
-  void extendSelectionRightByWord(SelectionChangedCause cause, [bool includeWhitespace = true, bool stopAtReversal = false]) {
+  void extendSelectionRightByWord(SelectionChangedCause cause,
+      [bool includeWhitespace = true, bool stopAtReversal = false]) {
     assert(selection != null);
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1441,7 +1510,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextSelection nextSelection = _extendGivenSelectionRightByWord(
@@ -1478,9 +1547,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return moveSelectionRightByLine(cause);
     }
 
-    final int lastOffset = math.max(selection!.baseOffset, selection!.extentOffset);
+    final int lastOffset =
+        math.max(selection!.baseOffset, selection!.extentOffset);
     final int startPoint = nextCharacter(lastOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
 
     late final TextSelection nextSelection;
     if (selection!.extentOffset >= selection!.baseOffset) {
@@ -1508,11 +1579,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // If the selection is collapsed at the end of the field already, then
     // nothing happens.
-    if (selection!.isCollapsed && selection!.extentOffset >= _plainText.length) {
+    if (selection!.isCollapsed &&
+        selection!.extentOffset >= _plainText.length) {
       return;
     }
 
-    final TextPosition positionBelow = _getTextPositionBelow(selection!.extentOffset);
+    final TextPosition positionBelow =
+        _getTextPositionBelow(selection!.extentOffset);
 
     late final TextSelection nextSelection;
     if (positionBelow.offset == selection!.extentOffset) {
@@ -1546,7 +1619,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (nextSelection == selection) {
       return;
     }
-    _cursorResetLocation -= selection!.extentOffset - nextSelection.extentOffset;
+    _cursorResetLocation -=
+        selection!.extentOffset - nextSelection.extentOffset;
     _setSelection(nextSelection, cause);
   }
 
@@ -1562,8 +1636,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     assert(selection != null);
 
     // If the previous character is the edge of a line, don't do anything.
-    final int previousPoint = previousCharacter(selection!.extentOffset, _plainText, true);
-    final TextSelection line = _getLineAtOffset(TextPosition(offset: previousPoint));
+    final int previousPoint =
+        previousCharacter(selection!.extentOffset, _plainText, true);
+    final TextSelection line =
+        _getLineAtOffset(TextPosition(offset: previousPoint));
     if (line.extentOffset == previousPoint) {
       return;
     }
@@ -1572,8 +1648,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // so we go back to the first non-whitespace before asking for the line
     // bounds, since _getLineAtOffset finds the line boundaries without
     // including whitespace (like the newline).
-    final int startPoint = previousCharacter(selection!.extentOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final int startPoint =
+        previousCharacter(selection!.extentOffset, _plainText, false);
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
     final TextSelection nextSelection = TextSelection.collapsed(
       offset: selectedLine.baseOffset,
     );
@@ -1593,7 +1671,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   ///   * [moveSelectionRightByWord], which is the same but in the opposite
   ///     direction.
-  void moveSelectionLeftByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
+  void moveSelectionLeftByWord(SelectionChangedCause cause,
+      [bool includeWhitespace = true]) {
     assert(selection != null);
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1603,7 +1682,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextSelection nextSelection = _moveGivenSelectionLeftByWord(
@@ -1660,8 +1739,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // so we go forward to the first non-whitespace character before asking
     // for the line bounds, since _getLineAtOffset finds the line
     // boundaries without including whitespace (like the newline).
-    final int startPoint = nextCharacter(selection!.extentOffset, _plainText, false);
-    final TextSelection selectedLine = _getLineAtOffset(TextPosition(offset: startPoint));
+    final int startPoint =
+        nextCharacter(selection!.extentOffset, _plainText, false);
+    final TextSelection selectedLine =
+        _getLineAtOffset(TextPosition(offset: startPoint));
     final TextSelection nextSelection = TextSelection.collapsed(
       offset: selectedLine.extentOffset,
     );
@@ -1681,7 +1762,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   ///   * [moveSelectionLeftByWord], which is the same but in the opposite
   ///     direction.
-  void moveSelectionRightByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
+  void moveSelectionRightByWord(SelectionChangedCause cause,
+      [bool includeWhitespace = true]) {
     assert(selection != null);
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1691,7 +1773,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextSelection nextSelection = _moveGivenSelectionRightByWord(
@@ -1716,7 +1798,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void moveSelectionToEnd(SelectionChangedCause cause) {
     assert(selection != null);
 
-    if (selection!.isCollapsed && selection!.extentOffset == _plainText.length) {
+    if (selection!.isCollapsed &&
+        selection!.extentOffset == _plainText.length) {
       return;
     }
     final TextSelection nextSelection = TextSelection.collapsed(
@@ -1758,7 +1841,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    final TextPosition positionAbove = _getTextPositionAbove(selection!.extentOffset);
+    final TextPosition positionAbove =
+        _getTextPositionAbove(selection!.extentOffset);
     late final TextSelection nextSelection;
     if (positionAbove.offset == selection!.extentOffset) {
       nextSelection = selection!.copyWith(baseOffset: 0, extentOffset: 0);
@@ -1777,7 +1861,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Handles shortcut functionality including cut, copy, paste and select all
   // using control/command + (X, C, V, A).
   Future<void> _handleShortcuts(LogicalKeyboardKey key) async {
-    final TextSelection selection = textSelectionDelegate.textEditingValue.selection;
+    final TextSelection selection =
+        textSelectionDelegate.textEditingValue.selection;
     final String text = textSelectionDelegate.textEditingValue.text;
     assert(selection != null);
     assert(_shortcutKeys.contains(key), 'shortcut key $key not recognized.');
@@ -1793,7 +1878,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         Clipboard.setData(ClipboardData(text: selection.textInside(text)));
         value = TextEditingValue(
           text: selection.textBefore(text) + selection.textAfter(text),
-          selection: TextSelection.collapsed(offset: math.min(selection.start, selection.end)),
+          selection: TextSelection.collapsed(
+              offset: math.min(selection.start, selection.end)),
         );
       }
     } else if (key == LogicalKeyboardKey.keyV && !_readOnly) {
@@ -1802,9 +1888,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       final ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
       if (data != null) {
         value = TextEditingValue(
-          text: selection.textBefore(text) + data.text! + selection.textAfter(text),
+          text: selection.textBefore(text) +
+              data.text! +
+              selection.textAfter(text),
           selection: TextSelection.collapsed(
-            offset: math.min(selection.start, selection.end) + data.text!.length,
+            offset:
+                math.min(selection.start, selection.end) + data.text!.length,
           ),
         );
       }
@@ -1825,8 +1914,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
   }
 
-  void _handleDelete({ required bool forward }) {
-    final TextSelection selection = textSelectionDelegate.textEditingValue.selection;
+  void _handleDelete({required bool forward}) {
+    final TextSelection selection =
+        textSelectionDelegate.textEditingValue.selection;
     final String text = textSelectionDelegate.textEditingValue.text;
     assert(_selection != null);
     if (_readOnly || !selection.isValid) {
@@ -1838,7 +1928,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // If not deleting a selection, delete the next/previous character.
     if (selection.isCollapsed) {
       if (!forward && textBefore.isNotEmpty) {
-        final int characterBoundary = previousCharacter(textBefore.length, textBefore);
+        final int characterBoundary =
+            previousCharacter(textBefore.length, textBefore);
         textBefore = textBefore.substring(0, characterBoundary);
         cursorPosition = characterBoundary;
       }
@@ -1847,7 +1938,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         textAfter = textAfter.substring(deleteCount);
       }
     }
-    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
+    final TextSelection newSelection =
+        TextSelection.collapsed(offset: cursorPosition);
     _setTextEditingValue(
       TextEditingValue(
         text: textBefore + textAfter,
@@ -1890,7 +1982,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // Returns the obscured text when [obscureText] is true. See
   // [obscureText] and [obscuringCharacter].
   String get _plainText {
-    _cachedPlainText ??= _textPainter.text!.toPlainText(includeSemanticsLabels: false);
+    _cachedPlainText ??=
+        _textPainter.text!.toPlainText(includeSemanticsLabels: false);
     return _cachedPlainText!;
   }
 
@@ -1898,8 +1991,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextSpan? get text => _textPainter.text as TextSpan?;
   final TextPainter _textPainter;
   set text(TextSpan? value) {
-    if (_textPainter.text == value)
-      return;
+    if (_textPainter.text == value) return;
     _textPainter.text = value;
     _cachedPlainText = null;
     markNeedsTextLayout();
@@ -1912,8 +2004,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextAlign get textAlign => _textPainter.textAlign;
   set textAlign(TextAlign value) {
     assert(value != null);
-    if (_textPainter.textAlign == value)
-      return;
+    if (_textPainter.textAlign == value) return;
     _textPainter.textAlign = value;
     markNeedsTextLayout();
   }
@@ -1937,8 +2028,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextDirection get textDirection => _textPainter.textDirection!;
   set textDirection(TextDirection value) {
     assert(value != null);
-    if (_textPainter.textDirection == value)
-      return;
+    if (_textPainter.textDirection == value) return;
     _textPainter.textDirection = value;
     markNeedsTextLayout();
     markNeedsSemanticsUpdate();
@@ -1956,8 +2046,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// the font.
   Locale? get locale => _textPainter.locale;
   set locale(Locale? value) {
-    if (_textPainter.locale == value)
-      return;
+    if (_textPainter.locale == value) return;
     _textPainter.locale = value;
     markNeedsTextLayout();
   }
@@ -1966,8 +2055,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// determine the strut to use.
   StrutStyle? get strutStyle => _textPainter.strutStyle;
   set strutStyle(StrutStyle? value) {
-    if (_textPainter.strutStyle == value)
-      return;
+    if (_textPainter.strutStyle == value) return;
     _textPainter.strutStyle = value;
     markNeedsTextLayout();
   }
@@ -1992,10 +2080,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ValueNotifier<bool> _showCursor;
   set showCursor(ValueNotifier<bool> value) {
     assert(value != null);
-    if (_showCursor == value)
-      return;
-    if (attached)
-      _showCursor.removeListener(_showHideCursor);
+    if (_showCursor == value) return;
+    if (attached) _showCursor.removeListener(_showHideCursor);
     _showCursor = value;
     if (attached) {
       _showHideCursor();
@@ -2013,8 +2099,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool _listenerAttached = false;
   set hasFocus(bool value) {
     assert(value != null);
-    if (_hasFocus == value)
-      return;
+    if (_hasFocus == value) return;
     _hasFocus = value;
     if (_hasFocus) {
       assert(!_listenerAttached);
@@ -2037,8 +2122,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool _forceLine = false;
   set forceLine(bool value) {
     assert(value != null);
-    if (_forceLine == value)
-      return;
+    if (_forceLine == value) return;
     _forceLine = value;
     markNeedsLayout();
   }
@@ -2048,8 +2132,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool _readOnly = false;
   set readOnly(bool value) {
     assert(value != null);
-    if (_readOnly == value)
-      return;
+    if (_readOnly == value) return;
     _readOnly = value;
     markNeedsSemanticsUpdate();
   }
@@ -2066,11 +2149,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// also controls the height of the actual editing widget.
   int? get maxLines => _maxLines;
   int? _maxLines;
+
   /// The value may be null. If it is not null, then it must be greater than zero.
   set maxLines(int? value) {
     assert(value == null || value > 0);
-    if (maxLines == value)
-      return;
+    if (maxLines == value) return;
     _maxLines = value;
     markNeedsTextLayout();
   }
@@ -2078,11 +2161,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// {@macro flutter.widgets.editableText.minLines}
   int? get minLines => _minLines;
   int? _minLines;
+
   /// The value may be null. If it is not null, then it must be greater than zero.
   set minLines(int? value) {
     assert(value == null || value > 0);
-    if (minLines == value)
-      return;
+    if (minLines == value) return;
     _minLines = value;
     markNeedsTextLayout();
   }
@@ -2092,8 +2175,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool _expands;
   set expands(bool value) {
     assert(value != null);
-    if (expands == value)
-      return;
+    if (expands == value) return;
     _expands = value;
     markNeedsTextLayout();
   }
@@ -2111,8 +2193,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   double get textScaleFactor => _textPainter.textScaleFactor;
   set textScaleFactor(double value) {
     assert(value != null);
-    if (_textPainter.textScaleFactor == value)
-      return;
+    if (_textPainter.textScaleFactor == value) return;
     _textPainter.textScaleFactor = value;
     markNeedsTextLayout();
   }
@@ -2126,8 +2207,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextSelection? get selection => _selection;
   TextSelection? _selection;
   set selection(TextSelection? value) {
-    if (_selection == value)
-      return;
+    if (_selection == value) return;
     _selection = value;
     _selectionPainter.highlightedRange = value;
     markNeedsPaint();
@@ -2143,13 +2223,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ViewportOffset _offset;
   set offset(ViewportOffset value) {
     assert(value != null);
-    if (_offset == value)
-      return;
-    if (attached)
-      _offset.removeListener(markNeedsPaint);
+    if (_offset == value) return;
+    if (attached) _offset.removeListener(markNeedsPaint);
     _offset = value;
-    if (attached)
-      _offset.addListener(markNeedsPaint);
+    if (attached) _offset.addListener(markNeedsPaint);
     markNeedsLayout();
   }
 
@@ -2157,8 +2234,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   double get cursorWidth => _cursorWidth;
   double _cursorWidth = 1.0;
   set cursorWidth(double value) {
-    if (_cursorWidth == value)
-      return;
+    if (_cursorWidth == value) return;
     _cursorWidth = value;
     markNeedsLayout();
   }
@@ -2173,8 +2249,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   double get cursorHeight => _cursorHeight ?? preferredLineHeight;
   double? _cursorHeight;
   set cursorHeight(double? value) {
-    if (_cursorHeight == value)
-      return;
+    if (_cursorHeight == value) return;
     _cursorHeight = value;
     markNeedsLayout();
   }
@@ -2188,8 +2263,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool get paintCursorAboveText => _paintCursorOnTop;
   bool _paintCursorOnTop;
   set paintCursorAboveText(bool value) {
-    if (_paintCursorOnTop == value)
-      return;
+    if (_paintCursorOnTop == value) return;
     _paintCursorOnTop = value;
     // Clear cached built-in painters and reconfigure painters.
     _cachedBuiltInForegroundPainters = null;
@@ -2227,8 +2301,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   LayerLink get startHandleLayerLink => _startHandleLayerLink;
   LayerLink _startHandleLayerLink;
   set startHandleLayerLink(LayerLink value) {
-    if (_startHandleLayerLink == value)
-      return;
+    if (_startHandleLayerLink == value) return;
     _startHandleLayerLink = value;
     markNeedsPaint();
   }
@@ -2240,8 +2313,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   LayerLink get endHandleLayerLink => _endHandleLayerLink;
   LayerLink _endHandleLayerLink;
   set endHandleLayerLink(LayerLink value) {
-    if (_endHandleLayerLink == value)
-      return;
+    if (_endHandleLayerLink == value) return;
     _endHandleLayerLink = value;
     markNeedsPaint();
   }
@@ -2271,8 +2343,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   bool? get enableInteractiveSelection => _enableInteractiveSelection;
   bool? _enableInteractiveSelection;
   set enableInteractiveSelection(bool? value) {
-    if (_enableInteractiveSelection == value)
-      return;
+    if (_enableInteractiveSelection == value) return;
     _enableInteractiveSelection = value;
     markNeedsTextLayout();
     markNeedsSemanticsUpdate();
@@ -2365,7 +2436,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // selections across multiple semantics nodes. Remove this platform check
     // once we can support it.
     // https://github.com/flutter/flutter/issues/77957
-    if (_semanticsInfo!.any((InlineSpanSemanticsInformation info) => info.recognizer != null) &&
+    if (_semanticsInfo!.any(
+            (InlineSpanSemanticsInformation info) => info.recognizer != null) &&
         defaultTargetPlatform != TargetPlatform.macOS) {
       assert(readOnly && !obscureText);
       // For Selectable rich text with recognizer, we need to create a semantics
@@ -2376,9 +2448,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
     config
-      ..value = obscureText
-          ? obscuringCharacter * _plainText.length
-          : _plainText
+      ..value =
+          obscureText ? obscuringCharacter * _plainText.length : _plainText
       ..isObscured = obscureText
       ..isMultiline = _isMultiline
       ..textDirection = textDirection
@@ -2389,20 +2460,21 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (hasFocus && selectionEnabled)
       config.onSetSelection = _handleSetSelection;
 
-    if (hasFocus && !readOnly)
-      config.onSetText = _handleSetText;
+    if (hasFocus && !readOnly) config.onSetText = _handleSetText;
 
     if (selectionEnabled && selection?.isValid == true) {
       config.textSelection = selection;
       if (_textPainter.getOffsetBefore(selection!.extentOffset) != null) {
         config
           ..onMoveCursorBackwardByWord = _handleMoveCursorBackwardByWord
-          ..onMoveCursorBackwardByCharacter = _handleMoveCursorBackwardByCharacter;
+          ..onMoveCursorBackwardByCharacter =
+              _handleMoveCursorBackwardByCharacter;
       }
       if (_textPainter.getOffsetAfter(selection!.extentOffset) != null) {
         config
           ..onMoveCursorForwardByWord = _handleMoveCursorForwardByWord
-          ..onMoveCursorForwardByCharacter = _handleMoveCursorForwardByCharacter;
+          ..onMoveCursorForwardByCharacter =
+              _handleMoveCursorForwardByCharacter;
       }
     }
   }
@@ -2418,7 +2490,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   @override
-  void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config, Iterable<SemanticsNode> children) {
+  void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config,
+      Iterable<SemanticsNode> children) {
     assert(_semanticsInfo != null && _semanticsInfo!.isNotEmpty);
     final List<SemanticsNode> newChildren = <SemanticsNode>[];
     TextDirection currentDirection = textDirection;
@@ -2426,7 +2499,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     double ordinal = 0.0;
     int start = 0;
     final Queue<SemanticsNode> newChildCache = Queue<SemanticsNode>();
-    for (final InlineSpanSemanticsInformation info in combineSemanticsInfo(_semanticsInfo!)) {
+    for (final InlineSpanSemanticsInformation info
+        in combineSemanticsInfo(_semanticsInfo!)) {
       assert(!info.isPlaceholder);
       final TextSelection selection = TextSelection(
         baseOffset: start,
@@ -2435,7 +2509,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       start += info.text.length;
 
       final TextDirection initialDirection = currentDirection;
-      final List<ui.TextBox> rects = _textPainter.getBoxesForSelection(selection);
+      final List<ui.TextBox> rects =
+          _textPainter.getBoxesForSelection(selection);
       if (rects.isEmpty) {
         continue;
       }
@@ -2508,10 +2583,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _handleMoveCursorForwardByCharacter(bool extentSelection) {
     assert(selection != null);
-    final int? extentOffset = _textPainter.getOffsetAfter(selection!.extentOffset);
-    if (extentOffset == null)
-      return;
-    final int baseOffset = !extentSelection ? extentOffset : selection!.baseOffset;
+    final int? extentOffset =
+        _textPainter.getOffsetAfter(selection!.extentOffset);
+    if (extentOffset == null) return;
+    final int baseOffset =
+        !extentSelection ? extentOffset : selection!.baseOffset;
     _setSelection(
       TextSelection(baseOffset: baseOffset, extentOffset: extentOffset),
       SelectionChangedCause.keyboard,
@@ -2520,10 +2596,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _handleMoveCursorBackwardByCharacter(bool extentSelection) {
     assert(selection != null);
-    final int? extentOffset = _textPainter.getOffsetBefore(selection!.extentOffset);
-    if (extentOffset == null)
-      return;
-    final int baseOffset = !extentSelection ? extentOffset : selection!.baseOffset;
+    final int? extentOffset =
+        _textPainter.getOffsetBefore(selection!.extentOffset);
+    if (extentOffset == null) return;
+    final int baseOffset =
+        !extentSelection ? extentOffset : selection!.baseOffset;
     _setSelection(
       TextSelection(baseOffset: baseOffset, extentOffset: extentOffset),
       SelectionChangedCause.keyboard,
@@ -2532,11 +2609,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _handleMoveCursorForwardByWord(bool extentSelection) {
     assert(selection != null);
-    final TextRange currentWord = _textPainter.getWordBoundary(selection!.extent);
+    final TextRange currentWord =
+        _textPainter.getWordBoundary(selection!.extent);
     final TextRange? nextWord = _getNextWord(currentWord.end);
-    if (nextWord == null)
-      return;
-    final int baseOffset = extentSelection ? selection!.baseOffset : nextWord.start;
+    if (nextWord == null) return;
+    final int baseOffset =
+        extentSelection ? selection!.baseOffset : nextWord.start;
     _setSelection(
       TextSelection(
         baseOffset: baseOffset,
@@ -2548,11 +2626,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   void _handleMoveCursorBackwardByWord(bool extentSelection) {
     assert(selection != null);
-    final TextRange currentWord = _textPainter.getWordBoundary(selection!.extent);
+    final TextRange currentWord =
+        _textPainter.getWordBoundary(selection!.extent);
     final TextRange? previousWord = _getPreviousWord(currentWord.start - 1);
-    if (previousWord == null)
-      return;
-    final int baseOffset = extentSelection ?  selection!.baseOffset : previousWord.start;
+    if (previousWord == null) return;
+    final int baseOffset =
+        extentSelection ? selection!.baseOffset : previousWord.start;
     _setSelection(
       TextSelection(
         baseOffset: baseOffset,
@@ -2564,22 +2643,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   TextRange? _getNextWord(int offset) {
     while (true) {
-      final TextRange range = _textPainter.getWordBoundary(TextPosition(offset: offset));
-      if (range == null || !range.isValid || range.isCollapsed)
-        return null;
-      if (!_onlyWhitespace(range))
-        return range;
+      final TextRange range =
+          _textPainter.getWordBoundary(TextPosition(offset: offset));
+      if (range == null || !range.isValid || range.isCollapsed) return null;
+      if (!_onlyWhitespace(range)) return range;
       offset = range.end;
     }
   }
 
   TextRange? _getPreviousWord(int offset) {
     while (offset >= 0) {
-      final TextRange range = _textPainter.getWordBoundary(TextPosition(offset: offset));
-      if (range == null || !range.isValid || range.isCollapsed)
-        return null;
-      if (!_onlyWhitespace(range))
-        return range;
+      final TextRange range =
+          _textPainter.getWordBoundary(TextPosition(offset: offset));
+      if (range == null || !range.isValid || range.isCollapsed) return null;
+      if (!_onlyWhitespace(range)) return range;
       offset = range.start - 1;
     }
     return null;
@@ -2610,12 +2687,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     _tap = TapGestureRecognizer(debugOwner: this)
       ..onTapDown = _handleTapDown
       ..onTap = _handleTap;
-    _longPress = LongPressGestureRecognizer(debugOwner: this)..onLongPress = _handleLongPress;
+    _longPress = LongPressGestureRecognizer(debugOwner: this)
+      ..onLongPress = _handleLongPress;
     _offset.addListener(markNeedsPaint);
     _showHideCursor();
     _showCursor.addListener(_showHideCursor);
-    if (_listenerAttached)
-      RawKeyboard.instance.addListener(_handleKeyEvent);
+    if (_listenerAttached) RawKeyboard.instance.addListener(_handleKeyEvent);
   }
 
   @override
@@ -2626,8 +2703,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     _showCursor.removeListener(_showHideCursor);
     // TODO(justinmc): This listener should be ported to Actions and removed.
     // https://github.com/flutter/flutter/issues/75004
-    if (_listenerAttached)
-      RawKeyboard.instance.removeListener(_handleKeyEvent);
+    if (_listenerAttached) RawKeyboard.instance.removeListener(_handleKeyEvent);
     super.detach();
     _foregroundRenderObject?.detach();
     _backgroundRenderObject?.detach();
@@ -2637,20 +2713,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void redepthChildren() {
     final RenderObject? foregroundChild = _foregroundRenderObject;
     final RenderObject? backgroundChild = _backgroundRenderObject;
-    if (foregroundChild != null)
-      redepthChild(foregroundChild);
-    if (backgroundChild != null)
-      redepthChild(backgroundChild);
+    if (foregroundChild != null) redepthChild(foregroundChild);
+    if (backgroundChild != null) redepthChild(backgroundChild);
   }
 
   @override
   void visitChildren(RenderObjectVisitor visitor) {
     final RenderObject? foregroundChild = _foregroundRenderObject;
     final RenderObject? backgroundChild = _backgroundRenderObject;
-    if (foregroundChild != null)
-      visitor(foregroundChild);
-    if (backgroundChild != null)
-      visitor(backgroundChild);
+    if (foregroundChild != null) visitor(foregroundChild);
+    if (backgroundChild != null) visitor(backgroundChild);
   }
 
   bool get _isMultiline => maxLines != 1;
@@ -2688,7 +2760,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   // We need to check the paint offset here because during animation, the start of
   // the text may position outside the visible region even when the text fits.
-  bool get _hasVisualOverflow => _maxScrollExtent > 0 || _paintOffset != Offset.zero;
+  bool get _hasVisualOverflow =>
+      _maxScrollExtent > 0 || _paintOffset != Offset.zero;
 
   /// Returns the local coordinates of the endpoints of the given selection.
   ///
@@ -2708,16 +2781,21 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     final Offset paintOffset = _paintOffset;
 
-    final List<ui.TextBox> boxes = selection.isCollapsed ?
-        <ui.TextBox>[] : _textPainter.getBoxesForSelection(selection);
+    final List<ui.TextBox> boxes = selection.isCollapsed
+        ? <ui.TextBox>[]
+        : _textPainter.getBoxesForSelection(selection);
     if (boxes.isEmpty) {
       // TODO(mpcomplete): This doesn't work well at an RTL/LTR boundary.
-      final Offset caretOffset = _textPainter.getOffsetForCaret(selection.extent, _caretPrototype);
-      final Offset start = Offset(0.0, preferredLineHeight) + caretOffset + paintOffset;
+      final Offset caretOffset =
+          _textPainter.getOffsetForCaret(selection.extent, _caretPrototype);
+      final Offset start =
+          Offset(0.0, preferredLineHeight) + caretOffset + paintOffset;
       return <TextSelectionPoint>[TextSelectionPoint(start, null)];
     } else {
-      final Offset start = Offset(boxes.first.start, boxes.first.bottom) + paintOffset;
-      final Offset end = Offset(boxes.last.end, boxes.last.bottom) + paintOffset;
+      final Offset start =
+          Offset(boxes.first.start, boxes.first.bottom) + paintOffset;
+      final Offset end =
+          Offset(boxes.last.end, boxes.last.bottom) + paintOffset;
       return <TextSelectionPoint>[
         TextSelectionPoint(start, boxes.first.direction),
         TextSelectionPoint(end, boxes.last.direction),
@@ -2735,18 +2813,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// given `range` is collapsed.
   Rect? getRectForComposingRange(TextRange range) {
     assert(constraints != null);
-    if (!range.isValid || range.isCollapsed)
-      return null;
+    if (!range.isValid || range.isCollapsed) return null;
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
 
     final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(
       TextSelection(baseOffset: range.start, extentOffset: range.end),
     );
 
-    return boxes.fold(
-      null,
-      (Rect? accum, TextBox incoming) => accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
-    )?.shift(_paintOffset);
+    return boxes
+        .fold(
+          null,
+          (Rect? accum, TextBox incoming) =>
+              accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
+        )
+        ?.shift(_paintOffset);
   }
 
   /// Returns the position in the text for the given global coordinate.
@@ -2776,9 +2856,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///    [TextPainter] object.
   Rect getLocalRectForCaret(TextPosition caretPosition) {
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    final Offset caretOffset = _textPainter.getOffsetForCaret(caretPosition, _caretPrototype);
+    final Offset caretOffset =
+        _textPainter.getOffsetForCaret(caretPosition, _caretPrototype);
     // This rect is the same as _caretPrototype but without the vertical padding.
-    final Rect rect = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight).shift(caretOffset + _paintOffset + cursorOffset);
+    final Rect rect = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight)
+        .shift(caretOffset + _paintOffset + cursorOffset);
     // Add additional cursor offset (generally only if on iOS).
     return rect.shift(_snapToPhysicalPixel(rect.topLeft));
   }
@@ -2856,9 +2938,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   @override
   @protected
-  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
-    final TextPosition textPosition = _textPainter.getPositionForOffset(position);
-    final InlineSpan? span = _textPainter.text!.getSpanForPosition(textPosition);
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    final TextPosition textPosition =
+        _textPainter.getPositionForOffset(position);
+    final InlineSpan? span =
+        _textPainter.text!.getSpanForPosition(textPosition);
     if (span != null && span is HitTestTarget) {
       result.add(HitTestEntry(span as HitTestTarget));
       return true;
@@ -2908,6 +2992,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void handleTapDown(TapDownDetails details) {
     _lastTapDownPosition = details.globalPosition;
   }
+
   void _handleTapDown(TapDownDetails details) {
     assert(!ignorePointer);
     handleTapDown(details);
@@ -2922,6 +3007,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void handleTap() {
     selectPosition(cause: SelectionChangedCause.tap);
   }
+
   void _handleTap() {
     assert(!ignorePointer);
     handleTap();
@@ -2946,6 +3032,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void handleLongPress() {
     selectWord(cause: SelectionChangedCause.longPress);
   }
+
   void _handleLongPress() {
     assert(!ignorePointer);
     handleLongPress();
@@ -2961,7 +3048,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If you have a [TextEditingController], it's generally easier to
   /// programmatically manipulate its `value` or `selection` directly.
   /// {@endtemplate}
-  void selectPosition({ required SelectionChangedCause cause }) {
+  void selectPosition({required SelectionChangedCause cause}) {
     selectPositionAt(from: _lastTapDownPosition!, cause: cause);
   }
 
@@ -2969,14 +3056,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// [from] corresponds to the [TextSelection.baseOffset], and [to] corresponds
   /// to the [TextSelection.extentOffset].
-  void selectPositionAt({ required Offset from, Offset? to, required SelectionChangedCause cause }) {
+  void selectPositionAt(
+      {required Offset from,
+      Offset? to,
+      required SelectionChangedCause cause}) {
     assert(cause != null);
     assert(from != null);
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    final TextPosition fromPosition = _textPainter.getPositionForOffset(globalToLocal(from - _paintOffset));
+    final TextPosition fromPosition =
+        _textPainter.getPositionForOffset(globalToLocal(from - _paintOffset));
     final TextPosition? toPosition = to == null
-      ? null
-      : _textPainter.getPositionForOffset(globalToLocal(to - _paintOffset));
+        ? null
+        : _textPainter.getPositionForOffset(globalToLocal(to - _paintOffset));
 
     final int baseOffset = fromPosition.offset;
     final int extentOffset = toPosition?.offset ?? fromPosition.offset;
@@ -2992,7 +3083,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Select a word around the location of the last tap down.
   ///
   /// {@macro flutter.rendering.RenderEditable.selectPosition}
-  void selectWord({ required SelectionChangedCause cause }) {
+  void selectWord({required SelectionChangedCause cause}) {
     selectWordsInRange(from: _lastTapDownPosition!, cause: cause);
   }
 
@@ -3002,14 +3093,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// beginning and end of a word respectively.
   ///
   /// {@macro flutter.rendering.RenderEditable.selectPosition}
-  void selectWordsInRange({ required Offset from, Offset? to, required SelectionChangedCause cause }) {
+  void selectWordsInRange(
+      {required Offset from,
+      Offset? to,
+      required SelectionChangedCause cause}) {
     assert(cause != null);
     assert(from != null);
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    final TextPosition firstPosition = _textPainter.getPositionForOffset(globalToLocal(from - _paintOffset));
+    final TextPosition firstPosition =
+        _textPainter.getPositionForOffset(globalToLocal(from - _paintOffset));
     final TextSelection firstWord = _getWordAtOffset(firstPosition);
-    final TextSelection lastWord = to == null ?
-      firstWord : _getWordAtOffset(_textPainter.getPositionForOffset(globalToLocal(to - _paintOffset)));
+    final TextSelection lastWord = to == null
+        ? firstWord
+        : _getWordAtOffset(_textPainter
+            .getPositionForOffset(globalToLocal(to - _paintOffset)));
 
     _setSelection(
       TextSelection(
@@ -3024,17 +3121,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// Move the selection to the beginning or end of a word.
   ///
   /// {@macro flutter.rendering.RenderEditable.selectPosition}
-  void selectWordEdge({ required SelectionChangedCause cause }) {
+  void selectWordEdge({required SelectionChangedCause cause}) {
     assert(cause != null);
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
     assert(_lastTapDownPosition != null);
-    final TextPosition position = _textPainter.getPositionForOffset(globalToLocal(_lastTapDownPosition! - _paintOffset));
+    final TextPosition position = _textPainter.getPositionForOffset(
+        globalToLocal(_lastTapDownPosition! - _paintOffset));
     final TextRange word = _textPainter.getWordBoundary(position);
     late TextSelection newSelection;
     if (position.offset - word.start <= 1) {
-      newSelection = TextSelection.collapsed(offset: word.start, affinity: TextAffinity.downstream);
+      newSelection = TextSelection.collapsed(
+          offset: word.start, affinity: TextAffinity.downstream);
     } else {
-      newSelection = TextSelection.collapsed(offset: word.end, affinity: TextAffinity.upstream);
+      newSelection = TextSelection.collapsed(
+          offset: word.end, affinity: TextAffinity.upstream);
     }
     _setSelection(newSelection, cause);
   }
@@ -3042,7 +3142,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextSelection _getWordAtOffset(TextPosition position) {
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextRange word = _textPainter.getWordBoundary(position);
@@ -3052,15 +3152,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // If text is obscured, the entire sentence should be treated as one word.
     if (obscureText) {
       return TextSelection(baseOffset: 0, extentOffset: _plainText.length);
-    // On iOS, select the previous word if there is a previous word, or select
-    // to the end of the next word if there is a next word. Select nothing if
-    // there is neither a previous word nor a next word.
-    //
-    // If the platform is Android and the text is read only, try to select the
-    // previous word if there is one; otherwise, select the single whitespace at
-    // the position.
-    } else if (_isWhitespace(_plainText.codeUnitAt(position.offset))
-        && position.offset > 0) {
+      // On iOS, select the previous word if there is a previous word, or select
+      // to the end of the next word if there is a next word. Select nothing if
+      // there is neither a previous word nor a next word.
+      //
+      // If the platform is Android and the text is read only, try to select the
+      // previous word if there is one; otherwise, select the single whitespace at
+      // the position.
+    } else if (_isWhitespace(_plainText.codeUnitAt(position.offset)) &&
+        position.offset > 0) {
       assert(defaultTargetPlatform != null);
       final TextRange? previousWord = _getPreviousWord(word.start);
       switch (defaultTargetPlatform) {
@@ -3107,7 +3207,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   TextSelection _getLineAtOffset(TextPosition position) {
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final TextRange line = _textPainter.getLineBoundary(position);
@@ -3120,17 +3220,19 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return TextSelection(baseOffset: line.start, extentOffset: line.end);
   }
 
-  void _layoutText({ double minWidth = 0.0, double maxWidth = double.infinity }) {
+  void _layoutText({double minWidth = 0.0, double maxWidth = double.infinity}) {
     assert(maxWidth != null && minWidth != null);
-    if (_textLayoutLastMaxWidth == maxWidth && _textLayoutLastMinWidth == minWidth)
-      return;
+    if (_textLayoutLastMaxWidth == maxWidth &&
+        _textLayoutLastMinWidth == minWidth) return;
     final double availableMaxWidth = math.max(0.0, maxWidth - _caretMargin);
     final double availableMinWidth = math.min(minWidth, availableMaxWidth);
-    final double textMaxWidth = _isMultiline ? availableMaxWidth : double.infinity;
-    final double textMinWidth = forceLine ? availableMaxWidth : availableMinWidth;
+    final double textMaxWidth =
+        _isMultiline ? availableMaxWidth : double.infinity;
+    final double textMinWidth =
+        forceLine ? availableMaxWidth : availableMinWidth;
     _textPainter.layout(
-        minWidth: textMinWidth,
-        maxWidth: textMaxWidth,
+      minWidth: textMinWidth,
+      maxWidth: textMaxWidth,
     );
     _textLayoutLastMinWidth = minWidth;
     _textLayoutLastMaxWidth = maxWidth;
@@ -3154,13 +3256,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        _caretPrototype = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight + 2);
+        _caretPrototype =
+            Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight + 2);
         break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth, cursorHeight - 2.0 * _kCaretHeightOffset);
+        _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth,
+            cursorHeight - 2.0 * _kCaretHeightOffset);
         break;
     }
   }
@@ -3172,20 +3276,24 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final double pixelMultiple = 1.0 / _devicePixelRatio;
     return Offset(
       globalOffset.dx.isFinite
-        ? (globalOffset.dx / pixelMultiple).round() * pixelMultiple - globalOffset.dx
-        : 0,
+          ? (globalOffset.dx / pixelMultiple).round() * pixelMultiple -
+              globalOffset.dx
+          : 0,
       globalOffset.dy.isFinite
-        ? (globalOffset.dy / pixelMultiple).round() * pixelMultiple - globalOffset.dy
-        : 0,
-      );
+          ? (globalOffset.dy / pixelMultiple).round() * pixelMultiple -
+              globalOffset.dy
+          : 0,
+    );
   }
 
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     _layoutText(minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
-    final double width = forceLine ? constraints.maxWidth : constraints
-        .constrainWidth(_textPainter.size.width + _caretMargin);
-    return Size(width, constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
+    final double width = forceLine
+        ? constraints.maxWidth
+        : constraints.constrainWidth(_textPainter.size.width + _caretMargin);
+    return Size(width,
+        constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
   }
 
   @override
@@ -3202,10 +3310,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // though we currently don't use those here.
     // See also RenderParagraph which has a similar issue.
     final Size textPainterSize = _textPainter.size;
-    final double width = forceLine ? constraints.maxWidth : constraints
-        .constrainWidth(_textPainter.size.width + _caretMargin);
-    size = Size(width, constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
-    final Size contentSize = Size(textPainterSize.width + _caretMargin, textPainterSize.height);
+    final double width = forceLine
+        ? constraints.maxWidth
+        : constraints.constrainWidth(_textPainter.size.width + _caretMargin);
+    size = Size(width,
+        constraints.constrainHeight(_preferredHeight(constraints.maxWidth)));
+    final Size contentSize =
+        Size(textPainterSize.width + _caretMargin, textPainterSize.height);
 
     final BoxConstraints painterConstraints = BoxConstraints.tight(contentSize);
 
@@ -3232,9 +3343,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   Offset calculateBoundedFloatingCursorOffset(Offset rawCursorOffset) {
     Offset deltaPosition = Offset.zero;
     final double topBound = -floatingCursorAddedMargin.top;
-    final double bottomBound = _textPainter.height - preferredLineHeight + floatingCursorAddedMargin.bottom;
+    final double bottomBound = _textPainter.height -
+        preferredLineHeight +
+        floatingCursorAddedMargin.bottom;
     final double leftBound = -floatingCursorAddedMargin.left;
-    final double rightBound = _textPainter.width + floatingCursorAddedMargin.right;
+    final double rightBound =
+        _textPainter.width + floatingCursorAddedMargin.right;
 
     if (_previousOffset != null)
       deltaPosition = rawCursorOffset - _previousOffset!;
@@ -3242,24 +3356,30 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     // If the raw cursor offset has gone off an edge, we want to reset the relative
     // origin of the dragging when the user drags back into the field.
     if (_resetOriginOnLeft && deltaPosition.dx > 0) {
-      _relativeOrigin = Offset(rawCursorOffset.dx - leftBound, _relativeOrigin.dy);
+      _relativeOrigin =
+          Offset(rawCursorOffset.dx - leftBound, _relativeOrigin.dy);
       _resetOriginOnLeft = false;
     } else if (_resetOriginOnRight && deltaPosition.dx < 0) {
-      _relativeOrigin = Offset(rawCursorOffset.dx - rightBound, _relativeOrigin.dy);
+      _relativeOrigin =
+          Offset(rawCursorOffset.dx - rightBound, _relativeOrigin.dy);
       _resetOriginOnRight = false;
     }
     if (_resetOriginOnTop && deltaPosition.dy > 0) {
-      _relativeOrigin = Offset(_relativeOrigin.dx, rawCursorOffset.dy - topBound);
+      _relativeOrigin =
+          Offset(_relativeOrigin.dx, rawCursorOffset.dy - topBound);
       _resetOriginOnTop = false;
     } else if (_resetOriginOnBottom && deltaPosition.dy < 0) {
-      _relativeOrigin = Offset(_relativeOrigin.dx, rawCursorOffset.dy - bottomBound);
+      _relativeOrigin =
+          Offset(_relativeOrigin.dx, rawCursorOffset.dy - bottomBound);
       _resetOriginOnBottom = false;
     }
 
     final double currentX = rawCursorOffset.dx - _relativeOrigin.dx;
     final double currentY = rawCursorOffset.dy - _relativeOrigin.dy;
-    final double adjustedX = math.min(math.max(currentX, leftBound), rightBound);
-    final double adjustedY = math.min(math.max(currentY, topBound), bottomBound);
+    final double adjustedX =
+        math.min(math.max(currentX, leftBound), rightBound);
+    final double adjustedY =
+        math.min(math.max(currentY, topBound), bottomBound);
     final Offset adjustedOffset = Offset(adjustedX, adjustedY);
 
     if (currentX < leftBound && deltaPosition.dx < 0)
@@ -3278,7 +3398,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Sets the screen position of the floating cursor and the text position
   /// closest to the cursor.
-  void setFloatingCursor(FloatingCursorDragState state, Offset boundedOffset, TextPosition lastTextPosition, { double? resetLerpValue }) {
+  void setFloatingCursor(FloatingCursorDragState state, Offset boundedOffset,
+      TextPosition lastTextPosition,
+      {double? resetLerpValue}) {
     assert(state != null);
     assert(boundedOffset != null);
     assert(lastTextPosition != null);
@@ -3296,9 +3418,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       _floatingCursorTextPosition = lastTextPosition;
       final double? animationValue = _resetFloatingCursorAnimationValue;
       final EdgeInsets sizeAdjustment = animationValue != null
-        ? EdgeInsets.lerp(_kFloatingCaretSizeIncrease, EdgeInsets.zero, animationValue)!
-        : _kFloatingCaretSizeIncrease;
-      _caretPainter.floatingCursorRect = sizeAdjustment.inflateRect(_caretPrototype).shift(boundedOffset);
+          ? EdgeInsets.lerp(
+              _kFloatingCaretSizeIncrease, EdgeInsets.zero, animationValue)!
+          : _kFloatingCaretSizeIncrease;
+      _caretPainter.floatingCursorRect =
+          sizeAdjustment.inflateRect(_caretPrototype).shift(boundedOffset);
     } else {
       _caretPainter.floatingCursorRect = null;
     }
@@ -3308,7 +3432,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void _paintContents(PaintingContext context, Offset offset) {
     assert(
       _textLayoutLastMaxWidth == constraints.maxWidth &&
-      _textLayoutLastMinWidth == constraints.minWidth,
+          _textLayoutLastMinWidth == constraints.minWidth,
       'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).',
     );
     final Offset effectiveOffset = offset + _paintOffset;
@@ -3322,16 +3446,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // The painters paint in the viewport's coordinate space, since the
     // textPainter's coordinate space is not known to high level widgets.
-    if (backgroundChild != null)
-      context.paintChild(backgroundChild, offset);
+    if (backgroundChild != null) context.paintChild(backgroundChild, offset);
 
     _textPainter.paint(context.canvas, effectiveOffset);
 
-    if (foregroundChild != null)
-      context.paintChild(foregroundChild, offset);
+    if (foregroundChild != null) context.paintChild(foregroundChild, offset);
   }
 
-  void _paintHandleLayers(PaintingContext context, List<TextSelectionPoint> endpoints) {
+  void _paintHandleLayers(
+      PaintingContext context, List<TextSelectionPoint> endpoints) {
     Offset startPoint = endpoints[0].point;
     startPoint = Offset(
       startPoint.dx.clamp(0.0, size.width),
@@ -3378,19 +3501,23 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ClipRectLayer? _clipRectLayer;
 
   @override
-  Rect? describeApproximatePaintClip(RenderObject child) => _hasVisualOverflow ? Offset.zero & size : null;
+  Rect? describeApproximatePaintClip(RenderObject child) =>
+      _hasVisualOverflow ? Offset.zero & size : null;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(ColorProperty('cursorColor', cursorColor));
-    properties.add(DiagnosticsProperty<ValueNotifier<bool>>('showCursor', showCursor));
+    properties.add(
+        DiagnosticsProperty<ValueNotifier<bool>>('showCursor', showCursor));
     properties.add(IntProperty('maxLines', maxLines));
     properties.add(IntProperty('minLines', minLines));
-    properties.add(DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
+    properties.add(
+        DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
     properties.add(ColorProperty('selectionColor', selectionColor));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor));
-    properties.add(DiagnosticsProperty<Locale>('locale', locale, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<Locale>('locale', locale, defaultValue: null));
     properties.add(DiagnosticsProperty<TextSelection>('selection', selection));
     properties.add(DiagnosticsProperty<ViewportOffset>('offset', offset));
   }
@@ -3410,8 +3537,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 class _RenderEditableCustomPaint extends RenderBox {
   _RenderEditableCustomPaint({
     RenderEditablePainter? painter,
-  }) : _painter = painter,
-       super();
+  })  : _painter = painter,
+        super();
 
   @override
   RenderEditable? get parent => super.parent as RenderEditable?;
@@ -3425,14 +3552,12 @@ class _RenderEditableCustomPaint extends RenderBox {
   RenderEditablePainter? get painter => _painter;
   RenderEditablePainter? _painter;
   set painter(RenderEditablePainter? newValue) {
-    if (newValue == painter)
-      return;
+    if (newValue == painter) return;
 
     final RenderEditablePainter? oldPainter = painter;
     _painter = newValue;
 
-    if (newValue?.shouldRepaint(oldPainter) ?? true)
-      markNeedsPaint();
+    if (newValue?.shouldRepaint(oldPainter) ?? true) markNeedsPaint();
 
     if (attached) {
       oldPainter?.removeListener(markNeedsPaint);
@@ -3490,7 +3615,6 @@ class _RenderEditableCustomPaint extends RenderBox {
 ///    and sets it as the background painter of the [RenderEditable].
 ///  * [CustomPainter] a similar class which paints within a [RenderCustomPaint].
 abstract class RenderEditablePainter extends ChangeNotifier {
-
   /// Determines whether repaint is needed when a new [RenderEditablePainter]
   /// is provided to a [RenderEditable].
   ///
@@ -3519,18 +3643,17 @@ abstract class RenderEditablePainter extends ChangeNotifier {
 
 class _TextHighlightPainter extends RenderEditablePainter {
   _TextHighlightPainter({
-      TextRange? highlightedRange,
-      Color? highlightColor,
-  }) : _highlightedRange = highlightedRange,
-       _highlightColor = highlightColor;
+    TextRange? highlightedRange,
+    Color? highlightColor,
+  })  : _highlightedRange = highlightedRange,
+        _highlightColor = highlightColor;
 
   final Paint highlightPaint = Paint();
 
   Color? get highlightColor => _highlightColor;
   Color? _highlightColor;
   set highlightColor(Color? newValue) {
-    if (newValue == _highlightColor)
-      return;
+    if (newValue == _highlightColor) return;
     _highlightColor = newValue;
     notifyListeners();
   }
@@ -3538,8 +3661,7 @@ class _TextHighlightPainter extends RenderEditablePainter {
   TextRange? get highlightedRange => _highlightedRange;
   TextRange? _highlightedRange;
   set highlightedRange(TextRange? newValue) {
-    if (newValue == _highlightedRange)
-      return;
+    if (newValue == _highlightedRange) return;
     _highlightedRange = newValue;
     notifyListeners();
   }
@@ -3551,8 +3673,7 @@ class _TextHighlightPainter extends RenderEditablePainter {
   ui.BoxHeightStyle _selectionHeightStyle = ui.BoxHeightStyle.tight;
   set selectionHeightStyle(ui.BoxHeightStyle value) {
     assert(value != null);
-    if (_selectionHeightStyle == value)
-      return;
+    if (_selectionHeightStyle == value) return;
     _selectionHeightStyle = value;
     notifyListeners();
   }
@@ -3564,8 +3685,7 @@ class _TextHighlightPainter extends RenderEditablePainter {
   ui.BoxWidthStyle _selectionWidthStyle = ui.BoxWidthStyle.tight;
   set selectionWidthStyle(ui.BoxWidthStyle value) {
     assert(value != null);
-    if (_selectionWidthStyle == value)
-      return;
+    if (_selectionWidthStyle == value) return;
     _selectionWidthStyle = value;
     notifyListeners();
   }
@@ -3579,27 +3699,28 @@ class _TextHighlightPainter extends RenderEditablePainter {
     }
 
     highlightPaint.color = color;
-    final List<TextBox> boxes = renderEditable._textPainter.getBoxesForSelection(
+    final List<TextBox> boxes =
+        renderEditable._textPainter.getBoxesForSelection(
       TextSelection(baseOffset: range.start, extentOffset: range.end),
       boxHeightStyle: selectionHeightStyle,
       boxWidthStyle: selectionWidthStyle,
     );
 
     for (final TextBox box in boxes)
-      canvas.drawRect(box.toRect().shift(renderEditable._paintOffset), highlightPaint);
+      canvas.drawRect(
+          box.toRect().shift(renderEditable._paintOffset), highlightPaint);
   }
 
   @override
   bool shouldRepaint(RenderEditablePainter? oldDelegate) {
-    if (identical(oldDelegate, this))
-      return false;
+    if (identical(oldDelegate, this)) return false;
     if (oldDelegate == null)
       return highlightColor != null && highlightedRange != null;
-    return oldDelegate is! _TextHighlightPainter
-        || oldDelegate.highlightColor != highlightColor
-        || oldDelegate.highlightedRange != highlightedRange
-        || oldDelegate.selectionHeightStyle != selectionHeightStyle
-        || oldDelegate.selectionWidthStyle != selectionWidthStyle;
+    return oldDelegate is! _TextHighlightPainter ||
+        oldDelegate.highlightColor != highlightColor ||
+        oldDelegate.highlightedRange != highlightedRange ||
+        oldDelegate.selectionHeightStyle != selectionHeightStyle ||
+        oldDelegate.selectionWidthStyle != selectionWidthStyle;
   }
 }
 
@@ -3609,8 +3730,7 @@ class _FloatingCursorPainter extends RenderEditablePainter {
   bool get shouldPaint => _shouldPaint;
   bool _shouldPaint = true;
   set shouldPaint(bool value) {
-    if (shouldPaint == value)
-      return;
+    if (shouldPaint == value) return;
     _shouldPaint = value;
     notifyListeners();
   }
@@ -3625,8 +3745,7 @@ class _FloatingCursorPainter extends RenderEditablePainter {
   Color? get caretColor => _caretColor;
   Color? _caretColor;
   set caretColor(Color? value) {
-    if (caretColor?.value == value?.value)
-      return;
+    if (caretColor?.value == value?.value) return;
 
     _caretColor = value;
     notifyListeners();
@@ -3635,8 +3754,7 @@ class _FloatingCursorPainter extends RenderEditablePainter {
   Radius? get cursorRadius => _cursorRadius;
   Radius? _cursorRadius;
   set cursorRadius(Radius? value) {
-    if (_cursorRadius == value)
-      return;
+    if (_cursorRadius == value) return;
     _cursorRadius = value;
     notifyListeners();
   }
@@ -3644,8 +3762,7 @@ class _FloatingCursorPainter extends RenderEditablePainter {
   Offset get cursorOffset => _cursorOffset;
   Offset _cursorOffset = Offset.zero;
   set cursorOffset(Offset value) {
-    if (_cursorOffset == value)
-      return;
+    if (_cursorOffset == value) return;
     _cursorOffset = value;
     notifyListeners();
   }
@@ -3653,29 +3770,29 @@ class _FloatingCursorPainter extends RenderEditablePainter {
   Color? get backgroundCursorColor => _backgroundCursorColor;
   Color? _backgroundCursorColor;
   set backgroundCursorColor(Color? value) {
-    if (backgroundCursorColor?.value == value?.value)
-      return;
+    if (backgroundCursorColor?.value == value?.value) return;
 
     _backgroundCursorColor = value;
-    if (showRegularCaret)
-      notifyListeners();
+    if (showRegularCaret) notifyListeners();
   }
 
   Rect? get floatingCursorRect => _floatingCursorRect;
   Rect? _floatingCursorRect;
   set floatingCursorRect(Rect? value) {
-    if (_floatingCursorRect == value)
-      return;
+    if (_floatingCursorRect == value) return;
     _floatingCursorRect = value;
     notifyListeners();
   }
 
-  void paintRegularCursor(Canvas canvas, RenderEditable renderEditable, Color caretColor, TextPosition textPosition) {
+  void paintRegularCursor(Canvas canvas, RenderEditable renderEditable,
+      Color caretColor, TextPosition textPosition) {
     final Rect caretPrototype = renderEditable._caretPrototype;
-    final Offset caretOffset = renderEditable._textPainter.getOffsetForCaret(textPosition, caretPrototype);
+    final Offset caretOffset = renderEditable._textPainter
+        .getOffsetForCaret(textPosition, caretPrototype);
     Rect caretRect = caretPrototype.shift(caretOffset + cursorOffset);
 
-    final double? caretHeight = renderEditable._textPainter.getFullHeightForCaret(textPosition, caretPrototype);
+    final double? caretHeight = renderEditable._textPainter
+        .getFullHeightForCaret(textPosition, caretPrototype);
     if (caretHeight != null) {
       switch (defaultTargetPlatform) {
         case TargetPlatform.iOS:
@@ -3707,7 +3824,8 @@ class _FloatingCursorPainter extends RenderEditablePainter {
     }
 
     caretRect = caretRect.shift(renderEditable._paintOffset);
-    final Rect integralRect = caretRect.shift(renderEditable._snapToPhysicalPixel(caretRect.topLeft));
+    final Rect integralRect =
+        caretRect.shift(renderEditable._snapToPhysicalPixel(caretRect.topLeft));
 
     if (shouldPaint) {
       final Radius? radius = cursorRadius;
@@ -3731,17 +3849,18 @@ class _FloatingCursorPainter extends RenderEditablePainter {
 
     // TODO(LongCatIsLooong): skip painting the caret when the selection is
     // (-1, -1).
-    if (selection == null || !selection.isCollapsed)
-      return;
+    if (selection == null || !selection.isCollapsed) return;
 
     final Rect? floatingCursorRect = this.floatingCursorRect;
 
     final Color? caretColor = floatingCursorRect == null
-      ? this.caretColor
-      : showRegularCaret ? backgroundCursorColor : null;
+        ? this.caretColor
+        : showRegularCaret
+            ? backgroundCursorColor
+            : null;
     final TextPosition caretTextPosition = floatingCursorRect == null
-      ? selection.extent
-      : renderEditable._floatingCursorTextPosition;
+        ? selection.extent
+        : renderEditable._floatingCursorTextPosition;
 
     if (caretColor != null) {
       paintRegularCursor(canvas, renderEditable, caretColor, caretTextPosition);
@@ -3749,35 +3868,36 @@ class _FloatingCursorPainter extends RenderEditablePainter {
 
     final Color? floatingCursorColor = this.caretColor?.withOpacity(0.75);
     // Floating Cursor.
-    if (floatingCursorRect == null || floatingCursorColor == null || !shouldPaint)
-      return;
+    if (floatingCursorRect == null ||
+        floatingCursorColor == null ||
+        !shouldPaint) return;
 
     canvas.drawRRect(
-      RRect.fromRectAndRadius(floatingCursorRect.shift(renderEditable._paintOffset), _kFloatingCaretRadius),
+      RRect.fromRectAndRadius(
+          floatingCursorRect.shift(renderEditable._paintOffset),
+          _kFloatingCaretRadius),
       floatingCursorPaint..color = floatingCursorColor,
     );
   }
 
   @override
   bool shouldRepaint(RenderEditablePainter? oldDelegate) {
-    if (identical(this, oldDelegate))
-      return false;
+    if (identical(this, oldDelegate)) return false;
 
-    if (oldDelegate == null)
-      return shouldPaint;
-    return oldDelegate is! _FloatingCursorPainter
-        || oldDelegate.shouldPaint != shouldPaint
-        || oldDelegate.showRegularCaret != showRegularCaret
-        || oldDelegate.caretColor != caretColor
-        || oldDelegate.cursorRadius != cursorRadius
-        || oldDelegate.cursorOffset != cursorOffset
-        || oldDelegate.backgroundCursorColor != backgroundCursorColor
-        || oldDelegate.floatingCursorRect != floatingCursorRect;
+    if (oldDelegate == null) return shouldPaint;
+    return oldDelegate is! _FloatingCursorPainter ||
+        oldDelegate.shouldPaint != shouldPaint ||
+        oldDelegate.showRegularCaret != showRegularCaret ||
+        oldDelegate.caretColor != caretColor ||
+        oldDelegate.cursorRadius != cursorRadius ||
+        oldDelegate.cursorOffset != cursorOffset ||
+        oldDelegate.backgroundCursorColor != backgroundCursorColor ||
+        oldDelegate.floatingCursorRect != floatingCursorRect;
   }
 }
 
 class _CompositeRenderEditablePainter extends RenderEditablePainter {
-  _CompositeRenderEditablePainter({ required this.painters });
+  _CompositeRenderEditablePainter({required this.painters});
 
   final List<RenderEditablePainter> painters;
 
@@ -3801,16 +3921,15 @@ class _CompositeRenderEditablePainter extends RenderEditablePainter {
 
   @override
   bool shouldRepaint(RenderEditablePainter? oldDelegate) {
-    if (identical(oldDelegate, this))
-      return false;
-    if (oldDelegate is! _CompositeRenderEditablePainter || oldDelegate.painters.length != painters.length)
-      return true;
+    if (identical(oldDelegate, this)) return false;
+    if (oldDelegate is! _CompositeRenderEditablePainter ||
+        oldDelegate.painters.length != painters.length) return true;
 
-    final Iterator<RenderEditablePainter> oldPainters = oldDelegate.painters.iterator;
+    final Iterator<RenderEditablePainter> oldPainters =
+        oldDelegate.painters.iterator;
     final Iterator<RenderEditablePainter> newPainters = painters.iterator;
     while (oldPainters.moveNext() && newPainters.moveNext())
-      if (newPainters.current.shouldRepaint(oldPainters.current))
-        return true;
+      if (newPainters.current.shouldRepaint(oldPainters.current)) return true;
 
     return false;
   }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1475,6 +1475,56 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
+
+        test('handles *-lock modifier keys', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection(baseOffset: 2, extentOffset: 2),
+        );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 2, extentOffset: 2),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      // Test with NumLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tet');
+      expect(delegate.textEditingValue.selection.baseOffset, 2);
+
+      // Test with CapsLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.capsLock, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.capsLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'te');
+      expect(delegate.textEditingValue.selection.baseOffset, 2);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
   });
 
   group('backspace', () {
@@ -1702,6 +1752,56 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
+    
+    test('handles *-lock modifier keys', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection(baseOffset: 2, extentOffset: 2),
+        );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 2, extentOffset: 2),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      // Test with NumLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tst');
+      expect(delegate.textEditingValue.selection.baseOffset, 1);
+
+      // Test with CapsLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.capsLock, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.capsLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'st');
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
   });
 
   test('getEndpointsForSelection handles empty characters', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1752,7 +1752,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
-    
+
     test('handles *-lock modifier keys', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -19,18 +19,20 @@ class FakeEditableTextState with TextSelectionDelegate {
   TextEditingValue textEditingValue = TextEditingValue.empty;
 
   @override
-  void hideToolbar([bool hideHandles = true]) { }
+  void hideToolbar([bool hideHandles = true]) {}
 
   @override
-  void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) { }
+  void userUpdateTextEditingValue(
+      TextEditingValue value, SelectionChangedCause cause) {}
 
   @override
-  void bringIntoView(TextPosition position) { }
+  void bringIntoView(TextPosition position) {}
 }
 
 void main() {
   test('RenderEditable respects clipBehavior', () {
-    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
+    const BoxConstraints viewport =
+        BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
     final TestClipPaintingContext context = TestClipPaintingContext();
 
     final String longString = 'a' * 10000;
@@ -45,11 +47,15 @@ void main() {
       textSelectionDelegate: FakeEditableTextState(),
       selection: const TextSelection(baseOffset: 0, extentOffset: 0),
     );
-    layout(defaultEditable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    layout(defaultEditable,
+        constraints: viewport,
+        phase: EnginePhase.composite,
+        onErrors: expectOverflowedErrors);
     defaultEditable.paint(context, Offset.zero);
     expect(context.clipBehavior, equals(Clip.hardEdge));
 
-    context.clipBehavior = Clip.none; // Reset as Clip.none won't write into clipBehavior.
+    context.clipBehavior =
+        Clip.none; // Reset as Clip.none won't write into clipBehavior.
     for (final Clip clip in Clip.values) {
       final RenderEditable editable = RenderEditable(
         text: TextSpan(text: longString),
@@ -61,7 +67,10 @@ void main() {
         selection: const TextSelection(baseOffset: 0, extentOffset: 0),
         clipBehavior: clip,
       );
-      layout(editable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+      layout(editable,
+          constraints: viewport,
+          phase: EnginePhase.composite,
+          onErrors: expectOverflowedErrors);
       editable.paint(context, Offset.zero);
       expect(context.clipBehavior, equals(clip));
     }
@@ -91,28 +100,27 @@ void main() {
     expect(
       editable.toStringDeep(minLevel: DiagnosticLevel.info),
       equalsIgnoringHashCodes(
-        'RenderEditable#00000 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE DETACHED\n'
-        ' │ parentData: MISSING\n'
-        ' │ constraints: MISSING\n'
-        ' │ size: MISSING\n'
-        ' │ cursorColor: null\n'
-        ' │ showCursor: ValueNotifier<bool>#00000(false)\n'
-        ' │ maxLines: 1\n'
-        ' │ minLines: null\n'
-        ' │ selectionColor: null\n'
-        ' │ textScaleFactor: 1.0\n'
-        ' │ locale: ja_JP\n'
-        ' │ selection: null\n'
-        ' │ offset: _FixedViewportOffset#00000(offset: 0.0)\n'
-        ' ╘═╦══ text ═══\n'
-        '   ║ TextSpan:\n'
-        '   ║   inherit: true\n'
-        '   ║   family: Ahem\n'
-        '   ║   size: 10.0\n'
-        '   ║   height: 1.0x\n'
-        '   ║   "12345"\n'
-        '   ╚═══════════\n'
-      ),
+          'RenderEditable#00000 NEEDS-LAYOUT NEEDS-PAINT NEEDS-COMPOSITING-BITS-UPDATE DETACHED\n'
+          ' │ parentData: MISSING\n'
+          ' │ constraints: MISSING\n'
+          ' │ size: MISSING\n'
+          ' │ cursorColor: null\n'
+          ' │ showCursor: ValueNotifier<bool>#00000(false)\n'
+          ' │ maxLines: 1\n'
+          ' │ minLines: null\n'
+          ' │ selectionColor: null\n'
+          ' │ textScaleFactor: 1.0\n'
+          ' │ locale: ja_JP\n'
+          ' │ selection: null\n'
+          ' │ offset: _FixedViewportOffset#00000(offset: 0.0)\n'
+          ' ╘═╦══ text ═══\n'
+          '   ║ TextSpan:\n'
+          '   ║   inherit: true\n'
+          '   ║   family: Ahem\n'
+          '   ║   size: 10.0\n'
+          '   ║   height: 1.0x\n'
+          '   ║   "12345"\n'
+          '   ╚═══════════\n'),
     );
   });
 
@@ -137,11 +145,13 @@ void main() {
         offset: 0,
       ),
     );
-    layout(editable, constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
+    layout(editable,
+        constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
     // Prepare for painting after layout.
     pumpFrame(phase: EnginePhase.compositingBits);
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) =>
+          editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
       paints..clipRect(rect: const Rect.fromLTRB(0.0, 0.0, 500.0, 10.0)),
     );
   });
@@ -160,7 +170,9 @@ void main() {
       text: const TextSpan(
         text: 'test',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -186,10 +198,13 @@ void main() {
     editable.showCursor = showCursor;
     pumpFrame(phase: EnginePhase.compositingBits);
 
-    expect(editable, paints..rect(
-      color: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
-      rect: const Rect.fromLTWH(40, 0, 1, 10),
-    ));
+    expect(
+        editable,
+        paints
+          ..rect(
+            color: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
+            rect: const Rect.fromLTWH(40, 0, 1, 10),
+          ));
 
     // Now change to a rounded caret.
     editable.cursorColor = const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF);
@@ -197,25 +212,31 @@ void main() {
     editable.cursorRadius = const Radius.circular(3);
     pumpFrame(phase: EnginePhase.compositingBits);
 
-    expect(editable, paints..rrect(
-      color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
-      rrect: RRect.fromRectAndRadius(
-        const Rect.fromLTWH(40, 0, 4, 10),
-        const Radius.circular(3),
-      ),
-    ));
+    expect(
+        editable,
+        paints
+          ..rrect(
+            color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
+            rrect: RRect.fromRectAndRadius(
+              const Rect.fromLTWH(40, 0, 4, 10),
+              const Radius.circular(3),
+            ),
+          ));
 
     editable.textScaleFactor = 2;
     pumpFrame(phase: EnginePhase.compositingBits);
 
     // Now the caret height is much bigger due to the bigger font scale.
-    expect(editable, paints..rrect(
-      color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
-      rrect: RRect.fromRectAndRadius(
-        const Rect.fromLTWH(80, 0, 4, 20),
-        const Radius.circular(3),
-      ),
-    ));
+    expect(
+        editable,
+        paints
+          ..rrect(
+            color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
+            rrect: RRect.fromRectAndRadius(
+              const Rect.fromLTWH(80, 0, 4, 20),
+              const Radius.circular(3),
+            ),
+          ));
 
     // Can turn off caret.
     showCursor.value = false;
@@ -262,7 +283,9 @@ void main() {
       text: const TextSpan(
         text: '中文测试文本是否正确',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -284,10 +307,13 @@ void main() {
     editable.showCursor = showCursor;
     pumpFrame(phase: EnginePhase.compositingBits);
 
-    expect(editable, paints..rect(
-      color: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
-      rect: const Rect.fromLTWH(40, 0, 1, 10),
-    ));
+    expect(
+        editable,
+        paints
+          ..rect(
+            color: const Color.fromARGB(0xFF, 0xFF, 0x00, 0x00),
+            rect: const Rect.fromLTWH(40, 0, 1, 10),
+          ));
 
     // Now change to a rounded caret.
     editable.cursorColor = const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF);
@@ -295,25 +321,31 @@ void main() {
     editable.cursorRadius = const Radius.circular(3);
     pumpFrame(phase: EnginePhase.compositingBits);
 
-    expect(editable, paints..rrect(
-      color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
-      rrect: RRect.fromRectAndRadius(
-        const Rect.fromLTWH(40, 0, 4, 10),
-        const Radius.circular(3),
-      ),
-    ));
+    expect(
+        editable,
+        paints
+          ..rrect(
+            color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
+            rrect: RRect.fromRectAndRadius(
+              const Rect.fromLTWH(40, 0, 4, 10),
+              const Radius.circular(3),
+            ),
+          ));
 
     editable.textScaleFactor = 2;
     pumpFrame(phase: EnginePhase.compositingBits);
 
     // Now the caret height is much bigger due to the bigger font scale.
-    expect(editable, paints..rrect(
-      color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
-      rrect: RRect.fromRectAndRadius(
-        const Rect.fromLTWH(80, 0, 4, 20),
-        const Radius.circular(3),
-      ),
-    ));
+    expect(
+        editable,
+        paints
+          ..rrect(
+            color: const Color.fromARGB(0xFF, 0x00, 0x00, 0xFF),
+            rrect: RRect.fromRectAndRadius(
+              const Rect.fromLTWH(80, 0, 4, 20),
+              const Radius.circular(3),
+            ),
+          ));
 
     // Can turn off caret.
     showCursor.value = false;
@@ -334,7 +366,9 @@ void main() {
       text: const TextSpan(
         text: 'test',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -375,7 +409,9 @@ void main() {
       text: const TextSpan(
         text: 'test',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -427,7 +463,8 @@ void main() {
       // This makes the scroll axis vertical.
       maxLines: 2,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
@@ -435,7 +472,9 @@ void main() {
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -450,7 +489,8 @@ void main() {
       paints..paragraph(offset: Offset.zero),
     );
 
-    editable.selectPositionAt(from: const Offset(0, 2), cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: const Offset(0, 2), cause: SelectionChangedCause.tap);
     pumpFrame();
 
     expect(currentSelection.isCollapsed, true);
@@ -467,7 +507,8 @@ void main() {
 
     // Tap the same place. But because the offset is scrolled up, the second line
     // gets tapped instead.
-    editable.selectPositionAt(from: const Offset(0, 2), cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: const Offset(0, 2), cause: SelectionChangedCause.tap);
     pumpFrame();
 
     expect(currentSelection.isCollapsed, true);
@@ -477,14 +518,14 @@ void main() {
     // Move over by one character.
     editable.handleTapDown(TapDownDetails(globalPosition: const Offset(10, 2)));
     pumpFrame();
-    editable.selectPosition(cause:SelectionChangedCause.tap);
+    editable.selectPosition(cause: SelectionChangedCause.tap);
     pumpFrame();
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 6);
 
     editable.handleTapDown(TapDownDetails(globalPosition: const Offset(20, 2)));
     pumpFrame();
-    editable.selectWord(cause:SelectionChangedCause.longPress);
+    editable.selectWord(cause: SelectionChangedCause.longPress);
     pumpFrame();
     expect(currentSelection.isCollapsed, false);
     expect(currentSelection.baseOffset, 5);
@@ -492,14 +533,16 @@ void main() {
 
     // Select one more character down but since it's still part of the same
     // word, the same word is selected.
-    editable.selectWordsInRange(from: const Offset(30, 2), cause:SelectionChangedCause.longPress);
+    editable.selectWordsInRange(
+        from: const Offset(30, 2), cause: SelectionChangedCause.longPress);
     pumpFrame();
     expect(currentSelection.isCollapsed, false);
     expect(currentSelection.baseOffset, 5);
     expect(currentSelection.extentOffset, 9);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61026
 
-  test('selects readonly renderEditable matches native behavior for android', () {
+  test('selects readonly renderEditable matches native behavior for android',
+      () {
     // Regression test for https://github.com/flutter/flutter/issues/79166.
     final TargetPlatform? previousPlatform = debugDefaultTargetPlatformOverride;
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
@@ -516,7 +559,8 @@ void main() {
       readOnly: true,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
@@ -524,7 +568,9 @@ void main() {
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -535,7 +581,8 @@ void main() {
     layout(editable);
 
     // Select the second white space, where the text position = 1.
-    editable.selectWordsInRange(from: const Offset(10, 2), cause:SelectionChangedCause.longPress);
+    editable.selectWordsInRange(
+        from: const Offset(10, 2), cause: SelectionChangedCause.longPress);
     pumpFrame();
     expect(currentSelection.isCollapsed, false);
     expect(currentSelection.baseOffset, 1);
@@ -559,7 +606,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
@@ -567,7 +615,9 @@ void main() {
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -578,7 +628,8 @@ void main() {
     layout(editable);
 
     // Select the second white space, where the text position = 1.
-    editable.selectWordsInRange(from: const Offset(10, 2), cause:SelectionChangedCause.longPress);
+    editable.selectWordsInRange(
+        from: const Offset(10, 2), cause: SelectionChangedCause.longPress);
     pumpFrame();
     expect(currentSelection.isCollapsed, false);
     expect(currentSelection.baseOffset, 1);
@@ -602,7 +653,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
@@ -610,7 +662,9 @@ void main() {
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -621,7 +675,8 @@ void main() {
     layout(editable);
 
     // Select the second white space, where the text position = 1.
-    editable.selectWordsInRange(from: const Offset(10, 2), cause:SelectionChangedCause.longPress);
+    editable.selectWordsInRange(
+        from: const Offset(10, 2), cause: SelectionChangedCause.longPress);
     pumpFrame();
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 1);
@@ -642,13 +697,16 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         currentSelection = selection;
       },
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -657,7 +715,10 @@ void main() {
 
     layout(editable);
 
-    editable.selectPositionAt(from: const Offset(30, 2), to: const Offset(10, 2), cause: SelectionChangedCause.drag);
+    editable.selectPositionAt(
+        from: const Offset(30, 2),
+        to: const Offset(10, 2),
+        cause: SelectionChangedCause.drag);
     pumpFrame();
 
     expect(currentSelection.isCollapsed, isFalse);
@@ -674,7 +735,9 @@ void main() {
     const TextSpan span = TextSpan(
       text: text,
       style: TextStyle(
-        height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+        height: 1.0,
+        fontSize: 10.0,
+        fontFamily: 'Ahem',
       ),
     );
 
@@ -683,7 +746,8 @@ void main() {
       textDirection: TextDirection.ltr,
       offset: ViewportOffset.zero(),
       selection: const TextSelection(baseOffset: 3, extentOffset: 4),
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         selectionChangedCount++;
         updatedSelection = selection;
       },
@@ -695,7 +759,10 @@ void main() {
     layout(editable1);
 
     // Shouldn't cause a selection change.
-    editable1.selectPositionAt(from: const Offset(30, 2), to: const Offset(42, 2), cause: SelectionChangedCause.drag);
+    editable1.selectPositionAt(
+        from: const Offset(30, 2),
+        to: const Offset(42, 2),
+        cause: SelectionChangedCause.drag);
     pumpFrame();
 
     expect(updatedSelection, isNull);
@@ -706,7 +773,8 @@ void main() {
       textDirection: TextDirection.ltr,
       offset: ViewportOffset.zero(),
       selection: const TextSelection(baseOffset: 3, extentOffset: 4),
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         selectionChangedCount++;
         updatedSelection = selection;
       },
@@ -718,7 +786,10 @@ void main() {
     layout(editable2);
 
     // Now this should cause a selection change.
-    editable2.selectPositionAt(from: const Offset(30, 2), to: const Offset(48, 2), cause: SelectionChangedCause.drag);
+    editable2.selectPositionAt(
+        from: const Offset(30, 2),
+        to: const Offset(48, 2),
+        cause: SelectionChangedCause.drag);
     pumpFrame();
 
     expect(updatedSelection!.baseOffset, 3);
@@ -746,11 +817,13 @@ void main() {
       promptRectRange: const TextRange(start: 0, end: 1),
     );
 
-    layout(editable, constraints: BoxConstraints.loose(const Size(1000.0, 1000.0)));
+    layout(editable,
+        constraints: BoxConstraints.loose(const Size(1000.0, 1000.0)));
     pumpFrame(phase: EnginePhase.compositingBits);
 
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) =>
+          editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
       paints..rect(color: promptRectColor),
     );
 
@@ -761,7 +834,8 @@ void main() {
 
     expect(editable.promptRectColor, null);
     expect(
-      (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+      (Canvas canvas) =>
+          editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
       isNot(paints..rect(color: promptRectColor)),
     );
   });
@@ -801,9 +875,12 @@ void main() {
       offset: ViewportOffset.zero(),
       textSelectionDelegate: delegate,
       text: const TextSpan(
-        text: '撒地方加咖啡哈金凤凰卡号方式剪坏算法发挥福建垃\nasfjafjajfjaslfjaskjflasjfksajf撒分开建安路口附近拉设\n计费可使肌肤撒附近埃里克圾房卡设计费"',
+        text:
+            '撒地方加咖啡哈金凤凰卡号方式剪坏算法发挥福建垃\nasfjafjajfjaslfjaskjflasjfksajf撒分开建安路口附近拉设\n计费可使肌肤撒附近埃里克圾房卡设计费"',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Roboto',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Roboto',
         ),
       ),
       startHandleLayerLink: LayerLink(),
@@ -836,9 +913,9 @@ void main() {
     const String text = 'one two three\n\nfour five six';
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(
-          text: text,
-          selection: TextSelection.collapsed(offset: 0),
-        );
+        text: text,
+        selection: TextSelection.collapsed(offset: 0),
+      );
     final ViewportOffset viewportOffset = ViewportOffset.zero();
     late TextSelection currentSelection;
 
@@ -849,7 +926,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
@@ -858,7 +936,9 @@ void main() {
       text: const TextSpan(
         text: text,
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -869,7 +949,8 @@ void main() {
     layout(editable);
     editable.hasFocus = true;
 
-    editable.selectPositionAt(from: Offset.zero, cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: Offset.zero, cause: SelectionChangedCause.tap);
     editable.selection = const TextSelection.collapsed(offset: 0);
     pumpFrame();
 
@@ -917,9 +998,9 @@ void main() {
   test('arrow keys and delete handle simple text correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(
-          text: 'test',
-          selection: TextSelection.collapsed(offset: 0),
-        );
+        text: 'test',
+        selection: TextSelection.collapsed(offset: 0),
+      );
     final ViewportOffset viewportOffset = ViewportOffset.zero();
     late TextSelection currentSelection;
 
@@ -930,7 +1011,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
@@ -939,7 +1021,9 @@ void main() {
       text: const TextSpan(
         text: 'test',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -950,7 +1034,8 @@ void main() {
     layout(editable);
     editable.hasFocus = true;
 
-    editable.selectPositionAt(from: Offset.zero, cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: Offset.zero, cause: SelectionChangedCause.tap);
     editable.selection = const TextSelection.collapsed(offset: 0);
     pumpFrame();
 
@@ -970,9 +1055,9 @@ void main() {
   test('arrow keys and delete handle surrogate pairs correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(
-          text: '0123😆6789',
-          selection: TextSelection.collapsed(offset: 0),
-        );
+        text: '0123😆6789',
+        selection: TextSelection.collapsed(offset: 0),
+      );
     final ViewportOffset viewportOffset = ViewportOffset.zero();
     late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
@@ -982,7 +1067,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
@@ -991,7 +1077,9 @@ void main() {
       text: const TextSpan(
         text: '0123😆6789',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -1021,9 +1109,9 @@ void main() {
   test('arrow keys and delete handle grapheme clusters correctly', () async {
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(
-          text: '0123👨‍👩‍👦2345',
-          selection: TextSelection.collapsed(offset: 0),
-        );
+        text: '0123👨‍👩‍👦2345',
+        selection: TextSelection.collapsed(offset: 0),
+      );
     final ViewportOffset viewportOffset = ViewportOffset.zero();
     late TextSelection currentSelection;
     final RenderEditable editable = RenderEditable(
@@ -1033,7 +1121,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
@@ -1042,7 +1131,9 @@ void main() {
       text: const TextSpan(
         text: '0123👨‍👩‍👦2345',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -1069,7 +1160,8 @@ void main() {
     expect(delegate.textEditingValue.text, '01232345');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-  test('arrow keys and delete handle surrogate pairs correctly case 2', () async {
+  test('arrow keys and delete handle surrogate pairs correctly case 2',
+      () async {
     const String text = '\u{1F44D}';
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(text: text);
@@ -1082,16 +1174,19 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
       text: const TextSpan(
-        text: text,  // Thumbs up
+        text: text, // Thumbs up
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -1102,7 +1197,8 @@ void main() {
     layout(editable);
     editable.hasFocus = true;
 
-    editable.selectPositionAt(from: Offset.zero, cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: Offset.zero, cause: SelectionChangedCause.tap);
     editable.selection = const TextSelection.collapsed(offset: 0);
     pumpFrame();
 
@@ -1119,12 +1215,13 @@ void main() {
     expect(delegate.textEditingValue.text, '');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-  test('arrow keys work after detaching the widget and attaching it again', () async {
+  test('arrow keys work after detaching the widget and attaching it again',
+      () async {
     final TextSelectionDelegate delegate = FakeEditableTextState()
       ..textEditingValue = const TextEditingValue(
-          text: 'W Szczebrzeszynie chrząszcz brzmi w trzcinie',
-          selection: TextSelection.collapsed(offset: 0),
-        );
+        text: 'W Szczebrzeszynie chrząszcz brzmi w trzcinie',
+        selection: TextSelection.collapsed(offset: 0),
+      );
     final ViewportOffset viewportOffset = ViewportOffset.zero();
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
@@ -1133,7 +1230,8 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
       },
       startHandleLayerLink: LayerLink(),
@@ -1141,7 +1239,9 @@ void main() {
       text: const TextSpan(
         text: 'W Szczebrzeszynie chrząszcz brzmi w trzcinie',
         style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          height: 1.0,
+          fontSize: 10.0,
+          fontFamily: 'Ahem',
         ),
       ),
       selection: const TextSelection.collapsed(
@@ -1155,7 +1255,8 @@ void main() {
     editable.detach();
     layout(editable);
     editable.hasFocus = true;
-    editable.selectPositionAt(from: Offset.zero, cause: SelectionChangedCause.tap);
+    editable.selectPositionAt(
+        from: Offset.zero, cause: SelectionChangedCause.tap);
     editable.selection = const TextSelection.collapsed(offset: 0);
     pumpFrame();
 
@@ -1172,7 +1273,8 @@ void main() {
 
     await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
     await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
-    expect(delegate.textEditingValue.text, 'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
+    expect(delegate.textEditingValue.text,
+        'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
   test('arrow keys with selection text', () async {
@@ -1188,14 +1290,15 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
       text: const TextSpan(
-        text: text,  // Thumbs up
+        text: text, // Thumbs up
         style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
       ),
       selection: const TextSelection.collapsed(
@@ -1248,14 +1351,15 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
       text: const TextSpan(
-        text: text,  // Thumbs up
+        text: text, // Thumbs up
         style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
       ),
       selection: const TextSelection.collapsed(
@@ -1312,14 +1416,15 @@ void main() {
       cursorColor: Colors.red,
       offset: viewportOffset,
       textSelectionDelegate: delegate,
-      onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {
+      onSelectionChanged: (TextSelection selection, RenderEditable renderObject,
+          SelectionChangedCause cause) {
         renderObject.selection = selection;
         currentSelection = selection;
       },
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
       text: const TextSpan(
-        text: text,  // Thumbs up
+        text: text, // Thumbs up
         style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
       ),
       selection: const TextSelection.collapsed(
@@ -1365,9 +1470,9 @@ void main() {
     test('handles selection', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3),
-          );
+          text: 'test',
+          selection: TextSelection(baseOffset: 1, extentOffset: 3),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1376,13 +1481,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: 'test',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection(baseOffset: 1, extentOffset: 3),
@@ -1392,7 +1500,8 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete,
+          platform: 'android');
       await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
       expect(delegate.textEditingValue.text, 'tt');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
@@ -1402,9 +1511,9 @@ void main() {
     test('is a no-op at the end of the text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 4),
-          );
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 4),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1413,13 +1522,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: 'test',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 4),
@@ -1429,7 +1541,8 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete,
+          platform: 'android');
       await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
@@ -1452,13 +1565,16 @@ void main() {
         offset: viewportOffset,
         textSelectionDelegate: delegate,
         obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: '****',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 0),
@@ -1468,22 +1584,21 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete,
+          platform: 'android');
       await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
 
       expect(delegate.textEditingValue.text, 'est');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
-  });
 
-  group('backspace', () {
-    test('handles selection', () async {
+    test('handles *-lock modifier keys', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3),
-          );
+          text: 'test',
+          selection: TextSelection(baseOffset: 2, extentOffset: 2),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1492,13 +1607,73 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: 'test',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 2, extentOffset: 2),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      // Test with NumLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.numLock,
+          platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tet');
+      expect(delegate.textEditingValue.selection.baseOffset, 2);
+
+      // Test with CapsLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.capsLock,
+          platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.capsLock,
+          platform: 'android');
+      expect(delegate.textEditingValue.text, 'te');
+      expect(delegate.textEditingValue.selection.baseOffset, 2);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+  });
+
+  group('backspace', () {
+    test('handles selection', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection(baseOffset: 1, extentOffset: 3),
+        );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection(baseOffset: 1, extentOffset: 3),
@@ -1508,8 +1683,10 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
       expect(delegate.textEditingValue.text, 'tt');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 1);
@@ -1518,9 +1695,9 @@ void main() {
     test('handles simple text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 3),
-          );
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 3),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1529,13 +1706,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: 'test',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 3),
@@ -1545,8 +1725,10 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
       expect(delegate.textEditingValue.text, 'tet');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 2);
@@ -1555,9 +1737,9 @@ void main() {
     test('handles surrogate pairs', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: '\u{1F44D}',
-            selection: TextSelection.collapsed(offset: 2),
-          );
+          text: '\u{1F44D}',
+          selection: TextSelection.collapsed(offset: 2),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1566,13 +1748,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
-          text: '\u{1F44D}',  // Thumbs up
+          text: '\u{1F44D}', // Thumbs up
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 2),
@@ -1582,8 +1767,10 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
       expect(delegate.textEditingValue.text, '');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
@@ -1592,9 +1779,9 @@ void main() {
     test('handles grapheme clusters', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: '0123👨‍👩‍👦2345',
-            selection: TextSelection.collapsed(offset: 12),
-          );
+          text: '0123👨‍👩‍👦2345',
+          selection: TextSelection.collapsed(offset: 12),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1603,13 +1790,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: '0123👨‍👩‍👦2345',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 12),
@@ -1619,8 +1809,10 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
       expect(delegate.textEditingValue.text, '01232345');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 4);
@@ -1629,9 +1821,9 @@ void main() {
     test('is a no-op at the start of the text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 0),
-          );
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 0),
+        );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
@@ -1640,13 +1832,16 @@ void main() {
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: 'test',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 0),
@@ -1656,8 +1851,10 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
@@ -1679,13 +1876,16 @@ void main() {
         offset: viewportOffset,
         textSelectionDelegate: delegate,
         obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
           text: '****',
           style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
           ),
         ),
         selection: const TextSelection.collapsed(offset: 4),
@@ -1695,13 +1895,72 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
 
       expect(delegate.textEditingValue.text, 'tes');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
+
+    test('handles *-lock modifier keys', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection(baseOffset: 2, extentOffset: 2),
+        );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection,
+            RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0,
+            fontSize: 10.0,
+            fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 2, extentOffset: 2),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      // Test with NumLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.numLock,
+          platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.numLock, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tst');
+      expect(delegate.textEditingValue.selection.baseOffset, 1);
+
+      // Test with CapsLock set
+      await simulateKeyDownEvent(LogicalKeyboardKey.capsLock,
+          platform: 'android');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace,
+          platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.capsLock,
+          platform: 'android');
+      expect(delegate.textEditingValue.text, 'st');
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
   });
 
   test('getEndpointsForSelection handles empty characters', () {
@@ -1718,8 +1977,9 @@ void main() {
       endHandleLayerLink: LayerLink(),
     );
     editable.layout(BoxConstraints.loose(const Size(100, 100)));
-    final List<TextSelectionPoint> endpoints = editable.getEndpointsForSelection(
-      const TextSelection(baseOffset: 0, extentOffset: 1));
+    final List<TextSelectionPoint> endpoints =
+        editable.getEndpointsForSelection(
+            const TextSelection(baseOffset: 0, extentOffset: 1));
     expect(endpoints[0].point.dx, 0);
   });
 
@@ -1732,8 +1992,10 @@ void main() {
     });
 
     test('throws for invalid indices', () {
-      expect(() => RenderEditable.nextCharacter(-1, '01234567'), throwsAssertionError);
-      expect(() => RenderEditable.nextCharacter(9, '01234567'), throwsAssertionError);
+      expect(() => RenderEditable.nextCharacter(-1, '01234567'),
+          throwsAssertionError);
+      expect(() => RenderEditable.nextCharacter(9, '01234567'),
+          throwsAssertionError);
     });
 
     test('skips spaces in normal strings when includeWhitespace is false', () {
@@ -1788,18 +2050,21 @@ void main() {
       editable.layout(const BoxConstraints.tightFor(width: 200));
 
       // Invalid range.
-      expect(editable.getRectForComposingRange(const TextRange(start: -1, end: 2)), isNull);
+      expect(
+          editable.getRectForComposingRange(const TextRange(start: -1, end: 2)),
+          isNull);
       // Collapsed range.
-      expect(editable.getRectForComposingRange(const TextRange.collapsed(2)), isNull);
+      expect(editable.getRectForComposingRange(const TextRange.collapsed(2)),
+          isNull);
 
       // Empty Editable.
       editable.text = emptyTextSpan;
       editable.layout(const BoxConstraints.tightFor(width: 200));
 
       expect(
-        editable.getRectForComposingRange(const TextRange(start: 0, end: 1)),
-        // On web this evaluates to a zero-width Rect.
-        anyOf(isNull, (Rect rect) => rect.width == 0));
+          editable.getRectForComposingRange(const TextRange(start: 0, end: 1)),
+          // On web this evaluates to a zero-width Rect.
+          anyOf(isNull, (Rect rect) => rect.width == 0));
     });
 
     test('more than 1 run on the same line', () {
@@ -1815,7 +2080,8 @@ void main() {
       // Give it a width that forces the editable to wrap.
       editable.layout(const BoxConstraints.tightFor(width: 200));
 
-      final Rect composingRect = editable.getRectForComposingRange(const TextRange(start: 0, end: 20 + 2))!;
+      final Rect composingRect = editable
+          .getRectForComposingRange(const TextRange(start: 0, end: 20 + 2))!;
 
       // Since the range covers an entire line, the Rect should also be almost
       // as wide as the entire paragraph (give or take 1 character).
@@ -1833,8 +2099,10 @@ void main() {
     });
 
     test('throws for invalid indices', () {
-      expect(() => RenderEditable.previousCharacter(-1, '01234567'), throwsAssertionError);
-      expect(() => RenderEditable.previousCharacter(9, '01234567'), throwsAssertionError);
+      expect(() => RenderEditable.previousCharacter(-1, '01234567'),
+          throwsAssertionError);
+      expect(() => RenderEditable.previousCharacter(9, '01234567'),
+          throwsAssertionError);
     });
 
     test('skips spaces in normal strings when includeWhitespace is false', () {
@@ -1893,7 +2161,9 @@ void main() {
       ),
     );
 
-    setUp(() { EditableText.debugDeterministicCursor = true; });
+    setUp(() {
+      EditableText.debugDeterministicCursor = true;
+    });
     tearDown(() {
       EditableText.debugDeterministicCursor = false;
       _TestRenderEditablePainter.paintHistory.clear();
@@ -1902,8 +2172,7 @@ void main() {
       editable.paintCount = 0;
 
       final AbstractNode? parent = editable.parent;
-      if (parent is RenderConstrainedBox)
-        parent.child = null;
+      if (parent is RenderConstrainedBox) parent.child = null;
     });
 
     test('paints in the correct order', () {
@@ -1915,10 +2184,13 @@ void main() {
       pumpFrame(phase: EnginePhase.compositingBits);
 
       expect(
-        (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+        (Canvas canvas) =>
+            editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
         paints
           ..paragraph()
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678)),
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678)),
       );
 
       // Background painter.
@@ -1926,9 +2198,12 @@ void main() {
       editable.painter = _TestRenderEditablePainter();
 
       expect(
-        (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+        (Canvas canvas) =>
+            editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
         paints
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678))
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678))
           ..paragraph(),
       );
 
@@ -1936,11 +2211,16 @@ void main() {
       editable.painter = _TestRenderEditablePainter();
 
       expect(
-        (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+        (Canvas canvas) =>
+            editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
         paints
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678))
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678))
           ..paragraph()
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678)),
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678)),
       );
     });
 
@@ -1954,11 +2234,13 @@ void main() {
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
 
-      editable.foregroundPainter = (currentPainter = _TestRenderEditablePainter()..repaint = false);
+      editable.foregroundPainter =
+          (currentPainter = _TestRenderEditablePainter()..repaint = false);
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 0);
 
-      editable.foregroundPainter = (currentPainter = _TestRenderEditablePainter()..repaint = true);
+      editable.foregroundPainter =
+          (currentPainter = _TestRenderEditablePainter()..repaint = true);
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
     });
@@ -1973,11 +2255,13 @@ void main() {
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
 
-      editable.painter = (currentPainter = _TestRenderEditablePainter()..repaint = false);
+      editable.painter =
+          (currentPainter = _TestRenderEditablePainter()..repaint = false);
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 0);
 
-      editable.painter = (currentPainter = _TestRenderEditablePainter()..repaint = true);
+      editable.painter =
+          (currentPainter = _TestRenderEditablePainter()..repaint = true);
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
     });
@@ -2013,9 +2297,11 @@ void main() {
       FlutterErrorDetails? errorDetails;
       editable.painter = painter;
       editable.foregroundPainter = painter;
-      pumpFrame(phase: EnginePhase.paint, onErrors: () {
-        errorDetails = renderer.takeFlutterErrorDetails();
-      });
+      pumpFrame(
+          phase: EnginePhase.paint,
+          onErrors: () {
+            errorDetails = renderer.takeFlutterErrorDetails();
+          });
       expect(errorDetails, isNull);
 
       expect(
@@ -2023,14 +2309,21 @@ void main() {
         <_TestRenderEditablePainter>[painter, painter],
       );
       expect(
-        (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+        (Canvas canvas) =>
+            editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
         paints
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678))
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678))
           ..paragraph()
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678)),
+          ..rect(
+              rect: const Rect.fromLTRB(1, 1, 1, 1),
+              color: const Color(0x12345678)),
       );
     });
-    test('does not repaint the render editable when custom painters need repaint', () {
+    test(
+        'does not repaint the render editable when custom painters need repaint',
+        () {
       layout(editable, constraints: BoxConstraints.loose(const Size(100, 100)));
 
       final _TestRenderEditablePainter painter = _TestRenderEditablePainter();
@@ -2071,11 +2364,13 @@ void main() {
 
       pumpFrame(phase: EnginePhase.compositingBits);
       expect(
-        (Canvas canvas) => editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
-        paints
-          ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678))
-          ..paragraph()
-      );
+          (Canvas canvas) =>
+              editable.paint(TestRecordingPaintingContext(canvas), Offset.zero),
+          paints
+            ..rect(
+                rect: const Rect.fromLTRB(1, 1, 1, 1),
+                color: const Color(0x12345678))
+            ..paragraph());
     });
   });
 }
@@ -2090,14 +2385,14 @@ class _TestRenderEditable extends RenderEditable {
     required LayerLink endHandleLayerLink,
     TextSelection? selection,
   }) : super(
-      textDirection: textDirection,
-      offset: offset,
-      textSelectionDelegate: textSelectionDelegate,
-      text: text,
-      startHandleLayerLink: startHandleLayerLink,
-      endHandleLayerLink: endHandleLayerLink,
-      selection: selection,
-    );
+          textDirection: textDirection,
+          offset: offset,
+          textSelectionDelegate: textSelectionDelegate,
+          text: text,
+          startHandleLayerLink: startHandleLayerLink,
+          endHandleLayerLink: endHandleLayerLink,
+          selection: selection,
+        );
 
   int paintCount = 0;
 
@@ -2111,12 +2406,14 @@ class _TestRenderEditable extends RenderEditable {
 class _TestRenderEditablePainter extends RenderEditablePainter {
   bool repaint = true;
   int paintCount = 0;
-  static final List<_TestRenderEditablePainter> paintHistory = <_TestRenderEditablePainter>[];
+  static final List<_TestRenderEditablePainter> paintHistory =
+      <_TestRenderEditablePainter>[];
 
   @override
   void paint(Canvas canvas, Size size, RenderEditable renderEditable) {
     paintCount += 1;
-    canvas.drawRect(const Rect.fromLTRB(1, 1, 1, 1), Paint()..color = const Color(0x12345678));
+    canvas.drawRect(const Rect.fromLTRB(1, 1, 1, 1),
+        Paint()..color = const Color(0x12345678));
     paintHistory.add(this);
   }
 


### PR DESCRIPTION
Fixes the situation where "NumLock" or "CapsLock" being in the "ON" state causes `Editable` to blocks the passing of "Backspace" and "Delete" key event to the `TextInputClient` observer. This is particularly problematic when using Android devices that have Physical Keyboards such as Chromebooks w/ Android Apps or Android Tablets/Phones using external keyboards (Bluetooth or USB-OTG connected). In such cases, if the external keyboard _does not_ have an extended number-pad, the "NumLock" key appears to _always be "ON"_, effectively blocking all "Delete" or "Backspace" keypress events.

Fixes https://github.com/flutter/flutter/issues/78769

This PR adds two new tests to the `flutter/packages/flutter/test/rendering/editable_test.dart` test suite, one under the "delete..." group and one under the "backspace..." group, both of which were failing prior to the modifications in this PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
