### PR TITLE
Update dartdoc to 0.42.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 0.41.0
+    "$PUB" global activate dartdoc 0.42.0
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
Change dartdoc version to 0.42.0.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v0.42.0

TL;DR: Performance is improved with the replacement of mustache with mustachio, and we no longer crash on the Q1 small feature set (though generic functions as type arguments does not yet work correctly).