### PR TITLE
Makes handle selection change to crash gracefully if the render edita…

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2490,7 +2490,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       assert(
         false,
         'current context or render editable should not be null when '
-        'update text editing value'
+        'updating the text editing value'
       );
       return;
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2484,6 +2484,16 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause? cause) {
+    // TODO(chunhtai): Figure out why context or renderEditable can be null
+    // https://github.com/flutter/flutter/issues/79818.
+    if (_editableKey.currentContext == null || _editableKey.currentContext!.findRenderObject() == null) {
+      assert(
+        false,
+        'current context or render editable should not be null when '
+        'update text editing value'
+      );
+      return;
+    }
     // Compare the current TextEditingValue with the pre-format new
     // TextEditingValue value, in case the formatter would reject the change.
     final bool shouldShowCaret = widget.readOnly

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2717,6 +2717,24 @@ void main() {
     semantics.dispose();
   });
 
+  // TODO(chunhtai): remove this test once we resolve
+  //  https://github.com/flutter/flutter/issues/79818
+  testWidgets('editable text state throws if userUpdateTextEditingValue is called without context', (WidgetTester tester) async {
+    final EditableTextState state = EditableTextState();
+    bool hasAssertion = false;
+    try {
+      state.userUpdateTextEditingValue(TextEditingValue.empty, null);
+    } on AssertionError catch(e) {
+      hasAssertion = true;
+      expect(
+        e.message,
+        'current context or render editable should not be null when '
+        'update text editing value'
+      );
+    }
+    expect(hasAssertion, isTrue);
+  });
+
   testWidgets('password fields become obscured with the right semantics when set', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2729,7 +2729,7 @@ void main() {
       expect(
         e.message,
         'current context or render editable should not be null when '
-        'update text editing value'
+        'updating the text editing value'
       );
     }
     expect(hasAssertion, isTrue);


### PR DESCRIPTION
…ble is null

related https://github.com/flutter/flutter/issues/79818

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
