### PR TITLE
BorderRadiusTween.lerp supports null begin/end values

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -11,7 +11,7 @@ const double _kFrontClosedHeight = 92.0; // front layer height when closed
 const double _kBackAppBarHeight = 56.0; // back layer (options) appbar height
 
 // The size of the front layer heading's left and right beveled corners.
-final Animatable<BorderRadius> _kFrontHeadingBevelRadius = BorderRadiusTween(
+final Animatable<BorderRadius?> _kFrontHeadingBevelRadius = BorderRadiusTween(
   begin: const BorderRadius.only(
     topLeft: Radius.circular(12.0),
     topRight: Radius.circular(12.0),
@@ -20,7 +20,7 @@ final Animatable<BorderRadius> _kFrontHeadingBevelRadius = BorderRadiusTween(
     topLeft: Radius.circular(_kFrontHeadingHeight),
     topRight: Radius.circular(_kFrontHeadingHeight),
   ),
-) as Animatable<BorderRadius>;
+);
 
 class _TappableWhileStatusIs extends StatefulWidget {
   const _TappableWhileStatusIs(
@@ -315,7 +315,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
                 color: Theme.of(context).canvasColor,
                 clipper: ShapeBorderClipper(
                   shape: BeveledRectangleBorder(
-                    borderRadius: _kFrontHeadingBevelRadius.transform(_controller!.value),
+                    borderRadius: _kFrontHeadingBevelRadius.transform(_controller!.value)!,
                   ),
                 ),
                 clipBehavior: Clip.antiAlias,

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -20,7 +20,7 @@ final Animatable<BorderRadius> _kFrontHeadingBevelRadius = BorderRadiusTween(
     topLeft: Radius.circular(_kFrontHeadingHeight),
     topRight: Radius.circular(_kFrontHeadingHeight),
   ),
-);
+) as Animatable<BorderRadius>;
 
 class _TappableWhileStatusIs extends StatefulWidget {
   const _TappableWhileStatusIs(

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -125,7 +125,7 @@ class EdgeInsetsGeometryTween extends Tween<EdgeInsetsGeometry> {
 /// [BorderRadius.lerp].
 ///
 /// See [Tween] for a discussion on how to use interpolation objects.
-class BorderRadiusTween extends Tween<BorderRadius> {
+class BorderRadiusTween extends Tween<BorderRadius?> {
   /// Creates a [BorderRadius] tween.
   ///
   /// The [begin] and [end] properties may be null; the null value
@@ -134,7 +134,7 @@ class BorderRadiusTween extends Tween<BorderRadius> {
 
   /// Returns the value this variable has at the given animation clock value.
   @override
-  BorderRadius lerp(double t) => BorderRadius.lerp(begin, end, t)!;
+  BorderRadius? lerp(double t) => BorderRadius.lerp(begin, end, t);
 }
 
 /// An interpolation between two [Border]s.

--- a/packages/flutter/test/animation/tween_test.dart
+++ b/packages/flutter/test/animation/tween_test.dart
@@ -219,4 +219,11 @@ void main() {
     expect(tween.transform(0.5), 0.31640625);
     expect(tween.transform(1.0), 1.0);
   });
+
+  test('BorderRadiusTween nullable test', () {
+    final BorderRadiusTween tween = BorderRadiusTween(begin: null, end: null);
+    expect(tween.transform(0.0), null);
+    expect(tween.transform(1.0), null);
+    expect(tween.lerp(0.0), null);
+  });
 }


### PR DESCRIPTION
Fixes #79558 

The doc says:
```dart
  /// Creates a [BorderRadius] tween.
  ///
  /// The [begin] and [end] properties may be null; the null value
  /// is treated as a right angle (no radius).
  BorderRadiusTween({ BorderRadius? begin, BorderRadius? end }) : super(begin: begin, end: end);

```