### PR TITLE
[web] Fix url strategy null safety

### DIFF
--- a/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
@@ -90,12 +90,12 @@ abstract class JsUrlStrategy {
   /// Push a new history entry.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
-  external void pushState(Object state, String title, String url);
+  external void pushState(Object? state, String title, String url);
 
   /// Replace the currently active history entry.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
-  external void replaceState(Object state, String title, String url);
+  external void replaceState(Object? state, String title, String url);
 
   /// Moves forwards or backwards through the history stack.
   ///

--- a/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
@@ -48,12 +48,12 @@ abstract class UrlStrategy {
   /// Push a new history entry.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
-  void pushState(Object state, String title, String url);
+  void pushState(Object? state, String title, String url);
 
   /// Replace the currently active history entry.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
-  void replaceState(Object state, String title, String url);
+  void replaceState(Object? state, String title, String url);
 
   /// Moves forwards or backwards through the history stack.
   ///
@@ -129,12 +129,12 @@ class HashUrlStrategy extends UrlStrategy {
   }
 
   @override
-  void pushState(Object state, String title, String url) {
+  void pushState(Object? state, String title, String url) {
     _platformLocation.pushState(state, title, prepareExternalUrl(url));
   }
 
   @override
-  void replaceState(Object state, String title, String url) {
+  void replaceState(Object? state, String title, String url) {
     _platformLocation.replaceState(state, title, prepareExternalUrl(url));
   }
 
@@ -245,12 +245,12 @@ abstract class PlatformLocation {
   /// Adds a new entry to the browser history stack.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
-  void pushState(Object state, String title, String url);
+  void pushState(Object? state, String title, String url);
 
   /// Replaces the current entry in the browser history stack.
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
-  void replaceState(Object state, String title, String url);
+  void replaceState(Object? state, String title, String url);
 
   /// Moves forwards or backwards through the history stack.
   ///
@@ -310,12 +310,12 @@ class BrowserPlatformLocation extends PlatformLocation {
   Object? get state => _history.state;
 
   @override
-  void pushState(Object state, String title, String url) {
+  void pushState(Object? state, String title, String url) {
     _history.pushState(state, title, url);
   }
 
   @override
-  void replaceState(Object state, String title, String url) {
+  void replaceState(Object? state, String title, String url) {
     _history.replaceState(state, title, url);
   }
 

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -17,6 +17,12 @@ void main() {
       location = TestPlatformLocation();
     });
 
+    test('allows null state', () {
+      final HashUrlStrategy strategy = HashUrlStrategy(location);
+      expect(() => strategy.pushState(null, '', '/'), returnsNormally);
+      expect(() => strategy.replaceState(null, '', '/'), returnsNormally);
+    });
+
     test('leading slash is optional', () {
       final HashUrlStrategy strategy = HashUrlStrategy(location);
 
@@ -46,6 +52,12 @@ void main() {
 
     setUp(() {
       location = TestPlatformLocation();
+    });
+
+    test('allows null state', () {
+      final PathUrlStrategy strategy = PathUrlStrategy(location);
+      expect(() => strategy.pushState(null, '', '/'), returnsNormally);
+      expect(() => strategy.replaceState(null, '', '/'), returnsNormally);
     });
 
     test('validates base href', () {
@@ -159,12 +171,12 @@ class TestPlatformLocation extends PlatformLocation {
   }
 
   @override
-  void pushState(dynamic state, String title, String url) {
+  void pushState(Object? state, String title, String url) {
     throw UnimplementedError();
   }
 
   @override
-  void replaceState(dynamic state, String title, String url) {
+  void replaceState(Object? state, String title, String url) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -172,14 +172,10 @@ class TestPlatformLocation extends PlatformLocation {
   }
 
   @override
-  void pushState(Object? state, String title, String url) {
-    throw UnimplementedError();
-  }
+  void pushState(Object? state, String title, String url) {}
 
   @override
-  void replaceState(Object? state, String title, String url) {
-    throw UnimplementedError();
-  }
+  void replaceState(Object? state, String title, String url) {}
 
   @override
   void go(int count) {

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -55,6 +55,7 @@ void main() {
     });
 
     test('allows null state', () {
+      location.baseHref = '/';
       final PathUrlStrategy strategy = PathUrlStrategy(location);
       expect(() => strategy.pushState(null, '', '/'), returnsNormally);
       expect(() => strategy.replaceState(null, '', '/'), returnsNormally);


### PR DESCRIPTION
The `pushState`/`replaceState` methods should accept a null `state` argument.

The `state` parameter is already nullable in the [engine](https://github.com/flutter/engine/blob/0860094837a7b334c9cac9d65d39e49e87fdad8a/lib/web_ui/lib/src/engine/navigation/url_strategy.dart#L33-L41).

Fixes https://github.com/flutter/flutter/issues/78017