### PR TITLE
Move cache from globals to globals_null_migrated

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_attach.dart
+++ b/packages/flutter_tools/bin/fuchsia_attach.dart
@@ -19,7 +19,7 @@ import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_device.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_workflow.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -18,7 +18,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/user_messages.dart';
 import '../build_info.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import 'android_sdk.dart';
 import 'gradle.dart';

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -14,7 +14,7 @@ import 'base/platform.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'cache.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 
 enum Artifact {
   /// The tool which compiles a dart kernel file into native code.

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -12,7 +12,7 @@ import '../base/common.dart';
 import '../base/os.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -9,7 +9,7 @@ import '../android/build_validation.dart';
 import '../android/gradle_utils.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -12,7 +12,7 @@ import '../base/deferred_component.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart' show FlutterCommandResult;

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -16,7 +16,7 @@ import 'base/process.dart';
 import 'base/user_messages.dart';
 import 'build_info.dart';
 import 'fuchsia/application_package.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 import 'ios/application_package.dart';
 import 'linux/application_package.dart';
 import 'macos/application_package.dart';

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -11,7 +11,6 @@ import 'base/context.dart';
 import 'base/io.dart';
 import 'base/net.dart';
 import 'build_system/build_system.dart';
-import 'cache.dart';
 import 'device.dart';
 import 'doctor.dart';
 import 'fuchsia/fuchsia_sdk.dart';
@@ -32,7 +31,6 @@ export 'globals_null_migrated.dart';
 
 Artifacts get artifacts => context.get<Artifacts>();
 BuildSystem get buildSystem => context.get<BuildSystem>();
-Cache get cache => context.get<Cache>();
 CrashReporter get crashReporter => context.get<CrashReporter>();
 Doctor get doctor => context.get<Doctor>();
 PersistentToolState get persistentToolState => PersistentToolState.instance;

--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -21,8 +21,10 @@ import 'base/template.dart';
 import 'base/terminal.dart';
 import 'base/time.dart';
 import 'base/user_messages.dart';
+import 'cache.dart';
 import 'ios/plist_parser.dart';
 
+Cache get cache => context.get<Cache>()!;
 Config get config => context.get<Config>()!;
 HttpClientFactory get httpClientFactory => context.get<HttpClientFactory>()!;
 Logger get logger => context.get<Logger>()!;

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import 'plist_parser.dart';
 

--- a/packages/flutter_tools/lib/src/test/font_config_manager.dart
+++ b/packages/flutter_tools/lib/src/test/font_config_manager.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import '../base/file_system.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 
 /// Manages a Font configuration that can be shared across multiple tests.
 class FontConfigManager {

--- a/packages/flutter_tools/lib/src/test/integration_test_device.dart
+++ b/packages/flutter_tools/lib/src/test/integration_test_device.dart
@@ -14,7 +14,7 @@ import '../application_package.dart';
 import '../base/common.dart';
 import '../build_info.dart';
 import '../device.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../vmservice.dart';
 import 'test_device.dart';
 

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -13,7 +13,7 @@ import 'base/process.dart';
 import 'base/time.dart';
 import 'cache.dart';
 import 'convert.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 
 /// The flutter GitHub repository.
 String get _flutterGit => globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';

--- a/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
@@ -5,8 +5,10 @@
 // @dart = 2.8
 
 import 'package:flutter_tools/src/base/error_handling_io.dart';
+import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/flutter_cache.dart';
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -114,11 +116,17 @@ void main() {
     fileSystem = globals.localFileSystem;
     logger = BufferLogger.test();
     analyzerSeparator = platform.isWindows ? '-' : '•';
+    final OperatingSystemUtils operatingSystemUtils = FakeOperatingSystemUtils();
     artifacts = CachedArtifacts(
-      cache: globals.cache,
+      cache: FlutterCache(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        osUtils: operatingSystemUtils,
+      ),
       fileSystem: fileSystem,
       platform: platform,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
+      operatingSystemUtils: operatingSystemUtils,
     );
     Cache.flutterRoot = Cache.defaultFlutterRoot(
       fileSystem: fileSystem,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -8,7 +8,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/commands/channel.dart';
 import 'package:flutter_tools/src/version.dart';
 

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/custom_devices/custom_device_config.dart';
 import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/linux/application_package.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import 'package:file/memory.dart';
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -19,7 +19,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';


### PR DESCRIPTION
Follow up on https://github.com/flutter/flutter/pull/79864 to move `context.get<Cache>()` from `globals.dart` to `globals_null_migrated.dart`.  Update imports.

Part of #71511