### PR TITLE
Check if reg can run before calling it on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -210,13 +210,15 @@ class GoogleChromeDevice extends ChromiumDevice {
     // See https://bugs.chromium.org/p/chromium/issues/detail?id=158372
     String version = 'unknown';
     if (_platform.isWindows) {
-      final ProcessResult result = await _processManager.run(<String>[
-        r'reg', 'query', r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon', '/v', 'version',
-      ]);
-      if (result.exitCode == 0) {
-        final List<String> parts = (result.stdout as String).split(RegExp(r'\s+'));
-        if (parts.length > 2) {
-          version = 'Google Chrome ' + parts[parts.length - 2];
+      if (_processManager.canRun('reg')) {
+        final ProcessResult result = await _processManager.run(<String>[
+          r'reg', 'query', r'HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon', '/v', 'version',
+        ]);
+        if (result.exitCode == 0) {
+          final List<String> parts = (result.stdout as String).split(RegExp(r'\s+'));
+          if (parts.length > 2) {
+            version = 'Google Chrome ' + parts[parts.length - 2];
+          }
         }
       }
     } else {
@@ -231,7 +233,6 @@ class GoogleChromeDevice extends ChromiumDevice {
     }
     return version.trim();
   }
-
 }
 
 /// The Microsoft Edge browser based on Chromium.
@@ -270,13 +271,15 @@ class MicrosoftEdgeDevice extends ChromiumDevice {
   Future<String> get sdkNameAndVersion async => _sdkNameAndVersion ??= await _getSdkNameAndVersion();
   String _sdkNameAndVersion;
   Future<String> _getSdkNameAndVersion() async {
-    final ProcessResult result = await _processManager.run(<String>[
-      r'reg', 'query', r'HKEY_CURRENT_USER\Software\Microsoft\Edge\BLBeacon', '/v', 'version',
-    ]);
-    if (result.exitCode == 0) {
-      final List<String> parts = (result.stdout as String).split(RegExp(r'\s+'));
-      if (parts.length > 2) {
-        return 'Microsoft Edge ' + parts[parts.length - 2];
+    if (_processManager.canRun('reg')) {
+      final ProcessResult result = await _processManager.run(<String>[
+        r'reg', 'query', r'HKEY_CURRENT_USER\Software\Microsoft\Edge\BLBeacon', '/v', 'version',
+      ]);
+      if (result.exitCode == 0) {
+        final List<String> parts = (result.stdout as String).split(RegExp(r'\s+'));
+        if (parts.length > 2) {
+          return 'Microsoft Edge ' + parts[parts.length - 2];
+        }
       }
     }
     // Return a non-null string so that the tool can validate the version

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -255,6 +255,42 @@ void main() {
     expect(processManager, hasNoRemainingExpectations);
   });
 
+  testWithoutContext('Chrome and Edge version check handles missing registry on Windows', () async {
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
+    processManager.excludedExecutables.add('reg');
+
+    final Platform platform = FakePlatform(
+        operatingSystem: 'windows', environment: <String, String>{});
+    final ChromiumLauncher chromeLauncher = ChromiumLauncher(
+      fileSystem: MemoryFileSystem.test(),
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: null,
+      browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
+    );
+    final MicrosoftEdgeDevice edgeDevice = MicrosoftEdgeDevice(
+      chromiumLauncher: chromeLauncher,
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      processManager: processManager,
+    );
+
+    expect(edgeDevice.isSupported(), true);
+    expect(await edgeDevice.sdkNameAndVersion, '');
+
+    final GoogleChromeDevice chromeDevice = GoogleChromeDevice(
+      chromiumLauncher: chromeLauncher,
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      processManager: processManager,
+      platform: platform,
+    );
+
+    expect(chromeDevice.isSupported(), true);
+    expect(await chromeDevice.sdkNameAndVersion, 'unknown');
+  });
+
   testWithoutContext('Edge is not supported on versions less than 73', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(


### PR DESCRIPTION
Check if `reg` is on search path before checking registry values.

Fixes https://github.com/flutter/flutter/issues/79896