### PR TITLE
Migrate tool version to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -167,11 +167,11 @@ abstract class ProcessUtils {
   Future<RunResult> run(
     List<String> cmd, {
     bool throwOnError = false,
-    RunResultChecker allowedFailures,
-    String workingDirectory,
+    RunResultChecker? allowedFailures,
+    String? workingDirectory,
     bool allowReentrantFlutter = false,
-    Map<String, String> environment,
-    Duration timeout,
+    Map<String, String>? environment,
+    Duration? timeout,
     int timeoutRetries = 0,
   });
 
@@ -180,10 +180,10 @@ abstract class ProcessUtils {
     List<String> cmd, {
     bool throwOnError = false,
     bool verboseExceptions = false,
-    RunResultChecker allowedFailures,
+    RunResultChecker? allowedFailures,
     bool hideStdout = false,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool allowReentrantFlutter = false,
     Encoding encoding = systemEncoding,
   });
@@ -192,9 +192,9 @@ abstract class ProcessUtils {
   /// directory. Completes when the process has been started.
   Future<Process> start(
     List<String> cmd, {
-    String workingDirectory,
+    String? workingDirectory,
     bool allowReentrantFlutter = false,
-    Map<String, String> environment,
+    Map<String, String>? environment,
   });
 
   /// This runs the command and streams stdout/stderr from the child process to
@@ -210,24 +210,24 @@ abstract class ProcessUtils {
   /// treated as errors, just as if they had been logged to stderr instead.
   Future<int> stream(
     List<String> cmd, {
-    String workingDirectory,
+    String? workingDirectory,
     bool allowReentrantFlutter = false,
     String prefix = '',
     bool trace = false,
-    RegExp filter,
-    RegExp stdoutErrorMatcher,
-    StringConverter mapFunction,
-    Map<String, String> environment,
+    RegExp? filter,
+    RegExp? stdoutErrorMatcher,
+    StringConverter? mapFunction,
+    Map<String, String>? environment,
   });
 
   bool exitsHappySync(
     List<String> cli, {
-    Map<String, String> environment,
+    Map<String, String>? environment,
   });
 
   Future<bool> exitsHappy(
     List<String> cli, {
-    Map<String, String> environment,
+    Map<String, String>? environment,
   });
 }
 

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -6,7 +6,7 @@
 
 import '../base/common.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../version.dart';
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -15,7 +15,7 @@ import '../dart/pub.dart';
 import '../features.dart';
 import '../flutter_manifest.dart';
 import '../flutter_project_metadata.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import '../runner/flutter_command.dart';

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -18,7 +18,7 @@ import '../convert.dart';
 import '../dart/pub.dart';
 import '../features.dart';
 import '../flutter_project_metadata.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import '../runner/flutter_command.dart';
 import '../template.dart';

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -25,7 +25,6 @@ import 'persistent_tool_state.dart';
 import 'project.dart';
 import 'reporting/reporting.dart';
 import 'runner/local_engine.dart';
-import 'version.dart';
 
 export 'globals_null_migrated.dart';
 
@@ -49,7 +48,6 @@ CocoaPodsValidator get cocoapodsValidator => context.get<CocoaPodsValidator>();
 LocalEngineLocator get localEngineLocator => context.get<LocalEngineLocator>();
 
 CocoaPods get cocoaPods => context.get<CocoaPods>();
-FlutterVersion get flutterVersion => context.get<FlutterVersion>();
 FuchsiaArtifacts get fuchsiaArtifacts => context.get<FuchsiaArtifacts>();
 IOSSimulatorUtils get iosSimulatorUtils => context.get<IOSSimulatorUtils>();
 IOSWorkflow get iosWorkflow => context.get<IOSWorkflow>();

--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -23,6 +23,7 @@ import 'base/time.dart';
 import 'base/user_messages.dart';
 import 'cache.dart';
 import 'ios/plist_parser.dart';
+import 'version.dart';
 
 Cache get cache => context.get<Cache>()!;
 Config get config => context.get<Config>()!;
@@ -32,6 +33,7 @@ OperatingSystemUtils get os => context.get<OperatingSystemUtils>()!;
 Signals get signals => context.get<Signals>() ?? LocalSignals.instance;
 AndroidStudio? get androidStudio => context.get<AndroidStudio>();
 AndroidSdk? get androidSdk => context.get<AndroidSdk>();
+FlutterVersion get flutterVersion => context.get<FlutterVersion>()!;
 
 /// Currently active implementation of the file system.
 ///

--- a/packages/flutter_tools/lib/src/sksl_writer.dart
+++ b/packages/flutter_tools/lib/src/sksl_writer.dart
@@ -13,7 +13,7 @@ import 'base/logger.dart';
 import 'build_info.dart';
 import 'convert.dart';
 import 'device.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 
 Future<String> sharedSkSlWriter(Device device, Map<String, Object> data, {
   File outputFile,

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -152,9 +152,7 @@ class FlutterVersion {
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
   void ensureVersionFile() {
-    if (Cache.flutterRoot != null) {
-      globals.fs.file(globals.fs.path.join(Cache.flutterRoot!, 'version')).writeAsStringSync(_frameworkVersion);
-    }
+    globals.fs.file(globals.fs.path.join(Cache.flutterRoot!, 'version')).writeAsStringSync(_frameworkVersion);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -112,11 +112,11 @@ class FlutterVersion {
           globals.processUtils,
           _workingDirectory,
         );
-        _channel = channel.substring(slash + 1);
+        channel = channel.substring(slash + 1);
       } else if (channel.isEmpty) {
-        _channel = 'unknown';
+        channel = 'unknown';
       } else {
-        _channel = channel;
+        channel = channel;
       }
       _channel = channel;
     }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -95,8 +95,9 @@ class FlutterVersion {
   /// The channel is the upstream branch.
   /// `master`, `dev`, `beta`, `stable`; or old ones, like `alpha`, `hackathon`, ...
   String get channel {
-    if (_channel == null) {
-      final String channel = _runGit(
+    String? channel = _channel;
+    if (channel == null) {
+      channel = _runGit(
         'git rev-parse --abbrev-ref --symbolic @{u}',
         globals.processUtils,
         _workingDirectory,
@@ -115,8 +116,9 @@ class FlutterVersion {
       } else {
         _channel = channel;
       }
+      _channel = channel;
     }
-    return _channel!;
+    return channel;
   }
 
   late GitTagVersion _gitTagVersion;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -16,6 +16,8 @@ import 'globals_null_migrated.dart' as globals;
 /// The flutter GitHub repository.
 String get _flutterGit => globals.platform.environment['FLUTTER_GIT_URL'] ?? 'https://github.com/flutter/flutter.git';
 
+const String _unknownFrameworkVersion = '0.0.0-unknown';
+
 /// The names of each channel/branch in order of increasing stability.
 enum Channel {
   master,
@@ -157,7 +159,7 @@ class FlutterVersion {
 
   @override
   String toString() {
-    final String versionText = frameworkVersion == 'unknown' ? '' : ' $frameworkVersion';
+    final String versionText = frameworkVersion == _unknownFrameworkVersion ? '' : ' $frameworkVersion';
     final String flutterText = 'Flutter$versionText • channel $channel • ${repositoryUrl ?? 'unknown source'}';
     final String frameworkText = 'Framework • revision $frameworkRevisionShort ($frameworkAge) • $frameworkCommitDate';
     final String engineText = 'Engine • revision $engineRevisionShort';
@@ -272,7 +274,7 @@ class FlutterVersion {
 
   /// Return a short string for the version (e.g. `master/0.0.59-pre.92`, `scroll_refactor/a76bc8e22b`).
   String getVersionString({ bool redactUnknownBranches = false }) {
-    if (frameworkVersion != 'unknown') {
+    if (frameworkVersion != _unknownFrameworkVersion) {
       return '${getBranchName(redactUnknownBranches: redactUnknownBranches)}/$frameworkVersion';
     }
     return '${getBranchName(redactUnknownBranches: redactUnknownBranches)}/$frameworkRevisionShort';
@@ -812,7 +814,7 @@ class GitTagVersion {
 
   String frameworkVersionFor(String revision) {
     if (x == null || y == null || z == null || (hash != null && !revision.startsWith(hash!))) {
-      return '0.0.0-unknown';
+      return _unknownFrameworkVersion;
     }
     if (commits == 0 && gitTag != null) {
       return gitTag!;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -99,24 +99,24 @@ class FlutterVersion {
   String get channel {
     String? channel = _channel;
     if (channel == null) {
-      channel = _runGit(
+      final String gitChannel = _runGit(
         'git rev-parse --abbrev-ref --symbolic @{u}',
         globals.processUtils,
         _workingDirectory,
       );
-      final int slash = channel.indexOf('/');
+      final int slash = gitChannel.indexOf('/');
       if (slash != -1) {
-        final String remote = channel.substring(0, slash);
+        final String remote = gitChannel.substring(0, slash);
         _repositoryUrl = _runGit(
           'git ls-remote --get-url $remote',
           globals.processUtils,
           _workingDirectory,
         );
-        channel = channel.substring(slash + 1);
-      } else if (channel.isEmpty) {
+        channel = gitChannel.substring(slash + 1);
+      } else if (gitChannel.isEmpty) {
         channel = 'unknown';
       } else {
-        channel = channel;
+        channel = gitChannel;
       }
       _channel = channel;
     }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -141,8 +141,8 @@ class FlutterVersion {
     );
   }
 
-  String? _frameworkVersion;
-  String? get frameworkVersion => _frameworkVersion;
+  late String _frameworkVersion;
+  String get frameworkVersion => _frameworkVersion;
 
   String get dartSdkVersion => globals.cache.dartSdkVersion;
 
@@ -150,8 +150,8 @@ class FlutterVersion {
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
   void ensureVersionFile() {
-    if (Cache.flutterRoot != null && _frameworkVersion != null) {
-      globals.fs.file(globals.fs.path.join(Cache.flutterRoot!, 'version')).writeAsStringSync(_frameworkVersion!);
+    if (Cache.flutterRoot != null) {
+      globals.fs.file(globals.fs.path.join(Cache.flutterRoot!, 'version')).writeAsStringSync(_frameworkVersion);
     }
   }
 
@@ -172,7 +172,7 @@ class FlutterVersion {
   }
 
   Map<String, Object> toJson() => <String, Object>{
-    'frameworkVersion': frameworkVersion ?? 'unknown',
+    'frameworkVersion': frameworkVersion,
     'channel': channel,
     'repositoryUrl': repositoryUrl ?? 'unknown source',
     'frameworkRevision': frameworkRevision,

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:meta/meta.dart';
 
 import 'base/common.dart';
@@ -45,7 +43,7 @@ String getNameForChannel(Channel channel) {
 ///
 /// Returns `null` if [name] is not in the list of official channels, according
 /// to [kOfficialChannels].
-Channel getChannelForName(String name) {
+Channel? getChannelForName(String name) {
   if (kOfficialChannels.contains(name)) {
     return Channel.values[kOfficialChannels.toList().indexOf(name)];
   }
@@ -60,8 +58,8 @@ class FlutterVersion {
   /// available upstream.
   FlutterVersion({
     SystemClock clock = const SystemClock(),
-    String workingDirectory,
-    String frameworkRevision,
+    String? workingDirectory,
+    String? frameworkRevision,
   }) : _clock = clock,
        _workingDirectory = workingDirectory {
     _frameworkRevision = frameworkRevision ?? _runGit(
@@ -74,7 +72,7 @@ class FlutterVersion {
   }
 
   final SystemClock _clock;
-  final String _workingDirectory;
+  final String? _workingDirectory;
 
   /// Fetches tags from the upstream Flutter repository and re-calculates the
   /// version.
@@ -87,13 +85,13 @@ class FlutterVersion {
     _frameworkVersion = gitTagVersion.frameworkVersionFor(_frameworkRevision);
   }
 
-  String _repositoryUrl;
-  String get repositoryUrl {
+  String? _repositoryUrl;
+  String? get repositoryUrl {
     final String _ = channel;
     return _repositoryUrl;
   }
 
-  String _channel;
+  String? _channel;
   /// The channel is the upstream branch.
   /// `master`, `dev`, `beta`, `stable`; or old ones, like `alpha`, `hackathon`, ...
   String get channel {
@@ -118,21 +116,21 @@ class FlutterVersion {
         _channel = channel;
       }
     }
-    return _channel;
+    return _channel!;
   }
 
-  GitTagVersion _gitTagVersion;
+  late GitTagVersion _gitTagVersion;
   GitTagVersion get gitTagVersion => _gitTagVersion;
 
   /// The name of the local branch.
   /// Use getBranchName() to read this.
-  String _branch;
+  String? _branch;
 
-  String _frameworkRevision;
+  late String _frameworkRevision;
   String get frameworkRevision => _frameworkRevision;
   String get frameworkRevisionShort => _shortGitRevision(frameworkRevision);
 
-  String _frameworkAge;
+  String? _frameworkAge;
   String get frameworkAge {
     return _frameworkAge ??= _runGit(
       gitLog(<String>['-n', '1', '--pretty=format:%ar']).join(' '),
@@ -141,8 +139,8 @@ class FlutterVersion {
     );
   }
 
-  String _frameworkVersion;
-  String get frameworkVersion => _frameworkVersion;
+  String? _frameworkVersion;
+  String? get frameworkVersion => _frameworkVersion;
 
   String get dartSdkVersion => globals.cache.dartSdkVersion;
 
@@ -150,7 +148,9 @@ class FlutterVersion {
   String get engineRevisionShort => _shortGitRevision(engineRevision);
 
   void ensureVersionFile() {
-    globals.fs.file(globals.fs.path.join(Cache.flutterRoot, 'version')).writeAsStringSync(_frameworkVersion);
+    if (Cache.flutterRoot != null && _frameworkVersion != null) {
+      globals.fs.file(globals.fs.path.join(Cache.flutterRoot!, 'version')).writeAsStringSync(_frameworkVersion!);
+    }
   }
 
   @override
@@ -192,7 +192,7 @@ class FlutterVersion {
   // If lenient is true, and the git command fails, a placeholder date is
   // returned. Otherwise, the VersionCheckError exception is propagated.
   static String _latestGitCommitDate({
-    String branch,
+    String? branch,
     bool lenient = false,
   }) {
     final List<String> args = gitLog(<String>[
@@ -285,33 +285,13 @@ class FlutterVersion {
       final String branch = _runGit('git rev-parse --abbrev-ref HEAD', globals.processUtils);
       return branch == 'HEAD' ? channel : branch;
     }();
-    if (redactUnknownBranches || _branch.isEmpty) {
+    if (redactUnknownBranches || _branch!.isEmpty) {
       // Only return the branch names we know about; arbitrary branch names might contain PII.
       if (!kOfficialChannels.contains(_branch)) {
         return '[user-branch]';
       }
     }
-    return _branch;
-  }
-
-  /// Returns true if `tentativeDescendantRevision` is a direct descendant to
-  /// the `tentativeAncestorRevision` revision on the Flutter framework repo
-  /// tree.
-  bool checkRevisionAncestry({
-    String tentativeDescendantRevision,
-    String tentativeAncestorRevision,
-  }) {
-    final ProcessResult result = globals.processManager.runSync(
-      <String>[
-        'git',
-        'merge-base',
-        '--is-ancestor',
-        tentativeAncestorRevision,
-        tentativeDescendantRevision
-      ],
-      workingDirectory: Cache.flutterRoot,
-    );
-    return result.exitCode == 0;
+    return _branch!;
   }
 
   /// The amount of time we wait before pinging the server to check for the
@@ -396,7 +376,7 @@ class FlutterVersion {
     // Get whether there's a newer version on the remote. This only goes
     // to the server if we haven't checked recently so won't happen on every
     // command.
-    final DateTime latestFlutterCommitDate = await _getLatestAvailableFlutterDate();
+    final DateTime? latestFlutterCommitDate = await _getLatestAvailableFlutterDate();
     final VersionCheckResult remoteVersionStatus = latestFlutterCommitDate == null
         ? VersionCheckResult.unknown
         : latestFlutterCommitDate.isAfter(localFrameworkCommitDate)
@@ -471,13 +451,13 @@ class FlutterVersion {
   ///
   /// Returns null if the cached version is out-of-date or missing, and we are
   /// unable to reach the server to get the latest version.
-  Future<DateTime> _getLatestAvailableFlutterDate() async {
+  Future<DateTime?> _getLatestAvailableFlutterDate() async {
     globals.cache.checkLockAcquired();
     final VersionCheckStamp versionCheckStamp = await VersionCheckStamp.load();
 
     if (versionCheckStamp.lastTimeVersionWasChecked != null) {
       final Duration timeSinceLastCheck = _clock.now().difference(
-        versionCheckStamp.lastTimeVersionWasChecked,
+        versionCheckStamp.lastTimeVersionWasChecked!,
       );
 
       // Don't ping the server too often. Return cached value if it's fresh.
@@ -520,16 +500,16 @@ class VersionCheckStamp {
     this.lastTimeWarningWasPrinted,
   });
 
-  final DateTime lastTimeVersionWasChecked;
-  final DateTime lastKnownRemoteVersion;
-  final DateTime lastTimeWarningWasPrinted;
+  final DateTime? lastTimeVersionWasChecked;
+  final DateTime? lastKnownRemoteVersion;
+  final DateTime? lastTimeWarningWasPrinted;
 
   /// The prefix of the stamp file where we cache Flutter version check data.
   @visibleForTesting
   static const String flutterVersionCheckStampFile = 'flutter_version_check';
 
   static Future<VersionCheckStamp> load() async {
-    final String versionCheckStamp = globals.cache.getStampFor(flutterVersionCheckStampFile);
+    final String? versionCheckStamp = globals.cache.getStampFor(flutterVersionCheckStampFile);
 
     if (versionCheckStamp != null) {
       // Attempt to parse stamp JSON.
@@ -551,7 +531,7 @@ class VersionCheckStamp {
   }
 
   static VersionCheckStamp fromJson(Map<String, dynamic> jsonObject) {
-    DateTime readDateTime(String property) {
+    DateTime? readDateTime(String property) {
       return jsonObject.containsKey(property)
           ? DateTime.parse(jsonObject[property] as String)
           : null;
@@ -565,9 +545,9 @@ class VersionCheckStamp {
   }
 
   Future<void> store({
-    DateTime newTimeVersionWasChecked,
-    DateTime newKnownRemoteVersion,
-    DateTime newTimeWarningWasPrinted,
+    DateTime? newTimeVersionWasChecked,
+    DateTime? newKnownRemoteVersion,
+    DateTime? newTimeWarningWasPrinted,
   }) async {
     final Map<String, String> jsonData = toJson();
 
@@ -588,9 +568,9 @@ class VersionCheckStamp {
   }
 
   Map<String, String> toJson({
-    DateTime updateTimeVersionWasChecked,
-    DateTime updateKnownRemoteVersion,
-    DateTime updateTimeWarningWasPrinted,
+    DateTime? updateTimeVersionWasChecked,
+    DateTime? updateKnownRemoteVersion,
+    DateTime? updateTimeWarningWasPrinted,
   }) {
     updateTimeVersionWasChecked = updateTimeVersionWasChecked ?? lastTimeVersionWasChecked;
     updateKnownRemoteVersion = updateKnownRemoteVersion ?? lastKnownRemoteVersion;
@@ -654,7 +634,7 @@ String _runSync(List<String> command, { bool lenient = true }) {
   return '';
 }
 
-String _runGit(String command, ProcessUtils processUtils, [String workingDirectory]) {
+String _runGit(String command, ProcessUtils processUtils, [String? workingDirectory]) {
   return processUtils.runSync(
     command.split(' '),
     workingDirectory: workingDirectory ?? Cache.flutterRoot,
@@ -678,7 +658,7 @@ Future<String> _run(List<String> command) async {
   );
 }
 
-String _shortGitRevision(String revision) {
+String _shortGitRevision(String? revision) {
   if (revision == null) {
     return '';
   }
@@ -710,33 +690,33 @@ class GitTagVersion {
       gitTag = '';
 
   /// The X in vX.Y.Z.
-  final int x;
+  final int? x;
 
   /// The Y in vX.Y.Z.
-  final int y;
+  final int? y;
 
   /// The Z in vX.Y.Z.
-  final int z;
+  final int? z;
 
   /// the F in vX.Y.Z+hotfix.F.
-  final int hotfix;
+  final int? hotfix;
 
   /// Number of commits since the vX.Y.Z tag.
-  final int commits;
+  final int? commits;
 
   /// The git hash (or an abbreviation thereof) for this commit.
-  final String hash;
+  final String? hash;
 
   /// The N in X.Y.Z-dev.N.M.
-  final int devVersion;
+  final int? devVersion;
 
   /// The M in X.Y.Z-dev.N.M.
-  final int devPatch;
+  final int? devPatch;
 
   /// The git tag that is this version's closest ancestor.
-  final String gitTag;
+  final String? gitTag;
 
-  static GitTagVersion determine(ProcessUtils processUtils, {String workingDirectory, bool fetchTags = false, String gitRef = 'HEAD'}) {
+  static GitTagVersion determine(ProcessUtils processUtils, {String? workingDirectory, bool fetchTags = false, String gitRef = 'HEAD'}) {
     if (fetchTags) {
       final String channel = _runGit('git rev-parse --abbrev-ref HEAD', processUtils, workingDirectory);
       if (channel == 'dev' || channel == 'beta' || channel == 'stable') {
@@ -783,26 +763,26 @@ class GitTagVersion {
   static GitTagVersion parseVersion(String version) {
     final RegExp versionPattern = RegExp(
       r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?(?:-(\d+)-g([a-f0-9]+))?$');
-    final Match match = versionPattern.firstMatch(version.trim());
+    final Match? match = versionPattern.firstMatch(version.trim());
     if (match == null) {
       return const GitTagVersion.unknown();
     }
 
-    final List<String> matchGroups = match.groups(<int>[1, 2, 3, 4, 5, 6]);
-    final int x = matchGroups[0] == null ? null : int.tryParse(matchGroups[0]);
-    final int y = matchGroups[1] == null ? null : int.tryParse(matchGroups[1]);
-    final int z = matchGroups[2] == null ? null : int.tryParse(matchGroups[2]);
-    final String devString = matchGroups[3];
-    int devVersion, devPatch;
+    final List<String?> matchGroups = match.groups(<int>[1, 2, 3, 4, 5, 6]);
+    final int? x = matchGroups[0] == null ? null : int.tryParse(matchGroups[0]!);
+    final int? y = matchGroups[1] == null ? null : int.tryParse(matchGroups[1]!);
+    final int? z = matchGroups[2] == null ? null : int.tryParse(matchGroups[2]!);
+    final String? devString = matchGroups[3];
+    int? devVersion, devPatch;
     if (devString != null) {
-      final Match devMatch = RegExp(r'^-(\d+)\.(\d+)\.pre$')
+      final Match? devMatch = RegExp(r'^-(\d+)\.(\d+)\.pre$')
         .firstMatch(devString);
-      final List<String> devGroups = devMatch.groups(<int>[1, 2]);
-      devVersion = devGroups[0] == null ? null : int.tryParse(devGroups[0]);
-      devPatch = devGroups[1] == null ? null : int.tryParse(devGroups[1]);
+      final List<String?>? devGroups = devMatch?.groups(<int>[1, 2]);
+      devVersion = devGroups?[0] == null ? null : int.tryParse(devGroups![0]!);
+      devPatch = devGroups?[1] == null ? null : int.tryParse(devGroups![1]!);
     }
     // count of commits past last tagged version
-    final int commits = matchGroups[4] == null ? 0 : int.tryParse(matchGroups[4]);
+    final int? commits = matchGroups[4] == null ? 0 : int.tryParse(matchGroups[4]!);
     final String hash = matchGroups[5] ?? '';
 
     return GitTagVersion(
@@ -829,20 +809,20 @@ class GitTagVersion {
   }
 
   String frameworkVersionFor(String revision) {
-    if (x == null || y == null || z == null || !revision.startsWith(hash)) {
+    if (x == null || y == null || z == null || (hash != null && !revision.startsWith(hash!))) {
       return '0.0.0-unknown';
     }
-    if (commits == 0) {
-      return gitTag;
+    if (commits == 0 && gitTag != null) {
+      return gitTag!;
     }
     if (hotfix != null) {
       // This is an unexpected state where untagged commits exist past a hotfix
-      return '$x.$y.$z+hotfix.${hotfix + 1}.pre.$commits';
+      return '$x.$y.$z+hotfix.${hotfix! + 1}.pre.$commits';
     }
     if (devPatch != null && devVersion != null) {
-      return '$x.$y.$z-${devVersion + 1}.0.pre.$commits';
+      return '$x.$y.$z-${devVersion! + 1}.0.pre.$commits';
     }
-    return '$x.$y.${z + 1}-0.0.pre.$commits';
+    return '$x.$y.${z! + 1}-0.0.pre.$commits';
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_runner_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:flutter_tools/src/version.dart';

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/utils.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 
@@ -290,39 +290,6 @@ void main() {
         FlutterVersion: () => FlutterVersion(clock: _testClock),
         ProcessManager: () => mockProcessManager,
         Cache: () => mockCache,
-      });
-
-      testUsingContext('versions comparison', () async {
-        fakeData(
-          mockProcessManager,
-          mockCache,
-          localCommitDate: getChannelOutOfDateVersion(),
-          errorOnFetch: true,
-          expectServerPing: true,
-          expectSetStamp: true,
-          channel: channel,
-        );
-        final FlutterVersion version = globals.flutterVersion;
-
-        when(mockProcessManager.runSync(
-          <String>['git', 'merge-base', '--is-ancestor', 'abcdef', '123456'],
-          workingDirectory: anyNamed('workingDirectory'),
-        )).thenReturn(ProcessResult(1, 0, '', ''));
-
-        expect(
-            version.checkRevisionAncestry(
-              tentativeDescendantRevision: '123456',
-              tentativeAncestorRevision: 'abcdef',
-            ),
-            true);
-
-        verify(mockProcessManager.runSync(
-          <String>['git', 'merge-base', '--is-ancestor', 'abcdef', '123456'],
-          workingDirectory: anyNamed('workingDirectory'),
-        ));
-      }, overrides: <Type, Generator>{
-        FlutterVersion: () => FlutterVersion(clock: _testClock),
-        ProcessManager: () => mockProcessManager,
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -61,17 +61,6 @@ void main() {
       });
 
       testUsingContext('prints nothing when Flutter installation looks fresh', () async {
-        fakeData(
-          mockProcessManager,
-          mockCache,
-          localCommitDate: getChannelUpToDateVersion(),
-          // Server will be pinged because we haven't pinged within last x days
-          expectServerPing: true,
-          remoteCommitDate: getChannelOutOfDateVersion(),
-          expectSetStamp: true,
-          channel: channel,
-        );
-
         processManager.addCommand(const FakeCommand(
           command: <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%H'],
           stdout: '1234abcd',
@@ -116,7 +105,40 @@ void main() {
           command: <String>['git', 'remote'],
         ));
 
-        await globals.flutterVersion.checkFlutterVersionFreshness();
+        processManager.addCommands(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%ar'],
+            stdout: '1 second ago',
+          ),
+          FakeCommand(
+            command: const <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%ad', '--date=iso'],
+            stdout: getChannelUpToDateVersion().toString(),
+          ),
+          FakeCommand(
+            command: const <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            stdout: channel,
+          ),
+        ]);
+
+        final FlutterVersion flutterVersion = globals.flutterVersion;
+        await flutterVersion.checkFlutterVersionFreshness();
+        expect(flutterVersion.channel, channel);
+        expect(flutterVersion.frameworkRevision, '1234abcd');
+        expect(flutterVersion.frameworkRevisionShort, '1234abcd');
+        expect(flutterVersion.frameworkVersion, '0.0.0-unknown');
+        expect(
+          flutterVersion.toString(),
+          'Flutter • channel $channel • unknown source\n'
+          'Framework • revision 1234abcd (1 second ago) • ${getChannelUpToDateVersion()}\n'
+          'Engine • revision \n'
+          'Tools • Dart null',
+        );
+        expect(flutterVersion.frameworkAge, '1 second ago');
+        expect(flutterVersion.getVersionString(), '$channel/1234abcd');
+        expect(flutterVersion.getBranchName(), channel);
+        expect(flutterVersion.getVersionString(redactUnknownBranches: true), '$channel/1234abcd');
+        expect(flutterVersion.getBranchName(redactUnknownBranches: true), channel);
+
         _expectVersionMessage('');
         expect(processManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
@@ -415,6 +437,42 @@ void main() {
       });
     });
   }
+
+  testUsingContext('version handles unknown branch', () async {
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>['git', '-c', 'log.showSignature=false', 'log', '-n', '1', '--pretty=format:%H'],
+        stdout: '1234abcd',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'tag', '--points-at', '1234abcd'],
+      ),
+      const FakeCommand(
+        command: <String>['git', 'describe', '--match', '*.*.*', '--long', '--tags', '1234abcd'],
+        stdout: '0.1.2-3-1234abcd',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--abbrev-ref', '--symbolic', '@{u}'],
+        stdout: 'feature-branch',
+      ),
+      const FakeCommand(
+        command: <String>['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout: 'feature-branch',
+      ),
+    ]);
+
+    final FlutterVersion flutterVersion = globals.flutterVersion;
+    expect(flutterVersion.channel, 'feature-branch');
+    expect(flutterVersion.getVersionString(), 'feature-branch/1234abcd');
+    expect(flutterVersion.getBranchName(), 'feature-branch');
+    expect(flutterVersion.getVersionString(redactUnknownBranches: true), '[user-branch]/1234abcd');
+    expect(flutterVersion.getBranchName(redactUnknownBranches: true), '[user-branch]');
+    expect(processManager.hasRemainingExpectations, isFalse);
+  }, overrides: <Type, Generator>{
+    FlutterVersion: () => FlutterVersion(clock: _testClock),
+    ProcessManager: () => processManager,
+    Cache: () => mockCache,
+  });
 
   testUsingContext('GitTagVersion', () {
     const String hash = 'abcdef';

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -527,11 +527,6 @@ class FakeFlutterVersion implements FlutterVersion {
   }
 
   @override
-  bool checkRevisionAncestry({String tentativeDescendantRevision, String tentativeAncestorRevision}) {
-    throw UnimplementedError();
-  }
-
-  @override
   Future<void> ensureVersionFile() async { }
 
   @override


### PR DESCRIPTION
Also added missing nullability to abstract `ProcessUtils` to match `_DefaultProcessUtils` so there wouldn't be warnings about `workingDirectory` being null.

Add some version_tests to cover unknown branches.

Part of #71511