### PR TITLE
add new try/prod builders for validate_ci_config

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -439,6 +439,12 @@
       "flaky": false
     },
     {
+      "name": "Linux validate_ci_config",
+      "repo": "flutter",
+      "task_name": "linux_validate_ci_config",
+      "flaky": true
+    },
+    {
       "name": "Linux web_tool_tests",
       "repo": "flutter",
       "task_name": "linux_web_tool_tests",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -222,6 +222,12 @@
       "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
     },
     {
+      "name": "Linux validate_ci_config",
+      "repo": "flutter",
+      "task_name": "linux_validate_ci_config",
+      "enabled": true
+    },
+    {
       "name": "Linux web_tool_tests",
       "repo": "flutter",
       "task_name": "linux_web_tool_tests",


### PR DESCRIPTION
must land after https://github.com/flutter/flutter/issues/79579 propagates.

part of https://github.com/flutter/flutter/issues/79579