### PR TITLE
Allow null Config.getValue() results

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -69,7 +69,7 @@ class AndroidSdk {
     String? findAndroidHomeDir() {
       String? androidHomeDir;
       if (globals.config.containsKey('android-sdk')) {
-        androidHomeDir = globals.config.getValue('android-sdk') as String;
+        androidHomeDir = globals.config.getValue('android-sdk') as String?;
       } else if (globals.platform.environment.containsKey(kAndroidHome)) {
         androidHomeDir = globals.platform.environment[kAndroidHome];
       } else if (globals.platform.environment.containsKey(kAndroidSdkRoot)) {

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -220,7 +220,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
 
   /// Locates the newest, valid version of Android Studio.
   static AndroidStudio? latestValid() {
-    final String configuredStudio = globals.config.getValue('android-studio-dir') as String;
+    final String? configuredStudio = globals.config.getValue('android-studio-dir') as String?;
     if (configuredStudio != null) {
       String configuredStudioPath = configuredStudio;
       if (globals.platform.isMacOS && !configuredStudioPath.endsWith('Contents')) {
@@ -283,7 +283,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       ));
     }
 
-    final String configuredStudioDir = globals.config.getValue('android-studio-dir') as String;
+    final String? configuredStudioDir = globals.config.getValue('android-studio-dir') as String?;
     if (configuredStudioDir != null) {
       FileSystemEntity configuredStudio = globals.fs.file(configuredStudioDir);
       if (configuredStudio.basename == 'Contents') {
@@ -377,7 +377,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       }
     }
 
-    final String configuredStudioDir = globals.config.getValue('android-studio-dir') as String;
+    final String? configuredStudioDir = globals.config.getValue('android-studio-dir') as String?;
     if (configuredStudioDir != null && !_hasStudioAt(configuredStudioDir)) {
       studios.add(AndroidStudio(configuredStudioDir,
           configured: configuredStudioDir));

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -104,9 +104,9 @@ class NoAndroidStudioValidator extends DoctorValidator {
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
 
-    final String cfgAndroidStudio = _config.getValue(
+    final String? cfgAndroidStudio = _config.getValue(
       'android-studio-dir',
-    ) as String;
+    ) as String?;
     if (cfgAndroidStudio != null) {
       messages.add(ValidationMessage.error(
         _userMessages.androidStudioMissing(cfgAndroidStudio),

--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -62,7 +62,7 @@ class Config {
     }
     try {
       ErrorHandlingFileSystem.noExitOnFailure(() {
-        _values = castStringKeyedMap(json.decode(_file.readAsStringSync())) ?? <String, dynamic>{};
+        _values = castStringKeyedMap(json.decode(_file.readAsStringSync())) as Map<String, Object>? ?? <String, Object>{};
       });
     } on FormatException {
       _logger
@@ -110,13 +110,13 @@ class Config {
 
   String get configPath => _file.path;
 
-  Map<String, dynamic> _values = <String, dynamic>{};
+  Map<String, Object> _values = <String, Object>{};
 
   Iterable<String> get keys => _values.keys;
 
   bool containsKey(String key) => _values.containsKey(key);
 
-  dynamic getValue(String key) => _values[key];
+  Object? getValue(String key) => _values[key];
 
   void setValue(String key, Object value) {
     _values[key] = value;

--- a/packages/flutter_tools/lib/src/ios/code_signing.dart
+++ b/packages/flutter_tools/lib/src/ios/code_signing.dart
@@ -223,7 +223,7 @@ Future<String?> _chooseSigningIdentity(
   }
 
   if (validCodeSigningIdentities.length > 1) {
-    final String savedCertChoice = config.getValue('ios-signing-cert') as String;
+    final String? savedCertChoice = config.getValue('ios-signing-cert') as String?;
 
     if (savedCertChoice != null) {
       if (validCodeSigningIdentities.contains(savedCertChoice)) {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/78932 incorrectly left `Config.getValue(String key)` as a `dynamic` instead of an `Object?` since it's possible the key hasn't been set yet.  That means at call sites null may be incorrectly cast as a non-null type.

Part of #71511