### PR TITLE
Update the no-response template.

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -10,7 +10,11 @@ responseRequiredLabel: "waiting for customer response"
 closeComment: >
   Without additional information, we are unfortunately not sure how to
   resolve this issue. We are therefore reluctantly going to close this
-  bug for now. Please don't hesitate to comment on the bug if you have
-  any more information for us; we will reopen it right away!
+  bug for now.
+
+  If you find this problem please file a new issue with the same description,
+  what happens, logs and the output of 'flutter doctor -v'. All system setups
+  can be slightly different so it's always better to open new issues and reference
+  related the related ones.
 
   Thanks for your contribution.

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -15,6 +15,6 @@ closeComment: >
   If you find this problem please file a new issue with the same description,
   what happens, logs and the output of 'flutter doctor -v'. All system setups
   can be slightly different so it's always better to open new issues and reference
-  related the related ones.
+  the related ones.
 
   Thanks for your contribution.


### PR DESCRIPTION
The update is to encourage people to open new bugs rather than adding
comments to already closed bugs.

Bug: https://github.com/flutter/flutter/issues/50549

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
