### PR TITLE
Revert "Support block delete with word and line modifiers"

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -670,6 +670,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       // _handleShortcuts depends on being started in the same stack invocation
       // as the _handleKeyEvent method
       _handleShortcuts(key);
+    } else if (key == LogicalKeyboardKey.delete) {
+      _handleDelete(forward: true);
+    } else if (key == LogicalKeyboardKey.backspace) {
+      _handleDelete(forward: false);
     }
   }
 
@@ -1011,381 +1015,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
-  // Deletes the current uncollapsed selection.
-  void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed == false);
-
-    if (_readOnly || !selection.isValid || selection.isCollapsed) {
-      return;
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = selection.textBefore(text);
-    final String textAfter = selection.textAfter(text);
-    final int cursorPosition = math.min(selection.start, selection.end);
-
-    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
-      cause,
-    );
-  }
-
-  // Deletes the from the current collapsed selection to the start of the field.
-  //
-  // The given SelectionChangedCause indicates the cause of this change and
-  // will be passed to onSelectionChanged.
-  //
-  // See also:
-  //   * _deleteToEnd
-  void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed);
-
-    if (_readOnly || !selection.isValid) {
-      return;
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = selection.textBefore(text);
-
-    if (textBefore.isEmpty) {
-      return;
-    }
-
-    final String textAfter = selection.textAfter(text);
-    const TextSelection newSelection = TextSelection.collapsed(offset: 0);
-    _setTextEditingValue(
-      TextEditingValue(text: textAfter, selection: newSelection),
-      cause,
-    );
-  }
-
-  // Deletes the from the current collapsed selection to the end of the field.
-  //
-  // The given SelectionChangedCause indicates the cause of this change and
-  // will be passed to onSelectionChanged.
-  //
-  // See also:
-  //   * _deleteToStart
-  void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed);
-
-    if (_readOnly || !selection.isValid) {
-      return;
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    final String textAfter = selection.textAfter(text);
-
-    if (textAfter.isEmpty) {
-      return;
-    }
-
-    final String textBefore = selection.textBefore(text);
-    final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore, selection: newSelection),
-      cause,
-    );
-  }
-
-  /// Deletes backwards from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a single character before the
-  /// cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
-  ///
-  /// See also:
-  ///
-  ///   * [deleteForward], which is same but in the opposite direction.
-  void delete(SelectionChangedCause cause) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    String textBefore = _selection!.textBefore(text);
-    if (textBefore.isEmpty) {
-      return;
-    }
-
-    final int characterBoundary = previousCharacter(textBefore.length, textBefore);
-    textBefore = textBefore.substring(0, characterBoundary);
-
-    final String textAfter = _selection!.textAfter(text);
-    final TextSelection newSelection = TextSelection.collapsed(offset: characterBoundary);
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
-      cause,
-    );
-  }
-
-  /// Deletes a word backwards from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a word before the cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// If [obscureText] is true, it treats the whole text content as
-  /// a single word.
-  ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
-  ///
-  /// {@template flutter.rendering.RenderEditable.whiteSpace}
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// extended past any whitespace and the first word following the whitespace.
-  /// {@endtemplate}
-  ///
-  /// See also:
-  ///
-  ///   * [deleteForwardByWord], which is same but in the opposite direction.
-  void deleteByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big line.
-    if (obscureText) {
-      return _deleteToStart(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    String textBefore = _selection!.textBefore(text);
-    if (textBefore.isEmpty) {
-      return;
-    }
-
-    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, includeWhitespace);
-    textBefore = textBefore.trimRight().substring(0, characterBoundary);
-
-    final String textAfter = _selection!.textAfter(text);
-    final TextSelection newSelection = TextSelection.collapsed(offset: characterBoundary);
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
-      cause,
-    );
-  }
-
-  /// Deletes a line backwards from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a line before the cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// If [obscureText] is true, it treats the whole text content as
-  /// a single word.
-  ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
-  ///
-  /// See also:
-  ///
-  ///   * [deleteForwardByLine], which is same but in the opposite direction.
-  void deleteByLine(SelectionChangedCause cause) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big line.
-    if (obscureText) {
-      return _deleteToStart(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    String textBefore = _selection!.textBefore(text);
-    if (textBefore.isEmpty) {
-      return;
-    }
-
-    // When there is a line break, line delete shouldn't do anything
-    final bool isPreviousCharacterBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
-    if (isPreviousCharacterBreakLine) {
-      return;
-    }
-
-    final TextSelection line = _getLineAtOffset(TextPosition(offset: textBefore.length - 1));
-    textBefore = textBefore.substring(0, line.start);
-
-    final String textAfter = _selection!.textAfter(text);
-    final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
-      cause,
-    );
-  }
-
-  /// Deletes in the foward direction from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a single character after the
-  /// cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
-  ///
-  /// See also:
-  ///
-  ///   * [delete], which is same but in the opposite direction.
-  void deleteForward(SelectionChangedCause cause) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = _selection!.textBefore(text);
-    String textAfter = _selection!.textAfter(text);
-
-    if (textAfter.isEmpty) {
-      return;
-    }
-
-    final int deleteCount = nextCharacter(0, textAfter);
-    textAfter = textAfter.substring(deleteCount);
-
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
-      cause,
-    );
-  }
-
-  /// Deletes a word in the foward direction from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a word after the cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// If [obscureText] is true, it treats the whole text content as
-  /// a single word.
-  ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
-  ///
-  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
-  ///
-  /// See also:
-  ///
-  ///   * [deleteByWord], which is same but in the opposite direction.
-  void deleteForwardByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big word.
-    if (obscureText) {
-      return _deleteToEnd(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    String textAfter = _selection!.textAfter(text);
-
-    if (textAfter.isEmpty) {
-      return;
-    }
-
-    final String textBefore = _selection!.textBefore(text);
-    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, includeWhitespace);
-    textAfter = textAfter.substring(characterBoundary - textBefore.length);
-
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
-      cause,
-    );
-  }
-
-  /// Deletes a line in the foward direction from the current selection.
-  ///
-  /// If the [selection] is collapsed, deletes a line after the cursor.
-  ///
-  /// If the [selection] is not collapsed, deletes the selection.
-  ///
-  /// If [obscureText] is true, it treats the whole text content as
-  /// a single word.
-  ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
-  ///
-  /// See also:
-  ///
-  ///   * [deleteByLine], which is same but in the opposite direction.
-  void deleteForwardByLine(SelectionChangedCause cause) {
-    assert(_selection != null);
-
-    if (_readOnly || !_selection!.isValid) {
-      return;
-    }
-
-    if (!_selection!.isCollapsed) {
-      return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big line.
-    if (obscureText) {
-      return _deleteToEnd(_selection!, cause);
-    }
-
-    final String text = textSelectionDelegate.textEditingValue.text;
-    String textAfter = _selection!.textAfter(text);
-    if (textAfter.isEmpty) {
-      return;
-    }
-
-    // When there is a line break, it shouldn't do anything.
-    final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
-    if (isNextCharacterBreakLine) {
-      return;
-    }
-
-    final String textBefore = _selection!.textBefore(text);
-    final TextSelection line = _getLineAtOffset(TextPosition(offset: textBefore.length));
-    textAfter = textAfter.substring(line.end - textBefore.length, textAfter.length);
-
-    _setTextEditingValue(
-      TextEditingValue(text: textBefore + textAfter, selection: _selection!),
-      cause,
-    );
-  }
-
   /// Keeping [selection]'s [TextSelection.baseOffset] fixed, move the
   /// [TextSelection.extentOffset] down by one line.
   ///
   /// If [selectionEnabled] is false, keeps the selection collapsed and just
   /// moves it down.
   ///
-  /// {@macro flutter.rendering.RenderEditable.cause}
+  /// {@template flutter.rendering.RenderEditable.cause}
+  /// The given [SelectionChangedCause] indicates the cause of this change and
+  /// will be passed to [onSelectionChanged].
+  /// {@endtemplate}
   ///
   /// See also:
   ///
@@ -1736,7 +1375,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, `includeWhitespace` is set to true, meaning that whitespace
+  /// can be considered a word in itself.  If set to false, the selection will
+  /// be extended past any whitespace and the first word following the
+  /// whitespace.
   ///
   /// {@template flutter.rendering.RenderEditable.stopAtReversal}
   /// The `stopAtReversal` parameter is false by default, meaning that it's
@@ -1778,10 +1420,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, `includeWhitespace` is set to true, meaning that whitespace
+  /// can be considered a word in itself.  If set to false, the selection will
+  /// be extended past any whitespace and the first word following the
+  /// whitespace.
   ///
   /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
-  ///
   ///
   /// See also:
   ///
@@ -1941,7 +1585,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, includeWhitespace is set to true, meaning that whitespace can
+  /// be considered a word in itself.  If set to false, the selection will be
+  /// moved past any whitespace and the first word following the whitespace.
   ///
   /// See also:
   ///
@@ -2027,7 +1673,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, includeWhitespace is set to true, meaning that whitespace can
+  /// be considered a word in itself.  If set to false, the selection will be
+  /// moved past any whitespace and the first word following the whitespace.
   ///
   /// See also:
   ///
@@ -2175,6 +1823,38 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         SelectionChangedCause.keyboard,
       );
     }
+  }
+
+  void _handleDelete({ required bool forward }) {
+    final TextSelection selection = textSelectionDelegate.textEditingValue.selection;
+    final String text = textSelectionDelegate.textEditingValue.text;
+    assert(_selection != null);
+    if (_readOnly || !selection.isValid) {
+      return;
+    }
+    String textBefore = selection.textBefore(text);
+    String textAfter = selection.textAfter(text);
+    int cursorPosition = math.min(selection.start, selection.end);
+    // If not deleting a selection, delete the next/previous character.
+    if (selection.isCollapsed) {
+      if (!forward && textBefore.isNotEmpty) {
+        final int characterBoundary = previousCharacter(textBefore.length, textBefore);
+        textBefore = textBefore.substring(0, characterBoundary);
+        cursorPosition = characterBoundary;
+      }
+      if (forward && textAfter.isNotEmpty) {
+        final int deleteCount = nextCharacter(0, textAfter);
+        textAfter = textAfter.substring(deleteCount);
+      }
+    }
+    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
+    _setTextEditingValue(
+      TextEditingValue(
+        text: textBefore + textAfter,
+        selection: newSelection,
+      ),
+      SelectionChangedCause.keyboard,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -36,12 +36,6 @@ class DefaultTextEditingActions extends Actions{
   // are called on which platform.
   static final Map<Type, Action<Intent>> _shortcutsActions = <Type, Action<Intent>>{
     DoNothingAndStopPropagationTextIntent: _DoNothingAndStopPropagationTextAction(),
-    DeleteTextIntent: _DeleteTextAction(),
-    DeleteByWordTextIntent: _DeleteByWordTextAction(),
-    DeleteByLineTextIntent: _DeleteByLineTextAction(),
-    DeleteForwardTextIntent: _DeleteForwardTextAction(),
-    DeleteForwardByWordTextIntent: _DeleteForwardByWordTextAction(),
-    DeleteForwardByLineTextIntent: _DeleteForwardByLineTextAction(),
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
@@ -80,48 +74,6 @@ class _DoNothingAndStopPropagationTextAction extends TextEditingAction<DoNothing
 
   @override
   void invoke(DoNothingAndStopPropagationTextIntent intent, [BuildContext? context]) {}
-}
-
-class _DeleteTextAction extends TextEditingAction<DeleteTextIntent> {
-  @override
-  Object? invoke(DeleteTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.delete(SelectionChangedCause.keyboard);
-  }
-}
-
-class _DeleteByWordTextAction extends TextEditingAction<DeleteByWordTextIntent> {
-  @override
-  Object? invoke(DeleteByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard, false);
-  }
-}
-
-class _DeleteByLineTextAction extends TextEditingAction<DeleteByLineTextIntent> {
-  @override
-  Object? invoke(DeleteByLineTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteByLine(SelectionChangedCause.keyboard);
-  }
-}
-
-class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent> {
-  @override
-  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteForward(SelectionChangedCause.keyboard);
-  }
-}
-
-class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardByWordTextIntent> {
-  @override
-  Object? invoke(DeleteForwardByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-  }
-}
-
-class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardByLineTextIntent> {
-  @override
-  Object? invoke(DeleteForwardByLineTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteForwardByLine(SelectionChangedCause.keyboard);
-  }
 }
 
 class _ExpandSelectionLeftByLineTextAction extends TextEditingAction<ExpandSelectionLeftByLineTextIntent> {

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -161,12 +161,6 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   );
 
   static final Map<LogicalKeySet, Intent> _androidShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -201,17 +195,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
-    //   * Meta + delete
-    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -246,17 +232,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
-    //   * Meta + delete
-    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -291,17 +269,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
-    //   * Meta + delete
-    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -336,17 +306,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
-    //   * Meta + delete
-    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionRightByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByWordTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByWordTextIntent(),
@@ -381,17 +343,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Home
     //   * Shift + end
     //   * Shift + home
-    //   * Control + delete
-    //   * Control + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -426,21 +380,11 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow left
     //   * Meta + shift + arrow right
     //   * Meta + shift + arrow up
-    //   * Meta + delete
-    //   * Meta + backspace
   };
 
   // Web handles its text selection natively and doesn't use any of these
   // shortcuts in Flutter.
   static final Map<LogicalKeySet, Intent> _webShortcuts = <LogicalKeySet, Intent>{
-    LogicalKeySet(LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -4,54 +4,6 @@
 
 import 'actions.dart';
 
-/// An [Intent] to delete a character in the backwards direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteTextIntent extends Intent{
-  /// Creates an instance of DeleteTextIntent.
-  const DeleteTextIntent();
-}
-
-/// An [Intent] to delete a word in the backwards direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteByWordTextIntent extends Intent{
-  /// Creates an instance of DeleteByWordTextIntent.
-  const DeleteByWordTextIntent();
-}
-
-/// An [Intent] to delete a line in the backwards direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteByLineTextIntent extends Intent{
-  /// Creates an instance of DeleteByLineTextIntent.
-  const DeleteByLineTextIntent();
-}
-
-/// An [Intent] to delete in the forward direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteForwardTextIntent extends Intent{
-  /// Creates an instance of DeleteForwardTextIntent.
-  const DeleteForwardTextIntent();
-}
-
-/// An [Intent] to delete a word in the forward direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteForwardByWordTextIntent extends Intent{
-  /// Creates an instance of DeleteByWordTextIntent.
-  const DeleteForwardByWordTextIntent();
-}
-
-/// An [Intent] to delete a line in the forward direction.
-///
-/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
-class DeleteForwardByLineTextIntent extends Intent{
-  /// Creates an instance of DeleteByLineTextIntent.
-  const DeleteForwardByLineTextIntent();
-}
-
 /// An [Intent] to send the event straight to the engine, but only if a
 /// TextEditingTarget is focused.
 ///

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -962,7 +962,8 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 0);
 
-    editable.deleteForward(SelectionChangedCause.keyboard);
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
     expect(delegate.textEditingValue.text, 'est');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1012,7 +1013,8 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    editable.deleteForward(SelectionChangedCause.keyboard);
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
     expect(delegate.textEditingValue.text, '01236789');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1062,7 +1064,8 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    editable.deleteForward(SelectionChangedCause.keyboard);
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
     expect(delegate.textEditingValue.text, '01232345');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1111,7 +1114,8 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 0);
 
-    editable.deleteForward(SelectionChangedCause.keyboard);
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
     expect(delegate.textEditingValue.text, '');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1166,7 +1170,8 @@ void main() {
     expect(editable.selection?.isCollapsed, true);
     expect(editable.selection?.baseOffset, 3);
 
-     editable.deleteForward(SelectionChangedCause.keyboard);
+    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
     expect(delegate.textEditingValue.text, 'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1396,7 +1401,7 @@ void main() {
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/58068
 
   group('delete', () {
-    test('when as a non-collapsed selection, it should delete a selection', () async {
+    test('handles selection', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1426,885 +1431,14 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.delete(SelectionChangedCause.keyboard);
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
       expect(delegate.textEditingValue.text, 'tt');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 1);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('when as simple text, it should delete the character to the left', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 3),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 3),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'tet');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 2);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('when has surrogate pairs, it should delete the pair', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: '\u{1F44D}',
-            selection: TextSelection.collapsed(offset: 2),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '\u{1F44D}',  // Thumbs up
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 2),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, '');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('when has grapheme clusters, it should delete the grapheme cluster', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: '0123👨‍👩‍👦2345',
-            selection: TextSelection.collapsed(offset: 12),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '0123👨‍👩‍👦2345',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 12),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, '01232345');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 4);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('when is at the start of the text, it should be a no-op', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 0),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 0),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('when input has obscured text, it should delete the character to the left', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test',
-          selection: TextSelection.collapsed(offset: 4),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 4),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'tes');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 3);
-    }, skip: isBrowser);
-
-    test('when using cjk characters', () async {
-        const String text = '用多個塊測試';
-        const int offset = 4;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        editable.delete(SelectionChangedCause.keyboard);
-        expect(delegate.textEditingValue.text, '用多個測試');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 3);
-      }, skip: isBrowser);
-
-    test('when using rtl', () async {
-      const String text = 'برنامج أهلا بالعالم';
-      const int offset = text.length;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.rtl,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.delete(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'برنامج أهلا بالعال');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, text.length - 1);
-    }, skip: isBrowser);
-  });
-
-  group('deleteByWord', () {
-    test('when cursor is on the middle of a word, it should delete the left part of the word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 8;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test h multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
-
-    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 10;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 9);
-    }, skip: isBrowser);
-
-    test('when cursor is after a word, it should delete the whole word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test  multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
-
-    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word to the left', () async {
-      const String text = 'test with   multiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
-
-    test('when cursor is preceeded by tabs spaces', () async {
-      const String text = 'test with\t\t\tmultiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
-
-    test('when cursor is preceeded by break line, it should delete the breaking line and the word right before it', () async {
-      const String text = 'test with\nmultiple blocks';
-      const int offset = 10;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
-
-    test('when using cjk characters', () async {
-        const String text = '用多個塊測試';
-        const int offset = 4;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        editable.deleteByWord(SelectionChangedCause.keyboard, false);
-        expect(delegate.textEditingValue.text, '用多個測試');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 3);
-      }, skip: isBrowser);
-
-    test('when using rtl', () async {
-      const String text = 'برنامج أهلا بالعالم';
-      const int offset = text.length;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.rtl,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'برنامج أهلا ');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 12);
-    }, skip: isBrowser);
-
-    test('when input has obscured text, it should delete everything before the selection', () async {
-      const int offset = 21;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test with multiple\n\n words',
-          selection: TextSelection.collapsed(offset: offset),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'words');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-  });
-
-  group('deleteByLine', () {
-    test('when cursor is on last character of a line, it should delete everything to the left', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = text.length;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, '');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-
-    test('when cursor is on the middle of a word, it should delete delete everything to the left', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 8;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'h multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-
-    test('when previous character is a breakline, it should preserve it', () async {
-      const String text = 'test with\nmultiple blocks';
-      const int offset = 10;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, text);
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when text is multiline, it should delete until the first line break it finds', () async {
-      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
-      const int offset = 22;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test with\n\nright here.\nmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 11);
-    }, skip: isBrowser);
-
-    test('when input has obscured text, it should delete everything before the selection', () async {
-      const int offset = 21;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test with multiple\n\n words',
-          selection: TextSelection.collapsed(offset: offset),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'words');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-  });
-
-  group('deleteForward', () {
-    test('when as a non-collapsed selection, it should delete a selection', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForward(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'tt');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 1);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 9);
-    }, skip: isBrowser);
-
-    test('when at the end of a text, it should be a no-op', () async {
+    test('is a no-op at the end of the text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -2334,13 +1468,14 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForward(SelectionChangedCause.keyboard);
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 4);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('when the input has obscured text, it should delete the forward character', () async {
+    test('handles obscured text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
           text: 'test',
@@ -2372,63 +1507,27 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForward(SelectionChangedCause.keyboard);
+      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+
       expect(delegate.textEditingValue.text, 'est');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
+  });
 
-    test('when using cjk characters', () async {
-        const String text = '用多個塊測試';
-        const int offset = 0;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        editable.deleteForward(SelectionChangedCause.keyboard);
-        expect(delegate.textEditingValue.text, '多個塊測試');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 0);
-      }, skip: isBrowser);
-
-    test('when using rtl', () async {
-      const String text = 'برنامج أهلا بالعالم';
-      const int offset = 0;
+  group('backspace', () {
+    test('handles selection', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
+            text: 'test',
+            selection: TextSelection(baseOffset: 1, extentOffset: 3),
           );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
         backgroundCursorColor: Colors.grey,
         selectionColor: Colors.black,
-        textDirection: TextDirection.rtl,
+        textDirection: TextDirection.ltr,
         cursorColor: Colors.red,
         offset: viewportOffset,
         textSelectionDelegate: delegate,
@@ -2436,34 +1535,104 @@ void main() {
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
-          text: text,
+          text: 'test',
           style: TextStyle(
             height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
         ),
-        selection: const TextSelection.collapsed(offset: offset),
+        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
       );
 
       layout(editable);
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForward(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tt');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 1);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('handles simple text', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: 'test',
+            selection: TextSelection.collapsed(offset: 3),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 3),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      expect(delegate.textEditingValue.text, 'tet');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 2);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('handles surrogate pairs', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: '\u{1F44D}',
+            selection: TextSelection.collapsed(offset: 2),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '\u{1F44D}',  // Thumbs up
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 2),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      expect(delegate.textEditingValue.text, '');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-  });
-
-  group('deleteForwardByWord', () {
-    test('when cursor is on the middle of a word, it should delete the next part of the word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 6;
+    test('handles grapheme clusters', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
+            text: '0123👨‍👩‍👦2345',
+            selection: TextSelection.collapsed(offset: 12),
           );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
@@ -2477,31 +1646,30 @@ void main() {
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
-          text: text,
+          text: '0123👨‍👩‍👦2345',
           style: TextStyle(
             height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
         ),
-        selection: const TextSelection.collapsed(offset: offset),
+        selection: const TextSelection.collapsed(offset: 12),
       );
 
       layout(editable);
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test w multiple blocks');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      expect(delegate.textEditingValue.text, '01232345');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
+      expect(delegate.textEditingValue.selection.baseOffset, 4);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('when cursor is before a word, it should delete the whole word', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 10;
+    test('is a no-op at the start of the text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
+            text: 'test',
+            selection: TextSelection.collapsed(offset: 0),
           );
       final ViewportOffset viewportOffset = ViewportOffset.zero();
       final RenderEditable editable = RenderEditable(
@@ -2515,220 +1683,30 @@ void main() {
         startHandleLayerLink: LayerLink(),
         endHandleLayerLink: LayerLink(),
         text: const TextSpan(
-          text: text,
+          text: 'test',
           style: TextStyle(
             height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
         ),
-        selection: const TextSelection.collapsed(offset: offset),
+        selection: const TextSelection.collapsed(offset: 0),
       );
 
       layout(editable);
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test with  blocks');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word', () async {
-      const String text = 'test with   multiple blocks';
-      const int offset = 9;
+    test('handles obscured text', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test with blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when cursor is before tabs, it should delete the tabs and the next word', () async {
-      const String text = 'test with\t\t\tmultiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test with blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when cursor is followed by break line, it should delete the next word', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test with blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when using cjk characters', () async {
-        const String text = '用多個塊測試';
-        const int offset = 0;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-        expect(delegate.textEditingValue.text, '多個塊測試');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, offset);
-      }, skip: isBrowser);
-
-    test('when using rtl', () async {
-      const String text = 'برنامج أهلا بالعالم';
-      const int offset = 0;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.rtl,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, ' أهلا بالعالم');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when input has obscured text, it should delete everything after the selection', () async {
-      const int offset = 4;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test with multiple\n\n words',
-          selection: TextSelection.collapsed(offset: offset),
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 4),
         );
 
       final ViewportOffset viewportOffset = ViewportOffset.zero();
@@ -2749,210 +1727,19 @@ void main() {
             height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
         ),
-        selection: const TextSelection.collapsed(offset: offset),
+        selection: const TextSelection.collapsed(offset: 4),
       );
 
       layout(editable);
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
-      expect(delegate.textEditingValue.text, 'test');
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+
+      expect(delegate.textEditingValue.text, 'tes');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-  });
-
-  group('deleteForwardByLine', () {
-    test('when cursor is on first character of a line, it should delete everything that follows', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 4;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when cursor is on the middle of a word, it should delete delete everything that follows', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 8;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test wit');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when next character is a breakline, it should preserve it', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, text);
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when text is multiline, it should delete until the first line break it finds', () async {
-      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
-      const int offset = 2;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'te\n\nMore stuff right here.\nmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
-    }, skip: isBrowser);
-
-    test('when input has obscured text, it should delete everything after the selection', () async {
-      const int offset = 4;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test with multiple\n\n words',
-          selection: TextSelection.collapsed(offset: offset),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, offset);
+      expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
   });
 


### PR DESCRIPTION
Reverts flutter/flutter#79695

This caused test failures:
```
03:16 +5088 ~14 -1: /b/s/w/ir/k/flutter/packages/flutter/test/rendering/editable_test.dart: RenderEditable registers and unregisters raw keyboard listener correctly [E]
  Expected: 'ow are you'
    Actual: 'how are you'
     Which: is different.
            Expected: ow are you ...
              Actual: how are yo ...
                      ^
             Differ at offset 0

  package:test_api                                   expect
  package:flutter_test/src/widget_tester.dart 440:3  expect
  test/rendering/editable_test.dart 1209:5           main.<fn>
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8850588200510579840/+/steps/run_test.dart_for_framework_tests_shard_and_subshard_libraries/0/logs/stdout/0

\cc @canastro 