### PR TITLE
Support block delete with word and line modifiers

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1130,12 +1130,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
-  /// 
+  ///
   /// {@template flutter.rendering.RenderEditable.whiteSpace}
   /// By default, includeWhitespace is set to true, meaning that whitespace can
   /// be considered a word in itself.  If set to false, the selection will be
@@ -1183,7 +1183,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
@@ -1269,12 +1269,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
-  /// 
+  ///
   /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
@@ -1318,7 +1318,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
-  /// 
+  ///
   /// If [obscureText] is true, it treats the whole text content as
   /// a single word.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1011,7 +1011,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
-  // Deletes the current uncollapsed [selection].
+  // Deletes the current uncollapsed selection.
   void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed == false);
 
@@ -1033,14 +1033,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   // Deletes the from the current collapsed selection to the start of the field.
   //
-  // The given [SelectionChangedCause] indicates the cause of this change and
-  // will be passed to [onSelectionChanged].
+  // The given SelectionChangedCause indicates the cause of this change and
+  // will be passed to onSelectionChanged.
   //
   // See also:
-  //
   //   * _deleteToEnd
   void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed == true);
+
     if (_readOnly || !selection.isValid) {
       return;
     }
@@ -1055,7 +1055,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   // Deletes the from the current collapsed selection to the end of the field.
+  //
+  // The given SelectionChangedCause indicates the cause of this change and
+  // will be passed to onSelectionChanged.
+  //
+  // See also:
+  //   * _deleteToStart
   void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == true);
+
     if (_readOnly || !selection.isValid) {
       return;
     }
@@ -1171,7 +1179,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// See also:
   ///
-  ///   * [deleteForwardByWord], which is same but in the opposite direction.
+  ///   * [deleteForwardByLine], which is same but in the opposite direction.
   void deleteByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
@@ -1298,7 +1306,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// See also:
   ///
-  ///   * [deleteByWord], which is same but in the opposite direction.
+  ///   * [deleteByLine], which is same but in the opposite direction.
   void deleteForwardByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
@@ -1321,7 +1329,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    // When there is a line break, it shouldn't do anything
+    // When there is a line break, it shouldn't do anything.
     final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
     if (isNextCharacterBreakLine) {
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1011,9 +1011,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
-  // Deletes the current uncollapsed [selection]
+  // Deletes the current uncollapsed [selection].
   void _deleteSelection(SelectionChangedCause cause) {
     assert(_selection != null);
+    assert(_selection?.isCollapsed == false);
 
     if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
       return;
@@ -1031,10 +1032,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single character before the current collapsed selection.
+  /// Deletes backwards from the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a single character before the 
+  /// cursor.
+  ///
+  /// If the [selection] is not collapsed, deletes the selection.
   ///
   /// {@template flutter.rendering.RenderEditable.cause}
   /// The given [SelectionChangedCause] indicates the cause of this change and
@@ -1072,15 +1075,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single word before the current collapsed selection.
+  /// Deletes a word before the current selection.
   ///
-  /// If the [selection] is not collapsed then it should delete the text
-  /// contained in the selection.
+  /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1119,15 +1120,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single line before the current collapsed selection.
+  /// Deletes a line before the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1166,15 +1165,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single character after the current collapsed selection.
+  /// Deletes in the foward direction from the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a single character after the 
+  /// cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1205,15 +1203,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single word after the current collapsed selection.
+  /// Deletes a word after the current selection.
   ///
-  /// If the [selection] is not collapsed then it should delete the text
-  /// contained in the selection.
+  /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1252,15 +1248,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a single line after the current collapsed selection.
+  /// Deletes a line after the current selection.
   ///
-  /// If current [selection] is not collapsed then it should delete the text
-  /// within the selection.
+  /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// If the [selection] is not collapsed, deletes the selection.
+  ///
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///
@@ -1304,10 +1298,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If [selectionEnabled] is false, keeps the selection collapsed and just
   /// moves it down.
   ///
-  /// {@template flutter.rendering.RenderEditable.cause}
-  /// The given [SelectionChangedCause] indicates the cause of this change and
-  /// will be passed to [onSelectionChanged].
-  /// {@endtemplate}
+  /// {@macro flutter.rendering.RenderEditable.cause}
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1011,13 +1011,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
+  // Deletes the current uncollapsed [selection]
   void _deleteSelection(SelectionChangedCause cause) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
       return;
     }
-    
+
     final String text = textSelectionDelegate.textEditingValue.text;
     final String textBefore = _selection!.textBefore(text);
     final String textAfter = _selection!.textAfter(text);
@@ -1059,7 +1060,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     if (textBefore.isEmpty) {
       return;
     }
-       
+
     final int characterBoundary = previousCharacter(textBefore.length, textBefore);
     textBefore = textBefore.substring(0, characterBoundary);
 
@@ -1086,11 +1087,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
   void deleteByWord(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
-    }    
-    
+    }
+
     if (!_selection!.isCollapsed) {
       return _deleteSelection(cause);
     }
@@ -1133,7 +1134,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
   void deleteByLine(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }
@@ -1180,7 +1181,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [delete], which is same but in the opposite direction.
   void deleteForward(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }
@@ -1219,18 +1220,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByWord], which is same but in the opposite direction.
   void deleteForwardByWord(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
-    }    
-    
+    }
+
     if (!_selection!.isCollapsed) {
       return _deleteSelection(cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
     String textAfter = _selection!.textAfter(text);
-    
+
     if (textAfter.isEmpty) {
       return;
     }
@@ -1266,7 +1267,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByWord], which is same but in the opposite direction.
   void deleteForwardByLine(SelectionChangedCause cause) {
     assert(_selection != null);
-    
+
     if (_readOnly || !_selection!.isValid) {
       return;
     }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1135,11 +1135,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
+  /// 
+  /// {@template flutter.rendering.RenderEditable.whiteSpace}
+  /// By default, includeWhitespace is set to true, meaning that whitespace can
+  /// be considered a word in itself.  If set to false, the selection will be
+  /// extended past any whitespace and the first word following the whitespace.
+  /// {@endtemplate}
   ///
   /// See also:
   ///
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
-  void deleteByWord(SelectionChangedCause cause) {
+  void deleteByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid) {
@@ -1161,7 +1167,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, false);
+    final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, includeWhitespace);
     textBefore = textBefore.trimRight().substring(0, characterBoundary);
 
     final String textAfter = _selection!.textAfter(text);
@@ -1268,11 +1274,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
+  /// 
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///
   ///   * [deleteByWord], which is same but in the opposite direction.
-  void deleteForwardByWord(SelectionChangedCause cause) {
+  void deleteForwardByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
     if (_readOnly || !_selection!.isValid) {
@@ -1296,7 +1304,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String textBefore = _selection!.textBefore(text);
-    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, false);
+    final int characterBoundary = _getRightByWord(_textPainter, textBefore.length, includeWhitespace);
     textAfter = textAfter.substring(characterBoundary - textBefore.length);
 
     _setTextEditingValue(
@@ -1714,10 +1722,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, `includeWhitespace` is set to true, meaning that whitespace
-  /// can be considered a word in itself.  If set to false, the selection will
-  /// be extended past any whitespace and the first word following the
-  /// whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@template flutter.rendering.RenderEditable.stopAtReversal}
   /// The `stopAtReversal` parameter is false by default, meaning that it's
@@ -1759,12 +1764,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, `includeWhitespace` is set to true, meaning that whitespace
-  /// can be considered a word in itself.  If set to false, the selection will
-  /// be extended past any whitespace and the first word following the
-  /// whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
+  /// 
   ///
   /// See also:
   ///
@@ -1924,9 +1927,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// moved past any whitespace and the first word following the whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///
@@ -2012,9 +2013,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
-  /// By default, includeWhitespace is set to true, meaning that whitespace can
-  /// be considered a word in itself.  If set to false, the selection will be
-  /// moved past any whitespace and the first word following the whitespace.
+  /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1075,7 +1075,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a word before the current selection.
+  /// Deletes a word backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
@@ -1120,7 +1120,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a line before the current selection.
+  /// Deletes a line backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
@@ -1203,7 +1203,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a word after the current selection.
+  /// Deletes a word in the foward direction from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
@@ -1248,7 +1248,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
-  /// Deletes a line after the current selection.
+  /// Deletes a line in the foward direction from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1046,6 +1046,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = selection.textBefore(text);
+
+    if (textBefore.isEmpty) {
+      return;
+    }
+
     final String textAfter = selection.textAfter(text);
     const TextSelection newSelection = TextSelection.collapsed(offset: 0);
     _setTextEditingValue(
@@ -1069,6 +1075,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
+    final String textAfter = selection.textAfter(text);
+
+    if (textAfter.isEmpty) {
+      return;
+    }
+
     final String textBefore = selection.textBefore(text);
     final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
     _setTextEditingValue(
@@ -1101,11 +1113,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
-    }
-
-    // When the text is obscured, the whole thing is treated as one big word.
-    if (obscureText) {
-      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1203,6 +1210,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return _deleteSelection(_selection!, cause);
     }
 
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
+    }
+
     final String text = textSelectionDelegate.textEditingValue.text;
     String textBefore = _selection!.textBefore(text);
     if (textBefore.isEmpty) {
@@ -1253,10 +1265,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final String textBefore = _selection!.textBefore(text);
     String textAfter = _selection!.textAfter(text);
 
-    if (textAfter.isNotEmpty) {
-      final int deleteCount = nextCharacter(0, textAfter);
-      textAfter = textAfter.substring(deleteCount);
+    if (textAfter.isEmpty) {
+      return;
     }
+
+    final int deleteCount = nextCharacter(0, textAfter);
+    textAfter = textAfter.substring(deleteCount);
 
     _setTextEditingValue(
       TextEditingValue(text: textBefore + textAfter, selection: _selection!),
@@ -1767,7 +1781,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// {@macro flutter.rendering.RenderEditable.whiteSpace}
   ///
   /// {@macro flutter.rendering.RenderEditable.stopAtReversal}
-  /// 
+  ///
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1103,12 +1103,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    // When there is a line break, word delete should delete a single character
-    final bool isPreviousCharacterBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
-    if (isPreviousCharacterBreakLine) {
-      return delete(cause);
-    }
-
     final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, false);
     textBefore = textBefore.trimRight().substring(0, characterBoundary);
 
@@ -1230,12 +1224,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (textAfter.isEmpty) {
       return;
-    }
-
-    // When next character is a line break, it should delete a single character
-    final bool isNextCharacterBreakLine = textAfter.codeUnitAt(0) == 0x0A;
-    if (isNextCharacterBreakLine) {
-      return deleteForward(cause);
     }
 
     final String textBefore = _selection!.textBefore(text);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1031,6 +1031,44 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     );
   }
 
+  // Deletes the from the current collapsed selection to the start of the field.
+  //
+  // The given [SelectionChangedCause] indicates the cause of this change and
+  // will be passed to [onSelectionChanged].
+  //
+  // See also:
+  //
+  //   * _deleteToEnd
+  void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == true);
+    if (_readOnly || !selection.isValid) {
+      return;
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textAfter = _selection!.textAfter(text);
+    const TextSelection newSelection = TextSelection.collapsed(offset: 0);
+    _setTextEditingValue(
+      TextEditingValue(text: textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
+  // Deletes the from the current collapsed selection to the end of the field.
+  void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
+    if (_readOnly || !selection.isValid) {
+      return;
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = _selection!.textBefore(text);
+    final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore, selection: newSelection),
+      cause,
+    );
+  }
+
   /// Deletes backwards from the current selection.
   ///
   /// If the [selection] is collapsed, deletes a single character before the
@@ -1055,6 +1093,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big word.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1094,6 +1137,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToStart(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1218,6 +1266,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return _deleteSelection(_selection!, cause);
     }
 
+    // When the text is obscured, the whole thing is treated as one big word.
+    if (obscureText) {
+      return _deleteToEnd(_selection!, cause);
+    }
+
     final String text = textSelectionDelegate.textEditingValue.text;
     String textAfter = _selection!.textAfter(text);
 
@@ -1255,6 +1308,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     if (!_selection!.isCollapsed) {
       return _deleteSelection(_selection!, cause);
+    }
+
+    // When the text is obscured, the whole thing is treated as one big line.
+    if (obscureText) {
+      return _deleteToEnd(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1034,7 +1034,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Deletes backwards from the current selection.
   ///
-  /// If the [selection] is collapsed, deletes a single character before the 
+  /// If the [selection] is collapsed, deletes a single character before the
   /// cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
@@ -1161,7 +1161,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   /// Deletes in the foward direction from the current selection.
   ///
-  /// If the [selection] is collapsed, deletes a single character after the 
+  /// If the [selection] is collapsed, deletes a single character after the
   /// cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1039,14 +1039,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // See also:
   //   * _deleteToEnd
   void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed == true);
+    assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textAfter = _selection!.textAfter(text);
+    final String textAfter = selection.textAfter(text);
     const TextSelection newSelection = TextSelection.collapsed(offset: 0);
     _setTextEditingValue(
       TextEditingValue(text: textAfter, selection: newSelection),
@@ -1062,14 +1062,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   // See also:
   //   * _deleteToStart
   void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
-    assert(selection.isCollapsed == true);
+    assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = _selection!.textBefore(text);
+    final String textBefore = selection.textBefore(text);
     final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
     _setTextEditingValue(
       TextEditingValue(text: textBefore, selection: newSelection),
@@ -1130,6 +1130,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1174,6 +1177,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line before the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1257,6 +1263,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a word after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///
@@ -1301,6 +1310,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// If the [selection] is collapsed, deletes a line after the cursor.
   ///
   /// If the [selection] is not collapsed, deletes the selection.
+  /// 
+  /// If [obscureText] is true, it treats the whole text content as
+  /// a single word.
   ///
   /// {@macro flutter.rendering.RenderEditable.cause}
   ///

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1012,18 +1012,17 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   // Deletes the current uncollapsed [selection].
-  void _deleteSelection(SelectionChangedCause cause) {
-    assert(_selection != null);
-    assert(_selection?.isCollapsed == false);
+  void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
+    assert(selection.isCollapsed == false);
 
-    if (_readOnly || !_selection!.isValid || _selection!.isCollapsed) {
+    if (_readOnly || !selection.isValid || selection.isCollapsed) {
       return;
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
-    final String textBefore = _selection!.textBefore(text);
-    final String textAfter = _selection!.textAfter(text);
-    final int cursorPosition = math.min(_selection!.start, _selection!.end);
+    final String textBefore = selection.textBefore(text);
+    final String textAfter = selection.textAfter(text);
+    final int cursorPosition = math.min(selection.start, selection.end);
 
     final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
     _setTextEditingValue(
@@ -1055,7 +1054,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1094,7 +1093,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1133,7 +1132,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1179,7 +1178,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1216,7 +1215,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;
@@ -1255,7 +1254,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (!_selection!.isCollapsed) {
-      return _deleteSelection(cause);
+      return _deleteSelection(_selection!, cause);
     }
 
     final String text = textSelectionDelegate.textEditingValue.text;

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -36,6 +36,10 @@ class DefaultTextEditingActions extends Actions{
   // are called on which platform.
   static final Map<Type, Action<Intent>> _shortcutsActions = <Type, Action<Intent>>{
     DoNothingAndStopPropagationTextIntent: _DoNothingAndStopPropagationTextAction(),
+    DeleteTextIntent: _DeleteTextAction(),
+    DeleteByWordTextIntent: _DeleteByWordTextAction(),
+    DeleteByLineTextIntent: _DeleteByLineTextAction(),
+    DeleteForwardTextIntent: _DeleteForwardTextAction(),
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
@@ -74,6 +78,34 @@ class _DoNothingAndStopPropagationTextAction extends TextEditingAction<DoNothing
 
   @override
   void invoke(DoNothingAndStopPropagationTextIntent intent, [BuildContext? context]) {}
+}
+
+class _DeleteTextAction extends TextEditingAction<DeleteTextIntent> {
+  @override
+  Object? invoke(DeleteTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.delete(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteByWordTextAction extends TextEditingAction<DeleteByWordTextIntent> {
+  @override
+  Object? invoke(DeleteByWordTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteByLineTextAction extends TextEditingAction<DeleteByLineTextIntent> {
+  @override
+  Object? invoke(DeleteByLineTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteByLine(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForward(SelectionChangedCause.keyboard);
+  }
 }
 
 class _ExpandSelectionLeftByLineTextAction extends TextEditingAction<ExpandSelectionLeftByLineTextIntent> {

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -110,16 +110,16 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
   }
 }
 
-class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardByWordTextIntent> {
   @override
-  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+  Object? invoke(DeleteForwardByWordTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
   }
 }
 
-class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardByLineTextIntent> {
   @override
-  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+  Object? invoke(DeleteForwardByLineTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForwardByLine(SelectionChangedCause.keyboard);
   }
 }

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -92,7 +92,7 @@ class _DeleteTextAction extends TextEditingAction<DeleteTextIntent> {
 class _DeleteByWordTextAction extends TextEditingAction<DeleteByWordTextIntent> {
   @override
   Object? invoke(DeleteByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard);
+    textEditingActionTarget!.renderEditable.deleteByWord(SelectionChangedCause.keyboard, false);
   }
 }
 
@@ -113,7 +113,7 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
 class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardByWordTextIntent> {
   @override
   Object? invoke(DeleteForwardByWordTextIntent intent, [BuildContext? context]) {
-    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
+    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_actions.dart
@@ -40,6 +40,8 @@ class DefaultTextEditingActions extends Actions{
     DeleteByWordTextIntent: _DeleteByWordTextAction(),
     DeleteByLineTextIntent: _DeleteByLineTextAction(),
     DeleteForwardTextIntent: _DeleteForwardTextAction(),
+    DeleteForwardByWordTextIntent: _DeleteForwardByWordTextAction(),
+    DeleteForwardByLineTextIntent: _DeleteForwardByLineTextAction(),
     ExtendSelectionDownTextIntent: _ExtendSelectionDownTextAction(),
     ExtendSelectionLeftByLineTextIntent: _ExtendSelectionLeftByLineTextAction(),
     ExtendSelectionLeftByWordTextIntent: _ExtendSelectionLeftByWordTextAction(),
@@ -105,6 +107,20 @@ class _DeleteForwardTextAction extends TextEditingAction<DeleteForwardTextIntent
   @override
   Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
     textEditingActionTarget!.renderEditable.deleteForward(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardByWordTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForwardByWord(SelectionChangedCause.keyboard);
+  }
+}
+
+class _DeleteForwardByLineTextAction extends TextEditingAction<DeleteForwardTextIntent> {
+  @override
+  Object? invoke(DeleteForwardTextIntent intent, [BuildContext? context]) {
+    textEditingActionTarget!.renderEditable.deleteForwardByLine(SelectionChangedCause.keyboard);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -161,6 +161,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   );
 
   static final Map<LogicalKeySet, Intent> _androidShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -198,6 +204,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -235,6 +247,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -272,6 +290,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -309,6 +333,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionRightByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByWordTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByWordTextIntent(),
@@ -346,6 +376,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -385,6 +421,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   // Web handles its text selection natively and doesn't use any of these
   // shortcuts in Flutter.
   static final Map<LogicalKeySet, Intent> _webShortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -201,6 +201,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
@@ -244,6 +245,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
@@ -287,6 +289,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
@@ -330,6 +333,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow up
     //   * Shift + end
     //   * Shift + home
+    //   * Meta + delete
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
@@ -373,6 +377,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Home
     //   * Shift + end
     //   * Shift + home
+    //   * Control + delete
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
@@ -416,6 +421,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow left
     //   * Meta + shift + arrow right
     //   * Meta + shift + arrow up
+    //   * Meta + delete
   };
 
   // Web handles its text selection natively and doesn't use any of these
@@ -425,6 +431,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -294,11 +294,11 @@ class DefaultTextEditingShortcuts extends Shortcuts {
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),
@@ -382,11 +382,11 @@ class DefaultTextEditingShortcuts extends Shortcuts {
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DeleteTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DeleteByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DeleteByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DeleteForwardTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DeleteForwardByWordTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DeleteForwardByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const MoveSelectionToEndTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const MoveSelectionLeftByLineTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const MoveSelectionRightByLineTextIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -202,6 +202,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _fuchsiaShortcuts = <LogicalKeySet, Intent>{
@@ -246,6 +247,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _iOSShortcuts = <LogicalKeySet, Intent>{
@@ -290,6 +292,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _linuxShortcuts = <LogicalKeySet, Intent>{
@@ -334,6 +337,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _macShortcuts = <LogicalKeySet, Intent>{
@@ -378,6 +382,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Shift + end
     //   * Shift + home
     //   * Control + delete
+    //   * Control + backspace
   };
 
   static final Map<LogicalKeySet, Intent> _windowsShortcuts = <LogicalKeySet, Intent>{
@@ -422,18 +427,20 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Meta + shift + arrow right
     //   * Meta + shift + arrow up
     //   * Meta + delete
+    //   * Meta + backspace
   };
 
   // Web handles its text selection natively and doesn't use any of these
   // shortcuts in Flutter.
   static final Map<LogicalKeySet, Intent> _webShortcuts = <LogicalKeySet, Intent>{
     LogicalKeySet(LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
-    LogicalKeySet(LogicalKeyboardKey.meta): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.backspace): const DoNothingAndStopPropagationTextIntent(),
+    LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowDown): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft): const DoNothingAndStopPropagationTextIntent(),
     LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight): const DoNothingAndStopPropagationTextIntent(),

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -4,7 +4,7 @@
 
 import 'actions.dart';
 
-/// An [Intent] to delete a character
+/// An [Intent] to delete a character in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteTextIntent extends Intent{
@@ -12,7 +12,7 @@ class DeleteTextIntent extends Intent{
   const DeleteTextIntent();
 }
 
-/// An [Intent] to delete a word
+/// An [Intent] to delete a word in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteByWordTextIntent extends Intent{
@@ -20,7 +20,7 @@ class DeleteByWordTextIntent extends Intent{
   const DeleteByWordTextIntent();
 }
 
-/// An [Intent] to delete a line
+/// An [Intent] to delete a line in the backwards direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteByLineTextIntent extends Intent{
@@ -28,7 +28,7 @@ class DeleteByLineTextIntent extends Intent{
   const DeleteByLineTextIntent();
 }
 
-/// An [Intent] to delete a character forward
+/// An [Intent] to delete in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardTextIntent extends Intent{
@@ -36,7 +36,7 @@ class DeleteForwardTextIntent extends Intent{
   const DeleteForwardTextIntent();
 }
 
-/// An [Intent] to delete a word forward
+/// An [Intent] to delete a word in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardByWordTextIntent extends Intent{
@@ -44,7 +44,7 @@ class DeleteForwardByWordTextIntent extends Intent{
   const DeleteForwardByWordTextIntent();
 }
 
-/// An [Intent] to delete a line forward
+/// An [Intent] to delete a line in the forward direction.
 ///
 /// {@macro flutter.widgets.TextEditingIntents.seeAlso}
 class DeleteForwardByLineTextIntent extends Intent{

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -4,6 +4,54 @@
 
 import 'actions.dart';
 
+/// An [Intent] to delete a character
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteTextIntent extends Intent{
+  /// Creates an instance of DeleteTextIntent.
+  const DeleteTextIntent();
+}
+
+/// An [Intent] to delete a word
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByWordTextIntent extends Intent{
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteByWordTextIntent();
+}
+
+/// An [Intent] to delete a line
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByLineTextIntent extends Intent{
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteByLineTextIntent();
+}
+
+/// An [Intent] to delete a character forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardTextIntent extends Intent{
+  /// Creates an instance of DeleteForwardTextIntent.
+  const DeleteForwardTextIntent();
+}
+
+/// An [Intent] to delete a word forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByWordTextIntent extends Intent{
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteForwardByWordTextIntent();
+}
+
+/// An [Intent] to delete a line forward
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByLineTextIntent extends Intent{
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteForwardByLineTextIntent();
+}
+
 /// An [Intent] to send the event straight to the engine, but only if a
 /// TextEditingTarget is focused.
 ///

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -962,8 +962,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 0);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, 'est');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1013,8 +1012,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, '01236789');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1064,8 +1062,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 4);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, '01232345');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1170,8 +1167,7 @@ void main() {
     expect(editable.selection?.isCollapsed, true);
     expect(editable.selection?.baseOffset, 3);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+     editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, 'W Sczebrzeszynie chrząszcz brzmi w trzcinie');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
@@ -1618,7 +1614,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
-  
+
     test('when using cjk characters', () async {
         const String text = '用多個塊測試';
         const int offset = 4;
@@ -1656,7 +1652,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = text.length;
@@ -1924,7 +1920,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = text.length;
@@ -2229,7 +2225,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
-  
+
     test('when using cjk characters', () async {
         const String text = '用多個塊測試';
         const int offset = 0;
@@ -2267,7 +2263,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 0);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = 0;
@@ -2301,11 +2297,11 @@ void main() {
       pumpFrame();
 
       editable.deleteForward(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم'); 
+      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
- 
+
   });
 
   group('deleteForwardByWord', () {
@@ -2536,7 +2532,7 @@ void main() {
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, offset);
       }, skip: isBrowser);
-  
+
     test('when using rtl', () async {
       const String text = 'برنامج أهلا بالعالم';
       const int offset = 0;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1958,6 +1958,45 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
     }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything before the selection', () async {
+      const int offset = 21;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'words');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
   });
 
   group('deleteByLine', () {
@@ -2111,6 +2150,45 @@ void main() {
       expect(delegate.textEditingValue.text, 'test with\n\nright here.\nmultiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything before the selection', () async {
+      const int offset = 21;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'words');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser);
   });
 
@@ -2569,6 +2647,45 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything after the selection', () async {
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
   });
 
   group('deleteForwardByLine', () {
@@ -2720,6 +2837,45 @@ void main() {
 
       editable.deleteForwardByLine(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'te\n\nMore stuff right here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+  
+    test('when input has obscured text, it should delete everything after the selection', () async {
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test with multiple\n\n words',
+          selection: TextSelection.collapsed(offset: offset),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1725,10 +1725,48 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test h multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 10;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 9);
     }, skip: isBrowser);
 
     test('when cursor is after a word, it should delete the whole word', () async {
@@ -1763,7 +1801,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test  multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1801,7 +1839,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1839,7 +1877,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1877,7 +1915,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 5);
@@ -1915,7 +1953,7 @@ void main() {
         editable.hasFocus = true;
         pumpFrame();
 
-        editable.deleteByWord(SelectionChangedCause.keyboard);
+        editable.deleteByWord(SelectionChangedCause.keyboard, false);
         expect(delegate.textEditingValue.text, '用多個測試');
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
@@ -1953,7 +1991,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'برنامج أهلا ');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
@@ -1992,7 +2030,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteByWord(SelectionChangedCause.keyboard);
+      editable.deleteByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'words');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
@@ -2229,6 +2267,44 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 1);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
+    test('when includeWhiteSpace is true, it should treat a whiteSpace as a single word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test withmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 9);
+    }, skip: isBrowser);
+
     test('when at the end of a text, it should be a no-op', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
@@ -2414,7 +2490,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test w multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2452,7 +2528,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with  blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2490,7 +2566,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2528,7 +2604,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2566,7 +2642,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2604,7 +2680,7 @@ void main() {
         editable.hasFocus = true;
         pumpFrame();
 
-        editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+        editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
         expect(delegate.textEditingValue.text, '多個塊測試');
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2642,7 +2718,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, ' أهلا بالعالم');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
@@ -2681,7 +2757,7 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard, false);
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1958,7 +1958,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 12);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything before the selection', () async {
       const int offset = 21;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2151,7 +2151,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 11);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything before the selection', () async {
       const int offset = 21;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2647,7 +2647,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything after the selection', () async {
       const int offset = 4;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2840,7 +2840,7 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-  
+
     test('when input has obscured text, it should delete everything after the selection', () async {
       const int offset = 4;
       final TextSelectionDelegate delegate = FakeEditableTextState()

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1401,7 +1401,7 @@ void main() {
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/58068
 
   group('delete', () {
-    test('handles selection', () async {
+    test('when as a non-collapsed selection, it should delete a selection', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1431,130 +1431,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tt');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 1);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('is a no-op at the end of the text', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection.collapsed(offset: 4),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 4),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
-      expect(delegate.textEditingValue.text, 'test');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 4);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('handles obscured text', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-          text: 'test',
-          selection: TextSelection.collapsed(offset: 0),
-        );
-
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        obscureText: true,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: '****',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection.collapsed(offset: 0),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
-
-      expect(delegate.textEditingValue.text, 'est');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
-  });
-
-  group('backspace', () {
-    test('handles selection', () async {
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
-            text: 'test',
-            selection: TextSelection(baseOffset: 1, extentOffset: 3),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: 'test',
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-          ),
-        ),
-        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
-      );
-
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
-
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      expect(delegate.textEditingValue.text, 'tt');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 1);
-    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
-
-    test('handles simple text', () async {
+    test('when as simple text, it should delete the character to the left', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1584,14 +1467,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tet');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 2);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles surrogate pairs', () async {
+    test('when has surrogate pairs, it should delete the pair', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: '\u{1F44D}',
@@ -1621,14 +1503,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, '');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles grapheme clusters', () async {
+    test('when has grapheme clusters, it should delete the grapheme cluster', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: '0123👨‍👩‍👦2345',
@@ -1658,14 +1539,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, '01232345');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 4);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('is a no-op at the start of the text', () async {
+    test('when is at the start of the text, it should be a no-op', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: 'test',
@@ -1695,14 +1575,13 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'test');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 0);
     }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 
-    test('handles obscured text', () async {
+    test('when input has obscured text, it should delete the character to the left', () async {
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
           text: 'test',
@@ -1734,12 +1613,1120 @@ void main() {
       editable.hasFocus = true;
       pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace, platform: 'android');
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace, platform: 'android');
-
+      editable.delete(SelectionChangedCause.keyboard);
       expect(delegate.textEditingValue.text, 'tes');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
+    }, skip: isBrowser);
+  
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 4;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.delete(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '用多個測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 3);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.delete(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'برنامج أهلا بالعال');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, text.length - 1);
+    }, skip: isBrowser);
+  });
+
+  group('deleteByWord', () {
+    test('when cursor is on the middle of a word, it should delete the left part of the word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is after a word, it should delete the whole word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test  multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word to the left', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by tabs spaces', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 4;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteByWord(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '用多個測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 3);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'برنامج أهلا ');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 12);
+    }, skip: isBrowser);
+  });
+
+  group('deleteByLine', () {
+    test('when cursor is on last character of a word, it should delete everything to the left', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, '');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('when cursor is on the middle of a word, it should delete delete everything to the left', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('when previous character is a breakline, it should preserve it', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, text);
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+
+    test('when text is multiline, it should delete until the first line break it finds', () async {
+      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
+      const int offset = 22;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nright here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+  });
+
+  group('deleteForward', () {
+    test('when as a non-collapsed selection, it should delete a selection', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: 'test',
+            selection: TextSelection(baseOffset: 1, extentOffset: 3),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection(baseOffset: 1, extentOffset: 3),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'tt');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 1);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('when at the end of a text, it should be a no-op', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: 'test',
+            selection: TextSelection.collapsed(offset: 4),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: 'test',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 4),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 4);
+    }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
+
+    test('when the input has obscured text, it should delete the forward character', () async {
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+          text: 'test',
+          selection: TextSelection.collapsed(offset: 0),
+        );
+
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        obscureText: true,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: '****',
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: 0),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'est');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+  
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 0;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteForward(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '多個塊測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 0);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = 0;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForward(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'رنامج أهلا بالعالم'); 
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+ 
+  });
+
+  group('deleteForwardByWord', () {
+    test('when cursor is on the middle of a word, it should delete the next part of the word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 6;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test w multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is before a word, it should delete the whole word', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 10;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with  blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is preceeded by white spaces, it should delete the spaces and the next word', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is before tabs, it should delete the tabs and the next word', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is followed by break line, it should delete a single break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when using cjk characters', () async {
+        const String text = '用多個塊測試';
+        const int offset = 0;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+        expect(delegate.textEditingValue.text, '多個塊測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, offset);
+      }, skip: isBrowser);
+  
+    test('when using rtl', () async {
+      const String text = 'برنامج أهلا بالعالم';
+      const int offset = 0;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.rtl,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByWord(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, ' أهلا بالعالم');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+  });
+
+  group('deleteForwardByLine', () {
+    test('when cursor is on first character of a line, it should delete everything that follows', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when cursor is on the middle of a word, it should delete delete everything that follows', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'test wit');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when next character is a breakline, it should preserve it', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, text);
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
+    }, skip: isBrowser);
+
+    test('when text is multiline, it should delete until the first line break it finds', () async {
+      const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
+      const int offset = 2;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      editable.deleteForwardByLine(SelectionChangedCause.keyboard);
+      expect(delegate.textEditingValue.text, 'te\n\nMore stuff right here.\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
   });
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1845,9 +1845,9 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 5);
     }, skip: isBrowser);
 
-    test('when cursor is preceeded by break line', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
+    test('when cursor is preceeded by break line, it should delete the breaking line and the word right before it', () async {
+      const String text = 'test with\nmultiple blocks';
+      const int offset = 10;
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: text,
@@ -1878,9 +1878,9 @@ void main() {
       pumpFrame();
 
       editable.deleteByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 11);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
     }, skip: isBrowser);
 
     test('when using cjk characters', () async {
@@ -2038,8 +2038,8 @@ void main() {
     }, skip: isBrowser);
 
     test('when previous character is a breakline, it should preserve it', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
+      const String text = 'test with\nmultiple blocks';
+      const int offset = 10;
       final TextSelectionDelegate delegate = FakeEditableTextState()
         ..textEditingValue = const TextEditingValue(
             text: text,
@@ -2074,7 +2074,6 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
-
 
     test('when text is multiline, it should delete until the first line break it finds', () async {
       const String text = 'test with\n\nMore stuff right here.\nmultiple blocks';
@@ -2457,7 +2456,7 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);
 
-    test('when cursor is followed by break line, it should delete a single break line', () async {
+    test('when cursor is followed by break line, it should delete the next word', () async {
       const String text = 'test with\n\n\nmultiple blocks';
       const int offset = 9;
       final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -2490,7 +2489,7 @@ void main() {
       pumpFrame();
 
       editable.deleteForwardByWord(SelectionChangedCause.keyboard);
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.text, 'test with blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, offset);
     }, skip: isBrowser);

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -2000,7 +2000,7 @@ void main() {
   });
 
   group('deleteByLine', () {
-    test('when cursor is on last character of a word, it should delete everything to the left', () async {
+    test('when cursor is on last character of a line, it should delete everything to the left', () async {
       const String text = 'test with multiple blocks';
       const int offset = text.length;
       final TextSelectionDelegate delegate = FakeEditableTextState()

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1111,8 +1111,7 @@ void main() {
     expect(currentSelection.isCollapsed, true);
     expect(currentSelection.baseOffset, 0);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, '');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1204,8 +1204,7 @@ void main() {
     final PipelineOwner pipelineOwner = PipelineOwner();
     editable.attach(pipelineOwner);
 
-    await simulateKeyDownEvent(LogicalKeyboardKey.delete, platform: 'android');
-    await simulateKeyUpEvent(LogicalKeyboardKey.delete, platform: 'android');
+    editable.deleteForward(SelectionChangedCause.keyboard);
     expect(delegate.textEditingValue.text, 'ow are you');
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61021
 


### PR DESCRIPTION
This PR focuses on supporting modifiers to delete blocks of text in a editable widget.

### Shortcuts per OS
* macOS
  * **CMD (⌘) + Backspace**: Delete all words left to the cursor
  * **Option + Backspace**: Delete word left to the cursor
* Non macOS
  * **Alt + Backspace**: Delete all words left to the cursor
  * **Ctrl + Backspace**: Delete word left to the cursor

### Some cases for reference:

**case: 'text with| multiple words'**
word modifier + backspace: 'text | multiple words'
line modifier + backspace: '| multiple words'
word modifier + delete: 'text with| words'
line modifier + delete: 'text with|'

**case: 'text with multiple\n|words'**
word modifier + backspace: 'text with |words'
line modifier + backspace: 'text with multiple\n|words'
word modifier + delete: 'text with multiple\n|'
line modifier + delete: 'text with multiple\n|'

**case: 'text with multiple|\nwords'**
word modifier + backspace: 'text with |\nwords'
line modifier + backspace: '|\nwords'
word modifier + delete: 'text with multiple|'
line modifier + delete: 'text with multiple|\nwords'

**case: 'text with\n|\nmultiple words' in obscure text**
word modifier + backspace: '|\nmultiple words'
line modifier + backspace: '|\nmultiple words'
word modifier + delete: 'text with\n|'
line modifier + delete: 'text with\n|'

**case: 用多個塊測試** (cursor at offset 4)
backspace: '用多個測試' (cursor at offset 3)
word modifier + backspace: '用多個測試' (cursor at offset 3)
line modifier + backspace: '測試' (cursor at offset 0)
word modifier + delete: '用多個塊試' (cursor at offset 4)
line modifier + delete: '用多個塊' (cursor at offset 4)

**case: برنامج أهلا بالعالم** (cursor at offset 4 - from the right)
backspace: برنمج أهلا بالعالم  (cursor at offset 3 - from the right)
word modifier + backspace: مج أهلا بالعالم (cursor at offset 0 - from the right)
word modifier + delete: برنا أهلا بالعالم  (cursor at offset 4 - from the right)

### Related issue: 
* Fixes https://github.com/flutter/flutter/issues/57015
* Fixes https://github.com/flutter/flutter/issues/77547

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
