### PR TITLE
Use testUsingContext in downgrade_upgrade_integration_test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 
 import '../src/common.dart';
+import '../src/context.dart';
 import 'test_utils.dart';
 
 const String _kInitialVersion = 'v1.9.1';
@@ -26,7 +27,6 @@ final ProcessUtils processUtils = ProcessUtils(processManager: processManager, l
   outputPreferences: OutputPreferences.test(wrapText: true),
 ));
 final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
-final String dartBin = fileSystem.path.join(getFlutterRoot(), 'bin', platform.isWindows ? 'dart.bat' : 'dart');
 
 /// A test for flutter upgrade & downgrade that checks out a parallel flutter repo.
 void main() {
@@ -46,7 +46,7 @@ void main() {
     }
   });
 
-  testWithoutContext('Can upgrade and downgrade a Flutter checkout', () async {
+  testUsingContext('Can upgrade and downgrade a Flutter checkout', () async {
     final Directory testDirectory = parentDirectory.childDirectory('flutter');
     testDirectory.createSync(recursive: true);
 


### PR DESCRIPTION
`downgrade_upgrade_integration_test` fails locally when run via
```
$ flutter test test/integration.shard/downgrade_upgrade_integration_test.dart
...
Step 4 - upgrade to the newest dev
test/src/common.dart 207:5                                            _NoContext.get
package:flutter_tools/src/globals_null_migrated.dart 157:45           shutdownHooks
package:flutter_tools/src/globals_null_migrated.dart 166:3            localFileSystem
test/src/common.dart 64:49                                            getFlutterRoot
test/integration.shard/downgrade_upgrade_integration_test.dart 28:48  flutterBin
test/integration.shard/downgrade_upgrade_integration_test.dart        flutterBin
test/integration.shard/downgrade_upgrade_integration_test.dart 91:7   main.<fn>

Unsupported operation: context.get<ShutdownHooks> is not supported in test methods. Use Testbed or testUsingContext if accessing Zone injected values.
```

It succeeds on LUCI because that `getFlutterRoot` is bypassed because the `FLUTTER_ROOT` env is set when run as:
```
$ SHARD=tool_integration_tests dart dev/bots/test.dart
```

Use `testUsingContext` instead of `testWithoutContext`.