### PR TITLE
[flutter_tools] handle out of date xcode config in assemble

### DIFF
--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -291,7 +291,15 @@ class AssembleCommand extends FlutterCommand {
       }
     }
     Target target;
-    final List<String> decodedDefines = decodeDartDefines(environment.defines, kDartDefines);
+    List<String> decodedDefines;
+    try {
+      decodedDefines = decodeDartDefines(environment.defines, kDartDefines);
+    } on FormatException {
+      throwToolExit(
+        'Error parsing assemble command: your generated configuration may be out of date. '
+        "Try re-running 'flutter build ios' or the appropriate build command."
+      );
+    }
     if (FlutterProject.current().manifest.deferredComponents != null
         && decodedDefines.contains('validate-deferred-components=true')
         && deferredTargets.isNotEmpty

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -90,7 +90,6 @@ List<Target> _kDefaultTargets = <Target>[
 // When fixing this, remove the hack in test/general.shard/args_test.dart that ignores these names.
 const bool useLegacyNames = true;
 
-
 /// Assemble provides a low level API to interact with the flutter tool build
 /// system.
 class AssembleCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -90,6 +90,7 @@ List<Target> _kDefaultTargets = <Target>[
 // When fixing this, remove the hack in test/general.shard/args_test.dart that ignores these names.
 const bool useLegacyNames = true;
 
+
 /// Assemble provides a low level API to interact with the flutter tool build
 /// system.
 class AssembleCommand extends FlutterCommand {

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -99,6 +99,28 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
   });
 
+  testUsingContext('flutter assemble throws ToolExit if dart-defines are not base64 encoded', () async {
+    final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand(
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+    ));
+
+    final List<String> command = <String>[
+      'assemble',
+      '--output',
+      'Output',
+      '--DartDefines=flutter.inspector.structuredErrors%3Dtrue',
+      'debug_macos_bundle_flutter_assets',
+    ];
+    expect(
+      commandRunner.run(command),
+      throwsToolExit(message: 'Error parsing assemble command: your generated configuration may be out of date')
+    );
+  }, overrides: <Type, Generator>{
+    Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
   testUsingContext('flutter assemble throws ToolExit if called with non-existent rule', () async {
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand(
       buildSystem: TestBuildSystem.all(BuildResult(success: true)),


### PR DESCRIPTION
Fixes #78904

If a generated xcconfig is really out of date, it will hit a base64 encode error since we migrated this encoding from URI based stuff to fix windows desktop. Catch the error and rethrow a specific tool exit.