### PR TITLE
[flutter_tools] add method to check if feature flag can be enabled on a given channel

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -57,6 +57,9 @@ abstract class FeatureFlags {
   ///
   /// Prefer using one of the specific getters above instead of this API.
   bool isEnabled(Feature feature) => false;
+
+  /// Whether the feature can be enabled on the current channel.
+  bool canBeEnabled(Feature feature) => true;
 }
 
 /// All current Flutter feature flags.

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -78,4 +78,11 @@ class FlutterFeatureFlags implements FeatureFlags {
     }
     return isEnabled;
   }
+
+  @override
+  bool canBeEnabled(Feature feature) {
+    final String currentChannel = _flutterVersion.channel;
+    final FeatureChannelSetting featureSetting = feature.getSettingForChannel(currentChannel);
+    return featureSetting.available;
+  }
 }

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -76,6 +76,25 @@ void main() {
       expect(feature.getSettingForChannel('unknown'), masterSetting);
     });
 
+    testWithoutContext('canBeEnabled only checks the channel for compatibility', () {
+      const FeatureChannelSetting masterSetting = FeatureChannelSetting(available: true);
+      const FeatureChannelSetting devSetting = FeatureChannelSetting(available: true);
+      const FeatureChannelSetting betaSetting = FeatureChannelSetting(available: false);
+      const FeatureChannelSetting stableSetting = FeatureChannelSetting(available: false);
+      const Feature feature = Feature(
+        name: 'example',
+        master: masterSetting,
+        dev: devSetting,
+        beta: betaSetting,
+        stable: stableSetting,
+      );
+
+      expect(createFlags('master').canBeEnabled(feature), true);
+      expect(createFlags('dev').canBeEnabled(feature), true);
+      expect(createFlags('beta').canBeEnabled(feature), false);
+      expect(createFlags('stable').canBeEnabled(feature), false);
+    });
+
     testWithoutContext('env variables are only enabled with "true" string', () {
       platform.environment = <String, String>{'FLUTTER_WEB': 'hello'};
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -628,6 +628,9 @@ class TestFeatureFlags implements FeatureFlags {
     }
     return false;
   }
+
+  @override
+  bool canBeEnabled(Feature feature) => true;
 }
 
 class FakeStatusLogger extends DelegatingLogger {


### PR DESCRIPTION
So that we can avoid expose the UWP stuff until it is ready for https://github.com/flutter/flutter/pull/79977