### PR TITLE
Add a potentially missing TextSelectionOverlay dispose

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2139,7 +2139,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // EditableWidget, not just changes triggered by user gestures.
     requestKeyboard();
     if (widget.selectionControls == null) {
-      _selectionOverlay?.hide();
+      _selectionOverlay!.dispose();
       _selectionOverlay = null;
     } else {
       if (_selectionOverlay == null) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2139,7 +2139,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     // EditableWidget, not just changes triggered by user gestures.
     requestKeyboard();
     if (widget.selectionControls == null) {
-      _selectionOverlay!.dispose();
+      _selectionOverlay?.dispose();
       _selectionOverlay = null;
     } else {
       if (_selectionOverlay == null) {


### PR DESCRIPTION
This is an attempt at fixing a crash that has no repro yet where _selectionOverlay was used when it was null.  There seems to be a case where _selectionOverlay was not disposed when it should have been.