### PR TITLE
[flutter_tools] add timeline ANR integration test

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
@@ -55,6 +55,50 @@ class BasicProject extends Project {
   int get topLevelFunctionBreakpointLine => lineContaining(main, '// TOP LEVEL BREAKPOINT');
 }
 
+class BasicProjectWithTimelineTraces extends Project {
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ">=2.12.0-0 <3.0.0"
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'''
+  import 'dart:async';
+  import 'dart:developer';
+
+  import 'package:flutter/material.dart';
+
+  Future<void> main() async {
+    while (true) {
+      runApp(new MyApp());
+      await Future.delayed(const Duration(milliseconds: 50));
+      Timeline.instantSync('main');
+    }
+  }
+
+  class MyApp extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      topLevelFunction();
+      return new MaterialApp( // BUILD BREAKPOINT
+        title: 'Flutter Demo',
+        home: new Container(),
+      );
+    }
+  }
+
+  topLevelFunction() {
+    print("topLevelFunction"); // TOP LEVEL BREAKPOINT
+  }
+  ''';
+}
+
 class BasicProjectWithFlutterGen extends Project {
   @override
   final String generatedFile = '''

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -843,7 +843,11 @@ class SourcePosition {
 
 Future<Isolate> waitForExtension(VmService vmService, String extension) async {
   final Completer<void> completer = Completer<void>();
-  await vmService.streamListen(EventStreams.kExtension);
+  try {
+    await vmService.streamListen(EventStreams.kExtension);
+  } on RPCError {
+    // Do nothing, already subscribed.
+  }
   vmService.onExtensionEvent.listen((Event event) {
     if (event.json['extensionKind'] == 'Flutter.FrameworkInitialization') {
       completer.complete();

--- a/packages/flutter_tools/test/integration.shard/timeline_test.dart
+++ b/packages/flutter_tools/test/integration.shard/timeline_test.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter_tools/test/integration.shard/timeline_test.dart
+++ b/packages/flutter_tools/test/integration.shard/timeline_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/integration.shard/timeline_test.dart
+++ b/packages/flutter_tools/test/integration.shard/timeline_test.dart
@@ -1,0 +1,73 @@
+
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+import '../src/common.dart';
+import 'test_data/basic_project.dart';
+import 'test_driver.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  FlutterRunTestDriver flutter;
+  VmService vmService;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('vmservice_integration_test.');
+
+    final BasicProjectWithTimelineTraces project = BasicProjectWithTimelineTraces();
+    await project.setUpIn(tempDir);
+
+    flutter = FlutterRunTestDriver(tempDir);
+    await flutter.run(withDebugger: true);
+    final int port = flutter.vmServicePort;
+    vmService = await vmServiceConnectUri('ws://localhost:$port/ws');
+  });
+
+  tearDown(() async {
+    await flutter?.stop();
+    tryToDelete(tempDir);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/79498
+  testWithoutContext('Can connect to the timeline without getting ANR from the application', () async {
+    final Timer timer = Timer(const Duration(minutes: 5), () {
+      print(
+        'Warning: test isolate is still active after 5 minutes. This is likely an '
+        'app-not-responding error and not a flake. See https://github.com/flutter/flutter/issues/79498 '
+        'for the bug this test is attempting to exercise.'
+      );
+    });
+    await vmService.streamListen(EventStreams.kVM);
+    await vmService.streamListen(EventStreams.kIsolate);
+    await vmService.streamListen(EventStreams.kDebug);
+    await vmService.streamListen(EventStreams.kGC);
+    await vmService.streamListen(EventStreams.kExtension);
+    await vmService.streamListen(EventStreams.kTimeline);
+    await vmService.streamListen(EventStreams.kLogging);
+    await vmService.streamListen(EventStreams.kService);
+    await vmService.streamListen(EventStreams.kHeapSnapshot);
+    await vmService.streamListen(EventStreams.kStdout);
+    await vmService.streamListen(EventStreams.kStderr);
+    await Future<void>.delayed(const Duration(seconds: 10));
+
+    // Verify that the app can be interacted with by querying the brightness
+    final Isolate isolate = await waitForExtension(vmService, 'ext.flutter.brightnessOverride');
+    final Response response = await vmService.callServiceExtension(
+      'ext.flutter.brightnessOverride',
+      isolateId: isolate.id,
+    );
+    expect(response.json['value'], 'Brightness.light');
+    timer.cancel();
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/timeline_test.dart
+++ b/packages/flutter_tools/test/integration.shard/timeline_test.dart
@@ -64,17 +64,20 @@ void main() {
     ]);
 
 
-    // Verify that the app can be interacted with by querying the brightness.
-    // There may be a delay before the app stops responding, so poll for at least
-    // 30 seconds.
+    // Verify that the app can be interacted with by querying the brightness
+    // for 30 seconds. Once this time has elapsed, wait for any pending requests and
+    // exit. If the app stops responding, the requests made will hang.
+    bool interactionCompleted = false;
+    Timer(const Duration(seconds: 30), () {
+      interactionCompleted = true;
+    });
     final Isolate isolate = await waitForExtension(vmService, 'ext.flutter.brightnessOverride');
-    for (int i = 0; i < 10; i++) {
+    while (!interactionCompleted) {
       final Response response = await vmService.callServiceExtension(
         'ext.flutter.brightnessOverride',
         isolateId: isolate.id,
       );
       expect(response.json['value'], 'Brightness.light');
-      await Future<void>.delayed(const Duration(seconds: 3));
     }
     timer.cancel();
   });


### PR DESCRIPTION
To prevent https://github.com/flutter/flutter/issues/79498 from being able to roll into the framework, add a test which subscribes to all event streams, logs some timeline traces, and then checks if the app is responsive.

The nature of the bug means that this test will hang forever if it fails. To prevent this from being diagnosed as an infra issue, I added a 5 minute warning message which links to the bug in question.