### PR TITLE
[flutter_tools] Allow flutter build aar to know the null safety mode ahead of time

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -37,6 +37,7 @@ class BuildAarCommand extends BuildSubCommand {
         help: 'Build a release version of the current project.',
       );
     addTreeShakeIconsFlag();
+    usesTargetOption();
     usesFlavorOption();
     usesBuildNumberOption();
     usesPubOption();
@@ -131,7 +132,7 @@ class BuildAarCommand extends BuildSubCommand {
     displayNullSafetyMode(androidBuildInfo.first.buildInfo);
     await androidBuilder.buildAar(
       project: _getProject(),
-      target: '', // Not needed because this command only builds Android's code.
+      target: targetFile,
       androidBuildInfo: androidBuildInfo,
       outputDirectoryPath: stringArg('output-dir'),
       buildNumber: buildNumber,

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 // @dart = 2.8
-
 import 'package:meta/meta.dart';
 
 import '../android/android_builder.dart';
 import '../android/gradle_utils.dart';
 import '../base/common.dart';
+
+import '../base/file_system.dart';
 import '../base/os.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -37,7 +38,6 @@ class BuildAarCommand extends BuildSubCommand {
         help: 'Build a release version of the current project.',
       );
     addTreeShakeIconsFlag();
-    usesTargetOption();
     usesFlavorOption();
     usesBuildNumberOption();
     usesPubOption();
@@ -97,7 +97,9 @@ class BuildAarCommand extends BuildSubCommand {
       'By default, AARs are built for `release`, `debug` and `profile`.\n'
       'The POM file is used to include the dependencies that the AAR was compiled against.\n'
       'To learn more about how to use these artifacts, see '
-      'https://flutter.dev/go/build-aar';
+      'https://flutter.dev/go/build-aar\n'
+      'Note: this command builds applications assuming that the entrypoint is lib/main.dart. '
+      'This cannot currently be configured.';
 
   @override
   Future<FlutterCommandResult> runCommand() async {
@@ -115,11 +117,15 @@ class BuildAarCommand extends BuildSubCommand {
       ? stringArg('build-number')
       : '1.0';
 
+    final File targetFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'));
     for (final String buildMode in const <String>['debug', 'profile', 'release']) {
       if (boolArg(buildMode)) {
         androidBuildInfo.add(
           AndroidBuildInfo(
-            await getBuildInfo(forcedBuildMode: BuildMode.fromName(buildMode)),
+            await getBuildInfo(
+              forcedBuildMode: BuildMode.fromName(buildMode),
+              forcedTargetFile: targetFile,
+            ),
             targetArchs: targetArchitectures,
           )
         );
@@ -132,7 +138,7 @@ class BuildAarCommand extends BuildSubCommand {
     displayNullSafetyMode(androidBuildInfo.first.buildInfo);
     await androidBuilder.buildAar(
       project: _getProject(),
-      target: targetFile,
+      target: targetFile.path,
       androidBuildInfo: androidBuildInfo,
       outputDirectoryPath: stringArg('output-dir'),
       buildNumber: buildNumber,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -836,7 +836,7 @@ abstract class FlutterCommand extends Command<void> {
   ///
   /// Throws a [ToolExit] if the current set of options is not compatible with
   /// each other.
-  Future<BuildInfo> getBuildInfo({ BuildMode forcedBuildMode }) async {
+  Future<BuildInfo> getBuildInfo({ BuildMode forcedBuildMode, File forcedTargetFile }) async {
     final bool trackWidgetCreation = argParser.options.containsKey('track-widget-creation') &&
       boolArg('track-widget-creation');
 
@@ -886,8 +886,8 @@ abstract class FlutterCommand extends Command<void> {
       // passing a flag. Examine the entrypoint file to determine if it
       // is opted in or out.
       final bool wasNullSafetyFlagParsed = argResults.wasParsed(FlutterOptions.kNullSafety);
-      if (!wasNullSafetyFlagParsed && argParser.options.containsKey('target')) {
-        final File entrypointFile = globals.fs.file(targetFile);
+      if (!wasNullSafetyFlagParsed && (argParser.options.containsKey('target') || forcedTargetFile != null)) {
+        final File entrypointFile = forcedTargetFile ?? globals.fs.file(targetFile);
         final LanguageVersion languageVersion = determineLanguageVersion(
           entrypointFile,
           packageConfig.packageOf(entrypointFile.absolute.uri),

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -188,6 +188,28 @@ void main() {
     }, overrides: <Type, Generator>{
       AndroidBuilder: () => fakeAndroidBuilder,
     });
+
+    testUsingContext('supports configuring the target file', () async {
+      final String projectPath = await createProject(tempDir,
+        arguments: <String>['--no-pub']);
+      final File entrypoint = globals.fs.file(globals.fs.path.join(projectPath, 'lib', 'foo.dart'))
+        ..createSync(recursive: true);
+      await runCommandIn(
+        projectPath,
+        arguments: <String>[
+          '--no-debug',
+          '--no-profile',
+          '-t',
+          entrypoint.path,
+          '--target-platform',
+          'android-x86',
+        ],
+      );
+
+      expect(fakeAndroidBuilder.target,  entrypoint.path);
+    }, overrides: <Type, Generator>{
+      AndroidBuilder: () => fakeAndroidBuilder,
+    });
   });
 
   group('Gradle', () {

--- a/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_aar_test.dart
@@ -185,28 +185,7 @@ void main() {
       expect(buildInfo.splitDebugInfoPath, '/project-name/v1.2.3/');
       expect(buildInfo.dartObfuscation, isTrue);
       expect(buildInfo.dartDefines.contains('foo=bar'), isTrue);
-    }, overrides: <Type, Generator>{
-      AndroidBuilder: () => fakeAndroidBuilder,
-    });
-
-    testUsingContext('supports configuring the target file', () async {
-      final String projectPath = await createProject(tempDir,
-        arguments: <String>['--no-pub']);
-      final File entrypoint = globals.fs.file(globals.fs.path.join(projectPath, 'lib', 'foo.dart'))
-        ..createSync(recursive: true);
-      await runCommandIn(
-        projectPath,
-        arguments: <String>[
-          '--no-debug',
-          '--no-profile',
-          '-t',
-          entrypoint.path,
-          '--target-platform',
-          'android-x86',
-        ],
-      );
-
-      expect(fakeAndroidBuilder.target,  entrypoint.path);
+      expect(buildInfo.nullSafetyMode, NullSafetyMode.sound);
     }, overrides: <Type, Generator>{
       AndroidBuilder: () => fakeAndroidBuilder,
     });

--- a/packages/flutter_tools/test/src/test_flutter_command_runner.dart
+++ b/packages/flutter_tools/test/src/test_flutter_command_runner.dart
@@ -37,8 +37,6 @@ Future<String> createProject(Directory temp, { List<String> arguments }) async {
   final CreateCommand command = CreateCommand();
   final CommandRunner<void> runner = createTestCommandRunner(command);
   await runner.run(<String>['create', ...arguments, projectPath]);
-  // Created `.packages` since it's not created when the flag `--no-pub` is passed.
-  globals.fs.file(globals.fs.path.join(projectPath, '.packages')).createSync();
   return projectPath;
 }
 

--- a/packages/flutter_tools/test/src/test_flutter_command_runner.dart
+++ b/packages/flutter_tools/test/src/test_flutter_command_runner.dart
@@ -37,6 +37,8 @@ Future<String> createProject(Directory temp, { List<String> arguments }) async {
   final CreateCommand command = CreateCommand();
   final CommandRunner<void> runner = createTestCommandRunner(command);
   await runner.run(<String>['create', ...arguments, projectPath]);
+  // Created `.packages` since it's not created when the flag `--no-pub` is passed.
+  globals.fs.file(globals.fs.path.join(projectPath, '.packages')).createSync();
   return projectPath;
 }
 


### PR DESCRIPTION
Configures the build info with the correct target file so the sound-ness can be determined ahead of time. I was not able to repro the case where it ran without sound null safety, just autodetect. This may have reported the wrong info though.

I did notice that flutter build aar does not allow the target file to be configured, and only supports lib/main.dart. This needs to be fixed but requires a breaking change to the API.

Fixes https://github.com/flutter/flutter/issues/79956
