### PR TITLE
update SearchDelegate's leading and actions widgets can be null

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -180,7 +180,7 @@ abstract class SearchDelegate<T> {
   /// See also:
   ///
   ///  * [AppBar.leading], the intended use for the return value of this method.
-  Widget buildLeading(BuildContext context);
+  Widget? buildLeading(BuildContext context);
 
   /// Widgets to display after the search query in the [AppBar].
   ///
@@ -193,7 +193,7 @@ abstract class SearchDelegate<T> {
   /// See also:
   ///
   ///  * [AppBar.actions], the intended use for the return value of this method.
-  List<Widget> buildActions(BuildContext context);
+  List<Widget>? buildActions(BuildContext context);
 
   /// Widget to display across the bottom of the [AppBar].
   ///

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -771,6 +771,17 @@ void main() {
       expect(textField.style!.color, themeData.textTheme.bodyText1!.color);
       expect(textField.style!.color, isNot(equals(themeData.primaryColor)));
   });
+
+  // Regression test for: https://github.com/flutter/flutter/issues/78144
+  testWidgets('Leading and Actions widget can be null', (WidgetTester tester) async {
+    final _TestEmptySearchDelegate delegate = _TestEmptySearchDelegate();
+    await tester.pumpWidget(TestHomePage(delegate: delegate));
+
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class TestHomePage extends StatelessWidget {
@@ -910,4 +921,20 @@ class _TestSearchDelegate extends SearchDelegate<String> {
       child: Text('Bottom'),
     );
   }
+}
+
+class _TestEmptySearchDelegate extends SearchDelegate<String> {
+  _TestEmptySearchDelegate() : super();
+
+  @override
+  Widget? buildLeading(BuildContext context) => null;
+
+  @override
+  List<Widget>? buildActions(BuildContext context) => null;
+
+  @override
+  Widget buildSuggestions(BuildContext context) => const SizedBox();
+
+  @override
+  Widget buildResults(BuildContext context) => const SizedBox();
 }

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -773,7 +773,7 @@ void main() {
   });
 
   // Regression test for: https://github.com/flutter/flutter/issues/78144
-  testWidgets('Leading and Actions widget can be null', (WidgetTester tester) async {
+  testWidgets('Leading and Actions widgets can be null', (WidgetTester tester) async {
     final _TestEmptySearchDelegate delegate = _TestEmptySearchDelegate();
     await tester.pumpWidget(TestHomePage(delegate: delegate));
 


### PR DESCRIPTION
Fixes #78144 
The documentation says that they can be null.
```dart
  /// Widgets to display after the search query in the [AppBar].
  ///
  /// If the [query] is not empty, this should typically contain a button to
  /// clear the query and show the suggestions again (via [showSuggestions]) if
  /// the results are currently shown.
  ///
  /// Returns null if no widget should be shown.
  ///
  /// See also:
  ///
  ///  * [AppBar.actions], the intended use for the return value of this method.
```