### PR TITLE
Cast Config values map values to dynamic instead of Object

### DIFF
--- a/packages/flutter_tools/lib/src/base/config.dart
+++ b/packages/flutter_tools/lib/src/base/config.dart
@@ -62,7 +62,7 @@ class Config {
     }
     try {
       ErrorHandlingFileSystem.noExitOnFailure(() {
-        _values = castStringKeyedMap(json.decode(_file.readAsStringSync())) as Map<String, Object>? ?? <String, Object>{};
+        _values = castStringKeyedMap(json.decode(_file.readAsStringSync())) ?? <String, Object>{};
       });
     } on FormatException {
       _logger
@@ -110,7 +110,7 @@ class Config {
 
   String get configPath => _file.path;
 
-  Map<String, Object> _values = <String, Object>{};
+  Map<String, dynamic> _values = <String, Object>{};
 
   Iterable<String> get keys => _values.keys;
 

--- a/packages/flutter_tools/lib/src/base/context.dart
+++ b/packages/flutter_tools/lib/src/base/context.dart
@@ -118,7 +118,7 @@ class AppContext {
     if (value == null && _parent != null) {
       value = _parent!.get<T>();
     }
-    return _unboxNull(value ?? _generateIfNecessary(T, _fallbacks)) as T;
+    return _unboxNull(value ?? _generateIfNecessary(T, _fallbacks)) as T?;
   }
 
   /// Runs [body] in a child context and returns the value returned by [body].

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -23,9 +23,9 @@ class FileStorage {
       throw Exception('File storage format invalid');
     }
     final int version = json['version'] as int;
-    final List<Map<String, Object>> rawCachedFiles = (json['files'] as List<dynamic>).cast<Map<String, Object>>();
+    final List<Map<String, dynamic>> rawCachedFiles = (json['files'] as List<dynamic>).cast<Map<String, dynamic>>();
     final List<_FileHash> cachedFiles = <_FileHash>[
-      for (final Map<String, Object> rawFile in rawCachedFiles) _FileHash._fromJson(rawFile),
+      for (final Map<String, dynamic> rawFile in rawCachedFiles) _FileHash._fromJson(rawFile),
     ];
     return FileStorage(version, cachedFiles);
   }
@@ -48,7 +48,7 @@ class FileStorage {
 class _FileHash {
   _FileHash(this.path, this.hash);
 
-  factory _FileHash._fromJson(Map<String, Object> json) {
+  factory _FileHash._fromJson(Map<String, dynamic> json) {
     if (!json.containsKey('path') || !json.containsKey('hash')) {
       throw Exception('File storage format invalid');
     }

--- a/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/file_store_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:typed_data';
 
 import 'package:file/memory.dart';
@@ -78,7 +76,7 @@ void main() {
     fileCache.initialize();
     fileCache.diffFileList(<File>[file]);
     fileCache.persist();
-    final String currentHash =  fileCache.currentAssetKeys[file.path];
+    final String? currentHash = fileCache.currentAssetKeys[file.path];
     final Uint8List buffer = cacheFile
         .readAsBytesSync();
     FileStorage fileStorage = FileStorage.fromBuffer(buffer);

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
@@ -16,9 +14,9 @@ import 'package:test/fake.dart';
 import '../src/common.dart';
 
 void main() {
-  Config config;
-  MemoryFileSystem memoryFileSystem;
-  FakePlatform fakePlatform;
+  late Config config;
+  late MemoryFileSystem memoryFileSystem;
+  late FakePlatform fakePlatform;
 
   setUp(() {
     memoryFileSystem = MemoryFileSystem.test();
@@ -35,6 +33,7 @@ void main() {
       platform: fakePlatform,
     );
   });
+
   testWithoutContext('Config get set value', () async {
     expect(config.getValue('foo'), null);
     config.setValue('foo', 'bar');


### PR DESCRIPTION
Revert `Config._values` back to `Map<String, dynamic>` or the json decoding
https://github.com/flutter/flutter/blob/026ee9756cbbf574fdb7fde1f420813ee340a5c0/packages/flutter_tools/lib/src/base/config.dart#L65
 throws:
```
package:flutter_tools/src/base/config.dart 65:77             new Config.createForTesting.<fn>
package:flutter_tools/src/base/error_handling_io.dart 65:16  ErrorHandlingFileSystem.noExitOnFailure
package:flutter_tools/src/base/config.dart 64:31             new Config.createForTesting
package:flutter_tools/src/base/config.dart 36:19             new Config
test/general.shard/config_test.dart 113:14                   main.<fn>
dart:async                                                   runZoned
test/src/common.dart 184:14                                  testWithoutContext.<fn>
test/src/common.dart 183:18                                  testWithoutContext.<fn>
test/src/common.dart 154:18                                  test.<fn>
test/src/common.dart 150:5                                   test.<fn>

type 'CastMap<String, dynamic, String, dynamic>' is not a subtype of type 'Map<String, Object>?' in type cast
```
and https://github.com/flutter/flutter/blob/4a2ff6490f9864836b2eb3349086755dc0bc3db9/packages/flutter_tools/lib/src/build_system/file_store.dart#L26-L28 throws
```
dart:_internal                                                ListIterator.moveNext
package:flutter_tools/src/build_system/file_store.dart 28:49  new FileStorage.fromBuffer
test/general.shard/build_system/file_store_test.dart 82:43    main.<fn>
test/general.shard/build_system/file_store_test.dart 65:68    main.<fn>
dart:async                                                    runZoned
test/src/common.dart 184:14                                   testWithoutContext.<fn>
test/src/common.dart 183:18                                   testWithoutContext.<fn>
test/src/common.dart 154:18                                   test.<fn>
test/src/common.dart 150:5                                    test.<fn>

type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Object>' in type cast
```
This matches `convert/json.dart` encoding and decoding.


Part of #71511