### PR TITLE
Migrate fake_process_manager to null safety

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/android_device_stop_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_stop_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('AndroidDevice.stopApp handles a null ApplicationPackage', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -22,7 +22,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('AndroidDevice stores the requested id', () {

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -14,7 +14,6 @@ import 'package:mockito/mockito.dart';
 import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/mocks.dart' show MockAndroidSdk;
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -19,7 +19,7 @@ import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:process/process.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 class MockFile extends Mock implements File {}
 class MockFileSystem extends Mock implements FileSystem {}

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const String kExecutable = 'foo';
 const String kPath1 = '/bar/bin/$kExecutable';

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:mockito/mockito.dart';
 import 'package:fake_async/fake_async.dart';
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/mocks.dart' show MockProcessManager,
                                    flakyProcessFactory;

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -18,7 +18,7 @@ import 'package:flutter_tools/src/build_system/exceptions.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   FileSystem fileSystem;

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -21,7 +21,7 @@ import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../src/common.dart';
-import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 import '../../../src/fakes.dart';
 
 final Platform kNoAnsiPlatform = FakePlatform(stdoutSupportsAnsi: false);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/localizations_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/localizations/localizations_utils.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../src/common.dart';
-import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 
 void main() {
   // Verifies that values are correctly passed through the localizations

--- a/packages/flutter_tools/test/general.shard/compile_batch_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_batch_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/compile.dart';
 import 'package:package_config/package_config.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('StdoutHandler can parse output for successful batch compilation', () async {

--- a/packages/flutter_tools/test/general.shard/compile_expression_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_expression_test.dart
@@ -20,7 +20,7 @@ import 'package:package_config/package_config.dart';
 import 'package:process/process.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -17,7 +17,6 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:package_config/package_config.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -20,8 +20,8 @@ import 'package:http/http.dart';
 import 'package:http/testing.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 import '../src/fake_http_client.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   BufferLogger logger;

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -15,7 +15,6 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/localizations.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -16,8 +16,8 @@ import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 import '../src/fake_http_client.dart';
+import '../src/fake_process_manager.dart';
 
 void main() {
   BufferLogger logger;

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter_tools/src/version.dart';
 import 'package:mockito/mockito.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 
 /// Matches a doctor validation result.

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_dev_finder_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_dev_finder_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   MockFuchsiaArtifacts mockFuchsiaArtifacts;

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   FakeFuchsiaArtifacts fakeFuchsiaArtifacts;

--- a/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/code_signing_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   group('Auto signing', () {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -28,7 +28,7 @@ import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   final FakePlatform macPlatform = FakePlatform(operatingSystem: 'macos');

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_logger_test.dart
@@ -20,7 +20,7 @@ import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fake_vm_services.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/ios/ios_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_workflow_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -17,7 +17,7 @@ import 'package:flutter_tools/src/project.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 final FakePlatform linux = FakePlatform(

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/linux/linux_doctor.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 // A command that will return typical-looking 'clang++ --version' output with
 // the given version number.

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:test/fake.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fake_vm_services.dart';
 
 final vm_service.Isolate isolate = vm_service.Isolate(

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/windows/visual_studio.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const String programFilesPath = r'C:\Program Files (x86)';
 const String visualStudioPath = programFilesPath + r'\Microsoft Visual Studio\2017\Community';

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -124,7 +124,7 @@ class _FakeProcess implements io.Process {
     Duration duration,
     this.pid,
     this._stderr,
-    this.stdin,
+    IOSink? stdin,
     this._stdout,
     this._completer,
   ) : exitCode = Future<void>.delayed(duration).then((void value) {
@@ -133,6 +133,7 @@ class _FakeProcess implements io.Process {
         }
         return _exitCode;
       }),
+      stdin = stdin ?? IOSink(StreamController<List<int>>().sink),
       stderr = _stderr == null
         ? const Stream<List<int>>.empty()
         : Stream<List<int>>.value(utf8.encode(_stderr)),
@@ -245,7 +246,7 @@ abstract class FakeProcessManager implements ProcessManager {
       fakeCommand.duration,
       _pid,
       fakeCommand.stderr,
-      fakeCommand.stdin ?? IOSink(StreamController<List<int>>().sink),
+      fakeCommand.stdin,
       fakeCommand.stdout,
       fakeCommand.completer,
     );

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io show ProcessSignal, Process, ProcessStartMode, ProcessResult, systemEncoding;
@@ -22,7 +20,7 @@ typedef VoidCallback = void Function();
 @immutable
 class FakeCommand {
   const FakeCommand({
-    @required this.command,
+    required this.command,
     this.workingDirectory,
     this.environment,
     this.encoding,
@@ -46,7 +44,7 @@ class FakeCommand {
   /// be considered correct.
   ///
   /// If this is null, the working directory is ignored.
-  final String workingDirectory;
+  final String? workingDirectory;
 
   /// The environment that must be matched for this [FakeCommand] to be considered correct.
   ///
@@ -54,13 +52,13 @@ class FakeCommand {
   ///
   /// Otherwise, each key in this environment must be present and must have a
   /// value that matches the one given here for the [FakeCommand] to match.
-  final Map<String, String> environment;
+  final Map<String, String>? environment;
 
   /// The stdout and stderr encoding that must be matched for this [FakeCommand]
   /// to be considered correct.
   ///
   /// If this is null, then the encodings are ignored.
-  final Encoding encoding;
+  final Encoding? encoding;
 
   /// The time to allow to elapse before returning the [exitCode], if this command
   /// is "executed".
@@ -71,7 +69,7 @@ class FakeCommand {
 
   /// A callback that is run after [duration] expires but before the [exitCode]
   /// (and output) are passed back.
-  final VoidCallback onRun;
+  final VoidCallback? onRun;
 
   /// The process' exit code.
   ///
@@ -92,19 +90,19 @@ class FakeCommand {
 
   /// If provided, allows the command completion to be blocked until the future
   /// resolves.
-  final Completer<void> completer;
+  final Completer<void>? completer;
 
   /// An optional stdin sink that will be exposed through the resulting
   /// [FakeProcess].
-  final IOSink stdin;
+  final IOSink? stdin;
 
   /// If provided, this exception will be thrown when the fake command is run.
-  final dynamic exception;
+  final Object? exception;
 
   void _matches(
     List<String> command,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     Encoding encoding,
   ) {
     expect(command, equals(this.command));
@@ -143,7 +141,7 @@ class _FakeProcess implements io.Process {
         : Stream<List<int>>.value(utf8.encode(_stdout));
 
   final int _exitCode;
-  final Completer<void> _completer;
+  final Completer<void>? _completer;
 
   @override
   final Future<int> exitCode;
@@ -221,8 +219,8 @@ abstract class FakeProcessManager implements ProcessManager {
   @protected
   FakeCommand findCommand(
     List<String> command,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     Encoding encoding,
   );
 
@@ -230,24 +228,24 @@ abstract class FakeProcessManager implements ProcessManager {
 
   _FakeProcess _runCommand(
     List<String> command,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     Encoding encoding,
   ) {
     _pid += 1;
     final FakeCommand fakeCommand = findCommand(command, workingDirectory, environment, encoding);
     if (fakeCommand.exception != null) {
-      throw fakeCommand.exception;
+      throw fakeCommand.exception!;
     }
     if (fakeCommand.onRun != null) {
-      fakeCommand.onRun();
+      fakeCommand.onRun!();
     }
     return _FakeProcess(
       fakeCommand.exitCode,
       fakeCommand.duration,
       _pid,
       fakeCommand.stderr,
-      fakeCommand.stdin,
+      fakeCommand.stdin ?? IOSink(StreamController<List<int>>().sink),
       fakeCommand.stdout,
       fakeCommand.completer,
     );
@@ -256,8 +254,8 @@ abstract class FakeProcessManager implements ProcessManager {
   @override
   Future<io.Process> start(
     List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
     io.ProcessStartMode mode = io.ProcessStartMode.normal, // ignored
@@ -275,8 +273,8 @@ abstract class FakeProcessManager implements ProcessManager {
   @override
   Future<io.ProcessResult> run(
     List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
     Encoding stdoutEncoding = io.systemEncoding,
@@ -295,8 +293,8 @@ abstract class FakeProcessManager implements ProcessManager {
   @override
   io.ProcessResult runSync(
     List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
     Encoding stdoutEncoding = io.systemEncoding, // actual encoder is ignored
@@ -313,18 +311,20 @@ abstract class FakeProcessManager implements ProcessManager {
 
   /// Returns false if executable in [excludedExecutables].
   @override
-  bool canRun(dynamic executable, {String workingDirectory}) => !excludedExecutables.contains(executable);
+  bool canRun(dynamic executable, {String? workingDirectory}) => !excludedExecutables.contains(executable);
 
   Set<String> excludedExecutables = <String>{};
 
   @override
   bool killPid(int pid, [io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
     // Killing a fake process has no effect unless it has an attached completer.
-    final _FakeProcess fakeProcess = _fakeRunningProcesses[pid];
+    final _FakeProcess? fakeProcess = _fakeRunningProcesses[pid];
     if (fakeProcess == null) {
       return false;
     }
-    fakeProcess._completer.complete();
+    if (fakeProcess._completer != null) {
+      fakeProcess._completer!.complete();
+    }
     return true;
   }
 }
@@ -335,8 +335,8 @@ class _FakeAnyProcessManager extends FakeProcessManager {
   @override
   FakeCommand findCommand(
     List<String> command,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     Encoding encoding,
   ) {
     return FakeCommand(
@@ -369,8 +369,8 @@ class _SequenceProcessManager extends FakeProcessManager {
   @override
   FakeCommand findCommand(
     List<String> command,
-    String workingDirectory,
-    Map<String, String> environment,
+    String? workingDirectory,
+    Map<String, String>? environment,
     Encoding encoding,
   ) {
     expect(_commands, isNotEmpty,


### PR DESCRIPTION
Also swap `context.dart` imports where the test was only using the exported symbols from `fake_process_manager.dart` to make those tests easier to migrate.

Part of #71511