### PR TITLE
Fix the problem of too fast playback of some gifs

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -870,7 +870,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   // The requested duration for the current frame.
   Duration? _frameDuration;
   // The default duration for the frame that _frameDuration less than 10ms.
-  static const Duration _DefaultDuration = Duration(milliseconds: 67);
+  static const Duration _DefaultDuration = Duration(milliseconds: 100);
   // How many frames have been emitted so far.
   int _framesEmitted = 0;
   Timer? _timer;
@@ -901,7 +901,11 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
       // When the _frameDuration is less then 10ms, give the default delay time.
-      if (_frameDuration!.inMilliseconds < 10) {
+      // Force frames with a small or no duration to 100ms to be consistent
+      // with web browsers and picture decoding tools. This also avoids
+      // incorrect durations between frames when padding frames are
+      // discarded.
+      if (_frameDuration!.inMilliseconds <= 10) {
         _frameDuration = _DefaultDuration;
       }
       _nextFrame!.image.dispose();

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -886,7 +886,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       _decodeNextFrameAndSchedule();
     }
   }
-  
+
   void _handleAppFrame(Duration timestamp) {
     _frameCallbackScheduled = false;
     if (!hasListeners)

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -867,8 +867,10 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   ui.FrameInfo? _nextFrame;
   // When the current was first shown.
   late Duration _shownTimestamp;
-  // The requested duration for the current frame;
+  // The requested duration for the current frame.
   Duration? _frameDuration;
+  // The default duration for the frame that _frameDuration is 0.
+  final Duration _DEFAULT_DURATION = Duration(milliseconds: 67);
   // How many frames have been emitted so far.
   int _framesEmitted = 0;
   Timer? _timer;
@@ -884,7 +886,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       _decodeNextFrameAndSchedule();
     }
   }
-
+  
   void _handleAppFrame(Duration timestamp) {
     _frameCallbackScheduled = false;
     if (!hasListeners)
@@ -898,6 +900,10 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       ));
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
+      // When the _frameDuration is 0, give the default delay time.
+      if (_frameDuration!.inMilliseconds == 0) {
+        _frameDuration = _DEFAULT_DURATION;
+      }
       _nextFrame!.image.dispose();
       _nextFrame = null;
       final int completedCycles = _framesEmitted ~/ _codec!.frameCount;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -870,7 +870,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   // The requested duration for the current frame.
   Duration? _frameDuration;
   // The default duration for the frame that _frameDuration is 0.
-  final Duration _DEFAULT_DURATION = Duration(milliseconds: 67);
+  static const Duration _DefaultDuration = Duration(milliseconds: 67);
   // How many frames have been emitted so far.
   int _framesEmitted = 0;
   Timer? _timer;
@@ -902,7 +902,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       _frameDuration = _nextFrame!.duration;
       // When the _frameDuration is 0, give the default delay time.
       if (_frameDuration!.inMilliseconds == 0) {
-        _frameDuration = _DEFAULT_DURATION;
+        _frameDuration = _DefaultDuration;
       }
       _nextFrame!.image.dispose();
       _nextFrame = null;

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -869,7 +869,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
   late Duration _shownTimestamp;
   // The requested duration for the current frame.
   Duration? _frameDuration;
-  // The default duration for the frame that _frameDuration is 0.
+  // The default duration for the frame that _frameDuration less than 10ms.
   static const Duration _DefaultDuration = Duration(milliseconds: 67);
   // How many frames have been emitted so far.
   int _framesEmitted = 0;
@@ -900,8 +900,8 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       ));
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
-      // When the _frameDuration is 0, give the default delay time.
-      if (_frameDuration!.inMilliseconds == 0) {
+      // When the _frameDuration is less then 10ms, give the default delay time.
+      if (_frameDuration!.inMilliseconds < 10) {
         _frameDuration = _DefaultDuration;
       }
       _nextFrame!.image.dispose();


### PR DESCRIPTION
When the `_frameDuration` of a frame in the gif is 0, give the default delay time;
Fix the problem of too fast playback of some gifs.

Fixes https://github.com/flutter/flutter/issues/29130


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
