### PR TITLE
Adjust selection drag start position for viewport offset changes

### DIFF
--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -581,6 +581,44 @@ void main() {
     expect(editableText.selectionOverlay!.toolbarIsVisible, isFalse);
   });
 
+  testWidgets('test TextSelectionGestureDetectorBuilder drag with RenderEditable viewport offset change', (WidgetTester tester) async {
+    await pumpTextSelectionGestureDetectorBuilder(tester);
+    final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
+
+    // Reconfigure the RenderEditable for multi-line.
+    renderEditable.maxLines = null;
+    renderEditable.offset = ViewportOffset.fixed(20.0);
+    renderEditable.layout(const BoxConstraints.tightFor(width: 400, height: 300.0));
+    await tester.pumpAndSettle();
+
+    final TestGesture gesture = await tester.startGesture(
+      const Offset(200.0, 200.0),
+      kind: PointerDeviceKind.mouse,
+    );
+    addTearDown(gesture.removePointer);
+    await tester.pumpAndSettle();
+    expect(renderEditable.selectPositionAtCalled, isFalse);
+
+    await gesture.moveTo(const Offset(300.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(renderEditable.selectPositionAtCalled, isTrue);
+    expect(renderEditable.selectPositionAtFrom, const Offset(200.0, 200.0));
+    expect(renderEditable.selectPositionAtTo, const Offset(300.0, 200.0));
+
+    // Move the viewport offset (scroll).
+    renderEditable.offset = ViewportOffset.fixed(150.0);
+    renderEditable.layout(const BoxConstraints.tightFor(width: 400, height: 300.0));
+    await tester.pumpAndSettle();
+
+    await gesture.moveTo(const Offset(300.0, 400.0));
+    await tester.pumpAndSettle();
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(renderEditable.selectPositionAtCalled, isTrue);
+    expect(renderEditable.selectPositionAtFrom, const Offset(200.0, 70.0));
+    expect(renderEditable.selectPositionAtTo, const Offset(300.0, 400.0));
+  });
+
   testWidgets('test TextSelectionGestureDetectorBuilder selection disabled', (WidgetTester tester) async {
     await pumpTextSelectionGestureDetectorBuilder(tester, selectionEnabled: false);
     final TestGesture gesture = await tester.startGesture(
@@ -820,9 +858,13 @@ class FakeRenderEditable extends RenderEditable {
   }
 
   bool selectPositionAtCalled = false;
+  Offset? selectPositionAtFrom;
+  Offset? selectPositionAtTo;
   @override
   void selectPositionAt({ required Offset from, Offset? to, required SelectionChangedCause cause }) {
     selectPositionAtCalled = true;
+    selectPositionAtFrom = from;
+    selectPositionAtTo = to;
   }
 
   bool selectWordCalled = false;


### PR DESCRIPTION
Currently when selecting by dragging, both baseOffset and extentOffset are updated on each call to selectPositionAt() i.e. on each pointer update. If the viewport offset changes in the meantime on a scroll, this causes the baseOffset to move incorrectly:

![before](https://user-images.githubusercontent.com/72562119/114025068-03f64980-9875-11eb-9d13-c33c3c356751.gif)

This PR updates the drag start position with any RenderEditable offset changes, fixing this behaviour:

![after](https://user-images.githubusercontent.com/72562119/114025160-225c4500-9875-11eb-9e2a-7edade3af9f9.gif)

It replaces the previous PR https://github.com/flutter/flutter/pull/79144 so that the logic is kept in TextSelectionGestureDetectorBuilder. 

## Related issues
https://github.com/flutter/flutter/issues/69296

## Tests

I added the following tests:
```
 packages/flutter/test/widgets/text_selection_test.dart:
 testWidgets('test TextSelectionGestureDetectorBuilder drag with RenderEditable viewport offset change', (WidgetTester tester)
```

Relevant tests passing:
```
% ../../bin/flutter test test/rendering/editable_test.dart
00:15 +89: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_cursor_test.dart
00:08 +24: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_show_on_screen_test.dart
00:05 +17: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_test.dart
00:14 +171: All tests passed!
% ../../bin/flutter test test/widgets/text_selection_test.dart 
00:04 +24: All tests passed!
% ../../bin/flutter test test/widgets/selectable_text_test.dart
00:14 +143 ~2: All tests passed!
% ../../bin/flutter test test/material/text_field_test.dart
00:34 +303: All tests passed!
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
