### PR TITLE
Change test to not implement ByteData

### DIFF
--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -17,7 +17,7 @@ import '../image_data.dart';
 ByteData testByteData(double scale) => ByteData(8)..setFloat64(0, scale);
 
 extension on ByteData {
-  double get scale => this.getFloat64(0);
+  double get scale => getFloat64(0);
 }
 
 const String testManifest = '''

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -14,12 +14,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../image_data.dart';
 
-class TestByteData implements ByteData {
-  TestByteData(this.scale);
-  final double scale;
+ByteData testByteData(double scale) => ByteData(8)..setFloat64(0, scale);
 
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
+extension on ByteData {
+  double get scale => this.getFloat64(0);
 }
 
 const String testManifest = '''
@@ -44,22 +42,22 @@ class TestAssetBundle extends CachingAssetBundle {
     late ByteData data;
     switch (key) {
       case 'assets/image.png':
-        data = TestByteData(1.0);
+        data = testByteData(1.0);
         break;
       case 'assets/1.0x/image.png':
-        data = TestByteData(10.0); // see "...with a main asset and a 1.0x asset"
+        data = testByteData(10.0); // see "...with a main asset and a 1.0x asset"
         break;
       case 'assets/1.5x/image.png':
-        data = TestByteData(1.5);
+        data = testByteData(1.5);
         break;
       case 'assets/2.0x/image.png':
-        data = TestByteData(2.0);
+        data = testByteData(2.0);
         break;
       case 'assets/3.0x/image.png':
-        data = TestByteData(3.0);
+        data = testByteData(3.0);
         break;
       case 'assets/4.0x/image.png':
-        data = TestByteData(4.0);
+        data = testByteData(4.0);
         break;
     }
     return SynchronousFuture<ByteData>(data);
@@ -91,7 +89,7 @@ class TestAssetImage extends AssetImage {
   ImageStreamCompleter load(AssetBundleImageKey key, DecoderCallback decode) {
     late ImageInfo imageInfo;
     key.bundle.load(key.name).then<void>((ByteData data) {
-      final TestByteData testData = data as TestByteData;
+      final ByteData testData = data;
       final ui.Image image = images[testData.scale]!;
       assert(image != null, 'Expected ${testData.scale} to have a key in $images');
       imageInfo = ImageInfo(image: image, scale: key.scale);
@@ -312,12 +310,12 @@ void main() {
     Key key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, false, images, bundle));
     expect(getRenderImage(tester, key).size, const Size(200.0, 200.0));
-    // Verify we got the 10x scaled image, since the TestByteData said it should be 10x.
+    // Verify we got the 10x scaled image, since the test ByteData said it should be 10x.
     expect(getRenderImage(tester, key).image!.height, 480);
     key = GlobalKey();
     await pumpTreeToLayout(tester, buildImageAtRatio(image, key, ratio, true, images, bundle));
     expect(getRenderImage(tester, key).size, const Size(480.0, 480.0));
-    // Verify we got the 10x scaled image, since the TestByteData said it should be 10x.
+    // Verify we got the 10x scaled image, since the test ByteData said it should be 10x.
     expect(getRenderImage(tester, key).image!.height, 480);
   });
 


### PR DESCRIPTION
The test `test/widgets/image_resolution_test.dart` has a test class implementing `ByteData`.
Dart will make it a compile-time error to extend/implement/mix-in most of the types of `dart:typed_data` (breaking change: https://github.com/dart-lang/sdk/issues/45115, implementation: https://dart-review.googlesource.com/c/sdk/+/192186), so this test needs to stop doing so.

This is an attempt at a *minimal change* (because I am not familiar with the code at all). It's definitely possible to make other simplicifcations (like inlining the extension).

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
