### PR TITLE
Include debug symbol in xcframework when building iOS-framework

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -310,7 +310,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       'DeviceInfoPlugin.h',
     ));
 
-    if(mode != 'Debug') {
+    if (mode != 'Debug') {
       checkDirectoryExists(path.join(
         outputPath,
         mode,
@@ -349,7 +349,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
     'Release',
     'device_info.xcframework',
     localXcodeArmDirectoryName,
-    'BCSymbolMaps'
+    'BCSymbolMaps',
   ));
 
   section('Check all modes have generated plugin registrant');

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -310,6 +310,17 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       'DeviceInfoPlugin.h',
     ));
 
+    if(mode != 'Debug') {
+      checkDirectoryExists(path.join(
+        outputPath,
+        mode,
+        'device_info.xcframework',
+        localXcodeArmDirectoryName,
+        'dSYMs',
+        'device_info.framework.dSYM',
+      ));
+    }
+
     final String simulatorFrameworkPath = path.join(
       outputPath,
       mode,
@@ -332,6 +343,14 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
     checkFileExists(simulatorFrameworkPath);
     checkFileExists(simulatorFrameworkHeaderPath);
   }
+
+  checkDirectoryExists(path.join(
+    outputPath,
+    'Release',
+    'device_info.xcframework',
+    localXcodeArmDirectoryName,
+    'BCSymbolMaps'
+  ));
 
   section('Check all modes have generated plugin registrant');
 

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -533,7 +533,7 @@ end
                 entity.basename.endsWith('dSYM'))
             .map((FileSystemEntity entity) =>
                 <String>['-debug-symbols', entity.path])
-            .expand((i) => i)
+            .expand<String>((List<String> parameter) => parameter
       ],
       '-output',
       outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -533,7 +533,7 @@ end
                 entity.basename.endsWith('dSYM'))
             .map((FileSystemEntity entity) =>
                 <String>['-debug-symbols', entity.path])
-            .expand<String>((List<String> parameter) => parameter
+            .expand<String>((List<String> parameter) => parameter)
       ],
       '-output',
       outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -83,10 +83,6 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
         defaultsTo: true,
         hide: !verboseHelp,
       )
-      ..addFlag('include-dsym',
-          help: 'Whether to include dSYM and bcsymbolmap to xcframework',
-          negatable: false,
-          defaultsTo: false)
       ..addFlag('cocoapods',
         help: 'Produce a Flutter.podspec instead of an engine Flutter.xcframework (recommended if host app uses CocoaPods).',
       )
@@ -530,15 +526,14 @@ end
       for (Directory framework in frameworks) ...<String>[
         '-framework',
         framework.path,
-        if (boolArg('include-dsym'))
-          ...framework.parent
-              .listSync()
-              .where((FileSystemEntity entity) =>
-                  entity.basename.endsWith('bcsymbolmap') ||
-                  entity.basename.endsWith('dSYM'))
-              .map((FileSystemEntity entity) =>
-                  <String>['-debug-symbols', entity.path])
-              .expand((i) => i)
+        ...framework.parent
+            .listSync()
+            .where((FileSystemEntity entity) =>
+                entity.basename.endsWith('bcsymbolmap') ||
+                entity.basename.endsWith('dSYM'))
+            .map((FileSystemEntity entity) =>
+                <String>['-debug-symbols', entity.path])
+            .expand((i) => i)
       ],
       '-output',
       outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -83,6 +83,10 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
         defaultsTo: true,
         hide: !verboseHelp,
       )
+      ..addFlag('include-dsym',
+          help: 'Whether to include dSYM and bcsymbolmap to xcframework',
+          negatable: false,
+          defaultsTo: false)
       ..addFlag('cocoapods',
         help: 'Produce a Flutter.podspec instead of an engine Flutter.xcframework (recommended if host app uses CocoaPods).',
       )
@@ -525,7 +529,16 @@ end
       '-create-xcframework',
       for (Directory framework in frameworks) ...<String>[
         '-framework',
-        framework.path
+        framework.path,
+        if (boolArg('include-dsym'))
+          ...framework.parent
+              .listSync()
+              .where((FileSystemEntity entity) =>
+                  entity.basename.endsWith('bcsymbolmap') ||
+                  entity.basename.endsWith('dSYM'))
+              .map((FileSystemEntity entity) =>
+                  <String>['-debug-symbols', entity.path])
+              .expand((i) => i)
       ],
       '-output',
       outputDirectory.childDirectory('$frameworkBinaryName.xcframework').path


### PR DESCRIPTION
Fix #80063 #64730

Adding `dSYM` and `bcsymbolmap` to xcframework using `-debug-symbols` flag.

<img width="615" alt="after_dsym" src="https://user-images.githubusercontent.com/2084355/114067135-abe83300-98c6-11eb-90ba-f94374752ecd.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
