### PR TITLE
Migrate first_run and bot_detector to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/bot_detector.dart
+++ b/packages/flutter_tools/lib/src/base/bot_detector.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -15,9 +13,9 @@ import 'platform.dart';
 
 class BotDetector {
   BotDetector({
-    @required HttpClientFactory httpClientFactory,
-    @required Platform platform,
-    @required PersistentToolState persistentToolState,
+    required HttpClientFactory httpClientFactory,
+    required Platform platform,
+    required PersistentToolState persistentToolState,
   }) :
     _platform = platform,
     _azureDetector = AzureDetector(
@@ -31,7 +29,7 @@ class BotDetector {
 
   Future<bool> get isRunningOnBot async {
     if (_persistentToolState.isRunningOnBot != null) {
-      return _persistentToolState.isRunningOnBot;
+      return _persistentToolState.isRunningOnBot!;
     }
     if (
       // Explicitly stated to not be a bot.
@@ -86,18 +84,18 @@ class BotDetector {
 @visibleForTesting
 class AzureDetector {
   AzureDetector({
-    @required HttpClientFactory httpClientFactory,
+    required HttpClientFactory httpClientFactory,
   }) : _httpClientFactory = httpClientFactory;
 
   static const String _serviceUrl = 'http://169.254.169.254/metadata/instance';
 
   final HttpClientFactory _httpClientFactory;
 
-  bool _isRunningOnAzure;
+  bool? _isRunningOnAzure;
 
   Future<bool> get isRunningOnAzure async {
     if (_isRunningOnAzure != null) {
-      return _isRunningOnAzure;
+      return _isRunningOnAzure!;
     }
     const Duration connectionTimeout = Duration(milliseconds: 250);
     const Duration requestTimeout = Duration(seconds: 1);

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -13,7 +13,7 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/terminal.dart';
 import '../cache.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../persistent_tool_state.dart';
 import '../runner/flutter_command.dart';
 import '../version.dart';

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -13,7 +13,7 @@ import '../base/process.dart';
 import '../base/time.dart';
 import '../cache.dart';
 import '../dart/pub.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../version.dart';
 

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -6,10 +6,7 @@
 
 import 'android/gradle_utils.dart';
 import 'artifacts.dart';
-import 'base/bot_detector.dart';
 import 'base/context.dart';
-import 'base/io.dart';
-import 'base/net.dart';
 import 'build_system/build_system.dart';
 import 'device.dart';
 import 'doctor.dart';
@@ -21,7 +18,6 @@ import 'ios/xcodeproj.dart';
 import 'macos/cocoapods.dart';
 import 'macos/cocoapods_validator.dart';
 import 'macos/xcode.dart';
-import 'persistent_tool_state.dart';
 import 'project.dart';
 import 'reporting/reporting.dart';
 import 'runner/local_engine.dart';
@@ -32,7 +28,6 @@ Artifacts get artifacts => context.get<Artifacts>();
 BuildSystem get buildSystem => context.get<BuildSystem>();
 CrashReporter get crashReporter => context.get<CrashReporter>();
 Doctor get doctor => context.get<Doctor>();
-PersistentToolState get persistentToolState => PersistentToolState.instance;
 Usage get flutterUsage => context.get<Usage>();
 DeviceManager get deviceManager => context.get<DeviceManager>();
 
@@ -55,16 +50,6 @@ Xcode get xcode => context.get<Xcode>();
 XcodeProjectInterpreter get xcodeProjectInterpreter => context.get<XcodeProjectInterpreter>();
 
 XCDevice get xcdevice => context.get<XCDevice>();
-
-final BotDetector _defaultBotDetector = BotDetector(
-  httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
-  platform: globals.platform,
-  persistentToolState: persistentToolState,
-);
-
-BotDetector get botDetector => context.get<BotDetector>() ?? _defaultBotDetector;
-
-Future<bool> get isRunningOnBot => botDetector.isRunningOnBot;
 
 /// Gradle utils in the current [AppContext].
 GradleUtils get gradleUtils => context.get<GradleUtils>();

--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -6,6 +6,7 @@ import 'package:process/process.dart';
 
 import 'android/android_sdk.dart';
 import 'android/android_studio.dart';
+import 'base/bot_detector.dart';
 import 'base/config.dart';
 import 'base/context.dart';
 import 'base/error_handling_io.dart';
@@ -23,6 +24,7 @@ import 'base/time.dart';
 import 'base/user_messages.dart';
 import 'cache.dart';
 import 'ios/plist_parser.dart';
+import 'persistent_tool_state.dart';
 import 'version.dart';
 
 Cache get cache => context.get<Cache>()!;
@@ -34,6 +36,20 @@ Signals get signals => context.get<Signals>() ?? LocalSignals.instance;
 AndroidStudio? get androidStudio => context.get<AndroidStudio>();
 AndroidSdk? get androidSdk => context.get<AndroidSdk>();
 FlutterVersion get flutterVersion => context.get<FlutterVersion>()!;
+
+PersistentToolState? get persistentToolState => PersistentToolState.instance;
+
+BotDetector get botDetector => context.get<BotDetector>() ?? _defaultBotDetector;
+final BotDetector _defaultBotDetector = BotDetector(
+  httpClientFactory: context.get<HttpClientFactory>() ?? () => HttpClient(),
+  platform: platform,
+  persistentToolState: persistentToolState ?? PersistentToolState(
+    fileSystem: fs,
+    logger: logger,
+    platform: platform,
+  ),
+);
+Future<bool> get isRunningOnBot => botDetector.isRunningOnBot;
 
 /// Currently active implementation of the file system.
 ///

--- a/packages/flutter_tools/lib/src/reporting/first_run.dart
+++ b/packages/flutter_tools/lib/src/reporting/first_run.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
-import 'package:meta/meta.dart';
 
 import '../convert.dart';
 import '../persistent_tool_state.dart';
@@ -46,7 +43,7 @@ const String _kFlutterFirstRunMessage = '''
 /// need to be displayed.
 class FirstRunMessenger {
   FirstRunMessenger({
-    @required PersistentToolState persistentToolState
+    required PersistentToolState persistentToolState
   }) : _persistentToolState = persistentToolState;
 
   final PersistentToolState _persistentToolState;
@@ -64,7 +61,7 @@ class FirstRunMessenger {
     if (_persistentToolState.shouldRedisplayWelcomeMessage == false) {
       return false;
     }
-    final String oldHash = _persistentToolState.lastActiveLicenseTermsHash;
+    final String? oldHash = _persistentToolState.lastActiveLicenseTermsHash;
     return oldHash != _currentHash;
   }
 

--- a/packages/flutter_tools/test/general.shard/reporting/first_run_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/first_run_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/persistent_tool_state.dart';
@@ -48,7 +46,7 @@ void main() {
   });
 }
 
-FirstRunMessenger setUpFirstRunMessenger({bool redisplayWelcomeMessage, bool test = false }) {
+FirstRunMessenger setUpFirstRunMessenger({bool? redisplayWelcomeMessage, bool test = false }) {
   final MemoryFileSystem fileSystem = MemoryFileSystem.test();
   final PersistentToolState state = PersistentToolState.test(directory: fileSystem.currentDirectory, logger: BufferLogger.test());
   if (redisplayWelcomeMessage != null) {
@@ -63,7 +61,7 @@ FirstRunMessenger setUpFirstRunMessenger({bool redisplayWelcomeMessage, bool tes
 class TestFirstRunMessenger extends FirstRunMessenger {
   TestFirstRunMessenger(PersistentToolState persistentToolState) : super(persistentToolState: persistentToolState);
 
-  String overrideLicenseTerms;
+  String? overrideLicenseTerms;
 
   @override
   String get licenseTerms => overrideLicenseTerms ?? super.licenseTerms;


### PR DESCRIPTION
Also move into `botDetector` and `persistentToolState` into `globals_null_migrated`.

Part of #71511