### PR TITLE
[flutter_tools] Show upstream remote in `flutter doctor -v`

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -20,6 +20,8 @@ class UserMessages {
       'Flutter version $version at $flutterRoot';
   String flutterRevision(String revision, String age, String date) =>
       'Framework revision $revision ($age), $date';
+  String flutterUpstreamRepositoryUrl(String url) => 'Upstream repository $url';
+  String flutterGitUrl(String url) => 'FLUTTER_GIT_URL = $url';
   String engineRevision(String revision) => 'Engine revision $revision';
   String dartRevision(String revision) => 'Dart version $revision';
   String pubMirrorURL(String url) => 'Pub download mirror $url';

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -436,6 +436,10 @@ class FlutterValidator extends DoctorValidator {
         frameworkVersion,
         _flutterRoot(),
       )));
+      messages.add(ValidationMessage(_userMessages.flutterUpstreamRepositoryUrl(version.repositoryUrl ?? 'unknown')));
+      if (_platform.environment.containsKey('FLUTTER_GIT_URL')) {
+        messages.add(ValidationMessage(_userMessages.flutterGitUrl(_platform.environment['FLUTTER_GIT_URL'])));
+      }
       messages.add(ValidationMessage(_userMessages.flutterRevision(
         version.frameworkRevisionShort,
         version.frameworkAge,

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -118,11 +118,11 @@ void main() {
     expect(await flutterValidator.validate(), _matchDoctorValidation(
       validationType: ValidationType.partial,
       statusInfo: 'Channel unknown, 0.0.0, on Windows, locale en_US.UTF-8',
-      messages: const <ValidationMessage>[
+      messages: containsAll(const <ValidationMessage>[
         ValidationMessage('Flutter version 0.0.0 at sdk/flutter'),
         ValidationMessage.error('version error'),
       ]),
-    );
+    ));
   });
 
   testWithoutContext('FlutterValidator shows mirrors on pub and flutter cloud storage', () async {
@@ -160,6 +160,30 @@ void main() {
     ));
   });
 
+  testWithoutContext('FlutterValidator shows FLUTTER_GIT_URL environment variable when set', () async {
+    final FlutterValidator flutterValidator = FlutterValidator(
+      platform: FakePlatform(
+        localeName: 'en_US.UTF-8',
+        environment: <String, String> {
+          'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter.git',
+        },
+      ),
+      flutterVersion: () => FakeFlutterVersion(frameworkVersion: '1.0.0'),
+      userMessages: UserMessages(),
+      artifacts: Artifacts.test(),
+      fileSystem: MemoryFileSystem.test(),
+      processManager: FakeProcessManager.any(),
+      operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
+      flutterRoot: () => 'sdk/flutter',
+    );
+
+    expect(await flutterValidator.validate(), _matchDoctorValidation(
+      validationType: ValidationType.installed,
+      statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
+      messages: contains(const ValidationMessage('FLUTTER_GIT_URL = https://githubmirror.com/flutter.git')),
+    ));
+  });
+
   group('FlutterValidator shows flutter upstream remote', () {
     testWithoutContext('default url', () async {
       final FlutterValidator flutterValidator = FlutterValidator(
@@ -177,33 +201,6 @@ void main() {
         validationType: ValidationType.installed,
         statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
         messages: contains(const ValidationMessage('Upstream repository https://github.com/flutter/flutter.git')),
-      ));
-    });
-
-    testWithoutContext('overridden url using FLUTTER_GIT_URL environment variable', () async {
-      final FlutterValidator flutterValidator = FlutterValidator(
-        platform: FakePlatform(
-          localeName: 'en_US.UTF-8',
-          environment: <String, String> {
-            'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter.git',
-          },
-        ),
-        flutterVersion: () => FakeFlutterVersion(frameworkVersion: '1.0.0'),
-        userMessages: UserMessages(),
-        artifacts: Artifacts.test(),
-        fileSystem: MemoryFileSystem.test(),
-        processManager: FakeProcessManager.any(),
-        operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-        flutterRoot: () => 'sdk/flutter',
-      );
-
-      expect(await flutterValidator.validate(), _matchDoctorValidation(
-        validationType: ValidationType.installed,
-        statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
-        messages: containsAll(const <ValidationMessage>[
-          ValidationMessage('Upstream repository https://githubmirror.com/flutter.git'),
-          ValidationMessage('FLUTTER_GIT_URL = https://githubmirror.com/flutter.git'),
-        ]),
       ));
     });
 


### PR DESCRIPTION
This PR adds the upstream remote, and if set, the value of `FLUTTER_GIT_URL` variable, when running `flutter doctor -v`.

```
[✓] Flutter (Channel flutter_doctor_upstream_remote, 2.1.0-13.0.pre.557, on Linux, locale en_IN)
    • Flutter version 2.1.0-13.0.pre.557 at /mnt/D/Git/flutter
    • Upstream repository https://github.com/RoyARG02/flutter.git
    • FLUTTER_GIT_URL = https://github.com/flutter/flutter.git
    • Framework revision 68e207adb5 (10 days ago), 2021-03-30 16:08:18 +0530
    • Engine revision a9f4883dc8
    • Dart version 2.13.0 (build 2.13.0-219.0.dev)
```

## Related Issues

Fixes #79294.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
