### PR TITLE
Add BackdropFilter blend mode

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1818,11 +1818,29 @@ class BackdropFilterLayer extends ContainerLayer {
     }
   }
 
+  /// The blend mode to use to apply the filtered background content onto the background
+  /// surface.
+  ///
+  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
+  /// using this widget inside of a parent that uses a saveLayer may produce surprising
+  /// results. When rendering inside a saveLayer which implicitly presents a transparent
+  /// background, the results would look better with a [BlendMode.src] mode. Note that
+  /// the DOM-html renderer on web does not support this parameter so using any mode
+  /// but the default may produce different results.
+  BlendMode? get blendMode => _blendMode;
+  BlendMode? _blendMode;
+  set blendMode(BlendMode? value) {
+    if (value != _blendMode)
+      _blendMode = value;
+    markNeedsAddToScene();
+  }
+
   @override
   void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
     assert(filter != null);
     engineLayer = builder.pushBackdropFilter(
       filter!,
+      blendMode: blendMode!,
       oldLayer: _engineLayer as ui.BackdropFilterEngineLayer?,
     );
     addChildrenToScene(builder, layerOffset);

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1827,12 +1827,16 @@ class BackdropFilterLayer extends ContainerLayer {
   /// background, the results would look better with a [BlendMode.src] mode. Note that
   /// the DOM-html renderer on web does not support this parameter so using any mode
   /// but the default may produce different results.
+  ///
+  /// The scene must be explicitly recomposited after this property is changed
+  /// (as described at [Layer]).
   BlendMode? get blendMode => _blendMode;
   BlendMode? _blendMode;
   set blendMode(BlendMode? value) {
-    if (value != _blendMode)
+    if (value != _blendMode) {
       _blendMode = value;
-    markNeedsAddToScene();
+      markNeedsAddToScene();
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1803,6 +1803,7 @@ class BackdropFilterLayer extends ContainerLayer {
   ///
   /// The [filter] property must be non-null before the compositing phase of the
   /// pipeline.
+  ///
   /// The [blendMode] property will be defaulted to [BlendMode.srcOver] if it is
   /// not set to a non-null value before the compositing phase of the pipeline.
   BackdropFilterLayer({

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1803,7 +1803,13 @@ class BackdropFilterLayer extends ContainerLayer {
   ///
   /// The [filter] property must be non-null before the compositing phase of the
   /// pipeline.
-  BackdropFilterLayer({ ui.ImageFilter? filter }) : _filter = filter;
+  /// The [blendMode] property will be defaulted to [BlendMode.srcOver] if it is
+  /// not set to a non-null value before the compositing phase of the pipeline.
+  BackdropFilterLayer({
+    ui.ImageFilter? filter,
+    BlendMode? blendMode,
+  }) : _filter = filter,
+       _blendMode = blendMode;
 
   /// The filter to apply to the existing contents of the scene.
   ///
@@ -1821,12 +1827,8 @@ class BackdropFilterLayer extends ContainerLayer {
   /// The blend mode to use to apply the filtered background content onto the background
   /// surface.
   ///
-  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
-  /// using this widget inside of a parent that uses a saveLayer may produce surprising
-  /// results. When rendering inside a saveLayer which implicitly presents a transparent
-  /// background, the results would look better with a [BlendMode.src] mode. Note that
-  /// the DOM-html renderer on web does not support this parameter so using any mode
-  /// but the default may produce different results.
+  /// The default mode if this property is not set will be [BlendMode.srcOver].
+  /// {@macro flutter.widgets.BackdropFilter.blendMode}
   ///
   /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
@@ -1844,7 +1846,7 @@ class BackdropFilterLayer extends ContainerLayer {
     assert(filter != null);
     engineLayer = builder.pushBackdropFilter(
       filter!,
-      blendMode: blendMode!,
+      blendMode: blendMode ?? BlendMode.srcOver,
       oldLayer: _engineLayer as ui.BackdropFilterEngineLayer?,
     );
     addChildrenToScene(builder, layerOffset);

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1804,11 +1804,10 @@ class BackdropFilterLayer extends ContainerLayer {
   /// The [filter] property must be non-null before the compositing phase of the
   /// pipeline.
   ///
-  /// The [blendMode] property will be defaulted to [BlendMode.srcOver] if it is
-  /// not set to a non-null value before the compositing phase of the pipeline.
+  /// The [blendMode] property defaults to [BlendMode.srcOver].
   BackdropFilterLayer({
     ui.ImageFilter? filter,
-    BlendMode? blendMode,
+    BlendMode blendMode = BlendMode.srcOver,
   }) : _filter = filter,
        _blendMode = blendMode;
 
@@ -1828,14 +1827,14 @@ class BackdropFilterLayer extends ContainerLayer {
   /// The blend mode to use to apply the filtered background content onto the background
   /// surface.
   ///
-  /// The default mode if this property is not set will be [BlendMode.srcOver].
+  /// The default value of this property is [BlendMode.srcOver].
   /// {@macro flutter.widgets.BackdropFilter.blendMode}
   ///
   /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
-  BlendMode? get blendMode => _blendMode;
-  BlendMode? _blendMode;
-  set blendMode(BlendMode? value) {
+  BlendMode get blendMode => _blendMode;
+  BlendMode _blendMode;
+  set blendMode(BlendMode value) {
     if (value != _blendMode) {
       _blendMode = value;
       markNeedsAddToScene();
@@ -1847,7 +1846,7 @@ class BackdropFilterLayer extends ContainerLayer {
     assert(filter != null);
     engineLayer = builder.pushBackdropFilter(
       filter!,
-      blendMode: blendMode ?? BlendMode.srcOver,
+      blendMode: blendMode,
       oldLayer: _engineLayer as ui.BackdropFilterEngineLayer?,
     );
     addChildrenToScene(builder, layerOffset);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1171,7 +1171,7 @@ class RenderBackdropFilter extends RenderProxyBox {
   /// The blend mode to use to apply the filtered background content onto the background
   /// surface.
   ///
-  /// {@template flutter.widgets.BackdropFilter.blendMode}
+  /// {@macro flutter.widgets.BackdropFilter.blendMode}
   BlendMode get blendMode => _blendMode;
   BlendMode _blendMode;
   set blendMode(BlendMode value) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1141,9 +1141,11 @@ class RenderBackdropFilter extends RenderProxyBox {
   /// Creates a backdrop filter.
   ///
   /// The [filter] argument must not be null.
-  RenderBackdropFilter({ RenderBox? child, required ui.ImageFilter filter })
+  RenderBackdropFilter({ RenderBox? child, required ui.ImageFilter filter, BlendMode blendMode = BlendMode.srcOver })
     : assert(filter != null),
+      assert(blendMode != null),
       _filter = filter,
+      _blendMode = blendMode,
       super(child);
 
   @override
@@ -1164,6 +1166,25 @@ class RenderBackdropFilter extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  /// The blend mode to use to apply the filtered background content onto the background
+  /// surface.
+  ///
+  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
+  /// using this widget inside of a parent that uses a saveLayer may produce surprising
+  /// results. When rendering inside a saveLayer which implicitly presents a transparent
+  /// background, the results would look better with a [BlendMode.src] mode. Note that
+  /// the DOM-html renderer on web does not support this parameter so using any mode
+  /// but the default may produce different results.
+  BlendMode get blendMode => _blendMode;
+  BlendMode _blendMode;
+  set blendMode(BlendMode value) {
+    assert(value != null);
+    if (_blendMode == value)
+      return;
+    _blendMode = value;
+    markNeedsPaint();
+  }
+
   @override
   bool get alwaysNeedsCompositing => child != null;
 
@@ -1173,6 +1194,7 @@ class RenderBackdropFilter extends RenderProxyBox {
       assert(needsCompositing);
       layer ??= BackdropFilterLayer();
       layer!.filter = _filter;
+      layer!.blendMode = _blendMode;
       context.pushLayer(layer!, super.paint, offset);
     } else {
       layer = null;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1141,6 +1141,8 @@ class RenderBackdropFilter extends RenderProxyBox {
   /// Creates a backdrop filter.
   ///
   /// The [filter] argument must not be null.
+  /// The [blendMode] argument, if provided, must not be null
+  /// and will default to [BlendMode.srcOver].
   RenderBackdropFilter({ RenderBox? child, required ui.ImageFilter filter, BlendMode blendMode = BlendMode.srcOver })
     : assert(filter != null),
       assert(blendMode != null),
@@ -1169,12 +1171,7 @@ class RenderBackdropFilter extends RenderProxyBox {
   /// The blend mode to use to apply the filtered background content onto the background
   /// surface.
   ///
-  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
-  /// using this widget inside of a parent that uses a saveLayer may produce surprising
-  /// results. When rendering inside a saveLayer which implicitly presents a transparent
-  /// background, the results would look better with a [BlendMode.src] mode. Note that
-  /// the DOM-html renderer on web does not support this parameter so using any mode
-  /// but the default may produce different results.
+  /// {@template flutter.widgets.BackdropFilter.blendMode}
   BlendMode get blendMode => _blendMode;
   BlendMode _blendMode;
   set blendMode(BlendMode value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -166,6 +166,12 @@ class Directionality extends InheritedWidget {
 /// buffer. For the value 0.0, the child is simply not painted at all. For the
 /// value 1.0, the child is painted immediately without an intermediate buffer.
 ///
+/// The presence of the intermediate buffer which has a transparent background
+/// by default may cause some child widgets to behave differently. For example
+/// a [BackdropFilter] child will only be able to apply its filter to the content
+/// between this widget and the backdrop child and may require adjusting the
+/// [BackdropFilter.blendMode] property to produce the desired results.
+///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=9hltevOHQBw}
 ///
 /// {@tool snippet}
@@ -377,11 +383,17 @@ class ShaderMask extends SingleChildRenderObjectWidget {
 /// widget's clip. If there's no clip, the filter will be applied to the full
 /// screen.
 ///
-/// The results of the filter will be blended back into the background
-/// using the [blendMode] parameter. This parameter is not supported on all
-/// platforms, notably the html DOM renderer on the web platform, so using
-/// any blend mode except for the default [BlendMode.srcOver] is not portable
-/// at this time.
+/// The results of the filter will be blended back into the background using
+/// the [blendMode] parameter.
+/// {@template flutter.widgets.BackdropFilter.blendMode}
+/// The only value for [blendMode] that is supported on all platforms is
+/// [BlendMode.srcOver] which works well for most scenes. But that value may
+/// produce surprising results when a parent of the [BackdropFilter] uses a
+/// temporary buffer, or save layer, as does an [Opacity] widget. In that
+/// situation, a value of [BlendMode.src] can produce more pleasing results,
+/// but at the cost of incompatibility with some platforms, most notably the
+/// html renderer for web applications.
+/// {@endtemplate}
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=dYRs7Q1vfYI}
 ///
@@ -433,6 +445,8 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
   /// Creates a backdrop filter.
   ///
   /// The [filter] argument must not be null.
+  /// The [blendMode] argument will default to [BlendMode.srcOver] and must not be
+  /// null if provided.
   const BackdropFilter({
     Key? key,
     required this.filter,
@@ -450,12 +464,7 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
   /// The blend mode to use to apply the filtered background content onto the background
   /// surface.
   ///
-  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
-  /// using this widget inside of a parent that uses a saveLayer may produce surprising
-  /// results. When rendering inside a saveLayer which implicitly presents a transparent
-  /// background, the results would look better with a [BlendMode.src] mode. Note that
-  /// the DOM-html renderer on web does not support this parameter so using any mode
-  /// but the default may produce different results.
+  /// {@macro flutter.widgets.BackdropFilter.blendMode}
   final BlendMode blendMode;
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -377,6 +377,12 @@ class ShaderMask extends SingleChildRenderObjectWidget {
 /// widget's clip. If there's no clip, the filter will be applied to the full
 /// screen.
 ///
+/// The results of the filter will be blended back into the background
+/// using the [blendMode] parameter. This parameter is not supported on all
+/// platforms, notably the html DOM renderer on the web platform, so using
+/// any blend mode except for the default [BlendMode.srcOver] is not portable
+/// at this time.
+///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=dYRs7Q1vfYI}
 ///
 /// {@tool snippet}
@@ -431,6 +437,7 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
     Key? key,
     required this.filter,
     Widget? child,
+    this.blendMode = BlendMode.srcOver,
   }) : assert(filter != null),
        super(key: key, child: child);
 
@@ -440,14 +447,27 @@ class BackdropFilter extends SingleChildRenderObjectWidget {
   /// blur effect.
   final ui.ImageFilter filter;
 
+  /// The blend mode to use to apply the filtered background content onto the background
+  /// surface.
+  ///
+  /// The default mode is [BlendMode.srcOver] which is the most compatible mode, but
+  /// using this widget inside of a parent that uses a saveLayer may produce surprising
+  /// results. When rendering inside a saveLayer which implicitly presents a transparent
+  /// background, the results would look better with a [BlendMode.src] mode. Note that
+  /// the DOM-html renderer on web does not support this parameter so using any mode
+  /// but the default may produce different results.
+  final BlendMode blendMode;
+
   @override
   RenderBackdropFilter createRenderObject(BuildContext context) {
-    return RenderBackdropFilter(filter: filter);
+    return RenderBackdropFilter(filter: filter, blendMode: blendMode);
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderBackdropFilter renderObject) {
-    renderObject.filter = filter;
+    renderObject
+      ..filter = filter
+      ..blendMode = blendMode;
   }
 }
 

--- a/packages/flutter/test/widgets/backdrop_filter_test.dart
+++ b/packages/flutter/test/widgets/backdrop_filter_test.dart
@@ -45,4 +45,63 @@ void main() {
       matchesGoldenFile('backdrop_filter_test.cull_rect.png'),
     );
   });
+
+  testWidgets('BackdropFilter blendMode on saveLayer', (WidgetTester tester) async {
+    tester.binding.addTime(const Duration(seconds: 15));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Opacity(
+            opacity: 0.9,
+            child: Stack(
+              fit: StackFit.expand,
+              children: <Widget>[
+                Text('0 0 ' * 10000),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  // ClipRect needed for filtering the 200x200 area instead of the
+                  // whole screen.
+                  children: <Widget>[
+                    ClipRect(
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(
+                          sigmaX: 5.0,
+                          sigmaY: 5.0,
+                        ),
+                        child: Container(
+                          alignment: Alignment.center,
+                          width: 200.0,
+                          height: 200.0,
+                          color: Colors.yellow.withAlpha(0x7),
+                        ),
+                      ),
+                    ),
+                    ClipRect(
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(
+                          sigmaX: 5.0,
+                          sigmaY: 5.0,
+                        ),
+                        blendMode: BlendMode.src,
+                        child: Container(
+                          alignment: Alignment.center,
+                          width: 200.0,
+                          height: 200.0,
+                          color: Colors.yellow.withAlpha(0x7),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(RepaintBoundary).first,
+      matchesGoldenFile('backdrop_filter_test.saveLayer.blendMode.png'),
+    );
+  });
 }


### PR DESCRIPTION
This PR is the framework half of https://github.com/flutter/engine/pull/19631 which provides a way to control the blending of the BackdropFilter filter output onto the scene important for cases where the widget is inside of another parent widget that uses a saveLayer - most typically an Opacity widget.

I'd be particularly interested in hearing from @ferhatb as to whether the caveats about using this feature with the DOM renderer are appropriately worded (and in particular, how should we canonically refer to that platform?).