### PR TITLE
Remove crash_reporting and github_template from reporting library

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -20,7 +20,7 @@ import 'src/base/process.dart';
 import 'src/context_runner.dart';
 import 'src/doctor.dart';
 import 'src/globals.dart' as globals;
-import 'src/reporting/reporting.dart';
+import 'src/reporting/crash_reporting.dart';
 import 'src/runner/flutter_command.dart';
 import 'src/runner/flutter_command_runner.dart';
 

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -56,6 +56,7 @@ import 'macos/macos_workflow.dart';
 import 'macos/xcode.dart';
 import 'mdns_discovery.dart';
 import 'persistent_tool_state.dart';
+import 'reporting/crash_reporting.dart';
 import 'reporting/first_run.dart';
 import 'reporting/reporting.dart';
 import 'resident_runner.dart';

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -23,6 +23,7 @@ import 'macos/cocoapods_validator.dart';
 import 'macos/xcode.dart';
 import 'persistent_tool_state.dart';
 import 'project.dart';
+import 'reporting/crash_reporting.dart';
 import 'reporting/reporting.dart';
 import 'runner/local_engine.dart';
 

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -4,7 +4,20 @@
 
 // @dart = 2.8
 
-part of reporting;
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+
+import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/os.dart';
+import '../base/platform.dart';
+import '../project.dart';
+import 'github_template.dart';
+import 'reporting.dart';
 
 /// Tells crash backend that the error is from the Flutter CLI.
 const String _kProductId = 'Flutter_Tools';

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -4,7 +4,23 @@
 
 // @dart = 2.8
 
-part of reporting;
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
+
+import '../base/file_system.dart';
+import '../base/io.dart';
+import '../base/logger.dart';
+import '../base/process.dart';
+import '../build_system/exceptions.dart';
+import '../convert.dart';
+import '../devfs.dart';
+import '../flutter_manifest.dart';
+import '../flutter_project_metadata.dart';
+import '../project.dart';
+import '../version.dart';
 
 /// Provide suggested GitHub issue templates to user when Flutter encounters an error.
 class GitHubTemplateCreator {

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -9,37 +9,22 @@ library reporting;
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:http/http.dart' as http;
-import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:usage/usage_io.dart';
 
 import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
-import '../base/logger.dart';
-import '../base/os.dart';
-import '../base/platform.dart';
-import '../base/process.dart';
 import '../base/time.dart';
 import '../build_info.dart';
-import '../build_system/exceptions.dart';
-import '../convert.dart';
 import '../dart/language_version.dart';
-import '../devfs.dart';
 import '../doctor_validator.dart';
 import '../features.dart';
-import '../flutter_manifest.dart';
-import '../flutter_project_metadata.dart';
 import '../globals.dart' as globals;
-import '../project.dart';
 import '../runner/flutter_command.dart';
 import '../version.dart';
 import 'first_run.dart';
 
-part 'crash_reporting.dart';
 part 'disabled_usage.dart';
 part 'events.dart';
-part 'github_template.dart';
 part 'usage.dart';

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:flutter_tools/src/reporting/github_template.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
+++ b/packages/flutter_tools/test/integration.shard/forbidden_imports_test.dart
@@ -90,7 +90,7 @@ void main() {
   test('no unauthorized imports of package:http', () {
     final List<String> allowedPaths = <String>[
       // Used only for multi-part file uploads, which are non-trivial to reimplement.
-      fileSystem.path.join(flutterTools, 'lib', 'src', 'reporting', 'reporting.dart'),
+      fileSystem.path.join(flutterTools, 'lib', 'src', 'reporting', 'crash_reporting.dart'),
     ];
     bool _isNotAllowed(FileSystemEntity entity) => allowedPaths.every((String path) => path != entity.path);
 

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -30,6 +30,7 @@ import 'package:flutter_tools/src/ios/simulators.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/persistent_tool_state.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;


### PR DESCRIPTION
The reporting library needs to be migrated to null safety since it's a dependency of many other flutter_tools libraries. 
 Due to their dependencies, `crash_reporting` and `github_template` aren't ready to be converted to null safety.  `events` and `usage` will however be ready to migrate once https://github.com/flutter/flutter/pull/80096 merges.

From https://github.com/flutter/flutter/pull/36785 and talking with @zanderso the purpose of the `reporting` `part`s is to keep `Usage.sendEvent` protected.  That can be done without `crash_reporting` or `github_template` being in the library.  Pull them out of `reporting`.

Part of #71511