### PR TITLE
Migrate tools test fakes to null safety

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 import '../../src/testbed.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -29,8 +29,8 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_devices.dart';
 import '../../src/fake_vm_services.dart';
-import '../../src/fakes.dart';
 import '../../src/mocks.dart';
 import '../../src/test_flutter_command_runner.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/version.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 
 void main() {
   group('build ios-framework', () {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_web_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/web/compile.dart';
@@ -22,6 +21,7 @@ import 'package:flutter_tools/src/web/compile.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -65,20 +65,18 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
   testUsingContext('Refuses to build a debug build for web', () async {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
-    expect(() => runner.run(<String>['build', 'web', '--debug']),
+    expect(() => runner.run(<String>['build', 'web', '--debug', '--no-pub']),
       throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -86,14 +84,13 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
     expect(
-      () => runner.run(<String>['build', 'web']),
+      () => runner.run(<String>['build', 'web', '--no-pub']),
       throwsToolExit(message: '"build web" is not currently supported. To enable, run "flutter config --enable-web".')
     );
   }, overrides: <Type, Generator>{
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -101,14 +98,13 @@ void main() {
     final BuildCommand buildCommand = BuildCommand();
     final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
     setupFileSystemForEndToEndTest(fileSystem);
-    await runner.run(<String>['build', 'web']);
+    await runner.run(<String>['build', 'web', '--no-pub']);
 
     expect(fileSystem.file(fileSystem.path.join('lib', 'generated_plugin_registrant.dart')).existsSync(), true);
   }, overrides: <Type, Generator>{
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
   });
@@ -119,7 +115,6 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: false),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -129,7 +124,6 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
   });
 
@@ -137,7 +131,7 @@ void main() {
     final TestWebBuildCommand buildCommand = TestWebBuildCommand();
     final CommandRunner<void> runner = createTestCommandRunner(buildCommand);
     setupFileSystemForEndToEndTest(fileSystem);
-    await runner.run(<String>['build', 'web']);
+    await runner.run(<String>['build', 'web', '--no-pub']);
     final BuildInfo buildInfo =
         await buildCommand.webCommand.getBuildInfo(forcedBuildMode: BuildMode.debug);
     expect(buildInfo.dartDefines, contains('FLUTTER_WEB_AUTO_DETECT=true'));
@@ -145,7 +139,6 @@ void main() {
     Platform: () => fakePlatform,
     FileSystem: () => fileSystem,
     FeatureFlags: () => TestFeatureFlags(isWebEnabled: true),
-    Pub: () => FakePub(),
     ProcessManager: () => FakeProcessManager.any(),
     BuildSystem: () => TestBuildSystem.all(BuildResult(success: true)),
   });
@@ -217,4 +210,7 @@ class TestWebBuildCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async => null;
+
+  @override
+  bool get shouldRunPub => false;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -21,6 +21,7 @@ import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_devices.dart';
 import '../../src/fakes.dart';
 import '../../src/mocks.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -16,7 +16,6 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -106,4 +105,18 @@ void main() {
 class ScreenshotDevice extends Fake implements Device {
   @override
   Future<void> takeScreenshot(File outputFile) async {}
+}
+
+class FakePub extends Fake implements Pub {
+  @override
+  Future<void> get({
+    PubContext context,
+    String directory,
+    bool skipIfAbsent = false,
+    bool upgrade = false,
+    bool offline = false,
+    bool generateSyntheticPackage = false,
+    String flutterRootOverride,
+    bool checkUpToDate = false,
+  }) async { }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -31,6 +31,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_devices.dart';
 import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_shim_test.dart
@@ -14,7 +14,7 @@ import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/fakes.dart';
+import '../src/test_build_system.dart';
 
 // Tests for the temporary flutter assemble/bundle shim.
 void main() {

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -10,6 +10,7 @@ import 'package:file/src/interface/directory.dart';
 import 'package:file/src/interface/file.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device_config.dart';
@@ -21,6 +22,7 @@ import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:file/memory.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/project.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -517,4 +519,23 @@ void main() {
       ProcessManager: () => FakeProcessManager.any()
     }
   );
+}
+
+class FakeBundleBuilder extends Fake implements BundleBuilder {
+  @override
+  Future<void> build({
+    TargetPlatform platform,
+    BuildInfo buildInfo,
+    String mainPath,
+    String manifestPath = defaultManifestPath,
+    String applicationKernelFilePath,
+    String depfilePath,
+    String assetDirPath,
+    bool trackWidgetCreation = false,
+    List<String> extraFrontEndOptions = const <String>[],
+    List<String> extraGenSnapshotOptions = const <String>[],
+    List<String> fileSystemRoots,
+    String fileSystemScheme,
+    bool treeShakeIcons
+  }) async {}
 }

--- a/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/generate_synthetic_packages_test.dart
@@ -16,7 +16,7 @@ import 'package:flutter_tools/src/build_system/targets/localizations.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 
 void main() {
   testWithoutContext('calls buildSystem.build with blank l10n.yaml file', () async {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
+import '../../src/fake_devices.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -11,7 +11,7 @@ import 'package:fake_async/fake_async.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/fakes.dart';
+import '../src/fake_devices.dart';
 
 void main() {
   group('service_protocol discovery', () {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -26,6 +26,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fakes.dart';
+import '../src/test_build_system.dart';
 
 void main() {
   ResidentWebRunner residentWebRunner;

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -25,7 +25,6 @@ import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 import 'utils.dart';
 
@@ -566,23 +565,6 @@ class FakeDeprecatedCommand extends FlutterCommand {
   }
 }
 
-class FakeNullSafeCommand extends FlutterCommand {
-  FakeNullSafeCommand() {
-    addEnableExperimentation(hide: false);
-  }
-
-  @override
-  String get description => 'test null safety';
-
-  @override
-  String get name => 'safety';
-
-  @override
-  Future<FlutterCommandResult> runCommand() async {
-    return FlutterCommandResult.success();
-  }
-}
-
 class FakeTargetCommand extends FlutterCommand {
   FakeTargetCommand() {
     usesTargetOption();
@@ -667,3 +649,17 @@ class FakeClock extends Fake implements SystemClock {
 }
 
 class MockCache extends Mock implements Cache {}
+
+class FakePub extends Fake implements Pub {
+  @override
+  Future<void> get({
+    PubContext context,
+    String directory,
+    bool skipIfAbsent = false,
+    bool upgrade = false,
+    bool offline = false,
+    bool generateSyntheticPackage = false,
+    String flutterRootOverride,
+    bool checkUpToDate = false,
+  }) async { }
+}

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter_tools/src/tester/flutter_tester.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
+import '../../src/test_build_system.dart';
 
 void main() {
   MemoryFileSystem fileSystem;

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -4,6 +4,8 @@
 
 // @dart = 2.8
 
+import 'dart:async';
+
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -128,4 +130,84 @@ class FakeDeviceJsonData {
 
   final FakeDevice dev;
   final Map<String, Object> json;
+}
+
+class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
+  FakePollingDeviceDiscovery() : super('mock');
+
+  final List<Device> _devices = <Device>[];
+  final StreamController<Device> _onAddedController = StreamController<Device>.broadcast();
+  final StreamController<Device> _onRemovedController = StreamController<Device>.broadcast();
+
+  @override
+  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
+    lastPollingTimeout = timeout;
+    return _devices;
+  }
+
+  Duration lastPollingTimeout;
+
+  @override
+  bool get supportsPlatform => true;
+
+  @override
+  bool get canListAnything => true;
+
+  void addDevice(Device device) {
+    _devices.add(device);
+    _onAddedController.add(device);
+  }
+
+  void _removeDevice(Device device) {
+    _devices.remove(device);
+    _onRemovedController.add(device);
+  }
+
+  void setDevices(List<Device> devices) {
+    while(_devices.isNotEmpty) {
+      _removeDevice(_devices.first);
+    }
+    devices.forEach(addDevice);
+  }
+
+  @override
+  Stream<Device> get onAdded => _onAddedController.stream;
+
+  @override
+  Stream<Device> get onRemoved => _onRemovedController.stream;
+}
+
+/// A fake implementation of the [DeviceLogReader].
+class FakeDeviceLogReader extends DeviceLogReader {
+  @override
+  String get name => 'FakeLogReader';
+
+  StreamController<String> _cachedLinesController;
+
+  final List<String> _lineQueue = <String>[];
+  StreamController<String> get _linesController {
+    _cachedLinesController ??= StreamController<String>
+        .broadcast(onListen: () {
+      _lineQueue.forEach(_linesController.add);
+      _lineQueue.clear();
+    });
+    return _cachedLinesController;
+  }
+
+  @override
+  Stream<String> get logLines => _linesController.stream;
+
+  void addLine(String line) {
+    if (_linesController.hasListener) {
+      _linesController.add(line);
+    } else {
+      _lineQueue.add(line);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    _lineQueue.clear();
+    await _linesController.close();
+  }
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 import 'dart:io' as io show IOSink, ProcessSignal, Stdout, StdoutException;
 
@@ -12,52 +10,11 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
-import 'package:flutter_tools/src/build_info.dart';
-import 'package:flutter_tools/src/build_system/build_system.dart';
-import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/convert.dart';
-import 'package:flutter_tools/src/dart/pub.dart';
-import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/version.dart';
-import 'package:test/fake.dart';
-
-/// A fake implementation of the [DeviceLogReader].
-class FakeDeviceLogReader extends DeviceLogReader {
-  @override
-  String get name => 'FakeLogReader';
-
-  StreamController<String> _cachedLinesController;
-
-  final List<String> _lineQueue = <String>[];
-  StreamController<String> get _linesController {
-    _cachedLinesController ??= StreamController<String>
-      .broadcast(onListen: () {
-        _lineQueue.forEach(_linesController.add);
-        _lineQueue.clear();
-     });
-    return _cachedLinesController;
-  }
-
-  @override
-  Stream<String> get logLines => _linesController.stream;
-
-  void addLine(String line) {
-    if (_linesController.hasListener) {
-      _linesController.add(line);
-    } else {
-      _lineQueue.add(line);
-    }
-  }
-
-  @override
-  Future<void> dispose() async {
-    _lineQueue.clear();
-    await _linesController.close();
-  }
-}
 
 /// Environment with DYLD_LIBRARY_PATH=/path/to/libraries
 class FakeDyldEnvironmentArtifact extends ArtifactSet {
@@ -82,8 +39,8 @@ class FakeDyldEnvironmentArtifact extends ArtifactSet {
 class FakeProcess implements Process {
   FakeProcess({
     this.pid = 1,
-    Future<int> exitCode,
-    IOSink stdin,
+    Future<int>? exitCode,
+    IOSink? stdin,
     this.stdout = const Stream<List<int>>.empty(),
     this.stderr = const Stream<List<int>>.empty(),
   }) : exitCode = exitCode ?? Future<int>.value(0),
@@ -196,7 +153,7 @@ class MemoryIOSink implements IOSink {
   @override
   Future<void> addStream(Stream<List<int>> stream) {
     final Completer<void> completer = Completer<void>();
-    StreamSubscription<List<int>> sub;
+    late StreamSubscription<List<int>> sub;
     sub = stream.listen(
       (List<int> data) {
         try {
@@ -220,12 +177,12 @@ class MemoryIOSink implements IOSink {
   }
 
   @override
-  void write(Object obj) {
+  void write(Object? obj) {
     add(encoding.encode('$obj'));
   }
 
   @override
-  void writeln([ Object obj = '' ]) {
+  void writeln([ Object? obj = '' ]) {
     add(encoding.encode('$obj\n'));
   }
 
@@ -242,7 +199,7 @@ class MemoryIOSink implements IOSink {
   }
 
   @override
-  void addError(dynamic error, [ StackTrace stackTrace ]) {
+  void addError(dynamic error, [ StackTrace? stackTrace ]) {
     throw UnimplementedError();
   }
 
@@ -289,22 +246,22 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
   @override
   int get terminalColumns {
     if (_terminalColumns != null) {
-      return _terminalColumns;
+      return _terminalColumns!;
     }
     throw const io.StdoutException('unspecified mock value');
   }
   set terminalColumns(int value) => _terminalColumns = value;
-  int _terminalColumns;
+  int? _terminalColumns;
 
   @override
   int get terminalLines {
     if (_terminalLines != null) {
-      return _terminalLines;
+      return _terminalLines!;
     }
     throw const io.StdoutException('unspecified mock value');
   }
   set terminalLines(int value) => _terminalLines = value;
-  int _terminalLines;
+  int? _terminalLines;
 }
 
 /// A Stdio that collects stdout and supports simulated stdin.
@@ -328,93 +285,6 @@ class FakeStdio extends Stdio {
 
   List<String> get writtenToStdout => _stdout.writes.map<String>(_stdout.encoding.decode).toList();
   List<String> get writtenToStderr => _stderr.writes.map<String>(_stderr.encoding.decode).toList();
-}
-
-class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
-  FakePollingDeviceDiscovery() : super('mock');
-
-  final List<Device> _devices = <Device>[];
-  final StreamController<Device> _onAddedController = StreamController<Device>.broadcast();
-  final StreamController<Device> _onRemovedController = StreamController<Device>.broadcast();
-
-  @override
-  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
-    lastPollingTimeout = timeout;
-    return _devices;
-  }
-
-  Duration lastPollingTimeout;
-
-  @override
-  bool get supportsPlatform => true;
-
-  @override
-  bool get canListAnything => true;
-
-  void addDevice(Device device) {
-    _devices.add(device);
-    _onAddedController.add(device);
-  }
-
-  void _removeDevice(Device device) {
-    _devices.remove(device);
-    _onRemovedController.add(device);
-  }
-
-  void setDevices(List<Device> devices) {
-    while(_devices.isNotEmpty) {
-      _removeDevice(_devices.first);
-    }
-    devices.forEach(addDevice);
-  }
-
-  @override
-  Stream<Device> get onAdded => _onAddedController.stream;
-
-  @override
-  Stream<Device> get onRemoved => _onRemovedController.stream;
-}
-
-class LongPollingDeviceDiscovery extends PollingDeviceDiscovery {
-  LongPollingDeviceDiscovery() : super('forever');
-
-  final Completer<List<Device>> _completer = Completer<List<Device>>();
-
-  @override
-  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
-    return _completer.future;
-  }
-
-  @override
-  Future<void> stopPolling() async {
-    _completer.complete();
-  }
-
-  @override
-  Future<void> dispose() async {
-    _completer.complete();
-  }
-
-  @override
-  bool get supportsPlatform => true;
-
-  @override
-  bool get canListAnything => true;
-}
-
-class ThrowingPollingDeviceDiscovery extends PollingDeviceDiscovery {
-  ThrowingPollingDeviceDiscovery() : super('throw');
-
-  @override
-  Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
-    throw const ProcessException('fake-discovery', <String>[]);
-  }
-
-  @override
-  bool get supportsPlatform => true;
-
-  @override
-  bool get canListAnything => true;
 }
 
 class FakePlistParser implements PlistParser {
@@ -443,20 +313,6 @@ class FakeBotDetector implements BotDetector {
   Future<bool> get isRunningOnBot async => _isRunningOnBot;
 
   final bool _isRunningOnBot;
-}
-
-class FakePub extends Fake implements Pub {
-  @override
-  Future<void> get({
-    PubContext context,
-    String directory,
-    bool skipIfAbsent = false,
-    bool upgrade = false,
-    bool offline = false,
-    bool generateSyntheticPackage = false,
-    String flutterRootOverride,
-    bool checkUpToDate = false,
-  }) async { }
 }
 
 class FakeFlutterVersion implements FlutterVersion {
@@ -628,89 +484,12 @@ class TestFeatureFlags implements FeatureFlags {
 class FakeStatusLogger extends DelegatingLogger {
   FakeStatusLogger(Logger delegate) : super(delegate);
 
-  Status status;
+  late Status status;
 
   @override
-  Status startProgress(String message, {Duration timeout, String progressId, bool multilineOutput = false, bool includeTiming = true, int progressIndicatorPadding = kDefaultStatusPadding}) {
-    return status;
-  }
-}
-
-class TestBuildSystem implements BuildSystem {
-  /// Create a [BuildSystem] instance that returns the provided results in order.
-  TestBuildSystem.list(this._results, [this._onRun])
-    : _exception = null,
-      _singleResult = null;
-
-  /// Create a [BuildSystem] instance that returns the provided result for every build
-  /// and buildIncremental request.
-  TestBuildSystem.all(this._singleResult, [this._onRun])
-    : _exception = null,
-      _results = <BuildResult>[];
-
-  /// Create a [BuildSystem] instance that always throws the provided error for every build
-  /// and buildIncremental request.
-  TestBuildSystem.error(this._exception)
-    : _singleResult = null,
-      _results = <BuildResult>[],
-      _onRun = null;
-
-  final List<BuildResult> _results;
-  final BuildResult _singleResult;
-  final dynamic _exception;
-  final void Function(Target target, Environment environment) _onRun;
-  int _nextResult = 0;
-
-  @override
-  Future<BuildResult> build(Target target, Environment environment, {BuildSystemConfig buildSystemConfig = const BuildSystemConfig()}) async {
-    if (_onRun != null) {
-      _onRun(target, environment);
-    }
-    if (_exception != null) {
-      throw _exception;
-    }
-    if (_singleResult != null) {
-      return _singleResult;
-    }
-    if (_nextResult >= _results.length) {
-      throw StateError('Unexpected build request of ${target.name}');
-    }
-    return _results[_nextResult++];
-  }
-
-  @override
-  Future<BuildResult> buildIncremental(Target target, Environment environment, BuildResult previousBuild) async {
-    if (_onRun != null) {
-      _onRun(target, environment);
-    }
-    if (_exception != null) {
-      throw _exception;
-    }
-    if (_singleResult != null) {
-      return _singleResult;
-    }
-    if (_nextResult >= _results.length) {
-      throw StateError('Unexpected buildIncremental request of ${target.name}');
-    }
-    return _results[_nextResult++];
-  }
-}
-
-class FakeBundleBuilder extends Fake implements BundleBuilder {
-  @override
-  Future<void> build({
-    TargetPlatform platform,
-    BuildInfo buildInfo,
-    String mainPath,
-    String manifestPath = defaultManifestPath,
-    String applicationKernelFilePath,
-    String depfilePath,
-    String assetDirPath,
-    bool trackWidgetCreation = false,
-    List<String> extraFrontEndOptions = const <String>[],
-    List<String> extraGenSnapshotOptions = const <String>[],
-    List<String> fileSystemRoots,
-    String fileSystemScheme,
-    bool treeShakeIcons
-  }) => Future<void>.value();
+  Status startProgress(String message, {
+    String? progressId,
+    bool multilineOutput = false,
+    int progressIndicatorPadding = kDefaultStatusPadding,
+  }) => status;
 }

--- a/packages/flutter_tools/test/src/test_build_system.dart
+++ b/packages/flutter_tools/test/src/test_build_system.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/build_system/build_system.dart';
+
+class TestBuildSystem implements BuildSystem {
+  /// Create a [BuildSystem] instance that returns the provided results in order.
+  TestBuildSystem.list(this._results, [this._onRun])
+    : _exception = null,
+      _singleResult = null;
+
+  /// Create a [BuildSystem] instance that returns the provided result for every build
+  /// and buildIncremental request.
+  TestBuildSystem.all(this._singleResult, [this._onRun])
+    : _exception = null,
+      _results = <BuildResult>[];
+
+  /// Create a [BuildSystem] instance that always throws the provided error for every build
+  /// and buildIncremental request.
+  TestBuildSystem.error(this._exception)
+    : _singleResult = null,
+      _results = <BuildResult>[],
+      _onRun = null;
+
+  final List<BuildResult> _results;
+  final BuildResult _singleResult;
+  final dynamic _exception;
+  final void Function(Target target, Environment environment) _onRun;
+  int _nextResult = 0;
+
+  @override
+  Future<BuildResult> build(Target target, Environment environment, {BuildSystemConfig buildSystemConfig = const BuildSystemConfig()}) async {
+    if (_onRun != null) {
+      _onRun(target, environment);
+    }
+    if (_exception != null) {
+      throw _exception;
+    }
+    if (_singleResult != null) {
+      return _singleResult;
+    }
+    if (_nextResult >= _results.length) {
+      throw StateError('Unexpected build request of ${target.name}');
+    }
+    return _results[_nextResult++];
+  }
+
+  @override
+  Future<BuildResult> buildIncremental(Target target, Environment environment, BuildResult previousBuild) async {
+    if (_onRun != null) {
+      _onRun(target, environment);
+    }
+    if (_exception != null) {
+      throw _exception;
+    }
+    if (_singleResult != null) {
+      return _singleResult;
+    }
+    if (_nextResult >= _results.length) {
+      throw StateError('Unexpected buildIncremental request of ${target.name}');
+    }
+    return _results[_nextResult++];
+  }
+}


### PR DESCRIPTION
Move the classes that aren't null safe migration ready out of `fakes.dart`, then migrate it to null safety.  This will allow more tests to be migrated.

1. Move `FakeBundleBuilder`, `LongPollingDeviceDiscovery`, and `ThrowingPollingDeviceDiscovery` to the only files that use those classes
2. Move `FakePollingDeviceDiscovery` and `FakeDeviceLogReader` into `fake_devices.dart`
3. Move `TestBuildSystem` into its own file
4. Move the very simple `FakePub` to where it's used, or fix the test to not need it.

Part of #71511