### PR TITLE
Remove flutter_command dependency from reporting library

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -292,9 +292,9 @@ class AndroidGradleBuilder implements AndroidBuilder {
 
     final bool usesAndroidX = isAppUsingAndroidX(project.android.hostAppGradleRoot);
     if (usesAndroidX) {
-      BuildEvent('app-using-android-x', flutterUsage: _usage).send();
+      BuildEvent('app-using-android-x', type: 'gradle', flutterUsage: _usage).send();
     } else if (!usesAndroidX) {
-      BuildEvent('app-not-using-android-x', flutterUsage: _usage).send();
+      BuildEvent('app-not-using-android-x', type: 'gradle', flutterUsage: _usage).send();
       _logger.printStatus("${_logger.terminal.warningMark} Your app isn't using AndroidX.", emphasis: true);
       _logger.printStatus(
         'To avoid potential build failures, you can quickly migrate your app '
@@ -460,7 +460,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
 
     if (exitCode != 0) {
       if (detectedGradleError == null) {
-        BuildEvent('gradle-unknown-failure', flutterUsage: _usage).send();
+        BuildEvent('gradle-unknown-failure', type: 'gradle', flutterUsage: _usage).send();
         throwToolExit(
           'Gradle task $assembleTask failed with exit code $exitCode',
           exitCode: exitCode,
@@ -486,7 +486,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
                 shouldBuildPluginAsAar: shouldBuildPluginAsAar,
                 retries: retries - 1,
               );
-              BuildEvent(successEventLabel, flutterUsage: _usage).send();
+              BuildEvent(successEventLabel, type: 'gradle', flutterUsage: _usage).send();
               return;
             case GradleBuildStatus.retryWithAarPlugins:
               await buildGradleApp(
@@ -498,13 +498,13 @@ class AndroidGradleBuilder implements AndroidBuilder {
                 shouldBuildPluginAsAar: true,
                 retries: retries - 1,
               );
-              BuildEvent(successEventLabel, flutterUsage: _usage).send();
+              BuildEvent(successEventLabel, type: 'gradle', flutterUsage: _usage).send();
               return;
             case GradleBuildStatus.exit:
             // noop.
           }
         }
-        BuildEvent('gradle-${detectedGradleError.eventLabel}-failure', flutterUsage: _usage).send();
+        BuildEvent('gradle-${detectedGradleError.eventLabel}-failure', type: 'gradle', flutterUsage: _usage).send();
         throwToolExit(
           'Gradle task $assembleTask failed with exit code $exitCode',
           exitCode: exitCode,
@@ -798,7 +798,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
       } on ToolExit {
         // Log the entire plugin entry in `.flutter-plugins` since it
         // includes the plugin name and the version.
-        BuildEvent('gradle-plugin-aar-failure', eventError: plugin, flutterUsage: _usage).send();
+        BuildEvent('gradle-plugin-aar-failure', type: 'gradle', eventError: plugin, flutterUsage: _usage).send();
         throwToolExit('The plugin $pluginName could not be built due to the issue above.');
       }
     }
@@ -879,7 +879,7 @@ String _calculateSha(File file) {
 }
 
 void _exitWithUnsupportedProjectMessage(Usage usage, Terminal terminal) {
-  BuildEvent('unsupported-project', eventError: 'gradle-plugin', flutterUsage: usage).send();
+  BuildEvent('unsupported-project', type: 'gradle', eventError: 'gradle-plugin', flutterUsage: usage).send();
   throwToolExit(
     '${terminal.warningMark} Your app is using an unsupported Gradle project. '
     'To fix this problem, create a new project by running `flutter create -t app <app-directory>` '
@@ -1030,6 +1030,7 @@ void _exitWithExpectedFileNotFound({
   final String androidGradlePluginVersion =
   getGradleVersionForAndroidPlugin(project.android.hostAppGradleRoot, logger);
   BuildEvent('gradle-expected-file-not-found',
+    type: 'gradle',
     settings:
     'androidGradlePluginVersion: $androidGradlePluginVersion, '
       'fileExtension: $fileExtension',

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -199,6 +199,7 @@ final GradleHandledError androidXFailureHandler = GradleHandledError(
       // the incompatibility is coming from.
       BuildEvent(
         'gradle-android-x-failure',
+        type: 'gradle',
         eventError: 'app-not-using-plugins',
         flutterUsage: globals.flutterUsage,
       ).send();
@@ -212,6 +213,7 @@ final GradleHandledError androidXFailureHandler = GradleHandledError(
       );
       BuildEvent(
         'gradle-android-x-failure',
+        type: 'gradle',
         eventError: 'app-not-using-androidx',
         flutterUsage: globals.flutterUsage,
       ).send();
@@ -222,6 +224,7 @@ final GradleHandledError androidXFailureHandler = GradleHandledError(
       // AARs, Jetifier translated Support libraries for AndroidX equivalents.
       BuildEvent(
         'gradle-android-x-failure',
+        type: 'gradle',
         eventError: 'using-jetifier',
         flutterUsage: globals.flutterUsage,
       ).send();
@@ -233,6 +236,7 @@ final GradleHandledError androidXFailureHandler = GradleHandledError(
       );
       BuildEvent(
         'gradle-android-x-failure',
+        type: 'gradle',
         eventError: 'not-using-jetifier',
         flutterUsage: globals.flutterUsage,
       ).send();

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -255,7 +255,7 @@ void writeLocalProperties(File properties) {
 }
 
 void exitWithNoSdkMessage() {
-  BuildEvent('unsupported-project', eventError: 'android-sdk-not-found', flutterUsage: globals.flutterUsage).send();
+  BuildEvent('unsupported-project', type: 'gradle', eventError: 'android-sdk-not-found', flutterUsage: globals.flutterUsage).send();
   throwToolExit(
     '${globals.logger.terminal.warningMark} No Android SDK found. '
     'Try setting the ANDROID_SDK_ROOT environment variable.'

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -383,6 +383,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   } on ProcessException catch (e) {
     if (e.toString().contains('timed out')) {
       BuildEvent('xcode-show-build-settings-timeout',
+        type: 'ios',
         command: showBuildSettingsCommand.join(' '),
         flutterUsage: globals.flutterUsage,
       ).send();
@@ -535,6 +536,7 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
       result.xcodeBuildExecution.buildForPhysicalDevice &&
       result.stdout?.toUpperCase()?.contains('BITCODE') == true) {
     BuildEvent('xcode-bitcode-failure',
+      type: 'ios',
       command: result.xcodeBuildExecution.buildCommands.toString(),
       settings: result.xcodeBuildExecution.buildSettings.toString(),
       flutterUsage: flutterUsage,

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -436,6 +436,7 @@ class XcodeProjectInterpreter {
     } on Exception catch (error) {
       if (error is ProcessException && error.toString().contains('timed out')) {
         BuildEvent('xcode-show-build-settings-timeout',
+          type: 'ios',
           command: showBuildSettingsCommand.join(' '),
           flutterUsage: _usage,
         ).send();

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -152,6 +152,7 @@ class BuildEvent extends UsageEvent {
     String settings,
     String eventError,
     @required Usage flutterUsage,
+    @required String type,
   }) : _command = command,
   _settings = settings,
   _eventError = eventError,
@@ -159,9 +160,7 @@ class BuildEvent extends UsageEvent {
     // category
     'build',
     // parameter
-    FlutterCommand.current == null
-      ? 'unspecified'
-      : FlutterCommand.current.name,
+    type,
     label: label,
     flutterUsage: flutterUsage,
   );
@@ -191,10 +190,10 @@ class BuildEvent extends UsageEvent {
 
 /// An event that reports the result of a top-level command.
 class CommandResultEvent extends UsageEvent {
-  CommandResultEvent(String commandPath, FlutterCommandResult result)
+  CommandResultEvent(String commandPath, String result)
       : assert(commandPath != null),
         assert(result != null),
-        super(commandPath, result.toString(), flutterUsage: globals.flutterUsage);
+        super(commandPath, result, flutterUsage: globals.flutterUsage);
 
   @override
   void send() {

--- a/packages/flutter_tools/lib/src/reporting/reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/reporting.dart
@@ -21,7 +21,6 @@ import '../dart/language_version.dart';
 import '../doctor_validator.dart';
 import '../features.dart';
 import '../globals.dart' as globals;
-import '../runner/flutter_command.dart';
 import '../version.dart';
 import 'first_run.dart';
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1105,7 +1105,7 @@ abstract class FlutterCommand extends Command<void> {
     }
     assert(commandResult != null);
     // Send command result.
-    CommandResultEvent(commandPath, commandResult).send();
+    CommandResultEvent(commandPath, commandResult.toString()).send();
 
     // Send timing.
     final List<String> labels = <String>[

--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -376,7 +376,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'apk',
+          'gradle',
           label: 'gradle-r8-failure',
           parameters: <String, String>{},
         ),
@@ -442,7 +442,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'apk',
+          'gradle',
           label: 'app-not-using-android-x',
           parameters: <String, String>{},
         ),
@@ -499,7 +499,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'apk',
+          'gradle',
           label: 'app-using-android-x',
           parameters: <String, String>{},
         ),

--- a/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_appbundle_test.dart
@@ -161,7 +161,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'appbundle',
+          'gradle',
           label: 'app-not-using-android-x',
           parameters: <String, String>{},
         ),
@@ -201,7 +201,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'appbundle',
+          'gradle',
           label: 'app-using-android-x',
           parameters: <String, String>{},
         ),

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -120,7 +120,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-random-event-label-failure',
           parameters: <String, String>{},
         ),
@@ -222,7 +222,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-random-event-label-failure',
           parameters: <String, String>{},
         ),
@@ -309,7 +309,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-random-event-label-failure',
           parameters: <String, String>{},
         ),
@@ -466,7 +466,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-random-event-label-success',
           parameters: <String, String>{},
         ),
@@ -674,7 +674,7 @@ void main() {
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-random-event-label-failure',
           parameters: <String, String>{},
         ),

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -355,7 +355,7 @@ Command: /home/android/gradlew assembleRelease
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-android-x-failure',
           parameters: <String, String>{
             'cd43': 'app-not-using-plugins',
@@ -390,7 +390,7 @@ Command: /home/android/gradlew assembleRelease
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-android-x-failure',
           parameters: <String, String>{
             'cd43': 'app-not-using-androidx',
@@ -418,7 +418,7 @@ Command: /home/android/gradlew assembleRelease
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-android-x-failure',
           parameters: <String, String>{
             'cd43': 'using-jetifier',
@@ -453,7 +453,7 @@ Command: /home/android/gradlew assembleRelease
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',
-          'unspecified',
+          'gradle',
           label: 'gradle-android-x-failure',
           parameters: <String, String>{
             'cd43': 'not-using-jetifier',

--- a/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 
 void main() {
   FileSystem fileSystem;
@@ -309,8 +308,7 @@ void main() {
     expect(bundle.path, fileSystem.path.join('irrelevant','app', 'outputs', 'bundle', 'foo_barDebug', 'app-foo_bar-debug.aab'));
   });
 
-  // Context is required due to build failure analytics event grabbing FlutterCommand.current.
-  testUsingContext('AAB not found', () {
+  testWithoutContext('AAB not found', () {
     final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
     final TestUsage testUsage = TestUsage();
     expect(
@@ -331,7 +329,7 @@ void main() {
     expect(testUsage.events, contains(
       const TestUsageEvent(
         'build',
-        'unspecified',
+        'gradle',
         label: 'gradle-expected-file-not-found',
         parameters: <String, String> {
           'cd37': 'androidGradlePluginVersion: 6.7, fileExtension: .aab',

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
@@ -19,14 +18,8 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
-
-FakePlatform _kNoColorTerminalPlatform() => FakePlatform(stdoutSupportsAnsi: false);
-final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
-  Platform: _kNoColorTerminalPlatform,
-};
 
 class MockIosProject extends Mock implements IosProject {}
 
@@ -149,7 +142,7 @@ void main() {
       testUsage = TestUsage();
     });
 
-    testUsingContext('Sends analytics when bitcode fails', () async {
+    testWithoutContext('Sends analytics when bitcode fails', () async {
       const List<String> buildCommands = <String>['xcrun', 'cc', 'blah'];
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
@@ -166,7 +159,7 @@ void main() {
       expect(testUsage.events, contains(
         TestUsageEvent(
           'build',
-          'unspecified',
+          'ios',
           label: 'xcode-bitcode-failure',
           parameters: <String, String>{
             cdKey(CustomDimensions.buildEventCommand): buildCommands.toString(),
@@ -176,7 +169,7 @@ void main() {
       ));
     });
 
-    testUsingContext('No provisioning profile shows message', () async {
+    testWithoutContext('No provisioning profile shows message', () async {
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
@@ -247,9 +240,9 @@ Error launching application on iPhone.''',
         logger.errorText,
         contains("No Provisioning Profile was found for your project's Bundle Identifier or your \ndevice."),
       );
-    }, overrides: noColorTerminalOverride);
+    });
 
-    testUsingContext('No development team shows message', () async {
+    testWithoutContext('No development team shows message', () async {
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
@@ -328,9 +321,9 @@ Could not build the precompiled application for the device.''',
         logger.errorText,
         contains('Building a deployable iOS app requires a selected Development Team with a \nProvisioning Profile.'),
       );
-    }, overrides: noColorTerminalOverride);
+    });
 
-    testUsingContext('embedded and linked framework iOS mismatch shows message', () async {
+    testWithoutContext('embedded and linked framework iOS mismatch shows message', () async {
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
@@ -365,9 +358,9 @@ Exited (sigterm)''',
         logger.errorText,
         contains('Your Xcode project requires migration.'),
       );
-    }, overrides: noColorTerminalOverride);
+    });
 
-    testUsingContext('embedded and linked framework iOS simulator mismatch shows message', () async {
+    testWithoutContext('embedded and linked framework iOS simulator mismatch shows message', () async {
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
@@ -402,7 +395,7 @@ Exited (sigterm)''',
         logger.errorText,
         contains('Your Xcode project requires migration.'),
       );
-    }, overrides: noColorTerminalOverride);
+    });
   });
 
   group('Upgrades project.pbxproj for old asset usage', () {


### PR DESCRIPTION
The `reporting` library would be ready to migrate to null safety, except that `BuildEvent` and `CommandResultEvent` depend on `flutter_command`, which won't be null safe any time soon.

1. Instead of using the current command as the event parameter `FlutterCommand.current.name`, instead specify what kind of error is being reported (`gradle` or `ios`).  This may actually be better for coalescing errors since it probably doesn't matter if a gradle error happened from `build aar` vs `apk`?
2. Remove `FlutterCommandResult` parameter from `CommandResultEvent` and instead take a string, hoisting the `commandResult.toString()` logic up to its one call site.

Follow up to https://github.com/flutter/flutter/pull/80139
Part of #71511