### PR TITLE
Reduce number of project creates in gradle_plugin_*_apk_tests

### DIFF
--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -25,7 +25,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
+        Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -44,9 +44,7 @@ Future<void> main() async {
           'lib/x86/libapp.so',
           'lib/x86_64/libapp.so',
         ], apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease without explicit target platform');
 
         await inDirectory(pluginProject.exampleAndroidPath, () {
@@ -59,7 +57,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
+        apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -73,9 +71,7 @@ Future<void> main() async {
         ], apkFiles);
 
         checkCollectionDoesNotContain<String>(debugAssets, apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm, android-arm64');
 
         await inDirectory(pluginProject.exampleAndroidPath, () {
@@ -89,7 +85,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
+        apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -101,9 +97,7 @@ Future<void> main() async {
         ], apkFiles);
 
         checkCollectionDoesNotContain<String>(debugAssets, apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with '
                 'target platform = android-arm, android-arm64 and split per ABI');
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -27,7 +27,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
+        Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -45,9 +45,7 @@ Future<void> main() async {
           'lib/x86/libapp.so',
           'lib/x86_64/libapp.so',
         ], apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug with target platform = android-x86');
         // This is used by `flutter run`
         await inDirectory(pluginProject.exampleAndroidPath, () {
@@ -61,7 +59,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
+        apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -77,9 +75,7 @@ Future<void> main() async {
           'lib/x86/libapp.so',
           'lib/x86_64/libapp.so',
         ], apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleDebug with target platform = android-x64');
         // This is used by `flutter run`
 
@@ -94,7 +90,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.debugApkPath);
+        apkFiles = await getFilesInApk(pluginProject.debugApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -110,9 +106,7 @@ Future<void> main() async {
           'lib/x86/libapp.so',
           'lib/x86_64/libapp.so',
         ], apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm');
 
         await inDirectory(pluginProject.exampleAndroidPath, () {
@@ -126,7 +120,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
+        apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -140,9 +134,7 @@ Future<void> main() async {
           'lib/arm64-v8a/libflutter.so',
           'lib/arm64-v8a/libapp.so',
         ], apkFiles);
-      });
 
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
         section('APK content for task assembleRelease with target platform = android-arm64');
 
         await inDirectory(pluginProject.exampleAndroidPath, () {
@@ -156,7 +148,7 @@ Future<void> main() async {
           );
         });
 
-        final Iterable<String> apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
+        apkFiles = await getFilesInApk(pluginProject.releaseApkPath);
 
         checkCollectionContains<String>(<String>[
           ...flutterAssets,
@@ -187,9 +179,7 @@ Future<void> main() async {
         if (errorMessage != null) {
           throw TaskResult.failure(errorMessage);
         }
-      });
 
-      await runProjectTest((FlutterProject project) async {
         section('gradlew assembleProfile');
         await inDirectory(project.rootPath, () {
           return flutter(
@@ -200,9 +190,7 @@ Future<void> main() async {
             ],
           );
         });
-      });
 
-      await runProjectTest((FlutterProject project) async {
         section('gradlew assembleLocal (custom debug build)');
         await project.addCustomBuildType('local', initWith: 'debug');
         await project.runGradleTask('assembleLocal');
@@ -263,7 +251,7 @@ Future<void> main() async {
       await runProjectTest((FlutterProject project) async {
         section('gradlew on build script with error');
         await project.introduceError();
-        final ProcessResult result = await inDirectory(project.rootPath, () {
+        ProcessResult result = await inDirectory(project.rootPath, () {
           return executeFlutter('build', options: <String>[
             'apk',
             '--release',
@@ -273,7 +261,7 @@ Future<void> main() async {
         if (result.exitCode == 0)
           throw failure(
               'Gradle did not exit with error as expected', result);
-        final String output = '${result.stdout}\n${result.stderr}';
+        String output = '${result.stdout}\n${result.stderr}';
         if (output.contains('GradleException') ||
             output.contains('Failed to notify') ||
             output.contains('at org.gradle'))
@@ -282,6 +270,27 @@ Future<void> main() async {
         if (!output.contains('Build failed'))
           throw failure(
               'Gradle output should contain a readable error message',
+              result);
+
+        section('flutter build apk on build script with error');
+        await project.introduceError();
+        result = await inDirectory(project.rootPath, () {
+          return executeFlutter('build', options: <String>[
+            'apk',
+            '--release',
+          ]);
+        });
+        if (result.exitCode == 0)
+          throw failure(
+              'flutter build apk should fail when Gradle does', result);
+        output = '${result.stdout}\n${result.stderr}';
+        if (!output.contains('Build failed'))
+          throw failure(
+              'flutter build apk output should contain a readable Gradle error message',
+              result);
+        if (hasMultipleOccurrences(output, 'Build failed'))
+          throw failure(
+              'flutter build apk should not invoke Gradle repeatedly on error',
               result);
       });
 
@@ -300,45 +309,6 @@ Future<void> main() async {
         final String output = '${result.stdout}\n${result.stderr}';
         if (!output.contains('No file or variants found for asset: lib/gallery/example_code.dart.'))
           throw failure(output, result);
-      });
-
-      await runProjectTest((FlutterProject project) async {
-        section('flutter build apk on build script with error');
-        await project.introduceError();
-        final ProcessResult result = await inDirectory(project.rootPath, () {
-          return executeFlutter('build', options: <String>[
-            'apk',
-            '--release',
-          ]);
-        });
-        if (result.exitCode == 0)
-          throw failure(
-              'flutter build apk should fail when Gradle does', result);
-        final String output = '${result.stdout}\n${result.stderr}';
-        if (!output.contains('Build failed'))
-          throw failure(
-              'flutter build apk output should contain a readable Gradle error message',
-              result);
-        if (hasMultipleOccurrences(output, 'Build failed'))
-          throw failure(
-              'flutter build apk should not invoke Gradle repeatedly on error',
-              result);
-      });
-
-      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
-        section('gradlew assembleDebug on plugin example');
-        await inDirectory(pluginProject.exampleAndroidPath, () {
-          return flutter(
-            'build',
-            options: <String>[
-              'apk',
-              '--debug',
-            ],
-          );
-        });
-        if (!File(pluginProject.debugApkPath).existsSync())
-          throw TaskResult.failure(
-              'Gradle did not produce an apk file at the expected place');
       });
 
       return TaskResult.success(null);

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -493,7 +493,7 @@
       "name": "Mac gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "mac_gradle_plugin_light_apk_test",
-      "enabled": false,
+      "enabled": true,
       "run_if": ["dev/**", "bin/**"]
     },
     {


### PR DESCRIPTION
Reduce the time `gradle_plugin_*_apk_tests` integration tests take by reducing the number of project creations.  By not cleaning between builds, it also allows the tests to take advantage of `assemble` caching, if applicable.

On my machine this saved about a minute in `gradle_plugin_fat_apk_test` and three minutes in `gradle_plugin_light_apk_test`.