### PR TITLE
Cache location of Java binary in devicelab tests

### DIFF
--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -501,16 +501,22 @@ Future<int> dart(List<String> args) => exec(dartBin, <String>['--disable-dart-de
 /// Returns a future that completes with a path suitable for JAVA_HOME
 /// or with null, if Java cannot be found.
 Future<String> findJavaHome() async {
-  final Iterable<String> hits = grep(
-    'Java binary at: ',
-    from: await evalFlutter('doctor', options: <String>['-v']),
-  );
-  if (hits.isEmpty)
-    return null;
-  final String javaBinary = hits.first.split(': ').last;
-  // javaBinary == /some/path/to/java/home/bin/java
-  return path.dirname(path.dirname(javaBinary));
+  if (_javaHome == null) {
+    final Iterable<String> hits = grep(
+      'Java binary at: ',
+      from: await evalFlutter('doctor', options: <String>['-v']),
+    );
+    if (hits.isEmpty)
+      return null;
+    final String javaBinary = hits.first
+        .split(': ')
+        .last;
+    // javaBinary == /some/path/to/java/home/bin/java
+    _javaHome = path.dirname(path.dirname(javaBinary));
+  }
+  return _javaHome;
 }
+String _javaHome;
 
 Future<T> inDirectory<T>(dynamic directory, Future<T> Function() action) async {
   final String previousCwd = cwd;


### PR DESCRIPTION
I'm going to argue the merits of finding java_home by parsing the `flutter doctor` output, but at the least it can be cached for a given integration test.
 
I could it being run 9 times in https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8850394317393080144/+/u/run_gradle_plugin_light_apk_test/stdout, which I bet adds at least a minute...