### PR TITLE
Modified DataRow to be disabled when onSelectChanged is not set

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1018,7 +1018,7 @@ class DataTable extends StatelessWidget {
         tableRows[rowIndex].children![0] = _buildCheckbox(
           context: context,
           checked: row.selected,
-          onRowTap: () => row.onSelectChanged?.call(!row.selected),
+          onRowTap: row.onSelectChanged == null ? null : () => row.onSelectChanged?.call(!row.selected),
           onCheckboxChanged: row.onSelectChanged,
           overlayColor: row.color ?? effectiveDataRowColor,
           tristate: false,
@@ -1084,7 +1084,7 @@ class DataTable extends StatelessWidget {
           onLongPress: cell.onLongPress,
           onTapCancel: cell.onTapCancel,
           onTapDown: cell.onTapDown,
-          onSelectChanged: () => row.onSelectChanged?.call(!row.selected),
+          onSelectChanged: row.onSelectChanged == null ? null : () => row.onSelectChanged?.call(!row.selected),
           overlayColor: row.color ?? effectiveDataRowColor,
         );
         rowIndex += 1;

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1629,4 +1629,39 @@ void main() {
       _customHorizontalMargin,
     );
   });
+
+  testWidgets('DataRow is disabled when onSelectChanged is not set', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DataTable(
+            columns: const <DataColumn>[
+              DataColumn(label: Text('Col1')),
+              DataColumn(label: Text('Col2')),
+            ],
+            rows: <DataRow>[
+              DataRow(cells: const <DataCell>[
+                DataCell(Text('Hello')),
+                DataCell(Text('world')),
+              ],
+              onSelectChanged: (bool? value) {},
+              ),
+              const DataRow(cells: <DataCell>[
+                DataCell(Text('Bug')),
+                DataCell(Text('report')),
+              ]),
+              const DataRow(cells: <DataCell>[
+                DataCell(Text('GitHub')),
+                DataCell(Text('issue')),
+              ]),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.widgetWithText(TableRowInkWell, 'Hello'), findsOneWidget);
+    expect(find.widgetWithText(TableRowInkWell, 'Bug'), findsNothing);
+    expect(find.widgetWithText(TableRowInkWell, 'GitHub'), findsNothing);
+  });
 }


### PR DESCRIPTION
DataRow receives focus even when onSelectChanged is null. This change enables the user to override this behavior and prevent DataRow to receive focus by default.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes: #79800 
Fixes: #74022

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
