### PR TITLE
Remove a dynamic that is no longer necessary (and the TODO for it)

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -55,8 +55,7 @@ enum KeyEventResult {
 ///
 /// Returns a [KeyEventResult] that describes how, and whether, the key event
 /// was handled.
-// TODO(gspencergoog): Convert this from dynamic to KeyEventResult once migration is complete.
-typedef FocusOnKeyCallback = dynamic Function(FocusNode node, RawKeyEvent event);
+typedef FocusOnKeyCallback = KeyEventResult Function(FocusNode node, RawKeyEvent event);
 
 /// An attachment point for a [FocusNode].
 ///
@@ -1674,33 +1673,18 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
     bool handled = false;
     for (final FocusNode node in <FocusNode>[_primaryFocus!, ..._primaryFocus!.ancestors]) {
       if (node.onKey != null) {
-        // TODO(gspencergoog): Convert this from dynamic to KeyEventResult once migration is complete.
-        final dynamic result = node.onKey!(node, event);
-        assert(
-          result is bool || result is KeyEventResult,
-          'Value returned from onKey handler must be a non-null bool or KeyEventResult, not ${result.runtimeType}',
-        );
-        if (result is KeyEventResult) {
-          switch (result) {
-            case KeyEventResult.handled:
-              assert(_focusDebug('Node $node handled key event $event.'));
-              handled = true;
-              break;
-            case KeyEventResult.skipRemainingHandlers:
-              assert(_focusDebug('Node $node stopped key event propagation: $event.'));
-              handled = false;
-              break;
-            case KeyEventResult.ignored:
-              continue;
-          }
-        } else if (result is bool){
-          if (result) {
+        final KeyEventResult result = node.onKey!(node, event);
+        switch (result) {
+          case KeyEventResult.handled:
             assert(_focusDebug('Node $node handled key event $event.'));
             handled = true;
             break;
-          } else {
+          case KeyEventResult.skipRemainingHandlers:
+            assert(_focusDebug('Node $node stopped key event propagation: $event.'));
+            handled = false;
+            break;
+          case KeyEventResult.ignored:
             continue;
-          }
         }
         break;
       }

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1596,7 +1596,7 @@ void main() {
       bool? keyEventHandled;
       await tester.pumpWidget(
         Focus(
-          onKey: (_, __) => true, // This one does nothing.
+          onKey: (_, __) => KeyEventResult.ignored, // This one does nothing.
           focusNode: focusNode,
           child: Container(key: key1),
         ),
@@ -1611,7 +1611,7 @@ void main() {
         Focus(
           onKey: (FocusNode node, RawKeyEvent event) { // The updated handler handles the key.
             keyEventHandled = true;
-            return true;
+            return KeyEventResult.handled;
           },
           focusNode: focusNode,
           child: Container(key: key1),


### PR DESCRIPTION
This is a lingering `dynamic` usage left over from the transition to handling key events asynchronously.

Removed the `dynamic` reference and replaced it with the actual type (`KeyEventResult`) expected.