### PR TITLE
Handle null primary focus when receiving key events

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -356,17 +356,18 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
     );
     final Intent? matchedIntent = _find(keysPressed: keysPressed);
     if (matchedIntent != null) {
-      final BuildContext primaryContext = primaryFocus!.context!;
-      assert (primaryContext != null);
-      final Action<Intent>? action = Actions.maybeFind<Intent>(
-        primaryContext,
-        intent: matchedIntent,
-      );
-      if (action != null && action.isEnabled(matchedIntent)) {
-        Actions.of(primaryContext).invokeAction(action, matchedIntent, primaryContext);
-        return action.consumesKey(matchedIntent)
-            ? KeyEventResult.handled
-            : KeyEventResult.skipRemainingHandlers;
+      final BuildContext? primaryContext = primaryFocus?.context;
+      if (primaryContext != null) {
+        final Action<Intent>? action = Actions.maybeFind<Intent>(
+          primaryContext,
+          intent: matchedIntent,
+        );
+        if (action != null && action.isEnabled(matchedIntent)) {
+          Actions.of(primaryContext).invokeAction(action, matchedIntent, primaryContext);
+          return action.consumesKey(matchedIntent)
+              ? KeyEventResult.handled
+              : KeyEventResult.skipRemainingHandlers;
+        }
       }
     }
     return modal ? KeyEventResult.skipRemainingHandlers : KeyEventResult.ignored;

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -290,6 +290,37 @@ void main() {
       expect(invoked, isTrue);
       expect(pressedKeys, equals(<LogicalKeyboardKey>[LogicalKeyboardKey.shiftLeft]));
     });
+    testWidgets('ShortcutManager ignores keypresses with no primary focus', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(pressedKeys);
+      bool invoked = false;
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{
+            TestIntent: TestAction(
+              onInvoke: (Intent intent) {
+                invoked = true;
+                return true;
+              },
+            ),
+          },
+          child: Shortcuts(
+            manager: testManager,
+            shortcuts: <LogicalKeySet, Intent>{
+              LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
+            },
+            child: SizedBox(key: containerKey, width: 100, height: 100),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(primaryFocus, isNull);
+      expect(Shortcuts.of(containerKey.currentContext!), isNotNull);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      expect(invoked, isFalse);
+      expect(pressedKeys, isEmpty);
+    });
     testWidgets("Shortcuts passes to the next Shortcuts widget if it doesn't map the key", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];


### PR DESCRIPTION
## Description

This allows the key handling code in the shortcut manager to function when there is a null `primaryFocus`.  The primary focus can be null only in some special circumstances (e.g. when an app hasn't set any focus at all), but that shouldn't cause a crash.

## Associated Issues

- https://github.com/flutter/flutter/issues/80123

## Tests

Also added a test to check this.