### PR TITLE
create SDK package allowlist for core packages

### DIFF
--- a/dev/bots/allowlist.dart
+++ b/dev/bots/allowlist.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The SDK package allowlist.
+///
+/// The goal of the allowlist is to make it more difficult to accidentally add new dependencies
+/// to the core SDK packages that users depend on. Any dependencies add to this set can have a
+/// large impact on the allowed version solving of a given flutter application.
+///
+/// Before adding a new Dart Team owned dependency to this set, please clear with natebosch@
+/// or jakemac53@. For other packages please contact hixie@ or jonahwilliams@ .
+const Set<String> kCorePackageAllowList = <String>{
+  'characters',
+  'clock',
+  'collection',
+  'fake_async',
+  'file',
+  'intl',
+  'meta',
+  'path',
+  'stack_trace',
+  'test',
+  'test_api',
+  'typed_data',
+  'vector_math',
+  'vm_service',
+  'webdriver',
+  '_fe_analyzer_shared',
+  'analyzer',
+  'archive',
+  'args',
+  'async',
+  'boolean_selector',
+  'charcode',
+  'cli_util',
+  'convert',
+  'coverage',
+  'crypto',
+  'glob',
+  'http_multi_server',
+  'http_parser',
+  'io',
+  'js',
+  'logging',
+  'matcher',
+  'mime',
+  'node_preamble',
+  'package_config',
+  'pedantic',
+  'pool',
+  'pub_semver',
+  'shelf',
+  'shelf_packages_handler',
+  'shelf_static',
+  'shelf_web_socket',
+  'source_map_stack_trace',
+  'source_maps',
+  'source_span',
+  'stream_channel',
+  'string_scanner',
+  'sync_http',
+  'term_glyph',
+  'test_core',
+  'watcher',
+  'web_socket_channel',
+  'webkit_inspection_protocol',
+  'yaml',
+  'flutter',
+  'flutter_driver',
+  'flutter_localizations',
+  'flutter_test',
+  'integration_test'
+};

--- a/dev/bots/allowlist.dart
+++ b/dev/bots/allowlist.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// The SDK package allowlist.
+/// The SDK package allowlist for the flutter, flutter_test, flutter_driver, flutter_localizations,
+/// and integration_test packages.
 ///
 /// The goal of the allowlist is to make it more difficult to accidentally add new dependencies
-/// to the core SDK packages that users depend on. Any dependencies add to this set can have a
-/// large impact on the allowed version solving of a given flutter application.
+/// to the core SDK packages that users depend on. Any dependencies added to this set can have a
+/// large impact on the allowed version solving of a given flutter application because of how
+/// the SDK pins to an exact version.
 ///
 /// Before adding a new Dart Team owned dependency to this set, please clear with natebosch@
 /// or jakemac53@. For other packages please contact hixie@ or jonahwilliams@ .

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1175,25 +1175,21 @@ Future<void> _checkConsumerDependencies() async {
   // dev/bots/allowlist.dart
   const String kExpected = 'I7oyhZIbNXC2vq7m+uE8BA5IXUgMy+RhnZAkjS+O+U8=';
 
-  if (signature != kExpected) {
-    print(
-      'Warning: transitive closure sha256 does not match expected signature.\n'
-      'See dev/bots/allowlist.dart for instructions on how to update the '
-      'package allowlist.\n'
-      '$signature != $kExpected',
-    );
+  if (disallowed.isNotEmpty) {
+    exitWithError(<String>[
+      'Warning: transitive closure contained non-allowlisted packages:',
+      '${disallowed..join(', ')}',
+      'See dev/bots/allowlist.dart for instructions on how to update the package allowlist.',
+    ]);
   }
 
-  if (disallowed.isEmpty) {
-    exit(0);
+  if (signature != kExpected) {
+    exitWithError(<String>[
+      'Warning: transitive closure sha256 does not match expected signature.',
+      'See dev/bots/allowlist.dart for instructions on how to update the package allowlist.',
+      '$signature != $kExpected',
+    ]);
   }
-  print(
-    'Warning: transitive closure contained non-allowlisted packages:\n'
-    '${disallowed..join(', ')}\n'
-    'See dev/bots/allowlist.dart for instructions on how to update the '
-    'package allowlist.',
-  );
-  exit(1);
 }
 
 Future<void> _runFlutterAnalyze(String workingDirectory, {

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1173,7 +1173,7 @@ Future<void> _checkConsumerDependencies() async {
 
   // Do not change this signature without following the directions in
   // dev/bots/allowlist.dart
-  const String kExpected = 'I7oyhZIbNXC2vq7m+uE8BA5IXUgMy+RhnZAkjS+O+U8=';
+  const String kExpected = '3S20q38QbN+dDAp+jApXiTRaDgVGGBZ0t4bMJgD3AUY=';
 
   if (disallowed.isNotEmpty) {
     exitWithError(<String>[


### PR DESCRIPTION
FYI @Hixie @natebosch @jakemac53 

The original context for this PR was the accidental inclusion of the test_core dep in the integration_test dependency. If you would prefer different Dart team contact info or a more detailed accounting of the current packages please let me know.

This only covers the core packages since dependencies in the tool or integration_test do not really affect end users - though they do constraint the overall version solving

Fixes https://github.com/flutter/flutter/issues/74070
