### PR TITLE
make pub super verbose for LUCI CI

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -143,6 +143,12 @@ function upgrade_flutter () (
       PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
       VERBOSITY="--verbosity=normal"
     fi
+    # Increase verbosity for Flutter's LUCI CI infra.
+    if [[ -n "$LUCI_CI" ]]; then
+      PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_bot"
+      VERBOSITY="--verbosity=all"
+    fi
+
     export PUB_ENVIRONMENT="$PUB_ENVIRONMENT:flutter_install"
 
     if [[ -d "$FLUTTER_ROOT/.pub-cache" ]]; then


### PR DESCRIPTION
To help identify the cause of https://github.com/flutter/flutter/issues/80317 , make pub super verbose when building the flutter_tool running on LUCI