### PR TITLE
Remove mocks from fucshia_pm_test, reduce createMockProcess usage

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_apk_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_apk.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
@@ -22,7 +23,6 @@ import 'package:process/process.dart';
 import '../../src/android_common.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/mocks.dart' hide MockAndroidSdk;
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -537,3 +537,21 @@ class FakeAndroidSdk extends Fake implements AndroidSdk {
 }
 
 class MockProcessManager extends Mock implements ProcessManager {}
+
+/// Creates a mock process that returns with the given [exitCode], [stdout] and [stderr].
+Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr = '' }) {
+  final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(<List<int>>[
+    utf8.encode(stdout),
+  ]);
+  final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(<List<int>>[
+    utf8.encode(stderr),
+  ]);
+  final Process process = _MockBasicProcess();
+
+  when(process.stdout).thenAnswer((_) => stdoutStream);
+  when(process.stderr).thenAnswer((_) => stderrStream);
+  when(process.exitCode).thenAnswer((_) => Future<int>.value(exitCode));
+  return process;
+}
+
+class _MockBasicProcess extends Mock implements Process {}

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/bot_detector.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -19,7 +18,6 @@ import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/mocks.dart' as mocks;
 
 void main() {
   setUpAll(() {
@@ -292,13 +290,34 @@ void main() {
   testWithoutContext('pub get 69', () async {
     String error;
 
-    final MockProcessManager processMock = MockProcessManager(69);
+    const FakeCommand pubGetCommand = FakeCommand(
+      command: <String>[
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
+        'get',
+        '--no-precompile',
+      ],
+      exitCode: 69,
+      environment: <String, String>{'FLUTTER_ROOT': '', 'PUB_ENVIRONMENT': 'flutter_cli:flutter_tests'},
+    );
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+      pubGetCommand,
+    ]);
     final BufferLogger logger = BufferLogger.test();
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Pub pub = Pub(
       fileSystem: fileSystem,
       logger: logger,
-      processManager: processMock,
+      processManager: processManager,
       usage: TestUsage(),
       platform: FakePlatform(
         environment: const <String, String>{},
@@ -307,7 +326,6 @@ void main() {
     );
 
     FakeAsync().run((FakeAsync time) {
-      expect(processMock.lastPubEnvironment, isNull);
       expect(logger.statusText, '');
       pub.get(context: PubContext.flutterTests).then((void value) {
         error = 'test completed unexpectedly';
@@ -319,8 +337,7 @@ void main() {
         'Running "flutter pub get" in /...\n'
         'pub get failed (server unavailable) -- attempting retry 1 in 1 second...\n',
       );
-      expect(processMock.lastPubEnvironment, contains('flutter_cli:flutter_tests'));
-      expect(processMock.lastPubCache, isNull);
+
       time.elapse(const Duration(milliseconds: 500));
       expect(logger.statusText,
         'Running "flutter pub get" in /...\n'
@@ -361,18 +378,35 @@ void main() {
     });
     expect(logger.errorText, isEmpty);
     expect(error, isNull);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('pub get 66 shows message from pub', () async {
     final BufferLogger logger = BufferLogger.test();
     final FileSystem fileSystem = MemoryFileSystem.test();
+
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+        exitCode: 66,
+        stderr: 'err1\nerr2\nerr3\n',
+        stdout: 'out1\nout2\nout3\n',
+        environment: <String, String>{'FLUTTER_ROOT': '', 'PUB_ENVIRONMENT': 'flutter_cli:flutter_tests'},
+      ),
+    ]);
+
     final Pub pub = Pub(
       platform: FakePlatform(environment: const <String, String>{}),
       fileSystem: fileSystem,
       logger: logger,
       usage: TestUsage(),
       botDetector: const BotDetectorAlwaysNo(),
-      processManager: MockProcessManager(66, stderr: 'err1\nerr2\nerr3\n', stdout: 'out1\nout2\nout3\n'),
+      processManager: processManager,
     );
     try {
       await pub.get(context: PubContext.flutterTests);
@@ -391,46 +425,74 @@ void main() {
       'err2\n'
       'err3\n'
     );
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('pub cache in root is used', () async {
     String error;
-    final MockProcessManager processMock = MockProcessManager(69);
     final FileSystem fileSystem = MemoryFileSystem.test();
-    fileSystem.directory(Cache.flutterRoot).childDirectory('.pub-cache').createSync();
+    final Directory pubCache = fileSystem.directory(Cache.flutterRoot).childDirectory('.pub-cache')..createSync();
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      FakeCommand(
+        command: const <String>[
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+        exitCode: 69,
+        environment: <String, String>{
+          'FLUTTER_ROOT': '',
+          'PUB_ENVIRONMENT': 'flutter_cli:flutter_tests',
+          'PUB_CACHE': pubCache.path,
+        },
+      ),
+    ]);
 
     final Pub pub = Pub(
       platform: FakePlatform(environment: const <String, String>{}),
       usage: TestUsage(),
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: processMock,
+      processManager: processManager,
       botDetector: const BotDetectorAlwaysNo(),
     );
 
     FakeAsync().run((FakeAsync time) {
-      expect(processMock.lastPubEnvironment, isNull);
-      expect(processMock.lastPubCache, isNull);
       pub.get(context: PubContext.flutterTests).then((void value) {
         error = 'test completed unexpectedly';
       }, onError: (dynamic thrownError) {
         error = 'test failed unexpectedly: $thrownError';
       });
       time.elapse(const Duration(milliseconds: 500));
-
-      expect(processMock.lastPubCache, equals(fileSystem.path.join(Cache.flutterRoot, '.pub-cache')));
       expect(error, isNull);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 
   testWithoutContext('pub cache in environment is used', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     fileSystem.directory('custom/pub-cache/path').createSync(recursive: true);
-    final MockProcessManager processMock = MockProcessManager(69);
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+        exitCode: 69,
+        environment: <String, String>{
+          'FLUTTER_ROOT': '',
+          'PUB_ENVIRONMENT': 'flutter_cli:flutter_tests',
+          'PUB_CACHE': 'custom/pub-cache/path',
+        },
+      ),
+    ]);
     final Pub pub = Pub(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: processMock,
+      processManager: processManager,
       usage: TestUsage(),
       botDetector: const BotDetectorAlwaysNo(),
       platform: FakePlatform(
@@ -441,9 +503,6 @@ void main() {
     );
 
     FakeAsync().run((FakeAsync time) {
-      expect(processMock.lastPubEnvironment, isNull);
-      expect(processMock.lastPubCache, isNull);
-
       String error;
       pub.get(context: PubContext.flutterTests).then((void value) {
         error = 'test completed unexpectedly';
@@ -451,9 +510,8 @@ void main() {
         error = 'test failed unexpectedly: $thrownError';
       });
       time.elapse(const Duration(milliseconds: 500));
-
-      expect(processMock.lastPubCache, equals('custom/pub-cache/path'));
       expect(error, isNull);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 
@@ -463,7 +521,7 @@ void main() {
     final Pub pub = Pub(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: MockProcessManager(0),
+      processManager: FakeProcessManager.any(),
       botDetector: const BotDetectorAlwaysNo(),
       usage: usage,
       platform: FakePlatform(
@@ -493,7 +551,7 @@ void main() {
     final Pub pub = Pub(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: MockProcessManager(0),
+      processManager: FakeProcessManager.any(),
       botDetector: const BotDetectorAlwaysNo(),
       usage: usage,
       platform: FakePlatform(
@@ -536,11 +594,24 @@ void main() {
     final FileSystem fileSystem = MemoryFileSystem.test();
     fileSystem.directory('custom/pub-cache/path').createSync(recursive: true);
     final TestUsage usage = TestUsage();
+
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+        exitCode: 1,
+      ),
+    ]);
+
     final Pub pub = Pub(
       usage: usage,
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: MockProcessManager(1),
+      processManager: processManager,
       botDetector: const BotDetectorAlwaysNo(),
       platform: FakePlatform(
         environment: const <String, String>{
@@ -557,18 +628,31 @@ void main() {
     expect(usage.events, contains(
       const TestUsageEvent('pub-result', 'flutter-tests', label: 'failure'),
     ));
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('analytics sent on failed version solve', () async {
     final TestUsage usage = TestUsage();
     final FileSystem fileSystem = MemoryFileSystem.test();
+
+
+    final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
+          'get',
+          '--no-precompile',
+        ],
+        exitCode: 1,
+        stderr: 'version solving failed',
+      ),
+    ]);
+
     final Pub pub = Pub(
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
-      processManager: MockProcessManager(
-        1,
-        stderr: 'version solving failed',
-      ),
+      processManager: processManager,
       platform: FakePlatform(
         environment: <String, String>{
           'PUB_CACHE': 'custom/pub-cache/path',
@@ -588,6 +672,7 @@ void main() {
     expect(usage.events, contains(
       const TestUsageEvent('pub-result', 'flutter-tests', label: 'version-solving-failed'),
     ));
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Pub error handling', () async {
@@ -681,41 +766,4 @@ class BotDetectorAlwaysNo implements BotDetector {
 
   @override
   Future<bool> get isRunningOnBot async => false;
-}
-
-typedef StartCallback = void Function(List<dynamic> command);
-
-class MockProcessManager implements ProcessManager {
-  MockProcessManager(this.fakeExitCode, {
-    this.stdout = '',
-    this.stderr = '',
-  });
-
-  final int fakeExitCode;
-  final String stdout;
-  final String stderr;
-
-  String lastPubEnvironment;
-  String lastPubCache;
-
-  @override
-  Future<Process> start(
-    List<dynamic> command, {
-    String workingDirectory,
-    Map<String, String> environment,
-    bool includeParentEnvironment = true,
-    bool runInShell = false,
-    ProcessStartMode mode = ProcessStartMode.normal,
-  }) {
-    lastPubEnvironment = environment['PUB_ENVIRONMENT'];
-    lastPubCache = environment['PUB_CACHE'];
-    return Future<Process>.value(mocks.createMockProcess(
-      exitCode: fakeExitCode,
-      stdout: stdout,
-      stderr: stderr,
-    ));
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -191,6 +191,7 @@ abstract class FakeProcessManager implements ProcessManager {
   /// last command and verify its execution is successful, to ensure that all
   /// the specified commands are actually called.
   factory FakeProcessManager.list(List<FakeCommand> commands) = _SequenceProcessManager;
+  factory FakeProcessManager.empty() => _SequenceProcessManager(<FakeCommand>[]);
 
   FakeProcessManager._();
 

--- a/packages/flutter_tools/test/src/mocks.dart
+++ b/packages/flutter_tools/test/src/mocks.dart
@@ -5,7 +5,6 @@
 // @dart = 2.8
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart' show AndroidSdk;
@@ -155,24 +154,6 @@ _ProcessFactory flakyProcessFactory({
     );
   };
 }
-
-/// Creates a mock process that returns with the given [exitCode], [stdout] and [stderr].
-Process createMockProcess({ int exitCode = 0, String stdout = '', String stderr = '' }) {
-  final Stream<List<int>> stdoutStream = Stream<List<int>>.fromIterable(<List<int>>[
-    utf8.encode(stdout),
-  ]);
-  final Stream<List<int>> stderrStream = Stream<List<int>>.fromIterable(<List<int>>[
-    utf8.encode(stderr),
-  ]);
-  final Process process = _MockBasicProcess();
-
-  when(process.stdout).thenAnswer((_) => stdoutStream);
-  when(process.stderr).thenAnswer((_) => stderrStream);
-  when(process.exitCode).thenAnswer((_) => Future<int>.value(exitCode));
-  return process;
-}
-
-class _MockBasicProcess extends Mock implements Process {}
 
 class MockAndroidDevice extends Mock implements AndroidDevice {
   @override


### PR DESCRIPTION
Remove two usages of `createMockProcess`, moved it out of `mocks.dart` to the last test using it.
Use `FakeProcessManager` in the pub get test (the `MockProcessManager` in there wasn't a mockito mock, but removing its dependency on `mocks.dart` will soon allow me to migrate this test to null safety).

Add convenience `FakeProcessManager.empty()` factory.

Part of #71511