### PR TITLE
Mark Mac gradle_plugin_light_apk_test not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -880,7 +880,7 @@
       "name": "Mac gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "mac_gradle_plugin_light_apk_test",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac module_custom_host_app_name_test",


### PR DESCRIPTION
`Mac gradle_plugin_light_apk_test` was occasionally taking longer than 15 minutes to run and was marked flaky in https://github.com/flutter/flutter/pull/80163

https://github.com/flutter/flutter/pull/80171 and https://github.com/flutter/flutter/pull/80172 improvements have pushed this test to [under 13 minutes](https://ci.chromium.org/p/flutter/builders/prod/Mac%20gradle_plugin_light_apk_test/2264). 
 Mark the prod builder not flaky.