### PR TITLE
Revert "Remove a dynamic that is no longer necessary (and the TODO for it)"

### DIFF
--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1596,7 +1596,7 @@ void main() {
       bool? keyEventHandled;
       await tester.pumpWidget(
         Focus(
-          onKey: (_, __) => KeyEventResult.ignored, // This one does nothing.
+          onKey: (_, __) => true, // This one does nothing.
           focusNode: focusNode,
           child: Container(key: key1),
         ),
@@ -1611,7 +1611,7 @@ void main() {
         Focus(
           onKey: (FocusNode node, RawKeyEvent event) { // The updated handler handles the key.
             keyEventHandled = true;
-            return KeyEventResult.handled;
+            return true;
           },
           focusNode: focusNode,
           child: Container(key: key1),


### PR DESCRIPTION
Reverts flutter/flutter#80294

I believe this caused a post-submit error:
```
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr: [   +2 ms] Target dart2js failed: Exception: lib/studies/rally/login.dart:304:24:
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            Error: A value of type 'bool' can't be assigned to a variable of type 'KeyEventResult'.
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:             - 'KeyEventResult' is from 'package:flutter/src/widgets/focus_manager.dart' ('../../../w/recipe_cleanup/tmpRM1Yor/flutter%20sdk/packages/flutter/lib/src/widgets/focus_manager.dart').
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                            return true;
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                                   ^
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            lib/studies/rally/login.dart:307:20:
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            Error: A value of type 'bool' can't be assigned to a variable of type 'KeyEventResult'.
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:             - 'KeyEventResult' is from 'package:flutter/src/widgets/focus_manager.dart' ('../../../w/recipe_cleanup/tmpRM1Yor/flutter%20sdk/packages/flutter/lib/src/widgets/focus_manager.dart').
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                        return false;
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                               ^
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            lib/layout/highlight_focus.dart:85:18:
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            Error: A value of type 'bool' can't be assigned to a variable of type 'KeyEventResult'.
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:             - 'KeyEventResult' is from 'package:flutter/src/widgets/focus_manager.dart' ('../../../w/recipe_cleanup/tmpRM1Yor/flutter%20sdk/packages/flutter/lib/src/widgets/focus_manager.dart').
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                      return true;
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                             ^
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            lib/layout/highlight_focus.dart:87:18:
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:            Error: A value of type 'bool' can't be assigned to a variable of type 'KeyEventResult'.
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:             - 'KeyEventResult' is from 'package:flutter/src/widgets/focus_manager.dart' ('../../../w/recipe_cleanup/tmpRM1Yor/flutter%20sdk/packages/flutter/lib/src/widgets/focus_manager.dart').
[flutter_gallery_v2_web_compile_test] [STDOUT] stderr:                      return false;
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8850109423505652208/+/u/run_flutter_gallery_v2_web_compile_test/stdout