### PR TITLE
Remove run_if from try_builders.json

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -18,14 +18,12 @@ It follows format:
             "name":"yyy",
             "repo":"flutter",
             "taskName":"zzz",
-            "enabled":true,
-            "run_if":["a/b/", "c/d/**"]
+            "enabled":true
         }
     ]
 }
 ```
 * enabled(optional): `true` is the default value if unspecified
-* run_if(optional): will always be triggered if unspecified
 ### `prod_builders.json`
 It follows format:
 ```json

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -10,8 +10,7 @@
       "name": "Linux build_aar_module_test",
       "repo": "flutter",
       "task_name": "linux_build_aar_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux customer_testing",
@@ -35,69 +34,25 @@
       "name": "Linux docs",
       "repo": "flutter",
       "task_name": "linux_docs",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_test/",
-        "packages/flutter_drive/",
-        "packages/flutter_localizations/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux framework_tests_libraries",
       "repo": "flutter",
       "task_name": "linux_framework_tests_libraries",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux framework_tests_misc",
       "repo": "flutter",
       "task_name": "linux_framework_tests_misc",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux framework_tests_widgets",
       "repo": "flutter",
       "task_name": "linux_framework_tests_widgets",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux firebase_abstract_method_smoke_test",
@@ -127,92 +82,79 @@
       "name": "Linux gradle_desugar_classes_test",
       "repo": "flutter",
       "task_name": "linux_gradle_desugar_classes_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux gradle_plugin_bundle_test",
       "repo": "flutter",
       "task_name": "linux_gradle_plugin_bundle_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux gradle_plugin_fat_apk_test",
       "repo": "flutter",
       "task_name": "linux_gradle_plugin_fat_apk_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "linux_gradle_plugin_light_apk_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux module_host_with_custom_build_test",
       "repo": "flutter",
       "task_name": "linux_module_host_with_custom_build_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux module_custom_host_app_name_test",
       "repo": "flutter",
       "task_name": "linux_module_custom_host_app_name_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux module_test",
       "repo": "flutter",
       "task_name": "linux_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux plugin_test",
       "repo": "flutter",
       "task_name": "linux_plugin_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux tool_tests_general",
       "repo": "flutter",
       "task_name": "linux_tool_tests_general",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux tool_tests_commands",
       "repo": "flutter",
       "task_name": "linux_tool_tests_commands",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_1_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_2_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "linux_tool_integration_tests_3_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux validate_ci_config",
@@ -224,138 +166,97 @@
       "name": "Linux web_tool_tests",
       "repo": "flutter",
       "task_name": "linux_web_tool_tests",
-      "enabled": true,
-      "run_if": ["dev/", "packages/flutter_tools/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_benchmarks_html",
       "repo": "flutter",
       "task_name": "linux_web_benchmarks_html",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_0",
       "repo": "flutter",
       "task_name": "linux_web_tests_0",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_1",
       "repo": "flutter",
       "task_name": "linux_web_tests_1",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_2",
       "repo": "flutter",
       "task_name": "linux_web_tests_2",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_3",
       "repo": "flutter",
       "task_name": "linux_web_tests_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_4",
       "repo": "flutter",
       "task_name": "linux_web_tests_4",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_5",
       "repo": "flutter",
       "task_name": "linux_web_tests_5",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_6",
       "repo": "flutter",
       "task_name": "linux_web_tests_6",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_tests_7_last",
       "repo": "flutter",
       "task_name": "linux_web_tests_7_last",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_integration_tests",
       "repo": "flutter",
       "task_name": "linux_web_integration_tests",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_test/",
-        "packages/flutter_tools/",
-        "packages/flutter_web_plugins/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux web_long_running_tests_1_3",
       "repo": "flutter",
       "task_name": "web_long_running_tests_1_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_long_running_tests_2_3",
       "repo": "flutter",
       "task_name": "web_long_running_tests_2_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_long_running_tests_3_3",
       "repo": "flutter",
       "task_name": "web_long_running_tests_1_3",
-      "enabled": true,
-      "run_if": ["dev/", "packages/", "bin/"]
+      "enabled": true
     },
     {
       "name": "Linux web_e2e_test",
       "repo": "flutter",
       "task_name": "linux_web_e2e_test",
-      "enabled": true,
-      "run_if": [
-        "examples/hello_world/**",
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/flutter_test/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "packages/flutter_web_plugins/**",
-        "bin/**"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux web_smoke_test",
       "repo": "flutter",
       "task_name": "linux_web_smoke_test",
-      "enabled": true,
-      "run_if": [
-        "examples/hello_world/**",
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/flutter_test/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "packages/flutter_web_plugins/**",
-        "bin/**"
-      ]
+      "enabled": true
     },
     {
       "name": "Linux flutter_plugins",
@@ -367,15 +268,13 @@
       "name": "Mac build_aar_module_test",
       "repo": "flutter",
       "task_name": "mac_build_aar_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac build_ios_framework_module_test",
       "repo": "flutter",
       "task_name": "mac_build_ios_framework_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac build_tests_1_4",
@@ -411,174 +310,121 @@
       "name": "Mac framework_tests_libraries",
       "repo": "flutter",
       "task_name": "mac_framework_tests_libraries",
-      "enabled": true,
-      "run_if": [
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/integration_test/**",
-        "packages/flutter_localizations/**",
-        "packages/fuchsia_remote_debug_protocol/**",
-        "packages/flutter_test/**",
-        "packages/flutter_goldens/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "bin/**"
-      ]
+      "enabled": true
     },
     {
       "name": "Mac framework_tests_misc",
       "repo": "flutter",
       "task_name": "mac_framework_tests_misc",
-      "enabled": true,
-      "run_if": [
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/integration_test/**",
-        "packages/flutter_localizations/**",
-        "packages/fuchsia_remote_debug_protocol/**",
-        "packages/flutter_test/**",
-        "packages/flutter_goldens/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "bin/**"
-      ]
+      "enabled": true
     },
     {
       "name": "Mac framework_tests_widgets",
       "repo": "flutter",
       "task_name": "mac_framework_tests_widgets",
-      "enabled": true,
-      "run_if": [
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/integration_test/**",
-        "packages/flutter_localizations/**",
-        "packages/fuchsia_remote_debug_protocol/**",
-        "packages/flutter_test/**",
-        "packages/flutter_goldens/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "bin/**"
-      ]
+      "enabled": true
     },
     {
       "name": "Mac gradle_plugin_bundle_test",
       "repo": "flutter",
       "task_name": "mac_gradle_plugin_bundle_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac gradle_plugin_fat_apk_test",
       "repo": "flutter",
       "task_name": "mac_gradle_plugin_fat_apk_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "mac_gradle_plugin_light_apk_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac module_custom_host_app_name_test",
       "repo": "flutter",
       "task_name": "mac_module_custom_host_app_name_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac module_host_with_custom_build_test",
       "repo": "flutter",
       "task_name": "mac_module_host_with_custom_build_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac module_test",
       "repo": "flutter",
       "task_name": "mac_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac module_test_ios",
       "repo": "flutter",
       "task_name": "mac_module_test_ios",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac plugin_lint_mac",
       "repo": "flutter",
       "task_name": "mac_plugin_lint_mac",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac plugin_test",
       "repo": "flutter",
       "task_name": "mac_plugin_lint_mac",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac dart_plugin_registry_test",
       "repo": "flutter",
       "task_name": "dart_plugin_registry_test",
-      "enabled": false,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": false
     },
     {
       "name": "Mac tool_tests_general",
       "repo": "flutter",
       "task_name": "mac_tool_tests_general",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac tool_tests_commands",
       "repo": "flutter",
       "task_name": "tool_tests_commands",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_1_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_2_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "mac_tool_integration_tests_3_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Mac web_tool_tests",
       "repo": "flutter",
       "task_name": "mac_web_tool_tests",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows build_aar_module_test",
       "repo": "flutter",
       "task_name": "win_build_aar_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows build_tests_1_3",
@@ -608,139 +454,91 @@
       "name": "Windows framework_tests_libraries",
       "repo": "flutter",
       "task_name": "win_framework_tests_libraries",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Windows framework_tests_misc",
       "repo": "flutter",
       "task_name": "framework_tests_misc",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Windows framework_tests_widgets",
       "repo": "flutter",
       "task_name": "framework_tests_widgets",
-      "enabled": true,
-      "run_if": [
-        "dev/",
-        "packages/flutter/",
-        "packages/flutter_driver/",
-        "packages/integration_test/",
-        "packages/flutter_localizations/",
-        "packages/fuchsia_remote_debug_protocol/",
-        "packages/flutter_test/",
-        "packages/flutter_goldens/",
-        "packages/flutter_tools/lib/src/test/",
-        "bin/"
-      ]
+      "enabled": true
     },
     {
       "name": "Windows gradle_plugin_bundle_test",
       "repo": "flutter",
       "task_name": "win_gradle_plugin_bundle_test",
-      "enabled": true,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "win_gradle_plugin_light_apk_test",
-      "enabled": false,
-      "run_if": ["dev/**", "bin/**"]
+      "enabled": false
     },
     {
       "name": "Windows module_custom_host_app_name_test",
       "repo": "flutter",
       "task_name": "win_module_custom_host_app_name_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows module_test",
       "repo": "flutter",
       "task_name": "win_module_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows module_host_with_custom_build_test",
       "repo": "flutter",
       "task_name": "win_module_host_with_custom_build_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows plugin_test",
       "repo": "flutter",
       "task_name": "win_plugin_test",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows tool_tests_general",
       "repo": "flutter",
       "task_name": "tool_tests_general",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows tool_tests_commands",
       "repo": "flutter",
       "task_name": "tool_tests_commands",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows tool_integration_tests_1_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_1_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows tool_integration_tests_2_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_2_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows tool_integration_tests_3_3",
       "repo": "flutter",
       "task_name": "win_tool_integration_tests_3_3",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     },
     {
       "name": "Windows web_tool_tests",
       "repo": "flutter",
       "task_name": "win_web_tool_tests",
-      "enabled": true,
-      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
As we consolidate the infra configs into `.ci.yaml`, one point was to remove run_if support. This is because it's a workaround Flutter not having a build system (discussion in go/flutter-build-test-infra).

This reduces the complexity of Cocoon needing to query pull requests for the file diffs, but increases the try capacity infra needs to maintain. Looking at previous SLOs infra was generally at 5 minutes queue time where SLO is 10 minutes. We should have capacity to remove these conditionals.

https://github.com/flutter/flutter/issues/77858

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
