### PR TITLE
Find Intellij installations with Spotlight query on macOS

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -84,6 +84,7 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         platform: globals.platform,
         userMessages: userMessages,
         plistParser: globals.plistParser,
+        processManager: globals.processManager,
       ),
       ...VsCodeValidator.installedValidators(globals.fs, globals.platform),
     ];

--- a/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
@@ -3,14 +3,22 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/platform.dart';
 import '../base/user_messages.dart' hide userMessages;
 import '../base/version.dart';
+import '../convert.dart';
 import '../doctor_validator.dart';
 import '../ios/plist_parser.dart';
 import 'intellij.dart';
+
+const String _ultimateEditionTitle = 'IntelliJ IDEA Ultimate Edition';
+const String _ultimateEditionId = 'IntelliJIdea';
+const String _communityEditionTitle = 'IntelliJ IDEA Community Edition';
+const String _communityEditionId = 'IdeaIC';
 
 /// A doctor validator for both Intellij and Android Studio.
 abstract class IntelliJValidator extends DoctorValidator {
@@ -30,8 +38,8 @@ abstract class IntelliJValidator extends DoctorValidator {
   String? get pluginsPath;
 
   static const Map<String, String> _idToTitle = <String, String>{
-    'IntelliJIdea': 'IntelliJ IDEA Ultimate Edition',
-    'IdeaIC': 'IntelliJ IDEA Community Edition',
+    _ultimateEditionId: _ultimateEditionTitle,
+    _communityEditionId: _communityEditionTitle,
   };
 
   static final Version kMinIdeaVersion = Version(2017, 1, 0);
@@ -45,6 +53,7 @@ abstract class IntelliJValidator extends DoctorValidator {
     required Platform platform,
     required UserMessages userMessages,
     required PlistParser plistParser,
+    required ProcessManager processManager,
   }) {
     final FileSystemUtils fileSystemUtils = FileSystemUtils(fileSystem: fileSystem, platform: platform);
     if (platform.isWindows) {
@@ -68,6 +77,7 @@ abstract class IntelliJValidator extends DoctorValidator {
         fileSystemUtils: fileSystemUtils,
         userMessages: userMessages,
         plistParser: plistParser,
+        processManager: processManager,
       );
     }
     return <DoctorValidator>[];
@@ -369,9 +379,9 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
   final String? _homeDirPath;
 
   static const Map<String, String> _dirNameToId = <String, String>{
-    'IntelliJ IDEA.app': 'IntelliJIdea',
-    'IntelliJ IDEA Ultimate.app': 'IntelliJIdea',
-    'IntelliJ IDEA CE.app': 'IdeaIC',
+    'IntelliJ IDEA.app': _ultimateEditionId,
+    'IntelliJ IDEA Ultimate.app': _ultimateEditionId,
+    'IntelliJ IDEA CE.app': _communityEditionId,
   };
 
   static Iterable<DoctorValidator> installed({
@@ -379,6 +389,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     required FileSystemUtils fileSystemUtils,
     required UserMessages userMessages,
     required PlistParser plistParser,
+    required ProcessManager processManager,
   }) {
     final List<DoctorValidator> validators = <DoctorValidator>[];
     final String? homeDirPath = fileSystemUtils.homeDirPath;
@@ -421,6 +432,43 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
               checkForIntelliJ(subdirectory);
             }
           }
+        }
+      }
+
+      final ProcessResult ceQueryResult = processManager.runSync(<String>[
+        'mdfind',
+        'kMDItemCFBundleIdentifier="com.jetbrains.intellij.ce"',
+      ]);
+
+      for (final String installPath in LineSplitter.split(ceQueryResult.stdout as String)) {
+        if (!validators.whereType<IntelliJValidatorOnMac>().any((IntelliJValidatorOnMac e) => e.installPath == installPath)) {
+          validators.add(IntelliJValidatorOnMac(
+            _communityEditionTitle,
+            _communityEditionId,
+            installPath,
+            fileSystem: fileSystem,
+            userMessages: userMessages,
+            plistParser: plistParser,
+            homeDirPath: homeDirPath,
+          ));
+        }
+      }
+
+      final ProcessResult ultimateQueryResult = processManager.runSync(<String>[
+        'mdfind',
+        'kMDItemCFBundleIdentifier="com.jetbrains.intellij*"',
+      ]);
+      for (final String installPath in LineSplitter.split(ultimateQueryResult.stdout as String)) {
+        if (!validators.whereType<IntelliJValidatorOnMac>().any((IntelliJValidatorOnMac e) => e.installPath == installPath)) {
+          validators.add(IntelliJValidatorOnMac(
+            _ultimateEditionTitle,
+            _ultimateEditionId,
+            installPath,
+            fileSystem: fileSystem,
+            userMessages: userMessages,
+            plistParser: plistParser,
+            homeDirPath: homeDirPath,
+          ));
         }
       }
     } on FileSystemException catch (e) {


### PR DESCRIPTION
In addition to hard-coded `Applications` Intellij install locations, on macOS also query [Spotlight](https://support.apple.com/en-gb/HT204014) (the app search engine when you cmd-space) for all installs by searching with the command line tool `mdfind` for the app's bundle identifier (`com.jetbrains.intellij.ce` or  fall back to `com.jetbrains.intellij*`).

Now on my machine I see `IntelliJ IDEA` where I didn't before because the `(stable)` suffix in the app names prevented it from showing up:
```
[✓] IntelliJ IDEA Community Edition (version 2020.2.2)
    • IntelliJ at /Applications/IntelliJ CE (stable).app
    • Flutter plugin version 52.2.3
    • Dart plugin version 202.8443

[✓] IntelliJ IDEA Ultimate Edition (version 2020.2.2)
    • IntelliJ at /Applications/IntelliJ UE (stable).app
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
```

Fixes https://github.com/flutter/flutter/issues/43964

See also https://github.com/flutter/flutter/pull/80475 and https://github.com/flutter/flutter/pull/80477