### PR TITLE
[flutter_tools] use package:vm_service types for coverage collection requests

### DIFF
--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -35,6 +35,7 @@ void main() {
         )
       ],
     );
+    final Map<String, vm_service.Obj> coverageRefCache = <String, vm_service.Obj>{};
 
     final Map<String, Object> result = await collect(
       null,
@@ -42,9 +43,11 @@ void main() {
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
+      coverageRefCache: coverageRefCache,
     );
 
     expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
+    expect(coverageRefCache, isEmpty);
   });
 }

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -5,7 +5,7 @@
 // @dart = 2.8
 
 import 'package:flutter_tools/src/test/coverage_collector.dart';
-import 'package:vm_service/vm_service.dart' as vm_service;
+import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import '../src/fake_vm_services.dart';
@@ -16,9 +16,9 @@ void main() {
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
           method: 'getVM',
-          jsonResponse: (vm_service.VM.parse(<String, Object>{})
-            ..isolates = <vm_service.IsolateRef>[
-              vm_service.IsolateRef.parse(<String, Object>{
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
                 'id': '1'
               }),
             ]
@@ -35,7 +35,6 @@ void main() {
         )
       ],
     );
-    final Map<String, vm_service.Obj> coverageRefCache = <String, vm_service.Obj>{};
 
     final Map<String, Object> result = await collect(
       null,
@@ -43,11 +42,100 @@ void main() {
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
-      coverageRefCache: coverageRefCache,
     );
 
     expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[]});
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
-    expect(coverageRefCache, isEmpty);
+  });
+
+  testWithoutContext('Coverage collector processes coverage and script data', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        FakeVmServiceRequest(
+          method: 'getVM',
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
+                'id': '1'
+              }),
+            ]
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getScripts',
+          args: <String, Object>{
+            'isolateId': '1',
+          },
+          jsonResponse: ScriptList(scripts: <ScriptRef>[
+            ScriptRef(uri: 'foo.dart', id: '1'),
+          ]).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'scriptId': '1',
+            'forceCompile': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[],
+                  misses: <int>[],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'foo.dart',
+                id: '1',
+              ),
+            ],
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getObject',
+          args: <String, Object>{
+            'isolateId': '1',
+            'objectId': '1',
+          },
+          jsonResponse: Script(
+            uri: 'foo.dart',
+            id: '1',
+            library: LibraryRef(name: '', id: '1111', uri: 'foo.dart'),
+            tokenPosTable: <List<int>>[],
+          ).toJson(),
+        ),
+      ],
+    );
+
+    final Map<String, Object> result = await collect(
+      null,
+      (String predicate) => true,
+      connector: (Uri uri) async {
+        return fakeVmServiceHost.vmService;
+      },
+    );
+
+    expect(result, <String, Object>{'type': 'CodeCoverage', 'coverage': <Object>[
+      <String, Object>{
+        'source': 'foo.dart',
+        'script': <String, Object>{
+          'type': '@Script',
+          'fixedId': true,
+          'id': 'libraries/1/scripts/foo.dart',
+          'uri': 'foo.dart',
+          '_kind': 'library',
+        },
+        'hits': <Object>[],
+      },
+    ]});
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 }


### PR DESCRIPTION
~~Attempt to reduce coverage network chatter by caching script objects by URI~~ This was a failure.

Update the coverage collection to use the actual typed VM Service objects instead of Map<String, Object>