### PR TITLE
Triple-click to select all text in a TextField

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -765,6 +765,10 @@ enum SelectionChangedCause {
   /// the selection (or the location of the cursor) to change.
   doubleTap,
 
+  /// The user tapped three times in quick succession on the text and that caused
+  /// the selection to change.
+  tripleTap,
+
   /// The user long-pressed the text and that caused the selection (or the
   /// location of the cursor) to change.
   longPress,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1179,6 +1179,25 @@ class TextSelectionGestureDetectorBuilder {
     }
   }
 
+  /// Handler for [TextSelectionGestureDetector.onTripleTapDown].
+  ///
+  /// By default, it selects a paragraph through [RenderEditable.selectParagraph] if
+  /// selectionEnabled and shows toolbar if necessary.
+  ///
+  /// See also:
+  ///
+  ///  * [TextSelectionGestureDetector.onTripleTapDown], which triggers this
+  ///    callback.
+  @protected
+  void onTripleTapDown(TapDownDetails details) {
+    if (delegate.selectionEnabled) {
+      renderEditable.selectParagraph(cause: SelectionChangedCause.tripleTap);
+      if (shouldShowSelectionToolbar)
+        editableText.showToolbar();
+    }
+  }
+
+
   /// Handler for [TextSelectionGestureDetector.onDragSelectionStart].
   ///
   /// By default, it selects a text position specified in [details].
@@ -1263,6 +1282,7 @@ class TextSelectionGestureDetectorBuilder {
       onSingleLongTapMoveUpdate: onSingleLongTapMoveUpdate,
       onSingleLongTapEnd: onSingleLongTapEnd,
       onDoubleTapDown: onDoubleTapDown,
+      onTripleTapDown: onTripleTapDown,
       onDragSelectionStart: onDragSelectionStart,
       onDragSelectionUpdate: onDragSelectionUpdate,
       onDragSelectionEnd: onDragSelectionEnd,
@@ -1356,6 +1376,8 @@ class TextSelectionGestureDetector extends StatefulWidget {
   /// time (within [kDoubleTapTimeout]) to a previous short tap.
   final GestureTapDownCallback? onDoubleTapDown;
 
+  /// Called after a 3 taps that are close in space and within [kDoubleTapTimeout]
+  /// to a previous short tap.
   final GestureTapDownCallback? onTripleTapDown;
 
   /// Called when a mouse starts dragging to select text.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1476,6 +1476,7 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     assert(_lastDragStartDetails == null);
     _lastDragStartDetails = details;
     widget.onDragSelectionStart?.call(details);
+    _cancelDoubleAndTripleTap();
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
@@ -1513,8 +1514,7 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
   }
 
   void _forcePressStarted(ForcePressDetails details) {
-    _doubleTapTimer?.cancel();
-    _doubleTapTimer = null;
+    _cancelDoubleAndTripleTap();
     widget.onForcePressStart?.call(details);
   }
 
@@ -1538,7 +1538,7 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     if (!_isDoubleTap && widget.onSingleLongTapEnd != null) {
       widget.onSingleLongTapEnd!(details);
     }
-    _isDoubleTap = false;
+    _cancelDoubleAndTripleTap();
   }
 
   void _doubleTapTimeout() {
@@ -1551,6 +1551,17 @@ class _TextSelectionGestureDetectorState extends State<TextSelectionGestureDetec
     _lastTapOffset = null;
   }
 
+  void _cancelDoubleAndTripleTap() {
+    _tripleTapTimer?.cancel();
+    _tripleTapTimer = null;
+    _isTripleTap = false;
+
+    _doubleTapTimer?.cancel();
+    _doubleTapTimer = null;
+    _isDoubleTap = false;
+
+    _lastTapOffset = null;
+  }
   bool _isWithinDoubleTapTolerance(Offset secondTapOffset) {
     assert(secondTapOffset != null);
     if (_lastTapOffset == null) {

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -38,6 +38,7 @@ void main() {
   late int singleTapCancelCount;
   late int singleLongTapStartCount;
   late int doubleTapDownCount;
+  late int tripleTapDownCount;
   late int forcePressStartCount;
   late int forcePressEndCount;
   late int dragStartCount;
@@ -50,6 +51,7 @@ void main() {
   void _handleSingleTapCancel() { singleTapCancelCount++; }
   void _handleSingleLongTapStart(LongPressStartDetails details) { singleLongTapStartCount++; }
   void _handleDoubleTapDown(TapDownDetails details) { doubleTapDownCount++; }
+  void _handleTripleTapDown(TapDownDetails details) { tripleTapDownCount++; }
   void _handleForcePressStart(ForcePressDetails details) { forcePressStartCount++; }
   void _handleForcePressEnd(ForcePressDetails details) { forcePressEndCount++; }
   void _handleDragSelectionStart(DragStartDetails details) { dragStartCount++; }
@@ -62,6 +64,7 @@ void main() {
     singleTapCancelCount = 0;
     singleLongTapStartCount = 0;
     doubleTapDownCount = 0;
+    tripleTapDownCount = 0;
     forcePressStartCount = 0;
     forcePressEndCount = 0;
     dragStartCount = 0;
@@ -78,6 +81,7 @@ void main() {
         onSingleTapCancel: _handleSingleTapCancel,
         onSingleLongTapStart: _handleSingleLongTapStart,
         onDoubleTapDown: _handleDoubleTapDown,
+        onTripleTapDown: _handleTripleTapDown,
         onForcePressStart: _handleForcePressStart,
         onForcePressEnd: _handleForcePressEnd,
         onDragSelectionStart: _handleDragSelectionStart,
@@ -178,6 +182,38 @@ void main() {
     expect(tapCount, 2);
     expect(singleTapCancelCount, 0);
     expect(doubleTapDownCount, 1);
+    expect(singleLongTapStartCount, 0);
+  });
+
+  testWidgets('quick tap-tap-tap-hold is a triple tap down', (WidgetTester tester) async {
+    await pumpGestureDetector(tester);
+    await tester.tapAt(const Offset(200, 200));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(singleTapUpCount, 1);
+
+    await tester.tapAt(const Offset(200, 200));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final TestGesture gesture = await tester.startGesture(const Offset(200, 200));
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(singleTapUpCount, 1);
+    // Every down is counted.
+    expect(tapCount, 3);
+    // No cancels because the second tap of the double tap is a second successful
+    // single tap behind the scene.
+    expect(singleTapCancelCount, 0);
+    expect(doubleTapDownCount, 1);
+    expect(tripleTapDownCount, 1);
+    // The double tap down hold supersedes the single tap down.
+    expect(singleLongTapStartCount, 0);
+
+    await gesture.up();
+    // Nothing else happens on up.
+    expect(singleTapUpCount, 1);
+    expect(tapCount, 3);
+    expect(singleTapCancelCount, 0);
+    expect(doubleTapDownCount, 1);
+    expect(tripleTapDownCount, 1);
     expect(singleLongTapStartCount, 0);
   });
 


### PR DESCRIPTION
**This is a draft**

@justinmc I'm unaware of process to submit a draft PR so I can start a discussion and get feedback. Is there a preferred channel to discuss the overall implementation for text selection in a TextField?

This is a rough start at implementing `TextSelectionGestureDetector.onTripleTapDown` and linking that up to a rough `RenderEditable.selectParagraph(...)` It's a step toward resolving #63576.

I opted to copy the current structure of the code so I'm not refactoring and modifying behavior at the same time.

Here's a video of it in action:
https://user-images.githubusercontent.com/220686/114961643-d4c07900-9e2e-11eb-8e68-39679701c776.mov

The test "in a series of rapid taps, onTapDown and onDoubleTapDown alternate" is now failing. What is the purpose of this test? At least from testing on a Mac and Chrome, it doesn't seem like there's anything past a triple-click. Any further clicks appear to be ignored.


## Text selection behavior

I was getting confused by all the states so I drew a diagram to help better reason about the text selection behavior:
<details><summary>Text selection flow chart</summary>
<p>
<img src="https://user-images.githubusercontent.com/220686/114938574-e1c87280-9e04-11eb-913b-d240fb018833.png" />
</p>
</details>

These correspond to the following situations:
- Tap once to place a caret (+ drag to extend caret selection, or continue to double tap)
- Double tap to select a word (+ drag to extend word selection, or continue to triple tap)
- Triple tap to select a paragraph (+ drag to extend paragraph selection)

## Drag to extend bug

I noticed some incorrect behavior that may be worth correcting in a future PR. (Let me know if you think this should be a separate issue or if we want to increase the scope of this existing PR.)

* If you double-click a word and drag, it doesn't keep the original word as part of the selection. Instead it uses the last tap down position.
* If you triple-click a paragraph drag, it doesn't keep the original paragraph as part of the selection. Instead it uses the last tap down position.

I believe this is because, in the `onDragSelectionStart` and `onDragSelectionUpdate` handlers, we use `selectPositionAt`, which only supports a `from` and `to` point.

We may need to introduce something like `extendSelection` which take a `from` starting selection and `to` point. As you drag, this selection would get extended based on where the mouse cursor is.


**Before (TextSelectionGestureDetectorBuilder):**

```dart
  @protected
  void onDragSelectionStart(DragStartDetails details) {
    // ...
    renderEditable.selectPositionAt(
      from: details.globalPosition,
      cause: SelectionChangedCause.drag,
    );
  }

  @protected
  void onDragSelectionUpdate(DragStartDetails startDetails, DragUpdateDetails updateDetails) {
    // ...
    renderEditable.selectPositionAt(
      from: startDetails.globalPosition,
      to: updateDetails.globalPosition,
      cause: SelectionChangedCause.drag,
    );
  }
```


**After (TextSelectionGestureDetectorBuilder):**

```dart
  @protected
  void onDragSelectionStart(DragStartDetails details) {
    // ...
    renderEditable.setInitialDragSelection();
  }

  @protected
  void onDragSelectionUpdate(DragStartDetails startDetails, DragUpdateDetails updateDetails) {
    // ...
    renderEditable.extendDragSelection(
      to: updateDetails.globalPosition,
      cause: SelectionChangedCause.drag,
    );
  }
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
