### PR TITLE
Migrate android_views to null safety

### DIFF
--- a/dev/integration_tests/android_views/lib/main.dart
+++ b/dev/integration_tests/android_views/lib/main.dart
@@ -20,7 +20,7 @@ void main() {
 }
 
 class Home extends StatelessWidget {
-  const Home({Key key}) : super(key: key);
+  const Home({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -18,7 +18,7 @@ MethodChannel channel = const MethodChannel('android_views_integration');
 const String kEventsFileName = 'touchEvents';
 
 class MotionEventsPage extends PageWidget {
-  const MotionEventsPage({Key key})
+  const MotionEventsPage({Key? key})
       : super('Motion Event Tests', const ValueKey<String>('MotionEventsListTile'), key: key);
 
   @override
@@ -35,7 +35,7 @@ class MotionEventsPage extends PageWidget {
 class FutureDataHandler {
   final Completer<DataHandler> handlerCompleter = Completer<DataHandler>();
 
-  Future<String> handleMessage(String message) async {
+  Future<String> handleMessage(String? message) async {
     final DataHandler handler = await handlerCompleter.future;
     return handler(message);
   }
@@ -44,7 +44,7 @@ class FutureDataHandler {
 FutureDataHandler driverDataHandler = FutureDataHandler();
 
 class MotionEventsBody extends StatefulWidget {
-  const MotionEventsBody({Key key}) : super(key: key);
+  const MotionEventsBody({Key? key}) : super(key: key);
 
   @override
   State createState() => MotionEventsBodyState();
@@ -53,7 +53,7 @@ class MotionEventsBody extends StatefulWidget {
 class MotionEventsBodyState extends State<MotionEventsBody> {
   static const int kEventsBufferSize = 1000;
 
-  MethodChannel viewChannel;
+  late MethodChannel viewChannel;
 
   /// The list of motion events that were passed to the FlutterView.
   List<Map<String, dynamic>> flutterViewEvents = <Map<String, dynamic>>[];
@@ -103,7 +103,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
                 onPressed: () {
                   const StandardMessageCodec codec = StandardMessageCodec();
                   saveRecordedEvents(
-                    codec.encodeMessage(flutterViewEvents), context);
+                    codec.encodeMessage(flutterViewEvents)!, context);
                 },
               ),
             ),
@@ -171,15 +171,15 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
   }
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
-    if (!await channel.invokeMethod<bool>('getStoragePermission')) {
+    if (await channel.invokeMethod<bool>('getStoragePermission') == true) {
       showMessage(
           context, 'External storage permissions are required to save events');
       return;
     }
     try {
-      final Directory outDir = await getExternalStorageDirectory();
+      final Directory? outDir = await getExternalStorageDirectory();
       // This test only runs on Android so we can assume path separator is '/'.
-      final File file = File('${outDir.path}/$kEventsFileName');
+      final File file = File('${outDir?.path}/$kEventsFileName');
       await file.writeAsBytes(data.buffer.asUint8List(0, data.lengthInBytes), flush: true);
       showMessage(context, 'Saved original events to ${file.path}');
     } catch (e) {
@@ -209,7 +209,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
     });
   }
 
-  Future<String> handleDriverMessage(String message) async {
+  Future<String> handleDriverMessage(String? message) async {
     switch (message) {
       case 'run test':
         return playEventsFile();
@@ -253,7 +253,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
 }
 
 class TouchEventDiff extends StatelessWidget {
-  const TouchEventDiff(this.originalEvent, this.synthesizedEvent, {Key key}) : super(key: key);
+  const TouchEventDiff(this.originalEvent, this.synthesizedEvent, {Key? key}) : super(key: key);
 
   final Map<String, dynamic> originalEvent;
   final Map<String, dynamic> synthesizedEvent;

--- a/dev/integration_tests/android_views/lib/page.dart
+++ b/dev/integration_tests/android_views/lib/page.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 //
 /// A testing page has to override this in order to be put as one of the items in the main page.
 abstract class PageWidget extends StatelessWidget {
-  const PageWidget(this.title, this.tileKey, {Key key}) : super(key: key);
+  const PageWidget(this.title, this.tileKey, {Key? key}) : super(key: key);
 
   /// The title of the testing page
   ///

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import 'page.dart';
 
 class WindowManagerIntegrationsPage extends PageWidget {
-  const WindowManagerIntegrationsPage({Key key})
+  const WindowManagerIntegrationsPage({Key? key})
       : super('Window Manager Integrations Tests', const ValueKey<String>('WmIntegrationsListTile'), key: key);
 
   @override
@@ -18,7 +18,7 @@ class WindowManagerIntegrationsPage extends PageWidget {
 }
 
 class WindowManagerBody extends StatefulWidget {
-  const WindowManagerBody({Key key}) : super(key: key);
+  const WindowManagerBody({Key? key}) : super(key: key);
 
   @override
   State<WindowManagerBody> createState() => WindowManagerBodyState();
@@ -32,10 +32,10 @@ enum _LastTestStatus {
 
 class WindowManagerBodyState extends State<WindowManagerBody> {
 
-  MethodChannel viewChannel;
+  MethodChannel? viewChannel;
   _LastTestStatus lastTestStatus = _LastTestStatus.pending;
-  String lastError;
-  int id;
+  String? lastError;
+  int? id;
   int windowClickCount = 0;
 
   @override
@@ -87,11 +87,11 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
 
   Widget _statusWidget() {
     assert(lastTestStatus != _LastTestStatus.pending);
-    final String message = lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
+    final String? message = lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
     return Container(
       color: lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
       child: Text(
-        message,
+        message!,
         key: const ValueKey<String>('Status'),
         style: TextStyle(
           color: lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
@@ -107,7 +107,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       });
     }
     try {
-      await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
+      await viewChannel?.invokeMethod<void>('showAndHideAlertDialog');
       setState(() {
         lastTestStatus = _LastTestStatus.success;
       });
@@ -121,7 +121,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
 
   Future<void> onAddWindowPressed() async {
     try {
-      await viewChannel.invokeMethod<void>('addWindowAndWaitForClick');
+      await viewChannel?.invokeMethod<void>('addWindowAndWaitForClick');
       setState(() {
         windowClickCount++;
       });

--- a/dev/integration_tests/android_views/pubspec.yaml
+++ b/dev/integration_tests/android_views/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: An integration test for embedded platform views
 version: 1.0.0+1
 environment:
-  sdk: '>=2.9.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 Future<void> main() async {
-  FlutterDriver driver;
+  late FlutterDriver driver;
 
   setUpAll(() async {
     driver = await FlutterDriver.connect();


### PR DESCRIPTION
I have migrated dev/integration_tests/android_views with null safety.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
