### PR TITLE
Re-land Fix FlexibleSpaceBar Opacity when AppBar.toolbarHeight > ktoolbarHeight

### DIFF
--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -305,7 +305,11 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
           final double fadeStart = math.max(0.0, 1.0 - kToolbarHeight / deltaExtent);
           const double fadeEnd = 1.0;
           assert(fadeStart <= fadeEnd);
-          final double opacity = 1.0 - Interval(fadeStart, fadeEnd).transform(t);
+          // If the min and max extent are the same, the app bar cannot collapse
+          // and the content should be visible, so opacity = 1.
+          final double opacity = settings.maxExtent == settings.minExtent
+              ? 1.0
+              : 1.0 - Interval(fadeStart, fadeEnd).transform(t);
           double height = settings.maxExtent;
 
           // StretchMode.zoomBackground

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -121,7 +121,39 @@ void main() {
     expect(clipRect.size.height, minExtent);
   });
 
-  testWidgets('Collpased FlexibleSpaceBar has correct semantics', (WidgetTester tester) async {
+  testWidgets('FlexibleSpaceBar.background is visible when using height other than kToolbarHeight', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/80451
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            toolbarHeight: 300,
+            flexibleSpace: const FlexibleSpaceBar(
+              title: Text('Title'),
+              background:  Text('Background'),
+              collapseMode: CollapseMode.pin,
+            ),
+          ),
+          body: CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 1200.0,
+                  color: Colors.orange[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Opacity backgroundOpacity = tester.firstWidget(find.byType(Opacity));
+    expect(backgroundOpacity.opacity, 1.0);
+  });
+
+  testWidgets('Collapsed FlexibleSpaceBar has correct semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     const double expandedHeight = 200;
     await tester.pumpWidget(


### PR DESCRIPTION
Reverts flutter/flutter#80545
Original PR: https://github.com/flutter/flutter/pull/80453
Fixes: https://github.com/flutter/flutter/issues/80451
