### PR TITLE
Standardize how Java8 is set in gradle files

### DIFF
--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/complex_layout/android/app/build.gradle
+++ b/dev/benchmarks/complex_layout/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.example.macrobenchmarks"
         minSdkVersion 16

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "com.example.macrobenchmarks"
         minSdkVersion 16

--- a/dev/benchmarks/macrobenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "com.example.macrobenchmarks"
         minSdkVersion 16

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/microbenchmarks/android/app/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -12,7 +12,13 @@ android {
         self {
         }
     }
+
     compileSdkVersion 30
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         applicationId "dev.flutter.multipleflutters"

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -41,15 +41,6 @@ android {
             signingConfig debug.signingConfig
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {

--- a/dev/benchmarks/multiple_flutters/android/app/build.gradle
+++ b/dev/benchmarks/multiple_flutters/android/app/build.gradle
@@ -20,6 +20,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "dev.flutter.multipleflutters"
         minSdkVersion 24
@@ -37,10 +41,12 @@ android {
             signingConfig debug.signingConfig
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/platform_views_layout/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.stocks"
         minSdkVersion 16

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.stocks"
         minSdkVersion 16

--- a/dev/benchmarks/test_apps/stocks/android/app/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.stocks"
         minSdkVersion 16

--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -262,7 +262,7 @@ Future<void> main() async {
     } catch (e) {
       return TaskResult.failure(e.toString());
     } finally {
-      rmTree(tempDir);
+      // rmTree(tempDir);
     }
   });
 }

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -14,20 +14,23 @@ Future<void> main() async {
   await task(() async {
     try {
       await runPluginProjectTest((FlutterPluginProject pluginProject) async {
+
         section('check main plugin file exists');
-        final File pluginMainKotlinFile = File(path.join(
-          pluginProject.rootPath,
-          'android',
-          'src',
-          'main',
-          'kotlin',
+        final File pluginMainKotlinFile = File(
           path.join(
-            'com',
-            'example',
-            'aaa',
-            'AaaPlugin.kt',
-          )
-        ));
+            pluginProject.rootPath,
+            'android',
+            'src',
+            'main',
+            'kotlin',
+            path.join(
+              'com',
+              'example',
+              'aaa',
+              'AaaPlugin.kt',
+            ),
+          ),
+        );
 
         if (!pluginMainKotlinFile.existsSync()) {
           throw TaskResult.failure('Expected ${pluginMainKotlinFile.path} to exist, but it doesn\'t');

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -52,6 +52,7 @@ import java.util.HashMap
 class AaaPlugin: FlutterPlugin, MethodCallHandler {
   init {
     val map: HashMap<String, String> = HashMap<String, String>()
+    // getOrDefault is a JAVA8 feature.
     Log.d("AaaPlugin", map.getOrDefault("foo", "baz"))
   }
   /// The MethodChannel that will the communication between Flutter and native Android

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -1,0 +1,102 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/apk_utils.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  await task(() async {
+    try {
+      await runPluginProjectTest((FlutterPluginProject pluginProject) async {
+        section('check main plugin file exists');
+        final File pluginMainKotlinFile = File(path.join(
+          pluginProject.rootPath,
+          'android',
+          'src',
+          'main',
+          'kotlin',
+          path.join(
+            'com',
+            'example',
+            'aaa',
+            'AaaPlugin.kt',
+          )
+        ));
+
+        if (!pluginMainKotlinFile.existsSync()) {
+          throw TaskResult.failure('Expected ${pluginMainKotlinFile.path} to exist, but it doesn\'t');
+        }
+
+        section('add java 8 feature');
+        pluginMainKotlinFile.writeAsStringSync('''
+package com.example.aaa
+
+import android.util.Log
+import androidx.annotation.NonNull
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+
+import java.util.HashMap
+
+/** AaaPlugin */
+class AaaPlugin: FlutterPlugin, MethodCallHandler {
+  init {
+    val map: HashMap<String, String> = HashMap<String, String>()
+    Log.d("AaaPlugin", map.getOrDefault("foo", "baz"))
+  }
+  /// The MethodChannel that will the communication between Flutter and native Android
+  ///
+  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+  /// when the Flutter Engine is detached from the Activity
+  private lateinit var channel : MethodChannel
+
+  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "aaa")
+    channel.setMethodCallHandler(this)
+  }
+
+  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    if (call.method == "getPlatformVersion") {
+      result.success("Android \${android.os.Build.VERSION.RELEASE}")
+    } else {
+      result.notImplemented()
+    }
+  }
+
+  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+  }
+}
+''');
+
+        section('Compiles');
+        await inDirectory(pluginProject.exampleAndroidPath, () {
+          return flutter(
+            'build',
+            options: <String>[
+              'apk',
+              '--debug',
+              '--target-platform=android-arm'
+            ],
+          );
+        });
+
+      });
+      return TaskResult.success(null);
+    } on TaskResult catch (taskResult) {
+      return taskResult;
+    } catch (e) {
+      return TaskResult.failure(e.toString());
+    }
+  });
+}

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -37,7 +37,7 @@ Future<void> main() async {
         }
 
         section('add java 8 feature');
-        pluginMainKotlinFile.writeAsStringSync('''
+        pluginMainKotlinFile.writeAsStringSync(r'''
 package com.example.aaa
 
 import android.util.Log
@@ -71,7 +71,7 @@ class AaaPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "getPlatformVersion") {
-      result.success("Android \${android.os.Build.VERSION.RELEASE}")
+      result.success("Android ${android.os.Build.VERSION.RELEASE}")
     } else {
       result.notImplemented()
     }

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
@@ -32,6 +32,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
@@ -45,11 +45,6 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.abstract_method_smoke_test"
@@ -63,10 +58,6 @@ android {
         release {
             signingConfig signingConfigs.debug
         }
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 }
 

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/build.gradle
@@ -37,6 +37,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
@@ -8,8 +8,8 @@ android {
     compileSdkVersion 30
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
@@ -12,6 +12,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16

--- a/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
+++ b/dev/integration_tests/android_custom_host_app/SampleApp/build.gradle
@@ -12,10 +12,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
@@ -32,6 +32,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/build.gradle
@@ -37,6 +37,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
@@ -8,8 +8,8 @@ android {
     compileSdkVersion 30
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
@@ -12,6 +12,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16

--- a/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/android_host_app_v2_embedding/app/build.gradle
@@ -12,10 +12,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.add2app"
         minSdkVersion 16

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/android_semantics_testing/android/app/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/android_views/android/app/build.gradle
+++ b/dev/integration_tests/android_views/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/channels/android/app/build.gradle
+++ b/dev/integration_tests/channels/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/external_ui/android/app/build.gradle
+++ b/dev/integration_tests/external_ui/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.externalui"
         minSdkVersion 16

--- a/dev/integration_tests/external_ui/android/app/build.gradle
+++ b/dev/integration_tests/external_ui/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.externalui"
         minSdkVersion 16

--- a/dev/integration_tests/external_ui/android/app/build.gradle
+++ b/dev/integration_tests/external_ui/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.externalui"
         minSdkVersion 16

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 16

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 16

--- a/dev/integration_tests/flavors/android/app/build.gradle
+++ b/dev/integration_tests/flavors/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 16

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -42,6 +42,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.demo.gallery"
         minSdkVersion 16

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -47,6 +47,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.demo.gallery"
         minSdkVersion 16

--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -47,10 +47,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.demo.gallery"
         minSdkVersion 16

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 21

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 21

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "com.yourcompany.flavors"
         minSdkVersion 21

--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/hybrid_android_views/android/app/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.integration.platformviews"

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
+
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
+
     defaultConfig {
         applicationId "io.flutter.addtoapp"
         minSdkVersion 16

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -12,6 +12,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.addtoapp"
         minSdkVersion 16

--- a/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
+++ b/dev/integration_tests/module_host_with_custom_build_v2_embedding/app/build.gradle
@@ -12,10 +12,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.addtoapp"
         minSdkVersion 16

--- a/dev/integration_tests/non_nullable/android/app/build.gradle
+++ b/dev/integration_tests/non_nullable/android/app/build.gradle
@@ -32,6 +32,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/non_nullable/android/app/build.gradle
+++ b/dev/integration_tests/non_nullable/android/app/build.gradle
@@ -37,6 +37,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -26,6 +26,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/platform_interaction/android/app/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/app/build.gradle
@@ -21,6 +21,12 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/release_smoke_test/android/app/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.release_smoke_test"

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -21,6 +21,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/integration_tests/ui/android/app/build.gradle
+++ b/dev/integration_tests/ui/android/app/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -32,6 +32,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/dev/manual_tests/android/app/build.gradle
+++ b/dev/manual_tests/android/app/build.gradle
@@ -37,6 +37,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
         minSdkVersion 16

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
         minSdkVersion 16

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
         minSdkVersion 16

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
         minSdkVersion 16

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
         minSdkVersion 16

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
         minSdkVersion 16

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.layers"
         minSdkVersion 16

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.layers"
         minSdkVersion 16

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.layers"
         minSdkVersion 16

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
         minSdkVersion 16

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
         minSdkVersion 16

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
         minSdkVersion 16

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
         minSdkVersion 16

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
         minSdkVersion 16

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
         minSdkVersion 16

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -34,8 +34,12 @@ buildscript {
 
 android {
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -34,12 +34,8 @@ buildscript {
 
 android {
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
 }
 

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
@@ -27,6 +27,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
@@ -32,6 +32,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"

--- a/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-java.tmpl/app/build.gradle.tmpl
@@ -32,10 +32,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -33,6 +33,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -28,6 +28,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
@@ -21,6 +21,11 @@ apply plugin: "com.android.dynamic-feature"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         applicationVariants.all { variant ->
             main.assets.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_assets"
@@ -33,11 +38,6 @@ android {
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-    }
-
-    compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
     }
 }
 

--- a/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         applicationVariants.all { variant ->
             main.assets.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_assets"

--- a/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/deferred_component/build.gradle.tmpl
@@ -26,6 +26,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         applicationVariants.all { variant ->
             main.assets.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_assets"

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -6,8 +6,8 @@ android {
     compileSdkVersion 30
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -10,6 +10,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         applicationId "{{androidIdentifier}}.host"
         minSdkVersion 16

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/build.gradle.tmpl
@@ -10,10 +10,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         applicationId "{{androidIdentifier}}.host"
         minSdkVersion 16

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -32,6 +32,11 @@ version '1.0'
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -37,6 +37,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -37,10 +37,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -24,6 +24,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
     }

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -29,10 +29,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
     }

--- a/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-java.tmpl/build.gradle.tmpl
@@ -29,6 +29,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
     }

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -32,6 +32,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/plugin/android-kotlin.tmpl/build.gradle.tmpl
@@ -27,9 +27,15 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
         minSdkVersion 16
     }

--- a/packages/integration_test/android/build.gradle
+++ b/packages/integration_test/android/build.gradle
@@ -28,6 +28,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/integration_test/android/build.gradle
+++ b/packages/integration_test/android/build.gradle
@@ -33,6 +33,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+      jvmTarget = '1.8'
+    }
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/integration_test/android/build.gradle
+++ b/packages/integration_test/android/build.gradle
@@ -33,10 +33,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-      jvmTarget = '1.8'
-    }
-
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -31,6 +31,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.integration_test_example"

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -36,6 +36,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+      jvmTarget = '1.8'
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.integration_test_example"

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -36,10 +36,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-      jvmTarget = '1.8'
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.integration_test_example"


### PR DESCRIPTION
This is set from the plugin, but typically this is set from a user-defined gradle file.

This PR standardizes the way Java8 is set across the Gradle files. It also updates the template files for app, plugin and modules projects.

Fixes: https://github.com/flutter/flutter/issues/80442