### PR TITLE
Stop the DevTools child process if the runner terminates unexpectedly

### DIFF
--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -208,6 +208,8 @@ NoOpDevtoolsHandler createNoOpHandler(DevtoolsLauncher launcher, ResidentRunner 
 
 @visibleForTesting
 class NoOpDevtoolsHandler implements ResidentDevtoolsHandler {
+  bool wasShutdown = false;
+
   @override
   DevToolsServerAddress get activeDevToolsServer => null;
 
@@ -223,6 +225,7 @@ class NoOpDevtoolsHandler implements ResidentDevtoolsHandler {
 
   @override
   Future<void> shutdown() async {
+    wasShutdown = true;
     return;
   }
 }

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -200,6 +200,7 @@ class ColdRunner extends ResidentRunner {
       await flutterDevice.device.dispose();
     }
 
+    await residentDevtoolsHandler.shutdown();
     await stopEchoingDeviceLog();
   }
 

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1166,6 +1166,7 @@ class HotRunner extends ResidentRunner {
       await flutterDevice.device.dispose();
     }
     await _cleanupDevFS();
+    await residentDevtoolsHandler.shutdown();
     await stopEchoingDeviceLog();
   }
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2817,6 +2817,21 @@ void main() {
     expect(nextPlatform('fuchsia', TestFeatureFlags(isMacOSEnabled: true)), 'macOS');
     expect(() => nextPlatform('unknown', TestFeatureFlags()), throwsAssertionError);
   });
+
+  testUsingContext('cleanupAtFinish shuts down resident devtools handler', () => testbed.run(() async {
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        mockFlutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, vmserviceOutFile: 'foo'),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    await residentRunner.cleanupAtFinish();
+
+    expect((residentRunner.residentDevtoolsHandler as NoOpDevtoolsHandler).wasShutdown, true);
+  }));
 }
 
 class MockFlutterDevice extends Mock implements FlutterDevice {}


### PR DESCRIPTION
Without this the DevTools process will be leaked if the runner
gets a SIGTERM or loses its connection to the device.
