### PR TITLE
Migrate ios_add2app_life_cycle to null safety

### DIFF
--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
@@ -8,14 +8,14 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:collection/collection.dart';
 
-VoidCallback originalSemanticsListener;
+VoidCallback? originalSemanticsListener;
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   // Disconnects semantics listener for testing purposes.
   originalSemanticsListener = ui.window.onSemanticsEnabledChanged;
   ui.window.onSemanticsEnabledChanged = null;
-  RendererBinding.instance.setSemanticsEnabled(false);
+  RendererBinding.instance?.setSemanticsEnabled(false);
   // If the test passes, LifeCycleSpy will rewire the semantics listener back.
   runApp(const LifeCycleSpy());
 }
@@ -28,7 +28,7 @@ void main() {
 ///
 /// Rewiring semantics is a signal to native IOS test that the test has passed.
 class LifeCycleSpy extends StatefulWidget {
-  const LifeCycleSpy({Key key}) : super(key: key);
+  const LifeCycleSpy({Key? key}) : super(key: key);
 
   @override
   _LifeCycleSpyState createState() => _LifeCycleSpyState();
@@ -40,36 +40,36 @@ class _LifeCycleSpyState extends State<LifeCycleSpy> with WidgetsBindingObserver
     AppLifecycleState.inactive,
     AppLifecycleState.resumed,
   ];
-  List<AppLifecycleState> _actualLifeCycleSequence;
+  List<AppLifecycleState?>? _actualLifeCycleSequence;
 
   @override
   void initState(){
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    _actualLifeCycleSequence =  <AppLifecycleState>[
-      ServicesBinding.instance.lifecycleState
+    WidgetsBinding.instance?.addObserver(this);
+    _actualLifeCycleSequence =  <AppLifecycleState?>[
+      ServicesBinding.instance?.lifecycleState
     ];
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     setState(() {
-      _actualLifeCycleSequence = List<AppLifecycleState>.from(_actualLifeCycleSequence);
-      _actualLifeCycleSequence.add(state);
+      _actualLifeCycleSequence = List<AppLifecycleState>.from(_actualLifeCycleSequence!);
+      _actualLifeCycleSequence?.add(state);
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    if (const ListEquality<AppLifecycleState>().equals(_actualLifeCycleSequence, _expectedLifeCycleSequence)) {
+    if (const ListEquality<AppLifecycleState?>().equals(_actualLifeCycleSequence, _expectedLifeCycleSequence)) {
       // Rewires the semantics harness if test passes.
-      RendererBinding.instance.setSemanticsEnabled(true);
+      RendererBinding.instance?.setSemanticsEnabled(true);
       ui.window.onSemanticsEnabledChanged = originalSemanticsListener;
     }
     return const MaterialApp(

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new flutter module project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
I have migrated dev/integration_tests/ios_add2app_life_cycle with null safety.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
