### PR TITLE
Show Visual Studio Code Insiders in doctor

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -13,9 +13,6 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../doctor_validator.dart';
 
-// Include VS Code insiders (useful for debugging).
-const bool _includeInsiders = false;
-
 const String extensionIdentifier = 'Dart-Code.flutter';
 const String extensionMarketplaceUrl =
   'https://marketplace.visualstudio.com/items?itemName=$extensionIdentifier';
@@ -155,7 +152,6 @@ class VsCode {
       VsCodeInstallLocation(
         fileSystem.path.join('/Applications', 'Visual Studio Code - Insiders.app', 'Contents'),
         '.vscode-insiders',
-        isInsiders: true,
       ),
       if (homeDirPath != null)
         VsCodeInstallLocation(
@@ -166,7 +162,6 @@ class VsCode {
             'Contents',
           ),
           '.vscode-insiders',
-          isInsiders: true,
         ),
       for (final String vsCodePath in LineSplitter.split(vsCodeSpotlightResult))
         VsCodeInstallLocation(
@@ -177,7 +172,6 @@ class VsCode {
         VsCodeInstallLocation(
           fileSystem.path.join(vsCodeInsidersPath, 'Contents'),
           '.vscode-insiders',
-          isInsiders: true,
         ),
     }, fileSystem, platform);
   }
@@ -219,7 +213,6 @@ class VsCode {
             fileSystem.path.join(progFiles86, 'Microsoft VS Code Insiders'),
             '.vscode-insiders',
             edition: '32-bit edition',
-            isInsiders: true,
           ),
         ],
       if (progFiles != null)
@@ -233,14 +226,12 @@ class VsCode {
             fileSystem.path.join(progFiles, 'Microsoft VS Code Insiders'),
             '.vscode-insiders',
             edition: '64-bit edition',
-            isInsiders: true,
           ),
         ],
       if (localAppData != null)
         VsCodeInstallLocation(
           fileSystem.path.join(localAppData, r'Programs\Microsoft VS Code Insiders'),
           '.vscode-insiders',
-          isInsiders: true,
         ),
     ];
     return _findInstalled(searchLocations, fileSystem, platform);
@@ -258,7 +249,6 @@ class VsCode {
       const VsCodeInstallLocation(
         '/usr/share/code-insiders',
         '.vscode-insiders',
-        isInsiders: true,
       ),
     ], fileSystem, platform);
   }
@@ -268,14 +258,9 @@ class VsCode {
     FileSystem fileSystem,
     Platform platform,
   ) {
-    final Iterable<VsCodeInstallLocation> searchLocations =
-      _includeInsiders
-        ? allLocations
-        : allLocations.where((VsCodeInstallLocation p) => p.isInsiders != true);
-
     final List<VsCode> results = <VsCode>[];
 
-    for (final VsCodeInstallLocation searchLocation in searchLocations) {
+    for (final VsCodeInstallLocation searchLocation in allLocations) {
       final String? homeDirPath = FileSystemUtils(fileSystem: fileSystem, platform: platform).homeDirPath;
       if (homeDirPath != null && fileSystem.isDirectorySync(searchLocation.installPath)) {
         final String extensionDirectory = fileSystem.path.join(
@@ -323,24 +308,21 @@ class VsCodeInstallLocation {
     this.installPath,
     this.extensionsFolder, {
     this.edition,
-    bool? isInsiders
-  }) : isInsiders = isInsiders ?? false;
+  });
 
   final String installPath;
   final String extensionsFolder;
   final String? edition;
-  final bool isInsiders;
 
   @override
   bool operator ==(Object other) {
     return other is VsCodeInstallLocation &&
         other.installPath == installPath &&
         other.extensionsFolder == extensionsFolder &&
-        other.edition == edition &&
-        other.isInsiders == isInsiders;
+        other.edition == edition;
   }
 
   @override
   // Lowest bit is for isInsiders boolean.
-  int get hashCode => (installPath.hashCode ^ extensionsFolder.hashCode ^ edition.hashCode) << 1 | (isInsiders ? 1 : 0);
+  int get hashCode => installPath.hashCode ^ extensionsFolder.hashCode ^ edition.hashCode;
 }

--- a/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
+++ b/packages/flutter_tools/test/general.shard/vscode/vscode_test.dart
@@ -13,12 +13,11 @@ import '../../src/fake_process_manager.dart';
 
 void main() {
   testWithoutContext('VsCodeInstallLocation equality', () {
-    const VsCodeInstallLocation installLocation1 = VsCodeInstallLocation('abc', 'zyx', edition: '123', isInsiders: true);
-    const VsCodeInstallLocation installLocation2 = VsCodeInstallLocation('abc', 'zyx', edition: '123', isInsiders: true);
-    const VsCodeInstallLocation installLocation3 = VsCodeInstallLocation('cba', 'zyx', edition: '123', isInsiders: true);
-    const VsCodeInstallLocation installLocation4 = VsCodeInstallLocation('abc', 'xyz', edition: '123', isInsiders: true);
-    const VsCodeInstallLocation installLocation5 = VsCodeInstallLocation('abc', 'xyz', edition: '321', isInsiders: true);
-    const VsCodeInstallLocation installLocation6 = VsCodeInstallLocation('abc', 'zyx', edition: '123', isInsiders: false);
+    const VsCodeInstallLocation installLocation1 = VsCodeInstallLocation('abc', 'zyx', edition: '123');
+    const VsCodeInstallLocation installLocation2 = VsCodeInstallLocation('abc', 'zyx', edition: '123');
+    const VsCodeInstallLocation installLocation3 = VsCodeInstallLocation('cba', 'zyx', edition: '123');
+    const VsCodeInstallLocation installLocation4 = VsCodeInstallLocation('abc', 'xyz', edition: '123');
+    const VsCodeInstallLocation installLocation5 = VsCodeInstallLocation('abc', 'xyz', edition: '321');
 
     expect(installLocation1, installLocation2);
     expect(installLocation1.hashCode, installLocation2.hashCode);
@@ -28,8 +27,6 @@ void main() {
     expect(installLocation1.hashCode, isNot(installLocation4.hashCode));
     expect(installLocation1, isNot(installLocation5));
     expect(installLocation1.hashCode, isNot(installLocation5.hashCode));
-    expect(installLocation1, isNot(installLocation6));
-    expect(installLocation1.hashCode, isNot(installLocation6.hashCode));
   });
 
   testWithoutContext('VsCode.fromDirectory does not crash when packages.json is malformed', () {
@@ -44,7 +41,7 @@ void main() {
     expect(vsCode.version, Version.unknown);
   });
 
-  testWithoutContext('can locate non-Insider installations on macOS', () {
+  testWithoutContext('can locate installations on macOS', () {
     final FileSystem fileSystem = MemoryFileSystem.test();
     const String home = '/home/me';
     final Platform platform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{'HOME': home});
@@ -86,8 +83,7 @@ void main() {
     ]);
 
     final List<VsCode> installed = VsCode.allInstalled(fileSystem, platform, processManager);
-    // Finds three non-Insider installations.
-    expect(installed.length, 3);
+    expect(installed.length, 6);
     expect(processManager, hasNoRemainingExpectations);
   });
 }


### PR DESCRIPTION
This was already implemented, but hidden by a flag.  In `doctor` I now see Insiders installs:
```
[✓] VS Code (version 1.55.1)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.21.0

[✓] VS Code (version 1.56.0-insider)
    • VS Code at /Users/m/Applications/Visual Studio Code - Insiders.app/Contents
    • Flutter extension can be installed from:
      🔨 https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
```

Fixes https://github.com/flutter/flutter/issues/72489