### PR TITLE
Migrate platform_interaction to null safety

### DIFF
--- a/dev/integration_tests/platform_interaction/lib/main.dart
+++ b/dev/integration_tests/platform_interaction/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 }
 
 class TestApp extends StatefulWidget {
-  const TestApp({Key key}) : super(key: key);
+  const TestApp({Key? key}) : super(key: key);
 
   @override
   _TestAppState createState() => _TestAppState();
@@ -26,7 +26,7 @@ class _TestAppState extends State<TestApp> {
   static final List<TestStep> steps = <TestStep>[
     () => systemNavigatorPop(),
   ];
-  Future<TestStepResult> _result;
+  Future<TestStepResult>? _result;
   int _step = 0;
 
   void _executeNextStep() {

--- a/dev/integration_tests/platform_interaction/lib/src/system_navigation.dart
+++ b/dev/integration_tests/platform_interaction/lib/src/system_navigation.dart
@@ -14,7 +14,7 @@ Future<TestStepResult> systemNavigatorPop() {
 
   final Completer<TestStepResult> completer = Completer<TestStepResult>();
 
-  channel.setMessageHandler((String message) async {
+  channel.setMessageHandler((String? message) async {
     completer.complete(
         const TestStepResult('System navigation pop', '', TestStatus.ok));
     return '';

--- a/dev/integration_tests/platform_interaction/lib/src/test_step.dart
+++ b/dev/integration_tests/platform_interaction/lib/src/test_step.dart
@@ -23,12 +23,11 @@ class TestStepResult {
         return const TestStepResult('Executing', nothing, TestStatus.pending);
       case ConnectionState.done:
         if (snapshot.hasData) {
-          return snapshot.data;
+          return snapshot.data!;
         } else {
-          final TestStepResult result = snapshot.error as TestStepResult;
-          return result;
+          final Object? result = snapshot.error;
+          return result! as TestStepResult;
         }
-        break;
       default:
         throw 'Unsupported state ${snapshot.connectionState}';
     }

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/platform_interaction/test_driver/main_test.dart
+++ b/dev/integration_tests/platform_interaction/test_driver/main_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('channel suite', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect(printCommunication: true);
@@ -28,7 +28,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      driver?.close();
+      driver.close();
     });
   });
 }


### PR DESCRIPTION
I have migrated dev/integration_tests/platform_interaction with null safety.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
