### PR TITLE
Migrate dev/integration_tests/web to null safety

### DIFF
--- a/dev/integration_tests/web/lib/framework_stack_trace.dart
+++ b/dev/integration_tests/web/lib/framework_stack_trace.dart
@@ -17,7 +17,7 @@ import 'package:flutter/widgets.dart';
 // framework's ability to parse stack traces in all build modes.
 void main() async {
   final StringBuffer errorMessage = StringBuffer();
-  debugPrint = (String message, { int wrapWidth }) {
+  debugPrint = (String? message, { int? wrapWidth }) {
     errorMessage.writeln(message);
   };
 

--- a/dev/integration_tests/web/lib/service_worker_test.dart
+++ b/dev/integration_tests/web/lib/service_worker_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:html' as html;
 Future<void> main() async {
-  await html.window.navigator.serviceWorker.ready;
+  await html.window.navigator.serviceWorker?.ready;
   final String response = 'CLOSE?version=1';
   await html.HttpRequest.getString(response);
-  html.document.body.appendHtml(response);
+  html.document.body?.appendHtml(response);
 }

--- a/dev/integration_tests/web/lib/stack_trace.dart
+++ b/dev/integration_tests/web/lib/stack_trace.dart
@@ -158,5 +158,5 @@ class StackFrameEquality implements Equality<StackFrame> {
   }
 
   @override
-  bool isValidKey(Object o) => o is StackFrame;
+  bool isValidKey(Object? o) => o is StackFrame;
 }

--- a/dev/integration_tests/web/lib/web_directory_loading.dart
+++ b/dev/integration_tests/web/lib/web_directory_loading.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
       '/example',
       method: 'GET',
     );
-    final String body = request.responseText;
+    final String? body = request.responseText;
     if (body == 'This is an Example') {
       print('--- TEST SUCCEEDED ---');
     } else {

--- a/dev/integration_tests/web/pubspec.yaml
+++ b/dev/integration_tests/web/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_integration
 description: Integration test for web compilation.
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 flutter:
   assets:


### PR DESCRIPTION
I have migrated dev/integration_tests/web with null safety.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
