### PR TITLE
Migrate external_ui to null safety

### DIFF
--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -27,10 +27,10 @@ enum FrameState { initial, slow, afterSlow, fast, afterFast }
 
 class MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   int _widgetBuilds = 0;
-  late FrameState _state;
+  FrameState _state = FrameState.initial;
   String _summary = '';
   IconData? _icon;
-  double? _flutterFrameRate;
+  double _flutterFrameRate = 0;
 
   Future<void> _summarizeStats() async {
     final double? framesProduced = await channel.invokeMethod('getProducedFrameRate');
@@ -49,7 +49,7 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at .5x speed...';
         _state = FrameState.slow;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', _flutterFrameRate! ~/ 2);
+        channel.invokeMethod<void>('start', _flutterFrameRate ~/ 2);
         break;
       case FrameState.slow:
         debugPrint('Stopping .5x speed test...');
@@ -64,7 +64,7 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at 2x speed...';
         _state = FrameState.fast;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', (_flutterFrameRate! * 2).toInt());
+        channel.invokeMethod<void>('start', (_flutterFrameRate * 2).toInt());
         break;
       case FrameState.fast:
         debugPrint('Stopping 2x speed test...');
@@ -107,9 +107,9 @@ Widget builds: $_widgetBuilds''';
         ticker?.dispose();
         setState(() {
           _flutterFrameRate = tickCount * 1000 / elapsed.inMilliseconds;
-          debugPrint('Calibrated: frame rate ${_flutterFrameRate?.toStringAsFixed(1)}fps.');
+          debugPrint('Calibrated: frame rate ${_flutterFrameRate.toStringAsFixed(1)}fps.');
           _summary = '''
-Flutter frame rate is ${_flutterFrameRate?.toStringAsFixed(1)}fps.
+Flutter frame rate is ${_flutterFrameRate.toStringAsFixed(1)}fps.
 Press play to produce texture frames.''';
           _icon = Icons.play_arrow;
           _state = FrameState.initial;

--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -29,7 +29,7 @@ class MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   int _widgetBuilds = 0;
   late FrameState _state;
   String _summary = '';
-   IconData? _icon;
+  IconData? _icon;
   double? _flutterFrameRate;
 
   Future<void> _summarizeStats() async {

--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -96,7 +96,7 @@ Widget builds: $_widgetBuilds''';
     debugPrint('Awaiting calm (3 second pause)...');
     await Future<void>.delayed(const Duration(milliseconds: 3000));
     debugPrint('Calibrating...');
-    DateTime startTime;
+    late DateTime startTime;
     int tickCount = 0;
     Ticker? ticker;
     ticker = createTicker((Duration time) {

--- a/dev/integration_tests/external_ui/lib/main.dart
+++ b/dev/integration_tests/external_ui/lib/main.dart
@@ -15,7 +15,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key key}) : super(key: key);
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   State createState() => MyAppState();
@@ -27,17 +27,17 @@ enum FrameState { initial, slow, afterSlow, fast, afterFast }
 
 class MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   int _widgetBuilds = 0;
-  FrameState _state;
+  late FrameState _state;
   String _summary = '';
-  IconData _icon;
-  double _flutterFrameRate;
+   IconData? _icon;
+  double? _flutterFrameRate;
 
   Future<void> _summarizeStats() async {
-    final double framesProduced = await channel.invokeMethod('getProducedFrameRate');
-    final double framesConsumed = await channel.invokeMethod('getConsumedFrameRate');
+    final double? framesProduced = await channel.invokeMethod('getProducedFrameRate');
+    final double? framesConsumed = await channel.invokeMethod('getConsumedFrameRate');
     _summary = '''
-Produced: ${framesProduced.toStringAsFixed(1)}fps
-Consumed: ${framesConsumed.toStringAsFixed(1)}fps
+Produced: ${framesProduced?.toStringAsFixed(1)}fps
+Consumed: ${framesConsumed?.toStringAsFixed(1)}fps
 Widget builds: $_widgetBuilds''';
   }
 
@@ -49,7 +49,7 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at .5x speed...';
         _state = FrameState.slow;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', _flutterFrameRate ~/ 2);
+        channel.invokeMethod<void>('start', _flutterFrameRate! ~/ 2);
         break;
       case FrameState.slow:
         debugPrint('Stopping .5x speed test...');
@@ -64,7 +64,7 @@ Widget builds: $_widgetBuilds''';
         _summary = 'Producing texture frames at 2x speed...';
         _state = FrameState.fast;
         _icon = Icons.stop;
-        channel.invokeMethod<void>('start', (_flutterFrameRate * 2).toInt());
+        channel.invokeMethod<void>('start', (_flutterFrameRate! * 2).toInt());
         break;
       case FrameState.fast:
         debugPrint('Stopping 2x speed test...');
@@ -98,18 +98,18 @@ Widget builds: $_widgetBuilds''';
     debugPrint('Calibrating...');
     DateTime startTime;
     int tickCount = 0;
-    Ticker ticker;
+    Ticker? ticker;
     ticker = createTicker((Duration time) {
       tickCount += 1;
       if (tickCount == calibrationTickCount) { // about 10 seconds
         final Duration elapsed = DateTime.now().difference(startTime);
-        ticker.stop();
-        ticker.dispose();
+        ticker?.stop();
+        ticker?.dispose();
         setState(() {
           _flutterFrameRate = tickCount * 1000 / elapsed.inMilliseconds;
-          debugPrint('Calibrated: frame rate ${_flutterFrameRate.toStringAsFixed(1)}fps.');
+          debugPrint('Calibrated: frame rate ${_flutterFrameRate?.toStringAsFixed(1)}fps.');
           _summary = '''
-Flutter frame rate is ${_flutterFrameRate.toStringAsFixed(1)}fps.
+Flutter frame rate is ${_flutterFrameRate?.toStringAsFixed(1)}fps.
 Press play to produce texture frames.''';
           _icon = Icons.play_arrow;
           _state = FrameState.initial;

--- a/dev/integration_tests/external_ui/pubspec.yaml
+++ b/dev/integration_tests/external_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_ui
 description: A test of Flutter integrating external UIs.
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/external_ui/pubspec.yaml
+++ b/dev/integration_tests/external_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_ui
 description: A test of Flutter integrating external UIs.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/external_ui/test_driver/main_test.dart
+++ b/dev/integration_tests/external_ui/test_driver/main_test.dart
@@ -42,11 +42,11 @@ Future<void> main() async {
       await driver.tap(fab);
 
       final String statsSlow = await driver.getText(summary);
-      final Match? matchSlow = statsRegExp.matchAsPrefix(statsSlow);
+      final Match matchSlow = statsRegExp.matchAsPrefix(statsSlow)!;
       expect(matchSlow, isNotNull);
-      expect(double.parse(matchSlow?.group(1) ?? '0'), closeTo(flutterFrameRate / 2.0, 5.0));
-      expect(double.parse(matchSlow?.group(2) ?? '0'), closeTo(flutterFrameRate / 2.0, 5.0));
-      expect(int.parse(matchSlow?.group(3) ?? '0'), 1);
+      expect(double.parse(matchSlow.group(1)!), closeTo(flutterFrameRate / 2.0, 5.0));
+      expect(double.parse(matchSlow.group(2)!), closeTo(flutterFrameRate / 2.0, 5.0));
+      expect(int.parse(matchSlow.group(3)!), 1);
 
       // Texture frame stats at 2.0x Flutter frame rate
       await driver.tap(fab);

--- a/dev/integration_tests/external_ui/test_driver/main_test.dart
+++ b/dev/integration_tests/external_ui/test_driver/main_test.dart
@@ -54,11 +54,11 @@ Future<void> main() async {
       await driver.tap(fab);
 
       final String statsFast = await driver.getText(summary);
-      final Match? matchFast = statsRegExp.matchAsPrefix(statsFast);
+      final Match matchFast = statsRegExp.matchAsPrefix(statsFast)!;
       expect(matchFast, isNotNull);
-      expect(double.parse(matchFast?.group(1) ?? '0'), closeTo(flutterFrameRate * 2.0, 5.0));
-      expect(double.parse(matchFast?.group(2) ?? '0'), closeTo(flutterFrameRate, 10.0));
-      expect(int.parse(matchFast?.group(3) ?? '0'), 1);
+      expect(double.parse(matchFast.group(1)!), closeTo(flutterFrameRate * 2.0, 5.0));
+      expect(double.parse(matchFast.group(2)!), closeTo(flutterFrameRate, 10.0));
+      expect(int.parse(matchFast.group(3)!), 1);
     });
 
     tearDownAll(() async {

--- a/dev/integration_tests/external_ui/test_driver/main_test.dart
+++ b/dev/integration_tests/external_ui/test_driver/main_test.dart
@@ -13,7 +13,7 @@ const Duration samplingTime = Duration(seconds: 8);
 
 Future<void> main() async {
   group('texture suite', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -32,9 +32,9 @@ Future<void> main() async {
       await driver.waitFor(fab);
 
       final String calibrationResult = await driver.getText(summary);
-      final Match matchCalibration = calibrationRegExp.matchAsPrefix(calibrationResult);
+      final Match? matchCalibration = calibrationRegExp.matchAsPrefix(calibrationResult);
       expect(matchCalibration, isNotNull);
-      final double flutterFrameRate = double.parse(matchCalibration.group(1));
+      final double flutterFrameRate = double.parse(matchCalibration?.group(1) ?? '0');
 
       // Texture frame stats at 0.5x Flutter frame rate
       await driver.tap(fab);
@@ -42,11 +42,11 @@ Future<void> main() async {
       await driver.tap(fab);
 
       final String statsSlow = await driver.getText(summary);
-      final Match matchSlow = statsRegExp.matchAsPrefix(statsSlow);
+      final Match? matchSlow = statsRegExp.matchAsPrefix(statsSlow);
       expect(matchSlow, isNotNull);
-      expect(double.parse(matchSlow.group(1)), closeTo(flutterFrameRate / 2.0, 5.0));
-      expect(double.parse(matchSlow.group(2)), closeTo(flutterFrameRate / 2.0, 5.0));
-      expect(int.parse(matchSlow.group(3)), 1);
+      expect(double.parse(matchSlow?.group(1) ?? '0'), closeTo(flutterFrameRate / 2.0, 5.0));
+      expect(double.parse(matchSlow?.group(2) ?? '0'), closeTo(flutterFrameRate / 2.0, 5.0));
+      expect(int.parse(matchSlow?.group(3) ?? '0'), 1);
 
       // Texture frame stats at 2.0x Flutter frame rate
       await driver.tap(fab);
@@ -54,15 +54,15 @@ Future<void> main() async {
       await driver.tap(fab);
 
       final String statsFast = await driver.getText(summary);
-      final Match matchFast = statsRegExp.matchAsPrefix(statsFast);
+      final Match? matchFast = statsRegExp.matchAsPrefix(statsFast);
       expect(matchFast, isNotNull);
-      expect(double.parse(matchFast.group(1)), closeTo(flutterFrameRate * 2.0, 5.0));
-      expect(double.parse(matchFast.group(2)), closeTo(flutterFrameRate, 10.0));
-      expect(int.parse(matchFast.group(3)), 1);
+      expect(double.parse(matchFast?.group(1) ?? '0'), closeTo(flutterFrameRate * 2.0, 5.0));
+      expect(double.parse(matchFast?.group(2) ?? '0'), closeTo(flutterFrameRate, 10.0));
+      expect(int.parse(matchFast?.group(3) ?? '0'), 1);
     });
 
     tearDownAll(() async {
-      driver?.close();
+      driver.close();
     });
   });
 }


### PR DESCRIPTION
I have migrated dev/integration_tests/external_ui with null safety.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
