### PR TITLE
[ExpansionPanel]Added properties to modify ExpandIcon color

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -78,6 +78,9 @@ class ExpansionPanel {
     this.isExpanded = false,
     this.canTapOnHeader = false,
     this.backgroundColor,
+    this.iconColor,
+    this.disabledIconColor,
+    this.expandedIconColor
   }) : assert(headerBuilder != null),
        assert(body != null),
        assert(isExpanded != null),
@@ -105,6 +108,15 @@ class ExpansionPanel {
   ///
   /// Defaults to [ThemeData.cardColor].
   final Color? backgroundColor;
+
+  /// Defines the icon color of [ExpandIcon] when [isExpanded] is false.
+  final Color? iconColor;
+
+  /// Defines the icon color of [ExpandIcon] when [isExpanded] is true.
+  final Color? expandedIconColor;
+
+  /// Defines the icon color of [ExpandIcon] when [canTapOnHeader] is true.
+  final Color? disabledIconColor;
 }
 
 /// An expansion panel that allows for radio-like functionality.
@@ -128,12 +140,18 @@ class ExpansionPanelRadio extends ExpansionPanel {
     required Widget body,
     bool canTapOnHeader = false,
     Color? backgroundColor,
+    Color? iconColor,
+    Color? disabledIconColor,
+    Color? expandedIconColor,
   }) : assert(value != null),
       super(
         body: body,
         headerBuilder: headerBuilder,
         canTapOnHeader: canTapOnHeader,
         backgroundColor: backgroundColor,
+        iconColor: iconColor,
+        disabledIconColor: disabledIconColor,
+        expandedIconColor: expandedIconColor
       );
 
   /// The value that uniquely identifies a radio panel so that the currently
@@ -493,6 +511,9 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       Widget expandIconContainer = Container(
         margin: const EdgeInsetsDirectional.only(end: 8.0),
         child: ExpandIcon(
+          color: child.iconColor,
+          disabledColor: child.disabledIconColor,
+          expandedColor: child.expandedIconColor,
           isExpanded: _isChildExpanded(index),
           padding: const EdgeInsets.all(16.0),
           onPressed: !child.canTapOnHeader

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1493,6 +1493,7 @@ void main() {
     expect((mergeableMaterial.children.last as MaterialSlice).color, secondPanelColor);
   });
 
+  
   testWidgets('ExpansionPanelRadio.backgroundColor test', (WidgetTester tester) async {
     const Color firstPanelColor = Colors.red;
     const Color secondPanelColor = Colors.brown;
@@ -1526,5 +1527,66 @@ void main() {
 
     expect((mergeableMaterial.children.first as MaterialSlice).color, firstPanelColor);
     expect((mergeableMaterial.children.last as MaterialSlice).color, secondPanelColor);
+  });
+
+  testWidgets('ExpansionPanel.iconColor, ExpansionPanel.expandedIconColor, ExpansionPanel.disbaledColor test', (WidgetTester tester) async {
+    const Color firstIconColor = Colors.red;
+    const Color expandedIconColor = Colors.blue;
+    const Color disabledIconColor = Colors.amber;
+
+    await tester.pumpWidget(MaterialApp(
+      home: SingleChildScrollView(
+        child: ExpansionPanelList(
+          children: <ExpansionPanel>[
+            ExpansionPanel(
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return const Text('A');
+              },
+              body: const SizedBox(height: 100.0),
+              iconColor: firstIconColor,
+              expandedIconColor: expandedIconColor,
+              disabledIconColor: disabledIconColor
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
+    
+    expect(expandIcon.color, firstIconColor);
+    expect(expandIcon.expandedColor, expandedIconColor);
+    expect(expandIcon.disabledColor, disabledIconColor);
+  });
+
+    testWidgets('ExpansionPanelRadio.iconColor, ExpansionPanelRadio.expandedIconColor, ExpansionPanelRadio.disabledIconColor   test', (WidgetTester tester) async {
+    const Color firstIconColor = Colors.red;
+    const Color expandedIconColor = Colors.blue;
+    const Color disabledIconColor = Colors.amber;
+
+    await tester.pumpWidget(MaterialApp(
+      home: SingleChildScrollView(
+        child: ExpansionPanelList.radio(
+          children: <ExpansionPanelRadio>[
+            ExpansionPanelRadio(
+              headerBuilder: (BuildContext context, bool isExpanded) {
+                return const Text('A');
+              },
+              body: const SizedBox(height: 100.0),
+              iconColor: firstIconColor,
+              expandedIconColor: expandedIconColor,
+              disabledIconColor: disabledIconColor,
+              value:0,
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
+    
+    expect(expandIcon.color, firstIconColor);
+    expect(expandIcon.expandedColor, expandedIconColor);
+    expect(expandIcon.disabledColor, disabledIconColor);
   });
 }

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1492,7 +1492,6 @@ void main() {
     expect((mergeableMaterial.children.first as MaterialSlice).color, firstPanelColor);
     expect((mergeableMaterial.children.last as MaterialSlice).color, secondPanelColor);
   });
-
   
   testWidgets('ExpansionPanelRadio.backgroundColor test', (WidgetTester tester) async {
     const Color firstPanelColor = Colors.red;
@@ -1553,7 +1552,7 @@ void main() {
     ));
 
     final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
-    
+
     expect(expandIcon.color, firstIconColor);
     expect(expandIcon.expandedColor, expandedIconColor);
     expect(expandIcon.disabledColor, disabledIconColor);
@@ -1584,7 +1583,7 @@ void main() {
     ));
 
     final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
-    
+
     expect(expandIcon.color, firstIconColor);
     expect(expandIcon.expandedColor, expandedIconColor);
     expect(expandIcon.disabledColor, disabledIconColor);

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1492,7 +1492,7 @@ void main() {
     expect((mergeableMaterial.children.first as MaterialSlice).color, firstPanelColor);
     expect((mergeableMaterial.children.last as MaterialSlice).color, secondPanelColor);
   });
-  
+
   testWidgets('ExpansionPanelRadio.backgroundColor test', (WidgetTester tester) async {
     const Color firstPanelColor = Colors.red;
     const Color secondPanelColor = Colors.brown;

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -1542,26 +1542,41 @@ void main() {
                 return const Text('A');
               },
               body: const SizedBox(height: 100.0),
-              iconColor: firstIconColor,
-              expandedIconColor: expandedIconColor,
-              disabledIconColor: disabledIconColor
+              iconColor: MaterialStateProperty.resolveWith((Set<MaterialState>states) {
+                if (states.contains(MaterialState.selected)) {
+                  return expandedIconColor;
+                } else if (states.contains(MaterialState.disabled)) {
+                  return disabledIconColor;
+                }
+
+                return firstIconColor;
+
+              })
             ),
           ],
         ),
       ),
     ));
 
-    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
+    ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
 
     expect(expandIcon.color, firstIconColor);
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+
+    expandIcon = tester.widget(find.byType(ExpandIcon));
+
     expect(expandIcon.expandedColor, expandedIconColor);
-    expect(expandIcon.disabledColor, disabledIconColor);
+    expect(expandIcon.isExpanded, true);
   });
 
     testWidgets('ExpansionPanelRadio.iconColor, ExpansionPanelRadio.expandedIconColor, ExpansionPanelRadio.disabledIconColor   test', (WidgetTester tester) async {
     const Color firstIconColor = Colors.red;
     const Color expandedIconColor = Colors.blue;
     const Color disabledIconColor = Colors.amber;
+
 
     await tester.pumpWidget(MaterialApp(
       home: SingleChildScrollView(
@@ -1572,9 +1587,16 @@ void main() {
                 return const Text('A');
               },
               body: const SizedBox(height: 100.0),
-              iconColor: firstIconColor,
-              expandedIconColor: expandedIconColor,
-              disabledIconColor: disabledIconColor,
+              iconColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                if (states.contains(MaterialState.selected)) {
+                  return expandedIconColor;
+                } else if (states.contains(MaterialState.disabled)) {
+                  return disabledIconColor;
+                }
+
+                return firstIconColor;
+
+              }),
               value:0,
             ),
           ],
@@ -1582,10 +1604,15 @@ void main() {
       ),
     ));
 
-    final ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
+    ExpandIcon expandIcon = tester.widget(find.byType(ExpandIcon));
 
     expect(expandIcon.color, firstIconColor);
+
+    await tester.tap(find.byType(ExpandIcon));
+    await tester.pumpAndSettle();
+
+    expandIcon = tester.widget(find.byType(ExpandIcon));
+
     expect(expandIcon.expandedColor, expandedIconColor);
-    expect(expandIcon.disabledColor, disabledIconColor);
   });
 }


### PR DESCRIPTION
Added properties to the `ExpansionPanel` and `ExpansionPanelRadio` to change `ExpandIcon` color. Added the following properties:
 - `iconColor` to change `ExpandIcon.color` when `isExpanded` is false
 - `expandedIconColor` to change the `ExpandIcon.expandedColor` when `isExpanded` is true
 - `disabledIconColor` to change the `ExpandIcon.disabledColor` when `canTapOnHeader` is true 


Fixes #80295

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
