### PR TITLE
Add Android keystore files to project gitignore

### DIFF
--- a/packages/flutter_tools/templates/app/android.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app/android.tmpl/.gitignore
@@ -9,3 +9,5 @@ GeneratedPluginRegistrant.java
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
 key.properties
+**/*.keystore
+**/*.jks


### PR DESCRIPTION
It's common enough to store keystores in the app directory, so ignore them. 