### PR TITLE
[custom-devices] add screenshotting support

### DIFF
--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -604,22 +604,13 @@ class CustomDevice extends Device {
       throw UnsupportedError('Screenshotting is not supported for this device.');
     }
 
-    final List<String> interpolated = interpolateCommand(_config.screenshotCommand, <String, String>{});
+    final List<String> interpolated = interpolateCommand(
+      _config.screenshotCommand,
+      <String, String>{},
+    );
 
     final RunResult result = await _processUtils.run(interpolated, throwOnError: true);
-
-    // remove all non-base64 characters.
-    final String trimmedStdout = result.stdout.trim().replaceAll(RegExp(r'[^a-zA-Z0-9+/]+'), '');
-    if (trimmedStdout.isNotEmpty) {
-      _logger.printTrace('custom device screenshot command stdout: $trimmedStdout');
-    }
-
-    final String trimmedStderr = result.stderr.trim();
-    if (trimmedStderr.isNotEmpty) {
-      _logger.printTrace('custom device screenshot command stderr: $trimmedStderr');
-    }
-
-    await outputFile.writeAsBytes(base64Decode(trimmedStdout));
+    await outputFile.writeAsBytes(base64Decode(result.stdout));
   }
 
   @override

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -22,7 +22,8 @@ class CustomDeviceConfig {
     required this.uninstallCommand,
     required this.runDebugCommand,
     this.forwardPortCommand,
-    this.forwardPortSuccessRegex
+    this.forwardPortSuccessRegex,
+    this.screenshotCommand
   }) : assert(forwardPortCommand == null || forwardPortSuccessRegex != null);
 
   factory CustomDeviceConfig.fromJson(dynamic json) {
@@ -40,7 +41,8 @@ class CustomDeviceConfig {
       uninstallCommand: _castStringList(typedMap[_kUninstallCommand]!),
       runDebugCommand: _castStringList(typedMap[_kRunDebugCommand]!),
       forwardPortCommand: _castStringListOrNull(typedMap[_kForwardPortCommand]),
-      forwardPortSuccessRegex: _convertToRegexOrNull(typedMap[_kForwardPortSuccessRegex])
+      forwardPortSuccessRegex: _convertToRegexOrNull(typedMap[_kForwardPortSuccessRegex]),
+      screenshotCommand: _castStringListOrNull(typedMap[_kScreenshotCommand])
     );
   }
 
@@ -56,6 +58,7 @@ class CustomDeviceConfig {
   static const String _kRunDebugCommand = 'runDebug';
   static const String _kForwardPortCommand = 'forwardPort';
   static const String _kForwardPortSuccessRegex = 'forwardPortSuccessRegex';
+  static const String _kScreenshotCommand = 'screenshot';
 
   /// An example device config used for creating the default config file.
   static final CustomDeviceConfig example = CustomDeviceConfig(
@@ -70,7 +73,8 @@ class CustomDeviceConfig {
     uninstallCommand: const <String>['ssh', 'pi@raspberrypi', r'rm -rf "/tmp/${appName}"'],
     runDebugCommand: const <String>['ssh', 'pi@raspberrypi', r'flutter-pi "/tmp/${appName}"'],
     forwardPortCommand: const <String>['ssh', '-o', 'ExitOnForwardFailure=yes', '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}', 'pi@raspberrypi'],
-    forwardPortSuccessRegex: RegExp('Linux')
+    forwardPortSuccessRegex: RegExp('Linux'),
+    screenshotCommand: const <String>['ssh', 'pi@raspberrypi', 'fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64']
   );
 
   final String id;
@@ -85,8 +89,11 @@ class CustomDeviceConfig {
   final List<String> runDebugCommand;
   final List<String>? forwardPortCommand;
   final RegExp? forwardPortSuccessRegex;
+  final List<String>? screenshotCommand;
 
   bool get usesPortForwarding => forwardPortCommand != null;
+
+  bool get supportsScreenshotting => screenshotCommand != null;
 
   static List<String> _castStringList(Object object) {
     return (object as List<dynamic>).cast<String>();
@@ -113,7 +120,8 @@ class CustomDeviceConfig {
       _kUninstallCommand: uninstallCommand,
       _kRunDebugCommand: runDebugCommand,
       _kForwardPortCommand: forwardPortCommand,
-      _kForwardPortSuccessRegex: forwardPortSuccessRegex?.pattern
+      _kForwardPortSuccessRegex: forwardPortSuccessRegex?.pattern,
+      _kScreenshotCommand: screenshotCommand,
     };
   }
 
@@ -133,7 +141,9 @@ class CustomDeviceConfig {
     bool explicitForwardPortCommand = false,
     List<String>? forwardPortCommand,
     bool explicitForwardPortSuccessRegex = false,
-    RegExp? forwardPortSuccessRegex
+    RegExp? forwardPortSuccessRegex,
+    bool explicitScreenshotCommand = false,
+    List<String>? screenshotCommand
   }) {
     return CustomDeviceConfig(
       id: id ?? this.id,
@@ -147,7 +157,8 @@ class CustomDeviceConfig {
       uninstallCommand: uninstallCommand ?? this.uninstallCommand,
       runDebugCommand: runDebugCommand ?? this.runDebugCommand,
       forwardPortCommand: explicitForwardPortCommand ? forwardPortCommand : (forwardPortCommand ?? this.forwardPortCommand),
-      forwardPortSuccessRegex: explicitForwardPortSuccessRegex ? forwardPortSuccessRegex : (forwardPortSuccessRegex ?? this.forwardPortSuccessRegex)
+      forwardPortSuccessRegex: explicitForwardPortSuccessRegex ? forwardPortSuccessRegex : (forwardPortSuccessRegex ?? this.forwardPortSuccessRegex),
+      screenshotCommand: explicitScreenshotCommand ? screenshotCommand : (screenshotCommand ?? this.screenshotCommand),
     );
   }
 }

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -74,7 +74,7 @@ class CustomDeviceConfig {
     runDebugCommand: const <String>['ssh', 'pi@raspberrypi', r'flutter-pi "/tmp/${appName}"'],
     forwardPortCommand: const <String>['ssh', '-o', 'ExitOnForwardFailure=yes', '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}', 'pi@raspberrypi'],
     forwardPortSuccessRegex: RegExp('Linux'),
-    screenshotCommand: const <String>['ssh', 'pi@raspberrypi', 'fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64']
+    screenshotCommand: const <String>['ssh', 'pi@raspberrypi', r"fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64 | tr -d ' \n\t'"]
   );
 
   final String id;

--- a/packages/flutter_tools/static/custom-devices.schema.json
+++ b/packages/flutter_tools/static/custom-devices.schema.json
@@ -116,7 +116,7 @@
             },
             "minItems": 1,
             "default": [
-              "ssh", "pi@raspberrypi", "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64"
+              "ssh", "pi@raspberrypi", "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64 | tr -d ' \\n\\t'"
             ],
             "required": false
           }

--- a/packages/flutter_tools/static/custom-devices.schema.json
+++ b/packages/flutter_tools/static/custom-devices.schema.json
@@ -107,6 +107,18 @@
             "format": "regex",
             "default": "Linux",
             "required": false
+          },
+          "screenshot": {
+            "description": "Take a screenshot of the app as a png image. This command should take the screenshot, convert it to png, then base64 encode it and echo to stdout. Any stderr output will be ignored. If this command is not given, screenshotting will be disabled for this device.",
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "default": [
+              "ssh", "pi@raspberrypi", "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64"
+            ],
+            "required": false
           }
         }
       }

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -10,6 +10,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file/src/interface/directory.dart';
 import 'package:file/src/interface/file.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -545,7 +546,7 @@ void main() {
 
     await device.takeScreenshot(screenshotFile);
     expect(screenshotCommandWasExecuted, true);
-    expect(screenshotFile.existsSync(), true);
+    expect(screenshotFile, exists);
   });
 
   testWithoutContext('CustomDevice without screenshotting support', () async {


### PR DESCRIPTION
This implements #79678.

I tested it on my device and the flutter SDK part of this works. However it's still not possible to take screenshots of the app, at least when using flutter-pi because the device-part of screenshotting support is missing. I.e. there's currently no ready-to-use command to take screenshots of the Raspberry Pi when using KMS directly without X11 / Wayland. You can get a fbdev screenshot (and that's what I tested) and that works, but only shows the console. So in the future I'll probably add some kind of support inside flutter-pi to take screenshots.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
