### PR TITLE
Support flutter run --flavor out of the box on macOS

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -17,6 +17,32 @@ EchoError() {
   echo "$@" 1>&2
 }
 
+ParseFlutterBuildMode() {
+  # Use FLUTTER_BUILD_MODE if it's set, otherwise use the Xcode build configuration name
+  # This means that if someone wants to use an Xcode build config other than Debug/Profile/Release,
+  # they _must_ set FLUTTER_BUILD_MODE so we know what type of artifact to build.
+  local build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"
+
+  case "$build_mode" in
+    *release*) build_mode="release";;
+    *profile*) build_mode="profile";;
+    *debug*) build_mode="debug";;
+    *)
+      EchoError "========================================================================"
+      EchoError "ERROR: Unknown FLUTTER_BUILD_MODE: ${build_mode}."
+      EchoError "Valid values are 'Debug', 'Profile', or 'Release' (case insensitive)."
+      EchoError "This is controlled by the FLUTTER_BUILD_MODE environment variable."
+      EchoError "If that is not set, the CONFIGURATION environment variable is used."
+      EchoError ""
+      EchoError "You can fix this by either adding an appropriately named build"
+      EchoError "configuration, or adding an appropriate value for FLUTTER_BUILD_MODE to the"
+      EchoError ".xcconfig file for the current build configuration (${CONFIGURATION})."
+      EchoError "========================================================================"
+      exit -1;;
+  esac
+  echo "${build_mode}"
+}
+
 BuildApp() {
   # Set the working directory to the project root
   local project_path="${SOURCE_ROOT}/.."
@@ -39,7 +65,7 @@ BuildApp() {
   fi
 
   # Set the build mode
-  local build_mode="$(echo "${FLUTTER_BUILD_MODE:-${CONFIGURATION}}" | tr "[:upper:]" "[:lower:]")"
+  local build_mode="$(ParseFlutterBuildMode)"
 
   if [[ -n "$LOCAL_ENGINE" ]]; then
     if [[ $(echo "$LOCAL_ENGINE" | tr "[:upper:]" "[:lower:]") != *"$build_mode"* ]]; then


### PR DESCRIPTION
There's a tiny bug in the `macos_assemble.sh` script that causes the build to fail in the last phase. If the name of your custom scheme is `dev`, running `flutter run --flavor dev` will fail with an error message saying _"No target named "debug-dev_macos_bundle_flutter_assets" defined"_:

![image](https://user-images.githubusercontent.com/13744304/115202327-f9eb0b00-a0fe-11eb-8d68-8fbab49026bf.png)

It happens because [this line](https://github.com/flutter/flutter/blob/e94f36a7c5edc4389baa2baf86b87aa9280561b8/packages/flutter_tools/bin/macos_assemble.sh#L103) should be calling `debug-macos_bundle_flutter_assets` instead of `debug-dev_macos_bundle_flutter_assets`. This happens because `macos_assemble.sh` is missing [this part from xcode_backend.sh](https://github.com/flutter/flutter/blob/e94f36a7c5edc4389baa2baf86b87aa9280561b8/packages/flutter_tools/bin/xcode_backend.sh#L41-L65), which causes the `build_mode` variable to be parsed improperly to `debug-dev` instead of `debug`.

Fixes #64088.

**Edit: More changes are needed to fully support flavors. See: https://github.com/flutter/flutter/pull/80701#issuecomment-825451638**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.