### PR TITLE
Migrate tool emulators to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:meta/meta.dart';
@@ -17,17 +15,17 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../convert.dart';
-import '../device.dart';
+import '../device_categories.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
 
 class AndroidEmulators extends EmulatorDiscovery {
   AndroidEmulators({
-    @required AndroidSdk androidSdk,
-    @required AndroidWorkflow androidWorkflow,
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required ProcessManager processManager,
+    required AndroidSdk? androidSdk,
+    required AndroidWorkflow androidWorkflow,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required ProcessManager processManager,
   }) : _androidSdk = androidSdk,
        _androidWorkflow = androidWorkflow,
        _fileSystem = fileSystem,
@@ -36,7 +34,7 @@ class AndroidEmulators extends EmulatorDiscovery {
        _processUtils = ProcessUtils(logger: logger, processManager: processManager);
 
   final AndroidWorkflow _androidWorkflow;
-  final AndroidSdk _androidSdk;
+  final AndroidSdk? _androidSdk;
   final FileSystem _fileSystem;
   final Logger _logger;
   final ProcessManager _processManager;
@@ -50,14 +48,14 @@ class AndroidEmulators extends EmulatorDiscovery {
 
   @override
   bool get canLaunchAnything => _androidWorkflow.canListEmulators
-    && _androidSdk.getAvdManagerPath() != null;
+    && _androidSdk?.getAvdManagerPath() != null;
 
   @override
   Future<List<Emulator>> get emulators => _getEmulatorAvds();
 
   /// Return the list of available emulator AVDs.
   Future<List<AndroidEmulator>> _getEmulatorAvds() async {
-    final String emulatorPath = _androidSdk?.emulatorPath;
+    final String? emulatorPath = _androidSdk?.emulatorPath;
     if (emulatorPath == null) {
       return <AndroidEmulator>[];
     }
@@ -82,7 +80,7 @@ class AndroidEmulators extends EmulatorDiscovery {
 
   AndroidEmulator _loadEmulatorInfo(String id) {
     id = id.trim();
-    final String avdPath = _androidSdk.getAvdPath();
+    final String? avdPath = _androidSdk?.getAvdPath();
     final AndroidEmulator androidEmulatorWithoutProperties = AndroidEmulator(
       id,
       processManager: _processManager,
@@ -97,10 +95,11 @@ class AndroidEmulators extends EmulatorDiscovery {
       return androidEmulatorWithoutProperties;
     }
     final Map<String, String> ini = parseIniLines(iniFile.readAsLinesSync());
-    if (ini['path'] == null) {
+    final String? iniPath = ini['path'];
+    if (iniPath == null) {
       return androidEmulatorWithoutProperties;
     }
-    final File configFile = _fileSystem.file(_fileSystem.path.join(ini['path'], 'config.ini'));
+    final File configFile = _fileSystem.file(_fileSystem.path.join(iniPath, 'config.ini'));
     if (!configFile.existsSync()) {
       return androidEmulatorWithoutProperties;
     }
@@ -117,20 +116,20 @@ class AndroidEmulators extends EmulatorDiscovery {
 
 class AndroidEmulator extends Emulator {
   AndroidEmulator(String id, {
-    Map<String, String> properties,
-    @required Logger logger,
-    @required AndroidSdk androidSdk,
-    @required ProcessManager processManager,
+    Map<String, String>? properties,
+    required Logger logger,
+    AndroidSdk? androidSdk,
+    required ProcessManager processManager,
   }) : _properties = properties,
        _logger = logger,
        _androidSdk = androidSdk,
        _processUtils = ProcessUtils(logger: logger, processManager: processManager),
        super(id, properties != null && properties.isNotEmpty);
 
-  final Map<String, String> _properties;
+  final Map<String, String>? _properties;
   final Logger _logger;
   final ProcessUtils _processUtils;
-  final AndroidSdk _androidSdk;
+  final AndroidSdk? _androidSdk;
 
   // Android Studio uses the ID with underscores replaced with spaces
   // for the name if displayname is not set so we do the same.
@@ -138,7 +137,7 @@ class AndroidEmulator extends Emulator {
   String get name => _prop('avd.ini.displayname') ?? id.replaceAll('_', ' ').trim();
 
   @override
-  String get manufacturer => _prop('hw.device.manufacturer');
+  String? get manufacturer => _prop('hw.device.manufacturer');
 
   @override
   Category get category => Category.mobile;
@@ -146,12 +145,17 @@ class AndroidEmulator extends Emulator {
   @override
   PlatformType get platformType => PlatformType.android;
 
-  String _prop(String name) => _properties != null ? _properties[name] : null;
+  String? _prop(String name) => _properties != null ? _properties![name] : null;
 
   @override
   Future<void> launch() async {
+    final String? emulatorPath = _androidSdk?.emulatorPath;
+    if (emulatorPath == null) {
+      _logger.printError('The Android emulator could not be found.');
+      return;
+    }
     final Process process = await _processUtils.start(
-      <String>[_androidSdk.emulatorPath, '-avd', id],
+      <String>[emulatorPath, '-avd', id],
     );
 
     // Record output from the emulator process.

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -21,44 +21,14 @@ import 'base/user_messages.dart' hide userMessages;
 import 'base/utils.dart';
 import 'build_info.dart';
 import 'devfs.dart';
+import 'device_categories.dart';
 import 'device_port_forwarder.dart';
 import 'project.dart';
 import 'vmservice.dart';
 
+export 'device_categories.dart';
+
 DeviceManager get deviceManager => context.get<DeviceManager>();
-
-/// A description of the kind of workflow the device supports.
-class Category {
-  const Category._(this.value);
-
-  static const Category web = Category._('web');
-  static const Category desktop = Category._('desktop');
-  static const Category mobile = Category._('mobile');
-
-  final String value;
-
-  @override
-  String toString() => value;
-}
-
-/// The platform sub-folder that a device type supports.
-class PlatformType {
-  const PlatformType._(this.value);
-
-  static const PlatformType web = PlatformType._('web');
-  static const PlatformType android = PlatformType._('android');
-  static const PlatformType ios = PlatformType._('ios');
-  static const PlatformType linux = PlatformType._('linux');
-  static const PlatformType macos = PlatformType._('macos');
-  static const PlatformType windows = PlatformType._('windows');
-  static const PlatformType fuchsia = PlatformType._('fuchsia');
-  static const PlatformType custom = PlatformType._('custom');
-
-  final String value;
-
-  @override
-  String toString() => value;
-}
 
 /// A discovery mechanism for flutter-supported development devices.
 abstract class DeviceManager {

--- a/packages/flutter_tools/lib/src/device_categories.dart
+++ b/packages/flutter_tools/lib/src/device_categories.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A description of the kind of workflow the device supports.
+class Category {
+  const Category._(this.value);
+
+  static const Category web = Category._('web');
+  static const Category desktop = Category._('desktop');
+  static const Category mobile = Category._('mobile');
+
+  final String value;
+
+  @override
+  String toString() => value;
+}
+
+/// The platform sub-folder that a device type supports.
+class PlatformType {
+  const PlatformType._(this.value);
+
+  static const PlatformType web = PlatformType._('web');
+  static const PlatformType android = PlatformType._('android');
+  static const PlatformType ios = PlatformType._('ios');
+  static const PlatformType linux = PlatformType._('linux');
+  static const PlatformType macos = PlatformType._('macos');
+  static const PlatformType windows = PlatformType._('windows');
+  static const PlatformType fuchsia = PlatformType._('fuchsia');
+  static const PlatformType custom = PlatformType._('custom');
+
+  final String value;
+
+  @override
+  String toString() => value;
+}

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -2,20 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import '../base/process.dart';
-import '../device.dart';
+import '../device_categories.dart';
 import '../emulator.dart';
 import '../globals_null_migrated.dart' as globals;
-import 'simulators.dart';
+
+const String iosSimulatorId = 'apple_ios_simulator';
 
 class IOSEmulators extends EmulatorDiscovery {
   @override
   bool get supportsPlatform => globals.platform.isMacOS;
 
   @override
-  bool get canListAnything => globals.iosWorkflow.canListEmulators;
+  bool get canListAnything => globals.iosWorkflow?.canListEmulators ?? false;
 
   @override
   Future<List<Emulator>> get emulators async => getEmulators();
@@ -42,11 +41,15 @@ class IOSEmulator extends Emulator {
   @override
   Future<void> launch() async {
     Future<bool> launchSimulator(List<String> additionalArgs) async {
+      final String? simulatorPath = globals.xcode?.getSimulatorPath();
+      if (simulatorPath == null) {
+        return false;
+      }
       final List<String> args = <String>[
         'open',
         ...additionalArgs,
         '-a',
-        globals.xcode.getSimulatorPath(),
+        simulatorPath,
       ];
 
       final RunResult launchResult = await globals.processUtils.run(args);
@@ -70,7 +73,7 @@ class IOSEmulator extends Emulator {
 
 /// Return the list of iOS Simulators (there can only be zero or one).
 List<IOSEmulator> getEmulators() {
-  final String simulatorPath = globals.xcode.getSimulatorPath();
+  final String? simulatorPath = globals.xcode?.getSimulatorPath();
   if (simulatorPath == null) {
     return <IOSEmulator>[];
   }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -27,10 +27,9 @@ import '../macos/xcode.dart';
 import '../project.dart';
 import '../protocol_discovery.dart';
 import 'application_package.dart';
+import 'ios_emulators.dart';
 import 'mac.dart';
 import 'plist_parser.dart';
-
-const String iosSimulatorId = 'apple_ios_simulator';
 
 class IOSSimulators extends PollingDeviceDiscovery {
   IOSSimulators({

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -2,20 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_tools/src/android/android_emulator.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/device.dart';
-import 'package:mockito/mockito.dart';
+import 'package:flutter_tools/src/device_categories.dart';
+import 'package:test/fake.dart';
 import 'package:fake_async/fake_async.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/mocks.dart' show MockAndroidSdk;
 
 const String emulatorID = 'i1234';
 const String errorText = '[Android emulator test error]';
@@ -32,7 +30,7 @@ void main() {
         emulatorID,
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
-        androidSdk: MockAndroidSdk(),
+        androidSdk: FakeAndroidSdk(),
       );
       expect(emulator.id, emulatorID);
       expect(emulator.hasConfig, false);
@@ -45,7 +43,7 @@ void main() {
         properties: const <String, String>{'name': 'test'},
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
-        androidSdk: MockAndroidSdk(),
+        androidSdk: FakeAndroidSdk(),
       );
 
       expect(emulator.id, emulatorID);
@@ -65,7 +63,7 @@ void main() {
         properties: properties,
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
-        androidSdk: MockAndroidSdk(),
+        androidSdk: FakeAndroidSdk(),
       );
 
       expect(emulator.id, emulatorID);
@@ -86,7 +84,7 @@ void main() {
         properties: properties,
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
-        androidSdk: MockAndroidSdk(),
+        androidSdk: FakeAndroidSdk(),
       );
 
       expect(emulator.name, displayName);
@@ -104,7 +102,7 @@ void main() {
         properties: properties,
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
-        androidSdk: MockAndroidSdk(),
+        androidSdk: FakeAndroidSdk(),
       );
 
       expect(emulator.name, 'This is my ID');
@@ -127,11 +125,10 @@ void main() {
   });
 
   group('Android emulator launch ', () {
-    MockAndroidSdk mockSdk;
+    late FakeAndroidSdk fakeSdk;
 
     setUp(() {
-      mockSdk = MockAndroidSdk();
-      when(mockSdk.emulatorPath).thenReturn('emulator');
+      fakeSdk = FakeAndroidSdk();
     });
 
     testWithoutContext('succeeds', () async {
@@ -139,7 +136,7 @@ void main() {
         processManager: FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(command: kEmulatorLaunchCommand),
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         logger: BufferLogger.test(),
       );
 
@@ -164,7 +161,7 @@ void main() {
             duration: Duration(seconds: 1),
           ),
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         logger: logger,
       );
 
@@ -191,7 +188,7 @@ void main() {
             duration: Duration(seconds: 4),
           ),
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         logger: logger,
       );
       final Completer<void> completer = Completer<void>();
@@ -205,4 +202,9 @@ void main() {
       expect(logger.errorText, isEmpty);
     }, skip: true); // TODO(jonahwilliams): clean up with https://github.com/flutter/flutter/issues/60675
   });
+}
+
+class FakeAndroidSdk extends Fake implements AndroidSdk {
+  @override
+  String get emulatorPath => 'emulator';
 }

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -6,18 +6,18 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/device_categories.dart';
 import 'package:flutter_tools/src/emulator.dart';
 import 'package:flutter_tools/src/ios/ios_emulators.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fakes.dart';
-import '../src/mocks.dart';
 
 const FakeEmulator emulator1 = FakeEmulator('Nexus_5', 'Nexus 5', 'Google');
 const FakeEmulator emulator2 = FakeEmulator('Nexus_5X_API_27_x86', 'Nexus 5X', 'Google');
@@ -45,20 +45,15 @@ const FakeCommand kListEmulatorsCommand = FakeCommand(
 
 void main() {
   FakeProcessManager fakeProcessManager;
-  MockAndroidSdk mockSdk;
+  FakeAndroidSdk fakeSdk;
   FileSystem fileSystem;
   Xcode xcode;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     fakeProcessManager = FakeProcessManager.empty();
-    mockSdk = MockAndroidSdk();
+    fakeSdk = FakeAndroidSdk();
     xcode = Xcode.test(processManager: fakeProcessManager, fileSystem: fileSystem);
-
-    when(mockSdk.avdManagerPath).thenReturn('avdmanager');
-    when(mockSdk.getAvdManagerPath()).thenReturn('avdmanager');
-    when(mockSdk.emulatorPath).thenReturn('emulator');
-    when(mockSdk.adbPath).thenReturn('adb');
   });
 
   group('EmulatorManager', () {
@@ -74,9 +69,9 @@ void main() {
             stdout: 'existing-avd-1',
           ),
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -121,8 +116,7 @@ void main() {
     });
 
     testUsingContext('create emulator with a missing avdmanager does not crash.', () async {
-      when(mockSdk.avdManagerPath).thenReturn(null);
-      when(mockSdk.getAvdManagerPath()).thenReturn(null);
+      final FakeAndroidSdk fakeSdk = FakeAndroidSdk(avdManagerPath: null);
       final EmulatorManager emulatorManager = EmulatorManager(
         fileSystem: MemoryFileSystem.test(),
         logger: BufferLogger.test(),
@@ -132,9 +126,9 @@ void main() {
             stdout: 'existing-avd-1',
           ),
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -174,9 +168,9 @@ void main() {
             ],
           )
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -211,9 +205,9 @@ void main() {
             ],
           )
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -250,9 +244,9 @@ void main() {
               'Use --force if you want to replace it.'
           )
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -292,9 +286,9 @@ void main() {
             ],
           )
         ]),
-        androidSdk: mockSdk,
+        androidSdk: fakeSdk,
         androidWorkflow: AndroidWorkflow(
-          androidSdk: mockSdk,
+          androidSdk: fakeSdk,
           featureFlags: TestFeatureFlags(),
           operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
@@ -371,4 +365,26 @@ class FakeEmulator extends Emulator {
   Future<void> launch() {
     throw UnimplementedError('Not implemented in Mock');
   }
+}
+
+class FakeAndroidSdk extends Fake implements AndroidSdk {
+  FakeAndroidSdk({this.avdManagerPath = 'avdmanager'});
+
+  @override
+  String get emulatorPath => 'emulator';
+
+  @override
+  String get adbPath => 'adb';
+
+  @override
+  Map<String, String> get sdkManagerEnv => <String, String>{};
+
+  @override
+  String getAvdPath() => 'avd';
+
+  @override
+  String avdManagerPath;
+
+  @override
+  String getAvdManagerPath() => avdManagerPath;
 }


### PR DESCRIPTION
1. Pull `Category` and `PlatformType` out of `devices.dart` (which is not yet able to be null migrated), which are the only two classes `emulators` needed from that library.  Export the new `device_categories.dart` library from `devices.dart` to avoid import churn.
2. Make `ios_emulators` a dependency of the null unsafe `simulators` library, instead of the other way around, by moving the `iosSimulatorId` constant into `ios_emulators`.
3. `emulator.dart` imported `android_emulator` and `ios_emulators`, so migrate all three at the same time.
4. Remove mocks from `android_emulator_test` and `emulator_test`.  Migrate the former to null safety (the latter still has some null unsafe imports).

Part of #71511