### PR TITLE
Launch Chrome natively on ARM macOS

### DIFF
--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -241,6 +241,7 @@ class ChromiumLauncher {
       // Check if ARM Chrome is installed.
       // Mach-O 64-bit executable arm64
       if ((result.stdout as String).contains('arm64')) {
+        _logger.printTrace('Found ARM Chrome installation at $chromeExecutable, forcing native launch.');
         // If so, force Chrome to launch natively.
         args.insertAll(0, <String>['/usr/bin/arch', '-arm64']);
       }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -191,7 +191,12 @@ class ChromiumLauncher {
     }
 
     final int port = debugPort ?? await _operatingSystemUtils.findFreePort();
-    final List<String> args = <String>[
+
+    // Force Chrome to launch natively on ARM macOS.
+    final List<String> args = _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm
+        ? <String>['/usr/bin/arch', '-arm64e']
+        : <String>[];
+    args.addAll(<String>[
       chromeExecutable,
       // Using a tmp directory ensures that a new instance of chrome launches
       // allowing for the remote debug port to be enabled.
@@ -216,7 +221,7 @@ class ChromiumLauncher {
           '--window-size=2400,1800',
         ],
       url,
-    ];
+    ]);
 
     final Process? process = await _spawnChromiumProcess(args);
 

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -189,6 +189,74 @@ void main() {
     expect(logger.errorText, contains('Failed to restore Chrome preferences'));
   });
 
+  testWithoutContext('can launch Chrome natively on x86_64 macOS', () async {
+    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64);
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: macOSUtils,
+      browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
+    );
+
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'example_chrome',
+          '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+          '--remote-debugging-port=12345',
+          ...kChromeArgs,
+          'example_url',
+        ],
+        stderr: kDevtoolsStderr,
+      )
+    ]);
+
+    expect(
+          () async => chromiumLauncher.launch(
+        'example_url',
+        skipCheck: true,
+      ),
+      returnsNormally,
+    );
+  });
+
+  testWithoutContext('can launch Chrome natively on ARM macOS', () async {
+    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm);
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: macOSUtils,
+      browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
+    );
+
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          '/usr/bin/arch',
+          '-arm64e',
+          'example_chrome',
+          '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+          '--remote-debugging-port=12345',
+          ...kChromeArgs,
+          'example_url',
+        ],
+        stderr: kDevtoolsStderr,
+      )
+    ]);
+
+    expect(
+      () async => chromiumLauncher.launch(
+        'example_url',
+        skipCheck: true,
+      ),
+      returnsNormally,
+    );
+  });
+
   testWithoutContext('can launch chrome with a custom debug port', () async {
     processManager.addCommand(const FakeCommand(
       command: <String>[

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -189,7 +189,7 @@ void main() {
     expect(logger.errorText, contains('Failed to restore Chrome preferences'));
   });
 
-  testWithoutContext('can launch Chrome natively on x86_64 macOS', () async {
+  testWithoutContext('can launch Chrome on x86_64 macOS', () async {
     final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64);
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
@@ -222,7 +222,7 @@ void main() {
     );
   });
 
-  testWithoutContext('can launch Chrome natively on ARM macOS', () async {
+  testWithoutContext('can launch x86_64 Chrome on ARM macOS', () async {
     final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm);
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
@@ -236,8 +236,13 @@ void main() {
     processManager.addCommands(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          '/usr/bin/arch',
-          '-arm64e',
+          'file',
+          'example_chrome',
+        ],
+        stdout: 'Mach-O 64-bit executable x86_64',
+      ),
+      const FakeCommand(
+        command: <String>[
           'example_chrome',
           '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
           '--remote-debugging-port=12345',
@@ -246,6 +251,48 @@ void main() {
         ],
         stderr: kDevtoolsStderr,
       )
+    ]);
+
+    expect(
+          () async => chromiumLauncher.launch(
+        'example_url',
+        skipCheck: true,
+      ),
+      returnsNormally,
+    );
+  });
+
+  testWithoutContext('can launch ARM Chrome natively on ARM macOS when installed', () async {
+    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm);
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: macOSUtils,
+      browserFinder: findChromeExecutable,
+      logger: BufferLogger.test(),
+    );
+
+    processManager.addCommands(<FakeCommand>[
+      const FakeCommand(
+        command: <String>[
+          'file',
+          'example_chrome',
+        ],
+        stdout: 'Mach-O 64-bit executable arm64',
+      ),
+      const FakeCommand(
+        command: <String>[
+          '/usr/bin/arch',
+          '-arm64',
+          'example_chrome',
+          '--user-data-dir=/.tmp_rand0/flutter_tools_chrome_device.rand0',
+          '--remote-debugging-port=12345',
+          ...kChromeArgs,
+          'example_url',
+        ],
+        stderr: kDevtoolsStderr,
+      ),
     ]);
 
     expect(

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -296,7 +296,7 @@ class MockSimControl extends Mock implements SimControl {
 }
 
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
-  FakeOperatingSystemUtils({this.hostPlatform});
+  FakeOperatingSystemUtils({this.hostPlatform = HostPlatform.linux_x64});
 
   @override
   ProcessResult makeExecutable(File file) => null;

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -296,6 +296,8 @@ class MockSimControl extends Mock implements SimControl {
 }
 
 class FakeOperatingSystemUtils implements OperatingSystemUtils {
+  FakeOperatingSystemUtils({this.hostPlatform});
+
   @override
   ProcessResult makeExecutable(File file) => null;
 


### PR DESCRIPTION
Since the Flutter tool uses Rosetta translation on ARM macOS, all launched processes do the same by default.  This means that currently Chrome gets launched in Rosetta mode when running web apps.

If an ARM version of Chrome is installed, prepend `/usr/bin/arch -arm64` to force Chrome to launch natively without Rosetta. 
Fixes https://github.com/flutter/flutter/issues/79739