### PR TITLE
[flutter_tools] generate install manifest for UWP builds

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -29,11 +29,14 @@ const String kBundleSkSLPath = 'BundleSkSLPath';
 /// [additionalContent] may contain additional DevFS entries that will be
 /// included in the final bundle, but not the AssetManifest.json file.
 ///
+/// If [dyRun] is true, no assets are copied.
+///
 /// Returns a [Depfile] containing all assets used in the build.
 Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
   Map<String, DevFSContent> additionalContent,
   @required TargetPlatform targetPlatform,
   BuildMode buildMode,
+  bool dryRun = false,
 }) async {
   // Check for an SkSL bundle.
   final String shaderBundlePath = environment.inputs[kBundleSkSLPath];
@@ -98,6 +101,9 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
         final File file = environment.fileSystem.file(
           environment.fileSystem.path.join(outputDirectory.path, entry.key));
         outputs.add(file);
+        if (dryRun) {
+          return;
+        }
         file.parent.createSync(recursive: true);
         final DevFSContent content = entry.value;
         if (content is DevFSFileContent && content.file is File) {

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -29,14 +29,11 @@ const String kBundleSkSLPath = 'BundleSkSLPath';
 /// [additionalContent] may contain additional DevFS entries that will be
 /// included in the final bundle, but not the AssetManifest.json file.
 ///
-/// If [dyRun] is true, no assets are copied.
-///
 /// Returns a [Depfile] containing all assets used in the build.
 Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
   Map<String, DevFSContent> additionalContent,
   @required TargetPlatform targetPlatform,
   BuildMode buildMode,
-  bool dryRun = false,
 }) async {
   // Check for an SkSL bundle.
   final String shaderBundlePath = environment.inputs[kBundleSkSLPath];
@@ -101,9 +98,6 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
         final File file = environment.fileSystem.file(
           environment.fileSystem.path.join(outputDirectory.path, entry.key));
         outputs.add(file);
-        if (dryRun) {
-          return;
-        }
         file.parent.createSync(recursive: true);
         final DevFSContent content = entry.value;
         if (content is DevFSFileContent && content.file is File) {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -19,6 +19,7 @@ import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../migrations/cmake_custom_command_migration.dart';
 import '../project.dart';
+import 'install_manifest.dart';
 import 'visual_studio.dart';
 
 // From https://cmake.org/cmake/help/v3.15/manual/cmake-generators.7.html#visual-studio-generators
@@ -120,6 +121,7 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
   String target,
   VisualStudio visualStudioOverride,
 }) async {
+  final Directory buildDirectory = globals.fs.directory(getWindowsBuildUwpDirectory());
   if (!windowsProject.existsSync()) {
     throwToolExit(
       'No Windows UWP desktop project configured. See '
@@ -136,6 +138,14 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
    // Ensure that necessary ephemeral files are generated and up to date.
   _writeGeneratedFlutterConfig(windowsProject, buildInfo, target);
   createPluginSymlinks(windowsProject.parent);
+  await createManifest(
+    buildDirectory: buildDirectory,
+    logger: globals.logger,
+    platform: globals.platform,
+    project: windowsProject,
+    buildInfo: buildInfo,
+    fileSystem: globals.fs,
+  );
 
   final VisualStudio visualStudio = visualStudioOverride ?? VisualStudio(
     fileSystem: globals.fs,
@@ -149,7 +159,6 @@ Future<void> buildWindowsUwp(WindowsUwpProject windowsProject, BuildInfo buildIn
         'Please run `flutter doctor` for more details.');
   }
 
-  final Directory buildDirectory = globals.fs.directory(getWindowsBuildUwpDirectory());
   final String buildModeName = getNameForBuildMode(buildInfo.mode ?? BuildMode.release);
   final Status status = globals.logger.startProgress(
     'Building Windows application...',

--- a/packages/flutter_tools/lib/src/windows/install_manifest.dart
+++ b/packages/flutter_tools/lib/src/windows/install_manifest.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// @dart = 2.8
+
+import 'package:meta/meta.dart';
+
+import '../asset.dart';
+import '../base/common.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/platform.dart';
+import '../build_info.dart';
+import '../project.dart';
+
+/// Generate an install manifest that is required for CMAKE on UWP projects.
+Future<void> createManifest({
+  @required Logger logger,
+  @required FileSystem fileSystem,
+  @required Platform platform,
+  @required WindowsUwpProject project,
+  @required BuildInfo buildInfo,
+  @required Directory buildDirectory,
+}) async {
+  final List<File> outputs = <File>[];
+  final AssetBundle assetBundle = AssetBundleFactory.defaultInstance(
+    logger: logger,
+    fileSystem: fileSystem,
+    platform: platform,
+    splitDeferredAssets: false,
+  ).createBundle();
+  final int resultCode = await assetBundle.build(
+    packagesPath: buildInfo.packagesPath,
+    assetDirPath: buildDirectory.childDirectory('flutter_assets').path,
+  );
+  if (resultCode != 0) {
+    throwToolExit('Failed to build assets.');
+  }
+
+  if (buildInfo.mode.isPrecompiled) {
+    outputs.add(buildDirectory.childFile('app.so'));
+  } else {
+    outputs.add(buildDirectory.childDirectory('flutter_assets').childFile('kernel_blob.bin'));
+  }
+  for (final String key in assetBundle.entries.keys) {
+    outputs.add(buildDirectory.childDirectory('flutter_assets').childFile(key));
+  }
+  outputs.add(project.ephemeralDirectory.childFile('flutter_windows_winuwp.dll'));
+  outputs.add(project.ephemeralDirectory.childFile('flutter_windows_winuwp.dll.pdb'));
+  outputs.add(project.ephemeralDirectory.childFile('icudtl.dat'));
+  project.ephemeralDirectory.childFile('install_manifest')
+    ..createSync(recursive: true)
+    ..writeAsStringSync(outputs.map((File file) => file.absolute.path).join('\n'));
+}

--- a/packages/flutter_tools/lib/src/windows/install_manifest.dart
+++ b/packages/flutter_tools/lib/src/windows/install_manifest.dart
@@ -1,7 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 // @dart = 2.8
 
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
@@ -19,8 +19,13 @@ import '../../src/context.dart';
 final Platform platform = FakePlatform(operatingSystem: 'windows');
 
 void main() {
-  testWithoutContext('Generates install manifest for a debug build', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
+  FileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+  });
+
+  testUsingContext('Generates install manifest for a debug build', () async {
     final Logger logger = BufferLogger.test();
     final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
     final Directory buildDirectory = fileSystem.currentDirectory
@@ -45,10 +50,12 @@ void main() {
       '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
       '/winuwp/flutter/ephemeral/icudtl.dat',
     ]));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testWithoutContext('Generates install manifest for a release build', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
+  testUsingContext('Generates install manifest for a release build', () async {
     final Logger logger = BufferLogger.test();
     final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
     final Directory buildDirectory = fileSystem.currentDirectory
@@ -73,15 +80,11 @@ void main() {
       '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
       '/winuwp/flutter/ephemeral/icudtl.dat'
     ]));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
   });
 
-  FileSystem fileSystem;
-
-  setUp(() {
-    fileSystem = MemoryFileSystem.test();
-  });
-
-  // Assset system still uses build context.
   testUsingContext('Generates install manifest for a release build with assets', () async {
     final BufferLogger logger = BufferLogger.test();
     final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);

--- a/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
@@ -1,0 +1,141 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/windows/install_manifest.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+final Platform platform = FakePlatform(operatingSystem: 'windows');
+
+void main() {
+  testWithoutContext('Generates install manifest for a debug build', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Logger logger = BufferLogger.test();
+    final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+    final Directory buildDirectory = fileSystem.currentDirectory
+      .childDirectory('build')
+      .childDirectory('winuwp');
+
+    await createManifest(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+      project: flutterProject.windowsUwp,
+      buildDirectory: buildDirectory,
+      buildInfo: BuildInfo.debug,
+    );
+
+    final File manifest = flutterProject.windowsUwp.ephemeralDirectory.childFile('install_manifest');
+    expect(manifest, exists);
+    expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
+      '/build/winuwp/flutter_assets/kernel_blob.bin',
+      '/build/winuwp/flutter_assets/AssetManifest.json',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
+      '/winuwp/flutter/ephemeral/icudtl.dat',
+    ]));
+  });
+
+  testWithoutContext('Generates install manifest for a release build', () async {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Logger logger = BufferLogger.test();
+    final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+    final Directory buildDirectory = fileSystem.currentDirectory
+      .childDirectory('build')
+      .childDirectory('winuwp');
+
+    await createManifest(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+      project: flutterProject.windowsUwp,
+      buildDirectory: buildDirectory,
+      buildInfo: BuildInfo.release,
+    );
+
+    final File manifest = flutterProject.windowsUwp.ephemeralDirectory.childFile('install_manifest');
+    expect(manifest, exists);
+    expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
+      '/build/winuwp/app.so',
+      '/build/winuwp/flutter_assets/AssetManifest.json',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
+      '/winuwp/flutter/ephemeral/icudtl.dat'
+    ]));
+  });
+
+  FileSystem fileSystem;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem.test();
+  });
+
+  // Assset system still uses build context.
+  testUsingContext('Generates install manifest for a release build with assets', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final FlutterProject flutterProject = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
+    final Directory buildDirectory = fileSystem.currentDirectory
+      .childDirectory('build')
+      .childDirectory('winuwp');
+
+    fileSystem.currentDirectory.childDirectory('.dart_tool').childFile('package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": []
+}
+
+''');
+    fileSystem.currentDirectory.childFile('pubspec.yaml')
+      ..createSync()
+      ..writeAsStringSync('''
+name: foo
+
+flutter:
+  assets:
+    - assets/foo.png
+
+''');
+    fileSystem.currentDirectory
+      .childDirectory('assets')
+      .childFile('foo.png')
+      .createSync(recursive: true);
+
+    await createManifest(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+      project: flutterProject.windowsUwp,
+      buildDirectory: buildDirectory,
+      buildInfo: BuildInfo.release,
+    );
+
+    final File manifest = flutterProject.windowsUwp.ephemeralDirectory.childFile('install_manifest');
+    expect(manifest, exists);
+    expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
+      '/build/winuwp/app.so',
+      '/build/winuwp/flutter_assets/assets/foo.png',
+      '/build/winuwp/flutter_assets/AssetManifest.json',
+      '/build/winuwp/flutter_assets/FontManifest.json',
+      '/build/winuwp/flutter_assets/NOTICES',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
+      '/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
+      '/winuwp/flutter/ephemeral/icudtl.dat'
+    ]));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+}


### PR DESCRIPTION
Generate a manifest containing a newline separated list of all known assets for the UWP build, ahead of invoking cmake.

The file is written to `winuwp/flutter/ephemeral/install_manifest`

The contents might be something like

```
/build/winuwp/app.so
/build/winuwp/flutter_assets/AssetManifest.json
/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll
/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb
/winuwp/flutter/ephemeral/icudtl.dat
 ```