### PR TITLE
Log full app bundle location after "flutter build ios"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -59,7 +59,7 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
   bool get shouldCodesign => boolArg('codesign');
 
   @override
-  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs.directory(xcodeResultOutput);
+  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs.directory(xcodeResultOutput).parent;
 }
 
 /// Builds an .xcarchive and optionally .ipa for an iOS app to be generated for

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -425,9 +425,10 @@ Future<XcodeBuildResult> buildXcodeProject({
         globals.printTrace('Replacing iphoneos with iphonesimulator in TARGET_BUILD_DIR.');
         targetBuildDir = targetBuildDir.replaceFirst('iphoneos', 'iphonesimulator');
       }
+      final String appBundle = buildSettings['WRAPPER_NAME'];
       final String expectedOutputDirectory = globals.fs.path.join(
         targetBuildDir,
-        buildSettings['WRAPPER_NAME'],
+        appBundle,
       );
       if (globals.fs.directory(expectedOutputDirectory).existsSync()) {
         // Copy app folder to a place where other tools can find it without knowing
@@ -447,6 +448,10 @@ Future<XcodeBuildResult> buildXcodeProject({
             outputDir,
           ],
           throwOnError: true,
+        );
+        outputDir = globals.fs.path.join(
+          outputDir,
+          appBundle,
         );
       } else {
         globals.printError('Build succeeded but the expected app at $expectedOutputDirectory not found');

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -171,6 +171,7 @@ void main() {
     await createTestCommandRunner(command).run(
       const <String>['build', 'ios', '--no-pub']
     );
+    expect(testLogger.statusText, contains('build/ios/iphoneos/Runner.app'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -218,6 +218,7 @@ void main() {
     await createTestCommandRunner(command).run(
       const <String>['build', 'ipa', '--no-pub']
     );
+    expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
#77756 regressed the `flutter build ios` log output from
```
Built /Users/m/Projects/test_create/build/ios/iphoneos/Runner.app.
```
to 
```
Built /Users/m/Projects/test_create/build/ios/iphoneos.
```
(note the missing `Runner.app`)
Fixes https://github.com/flutter/flutter/issues/80837