### PR TITLE
Revert 'Remove back button when using end drawer #63272'

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -869,7 +869,7 @@ class _AppBarState extends State<AppBar> {
           tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
         );
       } else {
-        if (!hasEndDrawer && canPop)
+        if (canPop)
           leading = useCloseButton ? const CloseButton() : const BackButton();
       }
     }

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -297,6 +297,68 @@ void main() {
     expect(find.text('Item 22'), findsNothing);
   });
 
+  testWidgets('The back button works well with the endDrawer', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(),
+          endDrawer: const Drawer(),
+          body: const Center(child: Text('body')),
+          bottomSheet: DraggableScrollableSheet(
+            expand: false,
+            builder: (_, ScrollController controller) {
+              return ListView.builder(
+                itemExtent: 50.0,
+                itemCount: 50,
+                itemBuilder: (_, int index) => Text('Item $index'),
+                controller: controller,
+              );
+            },
+          ),
+          floatingActionButton: const FloatingActionButton(
+            onPressed: null,
+            child: Text('fab'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 22'), findsNothing);
+    expect(find.byType(BackButton).hitTestable(), findsNothing);
+
+    await tester.drag(find.text('Item 2'), const Offset(0, -20.0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 22'), findsNothing);
+    // We've started to drag up, we should have a back button now for a11y
+    expect(find.byType(BackButton).hitTestable(), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton).hitTestable(), findsNothing);
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 22'), findsNothing);
+
+    await tester.fling(find.text('Item 2'), const Offset(0.0, -600.0), 2000.0);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 22'), findsOneWidget);
+    expect(find.byType(BackButton).hitTestable(), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton).hitTestable(), findsNothing);
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 22'), findsNothing);
+  });
+
   testWidgets('Verify that a scrollable BottomSheet hides the fab when scrolled up', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 


### PR DESCRIPTION
Fixes #80256

#63272 introduces some  leading back button showing bugs when the `AppBar` have an `endDrawer`

This change reverts it and adds more tests.