### PR TITLE
deflake image_painting_event_test

### DIFF
--- a/dev/tracing_tests/test/image_painting_event_test.dart
+++ b/dev/tracing_tests/test/image_painting_event_test.dart
@@ -43,7 +43,10 @@ void main() {
 
   test('Image painting events - deduplicates across frames', () async {
     final Completer<Event> completer = Completer<Event>();
-    vmService.onExtensionEvent.first.then(completer.complete);
+    vmService
+        .onExtensionEvent
+        .firstWhere((Event event) => event.extensionKind == 'Flutter.ImageSizesForFrame')
+        .then(completer.complete);
 
     final ui.Image image = await createTestImage(width: 300, height: 300);
     final TestCanvas canvas = TestCanvas();
@@ -76,7 +79,10 @@ void main() {
 
   test('Image painting events - deduplicates across frames', () async {
     final Completer<Event> completer = Completer<Event>();
-    vmService.onExtensionEvent.first.then(completer.complete);
+    vmService
+        .onExtensionEvent
+        .firstWhere((Event event) => event.extensionKind == 'Flutter.ImageSizesForFrame')
+        .then(completer.complete);
 
     final ui.Image image = await createTestImage(width: 300, height: 300);
     final TestCanvas canvas = TestCanvas();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/80813 by not assuming the first event will always be the one we want

