### PR TITLE
fix unsorted directives

### DIFF
--- a/packages/flutter_driver/test/common.dart
+++ b/packages/flutter_driver/test/common.dart
@@ -7,8 +7,8 @@ import 'dart:io';
 import 'package:flutter_driver/src/common/error.dart';
 import 'package:test_api/test_api.dart'; // ignore: deprecated_member_use
 
-export 'package:test_api/test_api.dart' hide isInstanceOf; // ignore: deprecated_member_use
 export 'package:test_api/fake.dart'; // ignore: deprecated_member_use
+export 'package:test_api/test_api.dart' hide isInstanceOf; // ignore: deprecated_member_use
 
 /// A matcher that compares the type of the actual value to the type argument T.
 TypeMatcher<T> isInstanceOf<T>() => isA<T>();

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_driver/src/common/error.dart';
 import 'package:flutter_driver/src/common/health.dart';
 import 'package:flutter_driver/src/common/layer_tree.dart';
 import 'package:flutter_driver/src/common/wait.dart';
 import 'package:flutter_driver/src/driver/driver.dart';
 import 'package:flutter_driver/src/driver/timeline.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:vm_service/vm_service.dart' as vms;
 
 import '../../common.dart';

--- a/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
+++ b/packages/flutter_driver/test/src/real_tests/stubs/stub_finder_extension.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/src/widgets/framework.dart';
-import 'package:flutter_test/src/finders.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_driver/src/common/find.dart';
+import 'package:flutter_test/src/finders.dart';
 
 import 'stub_finder.dart';
 

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -10,10 +10,10 @@ import 'dart:typed_data' show Uint8List;
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_goldens_client/skia_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform/platform.dart';
 
-import 'package:flutter_goldens_client/skia_client.dart';
 export 'package:flutter_goldens_client/skia_client.dart';
 
 // If you are here trying to figure out how to use golden files in the Flutter

--- a/packages/flutter_localizations/lib/src/utils/date_localizations.dart
+++ b/packages/flutter_localizations/lib/src/utils/date_localizations.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:intl/date_symbols.dart' as intl;
 import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
+import 'package:intl/date_symbols.dart' as intl;
+
 import '../l10n/generated_date_localizations.dart' as date_localizations;
 
 /// Tracks if date i18n data has been loaded.

--- a/packages/flutter_localizations/test/cupertino/translations_test.dart
+++ b/packages/flutter_localizations/test/cupertino/translations_test.dart
@@ -5,11 +5,10 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
 
 import '../test_utils.dart';
 

--- a/packages/flutter_localizations/test/material/date_picker_test.dart
+++ b/packages/flutter_localizations/test/material/date_picker_test.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:intl/intl.dart' as intl;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart' as intl;
 
 void main() {
   late DateTime firstDate;

--- a/packages/flutter_localizations/test/material/translations_test.dart
+++ b/packages/flutter_localizations/test/material/translations_test.dart
@@ -5,11 +5,10 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
 
 import '../test_utils.dart';
 

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:ui' as ui;
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 class TestLocalizations {
   TestLocalizations(this.locale, this.prefix);

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -11,8 +11,8 @@ import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/targets/common.dart';
 import 'package:flutter_tools/src/build_system/targets/icon_tree_shaker.dart';
 import 'package:flutter_tools/src/bundle.dart';
-import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';


### PR DESCRIPTION
The upcoming linter release includes a fix to sort_directives that will trigger a host of new violations. This fixes issues that cropped up since https://github.com/flutter/flutter/pull/80817

See: https://dart-review.googlesource.com/c/sdk/+/196026

Failures: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8849308566291597920/+/steps/analyze_flutter_flutter/0/stdout

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
