### PR TITLE
Move FakeOperatingSystemUtils from context.dart to fakes.dart

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/analyze_once_test.dart
@@ -24,6 +24,7 @@ import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 final Platform _kNoColorTerminalPlatform = FakePlatform(stdoutSupportsAnsi: false);

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -17,7 +17,6 @@ import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fakes.dart';
 import '../../src/mocks.dart' show MockAndroidSdk, MockProcessManager;
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -12,7 +12,8 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/project.dart';
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
 
 void main() {
    group('injectGradleWrapperIfNeeded', () {

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -13,7 +13,8 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
+import '../src/fake_process_manager.dart';
+import '../src/fakes.dart';
 
 void main() {
   group('CachedArtifacts', () {

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -21,9 +21,9 @@ import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 import '../src/fake_http_client.dart';
 import '../src/fake_vm_services.dart';
+import '../src/fakes.dart';
 
 final FakeVmServiceRequest createDevFSRequest = FakeVmServiceRequest(
   method: '_createDevFS',

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -42,6 +42,7 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_vm_services.dart';
+import '../../src/fakes.dart';
 
 final vm_service.Isolate fakeIsolate = vm_service.Isolate(
   id: '1',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -8,8 +8,8 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
 
 const Map<String, String> kDyLdLibEntry = <String, String>{
   'DYLD_LIBRARY_PATH': '/path/to/libs',

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -10,18 +10,17 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
-
-class MockIosProject extends Mock implements IosProject {}
 
 void main() {
   BufferLogger logger;
@@ -414,12 +413,9 @@ Exited (sigterm)''',
       'another line';
 
     testWithoutContext('upgradePbxProjWithFlutterAssets', () async {
-      final MockIosProject project = MockIosProject();
       final File pbxprojFile = MemoryFileSystem.test().file('project.pbxproj')
         ..writeAsStringSync(flutterAssetPbxProjLines);
-
-      when(project.xcodeProjectInfoFile).thenReturn(pbxprojFile);
-      when(project.hostAppBundleName(any)).thenAnswer((_) => Future<String>.value('UnitTestRunner.app'));
+      final FakeIosProject project = FakeIosProject(pbxprojFile);
 
       bool result = upgradePbxProjWithFlutterAssets(project, logger);
       expect(result, true);
@@ -487,4 +483,16 @@ Exited (sigterm)''',
       expect(processManager, hasNoRemainingExpectations);
     });
   });
+}
+
+class FakeIosProject extends Fake implements IosProject {
+  FakeIosProject(this.xcodeProjectInfoFile);
+  @override
+  final File xcodeProjectInfoFile;
+
+  @override
+  Future<String> hostAppBundleName(BuildInfo buildInfo) async => 'UnitTestRunner.app';
+
+  @override
+  final Directory xcodeProject = null;
 }

--- a/packages/flutter_tools/test/general.shard/license_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/license_collector_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/convert.dart';
@@ -241,8 +239,8 @@ const String _kApacheLicense = r'''
 ''';
 
 void main() {
-  FileSystem fileSystem;
-  LicenseCollector licenseCollector;
+  late FileSystem fileSystem;
+  late LicenseCollector licenseCollector;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -25,8 +25,8 @@ import 'package:mockito/mockito.dart';
 import 'package:yaml/yaml.dart';
 
 import '../src/common.dart';
-import '../src/context.dart' hide FakeOperatingSystemUtils;
-import '../src/fakes.dart';
+import '../src/context.dart';
+import '../src/fakes.dart' hide FakeOperatingSystemUtils;
 import '../src/pubspec_schema.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:file/memory.dart';
@@ -14,7 +12,8 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/web/chrome.dart';
 
 import '../../src/common.dart';
-import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
 
 const List<String> kChromeArgs = <String>[
   '--disable-background-timer-throttling',
@@ -30,12 +29,12 @@ const List<String> kChromeArgs = <String>[
 const String kDevtoolsStderr = '\n\nDevTools listening\n\n';
 
 void main() {
-  FileExceptionHandler exceptionHandler;
-  ChromiumLauncher chromeLauncher;
-  FileSystem fileSystem;
-  Platform platform;
-  FakeProcessManager processManager;
-  OperatingSystemUtils operatingSystemUtils;
+  late FileExceptionHandler exceptionHandler;
+  late ChromiumLauncher chromeLauncher;
+  late FileSystem fileSystem;
+  late Platform platform;
+  late FakeProcessManager processManager;
+  late OperatingSystemUtils operatingSystemUtils;
 
   setUp(() {
     exceptionHandler = FileExceptionHandler();

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_validator_test.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_tools/src/base/user_messages.dart' hide userMessages;
 import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/windows/visual_studio.dart';
 import 'package:flutter_tools/src/windows/visual_studio_validator.dart';
-import 'package:mockito/mockito.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 
@@ -16,63 +14,50 @@ final UserMessages userMessages = UserMessages();
 
 void main() {
   group('Visual Studio validation', () {
-    MockVisualStudio mockVisualStudio;
+    late FakeVisualStudio fakeVisualStudio;
 
     setUp(() {
-      mockVisualStudio = MockVisualStudio();
-      // Default values regardless of whether VS is installed or not.
-      when(mockVisualStudio.workloadDescription).thenReturn('Desktop development');
-      when(mockVisualStudio.minimumVersionDescription).thenReturn('2019');
-      when(mockVisualStudio.necessaryComponentDescriptions()).thenReturn(<String>['A', 'B']);
+      fakeVisualStudio = FakeVisualStudio();
     });
 
     // Assigns default values for a complete VS installation with necessary components.
     void _configureMockVisualStudioAsInstalled() {
-      when(mockVisualStudio.isInstalled).thenReturn(true);
-      when(mockVisualStudio.isAtLeastMinimumVersion).thenReturn(true);
-      when(mockVisualStudio.isPrerelease).thenReturn(false);
-      when(mockVisualStudio.isComplete).thenReturn(true);
-      when(mockVisualStudio.isLaunchable).thenReturn(true);
-      when(mockVisualStudio.isRebootRequired).thenReturn(false);
-      when(mockVisualStudio.hasNecessaryComponents).thenReturn(true);
-      when(mockVisualStudio.fullVersion).thenReturn('16.2');
-      when(mockVisualStudio.displayName).thenReturn('Visual Studio Community 2019');
-      when(mockVisualStudio.getWindows10SDKVersion()).thenReturn('10.0.18362.0');
+      fakeVisualStudio.isPrerelease = false;
+      fakeVisualStudio.isRebootRequired = false;
+      fakeVisualStudio.fullVersion = '16.2';
+      fakeVisualStudio.displayName = 'Visual Studio Community 2019';
+      fakeVisualStudio.windows10SDKVersion = '10.0.18362.0';
     }
 
     // Assigns default values for a complete VS installation that is too old.
     void _configureMockVisualStudioAsTooOld() {
-      when(mockVisualStudio.isInstalled).thenReturn(true);
-      when(mockVisualStudio.isAtLeastMinimumVersion).thenReturn(false);
-      when(mockVisualStudio.isPrerelease).thenReturn(false);
-      when(mockVisualStudio.isComplete).thenReturn(true);
-      when(mockVisualStudio.isLaunchable).thenReturn(true);
-      when(mockVisualStudio.isRebootRequired).thenReturn(false);
-      when(mockVisualStudio.hasNecessaryComponents).thenReturn(true);
-      when(mockVisualStudio.fullVersion).thenReturn('15.1');
-      when(mockVisualStudio.displayName).thenReturn('Visual Studio Community 2017');
-      when(mockVisualStudio.getWindows10SDKVersion()).thenReturn('10.0.17763.0');
+      fakeVisualStudio.isAtLeastMinimumVersion = false;
+      fakeVisualStudio.isPrerelease = false;
+      fakeVisualStudio.isRebootRequired = false;
+      fakeVisualStudio.fullVersion = '15.1';
+      fakeVisualStudio.displayName = 'Visual Studio Community 2017';
+      fakeVisualStudio.windows10SDKVersion = '10.0.17763.0';
     }
 
     // Assigns default values for a missing VS installation.
     void _configureMockVisualStudioAsNotInstalled() {
-      when(mockVisualStudio.isInstalled).thenReturn(false);
-      when(mockVisualStudio.isAtLeastMinimumVersion).thenReturn(false);
-      when(mockVisualStudio.isPrerelease).thenReturn(false);
-      when(mockVisualStudio.isComplete).thenReturn(false);
-      when(mockVisualStudio.isLaunchable).thenReturn(false);
-      when(mockVisualStudio.isRebootRequired).thenReturn(false);
-      when(mockVisualStudio.hasNecessaryComponents).thenReturn(false);
-      when(mockVisualStudio.getWindows10SDKVersion()).thenReturn(null);
+      fakeVisualStudio.isInstalled = false;
+      fakeVisualStudio.isAtLeastMinimumVersion = false;
+      fakeVisualStudio.isPrerelease = false;
+      fakeVisualStudio.isComplete = false;
+      fakeVisualStudio.isLaunchable = false;
+      fakeVisualStudio.isRebootRequired = false;
+      fakeVisualStudio.hasNecessaryComponents = false;
+      fakeVisualStudio.windows10SDKVersion = null;
     }
 
     testWithoutContext('Emits a message when Visual Studio is a pre-release version', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.isPrerelease).thenReturn(true);
+      fakeVisualStudio.isPrerelease = true;
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage(userMessages.visualStudioIsPrerelease);
@@ -83,10 +68,10 @@ void main() {
     testWithoutContext('Emits a partial status when Visual Studio installation is incomplete', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.isComplete).thenReturn(false);
+      fakeVisualStudio.isComplete = false;
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioIsIncomplete);
@@ -98,10 +83,10 @@ void main() {
     testWithoutContext('Emits a partial status when Visual Studio installation needs rebooting', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.isRebootRequired).thenReturn(true);
+      fakeVisualStudio.isRebootRequired = true;
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioRebootRequired);
@@ -113,10 +98,10 @@ void main() {
     testWithoutContext('Emits a partial status when Visual Studio installation is not launchable', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.isLaunchable).thenReturn(false);
+      fakeVisualStudio.isLaunchable = false;
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(userMessages.visualStudioNotLaunchable);
@@ -128,15 +113,15 @@ void main() {
     testWithoutContext('Emits partial status when Visual Studio is installed but too old', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsTooOld();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(
         userMessages.visualStudioTooOld(
-          mockVisualStudio.minimumVersionDescription,
-          mockVisualStudio.workloadDescription,
+          fakeVisualStudio.minimumVersionDescription,
+          fakeVisualStudio.workloadDescription,
         ),
       );
 
@@ -147,10 +132,10 @@ void main() {
     testWithoutContext('Emits partial status when Visual Studio is installed without necessary components', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.hasNecessaryComponents).thenReturn(false);
+      fakeVisualStudio.hasNecessaryComponents = false;
       final ValidationResult result = await validator.validate();
 
       expect(result.type, ValidationType.partial);
@@ -159,10 +144,10 @@ void main() {
     testWithoutContext('Emits partial status when Visual Studio is installed but the SDK cannot be found', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
-      when(mockVisualStudio.getWindows10SDKVersion()).thenReturn(null);
+      fakeVisualStudio.windows10SDKVersion = null;
       final ValidationResult result = await validator.validate();
 
       expect(result.type, ValidationType.partial);
@@ -171,13 +156,13 @@ void main() {
     testWithoutContext('Emits installed status when Visual Studio is installed with necessary components', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsInstalled();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedDisplayNameMessage = ValidationMessage(
-        userMessages.visualStudioVersion(mockVisualStudio.displayName, mockVisualStudio.fullVersion));
+        userMessages.visualStudioVersion(fakeVisualStudio.displayName!, fakeVisualStudio.fullVersion!));
 
       expect(result.messages.contains(expectedDisplayNameMessage), true);
       expect(result.type, ValidationType.installed);
@@ -186,14 +171,14 @@ void main() {
     testWithoutContext('Emits missing status when Visual Studio is not installed', () async {
       final VisualStudioValidator validator = VisualStudioValidator(
         userMessages: userMessages,
-        visualStudio: mockVisualStudio,
+        visualStudio: fakeVisualStudio,
       );
       _configureMockVisualStudioAsNotInstalled();
 
       final ValidationResult result = await validator.validate();
       final ValidationMessage expectedMessage = ValidationMessage.error(
         userMessages.visualStudioMissing(
-          mockVisualStudio.workloadDescription,
+          fakeVisualStudio.workloadDescription,
         ),
       );
 
@@ -203,4 +188,51 @@ void main() {
   });
 }
 
-class MockVisualStudio extends Mock implements VisualStudio {}
+class FakeVisualStudio extends Fake implements VisualStudio {
+  @override
+  final String installLocation = 'bogus';
+
+  @override
+  final String displayVersion = 'version';
+
+  @override
+  final String minimumVersionDescription = '2019';
+
+  @override
+  List<String> necessaryComponentDescriptions() => <String>['A', 'B'];
+
+  @override
+  bool isInstalled = true;
+
+  @override
+  bool isAtLeastMinimumVersion = true;
+
+  @override
+  bool isPrerelease = true;
+
+  @override
+  bool isComplete = true;
+
+  @override
+  bool isLaunchable = true;
+
+  @override
+  bool isRebootRequired = true;
+
+  @override
+  bool hasNecessaryComponents = true;
+
+  @override
+  String? fullVersion;
+
+  @override
+  String? displayName;
+
+  String? windows10SDKVersion;
+
+  @override
+  String? getWindows10SDKVersion() => windows10SDKVersion;
+
+  @override
+  String get workloadDescription => 'Desktop development';
+}

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -296,46 +296,6 @@ class MockSimControl extends Mock implements SimControl {
   }
 }
 
-class FakeOperatingSystemUtils implements OperatingSystemUtils {
-  FakeOperatingSystemUtils({this.hostPlatform = HostPlatform.linux_x64});
-
-  @override
-  ProcessResult makeExecutable(File file) => null;
-
-  @override
-  HostPlatform hostPlatform = HostPlatform.linux_x64;
-
-  @override
-  void chmod(FileSystemEntity entity, String mode) { }
-
-  @override
-  File which(String execName) => null;
-
-  @override
-  List<File> whichAll(String execName) => <File>[];
-
-  @override
-  File makePipe(String path) => null;
-
-  @override
-  void unzip(File file, Directory targetDirectory) { }
-
-  @override
-  void unpack(File gzippedTarFile, Directory targetDirectory) { }
-
-  @override
-  Stream<List<int>> gzipLevel1Stream(Stream<List<int>> stream) => stream;
-
-  @override
-  String get name => 'fake OS name and version';
-
-  @override
-  String get pathVarSeparator => ';';
-
-  @override
-  Future<int> findFreePort({bool ipv6 = false}) async => 12345;
-}
-
 class MockIOSSimulatorUtils extends Mock implements IOSSimulatorUtils {}
 
 class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -513,9 +513,6 @@ class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
   @override
   List<File> whichAll(String execName) => <File>[];
 
-  // @override
-  // File makePipe(String path) => null;
-
   @override
   void unzip(File file, Directory targetDirectory) { }
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/version.dart';
+import 'package:test/fake.dart';
 
 /// Environment with DYLD_LIBRARY_PATH=/path/to/libraries
 class FakeDyldEnvironmentArtifact extends ArtifactSet {
@@ -492,4 +493,44 @@ class FakeStatusLogger extends DelegatingLogger {
     bool multilineOutput = false,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) => status;
+}
+
+class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
+  FakeOperatingSystemUtils({this.hostPlatform = HostPlatform.linux_x64});
+
+  @override
+  void makeExecutable(File file) { }
+
+  @override
+  HostPlatform hostPlatform = HostPlatform.linux_x64;
+
+  @override
+  void chmod(FileSystemEntity entity, String mode) { }
+
+  @override
+  File? which(String execName) => null;
+
+  @override
+  List<File> whichAll(String execName) => <File>[];
+
+  // @override
+  // File makePipe(String path) => null;
+
+  @override
+  void unzip(File file, Directory targetDirectory) { }
+
+  @override
+  void unpack(File gzippedTarFile, Directory targetDirectory) { }
+
+  @override
+  Stream<List<int>> gzipLevel1Stream(Stream<List<int>> stream) => stream;
+
+  @override
+  String get name => 'fake OS name and version';
+
+  @override
+  String get pathVarSeparator => ';';
+
+  @override
+  Future<int> findFreePort({bool ipv6 = false}) async => 12345;
 }


### PR DESCRIPTION
1. `fakes.dart` is null safe but `context.dart` is not.  Move `FakeOperatingSystemUtils` into `fakes.dart` so more dependencies can be migrated, plus it makes sense.  Make it null safe.  
2. Fix up imports.
2. Remove mocks from mac_test.dart and visual_studio_validator_test.dart
3. Migrate a few other tests to null safety.

Part of #71511