### PR TITLE
Revert "[flutter_tools] pin transitive deps during --transitive-closure"

### DIFF
--- a/dev/bots/allowlist.dart
+++ b/dev/bots/allowlist.dart
@@ -18,6 +18,7 @@ const Set<String> kCorePackageAllowList = <String>{
   'collection',
   'fake_async',
   'file',
+  'frontend_server_client',
   'intl',
   'meta',
   'path',
@@ -72,11 +73,5 @@ const Set<String> kCorePackageAllowList = <String>{
   'flutter_driver',
   'flutter_localizations',
   'flutter_test',
-  'integration_test',
-  'flutter_goldens',
-  'flutter_goldens_client',
-  'fuchsia_remote_debug_protocol',
-  'platform',
-  'process',
-  'sky_engine',
+  'integration_test'
 };

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1173,7 +1173,7 @@ Future<void> _checkConsumerDependencies() async {
 
   // Do not change this signature without following the directions in
   // dev/bots/allowlist.dart
-  const String kExpected = 'QnuXnTSwemf+qT+LAU8K8Bb0l9L20z4qT1PUEQlBrVg=';
+  const String kExpected = 'nkO7DCjvSMB6VKyw+V9MU46m3xFEk/oYSbmgAWqvbXE=';
 
   if (disallowed.isNotEmpty) {
     exitWithError(<String>[


### PR DESCRIPTION
Reverts flutter/flutter#80911

Broke the technical-debt benchmark: 

```
[technical_debt__cost] [STDOUT] stdout: Downloading video_player_web 2.0.0...
[technical_debt__cost] [STDOUT] stdout: Downloading video_player_platform_interface 4.1.0...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher_windows 2.0.0...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher_web 2.0.0...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher_platform_interface 2.0.2...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher_macos 2.0.0...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher_linux 2.0.0...
[technical_debt__cost] [STDOUT] stdout: Downloading connectivity_platform_interface 2.0.1...
[technical_debt__cost] [STDOUT] stdout: Downloading connectivity_macos 0.2.0...
[technical_debt__cost] [STDOUT] stdout: Downloading connectivity_for_web 0.4.0...
[technical_debt__cost] [STDOUT] stdout: Downloading flutter_gallery_assets 1.0.2...
[technical_debt__cost] [STDOUT] stdout: Downloading shrine_images 1.1.2...
[technical_debt__cost] [STDOUT] stdout: Downloading video_player 2.1.1...
[technical_debt__cost] [STDOUT] stdout: Downloading url_launcher 6.0.3...
[technical_debt__cost] [STDOUT] stdout: Downloading connectivity 3.0.3...
[technical_debt__cost] [STDOUT] stdout: Changed 86 dependencies!
[technical_debt__cost] [STDOUT] stderr: pub failed (65; The pubspec.lock file has changed since the .dart_tool/package_config.json file was generated, please run "pub get" again.)
[technical_debt__cost] [STDOUT] "/b/s/w/ir/k/recipe_cleanup/tmp8rHtS8/flutter sdk/bin/flutter" exit code: 65
[technical_debt__cost] [STDERR] Task failed: Executable "/b/s/w/ir/k/recipe_cleanup/tmp8rHtS8/flutter sdk/bin/flutter" failed with exit code 65.
```
TBR @gspencergoog 