### PR TITLE
[flutter_tools] remove usage of getIsolate in extension waiter

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -854,8 +854,8 @@ class FlutterVmService {
     try {
       final List<vm_service.IsolateRef> refs = await _getIsolateRefs(webIsolate);
       for (final vm_service.IsolateRef ref in refs) {
-        final vm_service.Isolate isolate = await service.getIsolate(ref.id);
-        if (isolate.extensionRPCs.contains(extensionName)) {
+        final vm_service.Isolate isolate = await getIsolateOrNull(ref.id);
+        if (isolate != null && isolate.extensionRPCs.contains(extensionName)) {
           return ref;
         }
       }


### PR DESCRIPTION
We introduced a new call to getIsolate, this is likely the source of the sentinel exceptions. use `getIsolateOrNull` instead. 

Adds a unit test that shows this method can complete successfully if the initially queried isolate disappears.
