### PR TITLE
[flutter_tools] fix asset directory paths for UWP

### DIFF
--- a/packages/flutter_tools/lib/src/windows/install_manifest.dart
+++ b/packages/flutter_tools/lib/src/windows/install_manifest.dart
@@ -41,10 +41,10 @@ Future<void> createManifest({
   if (buildInfo.mode.isPrecompiled) {
     outputs.add(buildDirectory.childFile('app.so'));
   } else {
-    outputs.add(buildDirectory.childDirectory('flutter_assets').childFile('kernel_blob.bin'));
+    outputs.add(buildDirectory.parent.childDirectory('flutter_assets').childFile('kernel_blob.bin'));
   }
   for (final String key in assetBundle.entries.keys) {
-    outputs.add(buildDirectory.childDirectory('flutter_assets').childFile(key));
+    outputs.add(buildDirectory.parent.childDirectory('flutter_assets').childFile(key));
   }
   outputs.add(project.ephemeralDirectory.childFile('flutter_windows_winuwp.dll'));
   outputs.add(project.ephemeralDirectory.childFile('flutter_windows_winuwp.dll.pdb'));

--- a/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/install_manifest_test.dart
@@ -44,8 +44,8 @@ void main() {
     final File manifest = flutterProject.windowsUwp.ephemeralDirectory.childFile('install_manifest');
     expect(manifest, exists);
     expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
-      'C:/build/winuwp/flutter_assets/kernel_blob.bin',
-      'C:/build/winuwp/flutter_assets/AssetManifest.json',
+      'C:/build/flutter_assets/kernel_blob.bin',
+      'C:/build/flutter_assets/AssetManifest.json',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
       'C:/winuwp/flutter/ephemeral/icudtl.dat',
@@ -75,7 +75,7 @@ void main() {
     expect(manifest, exists);
     expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
       'C:/build/winuwp/app.so',
-      'C:/build/winuwp/flutter_assets/AssetManifest.json',
+      'C:/build/flutter_assets/AssetManifest.json',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
       'C:/winuwp/flutter/ephemeral/icudtl.dat'
@@ -129,10 +129,10 @@ flutter:
     expect(manifest, exists);
     expect(manifest.readAsLinesSync(), unorderedEquals(<String>[
       'C:/build/winuwp/app.so',
-      'C:/build/winuwp/flutter_assets/assets/foo.png',
-      'C:/build/winuwp/flutter_assets/AssetManifest.json',
-      'C:/build/winuwp/flutter_assets/FontManifest.json',
-      'C:/build/winuwp/flutter_assets/NOTICES',
+      'C:/build/flutter_assets/assets/foo.png',
+      'C:/build/flutter_assets/AssetManifest.json',
+      'C:/build/flutter_assets/FontManifest.json',
+      'C:/build/flutter_assets/NOTICES',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll',
       'C:/winuwp/flutter/ephemeral/flutter_windows_winuwp.dll.pdb',
       'C:/winuwp/flutter/ephemeral/icudtl.dat'


### PR DESCRIPTION
These files are actually created in build and not build/winuwp
