### PR TITLE
Fix "LUCI console" link

### DIFF
--- a/dev/devicelab/README.md
+++ b/dev/devicelab/README.md
@@ -206,7 +206,7 @@ _TASK_- the name of your test that also matches the name of the
 
 1. Add prod builder to [flutter/infra devicelab_config.star](https://github.com/flutter/infra/blob/master/config/devicelab_config.star)
   - Example PR: https://github.com/flutter/infra/pull/401/files
-  - This will need to soak for 15 minutes after merged to propagate (should show up in [LUCI console[(https://ci.chromium.org/p/flutter/g/devicelab/console))
+  - This will need to soak for 15 minutes after merged to propagate (should show up in [LUCI console](https://ci.chromium.org/p/flutter/g/devicelab/console))
   - There are various lists for the different testbeds a test can run on
 2. Add task to [flutter/flutter prod_builders.json](https://github.com/flutter/flutter/blob/master/dev/prod_builders.json)
   - Example PR: https://github.com/flutter/flutter/pull/79913/files


### PR DESCRIPTION
Link is broken.  Previously looked like:
![Screen Shot 2021-04-22 at 5 02 00 PM](https://user-images.githubusercontent.com/682784/115799039-7cd4c580-a38c-11eb-9412-21513798f739.png)
