### PR TITLE
Fix error resolution when a completer is already set

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -333,10 +333,6 @@ abstract class ImageProvider<T extends Object> {
       },
       (T? key, Object exception, StackTrace? stack) async {
         await null; // wait an event turn in case a listener has been added to the image stream.
-        final ImageStreamCompleter imageCompleter = stream.completer ?? _ErrorImageCompleter();
-        if (stream.completer == null) {
-          stream.setCompleter(imageCompleter);
-        }
         InformationCollector? collector;
         assert(() {
           collector = () sync* {
@@ -346,7 +342,10 @@ abstract class ImageProvider<T extends Object> {
           };
           return true;
         }());
-        imageCompleter.reportError(
+        if (stream.completer == null) {
+          stream.setCompleter(_ErrorImageCompleter());
+        }
+        stream.completer!.reportError(
           exception: exception,
           stack: stack,
           context: ErrorDescription('while resolving an image'),

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -333,8 +333,10 @@ abstract class ImageProvider<T extends Object> {
       },
       (T? key, Object exception, StackTrace? stack) async {
         await null; // wait an event turn in case a listener has been added to the image stream.
-        final _ErrorImageCompleter imageCompleter = _ErrorImageCompleter();
-        stream.setCompleter(imageCompleter);
+        final ImageStreamCompleter imageCompleter = stream.completer ?? _ErrorImageCompleter();
+        if (stream.completer == null) {
+          stream.setCompleter(imageCompleter);
+        }
         InformationCollector? collector;
         assert(() {
           collector = () sync* {
@@ -344,7 +346,7 @@ abstract class ImageProvider<T extends Object> {
           };
           return true;
         }());
-        imageCompleter.setError(
+        imageCompleter.reportError(
           exception: exception,
           stack: stack,
           context: ErrorDescription('while resolving an image'),
@@ -1127,25 +1129,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
 }
 
 // A completer used when resolving an image fails sync.
-class _ErrorImageCompleter extends ImageStreamCompleter {
-  _ErrorImageCompleter();
-
-  void setError({
-    DiagnosticsNode? context,
-    required Object exception,
-    StackTrace? stack,
-    InformationCollector? informationCollector,
-    bool silent = false,
-  }) {
-    reportError(
-      context: context,
-      exception: exception,
-      stack: stack,
-      informationCollector: informationCollector,
-      silent: silent,
-    );
-  }
-}
+class _ErrorImageCompleter extends ImageStreamCompleter {}
 
 /// The exception thrown when the HTTP request to load a network image fails.
 class NetworkImageLoadException implements Exception {

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -668,7 +668,6 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// messages, but errors during development will still be reported.
   ///
   /// See [FlutterErrorDetails] for further details on these values.
-  @protected
   @pragma('vm:notify-debugger-on-exception')
   void reportError({
     DiagnosticsNode? context,

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -90,15 +90,17 @@ void main() {
     await testZone.run(() async {
       final ImageProvider imageProvider = LoadErrorCompleterImageProvider();
       final Completer<bool> caughtError = Completer<bool>();
+      final Completer<bool> onErrorCompleter = Completer<bool>();
       FlutterError.onError = (FlutterErrorDetails details) {
+        onErrorCompleter.complete(true);
         throw Error();
-      };
       final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
       result.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
       }, onError: (dynamic error, StackTrace? stackTrace) {
         caughtError.complete(true);
       }));
       expect(await caughtError.future, true);
+      expect(await onErrorCompleter.future, true);
     });
     expect(uncaught, false);
   });

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -94,6 +94,7 @@ void main() {
       FlutterError.onError = (FlutterErrorDetails details) {
         onErrorCompleter.complete(true);
         throw Error();
+      }
       final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
       result.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
       }, onError: (dynamic error, StackTrace? stackTrace) {

--- a/packages/flutter/test/painting/image_provider_test.dart
+++ b/packages/flutter/test/painting/image_provider_test.dart
@@ -94,7 +94,7 @@ void main() {
       FlutterError.onError = (FlutterErrorDetails details) {
         onErrorCompleter.complete(true);
         throw Error();
-      }
+      };
       final ImageStream result = imageProvider.resolve(ImageConfiguration.empty);
       result.addListener(ImageStreamListener((ImageInfo info, bool syncCall) {
       }, onError: (dynamic error, StackTrace? stackTrace) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/80969

The test this modifies was never actually getting into the `FlutterError.onError` because of an assertion around `setCompleter`. An upcoming dart roll made the whole test blow up. This version now asserts that we get into `FlutterError.onError` as expected, and passes with the Dart revision to the way Zone error handling happens.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
