### PR TITLE
Ignore directives ordering in generated sample code

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -264,6 +264,7 @@ class SampleChecker {
   List<Line> get headers {
     return _headers ??= <String>[
       '// generated code',
+      '// ignore_for_file: directives_ordering',
       '// ignore_for_file: unused_import',
       '// ignore_for_file: unused_element',
       '// ignore_for_file: unused_local_variable',


### PR DESCRIPTION
The next Dart SDK contains an updated linter which will (better) flag unsorted imports.  To avoid new errors (see https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8849231056528363792/+/u/flutter_analyze/stdout), this ignores directive ordering in generated samples.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
