### PR TITLE
Fix Hit Tests in RenderEditable when Scrolled

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3188,7 +3188,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   @override
   @protected
   bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
-    final TextPosition textPosition = _textPainter.getPositionForOffset(position);
+    final Offset effectivePosition = position - _paintOffset;
+    final TextPosition textPosition = _textPainter.getPositionForOffset(effectivePosition);
     final InlineSpan? span = _textPainter.text!.getSpanForPosition(textPosition);
     if (span != null && span is HitTestTarget) {
       result.add(HitTestEntry(span as HitTestTarget));

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -3453,9 +3453,9 @@ void main() {
         pumpFrame(phase: EnginePhase.compositingBits);
 
         final BoxHitTestResult result = BoxHitTestResult();
-        // At x=5, we should hit "B" as we are scrolled to the left by 5
+        // At x=6, we should hit "B" as we are scrolled to the left by 6
         // pixels.
-        editable.hitTest(result, position: const Offset(5.0, 0));
+        editable.hitTest(result, position: const Offset(6.0, 0));
         expect(result.path, hasLength(2));
         final HitTestTarget target = result.path.first.target;
         expect(target, isA<TextSpan>());

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -3329,6 +3330,137 @@ void main() {
           ..rect(rect: const Rect.fromLTRB(1, 1, 1, 1), color: const Color(0x12345678))
           ..paragraph(),
       );
+    });
+
+    group('hit testing', () {
+      test('hits correct TextSpan when not scrolled', () {
+        final TextSelectionDelegate delegate = FakeEditableTextState();
+        final RenderEditable editable = RenderEditable(
+          text: const TextSpan(
+            style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+            children: <InlineSpan>[
+              TextSpan(text: 'A'),
+              TextSpan(text: 'B'),
+            ],
+          ),
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          textDirection: TextDirection.ltr,
+          offset: ViewportOffset.fixed(0.0),
+          textSelectionDelegate: delegate,
+          selection: const TextSelection.collapsed(
+            offset: 0,
+          ),
+        );
+        layout(editable, constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
+        // Prepare for painting after layout.
+        pumpFrame(phase: EnginePhase.compositingBits);
+
+        BoxHitTestResult result = BoxHitTestResult();
+        editable.hitTest(result, position: Offset.zero);
+        // We expect two hit test entries in the path because the RenderEditable
+        // will add itself as well.
+        expect(result.path, hasLength(2));
+        HitTestTarget target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'A');
+        // Only testing the RenderEditable entry here once, not anymore below.
+        expect(result.path.last.target, isA<RenderEditable>());
+
+        result = BoxHitTestResult();
+        editable.hitTest(result, position: const Offset(15.0, 0.0));
+        expect(result.path, hasLength(2));
+        target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'B');
+      });
+
+      test('hits correct TextSpan when scrolled vertically', () {
+        final TextSelectionDelegate delegate = FakeEditableTextState();
+        final RenderEditable editable = RenderEditable(
+          text: const TextSpan(
+            style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+            children: <InlineSpan>[
+              TextSpan(text: 'A'),
+              TextSpan(text: 'B\n'),
+              TextSpan(text: 'C'),
+            ],
+          ),
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          textDirection: TextDirection.ltr,
+          // Given maxLines of null and an offset of 5, the editable will be
+          // scrolled vertically by 5 pixels.
+          maxLines: null,
+          offset: ViewportOffset.fixed(5.0),
+          textSelectionDelegate: delegate,
+          selection: const TextSelection.collapsed(
+            offset: 0,
+          ),
+        );
+        layout(editable, constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
+        // Prepare for painting after layout.
+        pumpFrame(phase: EnginePhase.compositingBits);
+
+        BoxHitTestResult result = BoxHitTestResult();
+        editable.hitTest(result, position: Offset.zero);
+        expect(result.path, hasLength(2));
+        HitTestTarget target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'A');
+
+        result = BoxHitTestResult();
+        editable.hitTest(result, position: const Offset(15.0, 0.0));
+        expect(result.path, hasLength(2));
+        target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'B\n');
+
+        result = BoxHitTestResult();
+        // When we hit at y=6 and are scrolled by -5 vertically, we expect "C"
+        // to be hit because the font size is 10.
+        editable.hitTest(result, position: const Offset(0.0, 6.0));
+        expect(result.path, hasLength(2));
+        target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'C');
+      });
+
+      test('hits correct TextSpan when scrolled horizontally', () {
+        final TextSelectionDelegate delegate = FakeEditableTextState();
+        final RenderEditable editable = RenderEditable(
+          text: const TextSpan(
+            style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+            children: <InlineSpan>[
+              TextSpan(text: 'A'),
+              TextSpan(text: 'B'),
+            ],
+          ),
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          textDirection: TextDirection.ltr,
+          // Given maxLines of 1 and an offset of 5, the editable will be
+          // scrolled by 5 pixels to the left.
+          maxLines: 1,
+          offset: ViewportOffset.fixed(5.0),
+          textSelectionDelegate: delegate,
+          selection: const TextSelection.collapsed(
+            offset: 0,
+          ),
+        );
+        layout(editable, constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
+        // Prepare for painting after layout.
+        pumpFrame(phase: EnginePhase.compositingBits);
+
+        final BoxHitTestResult result = BoxHitTestResult();
+        // At x=5, we should hit "B" as we are scrolled to the left by 5
+        // pixels.
+        editable.hitTest(result, position: const Offset(5.0, 0));
+        expect(result.path, hasLength(2));
+        final HitTestTarget target = result.path.first.target;
+        expect(target, isA<TextSpan>());
+        expect((target as TextSpan).text, 'B');
+      });
     });
   });
 }


### PR DESCRIPTION
This fixes `hitTestChildren` in `RenderEditable` by respecting the scroll `offset` (`_paintOffset` for applying the scroll axis).

Before, hit tests were broken when the `EditableText`/`TextField` was scrolled.

### Issues

Fixes #81038.

### Tests

The first test case I added was passing before (making sure that my change does not make that fail) and the latter two test cases were failing before.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
