### PR TITLE
Revert "Migrate channels to null safety"

### DIFF
--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -19,7 +19,7 @@ void main() {
 }
 
 class TestApp extends StatefulWidget {
-  const TestApp({Key? key}) : super(key: key);
+  const TestApp({Key key}) : super(key: key);
 
   @override
   _TestAppState createState() => _TestAppState();
@@ -155,7 +155,7 @@ class _TestAppState extends State<TestApp> {
     () => basicJsonMessageToUnknownChannel(),
     () => basicStandardMessageToUnknownChannel(),
   ];
-  Future<TestStepResult>? _result;
+  Future<TestStepResult> _result;
   int _step = 0;
 
   void _executeNextStep() {

--- a/dev/integration_tests/channels/lib/src/basic_messaging.dart
+++ b/dev/integration_tests/channels/lib/src/basic_messaging.dart
@@ -42,25 +42,25 @@ class ExtendedStandardMessageCodec extends StandardMessageCodec {
   }
 }
 
-Future<TestStepResult> basicBinaryHandshake(ByteData? message) async {
+Future<TestStepResult> basicBinaryHandshake(ByteData message) async {
   const BasicMessageChannel<ByteData> channel =
       BasicMessageChannel<ByteData>(
     'binary-msg',
     BinaryCodec(),
   );
-  return _basicMessageHandshake<ByteData?>(
+  return _basicMessageHandshake<ByteData>(
       'Binary >${toString(message)}<', channel, message);
 }
 
-Future<TestStepResult> basicStringHandshake(String? message) async {
+Future<TestStepResult> basicStringHandshake(String message) async {
   const BasicMessageChannel<String> channel = BasicMessageChannel<String>(
     'string-msg',
     StringCodec(),
   );
-  return _basicMessageHandshake<String?>('String >$message<', channel, message);
+  return _basicMessageHandshake<String>('String >$message<', channel, message);
 }
 
-Future<TestStepResult> basicJsonHandshake(Object? message) async {
+Future<TestStepResult> basicJsonHandshake(dynamic message) async {
   const BasicMessageChannel<dynamic> channel =
       BasicMessageChannel<dynamic>(
     'json-msg',
@@ -126,9 +126,9 @@ Future<TestStepResult> _basicMessageHandshake<T>(
   T message,
 ) async {
   final List<dynamic> received = <dynamic>[];
-  channel.setMessageHandler((T? message) async {
+  channel.setMessageHandler((T message) async {
     received.add(message);
-    return message!;
+    return message;
   });
   dynamic messageEcho = nothing;
   dynamic error = nothing;
@@ -150,7 +150,7 @@ Future<TestStepResult> _basicMessageHandshake<T>(
 /// Sends a message on a channel that no one listens on.
 Future<TestStepResult> _basicMessageToUnknownChannel<T>(
   String description,
-  BasicMessageChannel<T?> channel,
+  BasicMessageChannel<T> channel,
 ) async {
   dynamic messageEcho = nothing;
   dynamic error = nothing;

--- a/dev/integration_tests/channels/lib/src/test_step.dart
+++ b/dev/integration_tests/channels/lib/src/test_step.dart
@@ -44,11 +44,12 @@ class TestStepResult {
         return const TestStepResult('Executing', nothing, TestStatus.pending);
       case ConnectionState.done:
         if (snapshot.hasData) {
-          return snapshot.data!;
+          return snapshot.data;
         } else {
-          final TestStepResult result = snapshot.error! as TestStepResult;
+          final TestStepResult result = snapshot.error as TestStepResult;
           return result;
         }
+        break;
       default:
         throw 'Unsupported state ${snapshot.connectionState}';
     }

--- a/dev/integration_tests/channels/pubspec.yaml
+++ b/dev/integration_tests/channels/pubspec.yaml
@@ -2,7 +2,7 @@ name: channels
 description: Integration test for platform channels.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/channels/test_driver/main_test.dart
+++ b/dev/integration_tests/channels/test_driver/main_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 void main() {
   group('channel suite', () {
-    late FlutterDriver driver;
+    FlutterDriver driver;
 
     setUpAll(() async {
       driver = await FlutterDriver.connect();
@@ -28,7 +28,7 @@ void main() {
     }, timeout: const Timeout(Duration(minutes: 1)));
 
     tearDownAll(() async {
-      driver.close();
+      driver?.close();
     });
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#80641

Causing test failures on CI:

```
[channels_integration_test_ios] [STDOUT] stdout: [  +98 ms] fopen failed for data file: errno = 2 (No such file or directory)
[channels_integration_test_ios] [STDOUT] stdout: [        ] Errors found! Invalidating cache...
[channels_integration_test_ios] [STDOUT] stderr: [ +801 ms] VMServiceFlutterDriver: Connected to Flutter application.
[channels_integration_test_ios] [STDOUT] stdout: [   +4 ms] 00:01 [32m+0[0m: channel suite step through[0m
[channels_integration_test_ios] [STDOUT] stdout: [+4519 ms] 00:05 [32m+0[0m[31m -1[0m: channel suite step through [1m[31m[E][0m[0m
[channels_integration_test_ios] [STDOUT] stdout: [        ]   Failed at step 16 with status failed
[channels_integration_test_ios] [STDOUT] stdout: [  +24 ms]   package:test_api/src/frontend/expect.dart 153:31               fail
[channels_integration_test_ios] [STDOUT] stdout: [        ]   test_driver/main_test.dart 26:9                                main.<fn>.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1294:19                                   _CustomZone.registerBinaryCallback
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async-patch/async_patch.dart 61:8                         _asyncErrorWrapperHelper
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart                      Invoker.waitForOutstandingCallbacks.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1354:13                                   _rootRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1258:19                                   _CustomZone.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1789:10                                   _runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1711:10                                   runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 228:5                Invoker.waitForOutstandingCallbacks
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 383:17               Invoker._onRun.<fn>.<fn>.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   ===== asynchronous gap ===========================
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1286:19                                   _CustomZone.registerUnaryCallback
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async-patch/async_patch.dart 45:22                        _asyncThenWrapperHelper
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart                      Invoker._onRun.<fn>.<fn>.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1354:13                                   _rootRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1258:19                                   _CustomZone.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1789:10                                   _runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1711:10                                   runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 370:9                Invoker._onRun.<fn>.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 415:15               Invoker._guardIfGuarded
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 369:7                Invoker._onRun.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:stack_trace/src/chain.dart 94:24                       Chain.capture.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1354:13                                   _rootRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1258:19                                   _CustomZone.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1789:10                                   _runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1711:10                                   runZoned
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:stack_trace/src/chain.dart 92:12                       Chain.capture
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/invoker.dart 368:11               Invoker._onRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   package:test_api/src/backend/live_test_controller.dart 153:11  LiveTestController.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/future.dart 198:37                                  new Future.microtask.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1346:47                                   _rootRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1258:19                                   _CustomZone.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1162:7                                    _CustomZone.runGuarded
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1202:23                                   _CustomZone.bindCallbackGuarded.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1354:13                                   _rootRun
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1258:19                                   _CustomZone.run
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1162:7                                    _CustomZone.runGuarded
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/zone.dart 1202:23                                   _CustomZone.bindCallbackGuarded.<fn>
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/schedule_microtask.dart 40:21                       _microtaskLoop
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:async/schedule_microtask.dart 49:5                        _startMicrotaskLoop
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:isolate-patch/isolate_patch.dart 120:13                   _runPendingImmediateCallback
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:isolate-patch/timer_impl.dart 402:11                      _Timer._runTimers
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:isolate-patch/timer_impl.dart 426:5                       _Timer._handleMessage
[channels_integration_test_ios] [STDOUT] stdout: [        ]   dart:isolate-patch/isolate_patch.dart 184:12                   _RawReceivePortImpl._handleMessage
[channels_integration_test_ios] [STDOUT] stdout: [        ] 00:05 [32m+0[0m[31m -1[0m: channel suite (tearDownAll)[0m
[channels_integration_test_ios] [STDOUT] stdout: [  +18 ms] 00:05 [32m+0[0m[31m -1[0m: [31mSome tests failed.[0m
[channels_integration_test_ios] [STDOUT] stderr: [   +1 ms] Unhandled exception:
[channels_integration_test_ios] [STDOUT] stderr: [        ] Dummy exception to set exit code.
[channels_integration_test_ios] [STDOUT] stdout: [  +37 ms] executing: /opt/s/w/ir/k/recipe_cle
```

