### PR TITLE
Revert "[RenderEditable] Dont paint caret when selection is invalid"

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3703,10 +3703,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       _clipRectLayer = null;
       _paintContents(context, offset);
     }
-    final TextSelection? selection = this.selection;
-    if (selection != null) {
-      _paintHandleLayers(context, getEndpointsForSelection(selection));
-    }
+    _paintHandleLayers(context, getEndpointsForSelection(selection!));
   }
 
   ClipRectLayer? _clipRectLayer;
@@ -4063,7 +4060,9 @@ class _FloatingCursorPainter extends RenderEditablePainter {
     assert(renderEditable != null);
     final TextSelection? selection = renderEditable.selection;
 
-    if (selection == null || !selection.isCollapsed || !selection.isValid)
+    // TODO(LongCatIsLooong): skip painting the caret when the selection is
+    // (-1, -1).
+    if (selection == null || !selection.isCollapsed)
       return;
 
     final Rect? floatingCursorRect = this.floatingCursorRect;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -412,51 +412,6 @@ void main() {
     expect(editable, paintsExactlyCountTimes(#drawRect, 1));
   });
 
-  test('does not paint the caret when selection is null', () async {
-    final TextSelectionDelegate delegate = FakeEditableTextState();
-    final ValueNotifier<bool> showCursor = ValueNotifier<bool>(true);
-    final RenderEditable editable = RenderEditable(
-      backgroundCursorColor: Colors.grey,
-      selectionColor: Colors.black,
-      paintCursorAboveText: true,
-      textDirection: TextDirection.ltr,
-      cursorColor: Colors.red,
-      showCursor: showCursor,
-      offset: ViewportOffset.zero(),
-      textSelectionDelegate: delegate,
-      text: const TextSpan(
-        text: 'test',
-        style: TextStyle(
-          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-        ),
-      ),
-      startHandleLayerLink: LayerLink(),
-      endHandleLayerLink: LayerLink(),
-      selection: const TextSelection.collapsed(
-        offset: 2,
-        affinity: TextAffinity.upstream,
-      ),
-    );
-
-    layout(editable);
-
-    expect(
-      editable,
-      paints
-        ..paragraph()
-        // Red collapsed cursor is painted, not a selection box.
-        ..rect(color: Colors.red[500]),
-    );
-
-    // Let the RenderEditable paint again. Setting the selection to null should
-    // prevent the caret from being painted.
-    editable.selection = null;
-    // Still paints the paragraph.
-    expect(editable, paints..paragraph());
-    // No longer paints the caret.
-    expect(editable, isNot(paints..rect(color: Colors.red[500])));
-  });
-
   test('selects correct place with offsets', () {
     const String text = 'test\ntest';
     final TextSelectionDelegate delegate = FakeEditableTextState()


### PR DESCRIPTION
Reverts flutter/flutter#79607
 This breaks internal test b/185714061