### PR TITLE
Make compareTo more robust in semantics.dart

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -2353,7 +2353,7 @@ class _BoxEdge implements Comparable<_BoxEdge> {
 
   @override
   int compareTo(_BoxEdge other) {
-    return (offset - other.offset).sign.toInt();
+    return offset.compareTo(other.offset);
   }
 }
 
@@ -2381,7 +2381,7 @@ class _SemanticsSortGroup extends Comparable<_SemanticsSortGroup> {
 
   @override
   int compareTo(_SemanticsSortGroup other) {
-    return (startOffset - other.startOffset).sign.toInt();
+    return startOffset.compareTo(other.startOffset);
   }
 
   /// Sorts this group assuming that [nodes] belong to the same vertical group.


### PR DESCRIPTION
In b/180268307 we end up with double.NaN for _BoxEdge.offset, which is obviously a bug and shouldn't happen. In debug mode we guard against this with asserts. In release mode, those are turned off and the app crashes because `double.NaN.toInt()` is illegal.

This change makes the code more robust by avoiding the `toInt()` call. The bug where _BoxEdge.offset ends up being double.NaN is still present, though and I haven't been able to reproduce it to investigate why it is happening. :(

With this change, instead of crashing the traversal order of the SemanticsNodes may be not as expected.