### PR TITLE
Wait for frame rendering to stabilize before running the all_elements_bench benchmark

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/foundation/all_elements_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/all_elements_bench.dart
@@ -42,7 +42,10 @@ Future<void> main() async {
     ),
   ));
 
-  await SchedulerBinding.instance.endOfFrame;
+  // Wait for frame rendering to stabilize.
+  for (int i = 0; i < 5; i++) {
+    await SchedulerBinding.instance.endOfFrame;
+  }
 
   final Stopwatch watch = Stopwatch();
 


### PR DESCRIPTION
Without this, rendering of the initial frames will occur after the
benchmark measurement completes.  This may result in shader compilation
happening while the benchmark app is shutting down, which can cause
crashes.

See https://github.com/flutter/flutter/issues/77193
