### PR TITLE
Dispose thumbPainter in Switch to avoid crash

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -959,6 +959,10 @@ class _SwitchPainter extends ToggleablePainter {
   @override
   void dispose() {
     _cachedThumbPainter?.dispose();
+    _cachedThumbPainter = null;
+    _cachedThumbColor = null;
+    _cachedThumbImage = null;
+    _cachedThumbErrorListener = null;
     super.dispose();
   }
 }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -938,6 +938,7 @@ class _SwitchPainter extends ToggleablePainter {
         _cachedThumbColor = thumbColor;
         _cachedThumbImage = thumbImage;
         _cachedThumbErrorListener = thumbErrorListener;
+        _cachedThumbPainter?.dispose();
         _cachedThumbPainter = _createDefaultThumbDecoration(thumbColor, thumbImage, thumbErrorListener).createBoxPainter(_handleDecorationChanged);
       }
       final BoxPainter thumbPainter = _cachedThumbPainter!;
@@ -953,5 +954,11 @@ class _SwitchPainter extends ToggleablePainter {
     } finally {
       _isPainting = false;
     }
+  }
+
+  @override
+  void dispose() {
+    _cachedThumbPainter?.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
Fixes b/186203085

The thumpPainter is invoking its onChanged callback (_handleDecorationChanged) when the given ImageProvider finally completes to trigger a repaint. If the Switch is already disposed at that moment, the `notifyListeners` call in `_handleDecorationChanged` crashes. To avoid all that, the thumbPainter must be disposed when the Switch is disposed or when it is replaced with another painter.