### PR TITLE
[flutter_tools] skip copying 1GB of data from chrome cache dirs

### DIFF
--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -107,10 +107,12 @@ String getDisplayPath(String fullPath, FileSystem fileSystem) {
 /// source/destination file pair.
 ///
 /// Skips files if [shouldCopyFile] returns `false`.
+/// Does not recurse over directories if [shouldCopyDirectory] returns `false`.
 void copyDirectory(
   Directory srcDir,
   Directory destDir, {
   bool Function(File srcFile, File destFile)? shouldCopyFile,
+  bool Function(Directory)? shouldCopyDirectory,
   void Function(File srcFile, File destFile)? onFileCopied,
 }) {
   if (!srcDir.existsSync()) {
@@ -134,6 +136,9 @@ void copyDirectory(
       newFile.writeAsBytesSync(entity.readAsBytesSync());
       onFileCopied?.call(entity, newFile);
     } else if (entity is Directory) {
+      if (shouldCopyDirectory != null && !shouldCopyDirectory(entity)) {
+        continue;
+      }
       copyDirectory(
         entity,
         destDir.fileSystem.directory(newPath),

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -318,6 +318,13 @@ class ChromiumLauncher {
   ///
   /// Note: more detailed docs of the Chrome user preferences store exists here:
   /// https://www.chromium.org/developers/design-documents/preferences.
+  ///
+  /// This intentionally skips the Cache, Code Cache, and GPUCache directories.
+  /// While we're not sure exactly what is in them, this constitutes nearly 1 GB
+  /// of data for a fresh flutter run and adds significant overhead to all startups.
+  /// For workflows that may require this data, using the start-paused flag and
+  /// dart debug extension with a user controlled browser profile will lead to a
+  /// better experience.
   void _cacheUserSessionInformation(Directory userDataDir, Directory cacheDir) {
     final Directory targetChromeDefault = _fileSystem.directory(_fileSystem.path.join(cacheDir.path, _chromeDefaultPath));
     final Directory sourceChromeDefault = _fileSystem.directory(_fileSystem.path.join(userDataDir.path, _chromeDefaultPath));

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -324,7 +324,11 @@ class ChromiumLauncher {
     if (sourceChromeDefault.existsSync()) {
       targetChromeDefault.createSync(recursive: true);
       try {
-        copyDirectory(sourceChromeDefault, targetChromeDefault);
+        copyDirectory(
+          sourceChromeDefault,
+          targetChromeDefault,
+          shouldCopyDirectory: _isNotCacheDirectory
+        );
       } on FileSystemException catch (err) {
         // This is a best-effort update. Display the message in case the failure is relevant.
         // one possible example is a file lock due to multiple running chrome instances.
@@ -352,11 +356,22 @@ class ChromiumLauncher {
     try {
       if (sourceChromeDefault.existsSync()) {
         targetChromeDefault.createSync(recursive: true);
-        copyDirectory(sourceChromeDefault, targetChromeDefault);
+        copyDirectory(
+          sourceChromeDefault,
+          targetChromeDefault,
+          shouldCopyDirectory: _isNotCacheDirectory,
+        );
       }
     } on FileSystemException catch (err) {
       _logger.printError('Failed to restore Chrome preferences: $err');
     }
+  }
+
+  // Cache, Code Cache, and GPUCache are nearly 1GB of data
+  bool _isNotCacheDirectory(Directory directory) {
+    return !directory.path.endsWith('Cache') &&
+           !directory.path.endsWith('Code Cache') &&
+           !directory.path.endsWith('GPUCache');
   }
 
   Future<Chromium> _connect(Chromium chrome, bool skipCheck) async {

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -98,6 +99,25 @@ void main() {
 
       expect(destination.childFile('a.txt').existsSync(), isFalse);
       expect(destination.childDirectory('nested').childFile('a.txt').existsSync(), isFalse);
+    });
+
+    testWithoutContext('Skip directories if shouldCopyDirectory returns false', () {
+      final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+      final Directory origin = fileSystem.directory('/origin');
+      origin.createSync();
+      fileSystem.file(fileSystem.path.join('origin', 'a.txt')).writeAsStringSync('irrelevant');
+      fileSystem.directory('/origin/nested').createSync();
+      fileSystem.file(fileSystem.path.join('origin', 'nested', 'a.txt')).writeAsStringSync('irrelevant');
+      fileSystem.file(fileSystem.path.join('origin', 'nested', 'b.txt')).writeAsStringSync('irrelevant');
+
+      final Directory destination = fileSystem.directory('/destination');
+      copyDirectory(origin, destination, shouldCopyDirectory: (Directory directory) {
+        return !directory.path.endsWith('nested');
+      });
+
+      expect(destination, exists);
+      expect(destination.childDirectory('nested'), isNot(exists));
+      expect(destination.childDirectory('nested').childFile('b.txt'),isNot(exists));
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/81160

And unfortunately this blocks on both startup and teardown. The issues is that there appears to be about ~ 1 GB of binary data present in these folders. On my fairly beefy desktop machine this takes ~15 seconds on startup and another ~15 seconds on tear down.