### PR TITLE
Add darwin-arm64 support to flutter assemble

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -548,6 +548,7 @@ class CachedArtifacts implements Artifacts {
       case TargetPlatform.linux_x64:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.darwin_x64:
+      case TargetPlatform.darwin_arm64:
       case TargetPlatform.windows_x64:
         // TODO(jonahwilliams): remove once debug desktop artifacts are uploaded
         // under a separate directory from the host artifacts.
@@ -586,7 +587,8 @@ class CachedArtifacts implements Artifacts {
 
 TargetPlatform _currentHostPlatform(Platform platform, OperatingSystemUtils operatingSystemUtils) {
   if (platform.isMacOS) {
-    return TargetPlatform.darwin_x64;
+    return operatingSystemUtils.hostPlatform == HostPlatform.darwin_x64 ?
+             TargetPlatform.darwin_x64 : TargetPlatform.darwin_arm64;
   }
   if (platform.isLinux) {
     return operatingSystemUtils.hostPlatform == HostPlatform.linux_x64 ?

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -838,7 +838,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
   }
 
   String _genSnapshotPath() {
-    const List<String> clangDirs = <String>['.', 'clang_x64', 'clang_x86', 'clang_i386'];
+    const List<String> clangDirs = <String>['.', 'clang_x64', 'clang_x86', 'clang_i386', 'clang_arm64'];
     final String genSnapshotName = _artifactToFileName(Artifact.genSnapshot);
     for (final String clangDir in clangDirs) {
       final String genSnapshotPath = _fileSystem.path.join(engineOutPath, clangDir, genSnapshotName);

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -312,6 +312,7 @@ class AOTSnapshotter {
       TargetPlatform.android_x64,
       TargetPlatform.ios,
       TargetPlatform.darwin_x64,
+      TargetPlatform.darwin_arm64,
       TargetPlatform.linux_x64,
       TargetPlatform.linux_arm64,
       TargetPlatform.windows_x64,

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -360,7 +360,8 @@ String? validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String bu
     return null;
   }
   if (targetPlatform == TargetPlatform.ios ||
-      targetPlatform == TargetPlatform.darwin_x64) {
+      targetPlatform == TargetPlatform.darwin_x64 ||
+      targetPlatform == TargetPlatform.darwin_arm64) {
     // See CFBundleVersion at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildNumber = buildNumber.replaceAll(disallowed, '');
@@ -407,7 +408,8 @@ String? validatedBuildNameForPlatform(TargetPlatform targetPlatform, String buil
     return null;
   }
   if (targetPlatform == TargetPlatform.ios ||
-      targetPlatform == TargetPlatform.darwin_x64) {
+      targetPlatform == TargetPlatform.darwin_x64 ||
+      targetPlatform == TargetPlatform.darwin_arm64) {
     // See CFBundleShortVersionString at https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
     final RegExp disallowed = RegExp(r'[^\d\.]');
     String tmpBuildName = buildName.replaceAll(disallowed, '');
@@ -458,7 +460,7 @@ bool isEmulatorBuildMode(BuildMode mode) {
 enum TargetPlatform {
   android,
   ios,
-  // darwin_arm64 not yet supported, macOS desktop targets run in Rosetta as x86.
+  darwin_arm64,
   darwin_x64,
   linux_x64,
   linux_arm64,
@@ -551,6 +553,8 @@ String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch
         return 'ios-${getNameForDarwinArch(darwinArch)}';
       }
       return 'ios';
+    case TargetPlatform.darwin_arm64:
+      return 'darwin-arm64';
     case TargetPlatform.darwin_x64:
       return 'darwin-x64';
     case TargetPlatform.linux_x64:
@@ -592,6 +596,8 @@ TargetPlatform? getTargetPlatformForName(String platform) {
       return TargetPlatform.fuchsia_x64;
     case 'ios':
       return TargetPlatform.ios;
+    case 'darwin-arm64':
+      return TargetPlatform.darwin_arm64;
     case 'darwin-x64':
       return TargetPlatform.darwin_x64;
     case 'linux-x64':
@@ -662,7 +668,7 @@ String fuchsiaArchForTargetPlatform(TargetPlatform targetPlatform) {
 
 HostPlatform getCurrentHostPlatform() {
   if (globals.platform.isMacOS) {
-    return HostPlatform.darwin_x64;
+    return globals.os.hostPlatform;
   }
   if (globals.platform.isLinux) {
     // support x64 and arm64 architecture.
@@ -818,6 +824,7 @@ String getNameForTargetPlatformArch(TargetPlatform platform) {
     case TargetPlatform.windows_x64:
       return 'x64';
     case TargetPlatform.linux_arm64:
+    case TargetPlatform.darwin_arm64:
       return 'arm64';
     default:
       throw UnsupportedError('Unexpected target platform $platform');

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -173,7 +173,7 @@ DarwinArch _darwinArchForEnvironment(Environment environment) {
     case TargetPlatform.darwin_x64:
       return DarwinArch.x86_64;
     default:
-      throw Exception('Invalid macos target platform: $targetPlatform');
+      throw Exception('Invalid macOS target platform: $targetPlatform');
   }
 }
 

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -91,6 +91,7 @@ class BuildBundleCommand extends BuildSubCommand {
     // Check for target platforms that are only allowed via feature flags.
     switch (platform) {
       case TargetPlatform.darwin_x64:
+      case TargetPlatform.darwin_arm64:
         if (!featureFlags.isMacOSEnabled) {
           throwToolExit('macOS is not a supported target platform.');
         }

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -85,6 +85,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
       case TargetPlatform.tester:
         return FlutterTesterApp.fromCurrentDirectory(globals.fs);
       case TargetPlatform.darwin_x64:
+      case TargetPlatform.darwin_arm64:
         return applicationBinary == null
             ? MacOSApp.fromMacOSProject(FlutterProject.current().macos)
             : MacOSApp.fromPrebuiltApp(applicationBinary);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1445,6 +1445,7 @@ DevelopmentArtifact artifactFromTargetPlatform(TargetPlatform targetPlatform) {
     case TargetPlatform.ios:
       return DevelopmentArtifact.iOS;
     case TargetPlatform.darwin_x64:
+    case TargetPlatform.darwin_arm64:
       if (featureFlags.isMacOSEnabled) {
         return DevelopmentArtifact.macOS;
       }

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -181,6 +181,10 @@ void main() {
         artifacts.getEngineType(TargetPlatform.darwin_x64),
         'darwin-x64',
       );
+      expect(
+        artifacts.getEngineType(TargetPlatform.darwin_arm64),
+        'darwin-arm64',
+      );
     });
   });
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/81205

This introduces support for producing arm64 version of App.framework for `flutter assemble *_macos_bundle_flutter_assets` when `TargetPlatform=darwin-arm64` is defined.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
