### PR TITLE
Enable vm:notify-debugger-on-exception for more use cases enabled by upstream fix

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -451,10 +451,7 @@ mixin SchedulerBinding on BindingBase {
   ///
   /// Also returns false if there are no tasks remaining.
   @visibleForTesting
-  // TODO(goderbauer): Add pragma (and enable test in
-  //   break_on_framework_exceptions_test.dart) once debugger breaks on correct
-  //   line, https://github.com/dart-lang/sdk/issues/45684
-  // @pragma('vm:notify-debugger-on-exception')
+  @pragma('vm:notify-debugger-on-exception')
   bool handleEventLoopCallback() {
     if (_taskQueue.isEmpty || locked)
       return false;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2834,10 +2834,7 @@ class BuildOwner {
   ///
   /// After the current call stack unwinds, a microtask that notifies listeners
   /// about changes to global keys will run.
-  // TODO(goderbauer): Add pragma (and enable test in
-  //   break_on_framework_exceptions_test.dart) once debugger breaks on correct
-  //   line, https://github.com/dart-lang/sdk/issues/45684
-  // @pragma('vm:notify-debugger-on-exception')
+  @pragma('vm:notify-debugger-on-exception')
   void finalizeTree() {
     Timeline.startSync('Finalize tree', arguments: timelineArgumentsIndicatingLandmarkEvent);
     try {

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -446,7 +446,7 @@ void main() {
 
     final int breakLine = (await flutter.getSourceLocation()).line;
     expect(breakLine, project.lineContaining(project.test, "throw 'scheduled task';"));
-  }, skip: 'TODO(goderbauer): add pragma to SchedulerBinding.handleEventLoopCallback when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
+  });
 
   testWithoutContext('breaks when FrameCallback throws', () async {
     final TestProject project = TestProject(
@@ -665,7 +665,7 @@ void main() {
 
     final int breakLine = (await flutter.getSourceLocation()).line;
     expect(breakLine, project.lineContaining(project.test, "throw 'dispose';"));
-  }, skip: 'TODO(goderbauer): add pragma to BuildOwner.finalizeTree when https://github.com/dart-lang/sdk/issues/45684 is fixed and enable this test');
+  });
 
   testWithoutContext('breaks when rebuilding dirty elements throws', () async {
     final TestProject project = TestProject(


### PR DESCRIPTION
With https://github.com/dart-lang/sdk/issues/45684 fixed we can notify the debugger on more "unhandled" exceptions otherwise caught by the framework.

Remaining upstream issues: https://github.com/dart-lang/sdk/issues/45710 and https://github.com/dart-lang/sdk/issues/45673. Once those are fixed we can enable this for the last two remaining use cases.