### PR TITLE
[flutter_tools] give assets a shot to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -375,6 +375,7 @@ class CachedArtifacts implements Artifacts {
       case TargetPlatform.android_arm64:
       case TargetPlatform.android_x64:
       case TargetPlatform.android_x86:
+      case TargetPlatform.android:
         return _getAndroidArtifactPath(artifact, platform, mode);
       case TargetPlatform.ios:
         return _getIosArtifactPath(artifact, platform, mode, environmentType);
@@ -389,7 +390,6 @@ class CachedArtifacts implements Artifacts {
         return _getFuchsiaArtifactPath(artifact, platform, mode!);
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:
-      case TargetPlatform.android:
         throw StateError('');
     }
   }

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -18,10 +16,10 @@ import '../src/fakes.dart';
 
 void main() {
   group('CachedArtifacts', () {
-    CachedArtifacts artifacts;
-    Cache cache;
-    FileSystem fileSystem;
-    Platform platform;
+    late CachedArtifacts artifacts;
+    late Cache cache;
+    late FileSystem fileSystem;
+    late Platform platform;
 
     setUp(() {
       fileSystem = MemoryFileSystem.test();
@@ -185,10 +183,10 @@ void main() {
   });
 
   group('LocalEngineArtifacts', () {
-    LocalEngineArtifacts artifacts;
-    Cache cache;
-    FileSystem fileSystem;
-    Platform platform;
+    late LocalEngineArtifacts artifacts;
+    late Cache cache;
+    late FileSystem fileSystem;
+    late Platform platform;
 
     setUp(() {
       fileSystem = MemoryFileSystem.test();


### PR DESCRIPTION
With the host platform changes split out, this was much easier to migrate. Though still not great

Work towards https://github.com/flutter/flutter/issues/71511
