### PR TITLE
[flutter_tools] remove mocks from clean test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -13,7 +14,8 @@ import 'package:flutter_tools/src/commands/clean.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/project.dart';
-import 'package:mockito/mockito.dart';
+import 'package:meta/meta.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -35,33 +37,6 @@ void main() {
       MemoryFileSystem fs;
       Directory buildDirectory;
 
-      FlutterProject setupProjectUnderTest(Directory currentDirectory) {
-        // This needs to be run within testWithoutContext and not setUp since FlutterProject uses context.
-        final FlutterProject projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
-        projectUnderTest.ios.xcodeWorkspace.createSync(recursive: true);
-        projectUnderTest.macos.xcodeWorkspace.createSync(recursive: true);
-
-        projectUnderTest.dartTool.createSync(recursive: true);
-        projectUnderTest.packagesFile.createSync(recursive: true);
-        projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
-
-        projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
-        projectUnderTest.ios.ephemeralModuleDirectory.createSync(recursive: true);
-        projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
-        projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
-        projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
-        projectUnderTest.ios.deprecatedProjectFlutterFramework.createSync(recursive: true);
-        projectUnderTest.ios.flutterPodspec.createSync(recursive: true);
-
-        projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
-        projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
-        projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
-        projectUnderTest.flutterPluginsFile.createSync(recursive: true);
-        projectUnderTest.flutterPluginsDependenciesFile.createSync(recursive: true);
-
-        return projectUnderTest;
-      }
-
       setUp(() {
         fs = MemoryFileSystem.test();
 
@@ -70,34 +45,37 @@ void main() {
         buildDirectory.createSync(recursive: true);
       });
 
-      testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode', () async {
+      testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode for iOS and macOS', () async {
         final FlutterProject projectUnderTest = setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.version).thenReturn(Version(1000, 0, 0));
+        mockXcodeProjectInterpreter.isInstalled = true;
+        mockXcodeProjectInterpreter.version = Version(1000, 0, 0);
         await CleanCommand().runCommand();
 
-        expect(buildDirectory.existsSync(), isFalse);
-        expect(projectUnderTest.dartTool.existsSync(), isFalse);
-        expect(projectUnderTest.android.ephemeralDirectory.existsSync(), isFalse);
+        expect(buildDirectory, isNot(exists));
+        expect(projectUnderTest.dartTool, isNot(exists));
+        expect(projectUnderTest.android.ephemeralDirectory, isNot(exists));
 
-        expect(projectUnderTest.ios.ephemeralDirectory.existsSync(), isFalse);
-        expect(projectUnderTest.ios.ephemeralModuleDirectory.existsSync(), isFalse);
-        expect(projectUnderTest.ios.generatedXcodePropertiesFile.existsSync(), isFalse);
-        expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript.existsSync(), isFalse);
-        expect(projectUnderTest.ios.deprecatedCompiledDartFramework.existsSync(), isFalse);
-        expect(projectUnderTest.ios.deprecatedProjectFlutterFramework.existsSync(), isFalse);
-        expect(projectUnderTest.ios.flutterPodspec.existsSync(), isFalse);
+        expect(projectUnderTest.ios.ephemeralDirectory, isNot(exists));
+        expect(projectUnderTest.ios.ephemeralModuleDirectory, isNot(exists));
+        expect(projectUnderTest.ios.generatedXcodePropertiesFile, isNot(exists));
+        expect(projectUnderTest.ios.generatedEnvironmentVariableExportScript, isNot(exists));
+        expect(projectUnderTest.ios.deprecatedCompiledDartFramework, isNot(exists));
+        expect(projectUnderTest.ios.deprecatedProjectFlutterFramework, isNot(exists));
+        expect(projectUnderTest.ios.flutterPodspec, isNot(exists));
 
-        expect(projectUnderTest.linux.ephemeralDirectory.existsSync(), isFalse);
-        expect(projectUnderTest.macos.ephemeralDirectory.existsSync(), isFalse);
-        expect(projectUnderTest.windows.ephemeralDirectory.existsSync(), isFalse);
+        expect(projectUnderTest.linux.ephemeralDirectory, isNot(exists));
+        expect(projectUnderTest.macos.ephemeralDirectory, isNot(exists));
+        expect(projectUnderTest.windows.ephemeralDirectory, isNot(exists));
 
-        expect(projectUnderTest.flutterPluginsFile.existsSync(), isFalse);
-        expect(projectUnderTest.flutterPluginsDependenciesFile.existsSync(), isFalse);
-        expect(projectUnderTest.packagesFile.existsSync(), isFalse);
+        expect(projectUnderTest.flutterPluginsFile, isNot(exists));
+        expect(projectUnderTest.flutterPluginsDependenciesFile, isNot(exists));
+        expect(projectUnderTest.packagesFile, isNot(exists));
 
-        verify(mockXcodeProjectInterpreter.cleanWorkspace(any, 'Runner', verbose: false)).called(2);
+      expect(mockXcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+          CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', false),
+          CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', false),
+        ]);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -105,14 +83,18 @@ void main() {
         XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
       });
 
-      testUsingContext('$CleanCommand cleans Xcode verbosely', () async {
+      testUsingContext('$CleanCommand cleans Xcode verbosely for iOS and macOS', () async {
         setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(true);
-        when(mockXcodeProjectInterpreter.version).thenReturn(Version(1000, 0, 0));
+        mockXcodeProjectInterpreter.isInstalled = true;
+        mockXcodeProjectInterpreter.version = Version(1000, 0, 0);
 
         await CleanCommand(verbose: true).runCommand();
-        verify(mockXcodeProjectInterpreter.cleanWorkspace(any, 'Runner', verbose: true)).called(2);
+
+        expect(mockXcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+          CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', true),
+          CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', true),
+        ]);
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -125,6 +107,7 @@ void main() {
       FakePlatform windowsPlatform;
       MemoryFileSystem fileSystem;
       FileExceptionHandler exceptionHandler;
+
       setUp(() {
         windowsPlatform = FakePlatform(operatingSystem: 'windows');
         exceptionHandler = FileExceptionHandler();
@@ -132,7 +115,7 @@ void main() {
       });
 
       testUsingContext('$CleanCommand prints a helpful error message on Windows', () async {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+        mockXcodeProjectInterpreter.isInstalled = false;
 
         final File file = fileSystem.file('file')..createSync();
         exceptionHandler.addError(
@@ -151,17 +134,20 @@ void main() {
         ProcessManager: () => FakeProcessManager.any(),
       });
 
-      testUsingContext('$CleanCommand handles missing permissions;', () async {
-        when(mockXcodeProjectInterpreter.isInstalled).thenReturn(false);
+      testUsingContext('$CleanCommand handles missing delete permissions', () async {
+        final FileExceptionHandler handler = FileExceptionHandler();
+        final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+        final File throwingFile = fileSystem.file('bad')
+          ..createSync();
+        handler.addError(throwingFile, FileSystemOp.delete, const FileSystemException('OS error: Access Denied'));
 
-        final MockFile mockFile = MockFile();
-        when(mockFile.existsSync()).thenThrow(const FileSystemException('OS error: Access Denied'));
-        when(mockFile.path).thenReturn('foo.dart');
+        mockXcodeProjectInterpreter.isInstalled = false;
 
         final CleanCommand command = CleanCommand();
-        command.deleteFile(mockFile);
-        expect(testLogger.errorText, contains('Cannot clean foo.dart'));
-        verifyNever(mockFile.deleteSync(recursive: true));
+        command.deleteFile(throwingFile);
+
+        expect(testLogger.errorText, contains('Failed to remove bad. A program may still be using a file in the directory or the directory itself'));
+        expect(throwingFile, exists);
       }, overrides: <Type, Generator>{
         Platform: () => windowsPlatform,
         Xcode: () => xcode,
@@ -170,11 +156,71 @@ void main() {
   });
 }
 
-class MockFile extends Mock implements File {}
+FlutterProject setupProjectUnderTest(Directory currentDirectory) {
+  // This needs to be run within testWithoutContext and not setUp since FlutterProject uses context.
+  final FlutterProject projectUnderTest = FlutterProject.fromDirectory(currentDirectory);
+  projectUnderTest.ios.xcodeWorkspace.createSync(recursive: true);
+  projectUnderTest.macos.xcodeWorkspace.createSync(recursive: true);
 
-class MockXcodeProjectInterpreter extends Mock implements XcodeProjectInterpreter {
+  projectUnderTest.dartTool.createSync(recursive: true);
+  projectUnderTest.packagesFile.createSync(recursive: true);
+  projectUnderTest.android.ephemeralDirectory.createSync(recursive: true);
+
+  projectUnderTest.ios.ephemeralDirectory.createSync(recursive: true);
+  projectUnderTest.ios.ephemeralModuleDirectory.createSync(recursive: true);
+  projectUnderTest.ios.generatedXcodePropertiesFile.createSync(recursive: true);
+  projectUnderTest.ios.generatedEnvironmentVariableExportScript.createSync(recursive: true);
+  projectUnderTest.ios.deprecatedCompiledDartFramework.createSync(recursive: true);
+  projectUnderTest.ios.deprecatedProjectFlutterFramework.createSync(recursive: true);
+  projectUnderTest.ios.flutterPodspec.createSync(recursive: true);
+
+  projectUnderTest.linux.ephemeralDirectory.createSync(recursive: true);
+  projectUnderTest.macos.ephemeralDirectory.createSync(recursive: true);
+  projectUnderTest.windows.ephemeralDirectory.createSync(recursive: true);
+  projectUnderTest.flutterPluginsFile.createSync(recursive: true);
+  projectUnderTest.flutterPluginsDependenciesFile.createSync(recursive: true);
+
+  return projectUnderTest;
+}
+
+class MockXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
+  @override
+  bool isInstalled = true;
+
+  @override
+  Version version = Version(0, 0, 0);
+
   @override
   Future<XcodeProjectInfo> getInfo(String projectPath, {String projectFilename}) async {
     return XcodeProjectInfo(null, null, <String>['Runner'], BufferLogger.test());
   }
+
+  final List<CleanWorkspaceCall> workspaces = <CleanWorkspaceCall>[];
+
+  @override
+  Future<void> cleanWorkspace(String workspacePath, String scheme, {bool verbose = false}) async {
+    workspaces.add(CleanWorkspaceCall(workspacePath, scheme, verbose));
+    return;
+  }
+}
+
+@immutable
+class CleanWorkspaceCall {
+  const CleanWorkspaceCall(this.workspacePath, this.scheme, this.verbose);
+
+  final String workspacePath;
+  final String scheme;
+  final bool verbose;
+
+  @override
+  bool operator ==(Object other) => other is CleanWorkspaceCall &&
+    workspacePath == other.workspacePath &&
+    scheme == other.scheme &&
+    verbose == other.verbose;
+
+  @override
+  int get hashCode => workspacePath.hashCode;
+
+  @override
+  String toString() => '{$workspacePath, $scheme, $verbose}';
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -23,13 +23,13 @@ import '../../src/context.dart';
 void main() {
   group('clean command', () {
     Xcode xcode;
-    MockXcodeProjectInterpreter mockXcodeProjectInterpreter;
+    FakeXcodeProjectInterpreter xcodeProjectInterpreter;
 
     setUp(() {
-      mockXcodeProjectInterpreter = MockXcodeProjectInterpreter();
+      xcodeProjectInterpreter = FakeXcodeProjectInterpreter();
       xcode = Xcode.test(
         processManager: FakeProcessManager.any(),
-        xcodeProjectInterpreter: mockXcodeProjectInterpreter,
+        xcodeProjectInterpreter: xcodeProjectInterpreter,
       );
     });
 
@@ -48,8 +48,8 @@ void main() {
       testUsingContext('$CleanCommand removes build and .dart_tool and ephemeral directories, cleans Xcode for iOS and macOS', () async {
         final FlutterProject projectUnderTest = setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
-        mockXcodeProjectInterpreter.isInstalled = true;
-        mockXcodeProjectInterpreter.version = Version(1000, 0, 0);
+        xcodeProjectInterpreter.isInstalled = true;
+        xcodeProjectInterpreter.version = Version(1000, 0, 0);
         await CleanCommand().runCommand();
 
         expect(buildDirectory, isNot(exists));
@@ -72,7 +72,7 @@ void main() {
         expect(projectUnderTest.flutterPluginsDependenciesFile, isNot(exists));
         expect(projectUnderTest.packagesFile, isNot(exists));
 
-      expect(mockXcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+      expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
           CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', false),
           CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', false),
         ]);
@@ -86,12 +86,12 @@ void main() {
       testUsingContext('$CleanCommand cleans Xcode verbosely for iOS and macOS', () async {
         setupProjectUnderTest(fs.currentDirectory);
         // Xcode is installed and version satisfactory.
-        mockXcodeProjectInterpreter.isInstalled = true;
-        mockXcodeProjectInterpreter.version = Version(1000, 0, 0);
+        xcodeProjectInterpreter.isInstalled = true;
+        xcodeProjectInterpreter.version = Version(1000, 0, 0);
 
         await CleanCommand(verbose: true).runCommand();
 
-        expect(mockXcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
+        expect(xcodeProjectInterpreter.workspaces, const <CleanWorkspaceCall>[
           CleanWorkspaceCall('/ios/Runner.xcworkspace', 'Runner', true),
           CleanWorkspaceCall('/macos/Runner.xcworkspace', 'Runner', true),
         ]);
@@ -115,7 +115,7 @@ void main() {
       });
 
       testUsingContext('$CleanCommand prints a helpful error message on Windows', () async {
-        mockXcodeProjectInterpreter.isInstalled = false;
+        xcodeProjectInterpreter.isInstalled = false;
 
         final File file = fileSystem.file('file')..createSync();
         exceptionHandler.addError(
@@ -141,7 +141,7 @@ void main() {
           ..createSync();
         handler.addError(throwingFile, FileSystemOp.delete, const FileSystemException('OS error: Access Denied'));
 
-        mockXcodeProjectInterpreter.isInstalled = false;
+        xcodeProjectInterpreter.isInstalled = false;
 
         final CleanCommand command = CleanCommand();
         command.deleteFile(throwingFile);
@@ -183,7 +183,7 @@ FlutterProject setupProjectUnderTest(Directory currentDirectory) {
   return projectUnderTest;
 }
 
-class MockXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
+class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterpreter {
   @override
   bool isInstalled = true;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/clean_test.dart
@@ -80,7 +80,7 @@ void main() {
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         Xcode: () => xcode,
-        XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
 
       testUsingContext('$CleanCommand cleans Xcode verbosely for iOS and macOS', () async {
@@ -99,7 +99,7 @@ void main() {
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
         Xcode: () => xcode,
-        XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
       });
     });
 


### PR DESCRIPTION
Work towards #71511

Remove mocks from clean command test. Replace test which threw error on exists to one that throws an error on delete.