### PR TITLE
[flutter_tools] remove mocks from test_compiler test

### DIFF
--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -5,7 +5,6 @@
 // @dart = 2.8
 
 import 'package:file/memory.dart';
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -13,8 +12,8 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/test_compiler.dart';
-import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config_types.dart';
+import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -34,36 +33,25 @@ final BuildInfo debugBuild = BuildInfo(
 );
 
 void main() {
-  MockResidentCompiler residentCompiler;
+  FakeResidentCompiler residentCompiler;
   FileSystem fileSystem;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('test/foo.dart').createSync(recursive: true);
-    residentCompiler = MockResidentCompiler();
+    residentCompiler = FakeResidentCompiler(fileSystem);
   });
 
   testUsingContext('TestCompiler reports a dill file when compile is successful', () async {
+    residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 0, <Uri>[]);
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
       FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       residentCompiler,
     );
-    when(residentCompiler.recompile(
-      any,
-      <Uri>[Uri.parse('test/foo.dart')],
-      outputPath: testCompiler.outputDill.path,
-      packageConfig: anyNamed('packageConfig'),
-      projectRootPath: anyNamed('projectRootPath'),
-      fs: anyNamed('fs'),
-    )).thenAnswer((Invocation invocation) async {
-      fileSystem.file('abc.dill').createSync();
-      return const CompilerOutput('abc.dill', 0, <Uri>[]);
-    });
 
     expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart.dill');
-    expect(fileSystem.file('test/foo.dart.dill'), exists);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Platform: () => linuxPlatform,
@@ -72,26 +60,15 @@ void main() {
   });
 
   testUsingContext('TestCompiler reports null when a compile fails', () async {
+    residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 1, <Uri>[]);
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
       FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       residentCompiler,
     );
-    when(residentCompiler.recompile(
-      any,
-      <Uri>[Uri.parse('test/foo.dart')],
-      outputPath: testCompiler.outputDill.path,
-      packageConfig: anyNamed('packageConfig'),
-      projectRootPath: anyNamed('projectRootPath'),
-      fs: anyNamed('fs'),
-    )).thenAnswer((Invocation invocation) async {
-      fileSystem.file('abc.dill').createSync();
-      return const CompilerOutput('abc.dill', 1, <Uri>[]);
-    });
 
     expect(await testCompiler.compile(Uri.parse('test/foo.dart')), null);
-    expect(fileSystem.file('test/foo.dart.dill'), isNot(exists));
-    verify(residentCompiler.shutdown()).called(1);
+    expect(residentCompiler.didShutdown, true);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Platform: () => linuxPlatform,
@@ -112,7 +89,7 @@ void main() {
     await testCompiler.dispose();
 
     expect(testCompiler.compilerController.isClosed, true);
-    verify(residentCompiler.shutdown()).called(1);
+    expect(residentCompiler.didShutdown, true);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     Platform: () => linuxPlatform,
@@ -129,7 +106,7 @@ class FakeTestCompiler extends TestCompiler {
     this.residentCompiler,
   ) : super(buildInfo, flutterProject);
 
-  final MockResidentCompiler residentCompiler;
+  final FakeResidentCompiler residentCompiler;
 
   @override
   Future<ResidentCompiler> createCompiler() async {
@@ -137,4 +114,38 @@ class FakeTestCompiler extends TestCompiler {
   }
 }
 
-class MockResidentCompiler extends Mock implements ResidentCompiler {}
+class FakeResidentCompiler extends Fake implements ResidentCompiler {
+  FakeResidentCompiler(this.fileSystem);
+
+  final FileSystem fileSystem;
+
+  CompilerOutput compilerOutput;
+  bool didShutdown = false;
+
+  @override
+  Future<CompilerOutput> recompile(
+    Uri mainUri,
+    List<Uri> invalidatedFiles, {
+    String outputPath,
+    PackageConfig packageConfig,
+    String projectRootPath,
+    FileSystem fs,
+    bool suppressErrors = false,
+  }) async {
+    if (compilerOutput != null) {
+      fileSystem.file(compilerOutput.outputFilename).createSync(recursive: true);
+    }
+    return compilerOutput;
+  }
+
+  @override
+  void accept() { }
+
+  @override
+  void reset() { }
+
+  @override
+  Future<void> shutdown() async {
+    didShutdown = true;
+  }
+}


### PR DESCRIPTION
Work towards #71511

Remove mocks from test compiler test. Remove assertions on the output file existing since that is created by the mock