### PR TITLE
Deprecate ThemeData accentColor, accentColorBright, accentIconTheme, accentTextTheme

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1052,9 +1052,9 @@ class ThemeData with Diagnosticable {
   ///
   /// The material library no longer uses this property and most uses
   /// of [accentColor] have been replaced with
-  /// the theme's [colorScheme] [ColorScheme.secondaryColor].
+  /// the theme's [colorScheme] [ColorScheme.secondary].
   /// You can configure the color of a [textTheme] [TextStyle] so that it
-  /// contrasts well with the [ColorScheme.secondaryColor] like this:
+  /// contrasts well with the [ColorScheme.secondary] like this:
   ///
   /// ```dart
   /// final ThemeData theme = Theme.of(context);
@@ -1085,7 +1085,7 @@ class ThemeData with Diagnosticable {
   ///
   /// The material library no longer uses this property and most uses
   /// of [accentColor] have been replaced with
-  /// the theme's [colorScheme] [ColorScheme.secondaryColor].
+  /// the theme's [colorScheme] [ColorScheme.secondary].
   @Deprecated(
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.3.0-0.1.pre.',

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -224,7 +224,15 @@ class ThemeData with Diagnosticable {
     Brightness? primaryColorBrightness,
     Color? primaryColorLight,
     Color? primaryColorDark,
+    @Deprecated(
+      'Use colorScheme.secondary instead. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     Color? accentColor,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     Brightness? accentColorBrightness,
     Color? canvasColor,
     Color? shadowColor,
@@ -268,6 +276,10 @@ class ThemeData with Diagnosticable {
     String? fontFamily,
     TextTheme? textTheme,
     TextTheme? primaryTextTheme,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     TextTheme? accentTextTheme,
     InputDecorationTheme? inputDecorationTheme,
     IconThemeData? iconTheme,
@@ -550,7 +562,15 @@ class ThemeData with Diagnosticable {
     required this.primaryColorDark,
     required this.canvasColor,
     required this.shadowColor,
+    @Deprecated(
+      'Use colorScheme.secondary instead. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     required this.accentColor,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     required this.accentColorBrightness,
     required this.scaffoldBackgroundColor,
     required this.bottomAppBarColor,
@@ -591,6 +611,10 @@ class ThemeData with Diagnosticable {
     required this.toggleableActiveColor,
     required this.textTheme,
     required this.primaryTextTheme,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     required this.accentTextTheme,
     required this.inputDecorationTheme,
     required this.iconTheme,
@@ -877,11 +901,19 @@ class ThemeData with Diagnosticable {
   /// well as a color that contrasts well with the secondary color called
   /// [ColorScheme.onSecondary]. It might be simpler to just configure an app's
   /// visuals in terms of the theme's [colorScheme].
+  @Deprecated(
+    'Use colorScheme.secondary instead. '
+    'This feature was deprecated after v2.3.0-0.1.pre.',
+  )
   final Color accentColor;
 
   /// The brightness of the [accentColor]. Used to determine the color of text
   /// and icons placed on top of the accent color (e.g. the icons on a floating
   /// action button).
+  @Deprecated(
+    'No longer used by the framework, please remove any reference to it. '
+    'This feature was deprecated after v2.3.0-0.1.pre.',
+  )
   final Brightness accentColorBrightness;
 
   /// The default color of the [Material] that underlies the [Scaffold]. The
@@ -1005,6 +1037,10 @@ class ThemeData with Diagnosticable {
   final TextTheme primaryTextTheme;
 
   /// A text theme that contrasts with the accent color.
+  @Deprecated(
+    'No longer used by the framework, please remove any reference to it. '
+    'This feature was deprecated after v2.3.0-0.1.pre.',
+  )
   final TextTheme accentTextTheme;
 
   /// The default [InputDecoration] values for [InputDecorator], [TextField],

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1086,6 +1086,10 @@ class ThemeData with Diagnosticable {
   /// The material library no longer uses this property and most uses
   /// of [accentColor] have been replaced with
   /// the theme's [colorScheme] [ColorScheme.secondaryColor].
+  @Deprecated(
+    'No longer used by the framework, please remove any reference to it. '
+    'This feature was deprecated after v2.3.0-0.1.pre.',
+  )
   final IconThemeData accentIconTheme;
 
   /// The colors and shapes used to render [Slider].

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -619,6 +619,10 @@ class ThemeData with Diagnosticable {
     required this.inputDecorationTheme,
     required this.iconTheme,
     required this.primaryIconTheme,
+    @Deprecated(
+      'No longer used by the framework, please remove any reference to it. '
+      'This feature was deprecated after v2.3.0-0.1.pre.',
+    )
     required this.accentIconTheme,
     required this.sliderTheme,
     required this.tabBarTheme,
@@ -893,23 +897,31 @@ class ThemeData with Diagnosticable {
   /// overlay on or off for dark themes.
   final Color shadowColor;
 
-  /// The foreground color for widgets (knobs, text, overscroll edge effect, etc).
+  /// Obsolete property that was originally used as the foreground
+  /// color for widgets (knobs, text, overscroll edge effect, etc).
   ///
-  /// Accent color is also known as the secondary color.
+  /// The material library no longer uses this property. In most cases
+  /// the theme's [colorScheme] [ColorScheme.secondary] property is now
+  /// used instead.
   ///
-  /// The theme's [colorScheme] property contains [ColorScheme.secondary], as
-  /// well as a color that contrasts well with the secondary color called
-  /// [ColorScheme.onSecondary]. It might be simpler to just configure an app's
-  /// visuals in terms of the theme's [colorScheme].
+  /// Apps should migrate uses of this property to the theme's [colorScheme]
+  /// [ColorScheme.secondary] color. In cases where a color is needed that
+  /// that contrasts well with the secondary color [ColorScheme.onSecondary]
+  /// can be used.
   @Deprecated(
     'Use colorScheme.secondary instead. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
   final Color accentColor;
 
-  /// The brightness of the [accentColor]. Used to determine the color of text
-  /// and icons placed on top of the accent color (e.g. the icons on a floating
-  /// action button).
+  /// Obsolete property that was originally used to determine the color
+  /// of text and icons placed on top of the accent color (e.g. the
+  /// icons on a floating action button).
+  ///
+  /// The material library no longer uses this property. The
+  /// [floatingActionButtonTheme] can be used to configure
+  /// the appearance of [FloatingActionButton]s. The brightness
+  /// of any color can be found with [ThemeData.estimateBrightnessForColor].
   @Deprecated(
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
@@ -963,8 +975,7 @@ class ThemeData with Diagnosticable {
   final Color selectedRowColor;
 
   /// The color used for widgets in their inactive (but enabled)
-  /// state. For example, an unchecked checkbox. Usually contrasted
-  /// with the [accentColor]. See also [disabledColor].
+  /// state. For example, an unchecked checkbox. See also [disabledColor].
   final Color unselectedWidgetColor;
 
   /// The color used for widgets that are inoperative, regardless of
@@ -1036,7 +1047,21 @@ class ThemeData with Diagnosticable {
   /// A text theme that contrasts with the primary color.
   final TextTheme primaryTextTheme;
 
-  /// A text theme that contrasts with the accent color.
+  /// Obsolete property that was originally used when a [TextTheme]
+  /// that contrasted well with the [accentColor] was needed.
+  ///
+  /// The material library no longer uses this property and most uses
+  /// of [accentColor] have been replaced with
+  /// the theme's [colorScheme] [ColorScheme.secondaryColor].
+  /// You can configure the color of a [textTheme] [TextStyle] so that it
+  /// contrasts well with the [ColorScheme.secondaryColor] like this:
+  ///
+  /// ```dart
+  /// final ThemeData theme = Theme.of(context);
+  /// theme.textTheme.headline1.copyWith(
+  ///   color: theme.colorScheme.onSecondary,
+  /// )
+  /// ```
   @Deprecated(
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
@@ -1055,7 +1080,12 @@ class ThemeData with Diagnosticable {
   /// An icon theme that contrasts with the primary color.
   final IconThemeData primaryIconTheme;
 
-  /// An icon theme that contrasts with the accent color.
+  /// Obsolete property that was originally used when an [IconTheme]
+  /// that contrasted well with the [accentColor] was needed.
+  ///
+  /// The material library no longer uses this property and most uses
+  /// of [accentColor] have been replaced with
+  /// the theme's [colorScheme] [ColorScheme.secondaryColor].
   final IconThemeData accentIconTheme;
 
   /// The colors and shapes used to render [Slider].
@@ -1182,8 +1212,7 @@ class ThemeData with Diagnosticable {
   /// icon themes of a [NavigationRail].
   final NavigationRailThemeData navigationRailTheme;
 
-  /// The color and geometry [TextTheme] values used to configure [textTheme],
-  /// [primaryTextTheme], and [accentTextTheme].
+  /// The color and geometry [TextTheme] values used to configure [textTheme].
   final Typography typography;
 
   /// Components of the [CupertinoThemeData] to override from the Material

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -51,15 +51,6 @@ void main() {
     expect(darkTheme.primaryTextTheme.headline6!.color, typography.white.headline6!.color);
   });
 
-  test('Default accent text theme contrasts with accent brightness', () {
-    final ThemeData lightTheme = ThemeData(accentColorBrightness: Brightness.light);
-    final ThemeData darkTheme = ThemeData(accentColorBrightness: Brightness.dark);
-    final Typography typography = Typography.material2018(platform: lightTheme.platform);
-
-    expect(lightTheme.accentTextTheme.headline6!.color, typography.black.headline6!.color);
-    expect(darkTheme.accentTextTheme.headline6!.color, typography.white.headline6!.color);
-  });
-
   test('Default chip label style gets a default bodyText1 if textTheme.bodyText1 is null', () {
     const TextTheme noBodyText1TextTheme = TextTheme(bodyText1: null);
     final ThemeData lightTheme = ThemeData(brightness: Brightness.light, textTheme: noBodyText1TextTheme);
@@ -86,15 +77,6 @@ void main() {
 
     expect(lightTheme.primaryTextTheme.headline6!.color, typography.black.headline6!.color);
     expect(darkTheme.primaryTextTheme.headline6!.color, typography.white.headline6!.color);
-  });
-
-  test('Default accent icon theme contrasts with accent brightness', () {
-    final ThemeData lightTheme = ThemeData(accentColorBrightness: Brightness.light);
-    final ThemeData darkTheme = ThemeData(accentColorBrightness: Brightness.dark);
-    final Typography typography = Typography.material2018(platform: lightTheme.platform);
-
-    expect(lightTheme.accentTextTheme.headline6!.color, typography.black.headline6!.color);
-    expect(darkTheme.accentTextTheme.headline6!.color, typography.white.headline6!.color);
   });
 
   testWidgets('Defaults to MaterialTapTargetBehavior.padded on mobile platforms and MaterialTapTargetBehavior.shrinkWrap on desktop', (WidgetTester tester) async {


### PR DESCRIPTION
Deprecate the ThemeData accentColor, accentColorBrightness, accentIconTheme, and accentTextTheme properties because they are no longer used by the material library (see https://github.com/flutter/flutter/issues/56918).

The official migration guide is https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties  

## Summary

The ThemeData `accentColor`, `accentColorBrightness`, `accentIconTheme` and `accentTextTheme` properties have been deprecated.

The Material Design spec no longer specifies or uses an "accent" color for the Material components. The default values for component colors are derived from the overall theme's color scheme. The `ColorScheme`'s `secondary` color is now typically used instead of `accentColor` and the `onSecondary` color is used when a contrasting color is needed.

## Context

This was a small part of the [Material Theme System Updates](https://flutter.dev/go/material-theme-system-updates) project.

As of Flutter 1.17, the ThemeData accent properties - accentColor, accentColorBrightness, accentIconTheme, and accentTextTheme - were no longer used by the Material library. They had been replaced by dependencies on the theme's `colorScheme` and `textTheme` properties as part of the long-term goal of making the default configurations of the
material components depend almost exclusively on these two properties.

The motivation for these changes is to make the theme system easier to understand and use. The default colors for all components are to be defined by the components themselves and based on the color scheme. The defaults for specific component types can be overridden with component-specific themes like `FloatingActionButtonTheme` or `CheckBoxTheme`. Previously, properties like accentColor were used by a handful of component types and only in some situations, which made it difficult to understand the implications of overriding them.

## Description of change

The ThemeData accentColor, accentColorBrightness, accentIconTheme and accentTextTheme properties have been deprecated because the Material library no longer uses them.

## Migration guide

### Application theme

`ThemeData` values no long need to specify accentColor, accentColorBrightness, accentIconTheme, or accentTextTheme.

To configure the appearance of the material components in about the same way as before, specify the color scheme's secondary color instead of accentColor.

Code before migration:

```dart
MaterialApp(
  theme: ThemeData(accentColor: myColor),
  // ...
);
```

Code after migration:

```dart
final ThemeData theme = ThemeData();
MaterialApp(
  theme: theme.copyWith(
    colorScheme: theme.colorScheme.copyWith(secondaryColor: myColor),
  ),
  //...
)
```

### `accentColor`

The closest backwards compatible `ColorScheme` color is `ColorScheme.secondary`. To hew most closely to the latest Material Design guidelines one can substitute `ColorScheme.primary` instead. If a contrasting color is needed then use `ColorScheme.onSecondary`.

Custom components that used to look up the theme's accentColor, can look up the `ColorScheme.secondary` instead.

Code before migration:

```dart
Color myColor = Theme.of(context).accentColor;
```

Code after migration:

```dart
Color myColor = Theme.of(context).colorScheme.secondary;
```

### `accentColorBrightness`

The static `ThemeData.estimateBrightnessForColor()` method can be used to compute the brightness of any color.


### `accentTextTheme`

This was white TextStyles for dark themes, black TextStyles for light themes. In most cases `textTheme` can be used instead. A common idiom was to refer to one TextStyle from accentTextTheme, since the text style's color was guaranteed to contrast well with the accent color (now `ColorScheme.secondaryColor`).  To get the same result now, specify the text style's color as `ColorScheme.onSecondary`:

Code before migration:

```dart
TextStyle style = Theme.of(context).accentTextTheme.headline1;
```

Code after migration:

```dart
final ThemeData theme = Theme.of(context);
TextStyle style = theme.textTheme.headline1.copyWith(
  color: theme.colorScheme.onSecondary,
)
```

### `accentIconTheme`

This property had only been used to configure the color of icons within a `FloatingActionButton`. It's now possible to configure the icon color directly or with the `FloatingActionButtonTheme`. See [FloatingActionButton and ThemeData's accent properties](https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties).


## Timeline

Landed in version: 2.3.0-0.1.pre<br>
In stable release: not yet

## References

Relevant issues:
* Issue #56918

Relevant PRs:
* PR #81336

Other:
* [Material Theme System Updates](flutter.dev/go/material-theme-system-updates)
