### PR TITLE
Fix bug in LongPressGestureRecognizer

### DIFF
--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -464,6 +464,13 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   }
 
   @override
+  void handleNonAllowedPointer(PointerDownEvent event) {
+    if (!_gestureAccepted) {
+      super.handleNonAllowedPointer(event);
+    }
+  }
+
+  @override
   void handleEvent(PointerEvent event) {
     assert(state != GestureRecognizerState.ready);
     if (state == GestureRecognizerState.possible && event.pointer == primaryPointer) {

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -288,6 +288,29 @@ void main() {
 
       longPress.dispose();
     });
+
+    testGesture('non-allowed pointer does not inadvertently reset the recognizer', (GestureTester tester) {
+      longPress = LongPressGestureRecognizer(kind: PointerDeviceKind.touch)..onLongPress = () {};
+
+      // Accept a long-press gesture
+      longPress.addPointer(down);
+      tester.closeArena(5);
+      tester.route(down);
+      tester.async.elapse(const Duration(milliseconds: 500));
+
+      // Add a non-allowed pointer (doesn't match the kind filter)
+      longPress.addPointer(const PointerDownEvent(
+        pointer: 101,
+        kind: PointerDeviceKind.mouse,
+        position: Offset(10, 10),
+      ));
+
+      // Moving the primary pointer should result in a normal event
+      tester.route(const PointerMoveEvent(
+        pointer: 5,
+        position: Offset(15, 15),
+      ));
+    });
   });
 
   group('long press drag', () {


### PR DESCRIPTION
It was incorrectly resetting state when it received a
non-allowed pointer but had already accepted a gesture.

Fixes https://github.com/flutter/flutter/issues/81339

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
