### PR TITLE
Remove Finder extended attributes before code signing iOS frameworks

### DIFF
--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -138,7 +138,14 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommand(
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -147,7 +154,7 @@ void main() {
         '--timestamp=none',
         frameworkDirectoryBinary.path,
       ]),
-    );
+    ]);
 
     await const DebugIosApplicationBundle().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);
@@ -184,7 +191,14 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommand(
+    processManager.addCommands(<FakeCommand>[
+      FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
+        frameworkDirectoryBinary.path,
+      ]),
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -192,7 +206,7 @@ void main() {
         'ABC123',
         frameworkDirectoryBinary.path,
       ]),
-    );
+    ]);
 
     await const ReleaseIosApplicationBundle().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -277,6 +277,7 @@ void main() {
     FakeCommand lipoCommandNonFatResult;
     FakeCommand lipoVerifyArm64Command;
     FakeCommand bitcodeStripCommand;
+    FakeCommand xattrRemoveCommand;
 
     setUp(() {
       final FileSystem fileSystem = MemoryFileSystem.test();
@@ -311,6 +312,14 @@ void main() {
         binary.path,
         '-m',
         '-o',
+        binary.path,
+      ]);
+
+      xattrRemoveCommand = FakeCommand(command: <String>[
+        'xattr',
+        '-r',
+        '-d',
+        'com.apple.FinderInfo',
         binary.path,
       ]);
     });
@@ -621,6 +630,54 @@ void main() {
       expect(processManager.hasRemainingExpectations, isFalse);
     });
 
+    testWithoutContext('logs when extended attribute fails', () async {
+      binary.createSync(recursive: true);
+
+      final Environment environment = Environment.test(
+        fileSystem.currentDirectory,
+        processManager: processManager,
+        artifacts: artifacts,
+        logger: logger,
+        fileSystem: fileSystem,
+        outputDir: outputDir,
+        defines: <String, String>{
+          kIosArchs: 'arm64',
+          kSdkRoot: 'path/to/iPhoneOS.sdk',
+          kBitcodeFlag: '',
+          kCodesignIdentity: 'ABC123',
+        },
+      );
+
+      processManager.addCommands(<FakeCommand>[
+        copyPhysicalFrameworkCommand,
+        lipoCommandNonFatResult,
+        lipoVerifyArm64Command,
+        bitcodeStripCommand,
+        FakeCommand(
+          command: <String>[
+            'xattr',
+            '-r',
+            '-d',
+            'com.apple.FinderInfo',
+            binary.path,
+          ],
+          exitCode: 1,
+          stderr: 'Failed to remove extended attributes',
+        ),
+        FakeCommand(command: <String>[
+          'codesign',
+          '--force',
+          '--sign',
+          'ABC123',
+          '--timestamp=none',
+          binary.path,
+        ]),
+      ]);
+
+      await const DebugUnpackIOS().build(environment);
+      expect(logger.traceText, contains('Failed to remove extended attributes'));
+    });
+
     testWithoutContext('fails when codesign fails', () async {
       binary.createSync(recursive: true);
 
@@ -644,6 +701,7 @@ void main() {
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
         bitcodeStripCommand,
+        xattrRemoveCommand,
         FakeCommand(command: <String>[
           'codesign',
           '--force',
@@ -688,6 +746,7 @@ void main() {
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
         bitcodeStripCommand,
+        xattrRemoveCommand,
         FakeCommand(command: <String>[
           'codesign',
           '--force',


### PR DESCRIPTION
Remove the `com.apple.FinderInfo` extended attributes from frameworks copied into the app before it is codesigned.

Similar to https://github.com/flutter/flutter/pull/54488
Fixes https://github.com/flutter/flutter/issues/80978