### PR TITLE
Mark dart_plugin_registry_test not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -922,7 +922,7 @@
       "name": "Mac dart_plugin_registry_test",
       "repo": "flutter",
       "task_name": "dart_plugin_registry_test",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac tool_tests_general",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -542,7 +542,7 @@
       "name": "Mac dart_plugin_registry_test",
       "repo": "flutter",
       "task_name": "dart_plugin_registry_test",
-      "enabled": false,
+      "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },
     {


### PR DESCRIPTION
`dart_plugin_registry_test` is passing on https://github.com/flutter/flutter/pull/79669.