### PR TITLE
Fixed ProgressIndicatorTheme.wrap()

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator_theme.dart
+++ b/packages/flutter/lib/src/material/progress_indicator_theme.dart
@@ -177,8 +177,7 @@ class ProgressIndicatorTheme extends InheritedTheme {
 
   @override
   Widget wrap(BuildContext context, Widget child) {
-    final ProgressIndicatorTheme? ancestorTheme = context.findAncestorWidgetOfExactType<ProgressIndicatorTheme>();
-    return identical(this, ancestorTheme) ? child : ProgressIndicatorTheme(data: data, child: child);
+    return ProgressIndicatorTheme(data: data, child: child);
   }
 
   @override

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -825,4 +825,35 @@ void main() {
       TargetPlatform.linux,
     }),
   );
+
+  testWidgets('ProgressIndicatorTheme.wrap() always creates a new ProgressIndicatorTheme', (WidgetTester tester) async {
+
+    late BuildContext builderContext;
+
+    const ProgressIndicatorThemeData themeData = ProgressIndicatorThemeData(
+      color: Color(0xFFFF0000),
+      linearTrackColor: Color(0xFF00FF00),
+    );
+
+    final ProgressIndicatorTheme progressTheme = ProgressIndicatorTheme(
+      data: themeData,
+      child: Builder(
+        builder: (BuildContext context) {
+          builderContext = context;
+          return const LinearProgressIndicator(value: 0.5);
+        }
+      ),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: progressTheme,
+    ));
+    final Widget wrappedTheme = progressTheme.wrap(builderContext, Container());
+
+    // Make sure the returned widget is a new ProgressIndicatorTheme instance
+    // with the same theme data as the original.
+    expect(wrappedTheme, isNot(equals(progressTheme)));
+    expect(wrappedTheme, isInstanceOf<ProgressIndicatorTheme>());
+    expect((wrappedTheme as ProgressIndicatorTheme).data, themeData);
+  });
 }


### PR DESCRIPTION
The current implementation of `ProgressInidcatorTheme.wrap()` doesn't follow the current pattern for themes. It should just return a new instance of the theme wrapping the given child. This was missed in the review of #81075. This PR makes it  behave like the other themes.

There was a new test added to ensure this is working as desired.

Fixes: #81249

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
