### PR TITLE
[flutter_tools] Show linux distribution and kernel release in `flutter doctor`

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -35,6 +35,13 @@ abstract class OperatingSystemUtils {
         platform: platform,
         processManager: processManager,
       );
+    } else if (platform.isLinux) {
+      return _LinuxUtils(
+        fileSystem: fileSystem,
+        logger: logger,
+        platform: platform,
+        processManager: processManager,
+      );
     } else {
       return _PosixUtils(
         fileSystem: fileSystem,
@@ -280,6 +287,60 @@ class _PosixUtils extends OperatingSystemUtils {
       }
     }
     return _hostPlatform!;
+  }
+}
+
+class _LinuxUtils extends _PosixUtils {
+  _LinuxUtils({
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
+  }) : super(
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        );
+
+  String? _name;
+
+  @override
+  String get name {
+    if (_name == null) {
+      const String prettyNameKey = 'PRETTY_NAME';
+      final String osReleasePath = _fileSystem.file('/etc/os-release').existsSync()
+        ? '/etc/os-release'
+        : '/usr/lib/os-release';
+      try {
+        final String osRelease = _fileSystem.file(osReleasePath).readAsStringSync();
+        final String prettyName = _getOsReleaseValueForKey(osRelease, prettyNameKey);
+        final String kernelRelease = _platform.operatingSystemVersion.split(' ')[1];
+        _name = '$prettyName$kernelRelease';
+      } on Exception catch (e) {
+        _logger.printTrace('Failed obtaining name for Linux: $e');
+      }
+      _name ??= super.name;
+    }
+    return _name!;
+  }
+
+  String _getOsReleaseValueForKey(String osRelease, String key) {
+    final List<String> osReleaseSplitted = osRelease.split('\n');
+    for (String entry in osReleaseSplitted) {
+      entry = entry.trim();
+      final List<String> entryKeyValuePair = entry.split('=');
+      if(entryKeyValuePair[0] == key) {
+        final String value =  entryKeyValuePair[1];
+        final String quote = value[0];
+        if (quote == '\'' || quote == '"') {
+          return '${value.substring(0, value.length - 1).substring(1)} ';
+        } else {
+          return '$value ';
+        }
+      }
+    }
+    return '';
   }
 }
 

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -326,7 +326,7 @@ class _LinuxUtils extends _PosixUtils {
         // Split the operating system version which should be formatted as
         // "Linux kernelRelease build", by spaces.
         final List<String> osVersionSplitted = _platform.operatingSystemVersion.split(' ');
-        if (osVersionSplitted.length < 2) {
+        if (osVersionSplitted.length < 3) {
           // The operating system version didn't have the expected format.
           // Initialize as an empty string.
           kernelRelease = '';

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -426,7 +426,7 @@ void main() {
       expect(utils.name, 'Pretty Name 1.2.3-abcd');
     });
 
-    testWithoutContext('Linux name when "/etc/os-release" is missing', () async {
+    testWithoutContext('Linux name reads from "/usr/lib/os-release" if "/etc/os-release" is missing', () async {
       const String fakeOsRelease = '''
       NAME="Name"
       ID=id
@@ -441,8 +441,7 @@ void main() {
       LOGO=logo
       ''';
       final FileSystem fileSystem = MemoryFileSystem.test();
-      fileSystem.directory('/usr').createSync();
-      fileSystem.directory('/usr/lib').createSync();
+      fileSystem.directory('/usr/lib').createSync(recursive: true);
       fileSystem.file('/usr/lib/os-release').writeAsStringSync(fakeOsRelease);
 
       expect(fileSystem.file('/etc/os-release').existsSync(), false);
@@ -457,6 +456,54 @@ void main() {
         processManager: fakeProcessManager,
       );
       expect(utils.name, 'Pretty Name 1.2.3-abcd');
+    });
+
+    testWithoutContext('Linux name when reading "/etc/os-release" fails', () async {
+      final FileExceptionHandler handler = FileExceptionHandler();
+      final FileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);
+
+      fileSystem.directory('/etc').createSync();
+      final File osRelease = fileSystem.file('/etc/os-release');
+
+      handler.addError(osRelease, FileSystemOp.read, const FileSystemException());
+
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+          operatingSystemVersion: 'Linux 1.2.3-abcd #1 SMP PREEMPT Sat Jan 1 00:00:00 UTC 2000',
+        ),
+        processManager: fakeProcessManager,
+      );
+      expect(utils.name, 'Linux 1.2.3-abcd');
+    });
+
+    testWithoutContext('Linux name omits kernel release if undefined', () async {
+      const String fakeOsRelease = '''
+      NAME="Name"
+      ID=id
+      ID_LIKE=id_like
+      BUILD_ID=build_id
+      PRETTY_NAME="Pretty Name"
+      ANSI_COLOR="ansi color"
+      HOME_URL="https://home.url/"
+      DOCUMENTATION_URL="https://documentation.url/"
+      SUPPORT_URL="https://support.url/"
+      BUG_REPORT_URL="https://bug.report.url/"
+      LOGO=logo
+      ''';
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fileSystem.directory('/etc').createSync();
+      fileSystem.file('/etc/os-release').writeAsStringSync(fakeOsRelease);
+
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'linux'),
+        processManager: fakeProcessManager,
+      );
+      expect(utils.name, 'Pretty Name');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -500,7 +500,10 @@ void main() {
       final OperatingSystemUtils utils = OperatingSystemUtils(
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
-        platform: FakePlatform(operatingSystem: 'linux'),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+          operatingSystemVersion: 'undefinedOperatingSystemVersion',
+        ),
         processManager: fakeProcessManager,
       );
       expect(utils.name, 'Pretty Name');

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -380,6 +380,84 @@ void main() {
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
       expect(utils.name, 'product version build darwin-x64');
     });
+
+    testWithoutContext('Windows name', () async {
+      fakeProcessManager.addCommands(<FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'ver',
+          ],
+          stdout: 'version',
+        ),
+      ]);
+
+      final OperatingSystemUtils utils =
+          createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      expect(utils.name, 'version');
+    });
+
+    testWithoutContext('Linux name', () async {
+      const String fakeOsRelease = '''
+      NAME="Name"
+      ID=id
+      ID_LIKE=id_like
+      BUILD_ID=build_id
+      PRETTY_NAME="Pretty Name"
+      ANSI_COLOR="ansi color"
+      HOME_URL="https://home.url/"
+      DOCUMENTATION_URL="https://documentation.url/"
+      SUPPORT_URL="https://support.url/"
+      BUG_REPORT_URL="https://bug.report.url/"
+      LOGO=logo
+      ''';
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fileSystem.directory('/etc').createSync();
+      fileSystem.file('/etc/os-release').writeAsStringSync(fakeOsRelease);
+
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+          operatingSystemVersion: 'Linux 1.2.3-abcd #1 SMP PREEMPT Sat Jan 1 00:00:00 UTC 2000',
+        ),
+        processManager: fakeProcessManager,
+      );
+      expect(utils.name, 'Pretty Name 1.2.3-abcd');
+    });
+
+    testWithoutContext('Linux name when "/etc/os-release" is missing', () async {
+      const String fakeOsRelease = '''
+      NAME="Name"
+      ID=id
+      ID_LIKE=id_like
+      BUILD_ID=build_id
+      PRETTY_NAME="Pretty Name"
+      ANSI_COLOR="ansi color"
+      HOME_URL="https://home.url/"
+      DOCUMENTATION_URL="https://documentation.url/"
+      SUPPORT_URL="https://support.url/"
+      BUG_REPORT_URL="https://bug.report.url/"
+      LOGO=logo
+      ''';
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fileSystem.directory('/usr').createSync();
+      fileSystem.directory('/usr/lib').createSync();
+      fileSystem.file('/usr/lib/os-release').writeAsStringSync(fakeOsRelease);
+
+      expect(fileSystem.file('/etc/os-release').existsSync(), false);
+
+      final OperatingSystemUtils utils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(
+          operatingSystem: 'linux',
+          operatingSystemVersion: 'Linux 1.2.3-abcd #1 SMP PREEMPT Sat Jan 1 00:00:00 UTC 2000',
+        ),
+        processManager: fakeProcessManager,
+      );
+      expect(utils.name, 'Pretty Name 1.2.3-abcd');
+    });
   });
 
   testWithoutContext('If unzip fails, include stderr in exception text', () {


### PR DESCRIPTION
Replaces the name `Linux` for Linux host platform/device with `PRETTY_NAME` in either `/etc/os-release` or `/usr/lib/os-release`, whichever exists first, and the kernel release from `Platform`.

```sh
[✓] Flutter (Channel linux_version, 2.3.0-1.0.pre.145, on Manjaro Linux 5.11.14-1-MANJARO, locale en_IN.UTF-8)
    • Flutter version 2.3.0-1.0.pre.145 at /mnt/D/Git/flutter
    • Upstream repository git@github.com:RoyARG02/flutter.git
...
[✓] Connected device (2 available)
    • Linux (desktop) • linux  • linux-x64      • Manjaro Linux 5.11.14-1-MANJARO
    • Chrome (web)    • chrome • web-javascript • Chromium 90.0.4430.85 Manjaro Linux

• No issues found!
```

Creates `_LinuxUtils` to override the name from `_PosixUtils`.

Fixes #50575.
Fixes #65095.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
