### PR TITLE
Reoderable drag start listener/draggable parameter

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1005,6 +1005,7 @@ class ReorderableDragStartListener extends StatelessWidget {
     Key? key,
     required this.child,
     required this.index,
+    this.draggable = true,
   }) : super(key: key);
 
   /// The widget for which the application would like to respond to a tap and
@@ -1014,10 +1015,13 @@ class ReorderableDragStartListener extends StatelessWidget {
   /// The index of the associated item that will be dragged in the list.
   final int index;
 
+  /// Whether the associated item can be dragged in the list
+  final bool draggable;
+
   @override
   Widget build(BuildContext context) {
     return Listener(
-      onPointerDown: (PointerDownEvent event) => _startDragging(context, event),
+      onPointerDown: draggable ? (PointerDownEvent event) => _startDragging(context, event) : null,
       child: child,
     );
   }

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -267,6 +267,103 @@ void main() {
     await tester.pumpAndSettle();
     expect(getItemFadeTransition(), findsNothing);
   });
+
+  group('$ReorderableDragStartListener', () {
+    testWidgets('It should allow the item to be dragged when draggable is true', (WidgetTester tester) async {
+      const int itemCount = 5;
+      int onReorderCallCount = 0;
+      final List<int> items = List<int>.generate(itemCount, (int index) => index);
+
+      void handleReorder(int fromIndex, int toIndex) {
+        onReorderCallCount++;
+        if (toIndex > fromIndex) {
+          toIndex -= 1;
+        }
+        items.insert(toIndex, items.removeAt(fromIndex));
+      }
+      // The list has five elements of height 100
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReorderableListView.builder(
+            itemCount: itemCount,
+            itemBuilder: (_, int index) {
+              return SizedBox(
+                key: ValueKey<int>(items[index]),
+                height: 100,
+                child: ReorderableDragStartListener(
+                  child: Text('item ${items[index]}'),
+                  index: index,
+                ),
+              );
+            },
+            onReorder: handleReorder,
+            buildDefaultDragHandles: false,
+          ),
+        ),
+      );
+
+      // Start gesture on first item
+      final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('item 0')));
+      await tester.pump(kPressTimeout);
+
+      // Drag enough to move down the first item
+      await drag.moveBy(const Offset(0, 150));
+      await tester.pump();
+      await drag.up();
+      await tester.pumpAndSettle();
+
+      expect(onReorderCallCount, 1);
+      expect(items, orderedEquals(<int>[1, 0, 2, 3, 4]));
+    });
+
+    testWidgets('It should allow the item to be dragged when draggable is true', (WidgetTester tester) async {
+      const int itemCount = 5;
+      int onReorderCallCount = 0;
+      final List<int> items = List<int>.generate(itemCount, (int index) => index);
+
+      void handleReorder(int fromIndex, int toIndex) {
+        onReorderCallCount++;
+        if (toIndex > fromIndex) {
+          toIndex -= 1;
+        }
+        items.insert(toIndex, items.removeAt(fromIndex));
+      }
+      // The list has five elements of height 100
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReorderableListView.builder(
+            itemCount: itemCount,
+            itemBuilder: (_, int index) {
+              return SizedBox(
+                key: ValueKey<int>(items[index]),
+                height: 100,
+                child: ReorderableDragStartListener(
+                  child: Text('item ${items[index]}'),
+                  index: index,
+                  draggable: false,
+                ),
+              );
+            },
+            onReorder: handleReorder,
+            buildDefaultDragHandles: false,
+          ),
+        ),
+      );
+
+      // Start gesture on first item
+      final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('item 0')));
+      await tester.pump(kPressTimeout);
+
+      // Drag enough to move down the first item
+      await drag.moveBy(const Offset(0, 150));
+      await tester.pump();
+      await drag.up();
+      await tester.pumpAndSettle();
+
+      expect(onReorderCallCount, 0);
+      expect(items, orderedEquals(<int>[0, 1, 2, 3, 4]));
+    });
+  });
 }
 
 class TestList extends StatefulWidget {

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -275,7 +275,7 @@ void main() {
       final List<int> items = List<int>.generate(itemCount, (int index) => index);
 
       void handleReorder(int fromIndex, int toIndex) {
-        onReorderCallCount++;
+        onReorderCallCount += 1;
         if (toIndex > fromIndex) {
           toIndex -= 1;
         }
@@ -322,7 +322,7 @@ void main() {
       final List<int> items = List<int>.generate(itemCount, (int index) => index);
 
       void handleReorder(int fromIndex, int toIndex) {
-        onReorderCallCount++;
+        onReorderCallCount += 1;
         if (toIndex > fromIndex) {
           toIndex -= 1;
         }


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
