### PR TITLE
Added arrowHeadColor property to PaginatedDataTable

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -84,6 +84,7 @@ class PaginatedDataTable extends StatefulWidget {
     this.availableRowsPerPage = const <int>[defaultRowsPerPage, defaultRowsPerPage * 2, defaultRowsPerPage * 5, defaultRowsPerPage * 10],
     this.onRowsPerPageChanged,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.arrowHeadColor,
     required this.source,
     this.checkboxHorizontalMargin,
   }) : assert(actions == null || (actions != null && header != null)),
@@ -234,6 +235,9 @@ class PaginatedDataTable extends StatefulWidget {
   /// of the table and the checkbox, as well as the margin between the checkbox
   /// and the content in the first data column. This value defaults to 24.0.
   final double? checkboxHorizontalMargin;
+
+  /// Defines the color of the arrow heads in the footer.
+  final Color? arrowHeadColor;
 
   @override
   PaginatedDataTableState createState() => PaginatedDataTableState();
@@ -442,27 +446,27 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
       Container(width: 32.0),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: const Icon(Icons.skip_previous),
+          icon: Icon(Icons.skip_previous, color: widget.arrowHeadColor),
           padding: EdgeInsets.zero,
           tooltip: localizations.firstPageTooltip,
           onPressed: _firstRowIndex <= 0 ? null : _handleFirst,
         ),
       IconButton(
-        icon: const Icon(Icons.chevron_left),
+        icon: Icon(Icons.chevron_left, color: widget.arrowHeadColor),
         padding: EdgeInsets.zero,
         tooltip: localizations.previousPageTooltip,
         onPressed: _firstRowIndex <= 0 ? null : _handlePrevious,
       ),
       Container(width: 24.0),
       IconButton(
-        icon: const Icon(Icons.chevron_right),
+        icon: Icon(Icons.chevron_right, color: widget.arrowHeadColor),
         padding: EdgeInsets.zero,
         tooltip: localizations.nextPageTooltip,
         onPressed: _isNextPageUnavailable() ? null : _handleNext,
       ),
       if (widget.showFirstLastButtons)
         IconButton(
-          icon: const Icon(Icons.skip_next),
+          icon: Icon(Icons.skip_next, color: widget.arrowHeadColor),
           padding: EdgeInsets.zero,
           tooltip: localizations.lastPageTooltip,
           onPressed: _isNextPageUnavailable()

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -974,4 +974,32 @@ void main() {
 
     await binding.setSurfaceSize(null);
   });
+
+  testWidgets('PaginatedDataTable arrowHeadColor set properly', (WidgetTester tester) async {
+    await binding.setSurfaceSize(const Size(800, 800));
+    const Color arrowHeadColor = Color(0xFFE53935);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PaginatedDataTable(
+          arrowHeadColor: arrowHeadColor,
+          showFirstLastButtons: true,
+          header: const Text('Test table'),
+          source: TestDataSource(),
+          columns: const <DataColumn>[
+            DataColumn(label: Text('Name')),
+            DataColumn(label: Text('Calories'), numeric: true),
+            DataColumn(label: Text('Generation')),
+          ],
+        ),
+      )
+    );
+
+    final Iterable<Icon> icons = tester.widgetList(find.byType(Icon));
+
+    expect(icons.elementAt(0).color, arrowHeadColor);
+    expect(icons.elementAt(1).color, arrowHeadColor);
+    expect(icons.elementAt(2).color, arrowHeadColor);
+    expect(icons.elementAt(3).color, arrowHeadColor);
+  });
 }


### PR DESCRIPTION
Adds arrowHeadColor property to PaginatedDataTable to change color of arrowheads in the footer.

Fixes: #81269 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

