### PR TITLE
Add a fifth tool_integration_tests shard on Windows

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1297,27 +1297,33 @@
       "flaky": false
     },
     {
-      "name": "Windows tool_integration_tests_1_4",
+      "name": "Windows tool_integration_tests_1_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_1_4",
+      "task_name": "win_tool_integration_tests_1_5",
       "flaky": false
     },
     {
-      "name": "Windows tool_integration_tests_2_4",
+      "name": "Windows tool_integration_tests_2_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_2_4",
+      "task_name": "win_tool_integration_tests_2_5",
       "flaky": false
     },
     {
-      "name": "Windows tool_integration_tests_3_4",
+      "name": "Windows tool_integration_tests_3_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_3_4",
+      "task_name": "win_tool_integration_tests_3_5",
       "flaky": false
     },
     {
-      "name": "Windows tool_integration_tests_4_4",
+      "name": "Windows tool_integration_tests_4_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_4_4",
+      "task_name": "win_tool_integration_tests_4_5",
+      "flaky": false
+    },
+    {
+      "name": "Windows tool_integration_tests_5_5",
+      "repo": "flutter",
+      "task_name": "win_tool_integration_tests_5_5",
       "flaky": false
     },
     {

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -736,30 +736,37 @@
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },
     {
-      "name": "Windows tool_integration_tests_1_4",
+      "name": "Windows tool_integration_tests_1_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_1_4",
+      "task_name": "win_tool_integration_tests_1_5",
       "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },
     {
-      "name": "Windows tool_integration_tests_2_4",
+      "name": "Windows tool_integration_tests_2_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_2_4",
+      "task_name": "win_tool_integration_tests_2_5",
       "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },
     {
-      "name": "Windows tool_integration_tests_3_4",
+      "name": "Windows tool_integration_tests_3_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_3_4",
+      "task_name": "win_tool_integration_tests_3_5",
       "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },
     {
-      "name": "Windows tool_integration_tests_4_4",
+      "name": "Windows tool_integration_tests_4_5",
       "repo": "flutter",
-      "task_name": "win_tool_integration_tests_4_4",
+      "task_name": "win_tool_integration_tests_4_5",
+      "enabled": true,
+      "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
+    },
+    {
+      "name": "Windows tool_integration_tests_5_5",
+      "repo": "flutter",
+      "task_name": "win_tool_integration_tests_5_5",
       "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },


### PR DESCRIPTION
Requires https://github.com/flutter/infra/pull/425 to be submitted first.

The longest Windows tool_integration_tests shard is timing out:
https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20tool_integration_tests_1_4/172/overview
https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20tool_integration_tests_1_4/173/overview

Adding another shard...