### PR TITLE
Remove extended attributes from entire Flutter project

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -626,20 +626,7 @@ void _signFramework(Environment environment, String binaryPath, BuildMode buildM
   if (codesignIdentity == null || codesignIdentity.isEmpty) {
     return;
   }
-
-  // Extended attributes applied by Finder can cause code signing errors. Remove them.
-  // https://developer.apple.com/library/archive/qa/qa1940/_index.html
-  final ProcessResult xattrResult = environment.processManager.runSync(<String>[
-    'xattr',
-    '-r',
-    '-d',
-    'com.apple.FinderInfo',
-    binaryPath,
-  ]);
-  if (xattrResult.exitCode != 0) {
-    environment.logger.printTrace('Failed to remove FinderInfo extended attributes from $binaryPath.\n${xattrResult.stderr}');
-  }
-  final ProcessResult codesignResult = environment.processManager.runSync(<String>[
+  final ProcessResult result = environment.processManager.runSync(<String>[
     'codesign',
     '--force',
     '--sign',
@@ -650,7 +637,7 @@ void _signFramework(Environment environment, String binaryPath, BuildMode buildM
     ],
     binaryPath,
   ]);
-  if (codesignResult.exitCode != 0) {
-    throw Exception('Failed to codesign $binaryPath with identity $codesignIdentity.\n${codesignResult.stderr}');
+  if (result.exitCode != 0) {
+    throw Exception('Failed to codesign $binaryPath with identity $codesignIdentity.\n${result.stderr}');
   }
 }

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -122,7 +122,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     return XcodeBuildResult(success: false);
   }
 
-  await removeFinderExtendedAttributes(app.project.hostAppRoot, globals.processUtils, globals.logger);
+  await removeFinderExtendedAttributes(app.project.parent.directory, globals.processUtils, globals.logger);
 
   final XcodeProjectInfo projectInfo = await app.project.projectInfo();
   final String scheme = projectInfo.schemeFor(buildInfo);
@@ -445,19 +445,19 @@ Future<XcodeBuildResult> buildXcodeProject({
 /// Extended attributes applied by Finder can cause code signing errors. Remove them.
 /// https://developer.apple.com/library/archive/qa/qa1940/_index.html
 @visibleForTesting
-Future<void> removeFinderExtendedAttributes(Directory iosProjectDirectory, ProcessUtils processUtils, Logger logger) async {
+Future<void> removeFinderExtendedAttributes(Directory projectDirectory, ProcessUtils processUtils, Logger logger) async {
   final bool success = await processUtils.exitsHappy(
     <String>[
       'xattr',
       '-r',
       '-d',
       'com.apple.FinderInfo',
-      iosProjectDirectory.path,
+      projectDirectory.path,
     ]
   );
   // Ignore all errors, for example if directory is missing.
   if (!success) {
-    logger.printTrace('Failed to remove xattr com.apple.FinderInfo from ${iosProjectDirectory.path}');
+    logger.printTrace('Failed to remove xattr com.apple.FinderInfo from ${projectDirectory.path}');
   }
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -77,7 +77,7 @@ void main() {
   }
 
   const FakeCommand xattrCommand = FakeCommand(command: <String>[
-    'xattr', '-r', '-d', 'com.apple.FinderInfo', '/ios'
+    'xattr', '-r', '-d', 'com.apple.FinderInfo', '/'
   ]);
 
   FakeCommand _setUpRsyncCommand({void Function() onRun}) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -76,7 +76,7 @@ void main() {
   }
 
   const FakeCommand xattrCommand = FakeCommand(command: <String>[
-    'xattr', '-r', '-d', 'com.apple.FinderInfo', '/ios'
+    'xattr', '-r', '-d', 'com.apple.FinderInfo', '/'
   ]);
 
   // Creates a FakeCommand for the xcodebuild call to build the app

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -138,14 +138,7 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(command: <String>[
-        'xattr',
-        '-r',
-        '-d',
-        'com.apple.FinderInfo',
-        frameworkDirectoryBinary.path,
-      ]),
+    processManager.addCommand(
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -154,7 +147,7 @@ void main() {
         '--timestamp=none',
         frameworkDirectoryBinary.path,
       ]),
-    ]);
+    );
 
     await const DebugIosApplicationBundle().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);
@@ -191,14 +184,7 @@ void main() {
 
     final Directory frameworkDirectory = environment.outputDir.childDirectory('App.framework');
     final File frameworkDirectoryBinary = frameworkDirectory.childFile('App');
-    processManager.addCommands(<FakeCommand>[
-      FakeCommand(command: <String>[
-        'xattr',
-        '-r',
-        '-d',
-        'com.apple.FinderInfo',
-        frameworkDirectoryBinary.path,
-      ]),
+    processManager.addCommand(
       FakeCommand(command: <String>[
         'codesign',
         '--force',
@@ -206,7 +192,7 @@ void main() {
         'ABC123',
         frameworkDirectoryBinary.path,
       ]),
-    ]);
+    );
 
     await const ReleaseIosApplicationBundle().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);
@@ -291,7 +277,6 @@ void main() {
     FakeCommand lipoCommandNonFatResult;
     FakeCommand lipoVerifyArm64Command;
     FakeCommand bitcodeStripCommand;
-    FakeCommand xattrRemoveCommand;
 
     setUp(() {
       final FileSystem fileSystem = MemoryFileSystem.test();
@@ -326,14 +311,6 @@ void main() {
         binary.path,
         '-m',
         '-o',
-        binary.path,
-      ]);
-
-      xattrRemoveCommand = FakeCommand(command: <String>[
-        'xattr',
-        '-r',
-        '-d',
-        'com.apple.FinderInfo',
         binary.path,
       ]);
     });
@@ -644,54 +621,6 @@ void main() {
       expect(processManager.hasRemainingExpectations, isFalse);
     });
 
-    testWithoutContext('logs when extended attribute fails', () async {
-      binary.createSync(recursive: true);
-
-      final Environment environment = Environment.test(
-        fileSystem.currentDirectory,
-        processManager: processManager,
-        artifacts: artifacts,
-        logger: logger,
-        fileSystem: fileSystem,
-        outputDir: outputDir,
-        defines: <String, String>{
-          kIosArchs: 'arm64',
-          kSdkRoot: 'path/to/iPhoneOS.sdk',
-          kBitcodeFlag: '',
-          kCodesignIdentity: 'ABC123',
-        },
-      );
-
-      processManager.addCommands(<FakeCommand>[
-        copyPhysicalFrameworkCommand,
-        lipoCommandNonFatResult,
-        lipoVerifyArm64Command,
-        bitcodeStripCommand,
-        FakeCommand(
-          command: <String>[
-            'xattr',
-            '-r',
-            '-d',
-            'com.apple.FinderInfo',
-            binary.path,
-          ],
-          exitCode: 1,
-          stderr: 'Failed to remove extended attributes',
-        ),
-        FakeCommand(command: <String>[
-          'codesign',
-          '--force',
-          '--sign',
-          'ABC123',
-          '--timestamp=none',
-          binary.path,
-        ]),
-      ]);
-
-      await const DebugUnpackIOS().build(environment);
-      expect(logger.traceText, contains('Failed to remove extended attributes'));
-    });
-
     testWithoutContext('fails when codesign fails', () async {
       binary.createSync(recursive: true);
 
@@ -715,7 +644,6 @@ void main() {
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
         bitcodeStripCommand,
-        xattrRemoveCommand,
         FakeCommand(command: <String>[
           'codesign',
           '--force',
@@ -760,7 +688,6 @@ void main() {
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
         bitcodeStripCommand,
-        xattrRemoveCommand,
         FakeCommand(command: <String>[
           'codesign',
           '--force',

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -37,7 +37,7 @@ List<String> _xattrArgs(FlutterProject flutterProject) {
     '-r',
     '-d',
     'com.apple.FinderInfo',
-    flutterProject.ios.hostAppRoot.path,
+    flutterProject.directory.path,
   ];
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -445,10 +445,10 @@ Exited (sigterm)''',
   });
 
   group('remove Finder extended attributes', () {
-    Directory iosProjectDirectory;
+    Directory projectDirectory;
     setUp(() {
       final MemoryFileSystem fs = MemoryFileSystem.test();
-      iosProjectDirectory = fs.directory('ios');
+      projectDirectory = fs.directory('flutter_project');
     });
 
     testWithoutContext('removes xattr', () async {
@@ -458,11 +458,11 @@ Exited (sigterm)''',
           '-r',
           '-d',
           'com.apple.FinderInfo',
-          iosProjectDirectory.path,
+          projectDirectory.path,
         ])
       ]);
 
-      await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
+      await removeFinderExtendedAttributes(projectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
       expect(processManager, hasNoRemainingExpectations);
     });
 
@@ -473,12 +473,12 @@ Exited (sigterm)''',
           '-r',
           '-d',
           'com.apple.FinderInfo',
-          iosProjectDirectory.path,
+          projectDirectory.path,
         ], exitCode: 1,
         )
       ]);
 
-      await removeFinderExtendedAttributes(iosProjectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
+      await removeFinderExtendedAttributes(projectDirectory, ProcessUtils(processManager: processManager, logger: logger), logger);
       expect(logger.traceText, contains('Failed to remove xattr com.apple.FinderInfo'));
       expect(processManager, hasNoRemainingExpectations);
     });


### PR DESCRIPTION
Revert https://github.com/flutter/flutter/pull/81342, users reported that didn't fix https://github.com/flutter/flutter/issues/80978.

Instead of just removing the Finder extended attributes from the `ios` directory, do it for the entire Flutter project directory since users are reporting this is related to images in an asset directory in the root of their project.

Fixes https://github.com/flutter/flutter/issues/80978