### PR TITLE
Ignore the sort order of imports in generated_plugin_registrant.dart

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -520,6 +520,7 @@ const String _dartPluginRegistryTemplate = '''
 // Generated file. Do not edit.
 //
 
+// ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
 
 {{#plugins}}


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/58380