### PR TITLE
Revert "[flutter_tools] remove mocks, globals from golden comparator and test runner tests"

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -12,7 +12,6 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:pool/pool.dart';
-import 'package:process/process.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_static/shelf_static.dart';
@@ -52,7 +51,6 @@ class FlutterWebPlatform extends PlatformPlugin {
     @required ChromiumLauncher chromiumLauncher,
     @required Logger logger,
     @required Artifacts artifacts,
-    @required ProcessManager processManager,
   }) : _fileSystem = fileSystem,
       _flutterToolPackageConfig = flutterToolPackageConfig,
       _chromiumLauncher = chromiumLauncher,
@@ -77,9 +75,6 @@ class FlutterWebPlatform extends PlatformPlugin {
     _testGoldenComparator = TestGoldenComparator(
       shellPath,
       () => TestCompiler(buildInfo, flutterProject),
-      fileSystem: _fileSystem,
-      logger: _logger,
-      processManager: processManager,
     );
   }
 
@@ -116,7 +111,6 @@ class FlutterWebPlatform extends PlatformPlugin {
     @required Logger logger,
     @required ChromiumLauncher chromiumLauncher,
     @required Artifacts artifacts,
-    @required ProcessManager processManager,
   }) async {
     final shelf_io.IOServer server = shelf_io.IOServer(await HttpMultiServer.loopback(0));
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(
@@ -144,7 +138,6 @@ class FlutterWebPlatform extends PlatformPlugin {
       artifacts: artifacts,
       logger: logger,
       nullAssertions: nullAssertions,
-      processManager: processManager,
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -168,7 +168,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
             logger: globals.logger,
             fileSystem: globals.fs,
             artifacts: globals.artifacts,
-            processManager: globals.processManager,
             chromiumLauncher: ChromiumLauncher(
               fileSystem: globals.fs,
               platform: globals.platform,

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -17,8 +17,8 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/test/flutter_tester_device.dart';
 import 'package:flutter_tools/src/test/font_config_manager.dart';
 import 'package:meta/meta.dart';
+import 'package:mockito/mockito.dart';
 import 'package:stream_channel/stream_channel.dart';
-import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
@@ -80,7 +80,7 @@ void main() {
       ], environment: <String, String>{
         'FLUTTER_TEST': expectedFlutterTestValue,
         'FONTCONFIG_FILE': device.fontConfigManager.fontConfigFile.path,
-        'SERVER_PORT': '0',
+        'SERVER_PORT': 'null',
         'APP_NAME': '',
       });
     }
@@ -244,28 +244,17 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
   @override
   Future<DartDevelopmentService> startDds(Uri uri) async {
     _ddsServiceUriCompleter.complete(uri);
-    return FakeDartDevelopmentService(Uri.parse('http://localhost:${debuggingOptions.hostVmServicePort}'), Uri.parse('http://localhost:8080'));
+    final MockDartDevelopmentService mock = MockDartDevelopmentService();
+    when(mock.uri).thenReturn(Uri.parse('http://localhost:${debuggingOptions.hostVmServicePort}'));
+    return mock;
   }
 
   @override
-  Future<HttpServer> bind(InternetAddress host, int port) async => FakeHttpServer();
+  Future<HttpServer> bind(InternetAddress host, int port) async => MockHttpServer();
 
   @override
   Future<StreamChannel<String>> get remoteChannel async => StreamChannelController<String>().foreign;
 }
 
-class FakeDartDevelopmentService extends Fake implements DartDevelopmentService {
-  FakeDartDevelopmentService(this.uri, this.original);
-
-  final Uri original;
-
-  @override
-  final Uri uri;
-
-  @override
-  Uri get remoteVmServiceUri => original;
-}
-class FakeHttpServer extends Fake implements HttpServer {
-  @override
-  int get port => 0;
-}
+class MockDartDevelopmentService extends Mock implements DartDevelopmentService {}
+class MockHttpServer extends Mock implements HttpServer {}


### PR DESCRIPTION
Reverts flutter/flutter#81423

`test\integration.shard\overall_experience_test.dart: flutter error messages include a DevTools link` started failing on windows with this commit. Reverting to see if it fixes things.

https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20tool_integration_tests_4_5/21/overview