### PR TITLE
Add additional logging when devtools cannot launch

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -74,7 +74,9 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
           offline = true;
         }
       } on Exception catch (e) {
-        _logger.printTrace('Skipping devtools launch because connecting to pub.dev failed: $e');
+        _logger.printTrace(
+          'Skipping devtools launch because connecting to pub.dev failed with $e',
+        );
         offline = true;
       } on ArgumentError {
         if (!useOverrideUrl) {

--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -67,9 +67,14 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
         final io.HttpClientResponse response = await request.close();
         await response.drain<void>();
         if (response.statusCode != io.HttpStatus.ok) {
+          _logger.printTrace(
+            'Skipping devtools launch because pub.dev responded with HTTP '
+            'status code ${response.statusCode} instead of ${io.HttpStatus.ok}.',
+          );
           offline = true;
         }
-      } on Exception {
+      } on Exception catch (e) {
+        _logger.printTrace('Skipping devtools launch because connecting to pub.dev failed: $e');
         offline = true;
       } on ArgumentError {
         if (!useOverrideUrl) {

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -383,7 +383,7 @@ void main() {
 
     await launcher.launch(Uri.parse('http://127.0.0.1:1234/abcdefg'));
 
-    expect(logger.traceText, contains('Skipping devtools launch because connecting to pub.dev failed: Exception: Connection failed.'));
+    expect(logger.traceText, contains('Skipping devtools launch because connecting to pub.dev failed with Exception: Connection failed.'));
   });
 
   testWithoutContext('DevtoolsLauncher prints trace if connecting to pub.dev returns non-OK status code', () async {

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'dart:async';
+import 'dart:io' as io;
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -362,5 +363,49 @@ void main() {
     await launcher.launch(Uri.parse('http://127.0.0.1:1234/abcdefg'));
 
     expect(logger.errorText, contains('Failed to launch DevTools: ProcessException'));
+  });
+
+  testWithoutContext('DevtoolsLauncher prints trace if connecting to pub.dev throws', () async {
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: platform,
+      persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.list(<FakeRequest>[
+        FakeRequest(
+          Uri.https('pub.dev', ''),
+          method: HttpMethod.head,
+          responseError: Exception('Connection failed.'),
+        ),
+      ]),
+      processManager: FakeProcessManager.empty(),
+    );
+
+    await launcher.launch(Uri.parse('http://127.0.0.1:1234/abcdefg'));
+
+    expect(logger.traceText, contains('Skipping devtools launch because connecting to pub.dev failed: Exception: Connection failed.'));
+  });
+
+  testWithoutContext('DevtoolsLauncher prints trace if connecting to pub.dev returns non-OK status code', () async {
+    final DevtoolsLauncher launcher = DevtoolsServerLauncher(
+      pubExecutable: 'pub',
+      logger: logger,
+      platform: platform,
+      persistentToolState: persistentToolState,
+      httpClient: FakeHttpClient.list(<FakeRequest>[
+        FakeRequest(
+          Uri.https('pub.dev', ''),
+          method: HttpMethod.head,
+          response: const FakeResponse(
+            statusCode: io.HttpStatus.forbidden
+          ),
+        ),
+      ]),
+      processManager: FakeProcessManager.empty(),
+    );
+
+    await launcher.launch(Uri.parse('http://127.0.0.1:1234/abcdefg'));
+
+    expect(logger.traceText, contains('Skipping devtools launch because pub.dev responded with HTTP status code 403 instead of 200.'));
   });
 }

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -5,7 +5,6 @@
 // @dart = 2.8
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -397,7 +396,7 @@ void main() {
           Uri.https('pub.dev', ''),
           method: HttpMethod.head,
           response: const FakeResponse(
-            statusCode: io.HttpStatus.forbidden
+            statusCode: HttpStatus.forbidden
           ),
         ),
       ]),


### PR DESCRIPTION
Hopefully, these logs will help tracking down failures like https://github.com/flutter/flutter/issues/81486 quicker.