### PR TITLE
Revert "MouseRegion enter/exit event can be triggered with button pressed"

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -282,13 +282,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
         event is PointerAddedEvent ||
         event is PointerRemovedEvent) {
       assert(event.position != null);
-      _mouseTracker!.updateWithEvent(
-        event,
-        // Mouse events(enter and exit) can be triggered with or without buttons pressed.
-        // If the button is pressed, we need to re-execute the hit test instead of
-        // reusing the cached results to trigger possible events.
-        () => (hitTestResult == null || event.down) ? renderView.hitTestMouseTrackers(event.position) : hitTestResult,
-      );
+      _mouseTracker!.updateWithEvent(event, () => hitTestResult ?? renderView.hitTestMouseTrackers(event.position));
     }
     super.dispatchEvent(event, hitTestResult);
   }

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -76,42 +76,6 @@ class _HoverFeedbackState extends State<HoverFeedback> {
 }
 
 void main() {
-  testWidgets('onEnter and onExit can be triggered with mouse buttons pressed', (WidgetTester tester) async {
-    PointerEnterEvent? enter;
-    PointerExitEvent? exit;
-    await tester.pumpWidget(Center(
-      child: MouseRegion(
-        child: Container(
-          color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
-          width: 100.0,
-          height: 100.0,
-        ),
-        onEnter: (PointerEnterEvent details) => enter = details,
-        onExit: (PointerExitEvent details) => exit = details,
-      ),
-    ));
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, buttons: kPrimaryMouseButton);
-    await gesture.addPointer(location: Offset.zero);
-    await gesture.down(Offset.zero); // Press the mouse button.
-    addTearDown(gesture.removePointer);
-    await tester.pump();
-    enter = null;
-    exit = null;
-    // Trigger the enter event.
-    await gesture.moveTo(const Offset(400.0, 300.0));
-    expect(enter, isNotNull);
-    expect(enter!.position, equals(const Offset(400.0, 300.0)));
-    expect(enter!.localPosition, equals(const Offset(50.0, 50.0)));
-    expect(exit, isNull);
-
-    // Trigger the exit event.
-    await gesture.moveTo(const Offset(1.0, 1.0));
-    expect(exit, isNotNull);
-    expect(exit!.position, equals(const Offset(1.0, 1.0)));
-    expect(exit!.localPosition, equals(const Offset(-349.0, -249.0)));
-  });
-
   testWidgets('detects pointer enter', (WidgetTester tester) async {
     PointerEnterEvent? enter;
     PointerHoverEvent? move;


### PR DESCRIPTION
Reverts flutter/flutter#8114.

This PR has caused an internal breakage (internal issue b/186846732).