### PR TITLE
Minor cleanup to Linux application template format

### DIFF
--- a/packages/flutter_tools/templates/app/linux.tmpl/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/my_application.cc.tmpl
@@ -43,8 +43,7 @@ static void my_application_activate(GApplication* application) {
     gtk_header_bar_set_title(header_bar, "{{projectName}}");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  }
-  else {
+  } else {
     gtk_window_set_title(window, "{{projectName}}");
   }
 

--- a/packages/flutter_tools/templates/app/linux.tmpl/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/my_application.cc.tmpl
@@ -29,16 +29,16 @@ static void my_application_activate(GApplication* application) {
   // if future cases occur).
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
-  GdkScreen *screen = gtk_window_get_screen(window);
+  GdkScreen* screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
-     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-       use_header_bar = FALSE;
-     }
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
   }
 #endif
   if (use_header_bar) {
-    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "{{projectName}}");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
@@ -64,7 +64,7 @@ static void my_application_activate(GApplication* application) {
 }
 
 // Implements GApplication::local_command_line.
-static gboolean my_application_local_command_line(GApplication* application, gchar ***arguments, int *exit_status) {
+static gboolean my_application_local_command_line(GApplication* application, gchar*** arguments, int* exit_status) {
   MyApplication* self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
@@ -83,7 +83,7 @@ static gboolean my_application_local_command_line(GApplication* application, gch
 }
 
 // Implements GObject::dispose.
-static void my_application_dispose(GObject *object) {
+static void my_application_dispose(GObject* object) {
   MyApplication* self = MY_APPLICATION(object);
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);


### PR DESCRIPTION
There are a few formatting oddities in the Linux template:
- A block is indented three spaces instead of two.
- An `else` was on a new line instead of the previous line, which isn't our usual style.
- Pointer alignment (`Foo* foo` vs `Foo *foo`) is inconsistent.

The fixes all three (for the last, using `Foo* foo` as it's the dominant style for the template).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
