### PR TITLE
[flutter] reject mouse drags by default in scrollables

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,7 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     PointerDeviceKind? kind,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
-    this.enableMouseDrag = true,
+    this.supportedDevices = PointerDeviceKind.values,
   }) : assert(dragStartBehavior != null),
        super(debugOwner: debugOwner, kind: kind);
 
@@ -201,11 +201,10 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///    match the native behavior on that platform.
   GestureVelocityTrackerBuilder velocityTrackerBuilder;
 
-  /// Whether this gesture detector should accept pointers from a mouse device type.
+  /// The device types that this gesture recognizer will accept drags from.
   ///
-  /// This is used by scrollables to force mouse interactions to go through the
-  /// scroll wheel or scrollbar, instead of allowing drag gestures to move them.
-  final bool enableMouseDrag;
+  /// If not specified, defaults to all pointer kinds.
+  final List<PointerDeviceKind> supportedDevices;
 
   _DragState _state = _DragState.ready;
   late OffsetPair _initialPosition;
@@ -237,7 +236,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   bool isPointerAllowed(PointerEvent event) {
-    if (!enableMouseDrag && event.kind == PointerDeviceKind.mouse) {
+    if (!supportedDevices.contains(event.kind)) {
       return false;
     }
     if (_initialButtons == null) {
@@ -518,8 +517,8 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    bool enableMouseDrag = true,
-  }) : super(debugOwner: debugOwner, kind: kind, enableMouseDrag: enableMouseDrag);
+    List<PointerDeviceKind> supportedDevices = PointerDeviceKind.values,
+  }) : super(debugOwner: debugOwner, kind: kind, supportedDevices: supportedDevices);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
@@ -560,8 +559,8 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    bool enableMouseDrag = true,
-  }) : super(debugOwner: debugOwner, kind: kind, enableMouseDrag: enableMouseDrag);
+    List<PointerDeviceKind> supportedDevices = PointerDeviceKind.values,
+  }) : super(debugOwner: debugOwner, kind: kind, supportedDevices: supportedDevices);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,7 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     PointerDeviceKind? kind,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
-    this.rejectMousePointers = false,
+    this.enableMouseDrag = true,
   }) : assert(dragStartBehavior != null),
        super(debugOwner: debugOwner, kind: kind);
 
@@ -201,11 +201,11 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///    match the native behavior on that platform.
   GestureVelocityTrackerBuilder velocityTrackerBuilder;
 
-  /// Whether this gesture detector should reject pointers from a mouse device type.
+  /// Whether this gesture detector should accept pointers from a mouse device type.
   ///
   /// This is used by scrollables to force mouse interactions to go through the
   /// scroll wheel or scrollbar, instead of allowing drag gestures to move them.
-  final bool rejectMousePointers;
+  final bool enableMouseDrag;
 
   _DragState _state = _DragState.ready;
   late OffsetPair _initialPosition;
@@ -237,7 +237,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   bool isPointerAllowed(PointerEvent event) {
-    if (rejectMousePointers && event.kind == PointerDeviceKind.mouse) {
+    if (!enableMouseDrag && event.kind == PointerDeviceKind.mouse) {
       return false;
     }
     if (_initialButtons == null) {
@@ -518,8 +518,8 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    bool rejectMousePointers = false,
-  }) : super(debugOwner: debugOwner, kind: kind, rejectMousePointers: rejectMousePointers);
+    bool enableMouseDrag = true,
+  }) : super(debugOwner: debugOwner, kind: kind, enableMouseDrag: enableMouseDrag);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
@@ -560,8 +560,8 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    bool rejectMousePointers = false,
-  }) : super(debugOwner: debugOwner, kind: kind, rejectMousePointers: rejectMousePointers);
+    bool enableMouseDrag = true,
+  }) : super(debugOwner: debugOwner, kind: kind, enableMouseDrag: enableMouseDrag);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,7 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     PointerDeviceKind? kind,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
-    this.supportedDevices = PointerDeviceKind.values,
+    this.supportedDevices = _kAllPointerDeviceKinds
   }) : assert(dragStartBehavior != null),
        super(debugOwner: debugOwner, kind: kind);
 
@@ -204,7 +204,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   /// The device types that this gesture recognizer will accept drags from.
   ///
   /// If not specified, defaults to all pointer kinds.
-  final List<PointerDeviceKind> supportedDevices;
+  Set<PointerDeviceKind> supportedDevices;
 
   _DragState _state = _DragState.ready;
   late OffsetPair _initialPosition;
@@ -517,7 +517,7 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    List<PointerDeviceKind> supportedDevices = PointerDeviceKind.values,
+    Set<PointerDeviceKind> supportedDevices = _kAllPointerDeviceKinds,
   }) : super(debugOwner: debugOwner, kind: kind, supportedDevices: supportedDevices);
 
   @override
@@ -542,6 +542,10 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   String get debugDescription => 'vertical drag';
 }
 
+const Set<PointerDeviceKind> _kAllPointerDeviceKinds = <PointerDeviceKind>{
+  ...PointerDeviceKind.values,
+};
+
 /// Recognizes movement in the horizontal direction.
 ///
 /// Used for horizontal scrolling.
@@ -559,7 +563,7 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-    List<PointerDeviceKind> supportedDevices = PointerDeviceKind.values,
+    Set<PointerDeviceKind> supportedDevices = _kAllPointerDeviceKinds,
   }) : super(debugOwner: debugOwner, kind: kind, supportedDevices: supportedDevices);
 
   @override

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -69,6 +69,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     PointerDeviceKind? kind,
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
+    this.rejectMousePointers = false,
   }) : assert(dragStartBehavior != null),
        super(debugOwner: debugOwner, kind: kind);
 
@@ -200,6 +201,12 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///    match the native behavior on that platform.
   GestureVelocityTrackerBuilder velocityTrackerBuilder;
 
+  /// Whether this gesture detector should reject pointers from a mouse device type.
+  ///
+  /// This is used by scrollables to force mouse interactions to go through the
+  /// scroll wheel or scrollbar, instead of allowing drag gestures to move them.
+  final bool rejectMousePointers;
+
   _DragState _state = _DragState.ready;
   late OffsetPair _initialPosition;
   late OffsetPair _pendingDragOffset;
@@ -230,6 +237,9 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   @override
   bool isPointerAllowed(PointerEvent event) {
+    if (rejectMousePointers && event.kind == PointerDeviceKind.mouse) {
+      return false;
+    }
     if (_initialButtons == null) {
       switch (event.buttons) {
         case kPrimaryButton:
@@ -508,7 +518,8 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   VerticalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    bool rejectMousePointers = false,
+  }) : super(debugOwner: debugOwner, kind: kind, rejectMousePointers: rejectMousePointers);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {
@@ -549,7 +560,8 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   HorizontalDragGestureRecognizer({
     Object? debugOwner,
     PointerDeviceKind? kind,
-  }) : super(debugOwner: debugOwner, kind: kind);
+    bool rejectMousePointers = false,
+  }) : super(debugOwner: debugOwner, kind: kind, rejectMousePointers: rejectMousePointers);
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -52,7 +52,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool scrollbars = true,
     bool overscroll = true,
-    bool rejectMousePointers = false,
+    bool enableMouseDrag = false,
     ScrollPhysics? physics,
     TargetPlatform? platform,
   }) {
@@ -62,7 +62,7 @@ class ScrollBehavior {
       overscrollIndicator: overscroll,
       physics: physics,
       platform: platform,
-      rejectMousePointers: rejectMousePointers,
+      enableMouseDrag: enableMouseDrag,
     );
   }
 
@@ -72,7 +72,11 @@ class ScrollBehavior {
   TargetPlatform getPlatform(BuildContext context) => defaultTargetPlatform;
 
   /// Whether the scrollable should support click and drag with mice.
-  bool get rejectMousePointers => false;
+  ///
+  /// By default this feature is disabled. Enabling it will make it difficult
+  /// or impossible to select text in scrollable containers and is not
+  /// recommended.
+  bool get enableMouseDrag => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -205,7 +209,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscrollIndicator = true,
     this.physics,
     this.platform,
-    this.rejectMousePointers = false,
+    this.enableMouseDrag = false,
   });
 
   final ScrollBehavior delegate;
@@ -215,7 +219,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final TargetPlatform? platform;
 
   @override
-  final bool rejectMousePointers;
+  final bool enableMouseDrag;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -242,14 +246,14 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     bool overscroll = true,
     ScrollPhysics? physics,
     TargetPlatform? platform,
-    bool rejectMousePointers = false,
+    bool enableMouseDrag = false,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars,
       overscroll: overscroll,
       physics: physics,
       platform: platform,
-      rejectMousePointers: rejectMousePointers,
+      enableMouseDrag: enableMouseDrag,
     );
   }
 
@@ -270,7 +274,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         || oldDelegate.overscrollIndicator != overscrollIndicator
         || oldDelegate.physics != physics
         || oldDelegate.platform != platform
-        || oldDelegate.rejectMousePointers != rejectMousePointers
+        || oldDelegate.enableMouseDrag != enableMouseDrag
         || delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -52,6 +52,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool scrollbars = true,
     bool overscroll = true,
+    bool rejectMousePointers = false,
     ScrollPhysics? physics,
     TargetPlatform? platform,
   }) {
@@ -61,6 +62,7 @@ class ScrollBehavior {
       overscrollIndicator: overscroll,
       physics: physics,
       platform: platform,
+      rejectMousePointers: rejectMousePointers,
     );
   }
 
@@ -68,6 +70,9 @@ class ScrollBehavior {
   ///
   /// Defaults to the current platform.
   TargetPlatform getPlatform(BuildContext context) => defaultTargetPlatform;
+
+  /// Whether the scrollable should support click and drag with mice.
+  bool get rejectMousePointers => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -200,6 +205,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscrollIndicator = true,
     this.physics,
     this.platform,
+    this.rejectMousePointers = false,
   });
 
   final ScrollBehavior delegate;
@@ -207,6 +213,9 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscrollIndicator;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
+
+  @override
+  final bool rejectMousePointers;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -233,12 +242,14 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     bool overscroll = true,
     ScrollPhysics? physics,
     TargetPlatform? platform,
+    bool rejectMousePointers = false,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars,
       overscroll: overscroll,
       physics: physics,
       platform: platform,
+      rejectMousePointers: rejectMousePointers,
     );
   }
 
@@ -259,6 +270,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         || oldDelegate.overscrollIndicator != overscrollIndicator
         || oldDelegate.physics != physics
         || oldDelegate.platform != platform
+        || oldDelegate.rejectMousePointers != rejectMousePointers
         || delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -14,6 +14,9 @@ import 'scrollbar.dart';
 
 const Color _kDefaultGlowColor = Color(0xFFFFFFFF);
 
+/// Device types that scrollables should accept drag gestures from by default.
+const List<PointerDeviceKind> _kTouchLikeDeviceTypes = <PointerDeviceKind>[PointerDeviceKind.touch, PointerDeviceKind.stylus, PointerDeviceKind.invertedStylus];
+
 /// Describes how [Scrollable] widgets should behave.
 ///
 /// {@template flutter.widgets.scrollBehavior}
@@ -52,7 +55,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool scrollbars = true,
     bool overscroll = true,
-    bool enableMouseDrag = false,
+    List<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
   }) {
@@ -62,7 +65,7 @@ class ScrollBehavior {
       overscrollIndicator: overscroll,
       physics: physics,
       platform: platform,
-      enableMouseDrag: enableMouseDrag,
+      dragDevices: dragDevices,
     );
   }
 
@@ -71,12 +74,13 @@ class ScrollBehavior {
   /// Defaults to the current platform.
   TargetPlatform getPlatform(BuildContext context) => defaultTargetPlatform;
 
-  /// Whether the scrollable should support click and drag with mice.
+  /// The device kinds that the scrollable will accept drag gestures from.
   ///
-  /// By default this feature is disabled. Enabling it will make it difficult
-  /// or impossible to select text in scrollable containers and is not
-  /// recommended.
-  bool get enableMouseDrag => false;
+  /// By default only [PointerDeviceKind.touch], [PointerDeviceKind.stylus], and
+  /// [PointerDeviceKind.invertedStylus] are configured to create drag gestures.
+  /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
+  /// impossible to select text in scrollable containers and is not recommended.
+  List<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -209,17 +213,18 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscrollIndicator = true,
     this.physics,
     this.platform,
-    this.enableMouseDrag = false,
-  });
+    List<PointerDeviceKind>? dragDevices,
+  }) : _dragDevices = dragDevices;
 
   final ScrollBehavior delegate;
   final bool scrollbar;
   final bool overscrollIndicator;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
+  final List<PointerDeviceKind>? _dragDevices;
 
   @override
-  final bool enableMouseDrag;
+  List<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -246,14 +251,14 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     bool overscroll = true,
     ScrollPhysics? physics,
     TargetPlatform? platform,
-    bool enableMouseDrag = false,
+    List<PointerDeviceKind>? dragDevices,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars,
       overscroll: overscroll,
       physics: physics,
       platform: platform,
-      enableMouseDrag: enableMouseDrag,
+      dragDevices: dragDevices,
     );
   }
 
@@ -274,7 +279,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         || oldDelegate.overscrollIndicator != overscrollIndicator
         || oldDelegate.physics != physics
         || oldDelegate.platform != platform
-        || oldDelegate.enableMouseDrag != enableMouseDrag
+        || listEquals(oldDelegate.dragDevices, dragDevices)
         || delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -15,7 +15,11 @@ import 'scrollbar.dart';
 const Color _kDefaultGlowColor = Color(0xFFFFFFFF);
 
 /// Device types that scrollables should accept drag gestures from by default.
-const List<PointerDeviceKind> _kTouchLikeDeviceTypes = <PointerDeviceKind>[PointerDeviceKind.touch, PointerDeviceKind.stylus, PointerDeviceKind.invertedStylus];
+const Set<PointerDeviceKind> _kTouchLikeDeviceTypes = <PointerDeviceKind>{
+  PointerDeviceKind.touch,
+  PointerDeviceKind.stylus,
+  PointerDeviceKind.invertedStylus,
+};
 
 /// Describes how [Scrollable] widgets should behave.
 ///
@@ -55,7 +59,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool scrollbars = true,
     bool overscroll = true,
-    List<PointerDeviceKind>? dragDevices,
+    Set<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
   }) {
@@ -80,7 +84,7 @@ class ScrollBehavior {
   /// [PointerDeviceKind.invertedStylus] are configured to create drag gestures.
   /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
   /// impossible to select text in scrollable containers and is not recommended.
-  List<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
+  Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -213,7 +217,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscrollIndicator = true,
     this.physics,
     this.platform,
-    List<PointerDeviceKind>? dragDevices,
+    Set<PointerDeviceKind>? dragDevices,
   }) : _dragDevices = dragDevices;
 
   final ScrollBehavior delegate;
@@ -221,10 +225,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscrollIndicator;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
-  final List<PointerDeviceKind>? _dragDevices;
+  final Set<PointerDeviceKind>? _dragDevices;
 
   @override
-  List<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
+  Set<PointerDeviceKind> get dragDevices => _dragDevices ?? delegate.dragDevices;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -251,7 +255,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     bool overscroll = true,
     ScrollPhysics? physics,
     TargetPlatform? platform,
-    List<PointerDeviceKind>? dragDevices,
+    Set<PointerDeviceKind>? dragDevices,
   }) {
     return delegate.copyWith(
       scrollbars: scrollbars,
@@ -279,7 +283,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
         || oldDelegate.overscrollIndicator != overscrollIndicator
         || oldDelegate.physics != physics
         || oldDelegate.platform != platform
-        || listEquals(oldDelegate.dragDevices, dragDevices)
+        || setEquals<PointerDeviceKind>(oldDelegate.dragDevices, dragDevices)
         || delegate.shouldNotify(oldDelegate.delegate);
   }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -553,7 +553,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-              () => VerticalDragGestureRecognizer(),
+              () => VerticalDragGestureRecognizer(rejectMousePointers: true),
               (VerticalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -573,7 +573,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-              () => HorizontalDragGestureRecognizer(),
+              () => HorizontalDragGestureRecognizer(rejectMousePointers: true),
               (HorizontalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -553,7 +553,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-              () => VerticalDragGestureRecognizer(rejectMousePointers: _configuration.rejectMousePointers),
+              () => VerticalDragGestureRecognizer(enableMouseDrag: _configuration.enableMouseDrag),
               (VerticalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -573,7 +573,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-              () => HorizontalDragGestureRecognizer(rejectMousePointers: _configuration.rejectMousePointers),
+              () => HorizontalDragGestureRecognizer(enableMouseDrag: _configuration.enableMouseDrag),
               (HorizontalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -553,7 +553,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-              () => VerticalDragGestureRecognizer(rejectMousePointers: true),
+              () => VerticalDragGestureRecognizer(rejectMousePointers: _configuration.rejectMousePointers),
               (VerticalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -573,7 +573,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-              () => HorizontalDragGestureRecognizer(rejectMousePointers: true),
+              () => HorizontalDragGestureRecognizer(rejectMousePointers: _configuration.rejectMousePointers),
               (HorizontalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -553,7 +553,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-              () => VerticalDragGestureRecognizer(enableMouseDrag: _configuration.enableMouseDrag),
+              () => VerticalDragGestureRecognizer(supportedDevices: _configuration.dragDevices),
               (VerticalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -573,7 +573,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-              () => HorizontalDragGestureRecognizer(enableMouseDrag: _configuration.enableMouseDrag),
+              () => HorizontalDragGestureRecognizer(supportedDevices: _configuration.dragDevices),
               (HorizontalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -553,7 +553,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.vertical:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
-              () => VerticalDragGestureRecognizer(supportedDevices: _configuration.dragDevices),
+              () => VerticalDragGestureRecognizer(),
               (VerticalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -565,7 +565,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
-                  ..dragStartBehavior = widget.dragStartBehavior;
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..supportedDevices = _configuration.dragDevices;
               },
             ),
           };
@@ -573,7 +574,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         case Axis.horizontal:
           _gestureRecognizers = <Type, GestureRecognizerFactory>{
             HorizontalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<HorizontalDragGestureRecognizer>(
-              () => HorizontalDragGestureRecognizer(supportedDevices: _configuration.dragDevices),
+              () => HorizontalDragGestureRecognizer(),
               (HorizontalDragGestureRecognizer instance) {
                 instance
                   ..onDown = _handleDragDown
@@ -585,7 +586,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
-                  ..dragStartBehavior = widget.dragStartBehavior;
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..supportedDevices = _configuration.dragDevices;
               },
             ),
           };

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -182,7 +182,9 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Horizontal', (GestureTester tester) {
-    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(enableMouseDrag: false) ..dragStartBehavior = DragStartBehavior.down;
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>[
+      PointerDeviceKind.touch,
+    ]) ..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;
@@ -230,7 +232,9 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Vertical', (GestureTester tester) {
-    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(enableMouseDrag: false)..dragStartBehavior = DragStartBehavior.down;
+    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>[
+      PointerDeviceKind.touch,
+    ])..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -182,9 +182,9 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Horizontal', (GestureTester tester) {
-    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>[
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{
       PointerDeviceKind.touch,
-    ]) ..dragStartBehavior = DragStartBehavior.down;
+    }) ..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;
@@ -232,9 +232,9 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Vertical', (GestureTester tester) {
-    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>[
+    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{
       PointerDeviceKind.touch,
-    ])..dragStartBehavior = DragStartBehavior.down;
+    })..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -182,7 +182,7 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Horizontal', (GestureTester tester) {
-    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(rejectMousePointers: true) ..dragStartBehavior = DragStartBehavior.down;
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(enableMouseDrag: false) ..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;
@@ -230,7 +230,7 @@ void main() {
   });
 
   testGesture('Should reject mouse drag when configured to ignore mouse pointers - Vertical', (GestureTester tester) {
-    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(rejectMousePointers: true) ..dragStartBehavior = DragStartBehavior.down;
+    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(enableMouseDrag: false)..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);
 
     bool didStartDrag = false;

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -181,6 +181,102 @@ void main() {
     didEndDrag = false;
   });
 
+  testGesture('Should reject mouse drag when configured to ignore mouse pointers - Horizontal', (GestureTester tester) {
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer(rejectMousePointers: true) ..dragStartBehavior = DragStartBehavior.down;
+    addTearDown(drag.dispose);
+
+    bool didStartDrag = false;
+    drag.onStart = (_) {
+      didStartDrag = true;
+    };
+
+    double? updatedDelta;
+    drag.onUpdate = (DragUpdateDetails details) {
+      updatedDelta = details.primaryDelta;
+    };
+
+    bool didEndDrag = false;
+    drag.onEnd = (DragEndDetails details) {
+      didEndDrag = true;
+    };
+
+    final TestPointer pointer = TestPointer(5, PointerDeviceKind.mouse);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    drag.addPointer(down);
+    tester.closeArena(5);
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(down);
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.move(const Offset(20.0, 25.0)));
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.move(const Offset(20.0, 25.0)));
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.up());
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+  });
+
+  testGesture('Should reject mouse drag when configured to ignore mouse pointers - Vertical', (GestureTester tester) {
+    final VerticalDragGestureRecognizer drag = VerticalDragGestureRecognizer(rejectMousePointers: true) ..dragStartBehavior = DragStartBehavior.down;
+    addTearDown(drag.dispose);
+
+    bool didStartDrag = false;
+    drag.onStart = (_) {
+      didStartDrag = true;
+    };
+
+    double? updatedDelta;
+    drag.onUpdate = (DragUpdateDetails details) {
+      updatedDelta = details.primaryDelta;
+    };
+
+    bool didEndDrag = false;
+    drag.onEnd = (DragEndDetails details) {
+      didEndDrag = true;
+    };
+
+    final TestPointer pointer = TestPointer(5, PointerDeviceKind.mouse);
+    final PointerDownEvent down = pointer.down(const Offset(10.0, 10.0));
+    drag.addPointer(down);
+    tester.closeArena(5);
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(down);
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.move(const Offset(25.0, 20.0)));
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.move(const Offset(25.0, 20.0)));
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+
+    tester.route(pointer.up());
+    expect(didStartDrag, isFalse);
+    expect(updatedDelta, isNull);
+    expect(didEndDrag, isFalse);
+  });
+
   testGesture('Should report original timestamps', (GestureTester tester) {
     final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer() ..dragStartBehavior = DragStartBehavior.down;
     addTearDown(drag.dispose);

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -20,7 +20,7 @@ Future<void> pumpTest(
   bool enableMouseDrag = true,
 }) async {
   await tester.pumpWidget(MaterialApp(
-    scrollBehavior: const NoScrollbarBehavior().copyWith(enableMouseDrag: enableMouseDrag),
+    scrollBehavior: const NoScrollbarBehavior().copyWith(dragDevices: enableMouseDrag ? ui.PointerDeviceKind.values : null),
     theme: ThemeData(
       platform: platform,
     ),

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -20,7 +20,10 @@ Future<void> pumpTest(
   bool enableMouseDrag = true,
 }) async {
   await tester.pumpWidget(MaterialApp(
-    scrollBehavior: const NoScrollbarBehavior().copyWith(dragDevices: enableMouseDrag ? ui.PointerDeviceKind.values : null),
+    scrollBehavior: const NoScrollbarBehavior().copyWith(dragDevices: enableMouseDrag
+      ? <ui.PointerDeviceKind>{...ui.PointerDeviceKind.values}
+      : null,
+    ),
     theme: ThemeData(
       platform: platform,
     ),

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -17,10 +17,10 @@ Future<void> pumpTest(
   bool scrollable = true,
   bool reverse = false,
   ScrollController? controller,
-  bool rejectMousePointers = false,
+  bool enableMouseDrag = true,
 }) async {
   await tester.pumpWidget(MaterialApp(
-    scrollBehavior: const NoScrollbarBehavior().copyWith(rejectMousePointers: rejectMousePointers),
+    scrollBehavior: const NoScrollbarBehavior().copyWith(enableMouseDrag: enableMouseDrag),
     theme: ThemeData(
       platform: platform,
     ),
@@ -1272,7 +1272,7 @@ void main() {
   });
 
   testWidgets('Does not scroll with mouse pointer drag when behavior is configured to ignore them', (WidgetTester tester) async {
-    await pumpTest(tester, debugDefaultTargetPlatformOverride, rejectMousePointers: true);
+    await pumpTest(tester, debugDefaultTargetPlatformOverride, enableMouseDrag: false);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Scrollable), warnIfMissed: true), kind: ui.PointerDeviceKind.mouse);
 
     await gesture.moveBy(const Offset(0.0, -200));
@@ -1292,7 +1292,7 @@ void main() {
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS, TargetPlatform.android }));
 
   testWidgets('Does scroll with mouse pointer drag when behavior is not configured to ignore them', (WidgetTester tester) async {
-    await pumpTest(tester, debugDefaultTargetPlatformOverride, rejectMousePointers: false);
+    await pumpTest(tester, debugDefaultTargetPlatformOverride, enableMouseDrag: true);
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Scrollable), warnIfMissed: true), kind: ui.PointerDeviceKind.mouse);
 
     await gesture.moveBy(const Offset(0.0, -200));

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1269,6 +1269,26 @@ void main() {
 
     expect(tester.takeException(), null);
   });
+
+  testWidgets('Does not scroll with mouse pointer drag', (WidgetTester tester) async {
+    await pumpTest(tester, debugDefaultTargetPlatformOverride);
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(Scrollable), warnIfMissed: true), kind: ui.PointerDeviceKind.mouse);
+
+    await gesture.moveBy(const Offset(0.0, -200));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(getScrollOffset(tester), 0.0);
+
+    await gesture.moveBy(const Offset(0.0, 200));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(getScrollOffset(tester), 0.0);
+
+    await gesture.removePointer();
+    await tester.pump();
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 }
 
 // ignore: must_be_immutable

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -530,6 +530,7 @@ abstract class WidgetController {
     double touchSlopX = kDragSlopDefault,
     double touchSlopY = kDragSlopDefault,
     bool warnIfMissed = true,
+    PointerDeviceKind kind = PointerDeviceKind.touch,
   }) {
     return dragFrom(
       getCenter(finder, warnIfMissed: warnIfMissed, callee: 'drag'),
@@ -538,6 +539,7 @@ abstract class WidgetController {
       buttons: buttons,
       touchSlopX: touchSlopX,
       touchSlopY: touchSlopY,
+      kind: kind,
     );
   }
 
@@ -559,10 +561,11 @@ abstract class WidgetController {
     int buttons = kPrimaryButton,
     double touchSlopX = kDragSlopDefault,
     double touchSlopY = kDragSlopDefault,
+    PointerDeviceKind kind = PointerDeviceKind.touch,
   }) {
     assert(kDragSlopDefault > kTouchSlop);
     return TestAsyncUtils.guard<void>(() async {
-      final TestGesture gesture = await startGesture(startLocation, pointer: pointer, buttons: buttons);
+      final TestGesture gesture = await startGesture(startLocation, pointer: pointer, buttons: buttons, kind: kind);
       assert(gesture != null);
 
       final double xSign = offset.dx.sign;


### PR DESCRIPTION
Currently flutter web and desktop apps allow scrolling by dragging with the mouse. This feels unnatural compared to other desktop applications, and makes it harder to use more complex mouse gestures on items that are contained within a scrollable and impossible to accurately select text (since the text selection drag competes with the scroll drag).

~~This is likely a breaking change, so the old scrollable behavior is configurable via scroll behavior: `enableMouseDrag`~~

Nothing broke!

Fixes https://github.com/flutter/flutter/issues/71322