### PR TITLE
[flutter_tools] Make bundle sksl a define

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -70,7 +70,7 @@ BuildApp() {
 
   local bundle_sksl_path=""
   if [[ -n "$BUNDLE_SKSL_PATH" ]]; then
-    bundle_sksl_path="-iBundleSkSLPath=${BUNDLE_SKSL_PATH}"
+    bundle_sksl_path="-dBundleSkSLPath=${BUNDLE_SKSL_PATH}"
   fi
 
   local code_size_directory=""

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -83,7 +83,7 @@ or
       '-dTreeShakeIcons="$treeShakeIcons"',
       '-dDartObfuscation=$dartObfuscation',
       if (bundleSkSLPath != null)
-        '-iBundleSkSLPath=$bundleSkSLPath',
+        '-dBundleSkSLPath=$bundleSkSLPath',
       if (codeSizeDirectory != null)
         '-dCodeSizeDirectory=$codeSizeDirectory',
       if (splitDebugInfo != null)

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -82,7 +82,7 @@ BuildApp() {
 
   local bundle_sksl_path=""
   if [[ -n "$BUNDLE_SKSL_PATH" ]]; then
-    bundle_sksl_path="-iBundleSkSLPath=${BUNDLE_SKSL_PATH}"
+    bundle_sksl_path="-dBundleSkSLPath=${BUNDLE_SKSL_PATH}"
   fi
 
   # Default value of assets_path is flutter_assets

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -1075,7 +1075,7 @@ abstract class BaseFlutterTask extends DefaultTask {
                 args "--DartDefines=${dartDefines}"
             }
             if (bundleSkSLPath != null) {
-                args "-iBundleSkSLPath=${bundleSkSLPath}"
+                args "-dBundleSkSLPath=${bundleSkSLPath}"
             }
             if (codeSizeDirectory != null) {
                 args "-dCodeSizeDirectory=${codeSizeDirectory}"

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -36,7 +36,7 @@ Future<Depfile> copyAssets(Environment environment, Directory outputDirectory, {
   BuildMode buildMode,
 }) async {
   // Check for an SkSL bundle.
-  final String shaderBundlePath = environment.inputs[kBundleSkSLPath];
+  final String shaderBundlePath = environment.defines[kBundleSkSLPath] ?? environment.inputs[kBundleSkSLPath];
   final DevFSContent skslBundle = processSkSLBundle(
     shaderBundlePath,
     engineVersion: environment.engineVersion,

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -209,7 +209,7 @@ Future<void> _runFlutterBuild(Directory buildDirectory, BuildInfo buildInfo, Str
         '-dTreeShakeIcons="${buildInfo.treeShakeIcons}"',
         '-dDartObfuscation=${buildInfo.dartObfuscation}',
         if (buildInfo.bundleSkSLPath != null)
-          '-iBundleSkSLPath=${buildInfo.bundleSkSLPath}',
+          '-dBundleSkSLPath=${buildInfo.bundleSkSLPath}',
         if (buildInfo.codeSizeDirectory != null)
           '-dCodeSizeDirectory=${buildInfo.codeSizeDirectory}',
         if (buildInfo.splitDebugInfoPath != null)

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -103,7 +103,7 @@ void main() {
   });
 
   testUsingContext('DebugIosApplicationBundle', () async {
-    environment.inputs[kBundleSkSLPath] = 'bundle.sksl';
+    environment.defines[kBundleSkSLPath] = 'bundle.sksl';
     environment.defines[kBuildMode] = 'debug';
     environment.defines[kCodesignIdentity] = 'ABC123';
     // Precompiled dart data

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -205,7 +205,7 @@ void main() {
         mode: BuildMode.debug,
       ))
       .createSync();
-    environment.inputs[kBundleSkSLPath] = 'bundle.sksl';
+    environment.defines[kBundleSkSLPath] = 'bundle.sksl';
     fileSystem.file(
       artifacts.getArtifactPath(
         Artifact.vmSnapshotData,


### PR DESCRIPTION
There is currently a bug with the build system inputs functionality when re-running with the addition of a new input. Fixing this will take a bit more time, but since this was always a performance optimization we can instead just fallback to a define in the meantime.


