### PR TITLE
Enable library_private_types_in_public_api lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -122,6 +122,7 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
+    - library_private_types_in_public_api
     # - lines_longer_than_80_chars # not required by flutter style
     - list_remove_unrelated_type
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181

--- a/dev/benchmarks/macrobenchmarks/lib/src/animation_with_microtasks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/animation_with_microtasks.dart
@@ -8,8 +8,7 @@ class AnimationWithMicrotasks extends StatefulWidget {
   const AnimationWithMicrotasks({Key key}) : super(key: key);
 
   @override
-  _AnimationWithMicrotasksState createState() =>
-      _AnimationWithMicrotasksState();
+  State<AnimationWithMicrotasks> createState() => _AnimationWithMicrotasksState();
 }
 
 class _AnimationWithMicrotasksState extends State<AnimationWithMicrotasks> {

--- a/dev/benchmarks/macrobenchmarks/lib/src/backdrop_filter.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/backdrop_filter.dart
@@ -10,7 +10,7 @@ class BackdropFilterPage extends StatefulWidget {
   const BackdropFilterPage({Key key}) : super(key: key);
 
   @override
-  _BackdropFilterPageState createState() => _BackdropFilterPageState();
+  State<BackdropFilterPage> createState() => _BackdropFilterPageState();
 }
 
 class _BackdropFilterPageState extends State<BackdropFilterPage> with TickerProviderStateMixin {

--- a/dev/benchmarks/macrobenchmarks/lib/src/color_filter_and_fade.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/color_filter_and_fade.dart
@@ -12,7 +12,7 @@ class ColorFilterAndFadePage extends StatefulWidget {
   const ColorFilterAndFadePage({Key key}) : super(key: key);
 
   @override
-  _ColorFilterAndFadePageState createState() => _ColorFilterAndFadePageState();
+  State<ColorFilterAndFadePage> createState() => _ColorFilterAndFadePageState();
 }
 
 class _ColorFilterAndFadePageState extends State<ColorFilterAndFadePage> with TickerProviderStateMixin {

--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -23,7 +23,7 @@ class FilteredChildAnimationPage extends StatefulWidget {
   final bool initialUseRepaintBoundary;
 
   @override
-  _FilteredChildAnimationPageState createState() => _FilteredChildAnimationPageState();
+  State<FilteredChildAnimationPage> createState() => _FilteredChildAnimationPageState();
 }
 
 class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage> with SingleTickerProviderStateMixin {

--- a/dev/benchmarks/macrobenchmarks/lib/src/large_image_changer.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/large_image_changer.dart
@@ -11,7 +11,7 @@ class LargeImageChangerPage extends StatefulWidget {
   const LargeImageChangerPage({Key key}) : super(key: key);
 
   @override
-  _LargeImageChangerState createState() => _LargeImageChangerState();
+  State<LargeImageChangerPage> createState() => _LargeImageChangerState();
 }
 
 class _LargeImageChangerState extends State<LargeImageChangerPage> {

--- a/dev/benchmarks/macrobenchmarks/lib/src/multi_widget_construction.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/multi_widget_construction.dart
@@ -12,8 +12,7 @@ class MultiWidgetConstructTable extends StatefulWidget {
   final int rowCount;
 
   @override
-  _MultiWidgetConstructTableState createState() =>
-      _MultiWidgetConstructTableState();
+  State<MultiWidgetConstructTable> createState() => _MultiWidgetConstructTableState();
 }
 
 class _MultiWidgetConstructTableState extends State<MultiWidgetConstructTable>

--- a/dev/benchmarks/macrobenchmarks/lib/src/post_backdrop_filter.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/post_backdrop_filter.dart
@@ -10,7 +10,7 @@ class PostBackdropFilterPage extends StatefulWidget {
   const PostBackdropFilterPage({Key key}) : super(key: key);
 
   @override
-  _PostBackdropFilterPageState createState() => _PostBackdropFilterPageState();
+  State<PostBackdropFilterPage> createState() => _PostBackdropFilterPageState();
 }
 
 class _PostBackdropFilterPageState extends State<PostBackdropFilterPage> with TickerProviderStateMixin {

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
@@ -37,12 +37,12 @@ class _NestedMouseRegion extends StatelessWidget {
 /// Measures our ability to hit test mouse regions.
 class BenchMouseRegionGridHover extends WidgetRecorder {
   BenchMouseRegionGridHover() : super(name: benchmarkName) {
-    tester = _Tester(onDataPoint: handleDataPoint);
+    _tester = _Tester(onDataPoint: handleDataPoint);
   }
 
   static const String benchmarkName = 'bench_mouse_region_grid_hover';
 
-  _Tester tester;
+  _Tester _tester;
 
   void handleDataPoint(Duration duration) {
     profile.addDataPoint('hitTestDuration', duration, reported: true);
@@ -67,8 +67,8 @@ class BenchMouseRegionGridHover extends WidgetRecorder {
     if (!started) {
       started = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) async {
-        tester.start();
-        registerDidStop(tester.stop);
+        _tester.start();
+        registerDidStop(_tester.stop);
       });
     }
     super.frameDidDraw();

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
@@ -21,7 +21,7 @@ class BenchMouseRegionGridScroll extends WidgetRecorder {
 
   static const String benchmarkName = 'bench_mouse_region_grid_scroll';
 
-  final _Tester tester = _Tester();
+  final _Tester _tester = _Tester();
 
   // Use a non-trivial border to force Web to switch painter
   Border _getBorder(int columnIndex, int rowIndex) {
@@ -42,8 +42,8 @@ class BenchMouseRegionGridScroll extends WidgetRecorder {
     if (!started) {
       started = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) async {
-        tester.start();
-        registerDidStop(tester.stop);
+        _tester.start();
+        registerDidStop(_tester.stop);
       });
     }
     super.frameDidDraw();

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
@@ -56,12 +56,12 @@ class _NestedListener extends StatelessWidget {
 /// Measures our ability to hit test mouse regions.
 class BenchMouseRegionMixedGridHover extends WidgetRecorder {
   BenchMouseRegionMixedGridHover() : super(name: benchmarkName) {
-    tester = _Tester(onDataPoint: handleDataPoint);
+    _tester = _Tester(onDataPoint: handleDataPoint);
   }
 
   static const String benchmarkName = 'bench_mouse_region_mixed_grid_hover';
 
-  _Tester tester;
+  _Tester _tester;
 
   void handleDataPoint(Duration duration) {
     profile.addDataPoint('hitTestDuration', duration, reported: true);
@@ -86,8 +86,8 @@ class BenchMouseRegionMixedGridHover extends WidgetRecorder {
     if (!started) {
       started = true;
       SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) async {
-        tester.start();
-        registerDidStop(tester.stop);
+        _tester.start();
+        registerDidStop(_tester.stop);
       });
     }
     super.frameDidDraw();

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -203,11 +203,11 @@ enum _TestMode {
 /// colors. Each color's description is made of several [Text] nodes.
 class BenchBuildColorsGrid extends WidgetBuildRecorder {
   BenchBuildColorsGrid.canvas()
-      : mode = _TestMode.useCanvasTextLayout, super(name: canvasBenchmarkName);
+      : _mode = _TestMode.useCanvasTextLayout, super(name: canvasBenchmarkName);
   BenchBuildColorsGrid.dom()
-      : mode = _TestMode.useDomTextLayout, super(name: domBenchmarkName);
+      : _mode = _TestMode.useDomTextLayout, super(name: domBenchmarkName);
   BenchBuildColorsGrid.canvasKit()
-      : mode = _TestMode.useCanvasKit, super(name: canvasKitBenchmarkName);
+      : _mode = _TestMode.useCanvasKit, super(name: canvasKitBenchmarkName);
 
   /// Disables tracing for this benchmark.
   ///
@@ -224,16 +224,16 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
   static const String canvasKitBenchmarkName = 'text_canvas_kit_color_grid';
 
   /// Whether to use the new canvas-based text measurement implementation.
-  final _TestMode mode;
+  final _TestMode _mode;
 
   num _textLayoutMicros = 0;
 
   @override
   Future<void> setUpAll() async {
-    if (mode == _TestMode.useCanvasTextLayout) {
+    if (_mode == _TestMode.useCanvasTextLayout) {
       _useCanvasText(true);
     }
-    if (mode == _TestMode.useDomTextLayout) {
+    if (_mode == _TestMode.useDomTextLayout) {
       _useCanvasText(false);
     }
     registerEngineBenchmarkValueListener('text_layout', (num value) {
@@ -258,7 +258,7 @@ class BenchBuildColorsGrid extends WidgetBuildRecorder {
     // We need to do this before calling [super.frameDidDraw] because the latter
     // updates the value of [showWidget] in preparation for the next frame.
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/53877
-    if (showWidget && mode != _TestMode.useCanvasKit) {
+    if (showWidget && _mode != _TestMode.useCanvasKit) {
       profile.addDataPoint(
         'text_layout',
         Duration(microseconds: _textLayoutMicros.toInt()),

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_wrapbox_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_wrapbox_scroll.dart
@@ -34,7 +34,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/benchmarks/multiple_flutters/module/lib/main.dart
+++ b/dev/benchmarks/multiple_flutters/module/lib/main.dart
@@ -34,7 +34,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -99,7 +99,7 @@ class RotationContainer extends StatefulWidget {
   const RotationContainer({Key? key}) : super(key: key);
 
   @override
-  _RotationContainerState createState() => _RotationContainerState();
+  State<RotationContainer> createState() => _RotationContainerState();
 }
 
 class _RotationContainerState extends State<RotationContainer>

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -104,7 +104,7 @@ class RotationContainer extends StatefulWidget {
   const RotationContainer({Key? key}) : super(key: key);
 
   @override
-  _RotationContainerState createState() => _RotationContainerState();
+  State<RotationContainer> createState() => _RotationContainerState();
 }
 
 class _RotationContainerState extends State<RotationContainer>

--- a/dev/bots/test/analyze-sample-code-test-dart-ui/ui.dart
+++ b/dev/bots/test/analyze-sample-code-test-dart-ui/ui.dart
@@ -26,7 +26,7 @@ library dart.ui;
 /// }
 /// ```
 /// {@end-tool}
-const _KeepToString keepToString = _KeepToString();
+const Object keepToString = _KeepToString();
 
 class _KeepToString {
   const _KeepToString();

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -64,9 +64,9 @@ abstract class DeviceDiscovery {
       case DeviceOperatingSystem.android:
         return AndroidDeviceDiscovery();
       case DeviceOperatingSystem.androidArm:
-        return AndroidDeviceDiscovery(cpu: _AndroidCPU.arm);
+        return AndroidDeviceDiscovery(cpu: AndroidCPU.arm);
       case DeviceOperatingSystem.androidArm64:
-        return AndroidDeviceDiscovery(cpu: _AndroidCPU.arm64);
+        return AndroidDeviceDiscovery(cpu: AndroidCPU.arm64);
       case DeviceOperatingSystem.ios:
         return IosDeviceDiscovery();
       case DeviceOperatingSystem.fuchsia:
@@ -158,19 +158,19 @@ abstract class Device {
   }
 }
 
-enum _AndroidCPU {
+enum AndroidCPU {
   arm,
   arm64,
 }
 
 class AndroidDeviceDiscovery implements DeviceDiscovery {
-  factory AndroidDeviceDiscovery({_AndroidCPU cpu}) {
+  factory AndroidDeviceDiscovery({AndroidCPU cpu}) {
     return _instance ??= AndroidDeviceDiscovery._(cpu);
   }
 
   AndroidDeviceDiscovery._(this.cpu);
 
-  final _AndroidCPU cpu;
+  final AndroidCPU cpu;
 
   // Parses information about a device. Example:
   //
@@ -199,9 +199,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     if (cpu == null)
       return true;
     switch (cpu) {
-      case _AndroidCPU.arm64:
+      case AndroidCPU.arm64:
         return device.isArm64();
-      case _AndroidCPU.arm:
+      case AndroidCPU.arm:
         return device.isArm();
     }
     return true;

--- a/dev/integration_tests/abstract_method_smoke_test/lib/main.dart
+++ b/dev/integration_tests/abstract_method_smoke_test/lib/main.dart
@@ -32,7 +32,7 @@ class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
 
   @override
-  _HomePage createState() => _HomePage();
+  State<HomePage> createState() => _HomePage();
 }
 
 class _HomePage extends State<HomePage> {

--- a/dev/integration_tests/android_views/lib/wm_integrations.dart
+++ b/dev/integration_tests/android_views/lib/wm_integrations.dart
@@ -33,7 +33,7 @@ enum _LastTestStatus {
 class WindowManagerBodyState extends State<WindowManagerBody> {
 
   MethodChannel? viewChannel;
-  _LastTestStatus lastTestStatus = _LastTestStatus.pending;
+  _LastTestStatus _lastTestStatus = _LastTestStatus.pending;
   String? lastError;
   int? id;
   int windowClickCount = 0;
@@ -53,7 +53,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
               onPlatformViewCreated: onPlatformViewCreated,
             ),
           ),
-          if (lastTestStatus != _LastTestStatus.pending) _statusWidget(),
+          if (_lastTestStatus != _LastTestStatus.pending) _statusWidget(),
           if (viewChannel != null) ... <Widget>[
             ElevatedButton(
               key: const ValueKey<String>('ShowAlertDialog'),
@@ -86,34 +86,34 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
   }
 
   Widget _statusWidget() {
-    assert(lastTestStatus != _LastTestStatus.pending);
-    final String? message = lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
+    assert(_lastTestStatus != _LastTestStatus.pending);
+    final String? message = _lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
     return Container(
-      color: lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
+      color: _lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
       child: Text(
         message!,
         key: const ValueKey<String>('Status'),
         style: TextStyle(
-          color: lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
+          color: _lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
         ),
       ),
     );
   }
 
   Future<void> onShowAlertDialogPressed() async {
-    if (lastTestStatus != _LastTestStatus.pending) {
+    if (_lastTestStatus != _LastTestStatus.pending) {
       setState(() {
-        lastTestStatus = _LastTestStatus.pending;
+        _lastTestStatus = _LastTestStatus.pending;
       });
     }
     try {
       await viewChannel?.invokeMethod<void>('showAndHideAlertDialog');
       setState(() {
-        lastTestStatus = _LastTestStatus.success;
+        _lastTestStatus = _LastTestStatus.success;
       });
     } catch(e) {
       setState(() {
-        lastTestStatus = _LastTestStatus.error;
+        _lastTestStatus = _LastTestStatus.error;
         lastError = '$e';
       });
     }
@@ -127,7 +127,7 @@ class WindowManagerBodyState extends State<WindowManagerBody> {
       });
     } catch(e) {
       setState(() {
-        lastTestStatus = _LastTestStatus.error;
+        _lastTestStatus = _LastTestStatus.error;
         lastError = '$e';
       });
     }

--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -22,7 +22,7 @@ class TestApp extends StatefulWidget {
   const TestApp({Key key}) : super(key: key);
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 class _TestAppState extends State<TestApp> {

--- a/dev/integration_tests/flavors/lib/main.dart
+++ b/dev/integration_tests/flavors/lib/main.dart
@@ -15,7 +15,7 @@ class Flavor extends StatefulWidget {
   const Flavor({Key? key}) : super(key: key);
 
   @override
-  _FlavorState createState() => _FlavorState();
+  State<Flavor> createState() => _FlavorState();
 }
 
 class _FlavorState extends State<Flavor> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
@@ -420,7 +420,7 @@ class AnimationDemoHome extends StatefulWidget {
   static const String routeName = '/animation';
 
   @override
-  _AnimationDemoHomeState createState() => _AnimationDemoHomeState();
+  State<AnimationDemoHome> createState() => _AnimationDemoHomeState();
 }
 
 class _AnimationDemoHomeState extends State<AnimationDemoHome> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/calculator/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/calculator/home.dart
@@ -10,10 +10,10 @@ class Calculator extends StatefulWidget {
   const Calculator({Key? key}) : super(key: key);
 
   @override
-  _CalculatorState createState() => _CalculatorState();
+  State<Calculator> createState() => CalculatorState();
 }
 
-class _CalculatorState extends State<Calculator> {
+class CalculatorState extends State<Calculator> {
   /// As the user taps keys we update the current `_expression` and we also
   /// keep a stack of previous expressions so we can return to earlier states
   /// when the user hits the DEL key.
@@ -156,7 +156,7 @@ class CalcDisplay extends StatelessWidget {
 class KeyPad extends StatelessWidget {
   const KeyPad({ Key? key, this.calcState }) : super(key: key);
 
-  final _CalculatorState? calcState;
+  final CalculatorState? calcState;
 
   @override
   Widget build(BuildContext context) {
@@ -265,7 +265,7 @@ class CalcKey extends StatelessWidget {
 }
 
 class NumberKey extends CalcKey {
-  NumberKey(int value, _CalculatorState? calcState, {Key? key})
+  NumberKey(int value, CalculatorState? calcState, {Key? key})
     : super('$value', () {
         calcState!.handleNumberTap(value);
       }, key: key);

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -12,7 +12,7 @@ class CupertinoAlertDemo extends StatefulWidget {
   static const String routeName = '/cupertino/alert';
 
   @override
-  _CupertinoAlertDemoState createState() => _CupertinoAlertDemoState();
+  State<CupertinoAlertDemo> createState() => _CupertinoAlertDemoState();
 }
 
 class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_buttons_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_buttons_demo.dart
@@ -12,7 +12,7 @@ class CupertinoButtonsDemo extends StatefulWidget {
   static const String routeName = '/cupertino/buttons';
 
   @override
-  _CupertinoButtonDemoState createState() => _CupertinoButtonDemoState();
+  State<CupertinoButtonsDemo> createState() => _CupertinoButtonDemoState();
 }
 
 class _CupertinoButtonDemoState extends State<CupertinoButtonsDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_picker_demo.dart
@@ -17,7 +17,7 @@ class CupertinoPickerDemo extends StatefulWidget {
   static const String routeName = '/cupertino/picker';
 
   @override
-  _CupertinoPickerDemoState createState() => _CupertinoPickerDemoState();
+  State<CupertinoPickerDemo> createState() => _CupertinoPickerDemoState();
 }
 
 class _BottomPicker extends StatelessWidget {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
@@ -14,7 +14,7 @@ class CupertinoRefreshControlDemo extends StatefulWidget {
   static const String routeName = '/cupertino/refresh';
 
   @override
-  _CupertinoRefreshControlDemoState createState() => _CupertinoRefreshControlDemoState();
+  State<CupertinoRefreshControlDemo> createState() => _CupertinoRefreshControlDemoState();
 }
 
 class _CupertinoRefreshControlDemoState extends State<CupertinoRefreshControlDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_segmented_control_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_segmented_control_demo.dart
@@ -17,7 +17,7 @@ class CupertinoSegmentedControlDemo extends StatefulWidget {
   static const String routeName = 'cupertino/segmented_control';
 
   @override
-  _CupertinoSegmentedControlDemoState createState() => _CupertinoSegmentedControlDemoState();
+  State<CupertinoSegmentedControlDemo> createState() => _CupertinoSegmentedControlDemoState();
 }
 
 class _CupertinoSegmentedControlDemoState extends State<CupertinoSegmentedControlDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_slider_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_slider_demo.dart
@@ -12,7 +12,7 @@ class CupertinoSliderDemo extends StatefulWidget {
   static const String routeName = '/cupertino/slider';
 
   @override
-  _CupertinoSliderDemoState createState() => _CupertinoSliderDemoState();
+  State<CupertinoSliderDemo> createState() => _CupertinoSliderDemoState();
 }
 
 class _CupertinoSliderDemoState extends State<CupertinoSliderDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_switch_demo.dart
@@ -12,7 +12,7 @@ class CupertinoSwitchDemo extends StatefulWidget {
   static const String routeName = '/cupertino/switch';
 
   @override
-  _CupertinoSwitchDemoState createState() => _CupertinoSwitchDemoState();
+  State<CupertinoSwitchDemo> createState() => _CupertinoSwitchDemoState();
 }
 
 class _CupertinoSwitchDemoState extends State<CupertinoSwitchDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
@@ -10,7 +10,7 @@ class CupertinoTextFieldDemo extends StatefulWidget {
   static const String routeName = '/cupertino/text_fields';
 
   @override
-  _CupertinoTextFieldDemoState createState() {
+  State<CupertinoTextFieldDemo> createState() {
     return _CupertinoTextFieldDemoState();
   }
 }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -244,7 +244,7 @@ class BackdropDemo extends StatefulWidget {
   static const String routeName = '/material/backdrop';
 
   @override
-  _BackdropDemoState createState() => _BackdropDemoState();
+  State<BackdropDemo> createState() => _BackdropDemoState();
 }
 
 class _BackdropDemoState extends State<BackdropDemo> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/banner_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/banner_demo.dart
@@ -18,7 +18,7 @@ class BannerDemo extends StatefulWidget {
   static const String routeName = '/material/banner';
 
   @override
-  _BannerDemoState createState() => _BannerDemoState();
+  State<BannerDemo> createState() => _BannerDemoState();
 }
 
 class _BannerDemoState extends State<BannerDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_navigation_demo.dart
@@ -112,7 +112,7 @@ class BottomNavigationDemo extends StatefulWidget {
   static const String routeName = '/material/bottom_navigation';
 
   @override
-  _BottomNavigationDemoState createState() => _BottomNavigationDemoState();
+  State<BottomNavigationDemo> createState() => _BottomNavigationDemoState();
 }
 
 class _BottomNavigationDemoState extends State<BottomNavigationDemo>

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/buttons_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/buttons_demo.dart
@@ -51,7 +51,7 @@ class ButtonsDemo extends StatefulWidget {
   static const String routeName = '/material/buttons';
 
   @override
-  _ButtonsDemoState createState() => _ButtonsDemoState();
+  State<ButtonsDemo> createState() => _ButtonsDemoState();
 }
 
 class _ButtonsDemoState extends State<ButtonsDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -150,7 +150,7 @@ class SelectableTravelDestinationItem extends StatefulWidget {
   final ShapeBorder? shape;
 
   @override
-  _SelectableTravelDestinationItemState createState() => _SelectableTravelDestinationItemState();
+  State<SelectableTravelDestinationItem> createState() => _SelectableTravelDestinationItemState();
 }
 
 class _SelectableTravelDestinationItemState extends State<SelectableTravelDestinationItem> {
@@ -340,7 +340,7 @@ class CardsDemo extends StatefulWidget {
   static const String routeName = '/material/cards';
 
   @override
-  _CardsDemoState createState() => _CardsDemoState();
+  State<CardsDemo> createState() => _CardsDemoState();
 }
 
 class _CardsDemoState extends State<CardsDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/chip_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/chip_demo.dart
@@ -140,7 +140,7 @@ class ChipDemo extends StatefulWidget {
   static const String routeName = '/material/chip';
 
   @override
-  _ChipDemoState createState() => _ChipDemoState();
+  State<ChipDemo> createState() => _ChipDemoState();
 }
 
 class _ChipDemoState extends State<ChipDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
@@ -147,7 +147,7 @@ class DataTableDemo extends StatefulWidget {
   static const String routeName = '/material/data-table';
 
   @override
-  _DataTableDemoState createState() => _DataTableDemoState();
+  State<DataTableDemo> createState() => _DataTableDemoState();
 }
 
 class _DataTableDemoState extends State<DataTableDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/date_and_time_picker_demo.dart
@@ -118,7 +118,7 @@ class DateAndTimePickerDemo extends StatefulWidget {
   static const String routeName = '/material/date-and-time-pickers';
 
   @override
-  _DateAndTimePickerDemoState createState() => _DateAndTimePickerDemoState();
+  State<DateAndTimePickerDemo> createState() => _DateAndTimePickerDemoState();
 }
 
 class _DateAndTimePickerDemoState extends State<DateAndTimePickerDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/drawer_demo.dart
@@ -18,7 +18,7 @@ class DrawerDemo extends StatefulWidget {
   static const String routeName = '/material/drawer';
 
   @override
-  _DrawerDemoState createState() => _DrawerDemoState();
+  State<DrawerDemo> createState() => _DrawerDemoState();
 }
 
 class _DrawerDemoState extends State<DrawerDemo> with TickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_panels_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_panels_demo.dart
@@ -182,7 +182,7 @@ class ExpansionPanelsDemo extends StatefulWidget {
   static const String routeName = '/material/expansion_panels';
 
   @override
-  _ExpansionPanelsDemoState createState() => _ExpansionPanelsDemoState();
+  State<ExpansionPanelsDemo> createState() => _ExpansionPanelsDemoState();
 }
 
 class _ExpansionPanelsDemoState extends State<ExpansionPanelsDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/grid_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/grid_list_demo.dart
@@ -43,7 +43,7 @@ class GridPhotoViewer extends StatefulWidget {
   final Photo? photo;
 
   @override
-  _GridPhotoViewerState createState() => _GridPhotoViewerState();
+  State<GridPhotoViewer> createState() => _GridPhotoViewerState();
 }
 
 class _GridTitleText extends StatelessWidget {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
@@ -26,7 +26,7 @@ class ListDemo extends StatefulWidget {
   static const String routeName = '/material/list';
 
   @override
-  _ListDemoState createState() => _ListDemoState();
+  State<ListDemo> createState() => _ListDemoState();
 }
 
 class _ListDemoState extends State<ListDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/persistent_bottom_sheet_demo.dart
@@ -12,7 +12,7 @@ class PersistentBottomSheetDemo extends StatefulWidget {
   static const String routeName = '/material/persistent-bottom-sheet';
 
   @override
-  _PersistentBottomSheetDemoState createState() => _PersistentBottomSheetDemoState();
+  State<PersistentBottomSheetDemo> createState() => _PersistentBottomSheetDemoState();
 }
 
 class _PersistentBottomSheetDemoState extends State<PersistentBottomSheetDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/progress_indicator_demo.dart
@@ -12,7 +12,7 @@ class ProgressIndicatorDemo extends StatefulWidget {
   static const String routeName = '/material/progress-indicator';
 
   @override
-  _ProgressIndicatorDemoState createState() => _ProgressIndicatorDemoState();
+  State<ProgressIndicatorDemo> createState() => _ProgressIndicatorDemoState();
 }
 
 class _ProgressIndicatorDemoState extends State<ProgressIndicatorDemo> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
@@ -23,7 +23,7 @@ class ReorderableListDemo extends StatefulWidget {
   static const String routeName = '/material/reorderable-list';
 
   @override
-  _ListDemoState createState() => _ListDemoState();
+  State<ReorderableListDemo> createState() => _ListDemoState();
 }
 
 class _ListItem {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/search_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/search_demo.dart
@@ -12,7 +12,7 @@ class SearchDemo extends StatefulWidget {
   static const String routeName = '/material/search';
 
   @override
-  _SearchDemoState createState() => _SearchDemoState();
+  State<SearchDemo> createState() => _SearchDemoState();
 }
 
 class _SearchDemoState extends State<SearchDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/selection_controls_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/selection_controls_demo.dart
@@ -33,7 +33,7 @@ class SelectionControlsDemo extends StatefulWidget {
   static const String routeName = '/material/selection-controls';
 
   @override
-  _SelectionControlsDemoState createState() => _SelectionControlsDemoState();
+  State<SelectionControlsDemo> createState() => _SelectionControlsDemoState();
 }
 
 class _SelectionControlsDemoState extends State<SelectionControlsDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -14,7 +14,7 @@ class SliderDemo extends StatefulWidget {
   static const String routeName = '/material/slider';
 
   @override
-  _SliderDemoState createState() => _SliderDemoState();
+  State<SliderDemo> createState() => _SliderDemoState();
 }
 
 Path _downTriangle(double size, Offset thumbCenter, { bool invert = false }) {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/snack_bar_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/snack_bar_demo.dart
@@ -24,7 +24,7 @@ class SnackBarDemo extends StatefulWidget {
   static const String routeName = '/material/snack-bar';
 
   @override
-  _SnackBarDemoState createState() => _SnackBarDemoState();
+  State<SnackBarDemo> createState() => _SnackBarDemoState();
 }
 
 class _SnackBarDemoState extends State<SnackBarDemo> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/tabs_fab_demo.dart
@@ -40,7 +40,7 @@ class TabsFabDemo extends StatefulWidget {
   static const String routeName = '/material/tabs-fab';
 
   @override
-  _TabsFabDemoState createState() => _TabsFabDemoState();
+  State<TabsFabDemo> createState() => _TabsFabDemoState();
 }
 
 class _TabsFabDemoState extends State<TabsFabDemo> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -45,7 +45,7 @@ class PasswordField extends StatefulWidget {
   final ValueChanged<String>? onFieldSubmitted;
 
   @override
-  _PasswordFieldState createState() => _PasswordFieldState();
+  State<PasswordField> createState() => _PasswordFieldState();
 }
 
 class _PasswordFieldState extends State<PasswordField> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
@@ -71,7 +71,7 @@ class RecipeGridPage extends StatefulWidget {
   final List<Recipe?>? recipes;
 
   @override
-  _RecipeGridPageState createState() => _RecipeGridPageState();
+  State<RecipeGridPage> createState() => _RecipeGridPageState();
 }
 
 class _RecipeGridPageState extends State<RecipeGridPage> {
@@ -195,7 +195,7 @@ class PestoLogo extends StatefulWidget {
   final double? t;
 
   @override
-  _PestoLogoState createState() => _PestoLogoState();
+  State<PestoLogo> createState() => _PestoLogoState();
 }
 
 class _PestoLogoState extends State<PestoLogo> {
@@ -319,7 +319,7 @@ class RecipePage extends StatefulWidget {
   final Recipe? recipe;
 
   @override
-  _RecipePageState createState() => _RecipePageState();
+  State<RecipePage> createState() => _RecipePageState();
 }
 
 class _RecipePageState extends State<RecipePage> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -16,7 +16,7 @@ class ShrineApp extends StatefulWidget {
   const ShrineApp({Key? key}) : super(key: key);
 
   @override
-  _ShrineAppState createState() => _ShrineAppState();
+  State<ShrineApp> createState() => _ShrineAppState();
 }
 
 class _ShrineAppState extends State<ShrineApp> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
@@ -213,7 +213,7 @@ class Backdrop extends StatefulWidget {
   final AnimationController controller;
 
   @override
-  _BackdropState createState() => _BackdropState();
+  State<Backdrop> createState() => _BackdropState();
 }
 
 class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
@@ -30,10 +30,10 @@ class ExpandingBottomSheet extends StatefulWidget {
   final AnimationController hideController;
 
   @override
-  _ExpandingBottomSheetState createState() => _ExpandingBottomSheetState();
+  ExpandingBottomSheetState createState() => ExpandingBottomSheetState();
 
-  static _ExpandingBottomSheetState? of(BuildContext context, {bool isNullOk = false}) {
-    final _ExpandingBottomSheetState? result = context.findAncestorStateOfType<_ExpandingBottomSheetState>();
+  static ExpandingBottomSheetState? of(BuildContext context, {bool isNullOk = false}) {
+    final ExpandingBottomSheetState? result = context.findAncestorStateOfType<ExpandingBottomSheetState>();
     if (isNullOk || result != null) {
       return result;
     }
@@ -97,7 +97,7 @@ double _getPeakPoint({required double begin, required double end}) {
   return begin + (end - begin) * _kPeakVelocityProgress;
 }
 
-class _ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerProviderStateMixin {
+class ExpandingBottomSheetState extends State<ExpandingBottomSheet> with TickerProviderStateMixin {
   final GlobalKey _expandingBottomSheetKey = GlobalKey(debugLabel: 'Expanding bottom sheet');
 
   // The width of the Material, calculated by _widthFor() & based on the number
@@ -405,7 +405,7 @@ class ProductThumbnailRow extends StatefulWidget {
   const ProductThumbnailRow({Key? key}) : super(key: key);
 
   @override
-  _ProductThumbnailRowState createState() => _ProductThumbnailRowState();
+  State<ProductThumbnailRow> createState() => _ProductThumbnailRowState();
 }
 
 class _ProductThumbnailRowState extends State<ProductThumbnailRow> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
@@ -10,7 +10,7 @@ class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
 
   @override
-  _LoginPageState createState() => _LoginPageState();
+  State<LoginPage> createState() => _LoginPageState();
 }
 
 class _LoginPageState extends State<LoginPage> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
@@ -16,7 +16,7 @@ class ShoppingCartPage extends StatefulWidget {
   const ShoppingCartPage({Key? key}) : super(key: key);
 
   @override
-  _ShoppingCartPageState createState() => _ShoppingCartPageState();
+  State<ShoppingCartPage> createState() => _ShoppingCartPageState();
 }
 
 class _ShoppingCartPageState extends State<ShoppingCartPage> {

--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo.dart
@@ -13,7 +13,8 @@ class TransformationsDemo extends StatefulWidget {
 
   static const String routeName = '/transformations';
 
-  @override _TransformationsDemoState createState() => _TransformationsDemoState();
+  @override
+  State<TransformationsDemo> createState() => _TransformationsDemoState();
 }
 class _TransformationsDemoState extends State<TransformationsDemo> {
   // The radius of a hexagon tile in pixels.

--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
@@ -117,7 +117,8 @@ class GestureTransformable extends StatefulWidget {
   final double? initialScale;
   final double? initialRotation;
 
-  @override _GestureTransformableState createState() => _GestureTransformableState();
+  @override
+  State<GestureTransformable> createState() => _GestureTransformableState();
 }
 
 // A single user event can only represent one of these gestures. The user can't

--- a/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
@@ -98,7 +98,7 @@ class VideoPlayerLoading extends StatefulWidget {
   final VideoPlayerController? controller;
 
   @override
-  _VideoPlayerLoadingState createState() => _VideoPlayerLoadingState();
+  State<VideoPlayerLoading> createState() => _VideoPlayerLoadingState();
 }
 
 class _VideoPlayerLoadingState extends State<VideoPlayerLoading> {
@@ -212,7 +212,7 @@ class FadeAnimation extends StatefulWidget {
   final Duration duration;
 
   @override
-  _FadeAnimationState createState() => _FadeAnimationState();
+  State<FadeAnimation> createState() => _FadeAnimationState();
 }
 
 class _FadeAnimationState extends State<FadeAnimation> with SingleTickerProviderStateMixin {
@@ -275,7 +275,7 @@ class ConnectivityOverlay extends StatefulWidget {
   final Completer<void>? connectedCompleter;
 
   @override
-  _ConnectivityOverlayState createState() => _ConnectivityOverlayState();
+  State<ConnectivityOverlay> createState() => _ConnectivityOverlayState();
 }
 
 class _ConnectivityOverlayState extends State<ConnectivityOverlay> {
@@ -348,7 +348,7 @@ class VideoDemo extends StatefulWidget {
   static const String routeName = '/video';
 
   @override
-  _VideoDemoState createState() => _VideoDemoState();
+  State<VideoDemo> createState() => _VideoDemoState();
 }
 
 final DeviceInfoPlugin deviceInfoPlugin = DeviceInfoPlugin();

--- a/dev/integration_tests/flutter_gallery/lib/gallery/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/app.dart
@@ -39,7 +39,7 @@ class GalleryApp extends StatefulWidget {
   final bool testMode;
 
   @override
-  _GalleryAppState createState() => _GalleryAppState();
+  State<GalleryApp> createState() => _GalleryAppState();
 }
 
 class _GalleryAppState extends State<GalleryApp> {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -196,7 +196,7 @@ class Backdrop extends StatefulWidget {
   final Widget? backLayer;
 
   @override
-  _BackdropState createState() => _BackdropState();
+  State<Backdrop> createState() => _BackdropState();
 }
 
 class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
@@ -278,7 +278,7 @@ class GalleryHome extends StatefulWidget {
   static bool showPreviewBanner = true;
 
   @override
-  _GalleryHomeState createState() => _GalleryHomeState();
+  State<GalleryHome> createState() => _GalleryHomeState();
 }
 
 class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStateMixin {

--- a/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
@@ -33,9 +33,8 @@ enum _LastTestStatus {
 }
 
 class NestedViewEventBodyState extends State<NestedViewEventBody> {
-
   MethodChannel viewChannel;
-  _LastTestStatus lastTestStatus = _LastTestStatus.pending;
+  _LastTestStatus _lastTestStatus = _LastTestStatus.pending;
   String lastError;
   int id;
   int nestedViewClickCount = 0;
@@ -58,7 +57,7 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
                   onPlatformViewCreated: onPlatformViewCreated,
                 ) : null,
           ),
-          if (lastTestStatus != _LastTestStatus.pending) _statusWidget(),
+          if (_lastTestStatus != _LastTestStatus.pending) _statusWidget(),
           if (viewChannel != null) ... <Widget>[
             ElevatedButton(
               key: const ValueKey<String>('ShowAlertDialog'),
@@ -96,34 +95,34 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
   }
 
   Widget _statusWidget() {
-    assert(lastTestStatus != _LastTestStatus.pending);
-    final String message = lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
+    assert(_lastTestStatus != _LastTestStatus.pending);
+    final String message = _lastTestStatus == _LastTestStatus.success ? 'Success' : lastError;
     return Container(
-      color: lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
+      color: _lastTestStatus == _LastTestStatus.success ? Colors.green : Colors.red,
       child: Text(
         message,
         key: const ValueKey<String>('Status'),
         style: TextStyle(
-          color: lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
+          color: _lastTestStatus == _LastTestStatus.error ? Colors.yellow : null,
         ),
       ),
     );
   }
 
   Future<void> onShowAlertDialogPressed() async {
-    if (lastTestStatus != _LastTestStatus.pending) {
+    if (_lastTestStatus != _LastTestStatus.pending) {
       setState(() {
-        lastTestStatus = _LastTestStatus.pending;
+        _lastTestStatus = _LastTestStatus.pending;
       });
     }
     try {
       await viewChannel.invokeMethod<void>('showAndHideAlertDialog');
       setState(() {
-        lastTestStatus = _LastTestStatus.success;
+        _lastTestStatus = _LastTestStatus.success;
       });
     } catch(e) {
       setState(() {
-        lastTestStatus = _LastTestStatus.error;
+        _lastTestStatus = _LastTestStatus.error;
         lastError = '$e';
       });
     }
@@ -143,7 +142,7 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
       });
     } catch(e) {
       setState(() {
-        lastTestStatus = _LastTestStatus.error;
+        _lastTestStatus = _LastTestStatus.error;
         lastError = '$e';
       });
     }

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
@@ -32,7 +32,7 @@ class LifeCycleSpy extends StatefulWidget {
   const LifeCycleSpy({Key? key}) : super(key: key);
 
   @override
-  _LifeCycleSpyState createState() => _LifeCycleSpyState();
+  State<LifeCycleSpy> createState() => _LifeCycleSpyState();
 }
 
 class _LifeCycleSpyState extends State<LifeCycleSpy> with WidgetsBindingObserver {

--- a/dev/integration_tests/ios_app_with_extensions/lib/main.dart
+++ b/dev/integration_tests/ios_app_with_extensions/lib/main.dart
@@ -46,7 +46,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/integration_tests/ios_platform_view_tests/lib/main.dart
+++ b/dev/integration_tests/ios_platform_view_tests/lib/main.dart
@@ -34,7 +34,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/integration_tests/platform_interaction/lib/main.dart
+++ b/dev/integration_tests/platform_interaction/lib/main.dart
@@ -19,7 +19,7 @@ class TestApp extends StatefulWidget {
   const TestApp({Key? key}) : super(key: key);
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 class _TestAppState extends State<TestApp> {

--- a/dev/integration_tests/ui/lib/keyboard_resize.dart
+++ b/dev/integration_tests/ui/lib/keyboard_resize.dart
@@ -32,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/integration_tests/ui/lib/keyboard_textfield.dart
+++ b/dev/integration_tests/ui/lib/keyboard_textfield.dart
@@ -30,7 +30,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
+++ b/dev/integration_tests/web_e2e_tests/lib/text_editing_main.dart
@@ -25,7 +25,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -299,7 +299,7 @@ class DemoButton extends StatefulWidget {
   final String name;
 
   @override
-  _DemoButtonState createState() => _DemoButtonState();
+  State<DemoButton> createState() => _DemoButtonState();
 }
 
 class _DemoButtonState extends State<DemoButton> {
@@ -351,7 +351,7 @@ class FocusDemo extends StatefulWidget {
   static GlobalKey appKey = GlobalKey();
 
   @override
-  _FocusDemoState createState() => _FocusDemoState();
+  State<FocusDemo> createState() => _FocusDemoState();
 }
 
 class _FocusDemoState extends State<FocusDemo> {

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -41,7 +41,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class OptionModel extends ChangeNotifier {
@@ -139,7 +139,7 @@ class Options extends StatefulWidget {
   final OptionModel model;
 
   @override
-  _OptionsState createState() => _OptionsState();
+  State<Options> createState() => _OptionsState();
 }
 
 class _OptionsState extends State<Options> {

--- a/dev/manual_tests/lib/focus.dart
+++ b/dev/manual_tests/lib/focus.dart
@@ -20,7 +20,7 @@ class DemoButton extends StatefulWidget {
   final bool autofocus;
 
   @override
-  _DemoButtonState createState() => _DemoButtonState();
+  State<DemoButton> createState() => _DemoButtonState();
 }
 
 class _DemoButtonState extends State<DemoButton> {
@@ -77,7 +77,7 @@ class FocusDemo extends StatefulWidget {
   const FocusDemo({Key key}) : super(key: key);
 
   @override
-  _FocusDemoState createState() => _FocusDemoState();
+  State<FocusDemo> createState() => _FocusDemoState();
 }
 
 class _FocusDemoState extends State<FocusDemo> {

--- a/dev/manual_tests/lib/hover.dart
+++ b/dev/manual_tests/lib/hover.dart
@@ -33,7 +33,7 @@ class HoverDemo extends StatefulWidget {
   const HoverDemo({Key key}) : super(key: key);
 
   @override
-  _HoverDemoState createState() => _HoverDemoState();
+  State<HoverDemo> createState() => _HoverDemoState();
 }
 
 class _HoverDemoState extends State<HoverDemo> {

--- a/dev/manual_tests/lib/material_arc.dart
+++ b/dev/manual_tests/lib/material_arc.dart
@@ -409,7 +409,7 @@ class AnimationDemo extends StatefulWidget {
   const AnimationDemo({ Key key }) : super(key: key);
 
   @override
-  _AnimationDemoState createState() => _AnimationDemoState();
+  State<AnimationDemo> createState() => _AnimationDemoState();
 }
 
 class _AnimationDemoState extends State<AnimationDemo> with TickerProviderStateMixin {

--- a/dev/manual_tests/lib/raw_keyboard.dart
+++ b/dev/manual_tests/lib/raw_keyboard.dart
@@ -23,7 +23,7 @@ class RawKeyboardDemo extends StatefulWidget {
   const RawKeyboardDemo({Key key}) : super(key: key);
 
   @override
-  _HardwareKeyDemoState createState() => _HardwareKeyDemoState();
+  State<RawKeyboardDemo> createState() => _HardwareKeyDemoState();
 }
 
 class _HardwareKeyDemoState extends State<RawKeyboardDemo> {

--- a/dev/manual_tests/lib/text.dart
+++ b/dev/manual_tests/lib/text.dart
@@ -29,7 +29,7 @@ class Home extends StatefulWidget {
   const Home({ Key key }) : super(key: key);
 
   @override
-  _HomeState createState() => _HomeState();
+  State<Home> createState() => _HomeState();
 }
 
 class _HomeState extends State<Home> {
@@ -124,7 +124,7 @@ class Fuzzer extends StatefulWidget {
   final int seed;
 
   @override
-  _FuzzerState createState() => _FuzzerState();
+  State<Fuzzer> createState() => _FuzzerState();
 }
 
 class _FuzzerState extends State<Fuzzer> with SingleTickerProviderStateMixin {
@@ -539,7 +539,7 @@ class Underlines extends StatefulWidget {
   const Underlines({ Key key }) : super(key: key);
 
   @override
-  _UnderlinesState createState() => _UnderlinesState();
+  State<Underlines> createState() => _UnderlinesState();
 }
 
 class _UnderlinesState extends State<Underlines> {
@@ -644,7 +644,7 @@ class Fallback extends StatefulWidget {
   const Fallback({ Key key }) : super(key: key);
 
   @override
-  _FallbackState createState() => _FallbackState();
+  State<Fallback> createState() => _FallbackState();
 }
 
 class _FallbackState extends State<Fallback> {
@@ -739,7 +739,7 @@ class Bidi extends StatefulWidget {
   const Bidi({ Key key }) : super(key: key);
 
   @override
-  _BidiState createState() => _BidiState();
+  State<Bidi> createState() => _BidiState();
 }
 
 class _BidiState extends State<Bidi> {
@@ -816,7 +816,7 @@ class Zalgo extends StatefulWidget {
   final int seed;
 
   @override
-  _ZalgoState createState() => _ZalgoState();
+  State<Zalgo> createState() => _ZalgoState();
 }
 
 class _ZalgoState extends State<Zalgo> with SingleTickerProviderStateMixin {
@@ -923,7 +923,7 @@ class Painting extends StatefulWidget {
   final int seed;
 
   @override
-  _PaintingState createState() => _PaintingState();
+  State<Painting> createState() => _PaintingState();
 }
 
 class _PaintingState extends State<Painting> with SingleTickerProviderStateMixin {

--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -30,7 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino.tmpl
@@ -31,7 +31,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_page_scaffold.tmpl
@@ -34,7 +34,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_cupertino_ticker.tmpl
@@ -31,7 +31,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -31,7 +31,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material_ticker.tmpl
@@ -31,7 +31,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_restoration.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration.tmpl
@@ -34,7 +34,7 @@ class MyStatefulWidget extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_restoration_cupertino.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration_cupertino.tmpl
@@ -34,7 +34,7 @@ class MyStatefulWidget extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_restoration_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_restoration_material.tmpl
@@ -34,7 +34,7 @@ class MyStatefulWidget extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -34,7 +34,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
@@ -36,7 +36,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center_freeform_state.tmpl
@@ -36,7 +36,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/config/templates/stateful_widget_ticker.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_ticker.tmpl
@@ -30,7 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
   const MyStatefulWidget({Key? key}) : super(key: key);
 
   @override
-  _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 }
 
 /// This is the private State class that goes with MyStatefulWidget.

--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -60,7 +60,7 @@ class SnippetGenerator {
   /// Injects the [injections] into the [template], and turning the
   /// "description" injection into a comment. Only used for
   /// [SnippetType.sample] snippets.
-  String interpolateTemplate(List<_ComponentTuple> injections, String template, Map<String, Object?> metadata) {
+  String _interpolateTemplate(List<_ComponentTuple> injections, String template, Map<String, Object?> metadata) {
     final RegExp moustacheRegExp = RegExp('{{([^}]+)}}');
     final String interpolated = template.replaceAllMapped(moustacheRegExp, (Match match) {
       if (match[1] == 'description') {
@@ -158,7 +158,7 @@ class SnippetGenerator {
   ///
   /// Takes into account the [type] and doesn't substitute in the id and the app
   /// if not a [SnippetType.sample] snippet.
-  String interpolateSkeleton(
+  String _interpolateSkeleton(
     SnippetType type,
     List<_ComponentTuple> injections,
     String skeleton,
@@ -215,7 +215,7 @@ class SnippetGenerator {
 
   /// Parses the input for the various code and description segments, and
   /// returns them in the order found.
-  List<_ComponentTuple> parseInput(String input) {
+  List<_ComponentTuple> _parseInput(String input) {
     bool inCodeBlock = false;
     input = input.trim();
     final List<String> description = <String>[];
@@ -298,7 +298,7 @@ class SnippetGenerator {
     assert(template != null || type != SnippetType.sample);
     assert(metadata['id'] != null);
     assert(!showDartPad || type == SnippetType.sample, 'Only application samples work with dartpad.');
-    final List<_ComponentTuple> snippetData = parseInput(_loadFileAsUtf8(input));
+    final List<_ComponentTuple> snippetData = _parseInput(_loadFileAsUtf8(input));
     switch (type) {
       case SnippetType.sample:
         final Directory templatesDir = configuration.templatesDirectory;
@@ -312,7 +312,7 @@ class SnippetGenerator {
           exit(1);
         }
         final String templateContents = _loadFileAsUtf8(templateFile);
-        String app = interpolateTemplate(snippetData, templateContents, metadata);
+        String app = _interpolateTemplate(snippetData, templateContents, metadata);
 
         try {
           app = formatter.format(app);
@@ -343,6 +343,6 @@ class SnippetGenerator {
     }
     final String skeleton =
         _loadFileAsUtf8(configuration.getHtmlSkeletonFile(type, showDartPad: showDartPad));
-    return interpolateSkeleton(type, snippetData, skeleton, metadata);
+    return _interpolateSkeleton(type, snippetData, skeleton, metadata);
   }
 }

--- a/dev/tools/vitool/lib/vitool.dart
+++ b/dev/tools/vitool/lib/vitool.dart
@@ -206,7 +206,7 @@ List<SvgPath> _interpretSvgGroup(List<XmlNode> children, _Transform transform) {
     final XmlElement element = node as XmlElement;
 
     if (element.name.local == 'path') {
-      paths.add(SvgPath.fromElement(element).applyTransform(transform));
+      paths.add(SvgPath.fromElement(element)._applyTransform(transform));
     }
 
     if (element.name.local == 'g') {
@@ -313,9 +313,9 @@ class SvgPath {
     return SvgPath(id, commands);
   }
 
-  SvgPath applyTransform(_Transform transform) {
+  SvgPath _applyTransform(_Transform transform) {
     final List<SvgPathCommand> transformedCommands =
-      commands.map<SvgPathCommand>((SvgPathCommand c) => c.applyTransform(transform)).toList();
+      commands.map<SvgPathCommand>((SvgPathCommand c) => c._applyTransform(transform)).toList();
     return SvgPath(id, transformedCommands, opacity: opacity * transform.opacity);
   }
 
@@ -359,7 +359,7 @@ class SvgPathCommand {
   /// List of points used by this command.
   final List<Point<double>> points;
 
-  SvgPathCommand applyTransform(_Transform transform) {
+  SvgPathCommand _applyTransform(_Transform transform) {
     final List<Point<double>> transformedPoints =
     _vector3ArrayToPoints(
         transform.transformMatrix.applyToVector3Array(

--- a/examples/flutter_view/lib/main.dart
+++ b/examples/flutter_view/lib/main.dart
@@ -29,7 +29,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/examples/image_list/lib/main.dart
+++ b/examples/image_list/lib/main.dart
@@ -146,7 +146,7 @@ class MyHomePage extends StatefulWidget {
   final int port;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {

--- a/examples/layers/services/lifecycle.dart
+++ b/examples/layers/services/lifecycle.dart
@@ -8,7 +8,7 @@ class LifecycleWatcher extends StatefulWidget {
   const LifecycleWatcher({ Key? key }) : super(key: key);
 
   @override
-  _LifecycleWatcherState createState() => _LifecycleWatcherState();
+  State<LifecycleWatcher> createState() => _LifecycleWatcherState();
 }
 
 class _LifecycleWatcherState extends State<LifecycleWatcher>

--- a/examples/layers/widgets/spinning_square.dart
+++ b/examples/layers/widgets/spinning_square.dart
@@ -8,7 +8,7 @@ class SpinningSquare extends StatefulWidget {
   const SpinningSquare({Key? key}) : super(key: key);
 
   @override
-  _SpinningSquareState createState() => _SpinningSquareState();
+  State<SpinningSquare> createState() => _SpinningSquareState();
 }
 
 class _SpinningSquareState extends State<SpinningSquare> with SingleTickerProviderStateMixin {

--- a/examples/layers/widgets/styled_text.dart
+++ b/examples/layers/widgets/styled_text.dart
@@ -78,7 +78,7 @@ class StyledTextDemo extends StatefulWidget {
   const StyledTextDemo({Key? key}) : super(key: key);
 
   @override
-  _StyledTextDemoState createState() => _StyledTextDemoState();
+  State<StyledTextDemo> createState() => _StyledTextDemoState();
 }
 
 class _StyledTextDemoState extends State<StyledTextDemo> {

--- a/examples/platform_channel/lib/main.dart
+++ b/examples/platform_channel/lib/main.dart
@@ -11,7 +11,7 @@ class PlatformChannel extends StatefulWidget {
   const PlatformChannel({Key? key}) : super(key: key);
 
   @override
-  _PlatformChannelState createState() => _PlatformChannelState();
+  State<PlatformChannel> createState() => _PlatformChannelState();
 }
 
 class _PlatformChannelState extends State<PlatformChannel> {

--- a/examples/platform_channel_swift/lib/main.dart
+++ b/examples/platform_channel_swift/lib/main.dart
@@ -11,7 +11,7 @@ class PlatformChannel extends StatefulWidget {
   const PlatformChannel({Key? key}) : super(key: key);
 
   @override
-  _PlatformChannelState createState() => _PlatformChannelState();
+  State<PlatformChannel> createState() => _PlatformChannelState();
 }
 
 class _PlatformChannelState extends State<PlatformChannel> {

--- a/examples/platform_view/lib/main.dart
+++ b/examples/platform_view/lib/main.dart
@@ -32,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -141,7 +141,7 @@ enum AnimationBehavior {
 ///   final Duration duration;
 ///
 ///   @override
-///   _FooState createState() => _FooState();
+///   State<Foo> createState() => _FooState();
 /// }
 ///
 /// class _FooState extends State<Foo> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -448,7 +448,7 @@ class ThreePointCubic extends Curve {
 ///   final Widget child;
 ///
 ///   @override
-///   _FollowCurve2DState createState() => _FollowCurve2DState();
+///   State<FollowCurve2D> createState() => _FollowCurve2DState();
 /// }
 ///
 /// class _FollowCurve2DState extends State<FollowCurve2D> with TickerProviderStateMixin {

--- a/packages/flutter/lib/src/cupertino/activity_indicator.dart
+++ b/packages/flutter/lib/src/cupertino/activity_indicator.dart
@@ -72,8 +72,7 @@ class CupertinoActivityIndicator extends StatefulWidget {
   final double progress;
 
   @override
-  _CupertinoActivityIndicatorState createState() =>
-      _CupertinoActivityIndicatorState();
+  State<CupertinoActivityIndicator> createState() => _CupertinoActivityIndicatorState();
 }
 
 class _CupertinoActivityIndicatorState extends State<CupertinoActivityIndicator>

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -408,7 +408,7 @@ class CupertinoApp extends StatefulWidget {
   final ScrollBehavior? scrollBehavior;
 
   @override
-  _CupertinoAppState createState() => _CupertinoAppState();
+  State<CupertinoApp> createState() => _CupertinoAppState();
 
   /// The [HeroController] used for Cupertino page transitions.
   ///

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -137,7 +137,7 @@ class CupertinoButton extends StatefulWidget {
   bool get enabled => onPressed != null;
 
   @override
-  _CupertinoButtonState createState() => _CupertinoButtonState();
+  State<CupertinoButton> createState() => _CupertinoButtonState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -219,7 +219,7 @@ class CupertinoContextMenu extends StatefulWidget {
   final ContextMenuPreviewBuilder? previewBuilder;
 
   @override
-  _CupertinoContextMenuState createState() => _CupertinoContextMenuState();
+  State<CupertinoContextMenu> createState() => _CupertinoContextMenuState();
 }
 
 class _CupertinoContextMenuState extends State<CupertinoContextMenu> with TickerProviderStateMixin {

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -45,7 +45,7 @@ class CupertinoContextMenuAction extends StatefulWidget {
   final IconData? trailingIcon;
 
   @override
-  _CupertinoContextMenuActionState createState() => _CupertinoContextMenuActionState();
+  State<CupertinoContextMenuAction> createState() => _CupertinoContextMenuActionState();
 }
 
 class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction> {

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -183,7 +183,7 @@ bool _isInAccessibilityMode(BuildContext context) {
 ///   const MyStatefulWidget({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+///   State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 /// }
 ///
 /// class _MyStatefulWidgetState extends State<MyStatefulWidget> {
@@ -495,7 +495,7 @@ class CupertinoPopupSurface extends StatelessWidget {
 ///   const MyStatefulWidget({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyStatefulWidgetState createState() => _MyStatefulWidgetState();
+///   State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
 /// }
 ///
 /// class _MyStatefulWidgetState extends State<MyStatefulWidget> {

--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -44,7 +44,7 @@ const EdgeInsetsGeometry _kDefaultPadding =
 ///   const FlutterDemo({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _FlutterDemoState createState() => _FlutterDemoState();
+///   State<FlutterDemo> createState() => _FlutterDemoState();
 /// }
 ///
 /// class _FlutterDemoState extends State<FlutterDemo> {

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -407,9 +407,7 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   }
 
   @override
-  _CupertinoNavigationBarState createState() {
-    return _CupertinoNavigationBarState();
-  }
+  State<CupertinoNavigationBar> createState() => _CupertinoNavigationBarState();
 }
 
 // A state class exists for the nav bar so that the keys of its sub-components
@@ -668,7 +666,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   final bool stretch;
 
   @override
-  _CupertinoSliverNavigationBarState createState() => _CupertinoSliverNavigationBarState();
+  State<CupertinoSliverNavigationBar> createState() => _CupertinoSliverNavigationBarState();
 }
 
 // A state class exists for the nav bar so that the keys of its sub-components

--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -109,7 +109,7 @@ class CupertinoPageScaffold extends StatefulWidget {
   final bool resizeToAvoidBottomInset;
 
   @override
-  _CupertinoPageScaffoldState createState() => _CupertinoPageScaffoldState();
+  State<CupertinoPageScaffold> createState() => _CupertinoPageScaffoldState();
 }
 
 class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -469,7 +469,7 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
   }
 
   @override
-  _CupertinoSliverRefreshControlState createState() => _CupertinoSliverRefreshControlState();
+  State<CupertinoSliverRefreshControl> createState() => _CupertinoSliverRefreshControlState();
 }
 
 class _CupertinoSliverRefreshControlState extends State<CupertinoSliverRefreshControl> {

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -111,7 +111,7 @@ class CupertinoScrollbar extends RawScrollbar {
   final Radius radiusWhileDragging;
 
   @override
-  _CupertinoScrollbarState createState() => _CupertinoScrollbarState();
+  RawScrollbarState<CupertinoScrollbar> createState() => _CupertinoScrollbarState();
 }
 
 class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -28,7 +28,7 @@ import 'text_field.dart';
 ///   const MyPrefilledSearch({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyPrefilledSearchState createState() => _MyPrefilledSearchState();
+///   State<MyPrefilledSearch> createState() => _MyPrefilledSearchState();
 /// }
 ///
 /// class _MyPrefilledSearchState extends State<MyPrefilledSearch> {
@@ -59,7 +59,7 @@ import 'text_field.dart';
 ///   const MyPrefilledSearch({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyPrefilledSearchState createState() => _MyPrefilledSearchState();
+///   State<MyPrefilledSearch> createState() => _MyPrefilledSearchState();
 /// }
 ///
 /// class _MyPrefilledSearchState extends State<MyPrefilledSearch> {

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -187,7 +187,7 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   final EdgeInsetsGeometry? padding;
 
   @override
-  _SegmentedControlState<T> createState() => _SegmentedControlState<T>();
+  State<CupertinoSegmentedControl<T>> createState() => _SegmentedControlState<T>();
 }
 
 class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedControl<T>>

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -205,7 +205,7 @@ class CupertinoSlider extends StatefulWidget {
   final Color thumbColor;
 
   @override
-  _CupertinoSliderState createState() => _CupertinoSliderState();
+  State<CupertinoSlider> createState() => _CupertinoSliderState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -402,7 +402,7 @@ class CupertinoSlidingSegmentedControl<T> extends StatefulWidget {
   final EdgeInsetsGeometry padding;
 
   @override
-  _SegmentedControlState<T> createState() => _SegmentedControlState<T>();
+  State<CupertinoSlidingSegmentedControl<T>> createState() => _SegmentedControlState<T>();
 }
 
 class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T>>

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -129,7 +129,7 @@ class CupertinoSwitch extends StatefulWidget {
   final DragStartBehavior dragStartBehavior;
 
   @override
-  _CupertinoSwitchState createState() => _CupertinoSwitchState();
+  State<CupertinoSwitch> createState() => _CupertinoSwitchState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -312,7 +312,7 @@ class CupertinoTabScaffold extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _CupertinoTabScaffoldState createState() => _CupertinoTabScaffoldState();
+  State<CupertinoTabScaffold> createState() => _CupertinoTabScaffoldState();
 }
 
 class _CupertinoTabScaffoldState extends State<CupertinoTabScaffold> with RestorationMixin {

--- a/packages/flutter/lib/src/cupertino/tab_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/tab_scaffold.dart
@@ -23,7 +23,7 @@ import 'theme.dart';
 ///   const MyCupertinoTabScaffoldPage({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _CupertinoTabScaffoldPageState createState() => _CupertinoTabScaffoldPageState();
+///   State<MyCupertinoTabScaffoldPage> createState() => _CupertinoTabScaffoldPageState();
 /// }
 ///
 /// class _CupertinoTabScaffoldPageState extends State<MyCupertinoTabScaffoldPage> {

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -133,9 +133,7 @@ class CupertinoTabView extends StatefulWidget {
   final String? restorationScopeId;
 
   @override
-  _CupertinoTabViewState createState() {
-    return _CupertinoTabViewState();
-  }
+  State<CupertinoTabView> createState() => _CupertinoTabViewState();
 }
 
 class _CupertinoTabViewState extends State<CupertinoTabView> {

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -776,7 +776,7 @@ class CupertinoTextField extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _CupertinoTextFieldState createState() => _CupertinoTextFieldState();
+  State<CupertinoTextField> createState() => _CupertinoTextFieldState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -151,7 +151,7 @@ class _CupertinoTextFieldSelectionGestureDetectorBuilder extends TextSelectionGe
 ///   const MyPrefilledText({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyPrefilledTextState createState() => _MyPrefilledTextState();
+///   State<MyPrefilledText> createState() => _MyPrefilledTextState();
 /// }
 ///
 /// class _MyPrefilledTextState extends State<MyPrefilledText> {

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -298,8 +298,7 @@ class CupertinoTextFormFieldRow extends FormField<String> {
   final TextEditingController? controller;
 
   @override
-  _CupertinoTextFormFieldRowState createState() =>
-      _CupertinoTextFormFieldRowState();
+  FormFieldState<String> createState() => _CupertinoTextFormFieldRowState();
 }
 
 class _CupertinoTextFormFieldRowState extends FormFieldState<String> {

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1059,7 +1059,7 @@ class _NoDefaultValue {
 }
 
 /// Marker object indicating that a [DiagnosticsNode] has no default value.
-const _NoDefaultValue kNoDefaultValue = _NoDefaultValue();
+const Object kNoDefaultValue = _NoDefaultValue();
 
 bool _isSingleLine(DiagnosticsTreeStyle? style) {
   return style == DiagnosticsTreeStyle.singleLine;

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -17,8 +17,8 @@ import '_isolates_io.dart'
 /// {@macro flutter.foundation.compute.limitations}
 typedef ComputeCallback<Q, R> = FutureOr<R> Function(Q message);
 
-// The signature of [compute].
-typedef _ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q message, { String? debugLabel });
+/// The signature of [compute].
+typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q message, { String? debugLabel });
 
 /// Spawn an isolate, run `callback` on that isolate, passing it `message`, and
 /// (eventually) return the value returned by `callback`.
@@ -44,4 +44,4 @@ typedef _ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, 
 ///
 /// The `debugLabel` argument can be specified to provide a name to add to the
 /// [Timeline]. This is useful when profiling an application.
-const _ComputeImpl compute = _isolates.compute;
+const ComputeImpl compute = _isolates.compute;

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -197,7 +197,7 @@ abstract class MultiDragPointerState {
 ///    start vertically.
 ///  * [DelayedMultiDragGestureRecognizer], which only recognizes drags that
 ///    start after a long-press gesture.
-abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> extends GestureRecognizer {
+abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   /// Initialize the object.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
@@ -221,7 +221,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   /// [Drag] object returned by this callback.
   GestureMultiDragStartCallback? onStart;
 
-  Map<int, T>? _pointers = <int, T>{};
+  Map<int, MultiDragPointerState>? _pointers = <int, MultiDragPointerState>{};
 
   @override
   void addAllowedPointer(PointerDownEvent event) {
@@ -229,7 +229,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
     assert(event.pointer != null);
     assert(event.position != null);
     assert(!_pointers!.containsKey(event.pointer));
-    final T state = createNewPointerState(event);
+    final MultiDragPointerState state = createNewPointerState(event);
     _pointers![event.pointer] = state;
     GestureBinding.instance!.pointerRouter.addRoute(event.pointer, _handleEvent);
     state._setArenaEntry(GestureBinding.instance!.gestureArena.add(event.pointer, this));
@@ -239,7 +239,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   /// objects to track the pointer associated with the given event.
   @protected
   @factory
-  T createNewPointerState(PointerDownEvent event);
+  MultiDragPointerState createNewPointerState(PointerDownEvent event);
 
   void _handleEvent(PointerEvent event) {
     assert(_pointers != null);
@@ -247,7 +247,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
     assert(event.timeStamp != null);
     assert(event.position != null);
     assert(_pointers!.containsKey(event.pointer));
-    final T state = _pointers![event.pointer]!;
+    final MultiDragPointerState state = _pointers![event.pointer]!;
     if (event is PointerMoveEvent) {
       state._move(event);
       // We might be disposed here.
@@ -272,7 +272,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   @override
   void acceptGesture(int pointer) {
     assert(_pointers != null);
-    final T? state = _pointers![pointer];
+    final MultiDragPointerState? state = _pointers![pointer];
     if (state == null)
       return; // We might already have canceled this drag if the up comes before the accept.
     state.accepted((Offset initialPosition) => _startDrag(initialPosition, pointer));
@@ -280,7 +280,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
 
   Drag? _startDrag(Offset initialPosition, int pointer) {
     assert(_pointers != null);
-    final T state = _pointers![pointer]!;
+    final MultiDragPointerState state = _pointers![pointer]!;
     assert(state != null);
     assert(state._pendingDelta != null);
     Drag? drag;
@@ -298,7 +298,7 @@ abstract class MultiDragGestureRecognizer<T extends MultiDragPointerState> exten
   void rejectGesture(int pointer) {
     assert(_pointers != null);
     if (_pointers!.containsKey(pointer)) {
-      final T state = _pointers![pointer]!;
+      final MultiDragPointerState state = _pointers![pointer]!;
       assert(state != null);
       state.rejected();
       _removeState(pointer);
@@ -357,7 +357,7 @@ class _ImmediatePointerState extends MultiDragPointerState {
 ///    start vertically.
 ///  * [DelayedMultiDragGestureRecognizer], which only recognizes drags that
 ///    start after a long-press gesture.
-class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_ImmediatePointerState> {
+class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
   /// Create a gesture recognizer for tracking multiple pointers at once.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
@@ -376,7 +376,7 @@ class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Im
        );
 
   @override
-  _ImmediatePointerState createNewPointerState(PointerDownEvent event) {
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) {
     return _ImmediatePointerState(event.position, event.kind);
   }
 
@@ -416,7 +416,7 @@ class _HorizontalPointerState extends MultiDragPointerState {
 ///    the limitation that the drag must start horizontally.
 ///  * [VerticalMultiDragGestureRecognizer], which only recognizes drags that
 ///    start vertically.
-class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_HorizontalPointerState> {
+class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
   /// Create a gesture recognizer for tracking multiple pointers at once
   /// but only if they first move horizontally.
   ///
@@ -436,7 +436,7 @@ class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_H
        );
 
   @override
-  _HorizontalPointerState createNewPointerState(PointerDownEvent event) {
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) {
     return _HorizontalPointerState(event.position, event.kind);
   }
 
@@ -476,7 +476,7 @@ class _VerticalPointerState extends MultiDragPointerState {
 ///    the limitation that the drag must start vertically.
 ///  * [HorizontalMultiDragGestureRecognizer], which only recognizes drags that
 ///    start horizontally.
-class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_VerticalPointerState> {
+class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
   /// Create a gesture recognizer for tracking multiple pointers at once
   /// but only if they first move vertically.
   ///
@@ -496,7 +496,7 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Ver
        );
 
   @override
-  _VerticalPointerState createNewPointerState(PointerDownEvent event) {
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) {
     return _VerticalPointerState(event.position, event.kind);
   }
 
@@ -585,7 +585,7 @@ class _DelayedPointerState extends MultiDragPointerState {
 ///    the delay.
 ///  * [PanGestureRecognizer], which recognizes only one drag gesture at a time,
 ///    regardless of how many fingers are involved.
-class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_DelayedPointerState> {
+class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
   /// Creates a drag recognizer that works on a per-pointer basis after a delay.
   ///
   /// In order for a drag to be recognized by this recognizer, the pointer must
@@ -615,7 +615,7 @@ class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer<_Dela
   final Duration delay;
 
   @override
-  _DelayedPointerState createNewPointerState(PointerDownEvent event) {
+  MultiDragPointerState createNewPointerState(PointerDownEvent event) {
     return _DelayedPointerState(event.position, delay, event.kind);
   }
 

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -68,7 +68,7 @@ bool _isSameEvent(PointerSignalEvent event1, PointerSignalEvent event2) {
 ///   final Widget? child;
 ///
 ///   @override
-///   _ColorChangerState createState() => _ColorChangerState();
+///   State<ColorChanger> createState() => _ColorChangerState();
 /// }
 ///
 /// class _ColorChangerState extends State<ColorChanger> {

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -482,7 +482,7 @@ class LicensePage extends StatefulWidget {
   final String? applicationLegalese;
 
   @override
-  _LicensePageState createState() => _LicensePageState();
+  State<LicensePage> createState() => _LicensePageState();
 }
 
 class _LicensePageState extends State<LicensePage> {

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -663,7 +663,7 @@ class MaterialApp extends StatefulWidget {
   final bool debugShowMaterialGrid;
 
   @override
-  _MaterialAppState createState() => _MaterialAppState();
+  State<MaterialApp> createState() => _MaterialAppState();
 
   /// The [HeroController] used for Material page transitions.
   ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -722,7 +722,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   }
 
   @override
-  _AppBarState createState() => _AppBarState();
+  State<AppBar> createState() => _AppBarState();
 }
 
 class _AppBarState extends State<AppBar> {
@@ -1747,7 +1747,7 @@ class SliverAppBar extends StatefulWidget {
   final SystemUiOverlayStyle? systemOverlayStyle;
 
   @override
-  _SliverAppBarState createState() => _SliverAppBarState();
+  State<SliverAppBar> createState() => _SliverAppBarState();
 }
 
 // This class is only Stateful because it owns the TickerProvider used

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -423,7 +423,7 @@ class BottomNavigationBar extends StatefulWidget {
   final bool? enableFeedback;
 
   @override
-  _BottomNavigationBarState createState() => _BottomNavigationBarState();
+  State<BottomNavigationBar> createState() => _BottomNavigationBarState();
 }
 
 // This represents a single tile in the bottom navigation bar. It is intended

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -181,7 +181,7 @@ class BottomSheet extends StatefulWidget {
   final BoxConstraints? constraints;
 
   @override
-  _BottomSheetState createState() => _BottomSheetState();
+  State<BottomSheet> createState() => _BottomSheetState();
 
   /// Creates an [AnimationController] suitable for a
   /// [BottomSheet.animationController].

--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -311,7 +311,7 @@ class RawMaterialButton extends StatefulWidget {
   final bool enableFeedback;
 
   @override
-  _RawMaterialButtonState createState() => _RawMaterialButtonState();
+  State<RawMaterialButton> createState() => _RawMaterialButtonState();
 }
 
 class _RawMaterialButtonState extends State<RawMaterialButton> {

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -123,7 +123,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   bool get enabled => onPressed != null || onLongPress != null;
 
   @override
-  _ButtonStyleState createState() => _ButtonStyleState();
+  State<ButtonStyleButton> createState() => _ButtonStyleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -146,7 +146,7 @@ class CalendarDatePicker extends StatefulWidget {
   final SelectableDayPredicate? selectableDayPredicate;
 
   @override
-  _CalendarDatePickerState createState() => _CalendarDatePickerState();
+  State<CalendarDatePicker> createState() => _CalendarDatePickerState();
 }
 
 class _CalendarDatePickerState extends State<CalendarDatePicker> {
@@ -1146,7 +1146,7 @@ class YearPicker extends StatefulWidget {
   final DragStartBehavior dragStartBehavior;
 
   @override
-  _YearPickerState createState() => _YearPickerState();
+  State<YearPicker> createState() => _YearPickerState();
 }
 
 class _YearPickerState extends State<YearPicker> {

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -321,7 +321,7 @@ class Checkbox extends StatefulWidget {
   static const double width = 18.0;
 
   @override
-  _CheckboxState createState() => _CheckboxState();
+  State<Checkbox> createState() => _CheckboxState();
 }
 
 class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, ToggleableStateMixin {

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -919,7 +919,7 @@ class InputChip extends StatelessWidget
 ///   const MyThreeOptions({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyThreeOptionsState createState() => _MyThreeOptionsState();
+///   State<MyThreeOptions> createState() => _MyThreeOptionsState();
 /// }
 ///
 /// class _MyThreeOptionsState extends State<MyThreeOptions> {

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1628,7 +1628,7 @@ class RawChip extends StatefulWidget
   final bool tapEnabled;
 
   @override
-  _RawChipState createState() => _RawChipState();
+  State<RawChip> createState() => _RawChipState();
 }
 
 class _RawChipState extends State<RawChip> with TickerProviderStateMixin<RawChip> {

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -412,7 +412,7 @@ class DatePickerDialog extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _DatePickerDialogState createState() => _DatePickerDialogState();
+  State<DatePickerDialog> createState() => _DatePickerDialogState();
 }
 
 class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMixin {
@@ -1312,7 +1312,7 @@ class DateRangePickerDialog extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _DateRangePickerDialogState createState() => _DateRangePickerDialogState();
+  State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
 }
 
 class _DateRangePickerDialogState extends State<DateRangePickerDialog> with RestorationMixin {

--- a/packages/flutter/lib/src/material/date_picker_deprecated.dart
+++ b/packages/flutter/lib/src/material/date_picker_deprecated.dart
@@ -401,7 +401,7 @@ class MonthPicker extends StatefulWidget {
   final DragStartBehavior dragStartBehavior;
 
   @override
-  _MonthPickerState createState() => _MonthPickerState();
+  State<MonthPicker> createState() => _MonthPickerState();
 }
 
 class _MonthPickerState extends State<MonthPicker> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1139,7 +1139,7 @@ class DropdownButton<T> extends StatefulWidget {
   final bool? enableFeedback;
 
   @override
-  _DropdownButtonState<T> createState() => _DropdownButtonState<T>();
+  State<DropdownButton<T>> createState() => _DropdownButtonState<T>();
 }
 
 class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindingObserver {

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -97,7 +97,7 @@ class ExpandIcon extends StatefulWidget {
   final Color? expandedColor;
 
   @override
-  _ExpandIconState createState() => _ExpandIconState();
+  State<ExpandIcon> createState() => _ExpandIconState();
 }
 
 class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -181,7 +181,7 @@ class ExpansionTile extends StatefulWidget {
   final Color? collapsedTextColor;
 
   @override
-  _ExpansionTileState createState() => _ExpansionTileState();
+  State<ExpansionTile> createState() => _ExpansionTileState();
 }
 
 class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -237,7 +237,7 @@ class FlexibleSpaceBar extends StatefulWidget {
   }
 
   @override
-  _FlexibleSpaceBarState createState() => _FlexibleSpaceBarState();
+  State<FlexibleSpaceBar> createState() => _FlexibleSpaceBarState();
 }
 
 class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -6,7 +6,13 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/widgets.dart';
 
 // ignore_for_file: non_constant_identifier_names
-class _PlatformAdaptiveIcons {
+
+/// A set of platform-adaptive material design icons.
+///
+/// Use [Icons.adaptive] to access a static instance of this class.
+class PlatformAdaptiveIcons implements Icons {
+  const PlatformAdaptiveIcons._();
+
   static bool _isCupertino() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
@@ -171,7 +177,7 @@ class Icons {
   ///  * [Icon]
   ///  * [IconButton]
   ///  * <https://design.google.com/icons/>
-  static _PlatformAdaptiveIcons get adaptive => _PlatformAdaptiveIcons();
+  static PlatformAdaptiveIcons get adaptive => const PlatformAdaptiveIcons._();
 
   // Generated code: do not hand-edit.
   // See https://github.com/flutter/flutter/wiki/Updating-Material-Design-Fonts-&-Icons

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -238,7 +238,7 @@ class Ink extends StatefulWidget {
   }
 
   @override
-  _InkState createState() => _InkState();
+  State<Ink> createState() => _InkState();
 }
 
 class _InkState extends State<Ink> {

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -129,7 +129,7 @@ class InputDatePickerFormField extends StatefulWidget {
   final bool autofocus;
 
   @override
-  _InputDatePickerFormFieldState createState() => _InputDatePickerFormFieldState();
+  State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
 }
 
 class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1913,7 +1913,7 @@ class InputDecorator extends StatefulWidget {
   bool get _labelShouldWithdraw => !isEmpty || (isFocused && decoration.enabled);
 
   @override
-  _InputDecoratorState createState() => _InputDecoratorState();
+  State<InputDecorator> createState() => _InputDecoratorState();
 
   /// The RenderBox that defines this decorator's "container". That's the
   /// area which is filled if [InputDecoration.filled] is true. It's the area

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -317,7 +317,7 @@ class Material extends StatefulWidget {
   }
 
   @override
-  _MaterialState createState() => _MaterialState();
+  State<Material> createState() => _MaterialState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -142,7 +142,7 @@ class MergeableMaterial extends StatefulWidget {
   }
 
   @override
-  _MergeableMaterialState createState() => _MergeableMaterialState();
+  State<MergeableMaterial> createState() => _MergeableMaterialState();
 }
 
 class _AnimationTuple {

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -383,7 +383,7 @@ class NavigationRail extends StatefulWidget {
   }
 
   @override
-  _NavigationRailState createState() => _NavigationRailState();
+  State<NavigationRail> createState() => _NavigationRailState();
 }
 
 class _NavigationRailState extends State<NavigationRail> with TickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -112,7 +112,7 @@ class PopupMenuDivider extends PopupMenuEntry<Never> {
   bool represents(void value) => false;
 
   @override
-  _PopupMenuDividerState createState() => _PopupMenuDividerState();
+  State<PopupMenuDivider> createState() => _PopupMenuDividerState();
 }
 
 class _PopupMenuDividerState extends State<PopupMenuDivider> {
@@ -485,7 +485,7 @@ class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
   Widget? get child => super.child;
 
   @override
-  _CheckedPopupMenuItemState<T> createState() => _CheckedPopupMenuItemState<T>();
+  PopupMenuItemState<T, CheckedPopupMenuItem<T>> createState() => _CheckedPopupMenuItemState<T>();
 }
 
 class _CheckedPopupMenuItemState<T> extends PopupMenuItemState<T, CheckedPopupMenuItem<T>> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -346,7 +346,7 @@ class LinearProgressIndicator extends ProgressIndicator {
   final double? minHeight;
 
   @override
-  _LinearProgressIndicatorState createState() => _LinearProgressIndicatorState();
+  State<LinearProgressIndicator> createState() => _LinearProgressIndicatorState();
 }
 
 class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with SingleTickerProviderStateMixin {
@@ -630,7 +630,7 @@ class CircularProgressIndicator extends ProgressIndicator {
   final double strokeWidth;
 
   @override
-  _CircularProgressIndicatorState createState() => _CircularProgressIndicatorState();
+  State<CircularProgressIndicator> createState() => _CircularProgressIndicatorState();
 }
 
 class _CircularProgressIndicatorState extends State<CircularProgressIndicator> with SingleTickerProviderStateMixin {
@@ -857,7 +857,7 @@ class RefreshProgressIndicator extends CircularProgressIndicator {
   @override
   Color? get backgroundColor => super.backgroundColor;
   @override
-  _RefreshProgressIndicatorState createState() => _RefreshProgressIndicatorState();
+  State<CircularProgressIndicator> createState() => _RefreshProgressIndicatorState();
 }
 
 class _RefreshProgressIndicatorState extends _CircularProgressIndicatorState {

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -356,7 +356,7 @@ class Radio<T> extends StatefulWidget {
   bool get _selected => value == groupValue;
 
   @override
-  _RadioState<T> createState() => _RadioState<T>();
+  State<Radio<T>> createState() => _RadioState<T>();
 }
 
 class _RadioState<T> extends State<Radio<T>> with TickerProviderStateMixin, ToggleableStateMixin {

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -377,7 +377,7 @@ class RangeSlider extends StatefulWidget {
   static const double _minTouchTargetWidth = kMinInteractiveDimension;
 
   @override
-  _RangeSliderState createState() => _RangeSliderState();
+  State<RangeSlider> createState() => _RangeSliderState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -342,7 +342,7 @@ class ReorderableListView extends StatefulWidget {
   final Widget? prototypeItem;
 
   @override
-  _ReorderableListViewState createState() => _ReorderableListViewState();
+  State<ReorderableListView> createState() => _ReorderableListViewState();
 }
 
 class _ReorderableListViewState extends State<ReorderableListView> {

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -158,7 +158,7 @@ class ScaffoldMessenger extends StatefulWidget {
   ///   const MyApp({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///  _MyAppState createState() => _MyAppState();
+  ///  State<MyApp> createState() => _MyAppState();
   /// }
   ///
   /// class _MyAppState extends State<MyApp> {

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -166,7 +166,7 @@ class Scrollbar extends StatefulWidget {
   final ScrollNotificationPredicate? notificationPredicate;
 
   @override
-  _ScrollbarState createState() => _ScrollbarState();
+  State<Scrollbar> createState() => _ScrollbarState();
 }
 
 class _ScrollbarState extends State<Scrollbar> {

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -399,7 +399,7 @@ class SelectableText extends StatefulWidget {
   final SelectionChangedCallback? onSelectionChanged;
 
   @override
-  _SelectableTextState createState() => _SelectableTextState();
+  State<SelectableText> createState() => _SelectableTextState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -437,7 +437,7 @@ class Slider extends StatefulWidget {
   final _SliderType _sliderType ;
 
   @override
-  _SliderState createState() => _SliderState();
+  State<Slider> createState() => _SliderState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -281,7 +281,7 @@ class Stepper extends StatefulWidget {
   final ControlsWidgetBuilder? controlsBuilder;
 
   @override
-  _StepperState createState() => _StepperState();
+  State<Stepper> createState() => _StepperState();
 }
 
 class _StepperState extends State<Stepper> with TickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -34,7 +34,7 @@ import 'constants.dart';
 /// class MyTabbedPage extends StatefulWidget {
 ///   const MyTabbedPage({ Key? key }) : super(key: key);
 ///   @override
-///   _MyTabbedPageState createState() => _MyTabbedPageState();
+///   State<MyTabbedPage> createState() => _MyTabbedPageState();
 /// }
 ///
 /// class _MyTabbedPageState extends State<MyTabbedPage> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -416,7 +416,7 @@ class DefaultTabController extends StatefulWidget {
   }
 
   @override
-  _DefaultTabControllerState createState() => _DefaultTabControllerState();
+  State<DefaultTabController> createState() => _DefaultTabControllerState();
 }
 
 class _DefaultTabControllerState extends State<DefaultTabController> with SingleTickerProviderStateMixin {

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -59,7 +59,7 @@ class UnderlineTabIndicator extends Decoration {
   }
 
   @override
-  _UnderlinePainter createBoxPainter([ VoidCallback? onChanged ]) {
+  BoxPainter createBoxPainter([ VoidCallback? onChanged ]) {
     return _UnderlinePainter(this, onChanged);
   }
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -911,7 +911,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   }
 
   @override
-  _TabBarState createState() => _TabBarState();
+  State<TabBar> createState() => _TabBarState();
 }
 
 class _TabBarState extends State<TabBar> {
@@ -1325,7 +1325,7 @@ class TabBarView extends StatefulWidget {
   final DragStartBehavior dragStartBehavior;
 
   @override
-  _TabBarViewState createState() => _TabBarViewState();
+  State<TabBarView> createState() => _TabBarViewState();
 }
 
 class _TabBarViewState extends State<TabBarView> {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -818,7 +818,7 @@ class TextField extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _TextFieldState createState() => _TextFieldState();
+  State<TextField> createState() => _TextFieldState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -311,7 +311,7 @@ class TextFormField extends FormField<String> {
   final TextEditingController? controller;
 
   @override
-  _TextFormFieldState createState() => _TextFormFieldState();
+  FormFieldState<String> createState() => _TextFormFieldState();
 }
 
 class _TextFormFieldState extends FormFieldState<String> {

--- a/packages/flutter/lib/src/material/theme.dart
+++ b/packages/flutter/lib/src/material/theme.dart
@@ -213,7 +213,7 @@ class AnimatedTheme extends ImplicitlyAnimatedWidget {
   final Widget child;
 
   @override
-  _AnimatedThemeState createState() => _AnimatedThemeState();
+  AnimatedWidgetBaseState<AnimatedTheme> createState() => _AnimatedThemeState();
 }
 
 class _AnimatedThemeState extends AnimatedWidgetBaseState<AnimatedTheme> {

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1823,7 +1823,7 @@ class TimePickerDialog extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _TimePickerDialogState createState() => _TimePickerDialogState();
+  State<TimePickerDialog> createState() => _TimePickerDialogState();
 }
 
 // A restorable [TimePickerEntryMode] value.

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -203,7 +203,7 @@ class Tooltip extends StatefulWidget {
   final Duration? showDuration;
 
   @override
-  _TooltipState createState() => _TooltipState();
+  State<Tooltip> createState() => _TooltipState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -348,7 +348,7 @@ class UserAccountsDrawerHeader extends StatefulWidget {
   final Color arrowColor;
 
   @override
-  _UserAccountsDrawerHeaderState createState() => _UserAccountsDrawerHeaderState();
+  State<UserAccountsDrawerHeader> createState() => _UserAccountsDrawerHeaderState();
 }
 
 class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -373,7 +373,7 @@ class BoxDecoration extends Decoration {
   }
 
   @override
-  _BoxDecorationPainter createBoxPainter([ VoidCallback? onChanged ]) {
+  BoxPainter createBoxPainter([ VoidCallback? onChanged ]) {
     assert(onChanged != null || image == null);
     return _BoxDecorationPainter(this, onChanged);
   }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -683,11 +683,13 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   }
 }
 
-/// Key for the image obtained by a [ResizeImage].
+/// Key used internally by [ResizeImage].
 ///
 /// This is used to identify the precise resource in the [imageCache].
 @immutable
 class ResizeImageKey {
+  // Private constructor so nobody from the outside can poison the image cache
+  // with this key. It's only accessible to [ResizeImage] internally.
   const ResizeImageKey._(this._providerCacheKey, this._width, this._height);
 
   final Object _providerCacheKey;

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -683,28 +683,29 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   }
 }
 
+/// Key for the image obtained by a [ResizeImage].
+///
+/// This is used to identify the precise resource in the [imageCache].
 @immutable
-class _SizeAwareCacheKey {
-  const _SizeAwareCacheKey(this.providerCacheKey, this.width, this.height);
+class ResizeImageKey {
+  const ResizeImageKey._(this._providerCacheKey, this._width, this._height);
 
-  final Object providerCacheKey;
-
-  final int? width;
-
-  final int? height;
+  final Object _providerCacheKey;
+  final int? _width;
+  final int? _height;
 
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType)
       return false;
-    return other is _SizeAwareCacheKey
-        && other.providerCacheKey == providerCacheKey
-        && other.width == width
-        && other.height == height;
+    return other is ResizeImageKey
+        && other._providerCacheKey == _providerCacheKey
+        && other._width == _width
+        && other._height == _height;
   }
 
   @override
-  int get hashCode => hashValues(providerCacheKey, width, height);
+  int get hashCode => hashValues(_providerCacheKey, _width, _height);
 }
 
 /// Instructs Flutter to decode the image at the specified dimensions
@@ -715,7 +716,7 @@ class _SizeAwareCacheKey {
 ///
 /// The decoded image may still be displayed at sizes other than the
 /// cached size provided here.
-class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
+class ResizeImage extends ImageProvider<ResizeImageKey> {
   /// Creates an ImageProvider that decodes the image to the specified size.
   ///
   /// The cached image will be directly decoded and stored at the resolution
@@ -760,7 +761,7 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
   }
 
   @override
-  ImageStreamCompleter load(_SizeAwareCacheKey key, DecoderCallback decode) {
+  ImageStreamCompleter load(ResizeImageKey key, DecoderCallback decode) {
     Future<ui.Codec> decodeResize(Uint8List bytes, {int? cacheWidth, int? cacheHeight, bool? allowUpscaling}) {
       assert(
         cacheWidth == null && cacheHeight == null && allowUpscaling == null,
@@ -769,27 +770,27 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
       );
       return decode(bytes, cacheWidth: width, cacheHeight: height, allowUpscaling: this.allowUpscaling);
     }
-    final ImageStreamCompleter completer = imageProvider.load(key.providerCacheKey, decodeResize);
+    final ImageStreamCompleter completer = imageProvider.load(key._providerCacheKey, decodeResize);
     if (!kReleaseMode) {
-      completer.debugLabel = '${completer.debugLabel} - Resized(${key.width}×${key.height})';
+      completer.debugLabel = '${completer.debugLabel} - Resized(${key._width}×${key._height})';
     }
     return completer;
   }
 
   @override
-  Future<_SizeAwareCacheKey> obtainKey(ImageConfiguration configuration) {
-    Completer<_SizeAwareCacheKey>? completer;
+  Future<ResizeImageKey> obtainKey(ImageConfiguration configuration) {
+    Completer<ResizeImageKey>? completer;
     // If the imageProvider.obtainKey future is synchronous, then we will be able to fill in result with
     // a value before completer is initialized below.
-    SynchronousFuture<_SizeAwareCacheKey>? result;
+    SynchronousFuture<ResizeImageKey>? result;
     imageProvider.obtainKey(configuration).then((Object key) {
       if (completer == null) {
         // This future has completed synchronously (completer was never assigned),
         // so we can directly create the synchronous result to return.
-        result = SynchronousFuture<_SizeAwareCacheKey>(_SizeAwareCacheKey(key, width, height));
+        result = SynchronousFuture<ResizeImageKey>(ResizeImageKey._(key, width, height));
       } else {
         // This future did not synchronously complete.
-        completer.complete(_SizeAwareCacheKey(key, width, height));
+        completer.complete(ResizeImageKey._(key, width, height));
       }
     });
     if (result != null) {
@@ -797,7 +798,7 @@ class ResizeImage extends ImageProvider<_SizeAwareCacheKey> {
     }
     // If the code reaches here, it means the imageProvider.obtainKey was not
     // completed sync, so we initialize the completer for completion later.
-    completer = Completer<_SizeAwareCacheKey>();
+    completer = Completer<ResizeImageKey>();
     return completer.future;
   }
 }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -241,7 +241,7 @@ typedef DecoderCallback = Future<ui.Codec> Function(Uint8List bytes, {int? cache
 ///   final ImageProvider imageProvider;
 ///
 ///   @override
-///   _MyImageState createState() => _MyImageState();
+///   State<MyImage> createState() => _MyImageState();
 /// }
 ///
 /// class _MyImageState extends State<MyImage> {

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -288,7 +288,7 @@ class ShapeDecoration extends Decoration {
   }
 
   @override
-  _ShapeDecorationPainter createBoxPainter([ VoidCallback? onChanged ]) {
+  BoxPainter createBoxPainter([ VoidCallback? onChanged ]) {
     assert(onChanged != null || image == null);
     return _ShapeDecorationPainter(this, onChanged!);
   }

--- a/packages/flutter/lib/src/painting/text_span.dart
+++ b/packages/flutter/lib/src/painting/text_span.dart
@@ -127,7 +127,7 @@ class TextSpan extends InlineSpan implements HitTestTarget, MouseTrackerAnnotati
   ///   const BuzzingText({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _BuzzingTextState createState() => _BuzzingTextState();
+  ///   State<BuzzingText> createState() => _BuzzingTextState();
   /// }
   ///
   /// class _BuzzingTextState extends State<BuzzingText> {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3078,7 +3078,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   ///   const PngHome({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _PngHomeState createState() => _PngHomeState();
+  ///   State<PngHome> createState() => _PngHomeState();
   /// }
   ///
   /// class _PngHomeState extends State<PngHome> {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -40,7 +40,10 @@ typedef SetSelectionHandler = void Function(TextSelection selection);
 /// current text with the input `text`.
 typedef SetTextHandler = void Function(String text);
 
-typedef _SemanticsActionHandler = void Function(Object? args);
+/// Signature for a handler of a [SemanticsAction].
+///
+/// Returned by [SemanticsConfiguration.getActionHandler].
+typedef SemanticsActionHandler = void Function(Object? args);
 
 /// A tag for a [SemanticsNode].
 ///
@@ -1628,7 +1631,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   // TAGS, LABELS, ACTIONS
 
-  Map<SemanticsAction, _SemanticsActionHandler> _actions = _kEmptyConfig._actions;
+  Map<SemanticsAction, SemanticsActionHandler> _actions = _kEmptyConfig._actions;
   Map<CustomSemanticsAction, VoidCallback> _customSemanticsActions = _kEmptyConfig._customSemanticsActions;
 
   int _actionsAsBits = _kEmptyConfig._actionsAsBits;
@@ -1899,7 +1902,7 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
     _flags = config._flags;
     _textDirection = config.textDirection;
     _sortKey = config.sortKey;
-    _actions = Map<SemanticsAction, _SemanticsActionHandler>.from(config._actions);
+    _actions = Map<SemanticsAction, SemanticsActionHandler>.from(config._actions);
     _customSemanticsActions = Map<CustomSemanticsAction, VoidCallback>.from(config._customSemanticsActions);
     _actionsAsBits = config._actionsAsBits;
     _textSelection = config._textSelection;
@@ -2689,7 +2692,7 @@ class SemanticsOwner extends ChangeNotifier {
     notifyListeners();
   }
 
-  _SemanticsActionHandler? _getSemanticsActionHandlerForId(int id, SemanticsAction action) {
+  SemanticsActionHandler? _getSemanticsActionHandlerForId(int id, SemanticsAction action) {
     SemanticsNode? result = _nodes[id];
     if (result != null && result.isPartOfNodeMerging && !result._canPerformAction(action)) {
       result._visitDescendants((SemanticsNode node) {
@@ -2714,7 +2717,7 @@ class SemanticsOwner extends ChangeNotifier {
   /// the `args` parameter.
   void performAction(int id, SemanticsAction action, [ Object? args ]) {
     assert(action != null);
-    final _SemanticsActionHandler? handler = _getSemanticsActionHandlerForId(id, action);
+    final SemanticsActionHandler? handler = _getSemanticsActionHandlerForId(id, action);
     if (handler != null) {
       handler(args);
       return;
@@ -2725,7 +2728,7 @@ class SemanticsOwner extends ChangeNotifier {
       _nodes[id]!._showOnScreen!();
   }
 
-  _SemanticsActionHandler? _getSemanticsActionHandlerForPosition(SemanticsNode node, Offset position, SemanticsAction action) {
+  SemanticsActionHandler? _getSemanticsActionHandlerForPosition(SemanticsNode node, Offset position, SemanticsAction action) {
     if (node.transform != null) {
       final Matrix4 inverse = Matrix4.identity();
       if (inverse.copyInverse(node.transform!) == 0.0)
@@ -2747,7 +2750,7 @@ class SemanticsOwner extends ChangeNotifier {
     }
     if (node.hasChildren) {
       for (final SemanticsNode child in node._children!.reversed) {
-        final _SemanticsActionHandler? handler = _getSemanticsActionHandlerForPosition(child, position, action);
+        final SemanticsActionHandler? handler = _getSemanticsActionHandlerForPosition(child, position, action);
         if (handler != null)
           return handler;
       }
@@ -2767,7 +2770,7 @@ class SemanticsOwner extends ChangeNotifier {
     final SemanticsNode? node = rootSemanticsNode;
     if (node == null)
       return;
-    final _SemanticsActionHandler? handler = _getSemanticsActionHandlerForPosition(node, position, action);
+    final SemanticsActionHandler? handler = _getSemanticsActionHandlerForPosition(node, position, action);
     if (handler != null)
       handler(args);
   }
@@ -2854,7 +2857,7 @@ class SemanticsConfiguration {
   /// See also:
   ///
   ///  * [addAction] to add an action.
-  final Map<SemanticsAction, _SemanticsActionHandler> _actions = <SemanticsAction, _SemanticsActionHandler>{};
+  final Map<SemanticsAction, SemanticsActionHandler> _actions = <SemanticsAction, SemanticsActionHandler>{};
 
   int _actionsAsBits = 0;
 
@@ -2862,7 +2865,7 @@ class SemanticsConfiguration {
   ///
   /// The provided `handler` is called to respond to the user triggered
   /// `action`.
-  void _addAction(SemanticsAction action, _SemanticsActionHandler handler) {
+  void _addAction(SemanticsAction action, SemanticsActionHandler handler) {
     assert(handler != null);
     _actions[action] = handler;
     _actionsAsBits |= action.index;
@@ -3266,7 +3269,7 @@ class SemanticsConfiguration {
 
   /// Returns the action handler registered for [action] or null if none was
   /// registered.
-  _SemanticsActionHandler? getActionHandler(SemanticsAction action) => _actions[action];
+  SemanticsActionHandler? getActionHandler(SemanticsAction action) => _actions[action];
 
   /// Determines the position of this node among its siblings in the traversal
   /// sort order.

--- a/packages/flutter/lib/src/services/mouse_cursor.dart
+++ b/packages/flutter/lib/src/services/mouse_cursor.dart
@@ -381,7 +381,7 @@ class SystemMouseCursor extends MouseCursor {
 
   @override
   @protected
-  _SystemMouseCursorSession createSession(int device) => _SystemMouseCursorSession(this, device);
+  MouseCursorSession createSession(int device) => _SystemMouseCursorSession(this, device);
 
   @override
   bool operator ==(Object other) {

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -257,7 +257,7 @@ abstract class Action<T extends Intent> with Diagnosticable {
 ///   const ActionListenerExample({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _ActionListenerExampleState createState() => _ActionListenerExampleState();
+///   State<ActionListenerExample> createState() => _ActionListenerExampleState();
 /// }
 ///
 /// class _ActionListenerExampleState extends State<ActionListenerExample> {
@@ -605,7 +605,7 @@ class ActionDispatcher with Diagnosticable {
 ///   final ValueNotifier<bool> valueNotifier;
 ///
 ///   @override
-///   _SaveButtonState createState() => _SaveButtonState();
+///   State<SaveButton> createState() => _SaveButtonState();
 /// }
 ///
 /// class _SaveButtonState extends State<SaveButton> {
@@ -1129,7 +1129,7 @@ class _ActionsMarker extends InheritedWidget {
 ///   final Widget child;
 ///
 ///   @override
-///   _FadButtonState createState() => _FadButtonState();
+///   State<FadButton> createState() => _FadButtonState();
 /// }
 ///
 /// class _FadButtonState extends State<FadButton> {

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -375,7 +375,7 @@ class ActionListener extends StatefulWidget {
   final Widget child;
 
   @override
-  _ActionListenerState createState() => _ActionListenerState();
+  State<ActionListener> createState() => _ActionListenerState();
 }
 
 class _ActionListenerState extends State<ActionListener> {
@@ -1317,7 +1317,7 @@ class FocusableActionDetector extends StatefulWidget {
   final Widget child;
 
   @override
-  _FocusableActionDetectorState createState() => _FocusableActionDetectorState();
+  State<FocusableActionDetector> createState() => _FocusableActionDetectorState();
 }
 
 class _FocusableActionDetectorState extends State<FocusableActionDetector> {

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -234,7 +234,7 @@ class AnimatedCrossFade extends StatefulWidget {
   }
 
   @override
-  _AnimatedCrossFadeState createState() => _AnimatedCrossFadeState();
+  State<AnimatedCrossFade> createState() => _AnimatedCrossFadeState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -65,7 +65,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///   const AnimatedListSample({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _AnimatedListSampleState createState() => _AnimatedListSampleState();
+///   State<AnimatedListSample> createState() => _AnimatedListSampleState();
 /// }
 ///
 /// class _AnimatedListSampleState extends State<AnimatedListSample> {
@@ -545,7 +545,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
 ///   const SliverAnimatedListSample({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _SliverAnimatedListSampleState createState() => _SliverAnimatedListSampleState();
+///   State<SliverAnimatedListSample>  createState() => _SliverAnimatedListSampleState();
 /// }
 ///
 /// class _SliverAnimatedListSampleState extends State<SliverAnimatedListSample> {

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -115,7 +115,7 @@ class AnimatedSize extends StatefulWidget {
   final Clip clipBehavior;
 
   @override
-  _AnimatedSizeState createState() => _AnimatedSizeState();
+  State<AnimatedSize> createState() => _AnimatedSizeState();
 }
 
 class _AnimatedSizeState

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -248,7 +248,7 @@ class AnimatedSwitcher extends StatefulWidget {
   final AnimatedSwitcherLayoutBuilder layoutBuilder;
 
   @override
-  _AnimatedSwitcherState createState() => _AnimatedSwitcherState();
+  State<AnimatedSwitcher> createState() => _AnimatedSwitcherState();
 
   /// The transition builder used as the default value of [transitionBuilder].
   ///

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1117,7 +1117,7 @@ class WidgetsApp extends StatefulWidget {
   };
 
   @override
-  _WidgetsAppState createState() => _WidgetsAppState();
+  State<WidgetsApp> createState() => _WidgetsAppState();
 }
 
 class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -703,7 +703,7 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
   }
 
   @override
-  _RawAutocompleteState<T> createState() => _RawAutocompleteState<T>();
+  State<RawAutocomplete<T>> createState() => _RawAutocompleteState<T>();
 }
 
 class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> {

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -37,7 +37,7 @@ class AutomaticKeepAlive extends StatefulWidget {
   final Widget? child;
 
   @override
-  _AutomaticKeepAliveState createState() => _AutomaticKeepAliveState();
+  State<AutomaticKeepAlive> createState() => _AutomaticKeepAliveState();
 }
 
 class _AutomaticKeepAliveState extends State<AutomaticKeepAlive> {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7923,8 +7923,8 @@ class ColoredBox extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderColoredBox renderObject) {
-    renderObject.color = color;
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    (renderObject as _RenderColoredBox).color = color;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3118,7 +3118,7 @@ class Offstage extends SingleChildRenderObjectWidget {
   }
 
   @override
-  _OffstageElement createElement() => _OffstageElement(this);
+  SingleChildRenderObjectElement createElement() => _OffstageElement(this);
 }
 
 class _OffstageElement extends SingleChildRenderObjectElement {
@@ -6737,7 +6737,7 @@ class MouseRegion extends StatefulWidget {
   final Widget? child;
 
   @override
-  _MouseRegionState createState() => _MouseRegionState();
+  State<MouseRegion> createState() => _MouseRegionState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -7896,7 +7896,7 @@ class StatefulBuilder extends StatefulWidget {
   final StatefulWidgetBuilder builder;
 
   @override
-  _StatefulBuilderState createState() => _StatefulBuilderState();
+  State<StatefulBuilder> createState() => _StatefulBuilderState();
 }
 
 class _StatefulBuilderState extends State<StatefulBuilder> {
@@ -7918,7 +7918,7 @@ class ColoredBox extends SingleChildRenderObjectWidget {
   final Color color;
 
   @override
-  _RenderColoredBox createRenderObject(BuildContext context) {
+  RenderObject createRenderObject(BuildContext context) {
     return _RenderColoredBox(color: color);
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5494,7 +5494,7 @@ class Wrap extends MultiChildRenderObjectWidget {
 ///   const FlowMenu({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _FlowMenuState createState() => _FlowMenuState();
+///   State<FlowMenu> createState() => _FlowMenuState();
 /// }
 ///
 /// class _FlowMenuState extends State<FlowMenu> with SingleTickerProviderStateMixin {
@@ -6619,7 +6619,7 @@ class MouseRegion extends StatefulWidget {
   ///   final VoidCallback onExitButton;
   ///
   ///   @override
-  ///   _MyTimedButton createState() => _MyTimedButton();
+  ///   State<MyTimedButton> createState() => _MyTimedButton();
   /// }
   ///
   /// class _MyTimedButton extends State<MyTimedButton> {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -43,7 +43,7 @@ export 'dart:ui' show AppLifecycleState, Locale;
 ///   const AppLifecycleReactor({ Key? key }) : super(key: key);
 ///
 ///   @override
-///   _AppLifecycleReactorState createState() => _AppLifecycleReactorState();
+///   State<AppLifecycleReactor> createState() => _AppLifecycleReactorState();
 /// }
 ///
 /// class _AppLifecycleReactorState extends State<AppLifecycleReactor> with WidgetsBindingObserver {
@@ -138,7 +138,7 @@ abstract class WidgetsBindingObserver {
   ///   const MetricsReactor({ Key? key }) : super(key: key);
   ///
   ///   @override
-  ///   _MetricsReactorState createState() => _MetricsReactorState();
+  ///   State<MetricsReactor> createState() => _MetricsReactorState();
   /// }
   ///
   /// class _MetricsReactorState extends State<MetricsReactor> with WidgetsBindingObserver {
@@ -196,7 +196,7 @@ abstract class WidgetsBindingObserver {
   ///   const TextScaleFactorReactor({ Key? key }) : super(key: key);
   ///
   ///   @override
-  ///   _TextScaleFactorReactorState createState() => _TextScaleFactorReactorState();
+  ///   State<TextScaleFactorReactor> createState() => _TextScaleFactorReactorState();
   /// }
   ///
   /// class _TextScaleFactorReactorState extends State<TextScaleFactorReactor> with WidgetsBindingObserver {

--- a/packages/flutter/lib/src/widgets/color_filter.dart
+++ b/packages/flutter/lib/src/widgets/color_filter.dart
@@ -71,8 +71,8 @@ class ColorFiltered extends SingleChildRenderObjectWidget {
   RenderObject createRenderObject(BuildContext context) => _ColorFilterRenderObject(colorFilter);
 
   @override
-  void updateRenderObject(BuildContext context, _ColorFilterRenderObject renderObject) {
-    renderObject.colorFilter = colorFilter;
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    (renderObject as _ColorFilterRenderObject).colorFilter = colorFilter;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -232,7 +232,7 @@ class Dismissible extends StatefulWidget {
   final HitTestBehavior behavior;
 
   @override
-  _DismissibleState createState() => _DismissibleState();
+  State<Dismissible> createState() => _DismissibleState();
 }
 
 class _DismissibleClipper extends CustomClipper<Rect> {

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -458,7 +458,7 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// Subclasses can override this function to customize when they start
   /// recognizing a drag.
   @protected
-  MultiDragGestureRecognizer<MultiDragPointerState> createRecognizer(GestureMultiDragStartCallback onStart) {
+  MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
     switch (affinity) {
       case Axis.horizontal:
         return HorizontalMultiDragGestureRecognizer()..onStart = onStart;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -470,7 +470,7 @@ class Draggable<T extends Object> extends StatefulWidget {
   }
 
   @override
-  _DraggableState<T> createState() => _DraggableState<T>();
+  State<Draggable<T>> createState() => _DraggableState<T>();
 }
 
 /// Makes its child draggable starting from long press.
@@ -773,7 +773,7 @@ class DragTarget<T extends Object> extends StatefulWidget {
   final HitTestBehavior hitTestBehavior;
 
   @override
-  _DragTargetState<T> createState() => _DragTargetState<T>();
+  State<DragTarget<T>> createState() => _DragTargetState<T>();
 }
 
 List<T?> _mapAvatarsToData<T extends Object>(List<_DragAvatar<Object>> avatars) {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -152,7 +152,7 @@ class DraggableScrollableSheet extends StatefulWidget {
   final ScrollableWidgetBuilder builder;
 
   @override
-  _DraggableScrollableSheetState createState() => _DraggableScrollableSheetState();
+  State<DraggableScrollableSheet> createState() => _DraggableScrollableSheetState();
 }
 
 /// A [Notification] related to the extent, which is the size, and scroll

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -316,7 +316,7 @@ enum UnfocusDisposition {
 ///   const ColorfulButton({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _ColorfulButtonState createState() => _ColorfulButtonState();
+///   State<ColorfulButton> createState() => _ColorfulButtonState();
 /// }
 ///
 /// class _ColorfulButtonState extends State<ColorfulButton> {

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -540,7 +540,7 @@ class Focus extends StatefulWidget {
   }
 
   @override
-  _FocusState createState() => _FocusState();
+  State<Focus>  createState() => _FocusState();
 }
 
 class _FocusState extends State<Focus> {
@@ -944,7 +944,7 @@ class FocusScope extends Focus {
   }
 
   @override
-  _FocusScopeState createState() => _FocusScopeState();
+  State<Focus> createState() => _FocusScopeState();
 }
 
 class _FocusScopeState extends _FocusState {

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1754,7 +1754,7 @@ class FocusTraversalGroup extends StatefulWidget {
   }
 
   @override
-  _FocusTraversalGroupState createState() => _FocusTraversalGroupState();
+  State<FocusTraversalGroup> createState() => _FocusTraversalGroupState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1508,7 +1508,7 @@ class FocusTraversalOrder extends InheritedWidget {
 ///   final T order;
 ///
 ///   @override
-///   _OrderedButtonState<T> createState() => _OrderedButtonState<T>();
+///   State<OrderedButton<T>> createState() => _OrderedButtonState<T>();
 /// }
 ///
 /// class _OrderedButtonState<T> extends State<OrderedButton<T>> {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -664,7 +664,7 @@ abstract class StatelessWidget extends Widget {
 ///   const YellowBird({ Key? key }) : super(key: key);
 ///
 ///   @override
-///   _YellowBirdState createState() => _YellowBirdState();
+///   State<YellowBird> createState() => _YellowBirdState();
 /// }
 ///
 /// class _YellowBirdState extends State<YellowBird> {
@@ -693,7 +693,7 @@ abstract class StatelessWidget extends Widget {
 ///   final Widget? child;
 ///
 ///   @override
-///   _BirdState createState() => _BirdState();
+///   State<Bird> createState() => _BirdState();
 /// }
 ///
 /// class _BirdState extends State<Bird> {
@@ -743,7 +743,7 @@ abstract class StatefulWidget extends Widget {
   ///
   /// ```dart
   /// @override
-  /// _MyState createState() => _MyState();
+  /// State<MyWidget> createState() => _MyWidgetState();
   /// ```
   ///
   /// The framework can call this method multiple times over the lifetime of

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -370,7 +370,7 @@ class Hero extends StatefulWidget {
   }
 
   @override
-  _HeroState createState() => _HeroState();
+  State<Hero> createState() => _HeroState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1060,7 +1060,7 @@ class Image extends StatefulWidget {
   final bool isAntiAlias;
 
   @override
-  _ImageState createState() => _ImageState();
+  State<Image> createState() => _ImageState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -37,8 +37,8 @@ class ImageFiltered extends SingleChildRenderObjectWidget {
   RenderObject createRenderObject(BuildContext context) => _ImageFilterRenderObject(imageFilter);
 
   @override
-  void updateRenderObject(BuildContext context, _ImageFilterRenderObject renderObject) {
-    renderObject.imageFilter = imageFilter;
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    (renderObject as _ImageFilterRenderObject).imageFilter = imageFilter;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -729,7 +729,7 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   final Clip clipBehavior;
 
   @override
-  _AnimatedContainerState createState() => _AnimatedContainerState();
+  AnimatedWidgetBaseState<AnimatedContainer> createState() => _AnimatedContainerState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -880,7 +880,7 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
   final Widget? child;
 
   @override
-  _AnimatedPaddingState createState() => _AnimatedPaddingState();
+  AnimatedWidgetBaseState<AnimatedPadding> createState() => _AnimatedPaddingState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1024,7 +1024,7 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
   final double? widthFactor;
 
   @override
-  _AnimatedAlignState createState() => _AnimatedAlignState();
+  AnimatedWidgetBaseState<AnimatedAlign> createState() => _AnimatedAlignState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1213,7 +1213,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  _AnimatedPositionedState createState() => _AnimatedPositionedState();
+  AnimatedWidgetBaseState<AnimatedPositioned> createState() => _AnimatedPositionedState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1348,7 +1348,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  _AnimatedPositionedDirectionalState createState() => _AnimatedPositionedDirectionalState();
+  AnimatedWidgetBaseState<AnimatedPositionedDirectional> createState() => _AnimatedPositionedDirectionalState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1505,7 +1505,7 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  _AnimatedOpacityState createState() => _AnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<AnimatedOpacity> createState() => _AnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1639,7 +1639,7 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  _SliverAnimatedOpacityState createState() => _SliverAnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> createState() => _SliverAnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1763,7 +1763,7 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
   final ui.TextHeightBehavior? textHeightBehavior;
 
   @override
-  _AnimatedDefaultTextStyleState createState() => _AnimatedDefaultTextStyleState();
+  AnimatedWidgetBaseState<AnimatedDefaultTextStyle> createState() => _AnimatedDefaultTextStyleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1887,7 +1887,7 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
   final bool animateShadowColor;
 
   @override
-  _AnimatedPhysicalModelState createState() => _AnimatedPhysicalModelState();
+  AnimatedWidgetBaseState<AnimatedPhysicalModel> createState() => _AnimatedPhysicalModelState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -157,7 +157,7 @@ abstract class InheritedNotifier<T extends Listenable> extends InheritedWidget {
   }
 
   @override
-  _InheritedNotifierElement<T> createElement() => _InheritedNotifierElement<T>(this);
+  InheritedElement createElement() => _InheritedNotifierElement<T>(this);
 }
 
 class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -794,7 +794,8 @@ class InteractiveViewer extends StatefulWidget {
     return closestOverall;
   }
 
-  @override _InteractiveViewerState createState() => _InteractiveViewerState();
+  @override
+  State<InteractiveViewer> createState() => _InteractiveViewerState();
 }
 
 class _InteractiveViewerState extends State<InteractiveViewer> with TickerProviderStateMixin {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -44,7 +44,7 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
        super(key: key);
 
   @override
-  _LayoutBuilderElement<ConstraintType> createElement() => _LayoutBuilderElement<ConstraintType>(this);
+  RenderObjectElement createElement() => _LayoutBuilderElement<ConstraintType>(this);
 
   /// Called at layout time to construct the widget tree.
   ///
@@ -321,7 +321,7 @@ class LayoutBuilder extends ConstrainedLayoutBuilder<BoxConstraints> {
   LayoutWidgetBuilder get builder => super.builder;
 
   @override
-  _RenderLayoutBuilder createRenderObject(BuildContext context) => _RenderLayoutBuilder();
+  RenderObject createRenderObject(BuildContext context) => _RenderLayoutBuilder();
 }
 
 class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<RenderBox>, RenderConstrainedLayoutBuilder<BoxConstraints, RenderBox> {

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -737,7 +737,7 @@ class ListWheelScrollView extends StatefulWidget {
   final ScrollBehavior? scrollBehavior;
 
   @override
-  _ListWheelScrollViewState createState() => _ListWheelScrollViewState();
+  State<ListWheelScrollView> createState() => _ListWheelScrollViewState();
 }
 
 class _ListWheelScrollViewState extends State<ListWheelScrollView> {

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -474,7 +474,7 @@ class Localizations extends StatefulWidget {
   }
 
   @override
-  _LocalizationsState createState() => _LocalizationsState();
+  State<Localizations> createState() => _LocalizationsState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -230,8 +230,8 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderOverflowBar renderObject) {
-    renderObject
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    (renderObject as _RenderOverflowBar)
       ..spacing = spacing
       ..overflowSpacing = overflowSpacing
       ..overflowAlignment = overflowAlignment

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -218,7 +218,7 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   final Clip clipBehavior;
 
   @override
-  _RenderOverflowBar createRenderObject(BuildContext context) {
+  RenderObject createRenderObject(BuildContext context) {
     return _RenderOverflowBar(
       spacing: spacing,
       overflowSpacing: overflowSpacing,

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -194,7 +194,7 @@ class GlowingOverscrollIndicator extends StatefulWidget {
   final Widget? child;
 
   @override
-  _GlowingOverscrollIndicatorState createState() => _GlowingOverscrollIndicatorState();
+  State<GlowingOverscrollIndicator> createState() => _GlowingOverscrollIndicatorState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/page_storage.dart
+++ b/packages/flutter/lib/src/widgets/page_storage.dart
@@ -167,7 +167,7 @@ class PageStorageBucket {
 ///   const MyHomePage({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyHomePageState createState() => _MyHomePageState();
+///   State<MyHomePage> createState() => _MyHomePageState();
 /// }
 ///
 /// class _MyHomePageState extends State<MyHomePage> {

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -49,7 +49,7 @@ import 'viewport.dart';
 ///   const MyPageView({Key? key}) : super(key: key);
 ///
 ///   @override
-///   _MyPageViewState createState() => _MyPageViewState();
+///   State<MyPageView> createState() => _MyPageViewState();
 /// }
 ///
 /// class _MyPageViewState extends State<MyPageView> {
@@ -697,7 +697,7 @@ class PageView extends StatefulWidget {
   ///   const MyPageView({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _MyPageViewState createState() => _MyPageViewState();
+  ///   State<MyPageView> createState() => _MyPageViewState();
   /// }
   ///
   /// class _MyPageViewState extends State<MyPageView> {
@@ -751,7 +751,7 @@ class PageView extends StatefulWidget {
   ///   final String data;
   ///
   ///   @override
-  ///   _KeepAliveState createState() => _KeepAliveState();
+  ///   State<KeepAlive> createState() => _KeepAliveState();
   /// }
   ///
   /// class _KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin{

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -892,7 +892,7 @@ class PageView extends StatefulWidget {
   final bool padEnds;
 
   @override
-  _PageViewState createState() => _PageViewState();
+  State<PageView> createState() => _PageViewState();
 }
 
 class _PageViewState extends State<PageView> {

--- a/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
+++ b/packages/flutter/lib/src/widgets/raw_keyboard_listener.dart
@@ -65,7 +65,7 @@ class RawKeyboardListener extends StatefulWidget {
   final Widget child;
 
   @override
-  _RawKeyboardListenerState createState() => _RawKeyboardListenerState();
+  State<RawKeyboardListener> createState() => _RawKeyboardListenerState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -318,7 +318,7 @@ class ReorderableListState extends State<ReorderableList> {
   void startItemDragReorder({
     required int index,
     required PointerDownEvent event,
-    required MultiDragGestureRecognizer<MultiDragPointerState> recognizer,
+    required MultiDragGestureRecognizer recognizer,
   }) {
     _sliverReorderableListKey.currentState!.startItemDragReorder(index: index, event: event, recognizer: recognizer);
   }
@@ -519,7 +519,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   _DragInfo? _dragInfo;
   int? _insertIndex;
   Offset? _finalDropPosition;
-  MultiDragGestureRecognizer<MultiDragPointerState>? _recognizer;
+  MultiDragGestureRecognizer? _recognizer;
   bool _autoScrolling = false;
 
   late ScrollableState _scrollable;
@@ -562,7 +562,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   void startItemDragReorder({
     required int index,
     required PointerDownEvent event,
-    required MultiDragGestureRecognizer<MultiDragPointerState> recognizer,
+    required MultiDragGestureRecognizer recognizer,
   }) {
     assert(0 <= index && index < widget.itemCount);
     setState(() {
@@ -1073,7 +1073,7 @@ class ReorderableDragStartListener extends StatelessWidget {
   /// By default this returns an [ImmediateMultiDragGestureRecognizer] but
   /// subclasses can use this to customize the drag start gesture.
   @protected
-  MultiDragGestureRecognizer<MultiDragPointerState> createRecognizer() {
+  MultiDragGestureRecognizer createRecognizer() {
     return ImmediateMultiDragGestureRecognizer(debugOwner: this);
   }
 
@@ -1114,7 +1114,7 @@ class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
   }) : super(key: key, child: child, index: index);
 
   @override
-  MultiDragGestureRecognizer<MultiDragPointerState> createRecognizer() {
+  MultiDragGestureRecognizer createRecognizer() {
     return DelayedMultiDragGestureRecognizer(debugOwner: this);
   }
 }

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -632,7 +632,7 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 ///   final String? restorationId;
 ///
 ///   @override
-///   _RestorableCounterState createState() => _RestorableCounterState();
+///   State<RestorableCounter> createState() => _RestorableCounterState();
 /// }
 ///
 /// // The [State] object uses the [RestorationMixin] to make the current value

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1029,7 +1029,7 @@ class BackButtonListener extends StatefulWidget {
   final ValueGetter<Future<bool>> onBackButtonPressed;
 
   @override
-  _BackButtonListenerState createState() => _BackButtonListenerState();
+  State<BackButtonListener> createState() => _BackButtonListenerState();
 }
 
 class _BackButtonListenerState extends State<BackButtonListener> {

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -502,7 +502,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///   const HomePage({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _HomePageState createState() => _HomePageState();
+  ///   State<HomePage> createState() => _HomePageState();
   /// }
   ///
   /// class _HomePageState extends State<HomePage> {
@@ -532,7 +532,7 @@ mixin LocalHistoryRoute<T> on Route<T> {
   ///   const SecondPage({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _SecondPageState createState() => _SecondPageState();
+  ///   State<SecondPage> createState() => _SecondPageState();
   /// }
   ///
   /// class _SecondPageState extends State<SecondPage> {

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1364,7 +1364,7 @@ class ListView extends BoxScrollView {
   ///   const MyListView({Key? key}) : super(key: key);
   ///
   ///   @override
-  ///   _MyListViewState createState() => _MyListViewState();
+  ///   State<MyListView> createState() => _MyListViewState();
   /// }
   ///
   /// class _MyListViewState extends State<MyListView> {
@@ -1421,7 +1421,7 @@ class ListView extends BoxScrollView {
   ///   final String data;
   ///
   ///   @override
-  ///   _KeepAliveState createState() => _KeepAliveState();
+  ///   State<KeepAlive> createState() => _KeepAliveState();
   /// }
   ///
   /// class _KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin{

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -45,7 +45,7 @@ class SemanticsDebugger extends StatefulWidget {
   final TextStyle labelStyle;
 
   @override
-  _SemanticsDebuggerState createState() => _SemanticsDebuggerState();
+  State<SemanticsDebugger> createState() => _SemanticsDebuggerState();
 }
 
 class _SemanticsDebuggerState extends State<SemanticsDebugger> with WidgetsBindingObserver {

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1002,7 +1002,7 @@ class Shortcuts extends StatefulWidget {
   }
 
   @override
-  _ShortcutsState createState() => _ShortcutsState();
+  State<Shortcuts> createState() => _ShortcutsState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
+++ b/packages/flutter/lib/src/widgets/size_changed_layout_notifier.dart
@@ -58,7 +58,7 @@ class SizeChangedLayoutNotifier extends SingleChildRenderObjectWidget {
   }) : super(key: key, child: child);
 
   @override
-  _RenderSizeChangedWithCallback createRenderObject(BuildContext context) {
+  RenderObject createRenderObject(BuildContext context) {
     return _RenderSizeChangedWithCallback(
       onLayoutChangedCallback: () {
         SizeChangedLayoutNotification().dispatch(context);

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1670,7 +1670,7 @@ class SliverOffstage extends SingleChildRenderObjectWidget {
   }
 
   @override
-  _SliverOffstageElement createElement() => _SliverOffstageElement(this);
+  SingleChildRenderObjectElement createElement() => _SliverOffstageElement(this);
 }
 
 class _SliverOffstageElement extends SingleChildRenderObjectElement {

--- a/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/sliver_layout_builder.dart
@@ -39,7 +39,7 @@ class SliverLayoutBuilder extends ConstrainedLayoutBuilder<SliverConstraints> {
   SliverLayoutWidgetBuilder get builder => super.builder;
 
   @override
-  _RenderSliverLayoutBuilder createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
+  RenderObject createRenderObject(BuildContext context) => _RenderSliverLayoutBuilder();
 }
 
 class _RenderSliverLayoutBuilder extends RenderSliver with RenderObjectWithChildMixin<RenderSliver>, RenderConstrainedLayoutBuilder<SliverConstraints, RenderSliver> {

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -50,13 +50,13 @@ class SliverPrototypeExtentList extends SliverMultiBoxAdaptorWidget {
   final Widget prototypeItem;
 
   @override
-  _RenderSliverPrototypeExtentList createRenderObject(BuildContext context) {
+  RenderSliverMultiBoxAdaptor createRenderObject(BuildContext context) {
     final _SliverPrototypeExtentListElement element = context as _SliverPrototypeExtentListElement;
     return _RenderSliverPrototypeExtentList(childManager: element);
   }
 
   @override
-  _SliverPrototypeExtentListElement createElement() => _SliverPrototypeExtentListElement(this);
+  SliverMultiBoxAdaptorElement createElement() => _SliverPrototypeExtentListElement(this);
 }
 
 class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {

--- a/packages/flutter/lib/src/widgets/status_transitions.dart
+++ b/packages/flutter/lib/src/widgets/status_transitions.dart
@@ -24,7 +24,7 @@ abstract class StatusTransitionWidget extends StatefulWidget {
   Widget build(BuildContext context);
 
   @override
-  _StatusTransitionState createState() => _StatusTransitionState();
+  State<StatusTransitionWidget> createState() => _StatusTransitionState();
 }
 
 class _StatusTransitionState extends State<StatusTransitionWidget> {

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -303,7 +303,7 @@ class Table extends RenderObjectWidget {
   final List<Decoration?>? _rowDecorations;
 
   @override
-  _TableElement createElement() => _TableElement(this);
+  RenderObjectElement createElement() => _TableElement(this);
 
   @override
   RenderTable createRenderObject(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -133,7 +133,7 @@ abstract class AnimatedWidget extends StatefulWidget {
 
   /// Subclasses typically do not override this method.
   @override
-  _AnimatedState createState() => _AnimatedState();
+  State<AnimatedWidget> createState() => _AnimatedState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -51,7 +51,7 @@ typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, W
 ///   final String title;
 ///
 ///   @override
-///   _MyHomePageState createState() => _MyHomePageState();
+///   State<MyHomePage> createState() => _MyHomePageState();
 /// }
 ///
 /// class _MyHomePageState extends State<MyHomePage> {

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -188,7 +188,7 @@ class Viewport extends MultiChildRenderObjectWidget {
   }
 
   @override
-  _ViewportElement createElement() => _ViewportElement(this);
+  MultiChildRenderObjectElement createElement() => _ViewportElement(this);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -34,7 +34,12 @@ import 'gesture_detector.dart';
 /// [WidgetInspector.selectButtonBuilder].
 typedef InspectorSelectButtonBuilder = Widget Function(BuildContext context, VoidCallback onPressed);
 
-typedef _RegisterServiceExtensionCallback = void Function({
+/// Signature for a  method that registers the service extension `callback` with
+/// the given `name`.
+///
+/// Used as argument to [WidgetInspectorService.initServiceExtensions]. The
+/// [BindingBase.registerServiceExtension] implements this signature.
+typedef RegisterServiceExtensionCallback = void Function({
   required String name,
   required ServiceExtensionCallback callback,
 });
@@ -743,7 +748,7 @@ mixin WidgetInspectorService {
 
   FlutterExceptionHandler? _structuredExceptionHandler;
 
-  late _RegisterServiceExtensionCallback _registerServiceExtensionCallback;
+  late RegisterServiceExtensionCallback _registerServiceExtensionCallback;
   /// Registers a service extension method with the given name (full
   /// name "ext.flutter.inspector.name").
   ///
@@ -975,7 +980,7 @@ mixin WidgetInspectorService {
   ///  * <https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#rpcs-requests-and-responses>
   ///  * [BindingBase.initServiceExtensions], which explains when service
   ///    extensions can be used.
-  void initServiceExtensions(_RegisterServiceExtensionCallback registerServiceExtensionCallback) {
+  void initServiceExtensions(RegisterServiceExtensionCallback registerServiceExtensionCallback) {
     _structuredExceptionHandler = _reportError;
     if (isStructuredErrorsEnabled()) {
       FlutterError.onError = _structuredExceptionHandler;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2186,7 +2186,7 @@ class WidgetInspector extends StatefulWidget {
   final InspectorSelectButtonBuilder? selectButtonBuilder;
 
   @override
-  _WidgetInspectorState createState() => _WidgetInspectorState();
+  State<WidgetInspector> createState() => _WidgetInspectorState();
 }
 
 class _WidgetInspectorState extends State<WidgetInspector>

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -113,7 +113,7 @@ class WillPopScope extends StatefulWidget {
   final WillPopCallback? onWillPop;
 
   @override
-  _WillPopScopeState createState() => _WillPopScopeState();
+  State<WillPopScope> createState() => _WillPopScopeState();
 }
 
 class _WillPopScopeState extends State<WillPopScope> {

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -61,7 +61,7 @@ class _LongCupertinoLocalizations extends DefaultCupertinoLocalizations {
   static const LocalizationsDelegate<CupertinoLocalizations> delegate = _LongCupertinoLocalizationsDelegate();
 }
 
-const _LongCupertinoLocalizations longLocalizations = _LongCupertinoLocalizations();
+const _LongCupertinoLocalizations _longLocalizations = _LongCupertinoLocalizations();
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -492,10 +492,10 @@ void main() {
       ));
 
       // Initially, the menu isn't shown at all.
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsNothing);
       expect(find.text('▶'), findsNothing);
 
@@ -503,10 +503,10 @@ void main() {
       // paste button visible.
       await tester.longPressAt(textOffsetToPosition(tester, 4));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsNothing);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);
@@ -514,24 +514,24 @@ void main() {
       // Tap next to go to the second and final page.
       await tester.tap(find.text('▶'));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsOneWidget);
       expect(find.text('◀'), findsOneWidget);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '◀'), true);
       expect(appearsEnabled(tester, '▶'), false);
 
       // Tap select all to show the full selection menu.
-      await tester.tap(find.text(longLocalizations.selectAllButtonLabel));
+      await tester.tap(find.text(_longLocalizations.selectAllButtonLabel));
       await tester.pumpAndSettle();
 
       // Only one button fits on each page.
-      expect(find.text(longLocalizations.cutButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsNothing);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);
@@ -539,10 +539,10 @@ void main() {
       // Tap next to go to the second page.
       await tester.tap(find.text('▶'));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsOneWidget);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '◀'), true);
@@ -551,10 +551,10 @@ void main() {
       // Tap next to go to the third and final page.
       await tester.tap(find.text('▶'));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsOneWidget);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '◀'), true);
@@ -563,10 +563,10 @@ void main() {
       // Tap back to go to the second page again.
       await tester.tap(find.text('◀'));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.copyButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsOneWidget);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '◀'), true);
@@ -575,10 +575,10 @@ void main() {
       // Tap back to go to the first page again.
       await tester.tap(find.text('◀'));
       await tester.pumpAndSettle();
-      expect(find.text(longLocalizations.cutButtonLabel), findsOneWidget);
-      expect(find.text(longLocalizations.copyButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.pasteButtonLabel), findsNothing);
-      expect(find.text(longLocalizations.selectAllButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.cutButtonLabel), findsOneWidget);
+      expect(find.text(_longLocalizations.copyButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.pasteButtonLabel), findsNothing);
+      expect(find.text(_longLocalizations.selectAllButtonLabel), findsNothing);
       expect(find.text('◀'), findsNothing);
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -120,7 +120,7 @@ class TestApp extends StatefulWidget {
   final Size? mediaSize;
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 void verifyPaintedShadow(Finder customPaint, int elevation) {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -193,7 +193,7 @@ class TestApp extends StatefulWidget {
   final Size? mediaSize;
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 class _TestAppState extends State<TestApp> {

--- a/packages/flutter/test/material/expansion_panel_test.dart
+++ b/packages/flutter/test/material/expansion_panel_test.dart
@@ -32,7 +32,7 @@ class SimpleExpansionPanelListTestWidget extends StatefulWidget {
   }
 
   @override
-  _SimpleExpansionPanelListTestWidgetState createState() => _SimpleExpansionPanelListTestWidgetState();
+  State<SimpleExpansionPanelListTestWidget> createState() => _SimpleExpansionPanelListTestWidgetState();
 }
 
 class _SimpleExpansionPanelListTestWidgetState extends State<SimpleExpansionPanelListTestWidget> {

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -11,29 +11,29 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Basic floating action button locations', () {
     testWidgets('still animates motion when the floating action button is null', (WidgetTester tester) async {
-      await tester.pumpWidget(buildFrame(fab: null, location: null));
+      await tester.pumpWidget(_buildFrame(fab: null, location: null));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.endFloat));
+      await tester.pumpWidget(_buildFrame(fab: null, location: FloatingActionButtonLocation.endFloat));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
-      await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(_buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat));
 
       expect(find.byType(FloatingActionButton), findsNothing);
       expect(tester.binding.transientCallbackCount, greaterThan(0));
     });
 
     testWidgets('moves fab from center to end and back', (WidgetTester tester) async {
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat));
+      await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.endFloat));
 
       expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.centerFloat));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
@@ -42,7 +42,7 @@ void main() {
       expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(400.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat));
+      await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.endFloat));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
@@ -53,11 +53,11 @@ void main() {
     });
 
     testWidgets('moves to and from custom-defined positions', (WidgetTester tester) async {
-      await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation()));
+      await tester.pumpWidget(_buildFrame(location: const _StartTopFloatingActionButtonLocation()));
 
       expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(44.0, 56.0));
 
-      await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat));
+      await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.centerFloat));
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
       await tester.pumpAndSettle();
@@ -65,7 +65,7 @@ void main() {
       expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(400.0, 356.0));
       expect(tester.binding.transientCallbackCount, 0);
 
-      await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation()));
+      await tester.pumpWidget(_buildFrame(location: const _StartTopFloatingActionButtonLocation()));
 
       expect(tester.binding.transientCallbackCount, greaterThan(0));
 
@@ -176,38 +176,38 @@ void main() {
 
       testWidgets('moving the fab to centerFloat', (WidgetTester tester) async {
         // Create a scaffold with the fab at endFloat
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
         setupListener(tester);
 
         // Move the fab to centerFloat'
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
         await tester.pumpAndSettle();
       });
 
       testWidgets('interrupting motion towards the StartTop location.', (WidgetTester tester) async {
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
         setupListener(tester);
 
         // Move the fab to the top start after creating the fab.
-        await tester.pumpWidget(buildFrame(location: const _StartTopFloatingActionButtonLocation(), listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: const _StartTopFloatingActionButtonLocation(), listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Interrupt motion to move to the end float
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
         await tester.pumpAndSettle();
       });
 
       testWidgets('interrupting entrance to remove the fab.', (WidgetTester tester) async {
-        await tester.pumpWidget(buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(fab: null, location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
         setupListener(tester);
 
         // Animate the fab in.
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.endFloat, listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Remove the fab.
         await tester.pumpWidget(
-          buildFrame(
+          _buildFrame(
             fab: null,
             location: FloatingActionButtonLocation.endFloat,
             listener: geometryListener,
@@ -218,7 +218,7 @@ void main() {
 
       testWidgets('interrupting entrance of a new fab.', (WidgetTester tester) async {
         await tester.pumpWidget(
-          buildFrame(
+          _buildFrame(
             fab: null,
             location: FloatingActionButtonLocation.endFloat,
             listener: geometryListener,
@@ -227,12 +227,12 @@ void main() {
         setupListener(tester);
 
         // Bring in a new fab.
-        await tester.pumpWidget(buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
+        await tester.pumpWidget(_buildFrame(location: FloatingActionButtonLocation.centerFloat, listener: geometryListener));
         await tester.pump(kFloatingActionButtonSegue ~/ 2);
 
         // Interrupt motion to move the fab.
         await tester.pumpWidget(
-          buildFrame(
+          _buildFrame(
             location: FloatingActionButtonLocation.endFloat,
             listener: geometryListener,
           ),
@@ -244,7 +244,7 @@ void main() {
 
   testWidgets('Docked floating action button locations', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildFrame(
+      _buildFrame(
         location: FloatingActionButtonLocation.endDocked,
         bab: const SizedBox(height: 100.0),
         viewInsets: EdgeInsets.zero,
@@ -256,7 +256,7 @@ void main() {
     expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 500.0));
 
     await tester.pumpWidget(
-      buildFrame(
+      _buildFrame(
         location: FloatingActionButtonLocation.centerDocked,
         bab: const SizedBox(height: 100.0),
         viewInsets: EdgeInsets.zero,
@@ -267,7 +267,7 @@ void main() {
 
 
     await tester.pumpWidget(
-      buildFrame(
+      _buildFrame(
         location: FloatingActionButtonLocation.endDocked,
         bab: const SizedBox(height: 100.0),
         viewInsets: EdgeInsets.zero,
@@ -279,7 +279,7 @@ void main() {
 
   testWidgets('Docked floating action button locations: no BAB, small BAB', (WidgetTester tester) async {
     await tester.pumpWidget(
-      buildFrame(
+      _buildFrame(
         location: FloatingActionButtonLocation.endDocked,
         viewInsets: EdgeInsets.zero,
       ),
@@ -287,7 +287,7 @@ void main() {
     expect(tester.getCenter(find.byType(FloatingActionButton)), const Offset(756.0, 572.0));
 
     await tester.pumpWidget(
-      buildFrame(
+      _buildFrame(
         location: FloatingActionButtonLocation.endDocked,
         bab: const SizedBox(height: 16.0),
         viewInsets: EdgeInsets.zero,
@@ -1623,7 +1623,7 @@ class _GeometryCachePainter extends CustomPainter {
   }
 }
 
-Widget buildFrame({
+Widget _buildFrame({
   FloatingActionButton? fab = const FloatingActionButton(
     onPressed: null,
     child: Text('1'),

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2420,7 +2420,7 @@ class TestApp extends StatefulWidget {
   final Widget? child;
 
   @override
-  _TestAppState createState() => _TestAppState();
+  State<TestApp> createState() => _TestAppState();
 }
 
 class _TestAppState extends State<TestApp> {

--- a/packages/flutter/test/material/tabbed_scrollview_warp_test.dart
+++ b/packages/flutter/test/material/tabbed_scrollview_warp_test.dart
@@ -27,7 +27,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({ Key? key }) : super(key: key);
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -676,7 +676,7 @@ class Test extends StatefulWidget {
   const Test({ Key? key }) : super(key: key);
 
   @override
-  _TestState createState() => _TestState();
+  State<Test> createState() => _TestState();
 }
 
 class _TestState extends State<Test> {

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -11,7 +11,7 @@ class Leaf extends StatefulWidget {
   const Leaf({ required Key key, required this.child }) : super(key: key);
   final Widget child;
   @override
-  _LeafState createState() => _LeafState();
+  State<Leaf> createState() => _LeafState();
 }
 
 class _LeafState extends State<Leaf> {

--- a/packages/flutter/test/widgets/custom_painter_test.dart
+++ b/packages/flutter/test/widgets/custom_painter_test.dart
@@ -522,35 +522,35 @@ void _defineTests() {
       semanticsTester.dispose();
     });
 
-    testDiff('adds one item to an empty list', (_DiffTester tester) async {
+    _testDiff('adds one item to an empty list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>[],
         to: <String>['a'],
       );
     });
 
-    testDiff('removes the last item from the list', (_DiffTester tester) async {
+    _testDiff('removes the last item from the list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>['a'],
         to: <String>[],
       );
     });
 
-    testDiff('appends one item at the end of a non-empty list', (_DiffTester tester) async {
+    _testDiff('appends one item at the end of a non-empty list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>['a'],
         to: <String>['a', 'b'],
       );
     });
 
-    testDiff('prepends one item at the beginning of a non-empty list', (_DiffTester tester) async {
+    _testDiff('prepends one item at the beginning of a non-empty list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>['b'],
         to: <String>['a', 'b'],
       );
     });
 
-    testDiff('inserts one item in the middle of a list', (_DiffTester tester) async {
+    _testDiff('inserts one item in the middle of a list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>[
           'a-k',
@@ -564,7 +564,7 @@ void _defineTests() {
       );
     });
 
-    testDiff('removes one item from the middle of a list', (_DiffTester tester) async {
+    _testDiff('removes one item from the middle of a list', (_DiffTester tester) async {
       await tester.diff(
         from: <String>[
           'a-k',
@@ -578,7 +578,7 @@ void _defineTests() {
       );
     });
 
-    testDiff('swaps two items', (_DiffTester tester) async {
+    _testDiff('swaps two items', (_DiffTester tester) async {
       await tester.diff(
         from: <String>[
           'a-k',
@@ -591,7 +591,7 @@ void _defineTests() {
       );
     });
 
-    testDiff('finds and moved one keyed item', (_DiffTester tester) async {
+    _testDiff('finds and moved one keyed item', (_DiffTester tester) async {
       await tester.diff(
         from: <String>[
           'a-k',
@@ -696,7 +696,7 @@ void _defineTests() {
   });
 }
 
-void testDiff(String description, Future<void> Function(_DiffTester tester) testFunction) {
+void _testDiff(String description, Future<void> Function(_DiffTester tester) testFunction) {
   testWidgets(description, (WidgetTester tester) async {
     await testFunction(_DiffTester(tester));
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7663,7 +7663,7 @@ class TransformedEditableText extends StatefulWidget {
   final Key transformButtonKey;
 
   @override
-  _TransformedEditableTextState createState() => _TransformedEditableTextState();
+  State<TransformedEditableText> createState() => _TransformedEditableTextState();
 }
 
 class _TransformedEditableTextState extends State<TransformedEditableText> {

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1682,7 +1682,7 @@ class Decorate extends StatefulWidget {
   final void Function(bool isInBuild) build;
 
   @override
-  _DecorateState createState() => _DecorateState();
+  State<Decorate> createState() => _DecorateState();
 
   @override
   DecorateElement createElement() => DecorateElement(this);
@@ -1874,7 +1874,7 @@ class StatefulWidgetSpy extends StatefulWidget {
   final void Function(BuildContext)? onDidUpdateWidget;
 
   @override
-  _StatefulWidgetSpyState createState() => _StatefulWidgetSpyState();
+  State<StatefulWidgetSpy> createState() => _StatefulWidgetSpyState();
 }
 
 class _StatefulWidgetSpyState extends State<StatefulWidgetSpy> {

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -58,7 +58,7 @@ class ShowABCField extends StatefulWidget {
   final String fieldName;
 
   @override
-  _ShowABCFieldState createState() => _ShowABCFieldState();
+  State<ShowABCField> createState() => _ShowABCFieldState();
 }
 
 class _ShowABCFieldState extends State<ShowABCField> {

--- a/packages/flutter/test/widgets/keep_alive_test.dart
+++ b/packages/flutter/test/widgets/keep_alive_test.dart
@@ -15,7 +15,7 @@ class Leaf extends StatefulWidget {
   }) : super(key: key);
   final Widget child;
   @override
-  _LeafState createState() => _LeafState();
+  State<Leaf> createState() => _LeafState();
 }
 
 class _LeafState extends State<Leaf> {

--- a/packages/flutter/test/widgets/linked_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/linked_scroll_view_test.dart
@@ -261,7 +261,7 @@ class LinkedScrollActivity extends ScrollActivity {
 class Test extends StatefulWidget {
   const Test({ Key? key }) : super(key: key);
   @override
-  _TestState createState() => _TestState();
+  State<Test> createState() => _TestState();
 }
 
 class _TestState extends State<Test> {

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -55,7 +55,7 @@ class HoverFeedback extends StatefulWidget {
   final VoidCallback? onExit;
 
   @override
-  _HoverFeedbackState createState() => _HoverFeedbackState();
+  State<HoverFeedback> createState() => _HoverFeedbackState();
 }
 
 class _HoverFeedbackState extends State<HoverFeedback> {

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -411,7 +411,7 @@ class TestList extends StatefulWidget {
   final ReorderItemProxyDecorator? proxyDecorator;
 
   @override
-  _TestListState createState() => _TestListState();
+  State<TestList> createState() => _TestListState();
 }
 
 class _TestListState extends State<TestList> {

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -119,7 +119,7 @@ class PageView62209 extends StatefulWidget {
   const PageView62209({Key? key}) : super(key: key);
 
   @override
-  _PageView62209State createState() => _PageView62209State();
+  State<PageView62209> createState() => _PageView62209State();
 }
 
 class _PageView62209State extends State<PageView62209> {
@@ -181,7 +181,7 @@ class Carousel62209 extends StatefulWidget {
   final List<Carousel62209Page> pages;
 
   @override
-  _Carousel62209State createState() => _Carousel62209State();
+  State<Carousel62209> createState() => _Carousel62209State();
 }
 
 class _Carousel62209State extends State<Carousel62209> {

--- a/packages/flutter/test/widgets/scrollable_of_test.dart
+++ b/packages/flutter/test/widgets/scrollable_of_test.dart
@@ -12,7 +12,7 @@ class ScrollPositionListener extends StatefulWidget {
   final ValueChanged<String> log;
 
   @override
-  _ScrollPositionListenerState createState() => _ScrollPositionListenerState();
+  State<ScrollPositionListener> createState() => _ScrollPositionListenerState();
 }
 
 class _ScrollPositionListenerState extends State<ScrollPositionListener> {

--- a/packages/flutter/test/widgets/slivers_block_global_key_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_global_key_test.dart
@@ -12,7 +12,7 @@ class GenerationText extends StatefulWidget {
   const GenerationText(this.value, { Key? key }) : super(key: key);
   final int value;
   @override
-  _GenerationTextState createState() => _GenerationTextState();
+  State<GenerationText> createState() => _GenerationTextState();
 }
 
 class _GenerationTextState extends State<GenerationText> {

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -408,7 +408,7 @@ class SwitchingChildBuilderTest extends StatefulWidget {
   final List<Widget> children;
 
   @override
-  _SwitchingChildBuilderTest createState() => _SwitchingChildBuilderTest();
+  State<SwitchingChildBuilderTest> createState() => _SwitchingChildBuilderTest();
 }
 
 class _SwitchingChildBuilderTest extends State<SwitchingChildBuilderTest> {
@@ -481,7 +481,7 @@ class SwitchingChildListTest extends StatefulWidget {
   final double viewportFraction;
 
   @override
-  _SwitchingChildListTest createState() => _SwitchingChildListTest();
+  State<SwitchingChildListTest> createState() => _SwitchingChildListTest();
 }
 
 class _SwitchingChildListTest extends State<SwitchingChildListTest> {
@@ -518,7 +518,7 @@ class SwitchingSliverListTest extends StatefulWidget {
   final double viewportFraction;
 
   @override
-  _SwitchingSliverListTest createState() => _SwitchingSliverListTest();
+  State<SwitchingSliverListTest> createState() => _SwitchingSliverListTest();
 }
 
 class _SwitchingSliverListTest extends State<SwitchingSliverListTest> {
@@ -554,7 +554,7 @@ class WidgetTest0 extends StatefulWidget {
   final bool keepAlive;
 
   @override
-  _WidgetTest0State createState() => _WidgetTest0State();
+  State<WidgetTest0> createState() => _WidgetTest0State();
 }
 
 class _WidgetTest0State extends State<WidgetTest0> with AutomaticKeepAliveClientMixin{
@@ -587,7 +587,7 @@ class WidgetTest1 extends StatefulWidget {
   final bool keepAlive;
 
   @override
-  _WidgetTest1State createState() => _WidgetTest1State();
+  State<WidgetTest1> createState() => _WidgetTest1State();
 }
 
 class _WidgetTest1State extends State<WidgetTest1> with AutomaticKeepAliveClientMixin{
@@ -620,7 +620,7 @@ class WidgetTest2 extends StatefulWidget {
   final bool keepAlive;
 
   @override
-  _WidgetTest2State createState() => _WidgetTest2State();
+  State<WidgetTest2> createState() => _WidgetTest2State();
 }
 
 class _WidgetTest2State extends State<WidgetTest2> with AutomaticKeepAliveClientMixin{

--- a/packages/flutter/test/widgets/ticker_provider_test.dart
+++ b/packages/flutter/test/widgets/ticker_provider_test.dart
@@ -230,7 +230,7 @@ void main() {
 class BoringTickerTest extends StatefulWidget {
   const BoringTickerTest({ Key? key }) : super(key: key);
   @override
-  _BoringTickerTestState createState() => _BoringTickerTestState();
+  State<BoringTickerTest> createState() => _BoringTickerTestState();
 }
 
 class _BoringTickerTestState extends State<BoringTickerTest> with SingleTickerProviderStateMixin {

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -22,7 +22,7 @@ import 'widget_inspector_test_utils.dart';
 class ClockDemo extends StatefulWidget {
   const ClockDemo({ Key? key }) : super(key: key);
   @override
-  _ClockDemoState createState() => _ClockDemoState();
+  State<ClockDemo> createState() => _ClockDemoState();
 }
 
 class _ClockDemoState extends State<ClockDemo> {
@@ -65,7 +65,7 @@ class ClockText extends StatefulWidget {
   final int utcOffset;
 
   @override
-  _ClockTextState createState() => _ClockTextState();
+  State<ClockText> createState() => _ClockTextState();
 }
 
 class _ClockTextState extends State<ClockText> {
@@ -1961,7 +1961,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(numLocationEntries, equals(numDataEntries));
 
       final Map<int, _CreationLocation> knownLocations = <int, _CreationLocation>{};
-      addToKnownLocationsMap(
+      _addToKnownLocationsMap(
         knownLocations: knownLocations,
         newLocations: newLocations,
       );
@@ -2086,7 +2086,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(count, equals(1));
       // Verify the rebuild location is new.
       expect(knownLocations, isNot(contains(id)));
-      addToKnownLocationsMap(
+      _addToKnownLocationsMap(
         knownLocations: knownLocations,
         newLocations: newLocations,
       );
@@ -2161,7 +2161,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       final Map<int, _CreationLocation> knownLocations =
           <int, _CreationLocation>{};
-      addToKnownLocationsMap(
+      _addToKnownLocationsMap(
         knownLocations: knownLocations,
         newLocations: newLocations,
       );
@@ -3043,7 +3043,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
   }
 }
 
-void addToKnownLocationsMap({
+void _addToKnownLocationsMap({
   required Map<int, _CreationLocation> knownLocations,
   required Map<String, List<int>> newLocations,
 }) {

--- a/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
+++ b/packages/flutter/test_private/test/animated_icons_private_test.dart.tmpl
@@ -97,7 +97,7 @@ void main() {
 
     test('progress 0', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -119,7 +119,7 @@ void main() {
 
     test('progress 1', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(1.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -141,7 +141,7 @@ void main() {
 
     test('clamped progress', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(1.5),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -163,7 +163,7 @@ void main() {
 
     test('scale', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 0.5,
@@ -179,7 +179,7 @@ void main() {
 
     test('mirror', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -197,7 +197,7 @@ void main() {
 
     test('interpolated frame', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: movingBar.paths,
+        paths: _movingBar.paths,
         progress: const AlwaysStoppedAnimation<double>(0.5),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -219,7 +219,7 @@ void main() {
 
     test('curved frame', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(1.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -239,7 +239,7 @@ void main() {
 
     test('interpolated curved frame', () {
       final _AnimatedIconPainter painter = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.25),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -259,7 +259,7 @@ void main() {
 
     test('should not repaint same values', () {
       final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -268,7 +268,7 @@ void main() {
       );
 
       final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -281,7 +281,7 @@ void main() {
 
     test('should repaint on progress change', () {
       final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -290,7 +290,7 @@ void main() {
       );
 
       final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.1),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -303,7 +303,7 @@ void main() {
 
     test('should repaint on color change', () {
       final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF00FF00),
         scale: 1.0,
@@ -312,7 +312,7 @@ void main() {
       );
 
       final _AnimatedIconPainter painter2 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFFFF0000),
         scale: 1.0,
@@ -325,7 +325,7 @@ void main() {
 
     test('should repaint on paths change', () {
       final _AnimatedIconPainter painter1 = _AnimatedIconPainter(
-        paths: bow.paths,
+        paths: _bow.paths,
         progress: const AlwaysStoppedAnimation<double>(0.0),
         color: const Color(0xFF0000FF),
         scale: 1.0,
@@ -415,7 +415,7 @@ class Mock {
   }
 }
 
-const _AnimatedIconData movingBar = _AnimatedIconData(
+const _AnimatedIconData _movingBar = _AnimatedIconData(
   Size(48.0, 48.0),
   <_PathFrames>[
     _PathFrames(
@@ -457,7 +457,7 @@ const _AnimatedIconData movingBar = _AnimatedIconData(
   ],
 );
 
-const _AnimatedIconData bow = _AnimatedIconData(
+const _AnimatedIconData _bow = _AnimatedIconData(
   Size(48.0, 48.0),
   <_PathFrames>[
     _PathFrames(

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1490,8 +1490,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     renderView.prepareInitialFrame();
   }
 
-  @override
-  _LiveTestRenderView get renderView => super.renderView as _LiveTestRenderView;
+  _LiveTestRenderView get _liveTestRenderView => super.renderView as _LiveTestRenderView;
 
   void _handleViewNeedsPaint() {
     _viewNeedsPaint = true;
@@ -1519,14 +1518,14 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }) {
     switch (source) {
       case TestBindingEventSource.test:
-        final _LiveTestPointerRecord? record = renderView._pointers[event.pointer];
+        final _LiveTestPointerRecord? record = _liveTestRenderView._pointers[event.pointer];
         if (record != null) {
           record.position = event.position;
           if (!event.down)
             record.decay = _kPointerDecay;
           _handleViewNeedsPaint();
         } else if (event.down) {
-          renderView._pointers[event.pointer] = _LiveTestPointerRecord(
+          _liveTestRenderView._pointers[event.pointer] = _LiveTestPointerRecord(
             event.pointer,
             event.position,
           );
@@ -1619,7 +1618,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     assert(description != null);
     assert(!inTest);
     _inTest = true;
-    renderView._setDescription(description);
+    _liveTestRenderView._setDescription(description);
     // We drop the timeout on the floor in `flutter run` mode.
     // We could support it, but we'd have to automatically add the entire duration of pumps
     // and timers and so on, since those operate in real time when using this binding, but
@@ -1660,7 +1659,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Offset globalToLocal(Offset point) {
-    final Matrix4 transform = renderView.configuration.toHitTestMatrix();
+    final Matrix4 transform = _liveTestRenderView.configuration.toHitTestMatrix();
     final double det = transform.invert();
     assert(det != 0.0);
     final Offset result = MatrixUtils.transformPoint(transform, point);
@@ -1669,7 +1668,7 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Offset localToGlobal(Offset point) {
-    final Matrix4 transform = renderView.configuration.toHitTestMatrix();
+    final Matrix4 transform = _liveTestRenderView.configuration.toHitTestMatrix();
     return MatrixUtils.transformPoint(transform, point);
   }
 }

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -11,7 +11,7 @@ class CountButton extends StatefulWidget {
   const CountButton({Key? key}) : super(key: key);
 
   @override
-  _CountButtonState createState() => _CountButtonState();
+  State<CountButton> createState() => _CountButtonState();
 }
 
 class _CountButtonState extends State<CountButton> {
@@ -33,7 +33,7 @@ class AnimateSample extends StatefulWidget {
   const AnimateSample({Key? key}) : super(key: key);
 
   @override
-  _AnimateSampleState createState() => _AnimateSampleState();
+  State<AnimateSample> createState() => _AnimateSampleState();
 }
 
 class _AnimateSampleState extends State<AnimateSample>

--- a/packages/flutter_tools/analysis_options.yaml
+++ b/packages/flutter_tools/analysis_options.yaml
@@ -5,7 +5,8 @@ include: ../../analysis_options.yaml
 
 linter:
   rules:
-    unawaited_futures: true
-    curly_braces_in_flow_control_structures: true
     avoid_catches_without_on_clauses: true
+    curly_braces_in_flow_control_structures: true
+    library_private_types_in_public_api: false # Tool does not have any public API
     prefer_relative_imports: true
+    unawaited_futures: true

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -271,7 +271,7 @@ class _Attribute extends _Entry {
 class ApkManifestData {
   ApkManifestData._(this._data);
 
-  static bool isAttributeWithValuePresent(_Element baseElement,
+  static bool _isAttributeWithValuePresent(_Element baseElement,
       String childElement, String attributeName, String attributeValue) {
     final Iterable<_Element> allElements = baseElement.allElements(childElement);
     for (final _Element oneElement in allElements) {
@@ -339,12 +339,12 @@ class ApkManifestData {
       }
 
       for (final _Element element in intentFilters) {
-        final bool isMainAction = isAttributeWithValuePresent(
+        final bool isMainAction = _isAttributeWithValuePresent(
             element, 'action', 'android:name', '"android.intent.action.MAIN"');
         if (!isMainAction) {
           continue;
         }
-        final bool isLauncherCategory = isAttributeWithValuePresent(
+        final bool isLauncherCategory = _isAttributeWithValuePresent(
             element, 'category', 'android:name',
             '"android.intent.category.LAUNCHER"');
         if (!isLauncherCategory) {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -347,7 +347,7 @@ List<String> _wrapTextAsLines(String text, {
     int? lastWhitespace;
     // Find the start of the current line.
     for (int index = 0; index < splitLine.length; ++index) {
-      if (splitLine[index].character.isNotEmpty && isWhitespace(splitLine[index])) {
+      if (splitLine[index].character.isNotEmpty && _isWhitespace(splitLine[index])) {
         lastWhitespace = index;
       }
 
@@ -361,7 +361,7 @@ List<String> _wrapTextAsLines(String text, {
         result.add(joinRun(splitLine, currentLineStart, index));
 
         // Skip any intervening whitespace.
-        while (index < splitLine.length && isWhitespace(splitLine[index])) {
+        while (index < splitLine.length && _isWhitespace(splitLine[index])) {
           index++;
         }
 
@@ -378,7 +378,7 @@ List<String> _wrapTextAsLines(String text, {
 /// character.
 ///
 /// Based on: https://en.wikipedia.org/wiki/Whitespace_character#Unicode
-bool isWhitespace(_AnsiRun run) {
+bool _isWhitespace(_AnsiRun run) {
   final int rune = run.character.isNotEmpty ? run.character.codeUnitAt(0) : 0x0;
   return rune >= 0x0009 && rune <= 0x000D ||
       rune == 0x0020 ||

--- a/packages/flutter_tools/lib/src/build_system/file_store.dart
+++ b/packages/flutter_tools/lib/src/build_system/file_store.dart
@@ -24,20 +24,20 @@ class FileStorage {
     }
     final int version = json['version'] as int;
     final List<Map<String, dynamic>> rawCachedFiles = (json['files'] as List<dynamic>).cast<Map<String, dynamic>>();
-    final List<_FileHash> cachedFiles = <_FileHash>[
-      for (final Map<String, dynamic> rawFile in rawCachedFiles) _FileHash._fromJson(rawFile),
+    final List<FileHash> cachedFiles = <FileHash>[
+      for (final Map<String, dynamic> rawFile in rawCachedFiles) FileHash._fromJson(rawFile),
     ];
     return FileStorage(version, cachedFiles);
   }
 
   final int version;
-  final List<_FileHash> files;
+  final List<FileHash> files;
 
   List<int> toBuffer() {
     final Map<String, Object> json = <String, Object>{
       'version': version,
       'files': <Object>[
-        for (final _FileHash file in files) file.toJson(),
+        for (final FileHash file in files) file.toJson(),
       ],
     };
     return utf8.encode(jsonEncode(json));
@@ -45,14 +45,14 @@ class FileStorage {
 }
 
 /// A stored file hash and path.
-class _FileHash {
-  _FileHash(this.path, this.hash);
+class FileHash {
+  FileHash(this.path, this.hash);
 
-  factory _FileHash._fromJson(Map<String, dynamic> json) {
+  factory FileHash._fromJson(Map<String, dynamic> json) {
     if (!json.containsKey('path') || !json.containsKey('hash')) {
       throw Exception('File storage format invalid');
     }
-    return _FileHash(json['path']! as String, json['hash']! as String);
+    return FileHash(json['path']! as String, json['hash']! as String);
   }
 
   final String path;
@@ -142,7 +142,7 @@ class FileStore {
       _cacheFile.deleteSync();
       return;
     }
-    for (final _FileHash fileHash in fileStorage.files) {
+    for (final FileHash fileHash in fileStorage.files) {
       previousAssetKeys[fileHash.path] = fileHash.hash;
     }
     _logger.printTrace('Done initializing file store');
@@ -154,9 +154,9 @@ class FileStore {
     if (!_cacheFile.existsSync()) {
       _cacheFile.createSync(recursive: true);
     }
-    final List<_FileHash> fileHashes = <_FileHash>[];
+    final List<FileHash> fileHashes = <FileHash>[];
     for (final MapEntry<String, String> entry in currentAssetKeys.entries) {
-      fileHashes.add(_FileHash(entry.key, entry.value));
+      fileHashes.add(FileHash(entry.key, entry.value));
     }
     final FileStorage fileStorage = FileStorage(
       _kVersion,

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -416,7 +416,7 @@ class DaemonDomain extends Domain {
   }
 }
 
-typedef _RunOrAttach = Future<void> Function({
+typedef RunOrAttach = Future<void> Function({
   Completer<DebugConnectionInfo> connectionInfoCompleter,
   Completer<void> appStartedCompleter,
 });
@@ -539,7 +539,7 @@ class AppDomain extends Domain {
 
   Future<AppInstance> launch(
     ResidentRunner runner,
-    _RunOrAttach runOrAttach,
+    RunOrAttach runOrAttach,
     Device device,
     String projectDirectory,
     bool enableHotReload,

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -17,8 +17,8 @@ import '../globals.dart' as globals;
 import '../project.dart';
 
 /// A request to the [TestCompiler] for recompilation.
-class _CompilationRequest {
-  _CompilationRequest(this.mainUri, this.result);
+class CompilationRequest {
+  CompilationRequest(this.mainUri, this.result);
 
   Uri mainUri;
   Completer<String> result;
@@ -61,8 +61,8 @@ class TestCompiler {
     });
   }
 
-  final StreamController<_CompilationRequest> compilerController = StreamController<_CompilationRequest>();
-  final List<_CompilationRequest> compilationQueue = <_CompilationRequest>[];
+  final StreamController<CompilationRequest> compilerController = StreamController<CompilationRequest>();
+  final List<CompilationRequest> compilationQueue = <CompilationRequest>[];
   final FlutterProject flutterProject;
   final BuildInfo buildInfo;
   final String testFilePath;
@@ -76,7 +76,7 @@ class TestCompiler {
     if (compilerController.isClosed) {
       return null;
     }
-    compilerController.add(_CompilationRequest(mainDart, completer));
+    compilerController.add(CompilationRequest(mainDart, completer));
     return completer.future;
   }
 
@@ -117,7 +117,7 @@ class TestCompiler {
   }
 
   // Handle a compilation request.
-  Future<void> _onCompilationRequest(_CompilationRequest request) async {
+  Future<void> _onCompilationRequest(CompilationRequest request) async {
     final bool isEmpty = compilationQueue.isEmpty;
     compilationQueue.add(request);
     // Only trigger processing if queue was empty - i.e. no other requests
@@ -127,7 +127,7 @@ class TestCompiler {
       return;
     }
     while (compilationQueue.isNotEmpty) {
-      final _CompilationRequest request = compilationQueue.first;
+      final CompilationRequest request = compilationQueue.first;
       globals.printTrace('Compiling ${request.mainUri}');
       final Stopwatch compilerTime = Stopwatch()..start();
       bool firstCompile = false;

--- a/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(goderbauer): Remove this ignore when the documentation for the
+//   now private, then public typedefs is clear.
 // ignore_for_file: library_private_types_in_public_api
 
 @JS()

--- a/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: library_private_types_in_public_api
+
 @JS()
 library js_location_strategy;
 

--- a/packages/integration_test/example/lib/my_app.dart
+++ b/packages/integration_test/example/lib/my_app.dart
@@ -13,7 +13,7 @@ class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/integration_test/example/lib/my_web_app.dart
+++ b/packages/integration_test/example/lib/my_web_app.dart
@@ -13,7 +13,7 @@ class MyWebApp extends StatefulWidget {
   const MyWebApp({Key? key}) : super(key: key);
 
   @override
-  _MyWebAppState createState() => _MyWebAppState();
+  State<MyWebApp> createState() => _MyWebAppState();
 }
 
 class _MyWebAppState extends State<MyWebApp> {


### PR DESCRIPTION
This ensures that we do not reference private types in public API which - among other things - looks odd in docs.

Most of the things caught by this lint were actually pretty boring. I tried to group the more interesting changes in this commit: https://github.com/flutter/flutter/commit/111a4a7153a094a045db29b4d45f83cc00a7290b