### PR TITLE
Allow widget inspector's _Location.file to be null

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1525,7 +1525,7 @@ mixin WidgetInspectorService {
     if (location == null || location.file == null) {
       return false;
     }
-    final String file = Uri.parse(location.file).path;
+    final String file = Uri.parse(location.file!).path;
 
     // By default check whether the creation location was within package:flutter.
     if (_pubRootDirectories == null) {
@@ -2122,11 +2122,13 @@ class _ElementLocationStatsTracker {
       final Map<String, List<int>> locationsJson = <String, List<int>>{};
       for (final _LocationCount entry in newLocations) {
         final _Location location = entry.location;
-        final List<int> jsonForFile = locationsJson.putIfAbsent(
-          location.file,
-          () => <int>[],
-        );
-        jsonForFile..add(entry.id)..add(location.line)..add(location.column);
+        if (location.file != null) {
+          final List<int> jsonForFile = locationsJson.putIfAbsent(
+            location.file!,
+            () => <int>[],
+          );
+          jsonForFile..add(entry.id)..add(location.line)..add(location.column);
+        }
       }
       json['newLocations'] = locationsJson;
     }
@@ -2844,7 +2846,7 @@ class _Location {
   });
 
   /// File path of the location.
-  final String file;
+  final String? file;
 
   /// 1-based line number.
   final int line;
@@ -2880,7 +2882,9 @@ class _Location {
     if (name != null) {
       parts.add(name!);
     }
-    parts.add(file);
+    if (file != null) {
+      parts.add(file!);
+    }
     parts..add('$line')..add('$column');
     return parts.join(':');
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/81587

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
