### PR TITLE
Fix assert in RenderObject.getTransformTo()

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2397,8 +2397,8 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     }
     final List<RenderObject> renderers = <RenderObject>[];
     for (RenderObject renderer = this; renderer != ancestor; renderer = renderer.parent! as RenderObject) {
-      assert(renderer != null); // Failed to find ancestor in parent chain.
       renderers.add(renderer);
+      assert(renderer.parent != null); // Failed to find ancestor in parent chain.
     }
     if (ancestorSpecified)
       renderers.add(ancestor!);

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -106,12 +106,7 @@ void main() {
     renderObject1.attach(owner);
     final TestRenderObject renderObject2 = TestRenderObject();
     renderObject2.attach(owner);
-    try {
-      renderObject1.getTransformTo(renderObject2);
-      fail('assertion failure expected but not thrown');
-    } catch (error) {
-      expect(error, isA<AssertionError>());
-    }
+    expect(() => renderObject1.getTransformTo(renderObject2), throwsAssertionError);
   });
 
   test('PaintingContext.pushClipRect reuses the layer', () {

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -100,6 +100,20 @@ void main() {
     expect(() => data3.detach(), throwsAssertionError);
   });
 
+  test('RenderObject.getTransformTo asserts is argument is not descendant', () {
+    final PipelineOwner owner = PipelineOwner();
+    final TestRenderObject renderObject1 = TestRenderObject();
+    renderObject1.attach(owner);
+    final TestRenderObject renderObject2 = TestRenderObject();
+    renderObject2.attach(owner);
+    try {
+      renderObject1.getTransformTo(renderObject2);
+      fail('assertion failure expected but not thrown');
+    } catch (error) {
+      expect(error, isA<AssertionError>());
+    }
+  });
+
   test('PaintingContext.pushClipRect reuses the layer', () {
     _testPaintingContextLayerReuse<ClipRectLayer>((PaintingContextCallback painter, PaintingContext context, Offset offset, Layer? oldLayer) {
       return context.pushClipRect(true, offset, Rect.zero, painter, oldLayer: oldLayer as ClipRectLayer?);


### PR DESCRIPTION
The assert was never hitting because it was first hitting a
null cast error in the `renderer.parent!` line in the for
loop.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
