### PR TITLE
Clarify docs of Navigator.onPopPage

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -1515,7 +1515,7 @@ class Navigator extends StatefulWidget {
   final List<Page<dynamic>> pages;
 
   /// Called when [pop] is invoked but the current [Route] corresponds to a
-  /// [Page] found in the [pages] list.
+  /// [Page].
   ///
   /// The `result` argument is the value with which the route is to complete
   /// (e.g. the value returned from a dialog).


### PR DESCRIPTION
[`Navigator.onPopPage`](https://api.flutter.dev/flutter/widgets/Navigator/onPopPage.html) docs state:

> Called when pop is invoked but the current Route corresponds to a Page found in the pages list.

This doesn't agree with the code.  Navigator calls `onPopPage` if the `Route` corresponds to a `Page`.  It doesn't check that the page is in the pages list.  See [navigator.dart:5073](https://github.com/flutter/flutter/blob/99f19d05c331a04054535cad1c8087916eeacd60/packages/flutter/lib/src/widgets/navigator.dart#L5073).

Fixes #81610.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
