### PR TITLE
Add "onTap" callback to PopupMenuItem

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -219,6 +219,7 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   const PopupMenuItem({
     Key? key,
     this.value,
+    this.onTap,
     this.enabled = true,
     this.height = kMinInteractiveDimension,
     this.padding,
@@ -231,6 +232,9 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
 
   /// The value that will be returned by [showMenu] if this entry is selected.
   final T? value;
+
+  /// Called when the menu item is tapped.
+  final VoidCallback? onTap;
 
   /// Whether the user is permitted to select this item.
   ///
@@ -319,6 +323,8 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
   /// the menu route.
   @protected
   void handleTap() {
+    widget.onTap?.call();
+    
     Navigator.pop<T>(context, widget.value);
   }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -324,7 +324,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
   @protected
   void handleTap() {
     widget.onTap?.call();
-    
+
     Navigator.pop<T>(context, widget.value);
   }
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -297,22 +297,22 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Material(
           child: RepaintBoundary(
-            child: PopupMenuButton(
-              child: Text("Actions"),
-              itemBuilder: (context) => [
-                  PopupMenuItem(
-                      child: Text('First option'),
+            child: PopupMenuButton<void>(
+              child: const Text('Actions'),
+              itemBuilder: (BuildContext context) => <PopupMenuItem<void>>[
+                  PopupMenuItem<void>(
+                      child: const Text('First option'),
                       onTap: () {
                           menuItemTapCounters[0]++;
                       },
                   ),
-                  PopupMenuItem(
-                      child: Text('Second option'),
+                  PopupMenuItem<void>(
+                      child: const Text('Second option'),
                       onTap: () {
                           menuItemTapCounters[1]++;
                       },
                   ),
-                  PopupMenuItem(
+                  const PopupMenuItem<void>(
                       child: Text('Option without onTap'),
                   ),
               ],
@@ -361,26 +361,26 @@ void main() {
         child: Material(
           child: RepaintBoundary(
             child: PopupMenuButton<String>(
-              child: Text("Actions"),
-              onSelected: (value) { selected = value; },
-              itemBuilder: (context) => [
-                  PopupMenuItem(
-                      child: Text('First option'),
+              child: const Text('Actions'),
+              onSelected: (String value) { selected = value; },
+              itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
+                  PopupMenuItem<String>(
+                      child: const Text('First option'),
                       value: 'first',
                       onTap: () {
                           menuItemTapCounters[0]++;
                       },
                   ),
-                  PopupMenuItem(
-                      child: Text('Second option'),
+                  PopupMenuItem<String>(
+                      child: const Text('Second option'),
                       value: 'second',
                       onTap: () {
                           menuItemTapCounters[1]++;
                       },
                   ),
-                  PopupMenuItem(
-                      value: 'third',
+                 const PopupMenuItem<String>(
                       child: Text('Option without onTap'),
+                      value: 'third',
                   ),
               ],
             ),

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -289,6 +289,139 @@ void main() {
     expect(Focus.of(childKey.currentContext!).hasPrimaryFocus, isTrue);
   });
 
+  testWidgets('PopupMenuItem onTap callback is called when defined', (WidgetTester tester) async {
+    final List<int> menuItemTapCounters = <int>[0, 0];
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: RepaintBoundary(
+            child: PopupMenuButton(
+              child: Text("Actions"),
+              itemBuilder: (context) => [
+                  PopupMenuItem(
+                      child: Text('First option'),
+                      onTap: () {
+                          menuItemTapCounters[0]++;
+                      },
+                  ),
+                  PopupMenuItem(
+                      child: Text('Second option'),
+                      onTap: () {
+                          menuItemTapCounters[1]++;
+                      },
+                  ),
+                  PopupMenuItem(
+                      child: Text('Option without onTap'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tap the first tiem
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[1, 0]);
+
+    // Tap the item again
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 0]);
+
+    // Tap a different item
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Second option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+
+    // Tap an iteem without onTap
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Option without onTap'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+  });
+
+  testWidgets('PopupMenuItem can have both onTap and value', (WidgetTester tester) async {
+    final List<int> menuItemTapCounters = <int>[0, 0];
+    String? selected;
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: RepaintBoundary(
+            child: PopupMenuButton<String>(
+              child: Text("Actions"),
+              onSelected: (value) { selected = value; },
+              itemBuilder: (context) => [
+                  PopupMenuItem(
+                      child: Text('First option'),
+                      value: 'first',
+                      onTap: () {
+                          menuItemTapCounters[0]++;
+                      },
+                  ),
+                  PopupMenuItem(
+                      child: Text('Second option'),
+                      value: 'second',
+                      onTap: () {
+                          menuItemTapCounters[1]++;
+                      },
+                  ),
+                  PopupMenuItem(
+                      value: 'third',
+                      child: Text('Option without onTap'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tap the first item
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[1, 0]);
+    expect(selected, 'first');
+
+    // Tap the item again
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('First option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 0]);
+    expect(selected, 'first');
+
+    // Tap a different item
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Second option'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+    expect(selected, 'second');
+
+    // Tap an iteem without onTap
+    await tester.tap(find.text('Actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Option without onTap'));
+    await tester.pumpAndSettle();
+    expect(menuItemTapCounters, <int>[2, 1]);
+    expect(selected, 'third');
+  });
+
   testWidgets('PopupMenuItem is only focusable when enabled', (WidgetTester tester) async {
     final Key popupButtonKey = UniqueKey();
     final GlobalKey childKey = GlobalKey();


### PR DESCRIPTION
`PopupMenuItem` now accepts an optional callback named `onTap`, executed when the particular item is tapped. In other words, the callback behaves exactly the same as [`onTap` on `DropdownMenuItem`](https://api.flutter.dev/flutter/material/DropdownMenuItem/onTap.html).

Fixes #81682

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
