### PR TITLE
Ignore directive_ordering lint in samples.

### DIFF
--- a/dev/snippets/config/templates/stateful_widget.tmpl
+++ b/dev/snippets/config/templates/stateful_widget.tmpl
@@ -1,5 +1,7 @@
 /// Flutter code sample for {{element}}
 
+// ignore_for_file: directives_ordering
+
 {{description}}
 
 {{code-dartImports}}

--- a/dev/snippets/config/templates/stateful_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_material.tmpl
@@ -1,5 +1,7 @@
 /// Flutter code sample for {{element}}
 
+// ignore_for_file: directives_ordering
+
 {{description}}
 
 {{code-dartImports}}

--- a/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold.tmpl
@@ -1,5 +1,7 @@
 /// Flutter code sample for {{element}}
 
+// ignore_for_file: directives_ordering
+
 {{description}}
 
 {{code-dartImports}}

--- a/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
+++ b/dev/snippets/config/templates/stateful_widget_scaffold_center.tmpl
@@ -1,5 +1,7 @@
 /// Flutter code sample for {{element}}
 
+// ignore_for_file: directives_ordering
+
 {{description}}
 
 {{code-dartImports}}

--- a/dev/snippets/config/templates/stateless_widget_material.tmpl
+++ b/dev/snippets/config/templates/stateless_widget_material.tmpl
@@ -1,5 +1,7 @@
 /// Flutter code sample for {{element}}
 
+// ignore_for_file: directives_ordering
+
 {{description}}
 
 {{code-dartImports}}

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -212,10 +212,10 @@ class InteractiveViewer extends StatefulWidget {
   /// logged in the console for illustration.
   ///
   /// ```dart main
-  /// import 'package:vector_math/vector_math_64.dart' show Quad, Vector3;
-  ///
   /// import 'package:flutter/material.dart';
   /// import 'package:flutter/widgets.dart';
+  ///
+  /// import 'package:vector_math/vector_math_64.dart' show Quad, Vector3;
   ///
   /// void main() => runApp(const IVBuilderExampleApp());
   ///


### PR DESCRIPTION
Since imports are added from the template and from the sample it seems
impossible to guarantee correct import ordering.

Fixes https://github.com/flutter/flutter/issues/81689
