### PR TITLE
Revert "Fix benchmark"

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/animated_image_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/animated_image_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 Future<void> main() async {
-  const String fileName = 'animated_image';
+  const String fileName = 'large_image_changer';
 
   test('Animate for 250 frames', () async {
     final FlutterDriver driver = await FlutterDriver.connect();

--- a/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
+++ b/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
@@ -9,11 +9,8 @@ import 'package:flutter_devicelab/tasks/perf_tests.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(PerfTest(
+  await task(DevToolsMemoryTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test_driver/animated_image.dart',
-    'animated_image',
-    measureCpuGpu: true,
-    measureMemory: true,
   ).run);
 }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -777,8 +777,6 @@ const List<String> _kCommonScoreKeys = <String>[
   'worst_frame_rasterizer_time_millis',
   '90th_percentile_frame_rasterizer_time_millis',
   '99th_percentile_frame_rasterizer_time_millis',
-  'new_gen_gc_count',
-  'old_gen_gc_count',
 ];
 
 class PerfTestWithSkSL extends PerfTest {


### PR DESCRIPTION
Reverts flutter/flutter#81449

FYI @dnfield 

This looks to be breaking the tree with the following error:

```
Task result:
{
  "success": false,
  "reason": "Task failed: Invalid benchmark score key \"new_gen_gc_count\". It does not exist in task result data {\n  \"average_frame_build_time_millis\": 2.024,\n  \"90th_percentile_frame_build_time_millis\": 2.413,\n  \"99th_percentile_frame_build_time_millis\": 3.834,\n  \"worst_frame_build_time_millis\": 6.749,\n  \"missed_frame_build_budget_count\": 186,\n  \"average_frame_rasterizer_time_millis\": 6.728,\n  \"90th_percentile_frame_rasterizer_time_millis\": 9.068,\n  \"99th_percentile_frame_rasterizer_time_millis\": 11.384,\n  \"worst_frame_rasterizer_time_millis\": 12.224,\n  \"missed_frame_rasterizer_budget_count\": 186,\n  \"frame_count\": 185,\n  \"frame_build_times\": [\n    1742,\n    1740,\n    1654,\n    1601,\n    1650,\n    2369,\n    1664,\n    1761,\n    2348,\n    1756,\n    1786,\n    1868,\n    1790,\n    1797,\n    1896,\n    1817,\n    1803,\n    1855,\n    1756,\n    1902,\n    1873,\n    1805,\n    3169,\n    1967,\n    1939,\n    1830,\n    2085,\n    1970,\n    1932,\n    2172,\n    1940,\n    2008,\n    2126,\n    1984,\n    2045,\n    1892,\n    2035,\n    1716,\n    1864,\n    2062,\n    2082,\n    2029,\n    2270,\n    2309,\n    1724,\n    1724,\n    1734,\n    1750,\n    1750,\n    1650,\n    1805,\n    2072,\n    2115,\n    2084,\n    2130,\n    2126,\n    3834,\n    2825,\n    1823,\n    1794,\n    1841,\n    2244,\n    2359,\n    2184,\n    2793,\n    2735,\n    2479,\n    3253,\n    6749,\n    3466,\n    2816,\n    1483,\n    1522,\n    1625,\n    2093,\n    2413,\n    2444,\n    2100,\n    1855,\n    1707,\n    1914,\n    1720,\n    1774,\n    1789,\n    1858,\n    2039,\n    2089,\n    2052,\n    2163,\n    2081,\n    2070,\n    2066,\n    2483,\n    1946,\n    1964,\n    1991,\n    2007,\n    1956,\n    1921,\n    2036,\n    2734,\n    1766,\n    1854,\n    1805,\n    1855,\n    1819,\n    2142,\n    1809,\n    1776,\n    1811,\n    1776,\n    1724,\n    1744,\n    1687,\n    1743,\n    1711,\n    1462,\n    1436,\n    1732,\n    1687,\n    1454,\n    1682,\n    1688,\n    1641,\n    1680,\n    2349,\n    1852,\n    4495,\n    1470,\n    1314,\n    1445,\n    1922,\n    1791,\n    1865,\n    1762,\n    1926,\n    1866,\n    1961,\n    1893,\n    1901,\n    1949,\n    2104,\n    1873,\n    1851,\n    1915,\n    1889,\n    1934,\n    2017,\n    1955,\n    1964,\n    1620,\n    2238,\n    1709,\n    1746,\n    2339,\n    1917,\n    2211,\n    2117,\n    1930,\n    1936,\n    2021,\n    1977,\n    1979,\n    2029,\n    3159,\n    2959,\n    1733,\n    1738,\n    2211,\n    2088,\n    2080,\n    2103,\n    2531,\n    1808,\n    1797,\n    1758,\n    1863,\n    1784,\n    1805,\n    1845,\n    1924,\n    2266,\n    2370,\n    2372,\n    2431\n  ],\n  \"frame_rasterizer_times\": [\n    4648,\n    3363,\n    3828,\n    3579,\n    3488,\n    3392,\n    4984,\n    7792,\n    5520,\n    5240,\n    4982,\n    5095,\n    5424,\n    5517,\n    8249,\n    5499,\n    5447,\n    5988,\n    5334,\n    5441,\n    5790,\n    8314,\n    6498,\n    6543,\n    6745,\n    6343,\n    5913,\n    5985,\n    10461,\n    6693,\n    6520,\n    7014,\n    6366,\n    6611,\n    7071,\n    7902,\n    6749,\n    6045,\n    5802,\n    6108,\n    6473,\n    6965,\n    10420,\n    7704,\n    6217,\n    6497,\n    6171,\n    6091,\n    6306,\n    8877,\n    6432,\n    7898,\n    8262,\n    8186,\n    8635,\n    8646,\n    11470,\n    8592,\n    6938,\n    6926,\n    8436,\n    8830,\n    9068,\n    11384,\n    9476,\n    9458,\n    8882,\n    9424,\n    10435,\n    8835,\n    9720,\n    6259,\n    6022,\n    7852,\n    8190,\n    9157,\n    8239,\n    12224,\n    7487,\n    6265,\n    6013,\n    5961,\n    5953,\n    6540,\n    6334,\n    7769,\n    7031,\n    6780,\n    6554,\n    6289,\n    7092,\n    7245,\n    8378,\n    7043,\n    7056,\n    6668,\n    6464,\n    7122,\n    6788,\n    8740,\n    6058,\n    5770,\n    6229,\n    5964,\n    6335,\n    5997,\n    7061,\n    5581,\n    5609,\n    5682,\n    5391,\n    5869,\n    5629,\n    6460,\n    5342,\n    4810,\n    4422,\n    4364,\n    5300,\n    4987,\n    5239,\n    5342,\n    4903,\n    3854,\n    3399,\n    3792,\n    4946,\n    4227,\n    4655,\n    4400,\n    4426,\n    4778,\n    5260,\n    5298,\n    6311,\n    5729,\n    5626,\n    5600,\n    5006,\n    5149,\n    5893,\n    8215,\n    7088,\n    6126,\n    6387,\n    6231,\n    5970,\n    5835,\n    6582,\n    6389,\n    5452,\n    6030,\n    5390,\n    5924,\n    7214,\n    7223,\n    9084,\n    8694,\n    6948,\n    6187,\n    6582,\n    6960,\n    7005,\n    7644,\n    10314,\n    8941,\n    5905,\n    6138,\n    7324,\n    7551,\n    8405,\n    11209,\n    9192,\n    6794,\n    6772,\n    7166,\n    7116,\n    6936,\n    7066,\n    7045,\n    6980,\n    9156,\n    9344,\n    9255,\n    8944\n  ]\n}"
}

```