### PR TITLE
Turn off directives_ordering lint when analyzing samples

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -612,8 +612,17 @@ dependencies:
     sdk: flutter
 ''');
 
+
     // Copy in the analysis options from the Flutter root.
-    File(path.join(_flutterRoot,'analysis_options.yaml')).copySync(path.join(directory.path, 'analysis_options.yaml'));
+    final File rootAnalysisOptions = File(path.join(_flutterRoot,'analysis_options.yaml'));
+    final File analysisOptions = File(path.join(directory.path, 'analysis_options.yaml'));
+    analysisOptions.writeAsStringSync('''
+include: ${rootAnalysisOptions.absolute.path}
+
+analyzer:
+  errors:
+    directives_ordering: ignore
+''');
   }
 
   /// Writes out a sample section to the disk and returns the file.


### PR DESCRIPTION
## Description

This turns off the "directives_ordering" lint when analyzing samples, since it's indeterminate what the ordering will be, given that samples derive their imports both from the template and the example code.

This is temporary to avoid broken builds, but the correct solution is to reorder the output so that the imports are ordered properly so that we give the proper example for our users.

## Related Issues

- https://github.com/flutter/flutter/issues/81697