### PR TITLE
[flutter drive] Do not start dds if --no-dds

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -204,19 +204,21 @@ class FlutterDriverService extends DriverService {
     }
     _vmServiceUri = uri.toString();
     _device = device;
-    try {
-      await device.dds.startDartDevelopmentService(
-        uri,
-        debuggingOptions.ddsPort,
-        ipv6,
-        debuggingOptions.disableServiceAuthCodes,
-        logger: _logger,
-      );
-      _vmServiceUri = device.dds.uri.toString();
-    } on dds.DartDevelopmentServiceException {
-      // If there's another flutter_tools instance still connected to the target
-      // application, DDS will already be running remotely and this call will fail.
-      // This can be ignored to continue to use the existing remote DDS instance.
+    if (debuggingOptions.enableDds) {
+      try {
+        await device.dds.startDartDevelopmentService(
+          uri,
+          debuggingOptions.ddsPort,
+          ipv6,
+          debuggingOptions.disableServiceAuthCodes,
+          logger: _logger,
+        );
+        _vmServiceUri = device.dds.uri.toString();
+      } on dds.DartDevelopmentServiceException {
+        // If there's another flutter_tools instance still connected to the target
+        // application, DDS will already be running remotely and this call will fail.
+        // This can be ignored to continue to use the existing remote DDS instance.
+      }
     }
     _vmService = await _vmServiceConnector(uri, device: _device);
     final DeviceLogReader logReader = await device.getLogReader(app: _applicationPackage);

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -222,7 +222,7 @@ void main() {
         command: <String>['dart', 'foo.test', '-rexpanded'],
         exitCode: 11,
         environment: <String, String>{
-          'VM_SERVICE_URL': 'http://127.0.0.1:1234/'
+          'VM_SERVICE_URL': 'http://127.0.0.1:63426/1UasC_ihpXY=/'
         },
       ),
     ]);
@@ -230,7 +230,9 @@ void main() {
     final Device device = FakeDevice(LaunchResult.succeeded(
       observatoryUri: Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/'),
     ));
+    final FakeDartDevelopmentService dds = device.dds as FakeDartDevelopmentService;
 
+    expect(dds.started, false);
     await driverService.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile, enableDds: false), true);
     final int testResult = await driverService.startTest(
       'foo.test',
@@ -240,6 +242,7 @@ void main() {
     );
 
     expect(testResult, 11);
+    expect(dds.started, false);
   });
 
   testWithoutContext('Safely stops and uninstalls application', () async {
@@ -365,32 +368,6 @@ void main() {
       false,
     );
     await driverService.stop();
-  });
-
-  testWithoutContext('Does not start DDS if --no-dds', () async {
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
-      getVM,
-      getVM,
-      const FakeVmServiceRequest(
-        method: 'ext.flutter.exit',
-        args: <String, Object>{
-          'isolateId': '1',
-        }
-      )
-    ]);
-    final FakeProcessManager processManager = FakeProcessManager.empty();
-    final DriverService driverService = setUpDriverService(processManager: processManager, vmService: fakeVmServiceHost.vmService);
-    final FakeDevice device = FakeDevice(LaunchResult.failed());
-    final FakeDartDevelopmentService dds = device.dds as FakeDartDevelopmentService;
-
-    expect(dds.started, false);
-    await driverService.reuseApplication(
-      Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/'),
-      device,
-      DebuggingOptions.enabled(BuildInfo.debug, enableDds: false),
-      false,
-    );
-    expect(dds.started, false);
   });
 }
 

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -366,6 +366,32 @@ void main() {
     );
     await driverService.stop();
   });
+
+  testWithoutContext('Does not start DDS if --no-dds', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
+      getVM,
+      getVM,
+      const FakeVmServiceRequest(
+        method: 'ext.flutter.exit',
+        args: <String, Object>{
+          'isolateId': '1',
+        }
+      )
+    ]);
+    final FakeProcessManager processManager = FakeProcessManager.empty();
+    final DriverService driverService = setUpDriverService(processManager: processManager, vmService: fakeVmServiceHost.vmService);
+    final FakeDevice device = FakeDevice(LaunchResult.failed());
+    final FakeDartDevelopmentService dds = device.dds as FakeDartDevelopmentService;
+
+    expect(dds.started, false);
+    await driverService.reuseApplication(
+      Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/'),
+      device,
+      DebuggingOptions.enabled(BuildInfo.debug, enableDds: false),
+      false,
+    );
+    expect(dds.started, false);
+  });
 }
 
 FlutterDriverService setUpDriverService({

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -234,6 +234,8 @@ void main() {
 
     expect(dds.started, false);
     await driverService.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile, enableDds: false), true);
+    expect(dds.started, false);
+
     final int testResult = await driverService.startTest(
       'foo.test',
       <String>[],


### PR DESCRIPTION
Lessens severity of https://github.com/flutter/flutter/issues/81707

Make sure we respect `--no-dds` on `flutter drive`. Without this, we unconditionally launch DDS.