### PR TITLE
[flutter_tools] Show configured settings only when running `flutter config`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -88,6 +88,7 @@ class ConfigCommand extends FlutterCommand {
                                   !globals.flutterUsage.suppressAnalytics;
     return
       'Configured Flutter settings.\n'
+      'To remove a setting, configure it to an empty string.\n'
       'Run "flutter config -h" to see all available settings.\n\n$values\n\n'
       'Analytics reporting is currently ${analyticsEnabled ? 'enabled' : 'disabled'}.';
   }

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -60,9 +60,8 @@ class ConfigCommand extends FlutterCommand {
   @override
   bool get shouldUpdateCache => false;
 
-  @override
-  String get usageFooter {
-    // List all config settings. for feature flags, include whether they
+  String get configuredSettings {
+    // List all configured settings. for feature flags, include whether they
     // are available.
     final Map<String, Feature> featuresByName = <String, Feature>{};
     final String channel = globals.flutterVersion.channel;
@@ -88,7 +87,8 @@ class ConfigCommand extends FlutterCommand {
     final bool analyticsEnabled = globals.flutterUsage.enabled &&
                                   !globals.flutterUsage.suppressAnalytics;
     return
-      '\nSettings:\n$values\n\n'
+      'Configured Flutter settings.\n'
+      'Run "flutter config -h" to see all available settings.\n\n$values\n\n'
       'Analytics reporting is currently ${analyticsEnabled ? 'enabled' : 'disabled'}.';
   }
 
@@ -159,7 +159,7 @@ class ConfigCommand extends FlutterCommand {
     }
 
     if (argResults.arguments.isEmpty) {
-      globals.printStatus(usage);
+      globals.printStatus(configuredSettings);
     } else {
       globals.printStatus('\nYou may need to restart any open editors for them to read new settings.');
     }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1393,6 +1393,9 @@ abstract class FlutterCommand extends Command<void> {
     return help;
   }
 
+  @override
+  void printUsage() => globals.printStatus(usage);
+
   ApplicationPackageFactory applicationPackages;
 
   /// Gets the parsed command-line option named [name] as `bool`.

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -54,7 +54,7 @@ void main() {
         'config',
       ]);
 
-      expect(testLogger.statusText.contains(configCommand.usage), false);
+      expect(testLogger.statusText, isNot(contains(configCommand.usage)));
       expect(testLogger.statusText, contains(configCommand.configuredSettings));
     }, overrides: <Type, Generator>{
       Usage: () => testUsage,
@@ -70,7 +70,7 @@ void main() {
       ]);
 
       expect(testLogger.statusText, contains(configCommand.usage));
-      expect(testLogger.statusText.contains(configCommand.configuredSettings), false);
+      expect(testLogger.statusText, isNot(contains(configCommand.configuredSettings)));
     }, overrides: <Type, Generator>{
       Usage: () => testUsage,
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -46,6 +46,35 @@ void main() {
   }
 
   group('config', () {
+    testUsingContext('only displays configured settings with empty arguments', () async {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      await commandRunner.run(<String>[
+        'config',
+      ]);
+
+      expect(testLogger.statusText.contains(configCommand.usage), false);
+      expect(testLogger.statusText, contains(configCommand.configuredSettings));
+    }, overrides: <Type, Generator>{
+      Usage: () => testUsage,
+    });
+
+    testUsingContext('does not display configured settings with --help', () async {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      await commandRunner.run(<String>[
+        'config',
+        '--help',
+      ]);
+
+      expect(testLogger.statusText, contains(configCommand.usage));
+      expect(testLogger.statusText.contains(configCommand.configuredSettings), false);
+    }, overrides: <Type, Generator>{
+      Usage: () => testUsage,
+    });
+
     testUsingContext('machine flag', () async {
       final ConfigCommand command = ConfigCommand();
       await command.handleMachine();

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -74,12 +74,13 @@ void main() {
     expect(result.stdout, contains('Running shutdown hooks'));
   });
 
-  testWithoutContext('flutter config contains all features', () async {
+  testWithoutContext('flutter config --help contains all features', () async {
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
       ...getLocalEngineArguments(),
       'config',
+      '--help',
     ]);
 
     // contains all of the experiments in features.dart


### PR DESCRIPTION
This PR makes running `flutter config` display only the settings configured by the user for their copy of the SDK.
```
$ flutter config
Configured Flutter settings.
To remove a setting, configure it to an empty string.
Run "flutter config -h" to see all available settings.

  enable-linux-desktop: true
  enable-web: true
  enable-ios: false

Analytics reporting is currently disabled.
```
Users could still view the available options `flutter config` provides by running `flutter config -h` or `flutter config --help`.

Additionally, overrides `Command.printUsage` in `FlutterCommand` to print usage instructions through `globals.printStatus`.

Fixes #81831.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
