### PR TITLE
Update perf_tests.dart

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1445,7 +1445,7 @@ class DevToolsMemoryTest {
       'global',
       'activate',
       'devtools',
-      '2.1.1',
+      '2.2.1',
     ]);
     _devToolsProcess = await startProcess(
       pubBin,

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1445,7 +1445,7 @@ class DevToolsMemoryTest {
       'global',
       'activate',
       'devtools',
-      '2.2.1',
+      '2.2.2',
     ]);
     _devToolsProcess = await startProcess(
       pubBin,


### PR DESCRIPTION
Roll devtools version just in case using an old version breaks the perf tests again.