### PR TITLE
Sort imports when interpolating sample templates

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -613,16 +613,10 @@ dependencies:
 ''');
 
 
-    // Copy in the analysis options from the Flutter root.
+    // Import the analysis options from the Flutter root.
     final File rootAnalysisOptions = File(path.join(_flutterRoot,'analysis_options.yaml'));
     final File analysisOptions = File(path.join(directory.path, 'analysis_options.yaml'));
-    analysisOptions.writeAsStringSync('''
-include: ${rootAnalysisOptions.absolute.path}
-
-analyzer:
-  errors:
-    directives_ordering: ignore
-''');
+    analysisOptions.writeAsStringSync('include: ${rootAnalysisOptions.absolute.path}');
   }
 
   /// Writes out a sample section to the disk and returns the file.

--- a/dev/snippets/test/snippets_test.dart
+++ b/dev/snippets/test/snippets_test.dart
@@ -30,6 +30,11 @@ void main() {
 
 {{description}}
 
+import 'package:flutter/material.dart';
+import '../foo.dart';
+
+{{code-imports}}
+
 {{code-my-preamble}}
 
 main() {
@@ -67,6 +72,10 @@ main() {
 A description of the snippet.
 
 On several lines.
+
+```dart imports
+import 'dart:ui';
+```
 
 ```my-dart_language my-preamble
 const String name = 'snippet';
@@ -108,6 +117,12 @@ void main() {
       expect(outputContents, contains('A description of the snippet.'));
       expect(outputContents, contains('void main() {'));
       expect(outputContents, contains("const String name = 'snippet';"));
+      final List<String> lines = outputContents.split('\n');
+      final int dartUiLine = lines.indexOf("import 'dart:ui';");
+      final int materialLine = lines.indexOf("import 'package:flutter/material.dart';");
+      final int otherLine = lines.indexOf("import '../foo.dart';");
+      expect(dartUiLine, lessThan(materialLine));
+      expect(materialLine, lessThan(otherLine));
     });
 
     test('generates snippets', () async {


### PR DESCRIPTION
## Description

This sorts the imports section of the samples when they are exported, so that we no longer need to suppress the `directives_ordering` lint when analyzing samples.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/81697

## Tests

- Added a snippets test that makes sure that snippet imports are sorted.