### PR TITLE
WIP - allow global keys for dropdown menu items

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1405,10 +1405,31 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (items.isEmpty) {
       innerItemsWidget = Container();
     } else {
+      // The [DropdownMenuItem]s that go into the [IndexedStack] later have
+      // to be recreated to avoid key duplication, particularly when [GlobalKey]s
+      // are used.
+      late final List<Widget> buttonItems;
+      if (widget.selectedItemBuilder == null) {
+        if (widget.items == null) {
+          buttonItems = <Widget>[];
+        } else {
+          buttonItems = widget.items!.map<DropdownMenuItem<T>>((DropdownMenuItem<T> item) {
+            return DropdownMenuItem<T>(
+              // The keys from the original list is left out.
+              onTap: item.onTap,
+              child: item.child,
+              enabled: item.enabled,
+            );
+          }).toList();
+        }
+      } else {
+        buttonItems = List<Widget>.from(widget.selectedItemBuilder!(context));
+      }
+
       innerItemsWidget = IndexedStack(
         index: _selectedIndex ?? hintIndex,
         alignment: AlignmentDirectional.centerStart,
-        children: widget.isDense ? items : items.map((Widget item) {
+        children: widget.isDense ? buttonItems : buttonItems.map((Widget item) {
           return widget.itemHeight != null
             ? SizedBox(height: widget.itemHeight, child: item)
             : Column(mainAxisSize: MainAxisSize.min, children: <Widget>[item]);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/80200.

Removes having the same set of keys be passed into both the dropdown menu button's `IndexedStack` children, as well as the items that appear when the dropdown route is displayed.

We still need to figure out what to recommend to users that want to provide keys to the dropdown menu's selected item.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
