### PR TITLE
Disable flutter_build_with_compilation_error_test on Windows

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -17,8 +17,11 @@ void main() {
   final List<String> targetPlatforms = <String>[
     'apk',
     'web',
-    if (platform.isWindows)
-      'windows',
+    // TODO(zra): Re-enable after https://github.com/flutter/flutter/issues/81837
+    // is addressed.
+    // https://github.com/flutter/flutter/issues/81950
+    // if (platform.isWindows)
+    //   'windows',
     if (platform.isMacOS)
       ...<String>['macos', 'ios'],
   ];


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/81837

https://github.com/flutter/flutter/issues/81950 to re-enabled

