### PR TITLE
Enable vm:notify-debugger-on-exception on handlePlatformMessage

### DIFF
--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -288,10 +288,7 @@ class _DefaultBinaryMessenger extends BinaryMessenger {
   }
 
   @override
-  // TODO(goderbauer): Add pragma (and enable test in
-  //   break_on_framework_exceptions_test.dart) when it works on async methods,
-  //   https://github.com/dart-lang/sdk/issues/45673
-  // @pragma('vm:notify-debugger-on-exception')
+  @pragma('vm:notify-debugger-on-exception')
   Future<void> handlePlatformMessage(
     String channel,
     ByteData? data,

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -122,7 +122,7 @@ void main() {
 
     final int breakLine = (await flutter.getSourceLocation()).line;
     expect(breakLine, project.lineContaining(project.test, "throw 'platform message callback';"));
-  }, skip: 'TODO(goderbauer): add pragma to _DefaultBinaryMessenger.handlePlatformMessage when async methods are supported (https://github.com/dart-lang/sdk/issues/45673) and enable this test');
+  });
 
   testWithoutContext('breaks when SliverChildBuilderDelegate.builder throws', () async {
     final TestProject project = TestProject(


### PR DESCRIPTION
This is now possible because https://github.com/dart-lang/sdk/issues/45673 was fixed.