### PR TITLE
Revert "Allow users to pass in Xcode build settings as env variables to flutter build macos FLUTTER_XCODE_"

### DIFF
--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -114,7 +114,6 @@ Future<void> buildMacOS({
       else
         '-quiet',
       'COMPILER_INDEX_STORE_ENABLE=NO',
-      ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ],
     trace: true,
     stdoutErrorMatcher: verboseLogging ? null : _anyOutput,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -45,15 +45,6 @@ final Platform macosPlatform = FakePlatform(
     'HOME': '/',
   }
 );
-
-final FakePlatform macosPlatformCustomEnv = FakePlatform(
-    operatingSystem: 'macos',
-    environment: <String, String>{
-      'FLUTTER_ROOT': '/',
-      'HOME': '/',
-    }
-);
-
 final Platform notMacosPlatform = FakePlatform(
   operatingSystem: 'linux',
   environment: <String, String>{
@@ -64,8 +55,6 @@ final Platform notMacosPlatform = FakePlatform(
 void main() {
   FileSystem fileSystem;
   TestUsage usage;
-  FakeProcessManager fakeProcessManager;
-  XcodeProjectInterpreter xcodeProjectInterpreter;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -74,8 +63,6 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     usage = TestUsage();
-    fakeProcessManager = FakeProcessManager.empty();
-    xcodeProjectInterpreter = FakeXcodeProjectInterpreter();
   });
 
   // Sets up the minimal mock project files necessary to look like a Flutter project.
@@ -312,50 +299,6 @@ void main() {
     Platform: () => macosPlatform,
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
     Artifacts: () => Artifacts.test(),
-  });
-
-  testUsingContext('build settings contains Flutter Xcode environment variables', () async {
-
-    macosPlatformCustomEnv.environment = Map<String, String>.unmodifiable(<String, String>{
-      'FLUTTER_XCODE_ASSETCATALOG_COMPILER_APPICON_NAME': 'AppIcon.special'
-    });
-
-    final FlutterProject flutterProject = FlutterProject.fromDirectory(fileSystem.currentDirectory);
-    final Directory flutterBuildDir = fileSystem.directory(getMacOSBuildDirectory());
-
-    fakeProcessManager.addCommands(<FakeCommand>[
-      FakeCommand(
-        command: <String>[
-          '/usr/bin/env',
-          'xcrun',
-          'xcodebuild',
-          '-workspace', flutterProject.macos.xcodeWorkspace.path,
-          '-configuration', 'Debug',
-          '-scheme', 'Runner',
-          '-derivedDataPath', flutterBuildDir.absolute.path,
-          'OBJROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Intermediates.noindex')}',
-          'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
-          '-quiet',
-          'COMPILER_INDEX_STORE_ENABLE=NO',
-          'ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon.special',
-        ],
-      ),
-    ]);
-
-    final BuildCommand command = BuildCommand();
-    createMinimalMockProjectFiles();
-
-    await createTestCommandRunner(command).run(
-        const <String>['build', 'macos', '--debug', '--no-pub']
-    );
-
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => fakeProcessManager,
-    Platform: () => macosPlatformCustomEnv,
-    FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: true),
-    XcodeProjectInterpreter: () => xcodeProjectInterpreter,
   });
 
   testUsingContext('macOS build supports build-name and build-number', () async {


### PR DESCRIPTION
Reverts flutter/flutter#81384

Mac_ios hot_mode_dev_cycle_macos_target__benchmark is failing with:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8847932325253177104/+/u/run_hot_mode_dev_cycle_macos_target__benchmark/stdout?format=raw