### PR TITLE
Fix crash when do multifinger gesture in XiaoMi or Huawei

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -549,10 +549,12 @@ class _AndroidMotionEventConverter {
   }
 
   void handlePointerCancelEvent(PointerCancelEvent event) {
-    pointerPositions.clear();
-    pointerProperties.clear();
-    usedAndroidPointerIds.clear();
-    downTimeMillis = null;
+    pointerPositions.remove(event.pointer);
+    usedAndroidPointerIds.remove(pointerProperties[event.pointer]!.id);
+    pointerProperties.remove(event.pointer);
+    if (pointerProperties.isEmpty) {
+      downTimeMillis = null;
+    }
   }
 
   AndroidMotionEvent? toAndroidMotionEvent(PointerEvent event) {


### PR DESCRIPTION
Fixes #69431

When three finger moving in some android mobile(XiaoMi or Huawei), the MIUI in XiaoMi  or EMUI in Huawei will cancel some of the finger moving. Then if flutter get the pointer cancel event ,it should remove the pointer which is canceled instead of cancel all the pointer.

When user moving three fingers in a webview which is shown on webview_flutter in Huawei or XiaoMi , there is an error in logcat, and the webview can not handle any touches any more:

   I/flutter: Null check operator used on a null value
    #0      _AndroidMotionEventConverter.toAndroidMotionEvent (package:flutter/src/services/platform_views.dart:605:31)
    #1      AndroidViewController.dispatchPointerEvent (package:flutter/src/services/platform_views.dart:873:31)
    #2      _PlatformViewGestureRecognizer.handleEvent (package:flutter/src/rendering/platform_view.dart:535:26)
    #3      PointerRouter._dispatch (package:flutter/src/gestures/pointer_router.dart:77:12)
    #4      PointerRouter._dispatchEventToRoutes.<anonymous closure> (package:flutter/src/gestures/pointer_router.dart:122:9)
    #5      _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:377:8)
    #6      PointerRouter._dispatchEventToRoutes (package:flutter/src/gestures/pointer_router.dart:120:18)
    #7      PointerRouter.route (package:flutter/src/gestures/pointer_router.dart:106:7)
    #8      GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:358:19)
    #9      GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart

After change the cancel method in platform_view.dart this error disappear, and webview can handle all the touches.

![101620369674_ pic](https://user-images.githubusercontent.com/35680007/117408283-49746800-af42-11eb-93d3-3c5dbc1c3434.jpg)

Fix crash when do three finger gesture #72611


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
