### PR TITLE
Prevent macOS individual pod framework signing

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -115,6 +115,12 @@ def flutter_additional_macos_build_settings(target)
     # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
     # If the pod only supports a higher version, do not delete to correctly produce an error.
     build_configuration.build_settings.delete 'MACOSX_DEPLOYMENT_TARGET' if inherit_deployment_target
+
+    # Avoid error about Pods-Runner not supporting provisioning profiles.
+    # Framework signing is handled at the app layer, not per framework, so disallow individual signing.
+    build_configuration.build_settings.delete 'EXPANDED_CODE_SIGN_IDENTITY'
+    build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+    build_configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
   end
 end
 


### PR DESCRIPTION
macOS frameworks shouldn't be individually codesigned, that should instead happen when (in this case a CocoaPods script) packages the framework into the app bundle.  

However, when the `PROVISIONING_PROFILE_SPECIFIER` Xcode build setting is passed (implemented in https://github.com/flutter/flutter/pull/81384 via the CI-friendly `FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER` environment variable, and then reverted), the framework is incorrectly being signed, which causes the error:
```
Pods-Runner does not support provisioning profiles, but provisioning profile match Development * has been manually specified.
```

Forbid the frameworks from being individually signed.

Fixes https://github.com/flutter/flutter/issues/71613 and unblocks relanding https://github.com/flutter/flutter/pull/81384.