### PR TITLE
Fix missing logger for Driver.reuseApplication

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -220,7 +220,7 @@ class FlutterDriverService extends DriverService {
         // This can be ignored to continue to use the existing remote DDS instance.
       }
     }
-    _vmService = await _vmServiceConnector(uri, device: _device);
+    _vmService = await _vmServiceConnector(uri, device: _device, logger: _logger);
     final DeviceLogReader logReader = await device.getLogReader(app: _applicationPackage);
     logReader.logLines.listen(_logger.printStatus);
 

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -168,7 +168,7 @@ typedef VMServiceConnector = Future<FlutterVmService> Function(Uri httpUri, {
   PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression,
   Device device,
-  Logger logger,
+  @required Logger logger,
 });
 
 /// Set up the VM Service client by attaching services for each of the provided
@@ -328,9 +328,9 @@ Future<FlutterVmService> connectToVmService(
 
 Future<vm_service.VmService> createVmServiceDelegate(
   Uri wsUri, {
-    io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
-    @required Logger logger,
-  }) async {
+  io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
+  @required Logger logger,
+}) async {
   final io.WebSocket channel = await _openChannel(wsUri.toString(), compression: compression, logger: logger);
   return vm_service.VmService(
     channel,

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -395,8 +395,9 @@ FlutterDriverService setUpDriverService({
       PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
       Object compression,
       Device device,
-      Logger logger,
+      @required Logger logger,
     }) async {
+      assert(logger != null);
       if (httpUri.scheme != 'http') {
         fail('Expected an HTTP scheme, found $httpUri');
       }


### PR DESCRIPTION
When reusing an existing application, the logger was set to null, which would make the tool crash when it tried to log anything.