### PR TITLE
Reland GC tracking benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/animated_image_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/animated_image_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
 Future<void> main() async {
-  const String fileName = 'large_image_changer';
+  const String fileName = 'animated_image';
 
   test('Animate for 250 frames', () async {
     final FlutterDriver driver = await FlutterDriver.connect();

--- a/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
+++ b/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
@@ -9,8 +9,11 @@ import 'package:flutter_devicelab/tasks/perf_tests.dart';
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(DevToolsMemoryTest(
+  await task(PerfTest(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
     'test_driver/animated_image.dart',
+    'animated_image',
+    measureCpuGpu: true,
+    measureMemory: true,
   ).run);
 }

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -87,6 +87,7 @@ class GalleryTransitionTest {
           : '${testFile}_test');
       section('DRIVE START');
       await flutter('drive', options: <String>[
+        '--no-dds',
         '--profile',
         if (needFullTimeline)
           '--trace-startup',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -705,6 +705,7 @@ class PerfTest {
       final String deviceId = device.deviceId;
 
       await flutter('drive', options: <String>[
+        '--no-dds', // TODO(dnfield): consider removing when https://github.com/flutter/flutter/issues/81707 is fixed
         '--no-android-gradle-daemon',
         '-v',
         '--verbose-system-logs',
@@ -777,6 +778,8 @@ const List<String> _kCommonScoreKeys = <String>[
   'worst_frame_rasterizer_time_millis',
   '90th_percentile_frame_rasterizer_time_millis',
   '99th_percentile_frame_rasterizer_time_millis',
+  'new_gen_gc_count',
+  'old_gen_gc_count',
 ];
 
 class PerfTestWithSkSL extends PerfTest {
@@ -868,6 +871,7 @@ class PerfTestWithSkSL extends PerfTest {
       _flutterPath,
       <String>[
         'run',
+        '--no-dds',
         if (deviceOperatingSystem == DeviceOperatingSystem.ios)
           ...<String>[
             '--device-timeout', '5',

--- a/packages/flutter_test/lib/src/frame_timing_summarizer.dart
+++ b/packages/flutter_test/lib/src/frame_timing_summarizer.dart
@@ -17,7 +17,11 @@ class FrameTimingSummarizer {
   /// Summarize `data` to frame build time and frame rasterizer time statistics.
   ///
   /// See [TimelineSummary.summaryJson] for detail.
-  factory FrameTimingSummarizer(List<FrameTiming> data) {
+  factory FrameTimingSummarizer(
+    List<FrameTiming> data, {
+    int? newGenGCCount,
+    int? oldGenGCCount,
+  }) {
     assert(data != null);
     assert(data.isNotEmpty);
     final List<Duration> frameBuildTime = List<Duration>.unmodifiable(
@@ -58,6 +62,8 @@ class FrameTimingSummarizer {
       p90VsyncOverhead: _findPercentile(vsyncOverheadSorted, 0.90),
       p99VsyncOverhead: _findPercentile(vsyncOverheadSorted, 0.99),
       worstVsyncOverhead: vsyncOverheadSorted.last,
+      newGenGCCount: newGenGCCount ?? -1,
+      oldGenGCCount: oldGenGCCount ?? -1,
     );
   }
 
@@ -79,6 +85,8 @@ class FrameTimingSummarizer {
     required this.p90VsyncOverhead,
     required this.p99VsyncOverhead,
     required this.worstVsyncOverhead,
+    required this.newGenGCCount,
+    required this.oldGenGCCount,
   });
 
   /// List of frame build time in microseconds
@@ -133,6 +141,12 @@ class FrameTimingSummarizer {
   /// The largest value of [vsyncOverhead] in milliseconds.
   final Duration worstVsyncOverhead;
 
+  /// The number of new generation GCs.
+  final int newGenGCCount;
+
+  /// The number of old generation GCs.
+  final int oldGenGCCount;
+
   /// Convert the summary result to a json object.
   ///
   /// See [TimelineSummary.summaryJson] for detail.
@@ -162,6 +176,8 @@ class FrameTimingSummarizer {
         'frame_rasterizer_times': frameRasterizerTime
             .map<int>((Duration datum) => datum.inMicroseconds)
             .toList(),
+        'new_gen_gc_count': newGenGCCount,
+        'old_gen_gc_count': oldGenGCCount,
       };
 }
 

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -220,7 +220,7 @@ class FlutterDriverService extends DriverService {
         // This can be ignored to continue to use the existing remote DDS instance.
       }
     }
-    _vmService = await _vmServiceConnector(uri, device: _device);
+    _vmService = await _vmServiceConnector(uri, device: _device, logger: _logger);
     final DeviceLogReader logReader = await device.getLogReader(app: _applicationPackage);
     logReader.logLines.listen(_logger.printStatus);
 

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -198,7 +198,7 @@ class FlutterDriverService extends DriverService {
   ) async {
     Uri uri;
     if (vmServiceUri.scheme == 'ws') {
-      uri = vmServiceUri.replace(scheme: 'http', path: vmServiceUri.path.replaceFirst('ws/', ''));
+      uri = vmServiceUri.replace(scheme: 'http', path: vmServiceUri.path.replaceFirst('/ws', ''));
     } else {
       uri = vmServiceUri;
     }

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -198,7 +198,9 @@ class FlutterDriverService extends DriverService {
   ) async {
     Uri uri;
     if (vmServiceUri.scheme == 'ws') {
-      uri = vmServiceUri.replace(scheme: 'http', path: vmServiceUri.path.replaceFirst('/ws', ''));
+      final List<String> segments = vmServiceUri.pathSegments.toList();
+      segments.remove('ws');
+      uri = vmServiceUri.replace(scheme: 'http', path: segments.join('/'));
     } else {
       uri = vmServiceUri;
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -168,7 +168,7 @@ typedef VMServiceConnector = Future<FlutterVmService> Function(Uri httpUri, {
   PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
   io.CompressionOptions compression,
   Device device,
-  Logger logger,
+  @required Logger logger,
 });
 
 /// Set up the VM Service client by attaching services for each of the provided
@@ -328,9 +328,9 @@ Future<FlutterVmService> connectToVmService(
 
 Future<vm_service.VmService> createVmServiceDelegate(
   Uri wsUri, {
-    io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
-    @required Logger logger,
-  }) async {
+  io.CompressionOptions compression = io.CompressionOptions.compressionDefault,
+  @required Logger logger,
+}) async {
   final io.WebSocket channel = await _openChannel(wsUri.toString(), compression: compression, logger: logger);
   return vm_service.VmService(
     channel,

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -395,8 +395,9 @@ FlutterDriverService setUpDriverService({
       PrintStructuredErrorLogMethod printStructuredErrorLogMethod,
       Object compression,
       Device device,
-      Logger logger,
+      @required Logger logger,
     }) async {
+      assert(logger != null);
       if (httpUri.scheme != 'http') {
         fail('Expected an HTTP scheme, found $httpUri');
       }

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -378,6 +378,30 @@ void main() {
     await driverService.stop();
   });
 
+  testWithoutContext('Can connect to existing application using ws URI (no trailing slash, ws in auth code)', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
+      getVM,
+      getVM,
+      const FakeVmServiceRequest(
+        method: 'ext.flutter.exit',
+        args: <String, Object>{
+          'isolateId': '1',
+        }
+      )
+    ]);
+    final FakeProcessManager processManager = FakeProcessManager.empty();
+    final DriverService driverService = setUpDriverService(processManager: processManager, vmService: fakeVmServiceHost.vmService);
+    final FakeDevice device = FakeDevice(LaunchResult.failed());
+
+    await driverService.reuseApplication(
+      Uri.parse('ws://127.0.0.1:63426/wsasC_ihpXY=/ws'),
+      device,
+      DebuggingOptions.enabled(BuildInfo.debug),
+      false,
+    );
+    await driverService.stop();
+  });
+
   testWithoutContext('Does not call flutterExit on device types that do not support it', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
       getVM,
@@ -424,7 +448,7 @@ FlutterDriverService setUpDriverService({
       if (httpUri.scheme != 'http') {
         fail('Expected an HTTP scheme, found $httpUri');
       }
-      if (httpUri.path.contains('/ws')) {
+      if (httpUri.path.endsWith('/ws')) {
         fail('Expected HTTP uri to not contain `/ws`, found $httpUri');
       }
       return vmService;

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -354,6 +354,29 @@ void main() {
     await driverService.stop();
   });
 
+  testWithoutContext('Can connect to existing application using ws URI (no trailing slash)', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
+      getVM,
+      getVM,
+      const FakeVmServiceRequest(
+        method: 'ext.flutter.exit',
+        args: <String, Object>{
+          'isolateId': '1',
+        }
+      )
+    ]);
+    final FakeProcessManager processManager = FakeProcessManager.empty();
+    final DriverService driverService = setUpDriverService(processManager: processManager, vmService: fakeVmServiceHost.vmService);
+    final FakeDevice device = FakeDevice(LaunchResult.failed());
+
+    await driverService.reuseApplication(
+      Uri.parse('ws://127.0.0.1:63426/1UasC_ihpXY=/ws'),
+      device,
+      DebuggingOptions.enabled(BuildInfo.debug),
+      false,
+    );
+    await driverService.stop();
+  });
 
   testWithoutContext('Does not call flutterExit on device types that do not support it', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
@@ -400,6 +423,9 @@ FlutterDriverService setUpDriverService({
       assert(logger != null);
       if (httpUri.scheme != 'http') {
         fail('Expected an HTTP scheme, found $httpUri');
+      }
+      if (httpUri.path.contains('/ws')) {
+        fail('Expected HTTP uri to not contain `/ws`, found $httpUri');
       }
       return vmService;
     }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -228,8 +228,7 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
       _vmService = vmService;
     }
     if (_vmService == null) {
-      final developer.ServiceProtocolInfo info =
-          await developer.Service.getInfo();
+      final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
       assert(info.serverUri != null);
       _vmService = await vm_io.vmServiceConnectUri(
         'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
@@ -302,6 +301,29 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     reportData![reportKey] = timeline.toJson();
   }
 
+  Future<_GarbageCollectionInfo> _runAndGetGCInfo(Future<void> Function() action) async {
+    if (kIsWeb) {
+      await action();
+      return const _GarbageCollectionInfo();
+    }
+
+    final vm.Timeline timeline = await traceTimeline(
+      action,
+      streams: <String>['GC'],
+    );
+
+    final int oldGenGCCount = timeline.traceEvents!.where((vm.TimelineEvent event) {
+      return event.json!['cat'] == 'GC' && event.json!['name'] == 'CollectOldGeneration';
+    }).length;
+    final int newGenGCCount = timeline.traceEvents!.where((vm.TimelineEvent event) {
+      return event.json!['cat'] == 'GC' && event.json!['name'] == 'CollectNewGeneration';
+    }).length;
+    return _GarbageCollectionInfo(
+      oldCount: oldGenGCCount,
+      newCount: newGenGCCount,
+    );
+  }
+
   /// Watches the [FrameTiming] during `action` and report it to the binding
   /// with key `reportKey`.
   ///
@@ -340,11 +362,16 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     await Future<void>.delayed(const Duration(seconds: 2)); // flush old FrameTimings
     final TimingsCallback watcher = frameTimings.addAll;
     addTimingsCallback(watcher);
-    await action();
+    final _GarbageCollectionInfo gcInfo = await _runAndGetGCInfo(action);
+
     await delayForFrameTimings(); // make sure all FrameTimings are reported
     removeTimingsCallback(watcher);
-    final FrameTimingSummarizer frameTimes =
-        FrameTimingSummarizer(frameTimings);
+
+    final FrameTimingSummarizer frameTimes = FrameTimingSummarizer(
+      frameTimings,
+      newGenGCCount: gcInfo.newCount,
+      oldGenGCCount: gcInfo.oldCount,
+    );
     reportData ??= <String, dynamic>{};
     reportData![reportKey] = frameTimes.summary;
   }
@@ -365,4 +392,12 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
     super.attachRootWidget(RepaintBoundary(child: rootWidget));
   }
+}
+
+@immutable
+class _GarbageCollectionInfo {
+  const _GarbageCollectionInfo({this.oldCount = -1, this.newCount = -1});
+
+  final int oldCount;
+  final int newCount;
 }


### PR DESCRIPTION
Relands the updates to the benchmarks to track GCs.

This contains #82064 and #82066 - those should land before this, since they're simpler changes and should not get reverted if this fails again in devicelab. However, this appears to make all the failing tests pass locally. Only other difference since last time is another spot that was missing `--no-dds`, visible in b72186ca2fc5ab96a1176310f3f9d01a40a52f3d