### PR TITLE
[RenderEditable] remove references to `textSelectionDelegate.textEditingValue`

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1037,21 +1037,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // See also:
   //   * _deleteToEnd
-  void _deleteToStart(TextSelection selection, SelectionChangedCause cause) {
+  void _deleteToStart(String currentText, TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
-    final String text = _plainText;
-    final String textBefore = selection.textBefore(text);
+    final String textBefore = selection.textBefore(currentText);
 
     if (textBefore.isEmpty) {
       return;
     }
 
-    final String textAfter = selection.textAfter(text);
+    final String textAfter = selection.textAfter(currentText);
     const TextSelection newSelection = TextSelection.collapsed(offset: 0);
     _setTextEditingValue(
       TextEditingValue(text: textAfter, selection: newSelection),
@@ -1066,21 +1065,20 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   //
   // See also:
   //   * _deleteToStart
-  void _deleteToEnd(TextSelection selection, SelectionChangedCause cause) {
+  void _deleteToEnd(String currentText, TextSelection selection, SelectionChangedCause cause) {
     assert(selection.isCollapsed);
 
     if (_readOnly || !selection.isValid) {
       return;
     }
 
-    final String text = _plainText;
-    final String textAfter = selection.textAfter(text);
+    final String textAfter = selection.textAfter(currentText);
 
     if (textAfter.isEmpty) {
       return;
     }
 
-    final String textBefore = selection.textBefore(text);
+    final String textBefore = selection.textBefore(currentText);
     final TextSelection newSelection = TextSelection.collapsed(offset: textBefore.length);
     _setTextEditingValue(
       TextEditingValue(text: textBefore, selection: newSelection),
@@ -1105,7 +1103,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForward], which is same but in the opposite direction.
   void delete(SelectionChangedCause cause) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1154,7 +1151,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByWord], which is same but in the opposite direction.
   void deleteByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1167,7 +1163,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // When the text is obscured, the whole thing is treated as one big line.
     if (obscureText) {
-      return _deleteToStart(selection, cause);
+      return _deleteToStart(text, selection, cause);
     }
 
     String textBefore = selection.textBefore(text);
@@ -1178,7 +1174,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final int characterBoundary = _getLeftByWord(_textPainter, textBefore.length, includeWhitespace);
     textBefore = textBefore.trimRight().substring(0, characterBoundary);
 
-    final String textAfter = _selection!.textAfter(text);
+    final String textAfter = selection.textAfter(text);
     final TextSelection newSelection = TextSelection.collapsed(offset: characterBoundary);
     _setTextEditingValue(
       TextEditingValue(text: textBefore + textAfter, selection: newSelection),
@@ -1202,7 +1198,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteForwardByLine], which is same but in the opposite direction.
   void deleteByLine(SelectionChangedCause cause) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1215,7 +1210,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // When the text is obscured, the whole thing is treated as one big line.
     if (obscureText) {
-      return _deleteToStart(selection, cause);
+      return _deleteToStart(text, selection, cause);
     }
 
     String textBefore = _selection!.textBefore(text);
@@ -1254,7 +1249,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [delete], which is same but in the opposite direction.
   void deleteForward(SelectionChangedCause cause) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1299,7 +1293,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByWord], which is same but in the opposite direction.
   void deleteForwardByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1312,7 +1305,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // When the text is obscured, the whole thing is treated as one big word.
     if (obscureText) {
-      return _deleteToEnd(_selection!, cause);
+      return _deleteToEnd(text, selection, cause);
     }
 
     String textAfter = _selection!.textAfter(text);
@@ -1347,7 +1340,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   ///   * [deleteByLine], which is same but in the opposite direction.
   void deleteForwardByLine(SelectionChangedCause cause) {
     final TextSelection? selection = _selection;
-    assert(_selection != null);
 
     if (_readOnly || selection == null || !selection.isValid) {
       return;
@@ -1360,10 +1352,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
     // When the text is obscured, the whole thing is treated as one big line.
     if (obscureText) {
-      return _deleteToEnd(_selection!, cause);
+      return _deleteToEnd(text, selection, cause);
     }
 
-    String textAfter = _selection!.textAfter(text);
+    String textAfter = selection.textAfter(text);
     if (textAfter.isEmpty) {
       return;
     }
@@ -1374,7 +1366,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return;
     }
 
-    final String textBefore = _selection!.textBefore(text);
+    final String textBefore = selection.textBefore(text);
     final TextSelection line = _getLineAtOffset(TextPosition(offset: textBefore.length));
     textAfter = textAfter.substring(line.end - textBefore.length, textAfter.length);
 


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/80226.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
