### PR TITLE
Prevent DiagnosticsStackTrace truncation

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -1218,6 +1218,9 @@ class DiagnosticsStackTrace extends DiagnosticsBlock {
   static DiagnosticsNode _createStackFrame(String frame) {
     return DiagnosticsNode.message(frame, allowWrap: false);
   }
+
+  @override
+  bool get allowTruncate => false;
 }
 
 class _FlutterErrorDetailsNode extends DiagnosticableNode<FlutterErrorDetails> {

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -213,10 +213,49 @@ Future<void> main() async {
       r'The following message was thrown:\n'
       r'exception - empty stack\n'
       r'\n'
-      r'When the exception was thrown, this was the stack:\n'
-      r'...\n'
+      r'When the exception was thrown, this was the stack\n'
       r'════════════════════════════════════════════════════════════════════════════════════════════════════$',
     ));
     console.clear();
+    FlutterError.resetErrorCount();
+  });
+
+  test('Stack traces are not truncated', () async {
+    const String stackString = '''
+#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:42:39)
+#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:38:5)
+#2      new Text (package:flutter/src/widgets/text.dart:287:10)
+#3      _MyHomePageState.build (package:hello_flutter/main.dart:72:16)
+#4      StatefulElement.build (package:flutter/src/widgets/framework.dart:4414:27)
+#5      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4303:15)
+#6      Element.rebuild (package:flutter/src/widgets/framework.dart:4027:5)
+#7      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:4286:5)
+#8      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4461:11)
+#9      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4281:5)
+#10      Element.inflateWidget (package:flutter/src/widgets/framework.dart:3276:14)''';
+
+    expect(console, isEmpty);
+    FlutterError.dumpErrorToConsole(FlutterErrorDetails(
+      exception: AssertionError('Test assertion'),
+      stack: StackTrace.fromString(stackString),
+    ));
+    final String x = console.join('\n');
+    expect(x, startsWith('''
+══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════
+The following assertion was thrown:
+Assertion failed: "Test assertion"
+
+When the exception was thrown, this was the stack:
+#2      new Text (package:flutter/src/widgets/text.dart:287:10)
+#3      _MyHomePageState.build (package:hello_flutter/main.dart:72:16)
+#4      StatefulElement.build (package:flutter/src/widgets/framework.dart:4414:27)
+#5      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4303:15)
+#6      Element.rebuild (package:flutter/src/widgets/framework.dart:4027:5)
+#7      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:4286:5)
+#8      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4461:11)
+#9      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4281:5)''',
+    ));
+    console.clear();
+    FlutterError.resetErrorCount();
   });
 }


### PR DESCRIPTION
Fixes #52732

### Background

Currently when an AssertionError is thrown, the stack trace gets truncated to the first 5 entries:

```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
setState() or markNeedsBuild() called when widget tree was locked.

This _ModalScope<dynamic> widget cannot be marked as needing to build because the framework is locked.
The widget on which setState() or markNeedsBuild() was called was: _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#6d889]
  state: _ModalScopeState<dynamic>#a176a
When the exception was thrown, this was the stack: 
#0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:3901:9)
#1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:3911:6)
#2      State.setState (package:flutter/src/widgets/framework.dart:1168:14)
#3      _ModalScopeState._routeSetState (package:flutter/src/widgets/routes.dart:664:5)
#4      ModalRoute.setState (package:flutter/src/widgets/routes.dart:784:30)
...
```

This only happens for errors that wrap their stack trace in a `DiagnosticsStackTrace`, which is later truncated by the `TextTreeRenderer` used in `dumpErrorToConsole`.

### Solution

The simple fix is to override `allowTruncate` in `DiagnosticsStackTrace`.
