### PR TITLE
Fix mac_plugin_test task name in try_builders

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -534,7 +534,7 @@
     {
       "name": "Mac plugin_test",
       "repo": "flutter",
-      "task_name": "mac_plugin_lint_mac",
+      "task_name": "mac_plugin_test",
       "enabled": true,
       "run_if": ["dev/**", "packages/flutter_tools/**", "bin/**"]
     },


### PR DESCRIPTION
Noticed this while writing the `.ci.yaml` migration scripts. This is a duplicate entry that already exists in the config.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
