### PR TITLE
Let RenderEditable.delete directly delete from the controller text.

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1011,6 +1011,25 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return _getTextPositionVertical(offset, verticalOffset);
   }
 
+  // Deletes the text within `selection` if it's non-empty.
+  void _deleteSelection(TextSelection selection, SelectionChangedCause cause) {
+    assert(!selection.isCollapsed);
+
+    if (_readOnly || !selection.isValid || selection.isCollapsed) {
+      return;
+    }
+
+    final String text = textSelectionDelegate.textEditingValue.text;
+    final String textBefore = selection.textBefore(text);
+    final String textAfter = selection.textAfter(text);
+    final int cursorPosition = math.min(selection.start, selection.end);
+    final TextSelection newSelection = TextSelection.collapsed(offset: cursorPosition);
+    _setTextEditingValue(
+      TextEditingValue(text: textBefore + textAfter, selection: newSelection),
+      cause,
+    );
+  }
+
   // Deletes the current non-empty selection.
   //
   // Operates on the text/selection contained in textSelectionDelegate, and does
@@ -1171,8 +1190,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void deleteByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
-    if (_readOnly || !_selection!.isValid || _deleteNonEmptySelection(cause)) {
+    if (_readOnly || !_selection!.isValid) {
       return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(_selection!, cause);
     }
 
     // When the text is obscured, the whole thing is treated as one big line.
@@ -1214,8 +1237,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void deleteByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
-    if (_readOnly || !_selection!.isValid || _deleteNonEmptySelection(cause)) {
+    if (_readOnly || !_selection!.isValid) {
       return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(_selection!, cause);
     }
 
     // When the text is obscured, the whole thing is treated as one big line.
@@ -1304,8 +1331,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void deleteForwardByWord(SelectionChangedCause cause, [bool includeWhitespace = true]) {
     assert(_selection != null);
 
-    if (_readOnly || !_selection!.isValid || _deleteNonEmptySelection(cause)) {
+    if (_readOnly || !_selection!.isValid) {
       return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(_selection!, cause);
     }
 
     // When the text is obscured, the whole thing is treated as one big word.
@@ -1347,8 +1378,12 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   void deleteForwardByLine(SelectionChangedCause cause) {
     assert(_selection != null);
 
-    if (_readOnly || !_selection!.isValid || _deleteNonEmptySelection(cause)) {
+    if (_readOnly || !_selection!.isValid) {
       return;
+    }
+
+    if (!_selection!.isCollapsed) {
+      return _deleteSelection(_selection!, cause);
     }
 
     // When the text is obscured, the whole thing is treated as one big line.

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -3464,7 +3464,7 @@ void main() {
     });
   });
 
-  group('delete API implementations are not racy', () {
+  group('delete API implementations', () {
     // Regression test for: https://github.com/flutter/flutter/issues/80226.
     //
     // This textSelectionDelegate has different text and selection from the
@@ -3486,7 +3486,10 @@ void main() {
         selection: const TextSelection(baseOffset: 0, extentOffset: 50),
       );
 
-      delegate.textEditingValue = const TextEditingValue(text: 'BBB', selection: TextSelection.collapsed(offset: 0));
+      delegate.textEditingValue = const TextEditingValue(
+        text: 'BBB',
+        selection: TextSelection.collapsed(offset: 0),
+      );
     });
 
     void verifyDoesNotCrashWithInconsistentTextEditingValue(void Function(SelectionChangedCause) method) {
@@ -3512,11 +3515,32 @@ void main() {
       expect(error, isNull);
     }
 
-    test('delete', () {
+    test('delete is not racy and handles composing region correctly', () {
+      delegate.textEditingValue = const TextEditingValue(
+        text: 'ABCDEF',
+        selection: TextSelection.collapsed(offset: 2),
+        composing: TextRange(start: 1, end: 6),
+      );
       verifyDoesNotCrashWithInconsistentTextEditingValue(editable.delete);
+      final TextEditingValue textEditingValue = editable.textSelectionDelegate.textEditingValue;
+      expect(textEditingValue.text, 'ACDEF');
+      expect(textEditingValue.selection.isCollapsed, isTrue);
+      expect(textEditingValue.selection.baseOffset, 1);
+      expect(textEditingValue.composing, const TextRange(start: 1, end: 5));
     });
-    test('deleteForward', () {
+
+    test('deleteForward is not racy and handles composing region correctly', () {
+      delegate.textEditingValue = const TextEditingValue(
+        text: 'ABCDEF',
+        selection: TextSelection.collapsed(offset: 2),
+        composing: TextRange(start: 2, end: 6),
+      );
       verifyDoesNotCrashWithInconsistentTextEditingValue(editable.deleteForward);
+      final TextEditingValue textEditingValue = editable.textSelectionDelegate.textEditingValue;
+      expect(textEditingValue.text, 'ABDEF');
+      expect(textEditingValue.selection.isCollapsed, isTrue);
+      expect(textEditingValue.selection.baseOffset, 2);
+      expect(textEditingValue.composing, const TextRange(start: 2, end: 5));
     });
   });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -3463,6 +3463,62 @@ void main() {
       });
     });
   });
+
+  group('delete API implementations are not racy', () {
+    // Regression test for: https://github.com/flutter/flutter/issues/80226.
+    //
+    // This textSelectionDelegate has different text and selection from the
+    // render editable.
+    final FakeEditableTextState delegate = FakeEditableTextState();
+
+    late RenderEditable editable;
+
+    setUp(() {
+      editable = RenderEditable(
+        text: TextSpan(
+          text: 'A ' * 50,
+        ),
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        textDirection: TextDirection.ltr,
+        offset: ViewportOffset.fixed(0),
+        textSelectionDelegate: delegate,
+        selection: const TextSelection(baseOffset: 0, extentOffset: 50),
+      );
+
+      delegate.textEditingValue = const TextEditingValue(text: 'BBB', selection: TextSelection.collapsed(offset: 0));
+    });
+
+    void verifyDoesNotCrashWithInconsistentTextEditingValue(void Function(SelectionChangedCause) method) {
+      editable = RenderEditable(
+        text: TextSpan(
+          text: 'A ' * 50,
+        ),
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        textDirection: TextDirection.ltr,
+        offset: ViewportOffset.fixed(0),
+        textSelectionDelegate: delegate,
+        selection: const TextSelection(baseOffset: 0, extentOffset: 50),
+      );
+
+      layout(editable, constraints: BoxConstraints.loose(const Size(500.0, 500.0)));
+      dynamic error;
+      try {
+        method(SelectionChangedCause.tap);
+      } catch (e) {
+        error = e;
+      }
+      expect(error, isNull);
+    }
+
+    test('delete', () {
+      verifyDoesNotCrashWithInconsistentTextEditingValue(editable.delete);
+    });
+    test('deleteForward', () {
+      verifyDoesNotCrashWithInconsistentTextEditingValue(editable.deleteForward);
+    });
+  });
 }
 
 class _TestRenderEditable extends RenderEditable {


### PR DESCRIPTION
Fixes `delete` and `deleteForward` so they operate directly on `TextEditingController.value`. Internal: b/187337775

Related: https://github.com/flutter/flutter/issues/80226

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
