### PR TITLE
Fixed a problem with the FAB position when constraints set on bottom sheet.

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -283,6 +283,7 @@ class _BottomSheetState extends State<BottomSheet> {
     if (constraints != null) {
       bottomSheet = Align(
         alignment: Alignment.bottomCenter,
+        heightFactor: 1.0,
         child: ConstrainedBox(
           constraints: constraints,
           child: bottomSheet,

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -910,9 +910,10 @@ void main() {
             constraints: BoxConstraints(maxWidth: 80),
           ),
         ),
-        home: const Scaffold(
-          body: Center(child: Text('body')),
-          bottomSheet: Text('BottomSheet'),
+        home: Scaffold(
+          body: const Center(child: Text('body')),
+          bottomSheet: const Text('BottomSheet'),
+          floatingActionButton: FloatingActionButton(onPressed: () {}, child: const Icon(Icons.add)),
         ),
       ));
       expect(find.text('BottomSheet'), findsOneWidget);
@@ -920,6 +921,12 @@ void main() {
       expect(
         tester.getRect(find.text('BottomSheet')),
         const Rect.fromLTRB(360, 558, 440, 600),
+      );
+      // Ensure the FAB is overlapping the top of the sheet
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(
+        tester.getRect(find.byIcon(Icons.add)),
+        const Rect.fromLTRB(744, 544, 768, 568),
       );
     });
 


### PR DESCRIPTION
If a floating action button is used on a scaffold and a bottom sheet is brought up with a constraint set on it (see #80527), the FAB will shoot up to to the top of the screen instead of riding the top of the sheet:

<img width="792" alt="Wrong" src="https://user-images.githubusercontent.com/19588/117738660-65ca0c00-b1b1-11eb-94a0-d65a3d312b09.png">

This PR fixes that problem by making sure the height of the bottom sheet is constrained to the height of its contents:

<img width="792" alt="Right" src="https://user-images.githubusercontent.com/19588/117738695-7f6b5380-b1b1-11eb-88d4-df55ffe09d03.png">

I also updated a test to make sure the FAB is correctly placed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
