### PR TITLE
📝 Added tests for toString to increase coverage

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -6,6 +6,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
 import 'message_codec.dart';
@@ -258,7 +259,7 @@ class AndroidPointerProperties {
 
   @override
   String toString() {
-    return 'AndroidPointerProperties(id: $id, toolType: $toolType)';
+    return '${objectRuntimeType(this, 'AndroidPointerProperties')}(id: $id, toolType: $toolType)';
   }
 }
 
@@ -342,7 +343,7 @@ class AndroidPointerCoords {
 
   @override
   String toString() {
-    return 'AndroidPointerCoords(orientation: $orientation, pressure: $pressure, size: $size, toolMajor: $toolMajor, toolMinor: $toolMinor, touchMajor: $touchMajor, touchMinor: $touchMinor, x: $x, y: $y)';
+    return '${objectRuntimeType(this, 'AndroidPointerCoords')}(orientation: $orientation, pressure: $pressure, size: $size, toolMajor: $toolMajor, toolMinor: $toolMinor, touchMajor: $touchMajor, touchMinor: $touchMinor, x: $x, y: $y)';
   }
 }
 
@@ -482,7 +483,7 @@ class AndroidMotionEvent {
 
   @override
   String toString() {
-    return 'AndroidPointerEvent(downTime: $downTime, eventTime: $eventTime, action: $action, pointerCount: $pointerCount, pointerProperties: $pointerProperties, pointerCoords: $pointerCoords, metaState: $metaState, buttonState: $buttonState, xPrecision: $xPrecision, yPrecision: $yPrecision, deviceId: $deviceId, edgeFlags: $edgeFlags, source: $source, flags: $flags)';
+    return 'AndroidPointerEvent(downTime: $downTime, eventTime: $eventTime, action: $action, pointerCount: $pointerCount, pointerProperties: $pointerProperties, pointerCoords: $pointerCoords, metaState: $metaState, buttonState: $buttonState, xPrecision: $xPrecision, yPrecision: $yPrecision, deviceId: $deviceId, edgeFlags: $edgeFlags, source: $source, flags: $flags, motionEventId: $motionEventId)';
   }
 }
 

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -163,7 +163,7 @@ class SystemUiOverlayStyle {
   }
 
   @override
-  String toString() => _toMap().toString();
+  String toString() => '${objectRuntimeType(this, 'SystemUiOverlayStyle')}(${_toMap()})';
 
   /// Creates a copy of this theme with the given fields replaced with new values.
   SystemUiOverlayStyle copyWith({

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -75,4 +75,11 @@ void main() {
       '   HTTP status code: 404\n',
     );
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/39998
+
+  test('toString works as intended', () async {
+    final Uri uri = Uri.http('example.org', '/path');
+    final NetworkAssetBundle bundle = NetworkAssetBundle(uri);
+
+    expect(bundle.toString(), 'NetworkAssetBundle#${shortHash(bundle)}($uri)');
+  });
 }

--- a/packages/flutter/test/services/asset_bundle_test.dart
+++ b/packages/flutter/test/services/asset_bundle_test.dart
@@ -76,10 +76,10 @@ void main() {
     );
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/39998
 
-  test('toString works as intended', () async {
+  test('toString works as intended', () {
     final Uri uri = Uri.http('example.org', '/path');
     final NetworkAssetBundle bundle = NetworkAssetBundle(uri);
 
     expect(bundle.toString(), 'NetworkAssetBundle#${shortHash(bundle)}($uri)');
-  });
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/39998
 }

--- a/packages/flutter/test/services/message_codecs_test.dart
+++ b/packages/flutter/test/services/message_codecs_test.dart
@@ -255,4 +255,14 @@ void main() {
       );
     });
   });
+
+  test('toString works as intended', () async {
+    const MethodCall methodCall = MethodCall('sample method');
+    final PlatformException platformException = PlatformException(code: '100');
+    final MissingPluginException missingPluginException = MissingPluginException();
+
+    expect(methodCall.toString(), 'MethodCall(sample method, null)');
+    expect(platformException.toString(), 'PlatformException(100, null, null, null)');
+    expect(missingPluginException.toString(), 'MissingPluginException(null)');
+  });
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -300,4 +300,46 @@ void main() {
       );
     });
   });
+
+  test('toString works as intended', () async {
+    const AndroidPointerProperties androidPointerProperties = AndroidPointerProperties(id: 0, toolType: 0);
+    const androidPointerCoords =
+    AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0);
+    final AndroidMotionEvent androidMotionEvent = AndroidMotionEvent(
+        downTime: 0,
+        eventTime: 0,
+        action: 0,
+        pointerCount: 0,
+        pointerProperties: <AndroidPointerProperties>[],
+        pointerCoords: <AndroidPointerCoords>[],
+        metaState: 0,
+        buttonState: 0,
+        xPrecision: 0.0,
+        yPrecision: 0.0,
+        deviceId: 0,
+        edgeFlags: 0,
+        source: 0,
+        flags: 0,
+        motionEventId: 0
+    );
+
+    expect(androidPointerProperties.toString(), 'AndroidPointerProperties(id: 0, toolType: 0)');
+    expect(androidPointerCoords.toString(),
+        'AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0)');
+    expect(androidMotionEvent.toString(), 'AndroidPointerEvent(downTime: 0, '
+        'eventTime: 0, '
+        'action: 0, '
+        'pointerCount: 0, '
+        'pointerProperties: [], '
+        'pointerCoords: [], '
+        'metaState: 0, '
+        'buttonState: 0, '
+        'xPrecision: 0.0, '
+        'yPrecision: 0.0, '
+        'deviceId: 0, '
+        'edgeFlags: 0, '
+        'source: 0, '
+        'flags: 0, '
+        'motionEventId: 0)');
+  });
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -306,10 +306,27 @@ void main() {
     expect(androidPointerProperties.toString(), 'AndroidPointerProperties(id: 0, toolType: 0)');
 
     const double zero = 0.0;
-    const AndroidPointerCoords androidPointerCoords =
-      AndroidPointerCoords(orientation: zero, pressure: zero, size: zero, toolMajor: zero, toolMinor: zero, touchMajor: zero, touchMinor: zero, x: zero, y: zero);
-    expect(androidPointerCoords.toString(),
-      'AndroidPointerCoords(orientation: $zero, pressure: $zero, size: $zero, toolMajor: $zero, toolMinor: $zero, touchMajor: $zero, touchMinor: $zero, x: $zero, y: $zero)');
+    const AndroidPointerCoords androidPointerCoords = AndroidPointerCoords(
+      orientation: zero,
+      pressure: zero,
+      size: zero,
+      toolMajor: zero,
+      toolMinor: zero,
+      touchMajor: zero,
+      touchMinor: zero,
+      x: zero,
+      y: zero
+    );
+    expect(androidPointerCoords.toString(), 'AndroidPointerCoords(orientation: $zero, '
+      'pressure: $zero, '
+      'size: $zero, '
+      'toolMajor: $zero, '
+      'toolMinor: $zero, '
+      'touchMajor: $zero, '
+      'touchMinor: $zero, '
+      'x: $zero, '
+      'y: $zero)',
+    );
 
     final AndroidMotionEvent androidMotionEvent = AndroidMotionEvent(
       downTime: 0,
@@ -342,6 +359,7 @@ void main() {
       'edgeFlags: 0, '
       'source: 0, '
       'flags: 0, '
-      'motionEventId: 0)');
+      'motionEventId: 0)',
+    );
   });
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -303,43 +303,44 @@ void main() {
 
   test('toString works as intended', () async {
     const AndroidPointerProperties androidPointerProperties = AndroidPointerProperties(id: 0, toolType: 0);
-    const androidPointerCoords =
-    AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0);
-    final AndroidMotionEvent androidMotionEvent = AndroidMotionEvent(
-        downTime: 0,
-        eventTime: 0,
-        action: 0,
-        pointerCount: 0,
-        pointerProperties: <AndroidPointerProperties>[],
-        pointerCoords: <AndroidPointerCoords>[],
-        metaState: 0,
-        buttonState: 0,
-        xPrecision: 0.0,
-        yPrecision: 0.0,
-        deviceId: 0,
-        edgeFlags: 0,
-        source: 0,
-        flags: 0,
-        motionEventId: 0
-    );
-
     expect(androidPointerProperties.toString(), 'AndroidPointerProperties(id: 0, toolType: 0)');
+
+    const AndroidPointerCoords androidPointerCoords =
+      AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0);
     expect(androidPointerCoords.toString(),
-        'AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0)');
+      'AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0)');
+
+    final AndroidMotionEvent androidMotionEvent = AndroidMotionEvent(
+      downTime: 0,
+      eventTime: 0,
+      action: 0,
+      pointerCount: 0,
+      pointerProperties: <AndroidPointerProperties>[],
+      pointerCoords: <AndroidPointerCoords>[],
+      metaState: 0,
+      buttonState: 0,
+      xPrecision: 0.0,
+      yPrecision: 0.0,
+      deviceId: 0,
+      edgeFlags: 0,
+      source: 0,
+      flags: 0,
+      motionEventId: 0
+    );
     expect(androidMotionEvent.toString(), 'AndroidPointerEvent(downTime: 0, '
-        'eventTime: 0, '
-        'action: 0, '
-        'pointerCount: 0, '
-        'pointerProperties: [], '
-        'pointerCoords: [], '
-        'metaState: 0, '
-        'buttonState: 0, '
-        'xPrecision: 0.0, '
-        'yPrecision: 0.0, '
-        'deviceId: 0, '
-        'edgeFlags: 0, '
-        'source: 0, '
-        'flags: 0, '
-        'motionEventId: 0)');
+      'eventTime: 0, '
+      'action: 0, '
+      'pointerCount: 0, '
+      'pointerProperties: [], '
+      'pointerCoords: [], '
+      'metaState: 0, '
+      'buttonState: 0, '
+      'xPrecision: 0.0, '
+      'yPrecision: 0.0, '
+      'deviceId: 0, '
+      'edgeFlags: 0, '
+      'source: 0, '
+      'flags: 0, '
+      'motionEventId: 0)');
   });
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -305,10 +305,11 @@ void main() {
     const AndroidPointerProperties androidPointerProperties = AndroidPointerProperties(id: 0, toolType: 0);
     expect(androidPointerProperties.toString(), 'AndroidPointerProperties(id: 0, toolType: 0)');
 
+    const double zero = 0.0;
     const AndroidPointerCoords androidPointerCoords =
-      AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0);
+      AndroidPointerCoords(orientation: zero, pressure: zero, size: zero, toolMajor: zero, toolMinor: zero, touchMajor: zero, touchMinor: zero, x: zero, y: zero);
     expect(androidPointerCoords.toString(),
-      'AndroidPointerCoords(orientation: 0.0, pressure: 0.0, size: 0.0, toolMajor: 0.0, toolMinor: 0.0, touchMajor: 0.0, touchMinor: 0.0, x: 0.0, y: 0.0)');
+      'AndroidPointerCoords(orientation: $zero, pressure: $zero, size: $zero, toolMajor: $zero, toolMinor: $zero, touchMajor: $zero, touchMinor: $zero, x: $zero, y: $zero)');
 
     final AndroidMotionEvent androidMotionEvent = AndroidMotionEvent(
       downTime: 0,
@@ -319,8 +320,8 @@ void main() {
       pointerCoords: <AndroidPointerCoords>[],
       metaState: 0,
       buttonState: 0,
-      xPrecision: 0.0,
-      yPrecision: 0.0,
+      xPrecision: zero,
+      yPrecision: zero,
       deviceId: 0,
       edgeFlags: 0,
       source: 0,
@@ -335,8 +336,8 @@ void main() {
       'pointerCoords: [], '
       'metaState: 0, '
       'buttonState: 0, '
-      'xPrecision: 0.0, '
-      'yPrecision: 0.0, '
+      'xPrecision: $zero, '
+      'yPrecision: $zero, '
       'deviceId: 0, '
       'edgeFlags: 0, '
       'source: 0, '

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -91,11 +91,12 @@ void main() {
     const SystemUiOverlayStyle systemUiOverlayStyle = SystemUiOverlayStyle();
 
     expect(systemUiOverlayStyle.toString(), 'SystemUiOverlayStyle({'
-        'systemNavigationBarColor: null, '
-        'systemNavigationBarDividerColor: null, '
-        'statusBarColor: null, '
-        'statusBarBrightness: null, '
-        'statusBarIconBrightness: null, '
-        'systemNavigationBarIconBrightness: null})');
+      'systemNavigationBarColor: null, '
+      'systemNavigationBarDividerColor: null, '
+      'statusBarColor: null, '
+      'statusBarBrightness: null, '
+      'statusBarIconBrightness: null, '
+      'systemNavigationBarIconBrightness: null})',
+    );
   });
 }

--- a/packages/flutter/test/services/system_chrome_test.dart
+++ b/packages/flutter/test/services/system_chrome_test.dart
@@ -86,4 +86,16 @@ void main() {
       arguments: <String>['SystemUiOverlay.top'],
     ));
   });
+
+  test('toString works as intended', () async {
+    const SystemUiOverlayStyle systemUiOverlayStyle = SystemUiOverlayStyle();
+
+    expect(systemUiOverlayStyle.toString(), 'SystemUiOverlayStyle({'
+        'systemNavigationBarColor: null, '
+        'systemNavigationBarDividerColor: null, '
+        'statusBarColor: null, '
+        'statusBarBrightness: null, '
+        'statusBarIconBrightness: null, '
+        'systemNavigationBarIconBrightness: null})');
+  });
 }


### PR DESCRIPTION
Added toString tests for `NetworkAssetBundle`, `MethodCall`, `PlatformException`, `MissingPluginException`, `AndroidPointerProperties`, `AndroidPointerCoords`,  `AndroidMotionEvent` and `SystemUiOverlayStyle`.

Fixes #82232 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
