### PR TITLE
use throwsA matcher instead of try-catch-fail

### DIFF
--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -24,14 +24,15 @@ void main() {
           return processRunner.runProcess(commandLine);
         })(<String>['this_executable_better_not_exist_2857632534321']),
         throwsA(isA<PreparePackageException>()));
-    try {
-      await processRunner.runProcess(<String>['this_executable_better_not_exist_2857632534321']);
-    } on PreparePackageException catch (e) {
-      expect(
-        e.message,
+
+    await expectLater(
+      () => processRunner.runProcess(<String>['this_executable_better_not_exist_2857632534321']),
+      throwsA(isA<PreparePackageException>().having(
+        (PreparePackageException error) => error.message,
+        'message',
         contains('ProcessException: Failed to find "this_executable_better_not_exist_2857632534321" in the search path'),
-      );
-    }
+      )),
+    );
   });
   for (final String platformName in <String>['macos', 'linux', 'windows']) {
     final FakePlatform platform = FakePlatform(

--- a/dev/integration_tests/ui/test_driver/driver_test.dart
+++ b/dev/integration_tests/ui/test_driver/driver_test.dart
@@ -26,12 +26,14 @@ void main() {
     });
 
     test('waitForAbsent should time out waiting for text "present" to disappear', () async {
-      try {
-        await driver.waitForAbsent(presentText, timeout: const Duration(seconds: 1));
-        fail('expected DriverError');
-      } on DriverError catch (error) {
-        expect(error.message, contains('Timeout while executing waitForAbsent'));
-      }
+      await expectLater(
+        () => driver.waitForAbsent(presentText, timeout: const Duration(seconds: 1)),
+        throwsA(isA<DriverError>().having(
+          (DriverError error) => error.message,
+          'message',
+          contains('Timeout while executing waitForAbsent'),
+        )),
+      );
     });
 
     test('waitForAbsent should resolve when text "present" disappears', () async {
@@ -51,12 +53,14 @@ void main() {
     });
 
     test('waitFor times out waiting for "present" to reappear', () async {
-      try {
-        await driver.waitFor(presentText, timeout: const Duration(seconds: 1));
-        fail('expected DriverError');
-      } on DriverError catch (error) {
-        expect(error.message, contains('Timeout while executing waitFor'));
-      }
+      await expectLater(
+        () => driver.waitFor(presentText, timeout: const Duration(seconds: 1)),
+        throwsA(isA<DriverError>().having(
+          (DriverError error) => error.message,
+          'message',
+          contains('Timeout while executing waitFor'),
+        )),
+      );
     });
 
     test('waitFor should resolve when text "present" reappears', () async {

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -30,20 +30,21 @@ Future<void> pumpWidgetWithBoilerplate(WidgetTester tester, Widget widget) async
 Future<void> main() async {
 
   testWidgets('Need at least 2 tabs', (WidgetTester tester) async {
-    try {
-      await pumpWidgetWithBoilerplate(tester, CupertinoTabBar(
+    await expectLater(
+      () => pumpWidgetWithBoilerplate(tester, CupertinoTabBar(
         items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
             label: 'Tab 1',
           ),
         ],
-      ));
-      fail('Should not be possible to create a tab bar with just one item');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('items.length'));
-      // Exception expected.
-    }
+      )),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('items.length'),
+      )),
+    );
   });
 
   testWidgets('Active and inactive colors', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -85,35 +85,37 @@ void main() {
   });
 
   testWidgets('Need at least 2 children', (WidgetTester tester) async {
-    final Map<int, Widget> children = <int, Widget>{};
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         boilerplate(
           child: CupertinoSegmentedControl<int>(
-            children: children,
+            children: const <int, Widget>{},
             onValueChanged: (int newValue) { },
           ),
         ),
-      );
-      fail('Should not be possible to create a segmented control with no children');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('children.length'));
-    }
-    try {
-      children[0] = const Text('Child 1');
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('children.length'),
+      )),
+    );
 
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         boilerplate(
           child: CupertinoSegmentedControl<int>(
-            children: children,
+            children: const <int, Widget>{0: Text('Child 1')},
             onValueChanged: (int newValue) { },
           ),
         ),
-      );
-      fail('Should not be possible to create a segmented control with just one child');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('children.length'));
-    }
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('children.length'),
+      )),
+    );
   });
 
   testWidgets('Padding works', (WidgetTester tester) async {
@@ -208,8 +210,8 @@ void main() {
     children[0] = const Text('Child 1');
     children[1] = const Text('Child 2');
 
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         boilerplate(
           child: CupertinoSegmentedControl<int>(
             children: children,
@@ -217,14 +219,13 @@ void main() {
             groupValue: 2,
           ),
         ),
-      );
-      fail(
-        'Should not be possible to create segmented control in which '
-        'value is not the key of one of the children widgets',
-      );
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('children'));
-    }
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('children'),
+      )),
+    );
   });
 
   testWidgets('Widgets have correct default text/icon styles, change correctly on selection', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -73,50 +73,56 @@ void main() {
   });
 
   testWidgets('Need at least 2 children', (WidgetTester tester) async {
-    final Map<int, Widget> children = <int, Widget>{};
     groupValue = null;
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         CupertinoSlidingSegmentedControl<int>(
-          children: children,
+          children: const <int, Widget>{},
           groupValue: groupValue,
           onValueChanged: defaultCallback,
         ),
-      );
-      fail('Should not be possible to create a segmented control with no children');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('children.length'));
-    }
-    try {
-      children[0] = const Text('Child 1');
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('children.length'),
+      )),
+    );
 
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         CupertinoSlidingSegmentedControl<int>(
-          children: children,
+          children: const <int, Widget>{0: Text('Child 1')},
           groupValue: groupValue,
           onValueChanged: defaultCallback,
         ),
-      );
-      fail('Should not be possible to create a segmented control with just one child');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('children.length'));
-    }
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('children.length'),
+      )),
+    );
 
     groupValue = -1;
-    try {
-      children[1] = const Text('Child 2');
-      children[2] = const Text('Child 3');
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         CupertinoSlidingSegmentedControl<int>(
-          children: children,
+          children: const <int, Widget>{
+            0: Text('Child 1'),
+            1: Text('Child 2'),
+            2: Text('Child 3'),
+          },
           groupValue: groupValue,
           onValueChanged: defaultCallback,
         ),
-      );
-      fail('Should not be possible to create a segmented control with a groupValue pointing to a non-existent child');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('groupValue must be either null or one of the keys in the children map'));
-    }
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
+        contains('groupValue must be either null or one of the keys in the children map'),
+      )),
+    );
   });
 
   testWidgets('Padding works', (WidgetTester tester) async {

--- a/packages/flutter/test/foundation/debug_test.dart
+++ b/packages/flutter/test/foundation/debug_test.dart
@@ -37,16 +37,14 @@ void main() {
     });
 
     test('returns failing future if action throws', () async {
-      try {
-        await debugInstrumentAction<void>('throws', () async {
+      await expectLater(
+        () => debugInstrumentAction<void>('throws', () async {
           await Future<void>.delayed(Duration.zero);
           throw 'Error';
-        });
-        fail('Error expected but not thrown');
-      } on String catch (error) {
-        expect(error, 'Error');
-        expect(printBuffer.toString(), matches(r'^Action "throws" took .+'));
-      }
+        }),
+        throwsA('Error'),
+      );
+      expect(printBuffer.toString(), matches(r'^Action "throws" took .+'));
     });
   });
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -576,8 +576,8 @@ void main() {
         );
       }).toList();
 
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: DropdownButtonFormField<String>(
@@ -587,15 +587,13 @@ void main() {
             ),
           ),
         ),
-      );
-
-      fail('Should not be possible to have duplicate item value');
-    } on AssertionError catch (error) {
-      expect(
-        error.toString(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
         contains("There should be exactly one item with [DropdownButton]'s value"),
-      );
-    }
+      )),
+    );
   });
 
   testWidgets('DropdownButtonFormField value should only appear in one menu item', (WidgetTester tester) async {
@@ -607,8 +605,8 @@ void main() {
         );
       }).toList();
 
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: DropdownButton<String>(
@@ -618,15 +616,13 @@ void main() {
             ),
           ),
         ),
-      );
-
-      fail('Should not be possible to have no items with passed in value');
-    } on AssertionError catch (error) {
-      expect(
-        error.toString(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
         contains("There should be exactly one item with [DropdownButton]'s value"),
-      );
-    }
+      )),
+    );
   });
 
   testWidgets('DropdownButtonFormField - selectedItemBuilder builds custom buttons', (WidgetTester tester) async {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -445,8 +445,8 @@ void main() {
         );
       }).toList();
 
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: DropdownButton<String>(
@@ -456,15 +456,13 @@ void main() {
             ),
           ),
         ),
-      );
-
-      fail('Should not be possible to have duplicate item value');
-    } on AssertionError catch (error) {
-      expect(
-        error.toString(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
         contains("There should be exactly one item with [DropdownButton]'s value"),
-      );
-    }
+      )),
+    );
   });
 
   testWidgets('DropdownButton value should only appear in one menu item', (WidgetTester tester) async {
@@ -476,8 +474,8 @@ void main() {
         );
       }).toList();
 
-    try {
-      await tester.pumpWidget(
+    await expectLater(
+      () => tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: DropdownButton<String>(
@@ -487,15 +485,13 @@ void main() {
             ),
           ),
         ),
-      );
-
-      fail('Should not be possible to have no items with passed in value');
-    } on AssertionError catch (error) {
-      expect(
-        error.toString(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.toString(),
+        '.toString()',
         contains("There should be exactly one item with [DropdownButton]'s value"),
-      );
-    }
+      )),
+    );
   });
 
   testWidgets('Dropdown form field uses form field state', (WidgetTester tester) async {

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -171,8 +171,8 @@ void main() {
   testWidgets(
     'children and isSelected properties have to be the same length',
     (WidgetTester tester) async {
-      try {
-        await tester.pumpWidget(
+      await expectLater(
+        () => tester.pumpWidget(
           Material(
             child: boilerplate(
               child: ToggleButtons(
@@ -184,15 +184,16 @@ void main() {
               ),
             ),
           ),
-        );
-        fail(
-          'Should not be possible to create a toggle button with mismatching '
-          'children.length and isSelected.length.',
-        );
-      } on AssertionError catch (e) {
-        expect(e.toString(), contains('children.length'));
-        expect(e.toString(), contains('isSelected.length'));
-      }
+        ),
+        throwsA(isA<AssertionError>().having(
+          (AssertionError error) => error.toString(),
+          '.toString()',
+          allOf(
+            contains('children.length'),
+            contains('isSelected.length'),
+          ),
+        )),
+      );
     },
   );
 

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -968,30 +968,41 @@ void main() {
       );
       expect(isHit, isTrue);
       expect(ran, isTrue);
+      isHit = false;
       ran = false;
 
-      try {
-        isHit = result.addWithOutOfBandPosition(
-          paintTransform: MatrixUtils.forceToPoint(Offset.zero), // cannot be inverted
-          hitTest: (BoxHitTestResult result) {
-            fail('non-invertible transform should be caught');
-          },
-        );
-        fail('no exception thrown');
-      } on AssertionError catch (e) {
-        expect(e.message, 'paintTransform must be invertible.');
-      }
+      expect(
+        () {
+          isHit = result.addWithOutOfBandPosition(
+            paintTransform: MatrixUtils.forceToPoint(Offset.zero), // cannot be inverted
+            hitTest: (BoxHitTestResult result) {
+              fail('non-invertible transform should be caught');
+            },
+          );
+        },
+        throwsA(isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          'paintTransform must be invertible.',
+        )),
+      );
+      expect(isHit, isFalse);
 
-      try {
-        isHit = result.addWithOutOfBandPosition(
-          hitTest: (BoxHitTestResult result) {
-            fail('addWithOutOfBandPosition should need some transformation of some sort');
-          },
-        );
-        fail('no exception thrown');
-      } on AssertionError catch (e) {
-        expect(e.message, 'Exactly one transform or offset argument must be provided.');
-      }
+      expect(
+        () {
+          isHit = result.addWithOutOfBandPosition(
+            hitTest: (BoxHitTestResult result) {
+              fail('addWithOutOfBandPosition should need some transformation of some sort');
+            },
+          );
+        },
+        throwsA(isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          'Exactly one transform or offset argument must be provided.',
+        )),
+      );
+      expect(isHit, isFalse);
     });
 
     test('error message', () {

--- a/packages/flutter/test/services/restoration_bucket_test.dart
+++ b/packages/flutter/test/services/restoration_bucket_test.dart
@@ -181,19 +181,20 @@ void main() {
     expect(child2.read<int>('foo'), isNull); // Value does not exist in this child.
 
     // child1 is not given up before running finalizers.
-    try {
-      manager.doSerialization();
-      fail('expected error');
-    } on FlutterError catch (e) {
-      expect(
-        e.message,
-        'Multiple owners claimed child RestorationBuckets with the same IDs.\n'
-        'The following IDs were claimed multiple times from the parent RestorationBucket(restorationId: root, owner: MockManager):\n'
-        ' * "child1" was claimed by:\n'
-        '   * SecondClaim\n'
-        '   * FirstClaim (current owner)',
-      );
-    }
+    expect(
+      () => manager.doSerialization(),
+      throwsA(isA<FlutterError>().having(
+        (FlutterError error) => error.message,
+        'message',
+        equals(
+          'Multiple owners claimed child RestorationBuckets with the same IDs.\n'
+          'The following IDs were claimed multiple times from the parent RestorationBucket(restorationId: root, owner: MockManager):\n'
+          ' * "child1" was claimed by:\n'
+          '   * SecondClaim\n'
+          '   * FirstClaim (current owner)',
+        ),
+      )),
+    );
   });
 
   test('claim child that is already claimed does not throw if given up', () {

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -50,16 +50,18 @@ void main() {
 
   group('construction check', () {
     testWidgets('ListWheelScrollView needs positive diameter ratio', (WidgetTester tester) async {
-      try {
-        ListWheelScrollView(
+      expect(
+        () => ListWheelScrollView(
           diameterRatio: nonconst(-2.0),
           itemExtent: 20.0,
           children: const <Widget>[],
-        );
-        fail('Expected failure with negative diameterRatio');
-      } on AssertionError catch (exception) {
-        expect(exception.message, contains("You can't set a diameterRatio of 0"));
-      }
+        ),
+        throwsA(isA<AssertionError>().having(
+          (AssertionError error) => error.message,
+          'message',
+          contains("You can't set a diameterRatio of 0"),
+        )),
+      );
     });
 
     testWidgets('ListWheelScrollView can have zero child', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -756,15 +756,14 @@ void main() {
 
   testWidgets('PageView can restore page', (WidgetTester tester) async {
     final PageController controller = PageController();
-    try {
-      controller.page;
-      fail('Accessing page before attaching should fail.');
-    } on AssertionError catch (e) {
-      expect(
-        e.message,
-        'PageController.page cannot be accessed before a PageView is built with it.',
-      );
-    }
+    expect(
+      () => controller.page,
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        equals('PageController.page cannot be accessed before a PageView is built with it.'),
+      )),
+    );
     final PageStorageBucket bucket = PageStorageBucket();
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -791,15 +790,14 @@ void main() {
         child: Container(),
       ),
     );
-    try {
-      controller.page;
-      fail('Accessing page after detaching all PageViews should fail.');
-    } on AssertionError catch (e) {
-      expect(
-        e.message,
-        'PageController.page cannot be accessed before a PageView is built with it.',
-      );
-    }
+    expect(
+      () => controller.page,
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        equals('PageController.page cannot be accessed before a PageView is built with it.'),
+      )),
+    );
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: PageStorage(

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -531,13 +531,14 @@ void main() {
         fakeClient.responses['waitFor'] = makeFakeResponse(<String, dynamic>{
           'message': 'This is a failure',
         }, isError: true);
-        try {
-          await driver.waitFor(find.byTooltip('foo'));
-          fail('expected an exception');
-        } catch (error) {
-          expect(error, isA<DriverError>());
-          expect((error as DriverError).message, 'Error in Flutter application: {message: This is a failure}');
-        }
+        await expectLater(
+          () => driver.waitFor(find.byTooltip('foo')),
+          throwsA(isA<DriverError>().having(
+            (DriverError error) => error.message,
+            'message',
+            'Error in Flutter application: {message: This is a failure}',
+          )),
+        );
       });
 
       test('uncaught remote error', () async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -819,12 +819,10 @@ class LoggerInterrupted implements Exception {
 
 Future<void> expectLoggerInterruptEndsTask(Future<void> task, StreamLogger logger) async {
   logger.interrupt(); // an exception during the task should cause it to fail...
-  try {
-    await task;
-    expect(false, isTrue); // (shouldn't reach here)
-  } on ToolExit catch (error) {
-    expect(error.exitCode, 2); // ...with exit code 2.
-  }
+  await expectLater(
+    () => task,
+    throwsA(isA<ToolExit>().having((ToolExit error) => error.exitCode, 'exitCode', 2)),
+  );
 }
 
 VMServiceConnector getFakeVmServiceFactory({

--- a/packages/flutter_tools/test/commands.shard/hermetic/logs_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/logs_test.dart
@@ -23,12 +23,10 @@ void main() {
 
     testUsingContext('fail with a bad device id', () async {
       final LogsCommand command = LogsCommand();
-      try {
-        await createTestCommandRunner(command).run(<String>['-d', 'abc123', 'logs']);
-        fail('Expect exception');
-      } on ToolExit catch (e) {
-        expect(e.exitCode ?? 1, 1);
-      }
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>['-d', 'abc123', 'logs']),
+        throwsA(isA<ToolExit>().having((ToolExit error) => error.exitCode, 'exitCode', anyOf(isNull, 1))),
+      );
     });
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -51,12 +51,10 @@ void main() {
 
     testUsingContext('fails when target not found', () async {
       final RunCommand command = RunCommand();
-      try {
-        await createTestCommandRunner(command).run(<String>['run', '-t', 'abc123', '--no-pub']);
-        fail('Expect exception');
-      } on ToolExit catch (e) {
-        expect(e.exitCode ?? 1, 1);
-      }
+      expect(
+        () => createTestCommandRunner(command).run(<String>['run', '-t', 'abc123', '--no-pub']),
+        throwsA(isA<ToolExit>().having((ToolExit error) => error.exitCode, 'exitCode', anyOf(isNull, 1))),
+      );
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -69,18 +67,20 @@ void main() {
       fileSystem.file('.packages').createSync();
 
       final RunCommand command = RunCommand();
-      try {
-        await createTestCommandRunner(command).run(<String>[
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>[
           'run',
           '--use-application-binary=app/bar/faz',
           '--fast-start',
           '--no-pub',
           '--show-test-device',
-        ]);
-        fail('Expect exception');
-      } on Exception catch (e) {
-        expect(e.toString(), isNot(contains('--fast-start is not supported with --use-application-binary')));
-      }
+        ]),
+        throwsA(isA<Exception>().having(
+          (Exception exception) => exception.toString(),
+          'toString',
+          isNot(contains('--fast-start is not supported with --use-application-binary')),
+        )),
+      );
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -97,15 +97,13 @@ void main() {
         ..createSync(recursive: true);
 
       final RunCommand command = RunCommand();
-      try {
-        await createTestCommandRunner(command).run(<String>[
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>[
           'run',
           '--no-pub',
-        ]);
-        fail('Expect exception');
-      } on Exception catch (e) {
-        expect(e, isA<ToolExit>());
-      }
+        ]),
+        throwsA(isA<ToolExit>()),
+      );
       final BufferLogger bufferLogger = globals.logger as BufferLogger;
       expect(
         bufferLogger.statusText,
@@ -124,16 +122,17 @@ void main() {
         .createSync(recursive: true);
 
       final RunCommand command = RunCommand();
-      try {
-        await createTestCommandRunner(command).run(<String>[
+      await expectLater(
+        () => createTestCommandRunner(command).run(<String>[
           'run',
           '--no-pub',
-        ]);
-        fail('Expect exception');
-      } on Exception catch (e) {
-        expect(e, isA<ToolExit>());
-        expect(e.toString(), contains('No pubspec.yaml file found'));
-      }
+        ]),
+        throwsA(isA<ToolExit>().having(
+          (ToolExit error) => error.toString(),
+          'toString()',
+          contains('No pubspec.yaml file found'),
+        )),
+      );
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -180,16 +179,14 @@ void main() {
           (Invocation invocation) => Future<List<Device>>.value(noDevices)
         );
 
-        try {
-          await createTestCommandRunner(command).run(<String>[
+        await expectLater(
+          () => createTestCommandRunner(command).run(<String>[
             'run',
             '--no-pub',
             '--no-hot',
-          ]);
-          fail('Expect exception');
-        } on ToolExit catch (e) {
-          expect(e.message, null);
-        }
+          ]),
+          throwsA(isA<ToolExit>().having((ToolExit error) => error.message, 'message', isNull)),
+        );
 
         expect(
           testLogger.statusText,
@@ -256,16 +253,14 @@ void main() {
             (Invocation invocation) => Future<List<Device>>.value(<Device>[]),
         );
 
-        try {
-          await createTestCommandRunner(command).run(<String>[
+        await expectLater(
+          () => createTestCommandRunner(command).run(<String>[
             'run',
             '--no-pub',
             '--no-hot',
-          ]);
-          fail('Expect exception');
-        } on ToolExit catch (e) {
-          expect(e.message, null);
-        }
+          ]),
+          throwsA(isA<ToolExit>().having((ToolExit error) => error.message, 'message', isNull)),
+        );
 
         expect(
           testLogger.statusText,

--- a/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/shell_completion_test.dart
@@ -61,15 +61,16 @@ void main() {
       final ShellCompletionCommand command = ShellCompletionCommand();
       const String outputFile = 'bash-setup.sh';
       globals.fs.file(outputFile).createSync();
-      try {
-        await createTestCommandRunner(command).run(
+      await expectLater(
+        () => createTestCommandRunner(command).run(
           <String>['bash-completion', outputFile],
-        );
-        fail('Expect ToolExit exception');
-      } on ToolExit catch (error) {
-        expect(error.exitCode ?? 1, 1);
-        expect(error.message, contains('Use --overwrite'));
-      }
+        ),
+        throwsA(
+          isA<ToolExit>()
+            .having((ToolExit error) => error.exitCode, 'exitCode', anyOf(isNull, 1))
+            .having((ToolExit error) => error.message, 'message', contains('Use --overwrite')),
+        ),
+      );
       expect(globals.fs.isFileSync(outputFile), isTrue);
       expect(globals.fs.file(outputFile).readAsStringSync(), isEmpty);
     }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/general.shard/base/context_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/context_test.dart
@@ -161,13 +161,18 @@ void main() {
             double: () => context.get<int>()! * 1.0,
           },
         );
-        try {
-          await value;
-          fail('ContextDependencyCycleException expected but not thrown.');
-        } on ContextDependencyCycleException catch (e) {
-          expect(e.cycle, <Type>[String, double, int]);
-          expect(e.toString(), 'Dependency cycle detected: String -> double -> int');
-        }
+        expect(
+          () => value,
+          throwsA(
+            isA<ContextDependencyCycleException>()
+              .having((ContextDependencyCycleException error) => error.cycle, 'cycle', <Type>[String, double, int])
+              .having(
+                (ContextDependencyCycleException error) => error.toString(),
+                'toString()',
+                'Dependency cycle detected: String -> double -> int',
+              ),
+          ),
+        );
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -211,13 +211,14 @@ void main() {
         exitCode: 1,
         stderr: stderr,
       ));
-      try {
-        processUtils.runSync(<String>['kaboom'], throwOnError: true);
-        fail('ProcessException expected.');
-      } on ProcessException catch (e) {
-        expect(e, isA<ProcessException>());
-        expect(e.message.contains(stderr), false);
-      }
+      expect(
+        () => processUtils.runSync(<String>['kaboom'], throwOnError: true),
+        throwsA(isA<ProcessException>().having(
+          (ProcessException error) => error.message,
+          'message',
+          isNot(contains(stderr)),
+        )),
+      );
     });
 
     testWithoutContext('throws with stderr in exception on failure with verboseExceptions', () async {

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -406,12 +406,10 @@ void main() {
       botDetector: const BotDetectorAlwaysNo(),
       processManager: processManager,
     );
-    try {
-      await pub.get(context: PubContext.flutterTests);
-      throw AssertionError('pubGet did not fail');
-    } on ToolExit catch (error) {
-      expect(error.message, 'pub get failed (66; err3)');
-    }
+    await expectLater(
+      () => pub.get(context: PubContext.flutterTests),
+      throwsA(isA<ToolExit>().having((ToolExit error) => error.message, 'message', 'pub get failed (66; err3)')),
+    );
     expect(logger.statusText,
       'Running "flutter pub get" in /...\n'
       'out1\n'

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -174,13 +174,14 @@ void main() {
 }
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {
-  ObjRef res;
-  try {
-    res = await flutter.evaluateInFrame('"test"');
-  } on RPCError catch (e) {
-    expect(e.message, contains('Expression evaluation is not supported for this configuration'));
-  }
-  expect(res, null);
+  await expectLater(
+    () => flutter.evaluateInFrame('"test"'),
+    throwsA(isA<RPCError>().having(
+      (RPCError error) => error.message,
+      'message',
+      contains('Expression evaluation is not supported for this configuration'),
+    )),
+  );
 }
 
 Future<void> checkStaticScope(FlutterTestDriver flutter) async {


### PR DESCRIPTION
This PR replace code like:

```dart
try {
  someSyncFunctionThatThrows();
  fail('expected Error');
} on Error catch (error) {
  expect(error.message, contains('some message'));
}
try {
  await someAsyncFunctionThatThrows();
  fail('expected Error');
} on Error catch (error) {
  expect(error.message, contains('some message'));
}
```

with

```dart
expect(
  () => someSyncFunctionThatThrows(),
  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
);
await expectLater(
  () => someAsyncFunctionThatThrows(),
  throwsA(isA<Error>().having((Error error) => error.message, 'message', contains('some message'))),
);
```