### PR TITLE
Add flutter_tools to trigger list for skp_generator

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -184,7 +184,7 @@
       "repo": "flutter",
       "task_name": "linux_skp_generator",
       "enabled": true,
-      "run_if": ["dev/", "packages/flutter/", "bin/"]
+      "run_if": ["dev/", "packages/flutter/", "packages/flutter_tools/", "bin/"]
     },
     {
       "name": "Linux tool_tests_general",


### PR DESCRIPTION
Turns out that since skp_generator relies on `flutter create`, we need to make sure we trigger precommit tests on changes to flutter_tools too.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
