### PR TITLE
Update positional parameter names to match SDK names

### DIFF
--- a/packages/flutter/lib/src/foundation/basic_types.dart
+++ b/packages/flutter/lib/src/foundation/basic_types.dart
@@ -136,7 +136,7 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
-  Iterable<T> map<T>(T Function(E e) f) {
+  Iterable<T> map<T>(T Function(E e) toElement) {
     return CachingIterable<T>(super.map<T>(f).iterator);
   }
 
@@ -146,7 +146,7 @@ class CachingIterable<E> extends IterableBase<E> {
   }
 
   @override
-  Iterable<T> expand<T>(Iterable<T> Function(E element) f) {
+  Iterable<T> expand<T>(Iterable<T> Function(E element) toElements) {
     return CachingIterable<T>(super.expand<T>(f).iterator);
   }
 


### PR DESCRIPTION
The SDK changed the names of some function parameters of `Iterable` from `f` to something more useful.
Because of the `avoid_renaming_method_parameters` lint, the Flutter code now has warnings where those are overridden.
This should change the (known so far) cases to match the SDK.

Fixes the issues found by 
https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8847556430102102816/+/u/flutter_analyze/stdout

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
