### PR TITLE
remove web e2e and smoke test builders

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -547,18 +547,6 @@
       "flaky": false
     },
     {
-      "name": "Linux web_e2e_test",
-      "repo": "flutter",
-      "task_name": "linux_web_e2e_test",
-      "flaky": false
-    },
-    {
-      "name": "Linux web_smoke_test",
-      "repo": "flutter",
-      "task_name": "linux_web_smoke_test",
-      "flaky": false
-    },
-    {
       "name": "Linux flutter_plugins",
       "repo": "flutter",
       "task_name": "flutter_plugins",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -340,38 +340,6 @@
       "run_if": ["dev/", "packages/", "bin/"]
     },
     {
-      "name": "Linux web_e2e_test",
-      "repo": "flutter",
-      "task_name": "linux_web_e2e_test",
-      "enabled": true,
-      "run_if": [
-        "examples/hello_world/**",
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/flutter_test/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "packages/flutter_web_plugins/**",
-        "bin/**"
-      ]
-    },
-    {
-      "name": "Linux web_smoke_test",
-      "repo": "flutter",
-      "task_name": "linux_web_smoke_test",
-      "enabled": true,
-      "run_if": [
-        "examples/hello_world/**",
-        "dev/**",
-        "packages/flutter/**",
-        "packages/flutter_driver/**",
-        "packages/flutter_test/**",
-        "packages/flutter_tools/lib/src/test/**",
-        "packages/flutter_web_plugins/**",
-        "bin/**"
-      ]
-    },
-    {
       "name": "Linux flutter_plugins",
       "repo": "flutter",
       "task_name": "flutter_plugins",


### PR DESCRIPTION
web e2e and smoke tests have been rolled into the web_long_running_tests shard.
