### PR TITLE
Fixed a problem with the first drag update on a reorderable list.

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'debug.dart';
@@ -521,6 +522,15 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   Offset? _finalDropPosition;
   MultiDragGestureRecognizer? _recognizer;
   bool _autoScrolling = false;
+  // To implement the gap for the dragged item, we replace the dragged item
+  // with a zero sized box, and then translate all of the later items down
+  // by the size of the dragged item. This allows us to keep the order of the
+  // list, while still being able to animate the gap between the items. However
+  // for the first frame of the drag, the item has not yet been replaced, so
+  // the calculations for the gap is off by the size of the gap. This flag is
+  // used to determine if the transition to the zero sized box has completed,
+  // so the calculations can compensate for it.
+  bool _dragStartTransitionComplete = false;
 
   late ScrollableState _scrollable;
   Axis get _scrollDirection => axisDirectionToAxis(_scrollable.axisDirection);
@@ -615,6 +625,10 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     final _ReorderableItemState item = _items[_dragIndex!]!;
     item.dragging = true;
     item.rebuild();
+    _dragStartTransitionComplete = false;
+    SchedulerBinding.instance!.addPostFrameCallback((Duration duration) {
+      _dragStartTransitionComplete = true;
+    });
 
     _insertIndex = item.index;
     _dragInfo = _DragInfo(
@@ -722,7 +736,14 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       if (item.index == _dragIndex! || !item.mounted)
         continue;
 
-      final Rect geometry = item.targetGeometry();
+      Rect geometry = item.targetGeometry();
+      if (!_dragStartTransitionComplete && _dragIndex! <= item.index) {
+        // Transition is not complete, so each item after the dragged item is still
+        // in its normal location and not moved up for the zero sized box that will
+        // replace the dragged item.
+        final Offset transitionOffset = _extentOffset(_reverse ? -gapExtent : gapExtent, _scrollDirection);
+        geometry = (geometry.topLeft - transitionOffset) & geometry.size;
+      }
       final double itemStart = _scrollDirection == Axis.vertical ? geometry.top : geometry.left;
       final double itemExtent = _scrollDirection == Axis.vertical ? geometry.height : geometry.width;
       final double itemEnd = itemStart + itemExtent;

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -527,9 +527,9 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   // by the size of the dragged item. This allows us to keep the order of the
   // list, while still being able to animate the gap between the items. However
   // for the first frame of the drag, the item has not yet been replaced, so
-  // the calculations for the gap is off by the size of the gap. This flag is
+  // the calculation for the gap is off by the size of the gap. This flag is
   // used to determine if the transition to the zero sized box has completed,
-  // so the calculations can compensate for it.
+  // so the gap calculation can compensate for it.
   bool _dragStartTransitionComplete = false;
 
   late ScrollableState _scrollable;

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -122,7 +122,7 @@ void main() {
     expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Drag item 0 downwards more than halfway to displace item 1.
-    await pressDragRelease(tester.getCenter(find.text('item 0')), const Offset(0, 151));
+    await pressDragRelease(tester.getCenter(find.text('item 0')), const Offset(0, 51));
     check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
     expect(tester.getTopLeft(find.text('item 1')), Offset.zero);
     expect(tester.getTopLeft(find.text('item 0')), const Offset(0, 100));
@@ -136,7 +136,7 @@ void main() {
     expect(items, orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Drag item 1 to item 3
-    await pressDragRelease(tester.getCenter(find.text('item 1')), const Offset(0, 251));
+    await pressDragRelease(tester.getCenter(find.text('item 1')), const Offset(0, 151));
     check(visible: <int>[0, 1, 2, 3, 4, 5], hidden: <int>[6, 7]);
     expect(tester.getTopLeft(find.text('item 0')), Offset.zero);
     expect(tester.getTopLeft(find.text('item 1')), const Offset(0, 300));
@@ -433,7 +433,7 @@ void main() {
       await tester.pump(kPressTimeout);
 
       // Drag enough to move down the first item
-      await drag.moveBy(const Offset(0, 150));
+      await drag.moveBy(const Offset(0, 50));
       await tester.pump();
       await drag.up();
       await tester.pumpAndSettle();


### PR DESCRIPTION
During the development of #81396 it was noticed the the drag calculations in the first frame of a reorderable list drag were off by the size of the dragged item. This is due to the implementation of the gap. During the drag the dragged item in the list is replaced by a zero sized item and all later items are just translated down by the gap size. This allows us to keep the order in the list while still being able to move the gap around based on the drag location. However, for the first frame of the drag the replacement of the zero sized box has not yet happened and any initial calculation of where the dragged item is will be off. During normal usage this isn't a problem because it is rare that you won't immediately have another drag event that will sort itself out. However in unit tests we only have a single drag event and it will be wrong.

This PR compensates for this issue and updates the tests so they are testing correct values.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
