### PR TITLE
[flutter_tool] Suggest how to increase the Android minSdkVersion

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -649,16 +649,18 @@ assembleProfile
   });
 
   group('higher minSdkVersion', () {
+    const String stdoutLine = 'uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:webview_flutter] /tmp/cirrus-ci-build/all_plugins/build/webview_flutter/intermediates/library_manifest/release/AndroidManifest.xml as the library might be using APIs not available in 16';
+
     testWithoutContext('pattern', () {
       expect(
-        minSdkVersion.test('uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:webview_flutter] /tmp/cirrus-ci-build/all_plugins/build/webview_flutter/intermediates/library_manifest/release/AndroidManifest.xml as the library might be using APIs not available in 16'),
+        minSdkVersion.test(stdoutLine),
         isTrue,
       );
     });
 
     testUsingContext('suggestion', () async {
       await minSdkVersion.handler(
-        line: 'uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:webview_flutter] /tmp/cirrus-ci-build/all_plugins/build/webview_flutter/intermediates/library_manifest/release/AndroidManifest.xml as the library might be using APIs not available in 16',
+        line: stdoutLine,
         project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
       );
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -29,6 +29,7 @@ void main() {
           flavorUndefinedHandler,
           r8FailureHandler,
           androidXFailureHandler,
+          minSdkVersion,
         ])
       );
     });
@@ -644,6 +645,45 @@ assembleProfile
       Platform: () => fakePlatform('android'),
       ProcessManager: () => fakeProcessManager,
       FileSystem: () => MemoryFileSystem.test(),
+    });
+  });
+
+  group('higher minSdkVersion', () {
+    testWithoutContext('pattern', () {
+      expect(
+        minSdkVersion.test('uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:webview_flutter] /tmp/cirrus-ci-build/all_plugins/build/webview_flutter/intermediates/library_manifest/release/AndroidManifest.xml as the library might be using APIs not available in 16'),
+        isTrue,
+      );
+    });
+
+    testUsingContext('suggestion', () async {
+      await minSdkVersion.handler(
+        line: 'uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:webview_flutter] /tmp/cirrus-ci-build/all_plugins/build/webview_flutter/intermediates/library_manifest/release/AndroidManifest.xml as the library might be using APIs not available in 16',
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
+      );
+
+      expect(
+        testLogger.statusText,
+        contains(
+          '\n'
+          'The plugin webview_flutter requires a higher Android SDK version.\n'
+          'Fix this issue by adding the following to the file /android/app/build.gradle:\n'
+          'android {\n'
+          '  defaultConfig {\n'
+          '    minSdkVersion 19\n'
+          '  }\n'
+          '}\n'
+          '\n'
+          'Note that your app won\'t be available to users running Android SDKs below 19.\n'
+          'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.\n'
+          ''
+        )
+      );
+    }, overrides: <Type, Generator>{
+      GradleUtils: () => FakeGradleUtils(),
+      Platform: () => fakePlatform('android'),
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.empty(),
     });
   });
 }


### PR DESCRIPTION
The `webview_flutter` and `google_maps` plugins will start to show these error messages. 

https://github.com/flutter/plugins/pull/3860 is bumping the minSdk in webview_flutter.

Related conversation: https://github.com/flutter/flutter/issues/82000
