### PR TITLE
Corrected OverflowBar layout when it is wider that its intrinsic width

### DIFF
--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -510,12 +510,17 @@ class _RenderOverflowBar extends RenderBox
       }
       size = constraints.constrain(Size(constraints.maxWidth, y - overflowSpacing));
     } else {
+      // Default horizontal layout.
       size = constraints.constrain(Size(actualWidth, maxChildHeight));
       child = firstChild;
       double x = rtl ? size.width - child!.size.width : 0;
       while (child != null) {
         final _OverflowBarParentData childParentData = child.parentData! as _OverflowBarParentData;
         childParentData.offset = Offset(x, (maxChildHeight - child.size.height) / 2);
+        // x is the horizontal origin of child. To advance x to the next child's
+        // origin for LTR: add the width of the current child. To advance x to
+        // the origin of the next child for RTL: subtract the width of the next
+        // child (if there is one).
         if (!rtl) {
           x += child.size.width + spacing;
         }

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -510,17 +510,20 @@ class _RenderOverflowBar extends RenderBox
       }
       size = constraints.constrain(Size(constraints.maxWidth, y - overflowSpacing));
     } else {
-      // Default horizontal layout
-      child = rtl ? lastChild : firstChild;
-      RenderBox? nextChild() => rtl ? childBefore(child!) : childAfter(child!);
-      double x  = 0;
+      size = constraints.constrain(Size(actualWidth, maxChildHeight));
+      child = firstChild;
+      double x = rtl ? size.width - child!.size.width : 0;
       while (child != null) {
         final _OverflowBarParentData childParentData = child.parentData! as _OverflowBarParentData;
         childParentData.offset = Offset(x, (maxChildHeight - child.size.height) / 2);
-        x += child.size.width + spacing;
-        child = nextChild();
+        if (!rtl) {
+          x += child.size.width + spacing;
+        }
+        child = childAfter(child);
+        if (rtl && child != null) {
+          x -= child.size.width + spacing;
+        }
       }
-      size = constraints.constrain(Size(actualWidth, maxChildHeight));
     }
   }
 

--- a/packages/flutter/test/widgets/overflow_bar_test.dart
+++ b/packages/flutter/test/widgets/overflow_bar_test.dart
@@ -234,4 +234,41 @@ void main() {
     await tester.pumpWidget(buildFrame(maxWidth: 150));
     expect(tester.getSize(find.byType(OverflowBar)).height, 166); // 166 = 50 + 8 + 25 + 8 + 75
   });
+
+
+  testWidgets('OverflowBar is wider that its intrinsic width', (WidgetTester tester) async {
+    final Key key0 = UniqueKey();
+    final Key key1 = UniqueKey();
+    final Key key2 = UniqueKey();
+
+    Widget buildFrame(TextDirection textDirection) {
+      return Directionality(
+        textDirection: textDirection,
+        child: SizedBox(
+          width: 800,
+          // intrinsic width = 50 + 10 + 60 + 10 + 70 = 200
+          child: OverflowBar(
+            spacing: 10,
+            children: <Widget>[
+              SizedBox(key: key0, width: 50, height: 50),
+              SizedBox(key: key1, width: 60, height: 50),
+              SizedBox(key: key2, width: 70, height: 50),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(TextDirection.ltr));
+    expect(tester.getSize(find.byType(OverflowBar)), const Size(800.0, 600.0));
+    expect(tester.getTopLeft(find.byKey(key0)).dx, 0);
+    expect(tester.getTopLeft(find.byKey(key1)).dx, 60);
+    expect(tester.getTopLeft(find.byKey(key2)).dx, 130);
+
+    await tester.pumpWidget(buildFrame(TextDirection.rtl));
+    expect(tester.getSize(find.byType(OverflowBar)), const Size(800.0, 600.0));
+    expect(tester.getTopLeft(find.byKey(key0)).dx, 750);
+    expect(tester.getTopLeft(find.byKey(key1)).dx, 680);
+    expect(tester.getTopLeft(find.byKey(key2)).dx, 600);
+  });
 }


### PR DESCRIPTION
OverflowBar layout was not correct when the text direction was RTL and the bar's width was constrained to be wider than its intrinsic width.

In the screenshots below, the blue outline is the bounds of the overflow bar. The top bar is LTR, the bottom is RTL.

## Incorrect Layout

<img width="422" alt="Screen Shot 2021-05-12 at 12 42 35 PM" src="https://user-images.githubusercontent.com/1377460/118035042-916b0480-b31f-11eb-8f1d-68bd724d182c.png">

## Correct Layout

<img width="425" alt="Screen Shot 2021-05-12 at 12 38 57 PM" src="https://user-images.githubusercontent.com/1377460/118034777-39cc9900-b31f-11eb-8594-440d5d8777a9.png">
