### PR TITLE
Mark linux_platform_channels_benchmarks not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -376,7 +376,7 @@
       "name": "Linux platform_channels_benchmarks",
       "repo": "flutter",
       "task_name": "linux_platform_channels_benchmarks",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",


### PR DESCRIPTION
`linux_platform_channels_benchmarks` introduced in #81414 is consistently passing.