### PR TITLE
Mark animated_image_gc_perf not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -328,7 +328,7 @@
       "name": "Linux animated_image_gc_perf",
       "repo": "flutter",
       "task_name": "animated_image_gc_perf",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Linux linux_chrome_dev_mode",


### PR DESCRIPTION
`animated_image_gc_perf` introduced in #81240 is consistently passing.