### PR TITLE
Turn on win_build_tests_2_3 shard, skip 'build windows' tests

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -441,8 +441,7 @@ Future<void> _runExampleProjectBuildTests(FileSystemEntity exampleDirectory) asy
   }
   if (Platform.isWindows) {
     if (Directory(path.join(examplePath, 'windows')).existsSync()) {
-      await _flutterBuildWin32(examplePath, release: false, additionalArgs: additionalArgs, verifyCaching: verifyCaching);
-      await _flutterBuildWin32(examplePath, release: true, additionalArgs: additionalArgs, verifyCaching: verifyCaching);
+      // TODO(jmagman): Re-add Windows build tests when Visual Studio is available https://github.com/flutter/flutter/issues/81956.
     } else {
       print('Example project ${path.basename(examplePath)} has no windows directory, skipping Win32');
     }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -505,21 +505,6 @@ Future<void> _flutterBuildMacOS(String relativePathToApplication, {
   );
 }
 
-Future<void> _flutterBuildWin32(String relativePathToApplication, {
-  @required bool release,
-  bool verifyCaching = false,
-  List<String> additionalArgs = const <String>[],
-}) async {
-  assert(Platform.isWindows);
-  await runCommand(flutter, <String>['config', '--enable-windows-desktop']);
-  print('${green}Testing Windows build$reset for $cyan$relativePathToApplication$reset...');
-  await _flutterBuild(relativePathToApplication, 'Windows', 'windows',
-    release: release,
-    verifyCaching: verifyCaching,
-    additionalArgs: additionalArgs
-  );
-}
-
 Future<void> _flutterBuild(
   String relativePathToApplication,
   String platformLabel,

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -579,7 +579,7 @@
       "name": "Windows build_tests_2_3",
       "repo": "flutter",
       "task_name": "win_build_tests_2_3",
-      "enabled": false
+      "enabled": true
     },
     {
       "name": "Windows build_tests_3_3",


### PR DESCRIPTION
Re-enable the shard disabled in https://github.com/flutter/flutter/pull/81955.  Continue to skip the `flutter build windows` tests until the right version of Visual Studio can be made available https://github.com/flutter/flutter/issues/81956.

This will allow the non-Windows Android and web tests to run on this shard.

Enable only in the try builder.  If this starts passing in prod I'll mark it unflaky in another PR.