### PR TITLE
shuffle tests in web_long_running_tests shard

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -880,6 +880,11 @@ Future<void> _runWebLongRunningTests() async {
       '--sound-null-safety',
     ]),
   ];
+
+  // Shuffling mixes fast tests with slow tests so shards take roughly the same
+  // amount of time to run.
+  tests.shuffle(math.Random(0));
+
   await _ensureChromeDriverIsRunning();
   await _runShardRunnerIndexOfTotalSubshard(tests);
   await _stopChromeDriver();


### PR DESCRIPTION
Shuffling tests mixes fast tests with slow tests so shards take roughly the same amount of time to run. This is what many other shards do.
