### PR TITLE
Sets textInputAction property of CupertinoSearchTextField to TextInputAction.search by default

### DIFF
--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -430,6 +430,7 @@ class _CupertinoSearchTextFieldState extends State<CupertinoSearchTextField>
       onSubmitted: widget.onSubmitted,
       focusNode: widget.focusNode,
       autocorrect: widget.autocorrect,
+      textInputAction: TextInputAction.search,
     );
   }
 }

--- a/packages/flutter/test/cupertino/search_field_test.dart
+++ b/packages/flutter/test/cupertino/search_field_test.dart
@@ -549,4 +549,17 @@ void main() {
     final CupertinoTextField textField = tester.widget(find.byType(CupertinoTextField));
     expect(textField.enabled, false);
   });
+
+  testWidgets('textInputAction is set to TextInputAction.search by default', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: CupertinoSearchTextField(),
+        ),
+      ),
+    );
+
+    final CupertinoTextField textField = tester.widget(find.byType(CupertinoTextField));
+    expect(textField.textInputAction, TextInputAction.search);
+  });
 }


### PR DESCRIPTION
Sets textInputAction property of CupertinoSearchTextField to TextInputAction.search by default 

Fixes: #82099 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

