### PR TITLE
[flutter_tools] swap web debugging protocol to ws

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -211,7 +211,7 @@ abstract class FlutterCommand extends Command<void> {
     );
     argParser.addOption('web-server-debug-protocol',
       allowed: <String>['sse', 'ws'],
-      defaultsTo: 'sse',
+      defaultsTo: 'ws',
       help: 'The protocol (SSE or WebSockets) to use for the debug service proxy '
       'when using the Web Server device and Dart Debug extension. '
       'This is useful for editors/debug adapters that do not support debugging '
@@ -220,7 +220,7 @@ abstract class FlutterCommand extends Command<void> {
     );
     argParser.addOption('web-server-debug-backend-protocol',
       allowed: <String>['sse', 'ws'],
-      defaultsTo: 'sse',
+      defaultsTo: 'ws',
       help: 'The protocol (SSE or WebSockets) to use for the Dart Debug Extension '
       'backend service when using the Web Server device. '
       'Using WebSockets can improve performance but may fail when connecting through '
@@ -229,7 +229,7 @@ abstract class FlutterCommand extends Command<void> {
     );
     argParser.addOption('web-server-debug-injected-client-protocol',
       allowed: <String>['sse', 'ws'],
-      defaultsTo: 'sse',
+      defaultsTo: 'ws',
       help: 'The protocol (SSE or WebSockets) to use for the injected client '
       'when using the Web Server device. '
       'Using WebSockets can improve performance but may fail when connecting through '

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -508,6 +508,20 @@ void main() {
       '--bundle-sksl-path=foo.json',
     ]), throwsToolExit(message: 'No SkSL shader bundle found at foo.json'));
   });
+
+  testUsingContext('Configures web connection options to use web sockets by default', () async {
+    final RunCommand command = RunCommand();
+    await expectLater(() => createTestCommandRunner(command).run(<String>[
+      'run',
+      '--no-pub',
+    ]), throwsToolExit());
+
+    final DebuggingOptions options = await command.createDebuggingOptions(true);
+
+    expect(options.webUseSseForDebugBackend, false);
+    expect(options.webUseSseForDebugProxy, false);
+    expect(options.webUseSseForInjectedClient, false);
+  });
 }
 
 class MockCache extends Mock implements Cache {}


### PR DESCRIPTION
websockets should work in all environments that sse works in, except for g3 where the flutter tool is not used. we believe this may help users that have trouble connecting due to firewall issues.

Staging so I don't forget about it while I figure out the testing situation.

FYI @ferhatb @grouma @DanTup 