### PR TITLE
[fuchsia_asset_builder] Write depfile

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_asset_builder.dart
+++ b/packages/flutter_tools/bin/fuchsia_asset_builder.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart' as libfs;
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/context_runner.dart';
@@ -22,6 +23,7 @@ const String _kOptionAsset = 'asset-dir';
 const String _kOptionManifest = 'manifest';
 const String _kOptionAssetManifestOut = 'asset-manifest-out';
 const String _kOptionComponentName = 'component-name';
+const String _kOptionDepfile = 'depfile';
 const List<String> _kRequiredOptions = <String>[
   _kOptionPackages,
   _kOptionAsset,
@@ -48,7 +50,8 @@ Future<void> run(List<String> args) async {
         help: 'The directory where to put temporary files')
     ..addOption(_kOptionManifest, help: 'The manifest file')
     ..addOption(_kOptionAssetManifestOut)
-    ..addOption(_kOptionComponentName);
+    ..addOption(_kOptionComponentName)
+    ..addOption(_kOptionDepfile);
   final ArgResults argResults = parser.parse(args);
   if (_kRequiredOptions
       .any((String option) => !argResults.options.contains(option))) {
@@ -79,6 +82,25 @@ Future<void> run(List<String> args) async {
 
   final String outputMan = argResults[_kOptionAssetManifestOut] as String;
   await writeFuchsiaManifest(assets, argResults[_kOptionAsset] as String, outputMan, argResults[_kOptionComponentName] as String);
+
+  if (argResults.options.contains(_kOptionDepfile)) {
+    await writeDepfile(assets, outputMan, argResults[_kOptionDepfile] as String);
+  }
+}
+
+Future<void> writeDepfile(AssetBundle assets, String outputManifest, String depfilePath) async {
+  final Depfile depfileContent = Depfile(
+    assets.inputFiles,
+    <libfs.File>[globals.fs.file(outputManifest)],
+  );
+  final DepfileService depfileService = DepfileService(
+    fileSystem: globals.fs,
+    logger: globals.logger,
+  );
+
+  final libfs.File depfile = globals.fs.file(depfilePath);
+  await depfile.create(recursive: true);
+  depfileService.writeToFile(depfileContent, depfile);
 }
 
 Future<void> writeFuchsiaManifest(AssetBundle assets, String outputBase, String fileDest, String componentName) async {

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 
@@ -30,9 +31,13 @@ void main() {
     // that AssetBundle with fonts also works on Windows.
     testUsingContext('app font uses local font file', () async {
       final AssetBundle asset = AssetBundleFactory.instance.createBundle();
+      final String manifestPath =
+          globals.fs.path.join(dataPath, 'main', 'pubspec.yaml');
+      final String packagesPath =
+          globals.fs.path.join(dataPath, 'main', '.packages');
       await asset.build(
-        manifestPath : globals.fs.path.join(dataPath, 'main', 'pubspec.yaml'),
-        packagesPath: globals.fs.path.join(dataPath, 'main', '.packages'),
+        manifestPath: manifestPath,
+        packagesPath: packagesPath,
       );
 
       expect(asset.entries.containsKey('FontManifest.json'), isTrue);
@@ -41,6 +46,16 @@ void main() {
         '[{"family":"packages/font/test_font","fonts":[{"asset":"packages/font/test_font_file"}]}]',
       );
       expect(asset.wasBuiltOnce(), true);
+      expect(
+        asset.inputFiles.map((File f) {
+          return f.path;
+        }),
+        <String>[
+          packagesPath,
+          globals.fs.path.join(dataPath, 'font', 'pubspec.yaml'),
+          manifestPath,
+        ],
+      );
     });
 
     testUsingContext('handles empty pubspec with .packages', () async {
@@ -54,10 +69,17 @@ void main() {
       );
       final AssetBundle asset = AssetBundleFactory.instance.createBundle();
       await asset.build(
-        manifestPath : globals.fs.path.join(dataPath, 'main', 'pubspec.yaml'), // file doesn't exist
+        manifestPath: globals.fs.path
+            .join(dataPath, 'main', 'pubspec.yaml'), // file doesn't exist
         packagesPath: globals.fs.path.join(dataPath, 'main', '.packages'),
       );
       expect(asset.wasBuiltOnce(), true);
+      expect(
+        asset.inputFiles.map((File f) {
+          return f.path;
+        }),
+        <String>[],
+      );
     });
   });
 }


### PR DESCRIPTION
fuchsia_asset_builder now accepts an optional flag "--depfile", when
provided, a GN/Ninja-style depfile will be written to the specified
location.

Test:
../../bin/flutter test test/general.shard/asset_test.dart
