### PR TITLE
Tool exit on xcodebuild -list when Xcode project is corrupted

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -235,6 +235,9 @@ class XcodeProjectInterpreter {
     // * -project is passed and the given project isn't there, or
     // * no -project is passed and there isn't a project.
     const int missingProjectExitCode = 66;
+    // The exit code returned by 'xcodebuild -list' when the project is corrupted.
+    const int corruptedProjectExitCode = 74;
+    bool _allowedFailures(int c) => c == missingProjectExitCode || c == corruptedProjectExitCode;
     final RunResult result = await _processUtils.run(
       <String>[
         ...xcrunCommand(),
@@ -243,10 +246,11 @@ class XcodeProjectInterpreter {
         if (projectFilename != null) ...<String>['-project', projectFilename],
       ],
       throwOnError: true,
-      allowedFailures: (int c) => c == missingProjectExitCode,
+      allowedFailures: _allowedFailures,
       workingDirectory: projectPath,
     );
-    if (result.exitCode == missingProjectExitCode) {
+    if (_allowedFailures(result.exitCode)) {
+      // User configuration error, tool exit instead of crashing.
       throwToolExit('Unable to get Xcode project information:\n ${result.stderr}');
     }
     return XcodeProjectInfo.fromXcodeBuildOutput(result.toString(), _logger);

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const String xcodebuild = '/usr/bin/xcodebuild';
 
@@ -80,7 +81,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.versionText, isNull);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild versionText returns null when xcodebuild is not installed', () {
@@ -107,7 +108,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.versionText, 'Xcode 8.3.3, Build version 8E3004b');
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild versionText handles Xcode version string with unexpected format', () {
@@ -121,7 +122,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.versionText, 'Xcode Ultra5000, Build version 8E3004b');
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild version parts can be parsed', () {
@@ -135,7 +136,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.version, Version(11, 4, 1));
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild minor and patch version default to 0', () {
@@ -149,7 +150,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.version, Version(11, 0, 0));
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild version parts is null when version has unexpected format', () {
@@ -162,7 +163,7 @@ void main() {
       ),
     ]);
     expect(xcodeProjectInterpreter.version, isNull);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild isInstalled is false when not on MacOS', () {
@@ -177,14 +178,14 @@ void main() {
     fileSystem.file(xcodebuild).deleteSync();
 
     expect(xcodeProjectInterpreter.isInstalled, isFalse);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild isInstalled is false when xcodebuild does not exist', () {
     fileSystem.file(xcodebuild).deleteSync();
 
     expect(xcodeProjectInterpreter.isInstalled, isFalse);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext(
@@ -202,7 +203,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.isInstalled, isFalse);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild isInstalled is false when version has unexpected format', () {
@@ -216,7 +217,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.isInstalled, isFalse);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild isInstalled is true when version has expected format', () {
@@ -230,7 +231,7 @@ void main() {
     ]);
 
     expect(xcodeProjectInterpreter.isInstalled, isTrue);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcrun runs natively on arm64', () {
@@ -250,7 +251,7 @@ void main() {
       '-arm64e',
       'xcrun',
     ]);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testUsingContext('xcodebuild build settings is empty when xcodebuild failed to get the build settings', () async {
@@ -283,7 +284,7 @@ void main() {
     expect(
         await xcodeProjectInterpreter.getBuildSettings('', buildContext: const XcodeProjectBuildContext(scheme: 'Free')),
         const <String, String>{});
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
@@ -317,7 +318,7 @@ void main() {
       ),
       const <String, String>{},
     );
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
@@ -344,7 +345,7 @@ void main() {
 
     expect(await xcodeProjectInterpreter.getBuildSettings('', buildContext: const XcodeProjectBuildContext()),
         const <String, String>{});
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
@@ -376,7 +377,7 @@ void main() {
     expect(
         await xcodeProjectInterpreter.getBuildSettings('', buildContext: const XcodeProjectBuildContext(scheme: 'Free')),
         const <String, String>{});
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
@@ -408,7 +409,7 @@ void main() {
     ]);
 
     await xcodeProjectInterpreter.cleanWorkspace('workspace_path', 'Free');
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild -list getInfo returns something when xcodebuild -list succeeds', () async {
@@ -430,7 +431,7 @@ void main() {
     );
 
     expect(await xcodeProjectInterpreter.getInfo(workingDirectory), isNotNull);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('xcodebuild -list getInfo throws a tool exit when it is unable to find a project', () async {
@@ -458,7 +459,33 @@ void main() {
     expect(
         () async => xcodeProjectInterpreter.getInfo(workingDirectory),
         throwsToolExit(message: stderr));
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  });
+
+  testWithoutContext('xcodebuild -list getInfo throws a tool exit when project is corrupted', () async {
+    const String workingDirectory = '/';
+    const String stderr = 'Useful Xcode failure message about corrupted project.';
+
+    fakeProcessManager.addCommands(const <FakeCommand>[
+      kWhichSysctlCommand,
+      kARMCheckCommand,
+      FakeCommand(
+        command: <String>['xcrun', 'xcodebuild', '-list'],
+        exitCode: 74,
+        stderr: stderr,
+      ),
+    ]);
+
+    final XcodeProjectInterpreter xcodeProjectInterpreter = XcodeProjectInterpreter(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: fakeProcessManager,
+      usage: TestUsage(),
+    );
+
+    expect(() async => xcodeProjectInterpreter.getInfo(workingDirectory), throwsToolExit(message: stderr));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('Xcode project properties from default project can be parsed', () {

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -456,9 +456,7 @@ void main() {
       usage: TestUsage(),
     );
 
-    expect(
-        () async => xcodeProjectInterpreter.getInfo(workingDirectory),
-        throwsToolExit(message: stderr));
+    expect(() => xcodeProjectInterpreter.getInfo(workingDirectory), throwsToolExit(message: stderr));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
@@ -484,7 +482,7 @@ void main() {
       usage: TestUsage(),
     );
 
-    expect(() async => xcodeProjectInterpreter.getInfo(workingDirectory), throwsToolExit(message: stderr));
+    expect(() => xcodeProjectInterpreter.getInfo(workingDirectory), throwsToolExit(message: stderr));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 


### PR DESCRIPTION
Add corrupted Xcode project exit code 74 to the ones that should be tool exited (https://github.com/flutter/flutter/pull/40375) instead of crashing with a process exception, since this is a user configuration issue and not something the tool should handle.

Fixes https://github.com/flutter/flutter/issues/63280