### PR TITLE
[flutter_tools] make failures to unforward android port non-fatal

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -1313,13 +1313,10 @@ class AndroidDevicePortForwarder extends DevicePortForwarder {
       ],
       throwOnError: false,
     );
-    // The port may have already been unforwarded, for example if there
-    // are multiple attach process already connected.
-    if (runResult.exitCode == 0 || runResult
-      .stderr.contains("listener '$tcpLine' not found")) {
+    if (runResult.exitCode == 0) {
       return;
     }
-    runResult.throwException('Process exited abnormally:\n$runResult');
+    _logger.printError('Failed to unforward port: $runResult');
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_port_forwarder_test.dart
@@ -143,7 +143,7 @@ void main() {
     await forwarder.unforward(ForwardedPort(456, 23));
   });
 
-  testWithoutContext('failures to unforward port throw exception if stderr is not recognized', () async {
+  testWithoutContext('failures to unforward port print error but are non-fatral', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>['adb', '-s', '1', 'forward', '--remove', 'tcp:456'],
@@ -151,13 +151,16 @@ void main() {
         exitCode: 1,
       )
     ]);
+    final BufferLogger logger = BufferLogger.test();
     final AndroidDevicePortForwarder forwarder = AndroidDevicePortForwarder(
       adbPath: 'adb',
       deviceId: '1',
       processManager: processManager,
-      logger: BufferLogger.test(),
+      logger: logger,
     );
 
-    expect(() => forwarder.unforward(ForwardedPort(456, 23)), throwsProcessException());
+    await forwarder.unforward(ForwardedPort(456, 23));
+
+    expect(logger.errorText, contains('Failed to unforward port: error: everything is broken!'));
   });
 }


### PR DESCRIPTION
Rather than trying to parse the stderr, just print a warning if the port failed to unforward and exit normally.