### PR TITLE
[flutter_tools] use try to delete in web cache

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -183,9 +183,7 @@ class FlutterWebSdk extends CachedArtifact {
       platformName += 'windows-x64';
     }
     final Uri url = Uri.parse('${cache.storageBaseUrl}/flutter_infra_release/flutter/$version/$platformName.zip');
-    if (location.existsSync()) {
-      location.deleteSync(recursive: true);
-    }
+    ErrorHandlingFileSystem.deleteIfExists(location, recursive: true);
     await artifactUpdater.downloadZipArchive('Downloading Web SDK...', url, location);
     // This is a temporary work-around for not being able to safely download into a shared directory.
     final FileSystem fileSystem = location.fileSystem;


### PR DESCRIPTION
To handle the weird edge cases around directory deletion or other readonly system errors, use ErrorHandlingFileSystem.tryToDelete instead.
