### PR TITLE
Fix single frame image is decoded even cached

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -974,7 +974,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
 
   @override
   void addListener(ImageStreamListener listener) {
-    if (!hasListeners && _codec != null)
+    if (!hasListeners && _codec != null && (_currentImage == null || _codec!.frameCount > 1))
       _decodeNextFrameAndSchedule();
     super.addListener(listener);
   }

--- a/packages/flutter/test/painting/fake_codec.dart
+++ b/packages/flutter/test/painting/fake_codec.dart
@@ -19,6 +19,7 @@ class FakeCodec implements ui.Codec {
   final int _repetitionCount;
   final List<ui.FrameInfo> _frameInfos;
   int _nextFrame = 0;
+  int _numFramesAsked = 0;
 
   /// Creates a FakeCodec from encoded image data.
   ///
@@ -38,8 +39,11 @@ class FakeCodec implements ui.Codec {
   @override
   int get repetitionCount => _repetitionCount;
 
+  int get numFramesAsked => _numFramesAsked;
+
   @override
   Future<ui.FrameInfo> getNextFrame() {
+    _numFramesAsked += 1;
     final SynchronousFuture<ui.FrameInfo> result =
       SynchronousFuture<ui.FrameInfo>(_frameInfos[_nextFrame]);
     _nextFrame = (_nextFrame + 1) % _frameCount;


### PR DESCRIPTION
This PR fixed unnecessary repeated decoding of a single frame image. We have encountered the problem of repeated decoding of pictures when using `Image.network()`, even if it is a picture that has been cached, `_decodeNextFrameAndSchedule` will still be executed in `MultiFrameImageStreamCompleter.addListener()` during building a new image widget.
Flutter use ImageCache to cache `ImageStreamCompleter`. 
- For single frame image (jpg, png and one frmae gif or webp), most of cached completer has a not null `_currentImage` and frame need be decoded only when `_currentImage` is null. Decoding is expensive and should not happen when we already known result.
- For multi frame image, which _codec!.frameCount > 1, just decode as usual.
![image](https://user-images.githubusercontent.com/11713363/118244560-3fb6ab80-b4d2-11eb-98ac-334356a5acb1.png)

Png, jpg, single-frame gif(duration 0 or 0.1s), multi-frame gif was tested and works fine.

fixed [#82532](https://github.com/flutter/flutter/issues/82532)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
