### PR TITLE
Remove symroot from generated iOS Xcode build settings

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -30,8 +30,6 @@ String flutterMacOSFrameworkDir(BuildMode mode, FileSystem fileSystem,
 /// useMacOSConfig: Optional parameter that controls whether we use the macOS
 /// project file instead. Defaults to false.
 ///
-/// setSymroot: Optional parameter to control whether to set SYMROOT.
-///
 /// targetOverride: Optional parameter, if null or unspecified the default value
 /// from xcode_backend.sh is used 'lib/main.dart'.
 Future<void> updateGeneratedXcodeProperties({
@@ -39,7 +37,6 @@ Future<void> updateGeneratedXcodeProperties({
   @required BuildInfo buildInfo,
   String targetOverride,
   bool useMacOSConfig = false,
-  bool setSymroot = true,
   String buildDirOverride,
 }) async {
   final List<String> xcodeBuildSettings = _xcodeBuildSettingsLines(
@@ -47,7 +44,6 @@ Future<void> updateGeneratedXcodeProperties({
     buildInfo: buildInfo,
     targetOverride: targetOverride,
     useMacOSConfig: useMacOSConfig,
-    setSymroot: setSymroot,
     buildDirOverride: buildDirOverride,
   );
 
@@ -149,7 +145,6 @@ List<String> _xcodeBuildSettingsLines({
   @required BuildInfo buildInfo,
   String targetOverride,
   bool useMacOSConfig = false,
-  bool setSymroot = true,
   String buildDirOverride,
 }) {
   final List<String> xcodeBuildSettings = <String>[];
@@ -171,10 +166,6 @@ List<String> _xcodeBuildSettingsLines({
 
   // The build outputs directory, relative to FLUTTER_APPLICATION_PATH.
   xcodeBuildSettings.add('FLUTTER_BUILD_DIR=${buildDirOverride ?? getBuildDirectory()}');
-
-  if (setSymroot) {
-    xcodeBuildSettings.add('SYMROOT=\${SOURCE_ROOT}/../${getIosBuildDirectory()}');
-  }
 
   final String buildName = parsedBuildName(manifest: project.manifest, buildInfo: buildInfo) ?? '1.0.0';
   xcodeBuildSettings.add('FLUTTER_BUILD_NAME=$buildName');

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -62,7 +62,6 @@ Future<void> buildMacOS({
     buildInfo: buildInfo,
     targetOverride: targetOverride,
     useMacOSConfig: true,
-    setSymroot: false,
   );
   await processPodsIfNeeded(flutterProject.macos, getMacOSBuildDirectory(), buildInfo.mode);
   // If the xcfilelists do not exist, create empty version.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -1164,7 +1164,6 @@ class MacOSProject extends FlutterProjectPlatform implements XcodeBasedProject {
         project: parent,
         buildInfo: BuildInfo.debug,
         useMacOSConfig: true,
-        setSymroot: false,
       );
     }
   }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1100,6 +1100,8 @@ void main() {
     expect(xcodeConfig, contains('FLUTTER_APPLICATION_PATH='));
     expect(xcodeConfig, contains('FLUTTER_TARGET='));
     expect(xcodeConfig, contains('COCOAPODS_PARALLEL_CODE_SIGN=true'));
+    // Avoid legacy build locations to support Swift Package Manager.
+    expect(xcodeConfig, isNot(contains('SYMROOT')));
 
     // Generated export environment variables script
     final String buildPhaseScriptPath = globals.fs.path.join('.ios', 'Flutter', 'flutter_export_environment.sh');
@@ -1110,6 +1112,8 @@ void main() {
     expect(buildPhaseScript, contains('FLUTTER_APPLICATION_PATH='));
     expect(buildPhaseScript, contains('FLUTTER_TARGET='));
     expect(buildPhaseScript, contains('COCOAPODS_PARALLEL_CODE_SIGN=true'));
+    // Do not override host app build settings.
+    expect(buildPhaseScript, isNot(contains('SYMROOT')));
 
     // Generated podspec
     final String podspecPath = globals.fs.path.join('.ios', 'Flutter', 'flutter_project.podspec');


### PR DESCRIPTION
Setting `SYMROOT` in the iOS generated build settings, which drops the project permanently into legacy build mode, preventing Swift Package Manager usage.  This PR no longer sets it.  @stuartmorgan had a good overview of the problem with this setting when he was working on getting macOS build set up https://github.com/flutter/flutter/issues/32494#issuecomment-491480157.

Setting `SYMROOT` seems unnecessary since Flutter passes in `BUILD_DIR=path/to/build/ios` into `xcodebuild`.  The built products are put in the correct place.  Opening the project on its own in Xcode will build to its own location, but it seems to always require a full rebuild when you switch now, so it's not sharing the right caching locations anyway.

Confirmed `flutter build ios`, `flutter run`, and `flutter build xcarchive` still works with `clean`s between.  These locations are also thoroughly tested with integration tests.

This will only prevent newly created Flutter projects from dropping into the legacy build location.  Users already in this state will need to fix up their project manually.

Prevent https://github.com/flutter/flutter/issues/76868 (will close with a future project migration).