### PR TITLE
Add cold boot option to emulator launch command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,3 +77,4 @@ Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
 Perqin Xie <perqinxie@gmail.com>
 Seongyun Kim <helloworld@cau.ac.kr>
 Ludwik Trammer <ludwik@gmail.com>
+Marian Triebe <m.triebe@live.de>

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -149,10 +149,15 @@ class AndroidEmulator extends Emulator {
   String _prop(String name) => _properties != null ? _properties[name] : null;
 
   @override
-  Future<void> launch({@visibleForTesting Duration startupDuration}) async {
-    final Process process = await _processUtils.start(
-      <String>[_androidSdk.emulatorPath, '-avd', id],
-    );
+  Future<void> launch({@visibleForTesting Duration startupDuration, bool coldBoot = false}) async {
+    final List<String> command = <String>[
+      _androidSdk.emulatorPath,
+      '-avd',
+      id,
+      if (coldBoot)
+        '-no-snapshot-load'
+    ];
+    final Process process = await _processUtils.start(command);
 
     // Record output from the emulator process.
     final List<String> stdoutList = <String>[];

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -15,6 +15,9 @@ class EmulatorsCommand extends FlutterCommand {
   EmulatorsCommand() {
     argParser.addOption('launch',
         help: 'The full or partial ID of the emulator to launch.');
+    argParser.addFlag('cold',
+        help: 'Used with the "--launch" flag to cold boot the emulator instance (Android only).',
+        negatable: false);
     argParser.addFlag('create',
         help: 'Creates a new Android emulator based on a Pixel device.',
         negatable: false);
@@ -43,7 +46,8 @@ class EmulatorsCommand extends FlutterCommand {
     }
 
     if (argResults.wasParsed('launch')) {
-      await _launchEmulator(stringArg('launch'));
+      final bool coldBoot = argResults.wasParsed('cold');
+      await _launchEmulator(stringArg('launch'), coldBoot: coldBoot);
     } else if (argResults.wasParsed('create')) {
       await _createEmulator(name: stringArg('name'));
     } else {
@@ -57,7 +61,7 @@ class EmulatorsCommand extends FlutterCommand {
     return FlutterCommandResult.success();
   }
 
-  Future<void> _launchEmulator(String id) async {
+  Future<void> _launchEmulator(String id, {bool coldBoot}) async {
     final List<Emulator> emulators =
         await emulatorManager.getEmulatorsMatching(id);
 
@@ -69,7 +73,7 @@ class EmulatorsCommand extends FlutterCommand {
         "More than one emulator matches '$id':",
       );
     } else {
-      await emulators.first.launch();
+      await emulators.first.launch(coldBoot: coldBoot);
     }
   }
 

--- a/packages/flutter_tools/lib/src/emulator.dart
+++ b/packages/flutter_tools/lib/src/emulator.dart
@@ -268,7 +268,7 @@ abstract class Emulator {
         && other.id == id;
   }
 
-  Future<void> launch();
+  Future<void> launch({bool coldBoot});
 
   @override
   String toString() => name;

--- a/packages/flutter_tools/lib/src/ios/ios_emulators.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_emulators.dart
@@ -40,7 +40,7 @@ class IOSEmulator extends Emulator {
   PlatformType get platformType => PlatformType.ios;
 
   @override
-  Future<void> launch() async {
+  Future<void> launch({bool coldBoot = false}) async {
     Future<bool> launchSimulator(List<String> additionalArgs) async {
       final List<String> args = <String>[
         'open',

--- a/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_emulator_test.dart
@@ -144,6 +144,22 @@ void main() {
       await emulator.launch(startupDuration: Duration.zero);
     });
 
+    testWithoutContext('succeeds with coldboot launch', () async {
+      final List<String> kEmulatorLauchColdBootCommand = <String>[
+        ...kEmulatorLaunchCommand,
+        '-no-snapshot-load'
+      ];
+      final AndroidEmulator emulator = AndroidEmulator(emulatorID,
+        processManager: FakeProcessManager.list(<FakeCommand>[
+          FakeCommand(command: kEmulatorLauchColdBootCommand),
+        ]),
+        androidSdk: mockSdk,
+        logger: BufferLogger.test(),
+      );
+
+      await emulator.launch(startupDuration: Duration.zero, coldBoot: true);
+    });
+
     testWithoutContext('prints error on failure', () async {
       final BufferLogger logger =  BufferLogger.test();
       final AndroidEmulator emulator = AndroidEmulator(emulatorID,

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -367,7 +367,7 @@ class FakeEmulator extends Emulator {
   PlatformType get platformType => PlatformType.android;
 
   @override
-  Future<void> launch() {
+  Future<void> launch({bool coldBoot = false}) {
     throw UnimplementedError('Not implemented in Mock');
   }
 }


### PR DESCRIPTION
The cold boot option is only available for AVD.

This PR implements the following feature request: #56828

closes #56828

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
