### PR TITLE
[flutter_tools] Fix Android Studio minor patches detection on Windows

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -413,14 +413,17 @@ void main() {
     windowsFileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio4.2\.home')
       ..createSync(recursive: true)
       ..writeAsStringSync(r'C:\Program Files\AndroidStudio');
+    windowsFileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio4.2\.appinfo')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(r'app.version.major=4&app.version.minor=2.1');
     windowsFileSystem
       .directory(r'C:\Program Files\AndroidStudio')
       .createSync(recursive: true);
 
-    final AndroidStudio studio = AndroidStudio.allInstalled().single;
+    final AndroidStudio studio = AndroidStudio.allInstalled().single;    
 
-    expect(studio.version, Version(4, 2, 0));
-    expect(studio.studioAppName, 'Android Studio 4.2');
+    expect(studio.version, Version(4, 2, 1));
+    expect(studio.studioAppName, 'Android Studio 4.2.1');
   }, overrides: <Type, Generator>{
     Platform: () => windowsPlatform,
     FileSystem: () => windowsFileSystem,

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -420,7 +420,7 @@ void main() {
       .directory(r'C:\Program Files\AndroidStudio')
       .createSync(recursive: true);
 
-    final AndroidStudio studio = AndroidStudio.allInstalled().single;    
+    final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
     expect(studio.version, Version(4, 2, 1));
     expect(studio.studioAppName, 'Android Studio 4.2.1');


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/70387 was filed late last year, looking into it I found that It is not possible to fix this, you cannot correctly report minor patches in `flutter doctor -v` for that version. However, this seems to be possible now with the new Android Studio  4.2 release which generates this file -> `AppData\Local\Google\AndroidStudio4.2\.appinfo`, this file contains two tags that we can use to determine the Android Studio version correctly including minor patches.

`app.version.major=4&app.version.minor=2`

(Note: Currently this `\AndroidStudio4.2\.appinfo`  file still reports `4.2`, even tho the latest version is `4.2.1` but this PR would improve this version detection when the Android Studio team adds more minor patches info to the file `AppData\Local\Google\AndroidStudio4.2\.appinfo` file. Intellij's `.appinfo` file  already correctly reports minor version `2021.1.1` )

This PR will eliminate the need to increment minor patches detection for `Android Studio 4.2` releases

To test this behavior, I've manually edited `.appinfo` file, below is the result (for test purposes only)

### Before
```console
[✓] Android Studio (version 4.2.0)
    • Android Studio at C:\Users\Taha\Code\android-studio
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.8+10-b944.6842174)
```
### After 
```console
[√] Android Studio (version 4.2.1)
    • Android Studio at C:\Users\Taha\Code\android-studio
    • Flutter plugin can be installed from:
       https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
       https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.8+10-b944.6842174)
```

We should close https://github.com/flutter/flutter/issues/70387 as there is no way to fix this in an older version of Android Studio. ex: `Android Studio 4.1.1`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
