### PR TITLE
[flutter_test/integration_test] added setSurfaceSize test coverage

### DIFF
--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -36,4 +36,62 @@ void main() {
     expect(hoverEvent!.position, location);
     await gesture.removePointer();
   });
+
+  testWidgets('hitTesting works when using setSurfaceSize', (WidgetTester tester) async {
+    int invocations = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: GestureDetector(
+            onTap: () {
+              invocations++;
+            },
+            child: const Text('Test'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(Text));
+    await tester.pump();
+    expect(invocations, 1);
+
+    await tester.binding.setSurfaceSize(const Size(200, 300));
+    await tester.pump();
+    await tester.tap(find.byType(Text));
+    await tester.pump();
+    expect(invocations, 2);
+
+    await tester.binding.setSurfaceSize(null);
+    await tester.pump();
+    await tester.tap(find.byType(Text));
+    await tester.pump();
+    expect(invocations, 3);
+  });
+
+  testWidgets('setSurfaceSize works', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: Center(child: Text('Test'))));
+
+    final Size windowCenter = tester.binding.window.physicalSize /
+        tester.binding.window.devicePixelRatio /
+        2;
+    final double windowCenterX = windowCenter.width;
+    final double windowCenterY = windowCenter.height;
+
+    Offset widgetCenter = tester.getRect(find.byType(Text)).center;
+    expect(widgetCenter.dx, windowCenterX);
+    expect(widgetCenter.dy, windowCenterY);
+
+    await tester.binding.setSurfaceSize(const Size(200, 300));
+    await tester.pump();
+    widgetCenter = tester.getRect(find.byType(Text)).center;
+    expect(widgetCenter.dx, 100);
+    expect(widgetCenter.dy, 150);
+
+    await tester.binding.setSurfaceSize(null);
+    await tester.pump();
+    widgetCenter = tester.getRect(find.byType(Text)).center;
+    expect(widgetCenter.dx, windowCenterX);
+    expect(widgetCenter.dy, windowCenterY);
+  });
 }

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -43,6 +43,38 @@ Future<void> main() async {
       integrationBinding.reportData = <String, dynamic>{'answer': 42};
     });
 
+    testWidgets('hitTesting works when using setSurfaceSize', (WidgetTester tester) async {
+      int invocations = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: GestureDetector(
+              onTap: () {
+                invocations++;
+              },
+              child: const Text('Test'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(Text));
+      await tester.pump();
+      expect(invocations, 1);
+
+      await tester.binding.setSurfaceSize(const Size(200, 300));
+      await tester.pump();
+      await tester.tap(find.byType(Text));
+      await tester.pump();
+      expect(invocations, 2);
+
+      await tester.binding.setSurfaceSize(null);
+      await tester.pump();
+      await tester.tap(find.byType(Text));
+      await tester.pump();
+      expect(invocations, 3);
+    });
+
     testWidgets('setSurfaceSize works', (WidgetTester tester) async {
       await tester.pumpWidget(const MaterialApp(home: Center(child: Text('Test'))));
 


### PR DESCRIPTION
This PR includes an updated test case for `integration_test` and a new test case for `flutter_test` to ensure that hit tests transform properly when using `setSurfaceSize`, for both the `IntegrationTestWidgetsFlutterBinding` and `LiveTestWidgetsFlutterBinding` bindings.

Aims to resolve https://github.com/flutter/flutter/issues/82557

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
