### PR TITLE
Fixed a lint complaint in packages/flutter/test/{cupertino,material}/scrollbar_test.dart

### DIFF
--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -918,7 +918,7 @@ void main() {
           rect: const Rect.fromLTRB(0.0, 0.0, 9.0, 594.0),
         )
         ..line(
-          p1: const Offset(0.0, 0.0),
+          p1: const Offset.zero,
           p2: const Offset(0.0, 594.0),
           strokeWidth: 1.0,
         )

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1529,7 +1529,7 @@ void main() {
           color: Colors.transparent,
         )
         ..line(
-          p1: const Offset(0.0, 0.0),
+          p1: const Offset.zero,
           p2: const Offset(0.0, 600.0),
           strokeWidth: 1.0,
           color: Colors.transparent,


### PR DESCRIPTION
Fix analyzer warnings:
```
   info • The constant 'Offset.zero' should be referenced instead of duplicating its value • packages/flutter/test/cupertino/scrollbar_test.dart:921:15 • use_named_constants
   info • The constant 'Offset.zero' should be referenced instead of duplicating its value • packages/flutter/test/material/scrollbar_test.dart:1532:15 • use_named_constants
```

Noticed the warnings in https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20analyze/3085/overview
