### PR TITLE
Fix 'You example app code is in' typo

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -483,7 +483,7 @@ void _printPluginDirectoryLocationMessage(String pluginPath, String projectName,
 
 Your plugin code is in $relativePluginMain.
 
-You example app code is in $relativeExampleMain.
+Your example app code is in $relativeExampleMain.
 
 ''');
   if (platformsString != null && platformsString.isNotEmpty) {


### PR DESCRIPTION
`You example app code is in ./example/lib/main.dart.` -> `Your example app code is in ./example/lib/main.dart.`
Fixes https://github.com/flutter/flutter/issues/82453