### PR TITLE
Gardening: mark flaky tests flaky.

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -82,7 +82,7 @@
       "name": "Linux complex_layout_scroll_perf__devtools_memory",
       "repo": "flutter",
       "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Linux complex_layout_semantics_perf",
@@ -322,7 +322,7 @@
       "name": "Linux large_image_changer_perf_android",
       "repo": "flutter",
       "task_name": "linux_large_image_changer_perf_android",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Linux animated_image_gc_perf",
@@ -364,7 +364,7 @@
       "name": "Linux new_gallery__crane_perf",
       "repo": "flutter",
       "task_name": "linux_new_gallery__crane_perf",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Linux picture_cache_perf__e2e_summary",
@@ -376,7 +376,7 @@
       "name": "Linux platform_channels_benchmarks",
       "repo": "flutter",
       "task_name": "linux_platform_channels_benchmarks",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -79,12 +79,6 @@
       "flaky": false
     },
     {
-      "name": "Linux complex_layout_scroll_perf__devtools_memory",
-      "repo": "flutter",
-      "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
-      "flaky": true
-    },
-    {
       "name": "Linux complex_layout_semantics_perf",
       "repo": "flutter",
       "task_name": "linux_complex_layout_semantics_perf",
@@ -319,12 +313,6 @@
       "flaky": false
     },
     {
-      "name": "Linux large_image_changer_perf_android",
-      "repo": "flutter",
-      "task_name": "linux_large_image_changer_perf_android",
-      "flaky": true
-    },
-    {
       "name": "Linux animated_image_gc_perf",
       "repo": "flutter",
       "task_name": "animated_image_gc_perf",
@@ -361,22 +349,10 @@
       "flaky": false
     },
     {
-      "name": "Linux new_gallery__crane_perf",
-      "repo": "flutter",
-      "task_name": "linux_new_gallery__crane_perf",
-      "flaky": true
-    },
-    {
       "name": "Linux picture_cache_perf__e2e_summary",
       "repo": "flutter",
       "task_name": "linux_picture_cache_perf__e2e_summary",
       "flaky": false
-    },
-    {
-      "name": "Linux platform_channels_benchmarks",
-      "repo": "flutter",
-      "task_name": "linux_platform_channels_benchmarks",
-      "flaky": true
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -79,6 +79,12 @@
       "flaky": false
     },
     {
+      "name": "Linux complex_layout_scroll_perf__devtools_memory",
+      "repo": "flutter",
+      "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
+      "flaky": true
+    },
+    {
       "name": "Linux complex_layout_semantics_perf",
       "repo": "flutter",
       "task_name": "linux_complex_layout_semantics_perf",
@@ -313,6 +319,12 @@
       "flaky": false
     },
     {
+      "name": "Linux large_image_changer_perf_android",
+      "repo": "flutter",
+      "task_name": "linux_large_image_changer_perf_android",
+      "flaky": true
+    },
+    {
       "name": "Linux animated_image_gc_perf",
       "repo": "flutter",
       "task_name": "animated_image_gc_perf",
@@ -349,10 +361,22 @@
       "flaky": false
     },
     {
+      "name": "Linux new_gallery__crane_perf",
+      "repo": "flutter",
+      "task_name": "linux_new_gallery__crane_perf",
+      "flaky": true
+    },
+    {
       "name": "Linux picture_cache_perf__e2e_summary",
       "repo": "flutter",
       "task_name": "linux_picture_cache_perf__e2e_summary",
       "flaky": false
+    },
+    {
+      "name": "Linux platform_channels_benchmarks",
+      "repo": "flutter",
+      "task_name": "linux_platform_channels_benchmarks",
+      "flaky": true
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -82,7 +82,8 @@
       "name": "Linux complex_layout_scroll_perf__devtools_memory",
       "repo": "flutter",
       "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
-      "flaky": true
+      "flaky": true,
+      "issue_url": "https://github.com/flutter/flutter/issues/82741"
     },
     {
       "name": "Linux complex_layout_semantics_perf",
@@ -322,7 +323,8 @@
       "name": "Linux large_image_changer_perf_android",
       "repo": "flutter",
       "task_name": "linux_large_image_changer_perf_android",
-      "flaky": true
+      "flaky": true,
+      "issue_url": "https://github.com/flutter/flutter/issues/82747"
     },
     {
       "name": "Linux animated_image_gc_perf",
@@ -364,7 +366,8 @@
       "name": "Linux new_gallery__crane_perf",
       "repo": "flutter",
       "task_name": "linux_new_gallery__crane_perf",
-      "flaky": true
+      "flaky": true,
+      "issue_url": "https://github.com/flutter/flutter/issues/82745"
     },
     {
       "name": "Linux picture_cache_perf__e2e_summary",
@@ -376,7 +379,8 @@
       "name": "Linux platform_channels_benchmarks",
       "repo": "flutter",
       "task_name": "linux_platform_channels_benchmarks",
-      "flaky": true
+      "flaky": true,
+      "issue_url": "https://github.com/flutter/flutter/issues/82743"
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",

--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -82,8 +82,7 @@
       "name": "Linux complex_layout_scroll_perf__devtools_memory",
       "repo": "flutter",
       "task_name": "linux_complex_layout_scroll_perf__devtools_memory",
-      "flaky": true,
-      "issue_url": "https://github.com/flutter/flutter/issues/82741"
+      "flaky": true
     },
     {
       "name": "Linux complex_layout_semantics_perf",
@@ -323,8 +322,7 @@
       "name": "Linux large_image_changer_perf_android",
       "repo": "flutter",
       "task_name": "linux_large_image_changer_perf_android",
-      "flaky": true,
-      "issue_url": "https://github.com/flutter/flutter/issues/82747"
+      "flaky": true
     },
     {
       "name": "Linux animated_image_gc_perf",
@@ -366,8 +364,7 @@
       "name": "Linux new_gallery__crane_perf",
       "repo": "flutter",
       "task_name": "linux_new_gallery__crane_perf",
-      "flaky": true,
-      "issue_url": "https://github.com/flutter/flutter/issues/82745"
+      "flaky": true
     },
     {
       "name": "Linux picture_cache_perf__e2e_summary",
@@ -379,8 +376,7 @@
       "name": "Linux platform_channels_benchmarks",
       "repo": "flutter",
       "task_name": "linux_platform_channels_benchmarks",
-      "flaky": true,
-      "issue_url": "https://github.com/flutter/flutter/issues/82743"
+      "flaky": true
     },
     {
       "name": "Linux platform_views_scroll_perf__timeline_summary",


### PR DESCRIPTION
This marks the following tests as flaky, per the gardener rotation:

- `linux_complex_layout_scroll_perf__devtools_memory`: https://github.com/flutter/flutter/issues/82741
- `linux_large_image_changer_perf_android`: https://github.com/flutter/flutter/issues/82747
- `linux_new_gallery__crane_perf`: https://github.com/flutter/flutter/issues/82745
- `linux_platform_channels_benchmarks`: https://github.com/flutter/flutter/issues/82743