### PR TITLE
Mark mac_ios_platform_channels_benchmarks_ios not flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1156,7 +1156,7 @@
       "name": "Mac_ios platform_channels_benchmarks_ios",
       "repo": "flutter",
       "task_name": "mac_ios_platform_channels_benchmarks_ios",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Mac_ios platform_interaction_test_ios",


### PR DESCRIPTION
`mac_ios_platform_channels_benchmarks_ios` has passed in prod since #82359.