### PR TITLE
Enable win_gradle_plugin_light_apk_test and mark unflaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1252,7 +1252,7 @@
       "name": "Windows gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "win_gradle_plugin_light_apk_test",
-      "flaky": true
+      "flaky": false
     },
     {
       "name": "Windows gradle_plugin_bundle_test",

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -658,7 +658,7 @@
       "name": "Windows gradle_plugin_light_apk_test",
       "repo": "flutter",
       "task_name": "win_gradle_plugin_light_apk_test",
-      "enabled": false,
+      "enabled": true,
       "run_if": ["dev/**", "bin/**"]
     },
     {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/80171 seems to have worked, `win_gradle_plugin_light_apk_test` is taking ~12 minutes and is no longer flaky on prod.
Fixes https://github.com/flutter/flutter/issues/80056

https://ci.chromium.org/p/flutter/builders/try/Windows%20gradle_plugin_light_apk_test/3769?