### PR TITLE
[devicelab] await flutter create call in platform channels benchmark

### DIFF
--- a/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
@@ -31,7 +31,7 @@ TaskFunction runTask(adb.DeviceOperatingSystem operatingSystem) {
         '.'
       ];
       print('\nExecuting: $flutterExe $createArgs $appDir');
-      utils.eval(flutterExe, createArgs);
+      await utils.eval(flutterExe, createArgs);
 
       final List<String> options = <String>[
         '-v',


### PR DESCRIPTION
The `flutter create` call was not awaited. This could lead to the application not being full created before the benchmark starts.

https://github.com/flutter/flutter/issues/82743