### PR TITLE
Do not crash if table children are replaced before they are layed out

### DIFF
--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -392,8 +392,7 @@ class _TableElement extends RenderObjectElement {
 
   @override
   void removeRenderObjectChild(RenderBox child, _TableSlot slot) {
-    final TableCellParentData childParentData = child.parentData! as TableCellParentData;
-    renderObject.setChild(childParentData.x!, childParentData.y!, null);
+    renderObject.setChild(slot.column, slot.row, null);
   }
 
   final Set<Element> _forgottenChildren = HashSet<Element>();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/60488 and b/169206304.

A RenderObject child of a table may be removed before the child has ever been layed out. In that case, the child's parentData has not been populated and `removeRenderObjectChild` crashes when accessing it. This change removes `removeRenderObjectChild`'s reliance on the parentData.