### PR TITLE
Default --no-tree-shake-icons to false for 'flutter build bundle'

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -90,7 +90,7 @@ class BuildBundleCommand extends BuildSubCommand {
   @override
   Future<void> validateCommand() async {
     if (argResults['tree-shake-icons'] as bool) {
-      throwToolExit('The "--tree-shake-icons" flag is deprecated and will be removed in a future version of Flutter.');
+      throwToolExit('The "--tree-shake-icons" flag is deprecated for "build bundle" and will be removed in a future version of Flutter.');
     }
     return super.validateCommand();
   }

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -16,7 +16,6 @@ import 'build.dart';
 
 class BuildBundleCommand extends BuildSubCommand {
   BuildBundleCommand({bool verboseHelp = false, this.bundleBuilder}) {
-    addTreeShakeIconsFlag();
     usesTargetOption();
     usesFilesystemOptions(hide: !verboseHelp);
     usesBuildNumberOption();
@@ -48,6 +47,13 @@ class BuildBundleCommand extends BuildSubCommand {
         defaultsTo: getAssetBuildDirectory(),
         help: 'The output directory for the kernel_blob.bin file, the native snapshet, the assets, etc. '
               'Can be used to redirect the output when driving the Flutter toolchain from another build system.',
+      )
+      ..addFlag(
+        'tree-shake-icons',
+        negatable: true,
+        defaultsTo: false,
+        hide: true,
+        help: '(deprecated) Icon font tree shaking is not supported by this command.',
       );
     usesPubOption();
     usesTrackWidgetCreation(verboseHelp: verboseHelp);
@@ -79,6 +85,14 @@ class BuildBundleCommand extends BuildSubCommand {
       CustomDimensions.commandBuildBundleTargetPlatform: stringArg('target-platform'),
       CustomDimensions.commandBuildBundleIsModule: '${flutterProject.isModule}',
     };
+  }
+
+  @override
+  Future<void> validateCommand() async {
+    if (argResults['tree-shake-icons'] as bool) {
+      throwToolExit('The "--tree-shake-icons" flag is deprecated and will be removed in a future version of Flutter.');
+    }
+    return super.validateCommand();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -52,7 +52,7 @@ class BuildBundleCommand extends BuildSubCommand {
         'tree-shake-icons',
         negatable: true,
         defaultsTo: false,
-        hide: true,
+        hide: !verboseHelp,
         help: '(deprecated) Icon font tree shaking is not supported by this command.',
       );
     usesPubOption();

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -136,6 +136,24 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });
 
+  testUsingContext('bundle --tree-shake-icons fails', () async {
+    globals.fs.file('lib/main.dart').createSync(recursive: true);
+    globals.fs.file('pubspec.yaml').createSync();
+    globals.fs.file('.packages').createSync();
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand()
+      ..bundleBuilder = FakeBundleBuilder());
+
+    expect(() => runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--release',
+      '--tree-shake-icons',
+    ]), throwsToolExit(message: 'tree-shake-icons'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
   testUsingContext('bundle can build for Windows if feature is enabled', () async {
     globals.fs.file('lib/main.dart').createSync(recursive: true);
     globals.fs.file('pubspec.yaml').createSync();
@@ -365,6 +383,84 @@ void main() {
         kTrackWidgetCreation: 'true',
         kFileSystemScheme: 'org-dartlang-root',
         kExtraGenSnapshotOptions: '--testflag,--testflag2',
+        kIconTreeShakerFlag: 'false',
+        kDeferredComponents: 'false',
+        kDartObfuscation: 'false',
+      });
+    }),
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('passes profile options through', () async {
+    globals.fs.file('lib/main.dart').createSync(recursive: true);
+    globals.fs.file('pubspec.yaml').createSync();
+    globals.fs.file('.packages').createSync();
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand());
+
+    await runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--profile',
+      '--dart-define=foo=bar',
+      '--target-platform=android-arm',
+      '--track-widget-creation',
+      '--filesystem-scheme=org-dartlang-root',
+      '--filesystem-root=test1,test2',
+      '--extra-gen-snapshot-options=--testflag,--testflag2',
+      '--extra-front-end-options=--testflagFront,--testflagFront2',
+    ]);
+  }, overrides: <Type, Generator>{
+    BuildSystem: () => TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
+      expect(environment.defines, <String, String>{
+        kBuildMode: 'profile',
+        kTargetPlatform: 'android-arm',
+        kTargetFile: globals.fs.path.join('lib', 'main.dart'),
+        kDartDefines: 'Zm9vPWJhcg==',
+        kTrackWidgetCreation: 'true',
+        kFileSystemScheme: 'org-dartlang-root',
+        kFileSystemRoots: 'test1,test2',
+        kExtraGenSnapshotOptions: '--testflag,--testflag2',
+        kExtraFrontEndOptions: '--testflagFront,--testflagFront2',
+        kIconTreeShakerFlag: 'false',
+        kDeferredComponents: 'false',
+        kDartObfuscation: 'false',
+      });
+    }),
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('passes release options through', () async {
+    globals.fs.file('lib/main.dart').createSync(recursive: true);
+    globals.fs.file('pubspec.yaml').createSync();
+    globals.fs.file('.packages').createSync();
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand());
+
+    await runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--release',
+      '--dart-define=foo=bar',
+      '--target-platform=android-arm',
+      '--track-widget-creation',
+      '--filesystem-scheme=org-dartlang-root',
+      '--filesystem-root=test1,test2',
+      '--extra-gen-snapshot-options=--testflag,--testflag2',
+      '--extra-front-end-options=--testflagFront,--testflagFront2',
+    ]);
+  }, overrides: <Type, Generator>{
+    BuildSystem: () => TestBuildSystem.all(BuildResult(success: true), (Target target, Environment environment) {
+      expect(environment.defines, <String, String>{
+        kBuildMode: 'release',
+        kTargetPlatform: 'android-arm',
+        kTargetFile: globals.fs.path.join('lib', 'main.dart'),
+        kDartDefines: 'Zm9vPWJhcg==',
+        kTrackWidgetCreation: 'true',
+        kFileSystemScheme: 'org-dartlang-root',
+        kFileSystemRoots: 'test1,test2',
+        kExtraGenSnapshotOptions: '--testflag,--testflag2',
+        kExtraFrontEndOptions: '--testflagFront,--testflagFront2',
         kIconTreeShakerFlag: 'false',
         kDeferredComponents: 'false',
         kDartObfuscation: 'false',


### PR DESCRIPTION
`flutter build bundle` should never have supported `--no-tree-shake-icons` since it doesn't generate a dill, just the assets, and so there's nothing for the icon tree shaker to run on.

"Disable" `flutter build bundle --tree-shake-icons` by hiding the flag and defaulting to false, and tool exiting if `--tree-shake-icons` is explicitly passed.  Do not remove the flag in order to support any `--no-tree-shake-icons` workarounds being used in the wild.

Fixes https://github.com/flutter/flutter/issues/81954