### PR TITLE
fix: Tasks scheduled through 'SchedulerBinding.instance.scheduleTask' were not executed

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -434,10 +434,18 @@ mixin SchedulerBinding on BindingBase {
   }
 
   // Scheduled by _ensureEventLoopCallback.
-  void _runTasks() {
+  Future<void> _runTasks() async {
     _hasRequestedAnEventLoopCallback = false;
     if (handleEventLoopCallback())
       _ensureEventLoopCallback(); // runs next task when there's time
+    else {
+      if (_taskQueue.isNotEmpty) {
+        // Avoid continuously adding tasks to the underlying queue
+        await endOfFrame;
+        // When the task queue is not empty, the judgment is made again
+        _ensureEventLoopCallback();
+      }
+    }
   }
 
   /// Execute the highest-priority task, if it is of a high enough priority.

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -5,14 +5,16 @@
 import 'dart:async';
 import 'dart:ui' show window;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'scheduler_tester.dart';
 
-class TestSchedulerBinding extends BindingBase with SchedulerBinding, ServicesBinding {
+class TestSchedulerBinding extends BindingBase with SchedulerBinding, ServicesBinding, SemanticsBinding {
   final Map<String, List<Map<String, dynamic>>> eventsDispatched = <String, List<Map<String, dynamic>>>{};
 
   @override
@@ -236,6 +238,19 @@ void main() {
     // callback that reschedules the engine frame.
     warmUpDrawFrame();
     expect(scheduler.hasScheduledFrame, isTrue);
+  });
+
+  test('The task was successfully executed after the animation', () async {
+    bool taskExecuted = false;
+    final AnimationController controller = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: const TestVSync(),
+    );
+    controller.forward();
+
+    // If the task is not scheduled round-robin, this code will block the test
+    await scheduler.scheduleTask(() => taskExecuted = true, Priority.idle);
+    expect(taskExecuted, isTrue);
   });
 }
 


### PR DESCRIPTION
## Related Issues

#82016 

## Description

This PR is for solving that tasks scheduled through 'SchedulerBinding.instance.scheduleTask' were not executed.
Before modification, if a task has a priority of idle, it will not be scheduled when the on-screen animation ends.
The problem is that once the 'handleEventLoopCallback()' returns false, the _TaskQueue will not be scheduled again until the next scheduleTask.
Therefore, when 'handleEventLoopCallback()' returns false, it is determined whether the queue is empty or not to continue scheduling.
To avoid frequent scheduling, wait until the next frame when 'handleEventLoopCallback() 'returns false (because I assume that by default the return value of 'handleEventLoopCallback()' does not change within the same frame).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->

[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat