### PR TITLE
Drag gesture recognizer accepts all pointers when any pointer is accepted

### DIFF
--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -365,6 +365,10 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
           localPosition: correctedPosition.local,
         );
       }
+      // This acceptGesture might have been called only for one pointer, instead
+      // of all pointers. Resolve all pointers to `accepted`. This won't cause
+      // infinite recursion because an accepted pointer won't be accepted again.
+      resolve(GestureDisposition.accepted);
     }
   }
 

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -1472,7 +1472,7 @@ void main() {
     tap.dispose();
 
     // Wait for microtasks to finish, during which drag claims victory.
-    tester.async.elapse(const Duration(milliseconds: 1));
+    tester.async.flushMicrotasks();
     expect(didStartDrag, true);
 
     // The pointer1 is released, leaving pointer2 drag's only pointer.

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -1440,4 +1440,56 @@ void main() {
       logs.clear();
     },
   );
+
+  testGesture('test1', (GestureTester tester) {
+    debugPrintGestureArenaDiagnostics = true;
+    final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer()
+      ..dragStartBehavior = DragStartBehavior.down;
+    final TapGestureRecognizer tap = TapGestureRecognizer()..onTap = () {};
+    final TapGestureRecognizer tap2 = TapGestureRecognizer()..onTap = () {};
+    addTearDown(drag.dispose);
+    addTearDown(tap.dispose);
+    addTearDown(tap2.dispose);
+
+    bool didStartDrag = false;
+    drag.onStart = (_) {
+      didStartDrag = true;
+    };
+
+    double? updatedDelta;
+    drag.onUpdate = (DragUpdateDetails details) {
+      updatedDelta = details.primaryDelta;
+    };
+
+    bool didEndDrag = false;
+    drag.onEnd = (DragEndDetails details) {
+      didEndDrag = true;
+    };
+
+    final TestPointer pointer1 = TestPointer(5);
+    final PointerDownEvent down1 = pointer1.down(const Offset(10.0, 10.0));
+    drag.addPointer(down1);
+    tap.addPointer(down1);
+    tester.closeArena(pointer1.pointer);
+    tester.route(down1);
+
+    final TestPointer pointer2 = TestPointer(6);
+    final PointerDownEvent down2 = pointer2.down(const Offset(10.0, 10.0));
+    drag.addPointer(down2);
+    tap2.addPointer(down2);
+    tester.closeArena(pointer2.pointer);
+    tester.route(down2);
+
+    print('Dispose Tap');
+    tap.dispose();
+
+    tester.async.elapse(const Duration(milliseconds: 1));
+    expect(didStartDrag, true);
+
+    tester.route(pointer1.up());
+
+    print('Dispose Drag');
+    drag.dispose();
+    debugPrintGestureArenaDiagnostics = false;
+  });
 }


### PR DESCRIPTION
Drag gesture recognizer now accepts all pointers when any pointer is accepted. This is useful when the accepted pointer is accepted by default, i.e. when all other arena memebers has quit (been disposed).

Fixes https://github.com/flutter/flutter/issues/82784.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
