### PR TITLE
Replace container in the `_ZoomEnterTransition`

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -317,7 +317,7 @@ class _ZoomEnterTransition extends StatelessWidget {
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        return Container(
+        return ColoredBox(
           color: Colors.black.withOpacity(opacity),
           child: child,
         );

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -205,4 +205,49 @@ void main() {
     await tester.pumpAndSettle();
     expect(builtCount, 1);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+  testWidgets('_ZoomPageTransition contains ColoredBox rather than Container', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => Material(
+        child: TextButton(
+          child: const Text('push'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return TextButton(
+            child: const Text('pop'),
+            onPressed: () { Navigator.pop(context); },
+          );
+        },
+      ),
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          pageTransitionsTheme: const PageTransitionsTheme(
+            builders: <TargetPlatform, PageTransitionsBuilder>{
+              TargetPlatform.android: ZoomPageTransitionsBuilder(),
+            },
+          ),
+        ),
+        routes: routes,
+      ),
+    );
+
+    expect(find.byType(ColoredBox), findsNWidgets(2));
+    expect(find.byType(Container), findsNothing);
+
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ColoredBox), findsNWidgets(2));
+    expect(find.byType(Container), findsNothing);
+
+    await tester.tap(find.text('pop'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ColoredBox), findsNWidgets(2));
+    expect(find.byType(Container), findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 }


### PR DESCRIPTION
This is a pre-migration of #82670 . If we make the zoom transition as default, it'll break many tests with `Container`s count test. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.