### PR TITLE
Enable vm:notify-debugger-on-exception for LayoutBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -115,11 +115,8 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   }
 
   void _layout(ConstraintType constraints) {
-    // TODO(goderbauer): When https://github.com/dart-lang/sdk/issues/45710 is
-    //   fixed: refactor the anonymous closure below into a named one, apply the
-    //   @pragma('vm:notify-debugger-on-exception') to it and enable the
-    //   corresponding test in break_on_framework_exceptions_test.dart.
-    owner!.buildScope(this, () {
+    @pragma('vm:notify-debugger-on-exception')
+    void layoutCallback() {
       Widget built;
       try {
         built = widget.builder(this, constraints);
@@ -152,7 +149,9 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
         );
         _child = updateChild(null, built, slot);
       }
-    });
+    }
+
+    owner!.buildScope(this, layoutCallback);
   }
 
   @override

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -388,7 +388,7 @@ void main() {
 
     final int breakLine = (await flutter.getSourceLocation()).line;
     expect(breakLine, project.lineContaining(project.test, "throw 'LayoutBuilder.builder';"));
-  }, skip: 'TODO(goderbauer): Once https://github.com/dart-lang/sdk/issues/45710 is fixed, fix TODO in _LayoutBuilderElement._layout and enable this test');
+  });
 
   testWithoutContext('breaks when _CallbackHookProvider callback throws', () async {
     final TestProject project = TestProject(


### PR DESCRIPTION
This is now possible since https://github.com/dart-lang/sdk/issues/45710 was fixed upstream.

This was the last known place missing the `@pragma('vm:notify-debugger-on-exception')`. The debugger should now break on all exceptions instead of having the framework print them to the console.

/cc @devoncarew 