### PR TITLE
Devicelab: removed unawaited where deemed necessary

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:flutter_devicelab/common.dart';
 import 'package:flutter_devicelab/framework/ab.dart';
 import 'package:flutter_devicelab/framework/manifest.dart';
 import 'package:flutter_devicelab/framework/runner.dart';
@@ -186,7 +185,7 @@ Future<void> _runABTest() async {
   abTest.finalize();
 
   final File jsonFile = _uniqueFile(args['ab-result-file'] as String ?? 'ABresults#.json');
-  unawaited(jsonFile.writeAsString(const JsonEncoder.withIndent('  ').convert(abTest.jsonMap)));
+  jsonFile.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(abTest.jsonMap));
 
   if (!silent) {
     section('Raw results');

--- a/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
@@ -6,7 +6,6 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -109,5 +108,5 @@ Future<TaskResult> _doTest() async {
 }
 
 Future<void> main() async {
-  unawaited(task(_doTest));
+  await task(_doTest);
 }

--- a/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -18,7 +17,7 @@ Future<void> main() async {
     try {
       await runProjectTest((FlutterProject flutterProject) async {
         section('APK contains plugin classes');
-        unawaited(flutterProject.addPlugin('google_maps_flutter', value: '^1.0.10'));
+        flutterProject.addPlugin('google_maps_flutter', value: '^1.0.10');
 
         await inDirectory(flutterProject.rootPath, () async {
           await flutter('build', options: <String>[

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -220,8 +219,8 @@ Future<void> main() async {
         });
 
         section('Configure');
-        unawaited(project.addPlugin('plugin_under_test',
-            value: '$platformLineSep    path: ${pluginDir.path}'));
+        project.addPlugin('plugin_under_test',
+            value: '$platformLineSep    path: ${pluginDir.path}');
         await project.addCustomBuildType('local', initWith: 'debug');
         await project.getPackages();
 
@@ -240,7 +239,7 @@ Future<void> main() async {
         await project.addCustomBuildType('local', initWith: 'debug');
         await project.addGlobalBuildType('local', initWith: 'debug');
         section('Add plugin');
-        await project.addPlugin('path_provider');
+        project.addPlugin('path_provider');
         await project.getPackages();
 
         await project.runGradleTask('assembleLocal');

--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -6,7 +6,6 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -56,7 +55,8 @@ Future<void> main() async {
           'Flutter',
         );
         // Exits 0 only if codesigned.
-        unawaited(eval('xcrun', <String>['codesign', '--verify', flutterFramework]));
+        final Future<String> flutterCodesign =
+            eval('xcrun', <String>['codesign', '--verify', flutterFramework]);
 
         final String appFramework = path.join(
           appBundle.path,
@@ -64,7 +64,10 @@ Future<void> main() async {
           'App.framework',
           'App',
         );
-        unawaited(eval('xcrun', <String>['codesign', '--verify', appFramework]));
+        final Future<String> appCodesign =
+            eval('xcrun', <String>['codesign', '--verify', appFramework]);
+        await flutterCodesign;
+        await appCodesign;
       });
 
       return TaskResult.success(null);

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -299,14 +299,14 @@ subprojects {
   /// Adds a plugin to the pubspec.
   /// In pubspec, each dependency is expressed as key, value pair joined by a colon `:`.
   /// such as `plugin_a`:`^0.0.1` or `plugin_a`:`\npath: /some/path`.
-  Future<void> addPlugin(String plugin, { String value = '' }) async {
+  void addPlugin(String plugin, { String value = '' }) {
     final File pubspec = File(path.join(rootPath, 'pubspec.yaml'));
-    String content = await pubspec.readAsString();
+    String content = pubspec.readAsStringSync();
     content = content.replaceFirst(
       '${platformLineSep}dependencies:$platformLineSep',
       '${platformLineSep}dependencies:$platformLineSep  $plugin: $value$platformLineSep',
     );
-    await pubspec.writeAsString(content, flush: true);
+    pubspec.writeAsStringSync(content, flush: true);
   }
 
   Future<void> getPackages() async {

--- a/dev/devicelab/lib/tasks/build_test_task.dart
+++ b/dev/devicelab/lib/tasks/build_test_task.dart
@@ -7,7 +7,6 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:flutter_devicelab/common.dart';
 
 import '../framework/devices.dart';
 import '../framework/task_result.dart';
@@ -109,7 +108,7 @@ abstract class BuildTestTask {
     }
 
     if (!testOnly) {
-      unawaited(build());
+      await build();
     }
 
     if (buildOnly) {


### PR DESCRIPTION
Changed `unawaited` usage in certain cases when introduced in https://github.com/flutter/flutter/pull/82833

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
