### PR TITLE
Add `ActionRegistry` for invoking actions that aren't in focus chain

### DIFF
--- a/dev/manual_tests/lib/registered_actions.dart
+++ b/dev/manual_tests/lib/registered_actions.dart
@@ -75,34 +75,41 @@ void main() {
 ///
 /// Shortcuts can be defined here, and they will be in effect for the whole app,
 /// although different widgets may fulfill them differently.
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
   static const String title = 'Shortcuts and Actions Demo';
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final ActionRegistry registry = ActionRegistry();
+
+  @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: title,
+      title: MyApp.title,
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
       home: Material(
         color: Colors.grey.shade100,
-        child: TargetedShortcuts(
+        child: Shortcuts(
           manager: LoggingShortcutManager(),
           shortcuts: const <ShortcutActivator, Intent>{
             SingleActivator(LogicalKeyboardKey.keyA, control: true): SelectAllIntent(),
             SingleActivator(LogicalKeyboardKey.keyS, control: true): SelectNoneIntent(),
+            SingleActivator(LogicalKeyboardKey.digit0): ToggleSelectIntent(0),
+            SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(1),
+            SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(2),
+            SingleActivator(LogicalKeyboardKey.digit3): ToggleSelectIntent(3),
+            SingleActivator(LogicalKeyboardKey.digit4): ToggleSelectIntent(4),
           },
-          child: Shortcuts(
-            shortcuts: const <ShortcutActivator, Intent>{
-              SingleActivator(LogicalKeyboardKey.digit0): ToggleSelectIntent(0),
-              SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(1),
-              SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(2),
-              SingleActivator(LogicalKeyboardKey.digit3): ToggleSelectIntent(3),
-              SingleActivator(LogicalKeyboardKey.digit4): ToggleSelectIntent(4),
-            },
+          child: Actions(
+            actions: const <Type, Action<Intent>>{},
+            registry: registry,
             child: Row(
               children: const <Widget>[
                 Expanded(flex: 1, child: MyMenu()),
@@ -122,7 +129,7 @@ class MyGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FocusTraversalGroup(
-      child: TargetedActions(
+      child: RegisteredActions(
         dispatcher: LoggingActionDispatcher(),
         actions: <Type, Action<Intent>>{
           SelectAllIntent: SelectAllAction(model),

--- a/dev/manual_tests/lib/registered_actions.dart
+++ b/dev/manual_tests/lib/registered_actions.dart
@@ -101,6 +101,7 @@ class _MyAppState extends State<MyApp> {
           shortcuts: const <ShortcutActivator, Intent>{
             SingleActivator(LogicalKeyboardKey.keyA, control: true): SelectAllIntent(),
             SingleActivator(LogicalKeyboardKey.keyS, control: true): SelectNoneIntent(),
+            SingleActivator(LogicalKeyboardKey.keyD, control: true): ToggleIndividualSelectIntent(),
             SingleActivator(LogicalKeyboardKey.digit0): ToggleSelectIntent(0),
             SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(1),
             SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(2),
@@ -216,31 +217,36 @@ class ItemBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: model,
-      builder: (BuildContext context, Widget? child) {
-        return Container(
-          margin: const EdgeInsets.all(8.0),
-          decoration: BoxDecoration(
-            borderRadius: const BorderRadius.all(Radius.circular(10)),
-            color: model.selectedItems.contains(item)
-                ? const Color(0x80ff8080)
-                : const Color(0x80ffffff),
-          ),
-          child: InkWell(
-            borderRadius: const BorderRadius.all(Radius.circular(10)),
-            highlightColor: Colors.indigo.shade100,
-            focusColor: Colors.indigo.shade400,
-            hoverColor: Colors.indigo.shade200,
-            onTap: () {
-              Actions.maybeInvoke(context, ToggleSelectItemIntent(item));
-            },
-            child: Center(
-              child: Text(item.name),
-            ),
-          ),
-        );
+    return RegisteredActions(
+      actions: <Type, Action<Intent>>{
+        ToggleIndividualSelectIntent: ToggleIndividualSelectAction(model, item),
       },
+      child: AnimatedBuilder(
+        animation: model,
+        builder: (BuildContext context, Widget? child) {
+          return Container(
+            margin: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+              color: model.selectedItems.contains(item)
+                  ? const Color(0x80ff8080)
+                  : const Color(0x80ffffff),
+            ),
+            child: InkWell(
+              borderRadius: const BorderRadius.all(Radius.circular(10)),
+              highlightColor: Colors.indigo.shade100,
+              focusColor: Colors.indigo.shade400,
+              hoverColor: Colors.indigo.shade200,
+              onTap: () {
+                Actions.maybeInvoke(context, ToggleSelectItemIntent(item));
+              },
+              child: Center(
+                child: Text(item.name),
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 }
@@ -289,6 +295,22 @@ class SelectIndexAction extends Action<SelectIndexIntent> {
   @override
   Object? invoke(covariant SelectIndexIntent intent) {
     model.select(model.items[intent.index]);
+  }
+}
+
+class ToggleIndividualSelectIntent extends Intent {
+  const ToggleIndividualSelectIntent();
+}
+
+class ToggleIndividualSelectAction extends Action<ToggleIndividualSelectIntent> {
+  ToggleIndividualSelectAction(this.model, this.item);
+
+  final Model model;
+  final Item item;
+
+  @override
+  Object? invoke(covariant ToggleIndividualSelectIntent intent) {
+    model.toggleSelect(item);
   }
 }
 

--- a/dev/manual_tests/lib/registered_actions.dart
+++ b/dev/manual_tests/lib/registered_actions.dart
@@ -110,11 +110,13 @@ class _MyAppState extends State<MyApp> {
           child: Actions(
             actions: const <Type, Action<Intent>>{},
             registry: registry,
-            child: Row(
-              children: const <Widget>[
-                Expanded(flex: 1, child: MyMenu()),
-                Expanded(flex: 5, child: MyGrid()),
-              ],
+            child: FocusScope(
+              child: Row(
+                children: const <Widget>[
+                  Expanded(flex: 1, child: MyMenu()),
+                  Expanded(flex: 5, child: MyGrid()),
+                ],
+              ),
             ),
           ),
         ),
@@ -157,8 +159,21 @@ class MyGrid extends StatelessWidget {
   }
 }
 
-class MyMenu extends StatelessWidget {
+class MyMenu extends StatefulWidget {
   const MyMenu({Key? key}) : super(key: key);
+
+  @override
+  State<MyMenu> createState() => _MyMenuState();
+}
+
+class _MyMenuState extends State<MyMenu> {
+  final FocusNode focusNode = FocusNode(debugLabel: 'Menu Focus');
+
+  @override
+  void initState() {
+    super.initState();
+    focusNode.requestFocus();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -171,16 +186,20 @@ class MyMenu extends StatelessWidget {
             Tooltip(
               message: 'Control-A',
               child: TextButton(
-                autofocus: true,
+                focusNode: focusNode,
                 child: const Text('SELECT ALL'),
-                onPressed: model.selectAll,
+                onPressed: () {
+                  Actions.invoke<SelectAllIntent>(context, const SelectAllIntent());
+                },
               ),
             ),
             Tooltip(
               message: 'Control-S',
               child: TextButton(
                 child: const Text('SELECT NONE'),
-                onPressed: model.selectNone,
+                onPressed: () {
+                  Actions.invoke<SelectNoneIntent>(context, const SelectNoneIntent());
+                },
               ),
             ),
           ],
@@ -210,7 +229,6 @@ class ItemBox extends StatelessWidget {
           ),
           child: InkWell(
             borderRadius: const BorderRadius.all(Radius.circular(10)),
-            canRequestFocus: true,
             highlightColor: Colors.indigo.shade100,
             focusColor: Colors.indigo.shade400,
             hoverColor: Colors.indigo.shade200,

--- a/dev/manual_tests/lib/registered_actions.dart
+++ b/dev/manual_tests/lib/registered_actions.dart
@@ -65,7 +65,7 @@ Model model = Model();
 void main() {
   model.items.addAll(
     List<Item>.generate(100, (int index) {
-      return Item('Item $index');
+      return Item('Item ${index + 1}');
     }),
   );
   runApp(const MyApp());
@@ -102,11 +102,11 @@ class _MyAppState extends State<MyApp> {
             SingleActivator(LogicalKeyboardKey.keyA, control: true): SelectAllIntent(),
             SingleActivator(LogicalKeyboardKey.keyS, control: true): SelectNoneIntent(),
             SingleActivator(LogicalKeyboardKey.keyD, control: true): ToggleIndividualSelectIntent(),
-            SingleActivator(LogicalKeyboardKey.digit0): ToggleSelectIntent(0),
-            SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(1),
-            SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(2),
-            SingleActivator(LogicalKeyboardKey.digit3): ToggleSelectIntent(3),
-            SingleActivator(LogicalKeyboardKey.digit4): ToggleSelectIntent(4),
+            SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(0),
+            SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(1),
+            SingleActivator(LogicalKeyboardKey.digit3): ToggleSelectIntent(2),
+            SingleActivator(LogicalKeyboardKey.digit4): ToggleSelectIntent(3),
+            SingleActivator(LogicalKeyboardKey.digit5): ToggleSelectIntent(4),
           },
           child: Actions(
             actions: const <Type, Action<Intent>>{},
@@ -130,9 +130,10 @@ class MyGrid extends StatelessWidget {
   const MyGrid({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+Widget build(BuildContext context) {
     return FocusTraversalGroup(
-      child: RegisteredActions(
+      child: Actions(
+        registerActions: true,
         dispatcher: LoggingActionDispatcher(),
         actions: <Type, Action<Intent>>{
           SelectAllIntent: SelectAllAction(model),
@@ -147,7 +148,7 @@ class MyGrid extends StatelessWidget {
             gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
               maxCrossAxisExtent: 200,
             ),
-            itemCount: 300,
+            itemCount: model.items.length,
             itemBuilder: (BuildContext context, int index) {
               return ItemBox(
                 item: model.items[index],
@@ -178,33 +179,31 @@ class _MyMenuState extends State<MyMenu> {
 
   @override
   Widget build(BuildContext context) {
-    return FocusTraversalGroup(
-      child: Container(
-        color: Colors.white,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            Tooltip(
-              message: 'Control-A',
-              child: TextButton(
-                focusNode: focusNode,
-                child: const Text('SELECT ALL'),
-                onPressed: () {
-                  Actions.invoke<SelectAllIntent>(context, const SelectAllIntent());
-                },
-              ),
+    return Container(
+      color: Colors.white,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: <Widget>[
+          Tooltip(
+            message: 'Control-A',
+            child: TextButton(
+              focusNode: focusNode,
+              child: const Text('SELECT ALL'),
+              onPressed: () {
+                Actions.invoke<SelectAllIntent>(context, const SelectAllIntent());
+              },
             ),
-            Tooltip(
-              message: 'Control-S',
-              child: TextButton(
-                child: const Text('SELECT NONE'),
-                onPressed: () {
-                  Actions.invoke<SelectNoneIntent>(context, const SelectNoneIntent());
-                },
-              ),
+          ),
+          Tooltip(
+            message: 'Control-S',
+            child: TextButton(
+              child: const Text('SELECT NONE'),
+              onPressed: () {
+                Actions.invoke<SelectNoneIntent>(context, const SelectNoneIntent());
+              },
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -217,7 +216,8 @@ class ItemBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RegisteredActions(
+    return Actions(
+      registerActions: true,
       actions: <Type, Action<Intent>>{
         ToggleIndividualSelectIntent: ToggleIndividualSelectAction(model, item),
       },
@@ -233,6 +233,7 @@ class ItemBox extends StatelessWidget {
                   : const Color(0x80ffffff),
             ),
             child: InkWell(
+              autofocus: false,
               borderRadius: const BorderRadius.all(Radius.circular(10)),
               highlightColor: Colors.indigo.shade100,
               focusColor: Colors.indigo.shade400,

--- a/dev/manual_tests/lib/targeted_actions.dart
+++ b/dev/manual_tests/lib/targeted_actions.dart
@@ -1,0 +1,344 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.13
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class Item {
+  const Item(this.name);
+
+  final String name;
+
+  @override
+  String toString() {
+    return name;
+  }
+}
+
+class Model extends ChangeNotifier {
+  Model()
+      : items = <Item>[],
+        selectedItems = <Item>{};
+
+  final List<Item> items;
+  final Set<Item> selectedItems;
+
+  void toggleSelect(Item item) {
+    if (selectedItems.contains(item)) {
+      deselect(item);
+    } else {
+      select(item);
+    }
+  }
+
+  void select(Item item) {
+    print('$item selected.');
+    selectedItems.add(item);
+    notifyListeners();
+  }
+
+  void deselect(Item item) {
+    print('$item deselected.');
+    selectedItems.remove(item);
+    notifyListeners();
+  }
+
+  void selectAll() {
+    print('Selected ${items.length - selectedItems.length} items.');
+    selectedItems.clear();
+    selectedItems.addAll(items);
+    notifyListeners();
+  }
+
+  void selectNone() {
+    print('Deselected ${selectedItems.length} items.');
+    selectedItems.clear();
+    notifyListeners();
+  }
+}
+
+Model model = Model();
+
+void main() {
+  model.items.addAll(
+    List<Item>.generate(100, (int index) {
+      return Item('Item $index');
+    }),
+  );
+  runApp(const MyApp());
+}
+
+/// The top level application class.
+///
+/// Shortcuts can be defined here, and they will be in effect for the whole app,
+/// although different widgets may fulfill them differently.
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String title = 'Shortcuts and Actions Demo';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: title,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: Material(
+        color: Colors.grey.shade100,
+        child: TargetedShortcuts(
+          manager: LoggingShortcutManager(),
+          shortcuts: const <ShortcutActivator, Intent>{
+            SingleActivator(LogicalKeyboardKey.keyA, control: true): SelectAllIntent(),
+            SingleActivator(LogicalKeyboardKey.keyS, control: true): SelectNoneIntent(),
+          },
+          child: Shortcuts(
+            shortcuts: const <ShortcutActivator, Intent>{
+              SingleActivator(LogicalKeyboardKey.digit0): ToggleSelectIntent(0),
+              SingleActivator(LogicalKeyboardKey.digit1): ToggleSelectIntent(1),
+              SingleActivator(LogicalKeyboardKey.digit2): ToggleSelectIntent(2),
+              SingleActivator(LogicalKeyboardKey.digit3): ToggleSelectIntent(3),
+              SingleActivator(LogicalKeyboardKey.digit4): ToggleSelectIntent(4),
+            },
+            child: Row(
+              children: const <Widget>[
+                Expanded(flex: 1, child: MyMenu()),
+                Expanded(flex: 5, child: MyGrid()),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class MyGrid extends StatelessWidget {
+  const MyGrid({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusTraversalGroup(
+      child: TargetedActions(
+        dispatcher: LoggingActionDispatcher(),
+        actions: <Type, Action<Intent>>{
+          SelectAllIntent: SelectAllAction(model),
+          SelectNoneIntent: SelectNoneAction(model),
+        },
+        child: Actions(
+          actions: <Type, Action<Intent>>{
+            ToggleSelectIntent: ToggleSelectAction(model),
+            ToggleSelectItemIntent: ToggleSelectItemAction(model),
+          },
+          child: GridView.builder(
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 200,
+            ),
+            itemCount: 300,
+            itemBuilder: (BuildContext context, int index) {
+              return ItemBox(
+                item: model.items[index],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class MyMenu extends StatelessWidget {
+  const MyMenu({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusTraversalGroup(
+      child: Container(
+        color: Colors.white,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            Tooltip(
+              message: 'Control-A',
+              child: TextButton(
+                autofocus: true,
+                child: const Text('SELECT ALL'),
+                onPressed: model.selectAll,
+              ),
+            ),
+            Tooltip(
+              message: 'Control-S',
+              child: TextButton(
+                child: const Text('SELECT NONE'),
+                onPressed: model.selectNone,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ItemBox extends StatelessWidget {
+  const ItemBox({Key? key, required this.item}) : super(key: key);
+
+  final Item item;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: model,
+      builder: (BuildContext context, Widget? child) {
+        return Container(
+          margin: const EdgeInsets.all(8.0),
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(Radius.circular(10)),
+            color: model.selectedItems.contains(item)
+                ? const Color(0x80ff8080)
+                : const Color(0x80ffffff),
+          ),
+          child: InkWell(
+            borderRadius: const BorderRadius.all(Radius.circular(10)),
+            canRequestFocus: true,
+            highlightColor: Colors.indigo.shade100,
+            focusColor: Colors.indigo.shade400,
+            hoverColor: Colors.indigo.shade200,
+            onTap: () {
+              Actions.maybeInvoke(context, ToggleSelectItemIntent(item));
+            },
+            child: Center(
+              child: Text(item.name),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class SelectAllIntent extends Intent {
+  const SelectAllIntent();
+}
+
+class SelectAllAction extends Action<SelectAllIntent> {
+  SelectAllAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant SelectAllIntent intent) {
+    model.selectAll();
+  }
+}
+
+class SelectNoneIntent extends Intent {
+  const SelectNoneIntent();
+}
+
+class SelectNoneAction extends Action<SelectNoneIntent> {
+  SelectNoneAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant SelectNoneIntent intent) {
+    model.selectNone();
+  }
+}
+
+class SelectIndexIntent extends Intent {
+  const SelectIndexIntent(this.index);
+
+  final int index;
+}
+
+class SelectIndexAction extends Action<SelectIndexIntent> {
+  SelectIndexAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant SelectIndexIntent intent) {
+    model.select(model.items[intent.index]);
+  }
+}
+
+class ToggleSelectItemIntent extends Intent {
+  const ToggleSelectItemIntent(this.item);
+
+  final Item item;
+}
+
+class ToggleSelectItemAction extends Action<ToggleSelectItemIntent> {
+  ToggleSelectItemAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant ToggleSelectItemIntent intent) {
+    model.toggleSelect(intent.item);
+  }
+}
+
+class DeselectIndexIntent extends Intent {
+  const DeselectIndexIntent(this.index);
+
+  final int index;
+}
+
+class DeselectIndexAction extends Action<DeselectIndexIntent> {
+  DeselectIndexAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant DeselectIndexIntent intent) {
+    model.deselect(model.items[intent.index]);
+  }
+}
+
+class ToggleSelectIntent extends Intent {
+  const ToggleSelectIntent(this.index);
+
+  final int index;
+}
+
+class ToggleSelectAction extends Action<ToggleSelectIntent> {
+  ToggleSelectAction(this.model);
+
+  final Model model;
+
+  @override
+  Object? invoke(covariant ToggleSelectIntent intent) {
+    model.toggleSelect(model.items[intent.index]);
+  }
+}
+
+/// A ShortcutManager that logs all keys that it handles.
+class LoggingShortcutManager extends ShortcutManager {
+  @override
+  KeyEventResult handleKeypress(BuildContext context, RawKeyEvent event) {
+    final KeyEventResult result = super.handleKeypress(context, event);
+    if (result == KeyEventResult.handled) {
+      print('Handled shortcut $event in $context');
+    }
+    return result;
+  }
+}
+
+/// An ActionDispatcher that logs all the actions that it invokes.
+class LoggingActionDispatcher extends ActionDispatcher {
+  @override
+  Object? invokeAction(
+      covariant Action<Intent> action,
+      covariant Intent intent, [
+        BuildContext? context,
+      ]) {
+    print('Action invoked: $action($intent) from $context');
+    super.invokeAction(action, intent, context);
+  }
+}

--- a/dev/manual_tests/windows/flutter/generated_plugin_registrant.cc
+++ b/dev/manual_tests/windows/flutter/generated_plugin_registrant.cc
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 #include "generated_plugin_registrant.h"
 
 

--- a/dev/manual_tests/windows/flutter/generated_plugin_registrant.cc
+++ b/dev/manual_tests/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 

--- a/dev/manual_tests/windows/flutter/generated_plugin_registrant.h
+++ b/dev/manual_tests/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/dev/manual_tests/windows/flutter/generated_plugin_registrant.h
+++ b/dev/manual_tests/windows/flutter/generated_plugin_registrant.h
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1029,7 +1029,7 @@ class Actions extends StatefulWidget {
 
     bool searchActions(InheritedElement element, [bool registered = false]) {
       final _ActionsMarker actionsMarker = element.widget as _ActionsMarker;
-      final Action<T>? result = (registered ? actionsMarker.registeredActions : actionsMarker.actions)[intent.runtimeType] as Action<T>?;
+      final Action<T>? result = (registered ? actionsMarker.registeredActions : actionsMarker.actions)[type] as Action<T>?;
       if (result != null) {
         context.dependOnInheritedElement(element);
         action = result;
@@ -1065,15 +1065,15 @@ class Actions extends StatefulWidget {
     // concrete type of the intent at compile time.
     final Type type = intent?.runtimeType ?? T;
     assert(
-    type != Intent,
-    'The type passed to "find" resolved to "Intent": either a non-Intent '
-        'generic type argument or an example intent derived from Intent must be '
-        'specified. Intent may be used as the generic type as long as the optional '
-        '"intent" argument is passed.',
+      type != Intent,
+      'The type passed to "find" resolved to "Intent": either a non-Intent '
+      'generic type argument or an example intent derived from Intent must be '
+      'specified. Intent may be used as the generic type as long as the optional '
+      '"intent" argument is passed.',
     );
     bool searchActions(InheritedElement element, [bool registered = false]) {
       final _ActionsMarker actionsMarker = element.widget as _ActionsMarker;
-      final Action<T>? result = (registered ? actionsMarker.registeredActions : actionsMarker.actions)[intent.runtimeType] as Action<T>?;
+      final Action<T>? result = (registered ? actionsMarker.registeredActions : actionsMarker.actions)[type] as Action<T>?;
       if (result != null) {
         context.dependOnInheritedElement(element);
         actions.add(result);
@@ -1128,6 +1128,7 @@ class Actions extends StatefulWidget {
   ) {
     assert(intent != null);
     assert(context != null);
+
     final Map<Action<T>, InheritedElement> actions = <Action<T>, InheritedElement>{};
     InheritedElement? actionElement;
     bool searchActions(InheritedElement element, [bool registered = false]) {
@@ -1244,7 +1245,7 @@ class Actions extends StatefulWidget {
 
 class _ActionsState extends State<Actions> {
   // The set of actions that this Actions widget is current listening to.
-  final Set<Action<Intent>> listenedActions = <Action<Intent>>{};
+  Set<Action<Intent>> listenedActions = <Action<Intent>>{};
   // Used to tell the marker to rebuild its dependencies when the state of an
   // action in the map changes.
   Object rebuildKey = Object();
@@ -1282,14 +1283,18 @@ class _ActionsState extends State<Actions> {
     for (final Action<Intent> action in addedActions) {
       action.addActionListener(_handleActionChanged);
     }
-    listenedActions.clear();
-    listenedActions.addAll(widgetActions);
+    listenedActions = widgetActions;
+  }
+
+  @override
+  void didUpdateWidget(Actions oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _udpateAllActionListeners();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _udpateAllActionListeners();
     if (widget.registeredActions != null) {
       registry = ActionsRegistry.maybeRegistryOf(context);
       registry?.registerActions(context);
@@ -1298,12 +1303,12 @@ class _ActionsState extends State<Actions> {
 
   @override
   void dispose() {
+    super.dispose();
     for (final Action<Intent> action in listenedActions) {
       action.removeActionListener(_handleActionChanged);
     }
     listenedActions.clear();
     registry?.unregisterActions(context);
-    super.dispose();
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1512,6 +1512,8 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     return true;
   }
 
+  final ActionRegistry actionRegistry = ActionRegistry();
+
   @override
   Widget build(BuildContext context) {
     Widget? routing;
@@ -1644,6 +1646,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
         // fall through to the defaultShortcuts.
         child: DefaultTextEditingShortcuts(
           child: Actions(
+            registry: actionRegistry,
             actions: widget.actions ?? WidgetsApp.defaultActions,
             child: DefaultTextEditingActions(
               child: FocusTraversalGroup(

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1645,17 +1645,18 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
         // DefaultTextEditingShortcuts is nested inside Shortcuts so that it can
         // fall through to the defaultShortcuts.
         child: DefaultTextEditingShortcuts(
-          child: Actions(
-            registry: actionRegistry,
-            actions: widget.actions ?? WidgetsApp.defaultActions,
-            child: DefaultTextEditingActions(
-              child: FocusTraversalGroup(
-                policy: ReadingOrderTraversalPolicy(),
-                child: _MediaQueryFromWindow(
-                  child: Localizations(
-                    locale: appLocale,
-                    delegates: _localizationsDelegates.toList(),
-                    child: title,
+          child: ActionsRegistry(
+            child: Actions(
+              actions: widget.actions ?? WidgetsApp.defaultActions,
+              child: DefaultTextEditingActions(
+                child: FocusTraversalGroup(
+                  policy: ReadingOrderTraversalPolicy(),
+                  child: _MediaQueryFromWindow(
+                    child: Localizations(
+                      locale: appLocale,
+                      delegates: _localizationsDelegates.toList(),
+                      child: title,
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -827,15 +827,19 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
     if (matchedIntent != null) {
       final BuildContext? primaryContext = primaryFocus?.context;
       if (primaryContext != null) {
-        final Action<Intent>? action = Actions.maybeFind<Intent>(
+        final List<Action<Intent>> actions = Actions.findAll<Intent>(
           primaryContext,
           intent: matchedIntent,
         );
-        if (action != null && action.isEnabled(matchedIntent)) {
-          Actions.of(primaryContext).invokeAction(action, matchedIntent, primaryContext);
-          return action.consumesKey(matchedIntent)
-              ? KeyEventResult.handled
-              : KeyEventResult.skipRemainingHandlers;
+        if (actions.isNotEmpty) {
+          bool keyConsumed = false;
+          for (final Action<Intent> action in actions) {
+            if (action.isEnabled(matchedIntent)) {
+              Actions.of(primaryContext).invokeAction(action, matchedIntent, primaryContext);
+              keyConsumed = action.consumesKey(matchedIntent) || keyConsumed;
+            }
+          }
+          return keyConsumed ? KeyEventResult.handled : KeyEventResult.skipRemainingHandlers;
         }
       }
     }

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -26,11 +26,14 @@ class ThirdTestIntent extends SecondTestIntent {
 class TestAction extends CallbackAction<TestIntent> {
   TestAction({
     required OnInvokeCallback onInvoke,
+    this.label = '',
   })  : assert(onInvoke != null),
         super(onInvoke: onInvoke);
 
   @override
   bool isEnabled(TestIntent intent) => enabled;
+
+  String label;
 
   bool get enabled => _enabled;
   bool _enabled = true;
@@ -56,6 +59,13 @@ class TestAction extends CallbackAction<TestIntent> {
   List<ActionListenerCallback> listeners = <ActionListenerCallback>[];
 
   void _testInvoke(TestIntent intent) => invoke(intent);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('label', label, defaultValue: ''));
+    properties.add(IntProperty('listeners', listeners.length, defaultValue: 0));
+  }
 }
 
 class TestDispatcher extends ActionDispatcher {
@@ -604,18 +614,21 @@ void main() {
       bool invoked2 = false;
       bool invoked3 = false;
       final TestAction action1 = TestAction(
+        label: 'action1',
         onInvoke: (Intent intent) {
           invoked1 = true;
           return invoked1;
         },
       );
       final TestAction action2 = TestAction(
+        label: 'action2',
         onInvoke: (Intent intent) {
           invoked2 = true;
           return invoked2;
         },
       );
       final TestAction action3 = TestAction(
+        label: 'action3',
         onInvoke: (Intent intent) {
           invoked3 = true;
           return invoked3;
@@ -707,6 +720,10 @@ void main() {
       expect(enabled2, isTrue);
       expect(result, isTrue);
       expect(invoked2, isTrue);
+
+      expect(action1.listeners.length, equals(2));
+      expect(action2.listeners.length, equals(3));
+      expect(action3.listeners.length, equals(2));
 
       await tester.pumpWidget(
         Actions(

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -664,7 +664,7 @@ void main() {
         ),
       );
 
-      Object? result = Actions.invoke(
+      Object? result = Actions.maybeInvoke<TestIntent>(
         containerKey.currentContext!,
         const TestIntent(),
       );
@@ -673,7 +673,7 @@ void main() {
       expect(invoked1, isFalse);
 
       action1.enabled = true;
-      result = Actions.invoke(
+      result = Actions.invoke<TestIntent>(
         containerKey.currentContext!,
         const TestIntent(),
       );
@@ -702,7 +702,7 @@ void main() {
       );
 
       await tester.pump();
-      result = Actions.invoke<TestIntent>(
+      result = Actions.maybeInvoke<TestIntent>(
         containerKey.currentContext!,
         const SecondTestIntent(),
       );


### PR DESCRIPTION
## Description

This is a WIP PR, I created it mainly to get feedback on the idea.

This is adds a way to invoke actions that aren't in the current focus chain, so that they can be bound to shortcuts at a top level, and invoked even if they aren't in the focus chain, as long as the shortcuts binding is in the focus chain.

There's a "manual_tests" app to illustrate a use case: you have a menu with buttons on it, and a grid.  Items in the grid are selectable, but the grid is the only thing that knows about the selection actions. The `control-a` (select all) and `control-s` (select none) are "registered" actions that work as long as something in the app has focus, and the `1`, `2`, `3` keys are regular shortcuts usable only when a grid item has focus.

It works by adding a registry for actions that can be attached to an `Actions` widget. The `Actions` widget then will not only search for actions in itself and its ancestors, but will also search for them in any registry that it or its ancestors have.

So, if you want an action to be available to an ancestor, bind the intent to a key in a `Shortcuts` widget, add a `RegisteredActions` widget in the descendant, and it will register those actions with the nearest `Actions` widget that has a registry (which might be the one in `WidgetsApp`). That allows scoping of the registered actions (just create a registry to stop them from being registered in a higher level registry), and invocation whenever the widget is in the tree.

One thing it doesn't fix is that you still need to know about the intent in order to add a key binding to it. I could fix that with a similar mechanism for registering shortcuts, but I wanted to see if this makes sense first.

cc @HansMuller @Hixie @goderbauer for feedback on the idea.

Here's a [design doc](https://docs.google.com/document/d/1RrAWQ-rq-XcrjJx4Jegn8NdJKNHfLem6MkAJrI8Q_1w/edit) for this design change.