### PR TITLE
Empty ci.yaml to prepare for migration

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -23,9 +23,3 @@
 enabled_branches:
   - master
 targets:
-  - name: analyze_linux
-    bringup: true
-    builder: Linux analyze
-    properties:
-      validation: analyze
-      validation_name: Analyze


### PR DESCRIPTION
There's an issue in cocoon where we cannot have duplicate builds between ci.yaml and prod_builders.json

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

