### PR TITLE
[flutter_tools] pin shelf version at 1.1.4

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -70,6 +70,10 @@ const Map<String, String> _kManuallyPinnedDependencies = <String, String>{
   'process_runner': '">=4.0.0-nullsafety.5"',
   'url_launcher': '">=6.0.0-nullsafety.1"',
   'video_player': '">=2.0.0-nullsafety.2"',
+  // This is pinned to avoid the performance regression from a reverted feature
+  // from https://github.com/dart-lang/shelf/issues/189 . This can be removed
+  // when a new major version of shelf is published.
+  'shelf': '1.1.4',
 };
 
 class UpdatePackagesCommand extends FlutterCommand {


### PR DESCRIPTION
It was reported in https://github.com/flutter/flutter/issues/81010 that loading a flutter web app that had a large javascript file was taking 4-5 minutes to load. This lead to a discovery that a CastList was being used, fixing that in https://github.com/dart-lang/shelf/pull/178 made this take milliseconds.

This is being reverted as an accidental breaking change for https://github.com/dart-lang/shelf/issues/189. In the meantime, we don't want to regress performance so let's pin the shelf version until there is another major release
