### PR TITLE
FlutterDriver: deprecate enableAccessibility; redirect it to setSemantics; add setSemantics tests

### DIFF
--- a/examples/hello_world/test_driver/smoke_web_engine_test.dart
+++ b/examples/hello_world/test_driver/smoke_web_engine_test.dart
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('enable accessibility', () async {
-      await driver.enableAccessibility();
+      await driver.setSemantics(true);
 
       await Future<void>.delayed(const Duration(seconds: 2));
 

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -174,8 +174,9 @@ abstract class FlutterDriver {
   async_io.WebDriver get webDriver => throw UnimplementedError();
 
   /// Enables accessibility feature.
+  @Deprecated('Use setSemantics instead')
   Future<void> enableAccessibility() async {
-    throw UnimplementedError();
+    await setSemantics(true);
   }
 
   /// Sends [command] to the Flutter Driver extensions.
@@ -522,6 +523,13 @@ abstract class FlutterDriver {
   ///
   /// Returns true when the call actually changed the state from on to off or
   /// vice versa.
+  ///
+  /// Does not enable or disable the assistive technology installed on the
+  /// device. For example, this does not enable VoiceOver on iOS, TalkBack on
+  /// Android, or NVDA on Windows.
+  ///
+  /// Enabling semantics on the web causes the engine to render ARIA-annotated
+  /// HTML.
   Future<bool> setSemantics(bool enabled, { Duration? timeout }) async {
     final SetSemanticsResult result = SetSemanticsResult.fromJson(await sendCommand(SetSemantics(enabled, timeout: timeout)));
     return result.changedState;

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -176,7 +176,7 @@ abstract class FlutterDriver {
   /// Enables accessibility feature.
   @Deprecated(
     'Call setSemantics(true) instead. '
-    'This feature was deprecated after 2.3.0-12.1.pre.'
+    'This feature was deprecated after v2.3.0-12.1.pre.'
   )
   Future<void> enableAccessibility() async {
     await setSemantics(true);

--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -174,7 +174,10 @@ abstract class FlutterDriver {
   async_io.WebDriver get webDriver => throw UnimplementedError();
 
   /// Enables accessibility feature.
-  @Deprecated('Use setSemantics instead')
+  @Deprecated(
+    'Call setSemantics(true) instead. '
+    'This feature was deprecated after 2.3.0-12.1.pre.'
+  )
   Future<void> enableAccessibility() async {
     await setSemantics(true);
   }

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -287,10 +287,6 @@ class VMServiceFlutterDriver extends FlutterDriver {
   /// Whether to log communication between host and app to `flutter_driver_commands.log`.
   final bool _logCommunicationToFile;
 
-  @override
-  Future<void> enableAccessibility() async {
-    throw UnsupportedError('VMServiceFlutterDriver does not support enableAccessibility');
-  }
 
   @override
   Future<Map<String, dynamic>> sendCommand(Command command) async {

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -39,7 +39,6 @@ class WebFlutterDriver extends FlutterDriver {
 
   final FlutterWebConnection _connection;
   DateTime _startTime;
-  bool _accessibilityEnabled = false;
   static int _nextDriverId = 0;
 
   /// The unique ID of this driver instance.
@@ -94,22 +93,6 @@ class WebFlutterDriver extends FlutterDriver {
       printCommunication: printCommunication,
       logCommunicationToFile: logCommunicationToFile,
     );
-  }
-
-  @override
-  Future<void> enableAccessibility() async {
-    if (!_accessibilityEnabled) {
-      // Clicks the button to enable accessibility via Javascript for Desktop Web.
-      //
-      // The tag used in the script is based on
-      // https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart#L193
-      //
-      // TODO(angjieli): Support Mobile Web. (https://github.com/flutter/flutter/issues/65192)
-      await webDriver.execute(
-          "document.querySelector('flt-semantics-placeholder').click();",
-          <String>[]);
-      _accessibilityEnabled = true;
-    }
   }
 
   @override

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -630,14 +630,30 @@ void main() {
       });
     });
 
-    group('VMServiceFlutterDriver Unsupported error', () {
-      test('enableAccessibility', () async {
-        expect(driver.enableAccessibility(), throwsUnsupportedError);
+    group('setSemantics', () {
+      test('can be enabled', () async {
+        fakeClient.responses['set_semantics'] = makeFakeResponse(<String, Object>{
+          'changedState': true,
+        });
+        await driver.setSemantics(true, timeout: _kTestTimeout);
+        expect(fakeClient.commandLog, <String>[
+          'ext.flutter.driver {command: set_semantics, timeout: $_kSerializedTestTimeout, enabled: true}',
+        ]);
       });
 
-      test('webDriver', () async {
-        expect(() => driver.webDriver, throwsUnsupportedError);
+      test('can be disabled', () async {
+        fakeClient.responses['set_semantics'] = makeFakeResponse(<String, Object>{
+          'changedState': false,
+        });
+        await driver.setSemantics(false, timeout: _kTestTimeout);
+        expect(fakeClient.commandLog, <String>[
+          'ext.flutter.driver {command: set_semantics, timeout: $_kSerializedTestTimeout, enabled: false}',
+        ]);
       });
+    });
+
+    test('VMServiceFlutterDriver does not support webDriver', () async {
+      expect(() => driver.webDriver, throwsUnsupportedError);
     });
   });
 


### PR DESCRIPTION
On mobile `FlutterDriver.enableAccessibility` never worked. On the web it has the same effect as `setSemantics`, except that it used to rely on an implementation detail that's not cross-platform (it would look for a specific DOM element and dispatch an artificial tap on it, which is brittle and doesn't work on all browsers).

Fixes https://github.com/flutter/flutter/issues/65192

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
