### PR TITLE
[flutter_tools] allow passing properties directly to Gradle

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -25,6 +25,7 @@ class BuildInfo {
     List<String>? extraFrontEndOptions,
     List<String>? extraGenSnapshotOptions,
     List<String>? fileSystemRoots,
+    this.androidProjectArgs = const <String>[],
     this.fileSystemScheme,
     this.buildNumber,
     this.buildName,
@@ -141,6 +142,10 @@ class BuildInfo {
   ///
   /// The Gradle daemon may also be disabled in the Android application's properties file.
   final bool androidGradleDaemon;
+
+  /// Additional key value pairs that are passed directly to the gradle project via the `-P`
+  /// flag.
+  final List<String> androidProjectArgs;
 
   /// The package configuration for the loaded application.
   ///
@@ -276,6 +281,8 @@ class BuildInfo {
         '-Pbundle-sksl-path=$bundleSkSLPath',
       if (codeSizeDirectory != null)
         '-Pcode-size-directory=$codeSizeDirectory',
+      for (String projectArg in androidProjectArgs)
+        '-P$projectArg',
     ];
   }
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -118,6 +118,7 @@ class FlutterOptions {
   static const String kNullAssertions = 'null-assertions';
   static const String kAndroidGradleDaemon = 'android-gradle-daemon';
   static const String kDeferredComponents = 'deferred-components';
+  static const String kAndroidProjectArgs = 'android-project-arg';
 }
 
 abstract class FlutterCommand extends Command<void> {
@@ -768,6 +769,13 @@ abstract class FlutterCommand extends Command<void> {
       defaultsTo: true,
       hide: hide,
     );
+    argParser.addMultiOption(
+      FlutterOptions.kAndroidProjectArgs,
+      help: 'Additional arguments specified as key=value that are passed directly to the gradle '
+            'project via the -P flag. These can be accesed in build.gradle via the "project.property" API.',
+      splitCommas: false,
+      abbr: 'P',
+    );
   }
 
   void addNativeNullAssertions({ bool hide = false }) {
@@ -971,6 +979,10 @@ abstract class FlutterCommand extends Command<void> {
     final bool androidGradleDaemon = !argParser.options.containsKey(FlutterOptions.kAndroidGradleDaemon)
       || boolArg(FlutterOptions.kAndroidGradleDaemon);
 
+    final List<String> androidProjectArgs = argParser.options.containsKey(FlutterOptions.kAndroidProjectArgs)
+      ? stringsArg(FlutterOptions.kAndroidProjectArgs)
+      : <String>[];
+
     if (dartObfuscation && (splitDebugInfoPath == null || splitDebugInfoPath.isEmpty)) {
       throwToolExit(
         '"--${FlutterOptions.kDartObfuscationOption}" can only be used in '
@@ -1042,6 +1054,7 @@ abstract class FlutterCommand extends Command<void> {
       codeSizeDirectory: codeSizeDirectory,
       androidGradleDaemon: androidGradleDaemon,
       packageConfig: packageConfig,
+      androidProjectArgs: androidProjectArgs,
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -139,6 +139,8 @@ void main() {
       bundleSkSLPath: 'foo/bar/baz.sksl.json',
       packagesPath: 'foo/.packages',
       codeSizeDirectory: 'foo/code-size',
+      // These values are ignored by toEnvironmentConfig
+      androidProjectArgs: <String>['foo=bar', 'fizz=bazz']
     );
 
     expect(buildInfo.toEnvironmentConfig(), <String, String>{
@@ -167,6 +169,7 @@ void main() {
       bundleSkSLPath: 'foo/bar/baz.sksl.json',
       packagesPath: 'foo/.packages',
       codeSizeDirectory: 'foo/code-size',
+      androidProjectArgs: <String>['foo=bar', 'fizz=bazz']
     );
 
     expect(buildInfo.toGradleConfig(), <String>[
@@ -178,7 +181,9 @@ void main() {
       '-Ptrack-widget-creation=true',
       '-Ptree-shake-icons=true',
       '-Pbundle-sksl-path=foo/bar/baz.sksl.json',
-      '-Pcode-size-directory=foo/code-size'
+      '-Pcode-size-directory=foo/code-size',
+      '-Pfoo=bar',
+      '-Pfizz=bazz'
     ]);
   });
 


### PR DESCRIPTION
Allow passing key value pairs directly to the gradle project.


Fixes https://github.com/flutter/flutter/issues/48707