### PR TITLE
Mark Mac_ios flutter_gallery__transition_perf_e2e_ios32 as flaky

### DIFF
--- a/dev/prod_builders.json
+++ b/dev/prod_builders.json
@@ -1012,7 +1012,7 @@
       "name": "Mac_ios flutter_gallery__transition_perf_e2e_ios32",
       "repo": "flutter",
       "task_name": "mac_ios_flutter_gallery__transition_perf_e2e_ios32",
-      "flaky": false
+      "flaky": true
     },
     {
       "name": "Mac_ios flutter_gallery_ios__compile",


### PR DESCRIPTION
Marking Mac_ios flutter_gallery__transition_perf_e2e_ios32 as flaky based on https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness

Issue: https://github.com/flutter/flutter/issues/82940