### PR TITLE
[flutter_conductor] fix candidates sub-command

### DIFF
--- a/dev/tools/lib/candidates.dart
+++ b/dev/tools/lib/candidates.dart
@@ -82,14 +82,18 @@ class CandidatesCommand extends Command<void> {
       final int y = int.parse(candidateMatch.group(2)!);
       final int m = int.parse(candidateMatch.group(3)!);
 
-      final RegExpMatch match = remotePattern.firstMatch(branchName)!;
+      final RegExpMatch? match = remotePattern.firstMatch(branchName);
+      // If this is not the correct remote
+      if (match == null) {
+        continue;
+      }
       if (x < currentVersion.x) {
         continue;
       }
       if (x == currentVersion.x && y < currentVersion.y) {
         continue;
       }
-      if (x == currentX && y == currentY && currentZ == 0 && m < currentM) {
+      if (x == currentX && y == currentY && currentZ == 0 && m <= currentM) {
         continue;
       }
       stdio.printStatus(match.group(1)!);

--- a/dev/tools/test/candidates_test.dart
+++ b/dev/tools/test/candidates_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     test('prints only branches from targeted remote', () async {
       const String currentVersion = '1.2.3';
-      const String branch = 'flutter-1.2-candidate.0';
+      const String branch = 'flutter-1.3-candidate.0';
 
       processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
@@ -64,7 +64,7 @@ void main() {
             '$remoteName/*',
           ],
           stdout: <String>[
-            'other-remote/branch1',
+            'other-remote/flutter-5.0-candidate.0',
             '$remoteName/$branch',
           ].join('\n'),
         ),
@@ -89,7 +89,65 @@ void main() {
       await runner.run(<String>['candidates', '--$kRemote', remoteName]);
       expect(stdio.stdout.contains('currentVersion = $currentVersion'), true);
       expect(stdio.stdout.contains(branch), true);
-      expect(stdio.stdout.contains('branch1'), false);
+      expect(stdio.stdout.contains('flutter-5.0-candidate.0'), false);
+    });
+
+    test('does not print branches older or equal to current version', () async {
+      const String currentVersion = '2.3.0-13.0.pre.48';
+      const String newBranch = 'flutter-2.4-candidate.0';
+      const String oldBranch = 'flutter-1.0-candidate.0';
+      const String currentBranch = 'flutter-2.3-candidate.13';
+
+      processManager = FakeProcessManager.list(<FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'fetch', remoteName],
+        ),
+        const FakeCommand(
+          command: <String>[flutterBinPath, 'help'],
+        ),
+        const FakeCommand(
+          command: <String>[flutterBinPath, '--version', '--machine'],
+          stdout: '{"frameworkVersion": "$currentVersion"}',
+        ),
+        FakeCommand(
+          command: const <String>[
+            'git',
+            'branch',
+            '--no-color',
+            '--remotes',
+            '--list',
+            '$remoteName/*',
+          ],
+          stdout: <String>[
+            '$remoteName/$oldBranch',
+            '$remoteName/$currentBranch',
+            '$remoteName/$newBranch',
+          ].join('\n'),
+        ),
+      ]);
+      final String pathSeparator = operatingSystem == 'windows' ? r'\' : '/';
+
+      platform = FakePlatform(
+        environment: <String, String>{
+          'HOME': <String>['path', 'to', 'home'].join(pathSeparator),
+        },
+        pathSeparator: pathSeparator,
+      );
+      final Checkouts checkouts = Checkouts(
+        fileSystem: fileSystem,
+        parentDirectory: fileSystem.directory(checkoutsParentDirectory),
+        platform: platform,
+        processManager: processManager,
+        stdio: stdio,
+      );
+
+      final CommandRunner<void> runner = createRunner(checkouts: checkouts);
+      await runner.run(<String>['candidates', '--$kRemote', remoteName]);
+      expect(stdio.stdout.contains('currentVersion = $currentVersion'), true);
+      expect(stdio.stdout.contains(newBranch), true);
+      expect(stdio.stdout.contains(oldBranch), false);
+      expect(stdio.stdout.contains(currentBranch), false);
+      print(stdio.stdout);
     });
   }, onPlatform: <String, dynamic>{
     'windows': const Skip('Flutter Conductor only supported on macos/linux'),


### PR DESCRIPTION
Before this the `conductor candidates` sub-command would print out the branch for the latest dev release, which should be excluded.