### PR TITLE
Add ownership for DeviceLab ios32 tests

### DIFF
--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -147,6 +147,10 @@
 /dev/devicelab/bin/tasks/smoke_catalina_hot_mode_dev_cycle_ios__benchmark.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/tiles_scroll_perf_ios__timeline_summary.dart @zanderso @flutter/engine
 
+# Mac iOS32 DeviceLab tests
+/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios32.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/native_ui_tests_ios32.dart @zanderso @flutter/engine
+
 # Host only DeviceLab tests
 /dev/devicelab/bin/tasks/build_aar_module_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart @zanderso @flutter/tool


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/81864 to add missing ownership info for ios32 tests.