### PR TITLE
Force user to atleast provide one from initalData or Future in FutureBuilder #83093

### DIFF
--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -694,6 +694,7 @@ class FutureBuilder<T> extends StatefulWidget {
     this.initialData,
     required this.builder,
   }) : assert(builder != null),
+       assert(!(future == null && initialData == null),'Future and initialData cannot be null at same time'),
        super(key: key);
 
   /// The asynchronous computation to which this builder is currently connected,

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -77,13 +77,14 @@ void main() {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(FutureBuilder<String>(
         key: key, future: null, builder: snapshotText,
+        initialData:'1'
       ));
-      expect(find.text('AsyncSnapshot<String>(ConnectionState.none, null, null, null)'), findsOneWidget);
+      expect(find.text('AsyncSnapshot<String>(ConnectionState.none, 1, null, null)'), findsOneWidget);
       final Completer<String> completer = Completer<String>();
       await tester.pumpWidget(FutureBuilder<String>(
         key: key, future: completer.future, builder: snapshotText,
       ));
-      expect(find.text('AsyncSnapshot<String>(ConnectionState.waiting, null, null, null)'), findsOneWidget);
+      expect(find.text('AsyncSnapshot<String>(ConnectionState.waiting, 1, null, null)'), findsOneWidget);
     });
     testWidgets('gracefully handles transition to null future', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
@@ -94,6 +95,7 @@ void main() {
       expect(find.text('AsyncSnapshot<String>(ConnectionState.waiting, null, null, null)'), findsOneWidget);
       await tester.pumpWidget(FutureBuilder<String>(
         key: key, future: null, builder: snapshotText,
+        initialData:'1'
       ));
       expect(find.text('AsyncSnapshot<String>(ConnectionState.none, null, null, null)'), findsOneWidget);
       completer.complete('hello');
@@ -289,12 +291,8 @@ void main() {
       await eventFiring(tester);
       expect(find.text('AsyncSnapshot<String>(ConnectionState.done, null, bad, trace)'), findsNWidgets(2));
     });
-    testWidgets('when Future is null', (WidgetTester tester) async {
-      await tester.pumpWidget(Column(children: <Widget>[
-        FutureBuilder<String>(future: null, builder: snapshotText),
-        StreamBuilder<String>(stream: null, builder: snapshotText),
-      ]));
-      expect(find.text('AsyncSnapshot<String>(ConnectionState.none, null, null, null)'), findsNWidgets(2));
+    testWidgets('When Future and InitialData both are null',(WidgetTester tester) async{
+      expect(()=>FutureBuilder<String>(builder: snapshotText,),throwsAssertionError);
     });
     testWidgets('when initialData is used with null Future and Stream', (WidgetTester tester) async {
       await tester.pumpWidget(Column(children: <Widget>[


### PR DESCRIPTION


Now forcing user to provide atleast one input from initialData or future in FutureBuilder.
I've already explained [why](https://github.com/flutter/flutter/issues/83081) here.

Issue Fixed: #83081

No Changes in flutter/tests repo

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

