### PR TITLE
Made the android platform channel benchmarks comparable to iOS

### DIFF
--- a/dev/benchmarks/platform_channels_benchmarks/android/app/src/main/kotlin/com/example/platform_channels_benchmarks/MainActivity.kt
+++ b/dev/benchmarks/platform_channels_benchmarks/android/app/src/main/kotlin/com/example/platform_channels_benchmarks/MainActivity.kt
@@ -12,6 +12,9 @@ import io.flutter.plugin.common.StandardMessageCodec
 import java.nio.ByteBuffer
 
 class MainActivity: FlutterActivity() {
+    // We allow for the caching of a response in the binary channel case since
+    // the reply requires a direct buffer, but the input is not a direct buffer.
+    // We can't directly send the input back to the reply currently.
     private var byteBufferCache : ByteBuffer? = null
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         val reset = BasicMessageChannel(flutterEngine.dartExecutor, "dev.flutter.echo.reset", StandardMessageCodec.INSTANCE)

--- a/dev/benchmarks/platform_channels_benchmarks/ios/Runner/AppDelegate.swift
+++ b/dev/benchmarks/platform_channels_benchmarks/ios/Runner/AppDelegate.swift
@@ -14,6 +14,11 @@ import UIKit
     GeneratedPluginRegistrant.register(with: self)
 
     let registrar = self.registrar(forPlugin: "Echo")!
+    let reset = FlutterBasicMessageChannel(
+      name: "dev.flutter.echo.reset", binaryMessenger: registrar.messenger())
+    reset.setMessageHandler { (input, reply) in
+      // noop
+    }
     let basicStandard = FlutterBasicMessageChannel(
       name: "dev.flutter.echo.basic.standard", binaryMessenger: registrar.messenger(),
       codec: FlutterStandardMessageCodec.sharedInstance())

--- a/dev/benchmarks/platform_channels_benchmarks/lib/main.dart
+++ b/dev/benchmarks/platform_channels_benchmarks/lib/main.dart
@@ -108,6 +108,10 @@ Future<void> _runTests() async {
     );
   }
 
+  const BasicMessageChannel<Object> resetChannel = BasicMessageChannel<Object>(
+    'dev.flutter.echo.reset',
+    StandardMessageCodec(),
+  );
   const BasicMessageChannel<Object> basicStandard = BasicMessageChannel<Object>(
     'dev.flutter.echo.basic.standard',
     StandardMessageCodec(),
@@ -129,6 +133,7 @@ Future<void> _runTests() async {
   const int numMessages = 2500;
 
   final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  resetChannel.send(true);
   await _runBasicStandardSmall(basicStandard, 1); // Warmup.
   printer.addResult(
     description: 'BasicMessageChannel/StandardMessageCodec/Flutter->Host/Small',
@@ -136,6 +141,7 @@ Future<void> _runTests() async {
     unit: 'µs',
     name: 'platform_channel_basic_standard_2host_small',
   );
+  resetChannel.send(true);
   await _runBasicStandardLarge(basicStandard, largeBuffer, 1); // Warmup.
   printer.addResult(
     description: 'BasicMessageChannel/StandardMessageCodec/Flutter->Host/Large',
@@ -144,6 +150,7 @@ Future<void> _runTests() async {
     unit: 'µs',
     name: 'platform_channel_basic_standard_2host_large',
   );
+  resetChannel.send(true);
   await _runBasicBinary(basicBinary, largeBufferBytes, 1); // Warmup.
   printer.addResult(
     description: 'BasicMessageChannel/BinaryCodec/Flutter->Host/Large',
@@ -151,6 +158,7 @@ Future<void> _runTests() async {
     unit: 'µs',
     name: 'platform_channel_basic_binary_2host_large',
   );
+  resetChannel.send(true);
   await _runBasicBinary(basicBinary, oneMB, 1); // Warmup.
   printer.addResult(
     description: 'BasicMessageChannel/BinaryCodec/Flutter->Host/1MB',


### PR DESCRIPTION
Right now you can't compare iOS and Android tests because there is an extra copy on Android.  This makes them more directly comparable.

issue: https://github.com/flutter/flutter/issues/81559

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
