### PR TITLE
Additional flags for xcodebuild

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -79,7 +79,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       )..addFlag(
       'allow-provisioning-updates',
       defaultsTo: false,
-      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode`s Accounts preference pane.',
+      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode Accounts preference pane.',
     )..addFlag(
       'allow-provisioning-device-registration',
       defaultsTo: false,

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -146,6 +146,8 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
           ...globals.xcode.xcrunCommand(),
           'xcodebuild',
           '-exportArchive',
+          '-allowProvisioningDeviceRegistration',
+          '-allowProvisioningUpdates',
           '-archivePath',
           globals.fs.path.absolute(app.archiveBundleOutputPath),
           '-exportPath',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -83,7 +83,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     )..addFlag(
       'allow-provisioning-device-registration',
       defaultsTo: false,
-      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if --allow-provisioning-updates is also passed.',
+      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if "--allow-provisioning-updates" is also passed.',
     );
   }
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -69,21 +69,12 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   BuildIOSArchiveCommand({@required bool verboseHelp})
       : super(verboseHelp: verboseHelp) {
-    argParser
-      ..addOption(
-        'export-options-plist',
-        valueHelp: 'ExportOptions.plist',
-        // TODO(jmagman): Update help text with link to Flutter docs.
-        help:
-        'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
-      )..addFlag(
-      'allow-provisioning-updates',
-      defaultsTo: false,
-      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode Accounts preference pane.',
-    )..addFlag(
-      'allow-provisioning-device-registration',
-      defaultsTo: false,
-      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if "--allow-provisioning-updates" is also passed.',
+    argParser.addOption(
+      'export-options-plist',
+      valueHelp: 'ExportOptions.plist',
+      // TODO(jmagman): Update help text with link to Flutter docs.
+      help:
+          'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
     );
   }
 
@@ -109,12 +100,6 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final bool shouldCodesign = true;
 
   String get exportOptionsPlist => stringArg('export-options-plist');
-
-  bool get allowProvisioningDeviceRegistration =>
-      boolArg('allow-provisioning-device-registration');
-
-  bool get allowProvisioningUpdates =>
-      boolArg('allow-provisioning-updates');
 
   @override
   Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs
@@ -161,10 +146,8 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
           ...globals.xcode.xcrunCommand(),
           'xcodebuild',
           '-exportArchive',
-          if(allowProvisioningDeviceRegistration)
-            '-allowProvisioningDeviceRegistration',
-          if(allowProvisioningUpdates)
-            '-allowProvisioningUpdates',
+          if (shouldCodesign) '-allowProvisioningDeviceRegistration',
+          if (shouldCodesign) '-allowProvisioningUpdates',
           '-archivePath',
           globals.fs.path.absolute(app.archiveBundleOutputPath),
           '-exportPath',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -80,7 +80,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       'allowProvisioningUpdates',
       defaultsTo: false,
       negatable: false,
-      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode\'s Accounts preference pane.',
+      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode`s Accounts preference pane.',
     )..addFlag(
       'allowProvisioningDeviceRegistration',
       defaultsTo: false,

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -69,12 +69,23 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   BuildIOSArchiveCommand({@required bool verboseHelp})
       : super(verboseHelp: verboseHelp) {
-    argParser.addOption(
-      'export-options-plist',
-      valueHelp: 'ExportOptions.plist',
-      // TODO(jmagman): Update help text with link to Flutter docs.
-      help:
-          'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
+    argParser
+      ..addOption(
+        'export-options-plist',
+        valueHelp: 'ExportOptions.plist',
+        // TODO(jmagman): Update help text with link to Flutter docs.
+        help:
+        'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
+      )..addFlag(
+      'allowProvisioningUpdates',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode\'s Accounts preference pane.',
+    )..addFlag(
+      'allowProvisioningDeviceRegistration',
+      defaultsTo: false,
+      negatable: false,
+      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.',
     );
   }
 
@@ -100,6 +111,12 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final bool shouldCodesign = true;
 
   String get exportOptionsPlist => stringArg('export-options-plist');
+
+  bool get allowProvisioningDeviceRegistration =>
+      boolArg('allowProvisioningDeviceRegistration');
+
+  bool get allowProvisioningUpdates =>
+      boolArg('allowProvisioningUpdates');
 
   @override
   Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs
@@ -146,8 +163,10 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
           ...globals.xcode.xcrunCommand(),
           'xcodebuild',
           '-exportArchive',
-          '-allowProvisioningDeviceRegistration',
-          '-allowProvisioningUpdates',
+          if(allowProvisioningDeviceRegistration)
+            '-allowProvisioningDeviceRegistration',
+          if(allowProvisioningUpdates)
+            '-allowProvisioningUpdates',
           '-archivePath',
           globals.fs.path.absolute(app.archiveBundleOutputPath),
           '-exportPath',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -146,8 +146,10 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
           ...globals.xcode.xcrunCommand(),
           'xcodebuild',
           '-exportArchive',
-          if (shouldCodesign) '-allowProvisioningDeviceRegistration',
-          if (shouldCodesign) '-allowProvisioningUpdates',
+          if (shouldCodesign) ...<String>[
+            '-allowProvisioningDeviceRegistration',
+            '-allowProvisioningUpdates',
+          ],
           '-archivePath',
           globals.fs.path.absolute(app.archiveBundleOutputPath),
           '-exportPath',

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -77,15 +77,13 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
         help:
         'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
       )..addFlag(
-      'allowProvisioningUpdates',
+      'allow-provisioning-updates',
       defaultsTo: false,
-      negatable: false,
       help: 'Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode`s Accounts preference pane.',
     )..addFlag(
-      'allowProvisioningDeviceRegistration',
+      'allow-provisioning-device-registration',
       defaultsTo: false,
-      negatable: false,
-      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.',
+      help: 'Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if --allow-provisioning-updates is also passed.',
     );
   }
 
@@ -113,10 +111,10 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   String get exportOptionsPlist => stringArg('export-options-plist');
 
   bool get allowProvisioningDeviceRegistration =>
-      boolArg('allowProvisioningDeviceRegistration');
+      boolArg('allow-provisioning-device-registration');
 
   bool get allowProvisioningUpdates =>
-      boolArg('allowProvisioningUpdates');
+      boolArg('allow-provisioning-updates');
 
   @override
   Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -109,6 +109,8 @@ void main() {
       'xcrun',
       'xcodebuild',
       '-exportArchive',
+      '-allowProvisioningDeviceRegistration',
+      '-allowProvisioningUpdates',
       '-archivePath',
       '/build/ios/archive/Runner.xcarchive',
       '-exportPath',

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -109,8 +109,6 @@ void main() {
       'xcrun',
       'xcodebuild',
       '-exportArchive',
-      '-allowProvisioningDeviceRegistration',
-      '-allowProvisioningUpdates',
       '-archivePath',
       '/build/ios/archive/Runner.xcarchive',
       '-exportPath',


### PR DESCRIPTION
## Short description
I added two parameters to the `xcodebuild` command which is invoked by the `flutter build ipa` command: 

- -allowProvisioningUpdates

Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane.

- -allowProvisioningDeviceRegistration

Allow xcodebuild to register your destination device on the developer portal if necessary. This flag only takes effect if -allowProvisioningUpdates is also passed.


## *List which issues are fixed by this PR.*
https://github.com/flutter/flutter/issues/83125

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
