### PR TITLE
Remove linux_validate_ci_config

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -224,10 +224,6 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_validate_ci_config
-    builder: Linux validate_ci_config
-    scheduler: luci
-
   - name: linux_web_tool_tests
     builder: Linux web_tool_tests
     scheduler: luci


### PR DESCRIPTION
Cocoon now adds `ci.yaml validation` check, and this is no longer needed.

## Issues

https://github.com/flutter/flutter/issues/82303

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
