### PR TITLE
Move AndroidX error handler to the end

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -72,10 +72,10 @@ final List<GradleHandledError> gradleErrors = <GradleHandledError>[
   permissionDeniedErrorHandler,
   flavorUndefinedHandler,
   r8FailureHandler,
-  androidXFailureHandler,
   minSdkVersion,
   transformInputIssue,
   lockFileDepMissing,
+  androidXFailureHandler,
 ];
 
 // Permission defined error message.

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -75,7 +75,7 @@ final List<GradleHandledError> gradleErrors = <GradleHandledError>[
   minSdkVersion,
   transformInputIssue,
   lockFileDepMissing,
-  androidXFailureHandler,
+  androidXFailureHandler, // Keep last since the pattern is broader.
 ];
 
 // Permission defined error message.

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -34,6 +34,7 @@ void main() {
           androidXFailureHandler,
         ])
       );
+      expect(gradleErrors.last, equals(androidXFailureHandler));
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -28,10 +28,10 @@ void main() {
           permissionDeniedErrorHandler,
           flavorUndefinedHandler,
           r8FailureHandler,
-          androidXFailureHandler,
           minSdkVersion,
           transformInputIssue,
           lockFileDepMissing,
+          androidXFailureHandler,
         ])
       );
     });


### PR DESCRIPTION
The error handlers are processed in the order that they appear in this list.  
The AndroidX error handler should be the last one, as it's a more broader 
pattern than the ones that come before.

For example, if there's an issue with the lockfiles, AndroidX handler misleads.
The fix gives the correct suggestion:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Resolved 'androidx.core:core:1.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.viewpager:viewpager:1.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.collection:collection:1.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.test.espresso:espresso-core:3.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.test:runner:1.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.loader:loader:1.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-runtime:2.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-common:2.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.fragment:fragment:1.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.test:rules:1.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.arch.core:core-runtime:2.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.savedstate:savedstate:1.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.test:monitor:1.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.arch.core:core-common:2.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.customview:customview:1.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-viewmodel:2.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-livedata-core:2.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-livedata:2.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.test.espresso:espresso-idling-resource:3.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.lifecycle:lifecycle-common-java8:2.2.0' which is not part of the dependency lock state
   > Resolved 'androidx.activity:activity:1.0.0' which is not part of the dependency lock state
   > Resolved 'androidx.annotation:annotation:1.1.0' which is not part of the dependency lock state
   > Resolved 'androidx.versionedparcelable:versionedparcelable:1.1.0' which is not part of the dependency lock state

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
Running Gradle task 'assembleDebug'...                              6.0s

You need to update the lockfile, or disable Gradle dependency locking.
To regenerate the lockfiles run: `./gradlew :generateLockfiles` in /Users/egarciad/p/flutter/dev/integration_tests/flutter_gallery/android/build.gradle
To remove dependency locking, remove the `dependencyLocking` from /Users/egarciad/p/flutter/dev/integration_tests/flutter_gallery/android/build.gradle
````
