### PR TITLE
[flutter_tools] support attach without a discovered device

### DIFF
--- a/packages/flutter_tools/lib/src/remote_device.dart
+++ b/packages/flutter_tools/lib/src/remote_device.dart
@@ -1,0 +1,94 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+
+import 'application_package.dart';
+import 'build_info.dart';
+import 'device.dart';
+import 'device_port_forwarder.dart';
+import 'project.dart';
+
+/// A remote device represents an attached to device that was not
+/// discovered through a device discoverer.
+///
+/// This can only be used from `flutter atttach --debug-url=`.
+class RemoteDevice extends Device {
+  RemoteDevice() : super('remote', category: Category.desktop, platformType: PlatformType.custom, ephemeral: true);
+
+  @override
+  void clearLogs() { }
+
+  @override
+  Future<void> dispose() async { }
+
+  @override
+  Future<String> get emulatorId async => null;
+
+  @override
+  FutureOr<DeviceLogReader> getLogReader({covariant ApplicationPackage app, bool includePastLogs = false}) {
+    return NoOpDeviceLogReader(id);
+  }
+
+  @override
+  Future<bool> installApp(covariant ApplicationPackage app, {String userIdentifier}) async {
+    return false;
+  }
+
+  @override
+  Future<bool> isAppInstalled(covariant ApplicationPackage app, {String userIdentifier}) async {
+    return false;
+  }
+
+  @override
+  Future<bool> isLatestBuildInstalled(covariant ApplicationPackage app) async {
+    return false;
+  }
+
+  @override
+  Future<bool> get isLocalEmulator async => false;
+
+  @override
+  bool isSupported() => true;
+
+  @override
+  bool isSupportedForProject(FlutterProject flutterProject) => true;
+
+  @override
+  String get name => id;
+
+  @override
+  DevicePortForwarder get portForwarder => const NoOpDevicePortForwarder();
+
+  @override
+  Future<String> get sdkNameAndVersion async => '';
+
+  @override
+  Future<LaunchResult> startApp(covariant ApplicationPackage package, {
+  	String mainPath,
+  	String route,
+  	DebuggingOptions debuggingOptions,
+  	Map<String, dynamic> platformArgs,
+  	bool prebuiltApplication = false,
+  	bool ipv6 = false,
+  	String userIdentifier,
+  }) async {
+    return LaunchResult.failed();
+  }
+
+  @override
+  Future<bool> stopApp(covariant ApplicationPackage app, {String userIdentifier}) async {
+    return false;
+  }
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.tester;
+
+  @override
+  Future<bool> uninstallApp(covariant ApplicationPackage app, {String userIdentifier}) async {
+    return false;
+  }
+}

--- a/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
@@ -13,93 +13,94 @@ import 'test_driver.dart';
 import 'test_utils.dart';
 
 void main() {
-  FlutterRunTestDriver _flutterRun, _flutterAttach;
+  FlutterRunTestDriver flutterRun;
+  FlutterRunTestDriver flutterAttach;
   final BasicProject _project = BasicProject();
   Directory tempDir;
 
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('attach_test.');
     await _project.setUpIn(tempDir);
-    _flutterRun = FlutterRunTestDriver(tempDir,    logPrefix: '   RUN  ');
-    _flutterAttach = FlutterRunTestDriver(
+    flutterRun = FlutterRunTestDriver(tempDir,    logPrefix: '   RUN  ');
+    flutterAttach = FlutterRunTestDriver(
       tempDir,
       logPrefix: 'ATTACH  ',
       // Only one DDS instance can be connected to the VM service at a time.
       // DDS can also only initialize if the VM service doesn't have any existing
-      // clients, so we'll just let _flutterRun be responsible for spawning DDS.
+      // clients, so we'll just let flutterRun be responsible for spawning DDS.
       spawnDdsInstance: false,
     );
   });
 
   tearDown(() async {
-    await _flutterAttach.detach();
-    await _flutterRun.stop();
+    await flutterAttach.detach();
+    await flutterRun.stop();
     tryToDelete(tempDir);
   });
 
   testWithoutContext('can hot reload', () async {
-    await _flutterRun.run(withDebugger: true);
-    await _flutterAttach.attach(_flutterRun.vmServicePort);
-    await _flutterAttach.hotReload();
+    await flutterRun.run(withDebugger: true);
+
+    await flutterAttach.attach(flutterRun.vmServiceHttp);
+    await flutterAttach.hotReload();
   });
 
   testWithoutContext('can detach, reattach, hot reload', () async {
-    await _flutterRun.run(withDebugger: true);
-    await _flutterAttach.attach(_flutterRun.vmServicePort);
-    await _flutterAttach.detach();
-    await _flutterAttach.attach(_flutterRun.vmServicePort);
-    await _flutterAttach.hotReload();
+    await flutterRun.run(withDebugger: true);
+    await flutterAttach.attach(flutterRun.vmServiceHttp);
+    await flutterAttach.detach();
+    await flutterAttach.attach(flutterRun.vmServiceHttp);
+    await flutterAttach.hotReload();
   });
 
   testWithoutContext('killing process behaves the same as detach ', () async {
-    await _flutterRun.run(withDebugger: true);
-    await _flutterAttach.attach(_flutterRun.vmServicePort);
-    await _flutterAttach.quit();
-    _flutterAttach = FlutterRunTestDriver(
+    await flutterRun.run(withDebugger: true);
+    await flutterAttach.attach(flutterRun.vmServiceHttp);
+    await flutterAttach.quit();
+    flutterAttach = FlutterRunTestDriver(
       tempDir,
       logPrefix: 'ATTACH-2',
       spawnDdsInstance: false,
     );
-    await _flutterAttach.attach(_flutterRun.vmServicePort);
-    await _flutterAttach.hotReload();
+    await flutterAttach.attach(flutterRun.vmServiceHttp);
+    await flutterAttach.hotReload();
   });
 
   testWithoutContext('sets activeDevToolsServerAddress extension', () async {
-    await _flutterRun.run(
+    await flutterRun.run(
       startPaused: true,
       withDebugger: true,
       additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9105'],
     );
-    await _flutterRun.resume();
+    await flutterRun.resume();
     await pollForServiceExtensionValue<String>(
-      testDriver: _flutterRun,
+      testDriver: flutterRun,
       extension: 'ext.flutter.activeDevToolsServerAddress',
       continuePollingValue: '',
       matches: equals('http://127.0.0.1:9105'),
     );
     await pollForServiceExtensionValue<String>(
-      testDriver: _flutterRun,
+      testDriver: flutterRun,
       extension: 'ext.flutter.connectedVmServiceUri',
       continuePollingValue: '',
       matches: isNotEmpty,
     );
 
-    final Response response = await _flutterRun.callServiceExtension('ext.flutter.connectedVmServiceUri');
+    final Response response = await flutterRun.callServiceExtension('ext.flutter.connectedVmServiceUri');
     final String vmServiceUri = response.json['value'] as String;
-
     // Attach with a different DevTools server address.
-    await _flutterAttach.attach(
-      _flutterRun.vmServicePort,
+    await flutterAttach.attach(
+      flutterRun.vmServiceHttp,
       additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9110'],
     );
     await pollForServiceExtensionValue<String>(
-      testDriver: _flutterAttach,
+      testDriver: flutterAttach,
       extension: 'ext.flutter.activeDevToolsServerAddress',
       continuePollingValue: '',
       matches: equals('http://127.0.0.1:9110'),
     );
     await pollForServiceExtensionValue<String>(
-      testDriver: _flutterRun,
+      testDriver: flutterRun,
       extension: 'ext.flutter.connectedVmServiceUri',
       continuePollingValue: '',
       matches: equals(vmServiceUri),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83127

Also removes use of --no-service-auth-code from attach tests