### PR TITLE
Migrate build_system, exceptions, and source to null safety

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -48,7 +48,7 @@ import 'src/commands/update_packages.dart';
 import 'src/commands/upgrade.dart';
 import 'src/devtools_launcher.dart';
 import 'src/features.dart';
-import 'src/globals.dart' as globals;
+import 'src/globals_null_migrated.dart' as globals;
 // Files in `isolated` are intentionally excluded from google3 tooling.
 import 'src/isolated/mustache_template.dart';
 import 'src/isolated/resident_web_runner.dart';

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:async/async.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
@@ -40,7 +38,7 @@ class BuildSystemConfig {
   /// The maximum number of concurrent tasks the build system will run.
   ///
   /// If not provided, defaults to [platform.numberOfProcessors].
-  final int resourcePoolSize;
+  final int? resourcePoolSize;
 }
 
 /// A Target describes a single step during a flutter build.
@@ -322,18 +320,18 @@ class Environment {
   ///
   /// [engineVersion] should be set to null for local engine builds.
   factory Environment({
-    @required Directory projectDir,
-    @required Directory outputDir,
-    @required Directory cacheDir,
-    @required Directory flutterRootDir,
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Artifacts artifacts,
-    @required ProcessManager processManager,
-    @required Platform platform,
-    @required String engineVersion,
-    @required bool generateDartPluginRegistry,
-    Directory buildDir,
+    required Directory projectDir,
+    required Directory outputDir,
+    required Directory cacheDir,
+    required Directory flutterRootDir,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Artifacts artifacts,
+    required ProcessManager processManager,
+    required Platform platform,
+    String? engineVersion,
+    required bool generateDartPluginRegistry,
+    Directory? buildDir,
     Map<String, String> defines = const <String, String>{},
     Map<String, String> inputs = const <String, String>{},
   }) {
@@ -382,20 +380,20 @@ class Environment {
   /// Any directories not provided will fallback to a [testDirectory]
   @visibleForTesting
   factory Environment.test(Directory testDirectory, {
-    Directory projectDir,
-    Directory outputDir,
-    Directory cacheDir,
-    Directory flutterRootDir,
-    Directory buildDir,
+    Directory? projectDir,
+    Directory? outputDir,
+    Directory? cacheDir,
+    Directory? flutterRootDir,
+    Directory? buildDir,
     Map<String, String> defines = const <String, String>{},
     Map<String, String> inputs = const <String, String>{},
-    String engineVersion,
-    Platform platform,
+    String? engineVersion,
+    Platform? platform,
     bool generateDartPluginRegistry = false,
-    @required FileSystem fileSystem,
-    @required Logger logger,
-    @required Artifacts artifacts,
-    @required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required Logger logger,
+    required Artifacts artifacts,
+    required ProcessManager processManager,
   }) {
     return Environment(
       projectDir: projectDir ?? testDirectory,
@@ -416,21 +414,21 @@ class Environment {
   }
 
   Environment._({
-    @required this.outputDir,
-    @required this.projectDir,
-    @required this.buildDir,
-    @required this.rootBuildDir,
-    @required this.cacheDir,
-    @required this.defines,
-    @required this.flutterRootDir,
-    @required this.processManager,
-    @required this.platform,
-    @required this.logger,
-    @required this.fileSystem,
-    @required this.artifacts,
-    @required this.engineVersion,
-    @required this.inputs,
-    @required this.generateDartPluginRegistry,
+    required this.outputDir,
+    required this.projectDir,
+    required this.buildDir,
+    required this.rootBuildDir,
+    required this.cacheDir,
+    required this.defines,
+    required this.flutterRootDir,
+    required this.processManager,
+    required this.platform,
+    required this.logger,
+    required this.fileSystem,
+    required this.artifacts,
+    this.engineVersion,
+    required this.inputs,
+    required this.generateDartPluginRegistry,
   });
 
   /// The [Source] value which is substituted with the path to [projectDir].
@@ -509,7 +507,7 @@ class Environment {
   final FileSystem fileSystem;
 
   /// The version of the current engine, or `null` if built with a local engine.
-  final String engineVersion;
+  final String? engineVersion;
 
   /// Whether to generate the Dart plugin registry.
   /// When [true], the main entrypoint is wrapped and the wrapper becomes
@@ -520,7 +518,7 @@ class Environment {
 /// The result information from the build system.
 class BuildResult {
   BuildResult({
-    @required this.success,
+    required this.success,
     this.exceptions = const <String, ExceptionMeasurement>{},
     this.performance = const <String, PerformanceMeasurement>{},
     this.inputFiles = const <File>[],
@@ -555,15 +553,15 @@ abstract class BuildSystem {
   Future<BuildResult> buildIncremental(
     Target target,
     Environment environment,
-    BuildResult previousBuild,
+    BuildResult? previousBuild,
   );
 }
 
 class FlutterBuildSystem extends BuildSystem {
   const FlutterBuildSystem({
-    @required FileSystem fileSystem,
-    @required Platform platform,
-    @required Logger logger,
+    required FileSystem fileSystem,
+    required Platform platform,
+    required Logger logger,
   }) : _fileSystem = fileSystem,
        _platform = platform,
        _logger = logger;
@@ -649,12 +647,12 @@ class FlutterBuildSystem extends BuildSystem {
   Future<BuildResult> buildIncremental(
     Target target,
     Environment environment,
-    BuildResult previousBuild,
+    BuildResult? previousBuild,
   ) async {
     environment.buildDir.createSync(recursive: true);
     environment.outputDir.createSync(recursive: true);
 
-    FileStore fileCache;
+    FileStore? fileCache;
     if (previousBuild == null || _incrementalFileStore[previousBuild] == null) {
       final File cacheFile = environment.buildDir.childFile(FileStore.kFileCache);
       fileCache = FileStore(
@@ -668,7 +666,7 @@ class FlutterBuildSystem extends BuildSystem {
     final Node node = target._toNode(environment);
     final _BuildInstance buildInstance = _BuildInstance(
       environment: environment,
-      fileCache: fileCache,
+      fileCache: fileCache!,
       buildSystemConfig: const BuildSystemConfig(),
       logger: _logger,
       fileSystem: _fileSystem,
@@ -733,7 +731,7 @@ class FlutterBuildSystem extends BuildSystem {
       // edited .last_config or deleted .dart_tool.
       return;
     }
-    final List<String> lastOutputs = (json.decode(outputsFile.readAsStringSync()) as List<Object>)
+    final List<String> lastOutputs = (json.decode(outputsFile.readAsStringSync()) as List<Object?>)
       .cast<String>();
     for (final String lastOutput in lastOutputs) {
       if (!currentOutputs.containsKey(lastOutput)) {
@@ -747,12 +745,12 @@ class FlutterBuildSystem extends BuildSystem {
 /// An active instance of a build.
 class _BuildInstance {
   _BuildInstance({
-    this.environment,
-    this.fileCache,
-    this.buildSystemConfig,
-    this.logger,
-    this.fileSystem,
-    Platform platform,
+    required this.environment,
+    required this.fileCache,
+    required this.buildSystemConfig,
+    required this.logger,
+    required this.fileSystem,
+    Platform? platform,
   })
     : resourcePool = Pool(buildSystemConfig.resourcePoolSize ?? platform?.numberOfProcessors ?? 1);
 
@@ -889,7 +887,7 @@ class ExceptionMeasurement {
   ExceptionMeasurement(this.target, this.exception, this.stackTrace, {this.fatal = false});
 
   final String target;
-  final dynamic exception;
+  final Object? exception;
   final StackTrace stackTrace;
 
   /// Whether this exception was a fatal build system error.
@@ -902,11 +900,11 @@ class ExceptionMeasurement {
 /// Helper class to collect measurement data.
 class PerformanceMeasurement {
   PerformanceMeasurement({
-    @required this.target,
-    @required this.elapsedMilliseconds,
-    @required this.skipped,
-    @required this.succeeded,
-    @required this.analyticsName,
+    required this.target,
+    required this.elapsedMilliseconds,
+    required this.skipped,
+    required this.succeeded,
+    required this.analyticsName,
   });
 
   final int elapsedMilliseconds;
@@ -984,7 +982,7 @@ class Node {
       _dirty = true;
       return;
     }
-    Map<String, Object> values;
+    Map<String, Object?>? values;
     try {
       values = castStringKeyedMap(json.decode(content));
     } on FormatException {
@@ -992,11 +990,11 @@ class Node {
       _dirty = true;
       return;
     }
-    final Object inputs = values['inputs'];
-    final Object outputs = values['outputs'];
-    if (inputs is List<Object> && outputs is List<Object>) {
-      inputs?.cast<String>()?.forEach(previousInputs.add);
-      outputs?.cast<String>()?.forEach(previousOutputs.add);
+    final Object? inputs = values?['inputs'];
+    final Object? outputs = values?['outputs'];
+    if (inputs is List<Object?> && outputs is List<Object?>) {
+      inputs.cast<String?>().whereType<String>().forEach(previousInputs.add);
+      outputs.cast<String?>().whereType<String>().forEach(previousOutputs.add);
     } else {
       // The json is malformed in some way.
       _dirty = true;
@@ -1067,9 +1065,9 @@ class Node {
       }
 
       final String absolutePath = file.path;
-      final String previousAssetKey = fileStore.previousAssetKeys[absolutePath];
+      final String? previousAssetKey = fileStore.previousAssetKeys[absolutePath];
       if (fileStore.currentAssetKeys.containsKey(absolutePath)) {
-        final String currentHash = fileStore.currentAssetKeys[absolutePath];
+        final String? currentHash = fileStore.currentAssetKeys[absolutePath];
         if (currentHash != previousAssetKey) {
           final InvalidatedReason reason = _invalidate(InvalidatedReasonKind.inputChanged);
           reason.data.add(absolutePath);
@@ -1099,9 +1097,9 @@ class Node {
         continue;
       }
       final String absolutePath = file.path;
-      final String previousHash = fileStore.previousAssetKeys[absolutePath];
+      final String? previousHash = fileStore.previousAssetKeys[absolutePath];
       if (fileStore.currentAssetKeys.containsKey(absolutePath)) {
-        final String currentHash = fileStore.currentAssetKeys[absolutePath];
+        final String? currentHash = fileStore.currentAssetKeys[absolutePath];
         if (currentHash != previousHash) {
           final InvalidatedReason reason = _invalidate(InvalidatedReasonKind.outputChanged);
           reason.data.add(absolutePath);
@@ -1159,8 +1157,6 @@ class InvalidatedReason {
       case InvalidatedReasonKind.outputSetChanged:
         return 'The following outputs were removed from the output set: ${data.join(',')}';
     }
-    assert(false);
-    return null;
   }
 }
 

--- a/packages/flutter_tools/lib/src/build_system/exceptions.dart
+++ b/packages/flutter_tools/lib/src/build_system/exceptions.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import '../base/file_system.dart';
 
 import 'build_system.dart';

--- a/packages/flutter_tools/lib/src/build_system/source.dart
+++ b/packages/flutter_tools/lib/src/build_system/source.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import '../artifacts.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
@@ -76,7 +74,7 @@ class SourceVisitor implements ResolvedFiles {
         .replaceAllMapped(_separatorExpr, (Match match) => '${match.group(1)}\n')
         .split('\n')
     // Expand escape sequences, so that '\ ', for example,ß becomes ' '
-        .map<String>((String path) => path.replaceAllMapped(_escapeExpr, (Match match) => match.group(1)).trim())
+        .map<String>((String path) => path.replaceAllMapped(_escapeExpr, (Match match) => match.group(1)!).trim())
         .where((String path) => path.isNotEmpty)
         .toSet()
         .map(environment.fileSystem.file);
@@ -93,7 +91,7 @@ class SourceVisitor implements ResolvedFiles {
     final List<String> segments = <String>[];
     final List<String> rawParts = pattern.split('/');
     final bool hasWildcard = rawParts.last.contains('*');
-    String wildcardFile;
+    String? wildcardFile;
     if (hasWildcard) {
       wildcardFile = rawParts.removeLast();
     }
@@ -141,7 +139,7 @@ class SourceVisitor implements ResolvedFiles {
     // example, `foo_*_.dart`. We want to match `foo_b_.dart` but not
     // `foo_.dart`. To do so, we first subtract the first section from the
     // string if the first segment matches.
-    final List<String> wildcardSegments = wildcardFile.split('*');
+    final List<String> wildcardSegments = wildcardFile?.split('*') ?? <String>[];
     if (wildcardSegments.length > 2) {
       throw InvalidPatternException(pattern);
     }
@@ -171,7 +169,7 @@ class SourceVisitor implements ResolvedFiles {
   /// To increase the performance of builds that use a known revision of Flutter,
   /// these are updated to point towards the engine.version file instead of
   /// the artifact itself.
-  void visitArtifact(Artifact artifact, TargetPlatform platform, BuildMode mode) {
+  void visitArtifact(Artifact artifact, TargetPlatform? platform, BuildMode? mode) {
     // This is not a local engine.
     if (environment.engineVersion != null) {
       sources.add(environment.flutterRootDir
@@ -232,7 +230,7 @@ abstract class Source {
   /// The source is provided by an [Artifact].
   ///
   /// If [artifact] points to a directory then all child files are included.
-  const factory Source.artifact(Artifact artifact, {TargetPlatform platform, BuildMode mode}) = _ArtifactSource;
+  const factory Source.artifact(Artifact artifact, {TargetPlatform? platform, BuildMode? mode}) = _ArtifactSource;
 
   /// The source is provided by an [HostArtifact].
   ///
@@ -269,8 +267,8 @@ class _ArtifactSource implements Source {
   const _ArtifactSource(this.artifact, { this.platform, this.mode });
 
   final Artifact artifact;
-  final TargetPlatform platform;
-  final BuildMode mode;
+  final TargetPlatform? platform;
+  final BuildMode? mode;
 
   @override
   void accept(SourceVisitor visitor) => visitor.visitArtifact(artifact, platform, mode);

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -21,7 +21,7 @@ import 'build_system/targets/common.dart';
 import 'cache.dart';
 import 'convert.dart';
 import 'devfs.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 import 'project.dart';
 
 String get defaultMainPath => globals.fs.path.join('lib', 'main.dart');

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -10,7 +10,7 @@ import '../build_info.dart';
 import '../commands/build_linux.dart';
 import '../commands/build_macos.dart';
 import '../commands/build_windows.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import 'build_aar.dart';
 import 'build_apk.dart';

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -18,7 +18,7 @@ import '../build_system/build_system.dart';
 import '../build_system/targets/ios.dart';
 import '../cache.dart';
 import '../flutter_plugins.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../macos/cocoapod_utils.dart';
 import '../project.dart';
 import '../runner/flutter_command.dart' show DevelopmentArtifact, FlutterCommandResult;

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -14,7 +14,7 @@ import '../cache.dart';
 import '../dart/generate_synthetic_packages.dart';
 import '../dart/pub.dart';
 import '../flutter_plugins.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -6,7 +6,6 @@
 
 import 'android/gradle_utils.dart';
 import 'base/context.dart';
-import 'build_system/build_system.dart';
 import 'device.dart';
 import 'doctor.dart';
 import 'fuchsia/fuchsia_sdk.dart';
@@ -21,7 +20,6 @@ import 'runner/local_engine.dart';
 
 export 'globals_null_migrated.dart';
 
-BuildSystem get buildSystem => context.get<BuildSystem>();
 CrashReporter get crashReporter => context.get<CrashReporter>();
 Doctor get doctor => context.get<Doctor>();
 DeviceManager get deviceManager => context.get<DeviceManager>();

--- a/packages/flutter_tools/lib/src/globals_null_migrated.dart
+++ b/packages/flutter_tools/lib/src/globals_null_migrated.dart
@@ -23,6 +23,7 @@ import 'base/template.dart';
 import 'base/terminal.dart';
 import 'base/time.dart';
 import 'base/user_messages.dart';
+import 'build_system/build_system.dart';
 import 'cache.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_parser.dart';
@@ -33,6 +34,7 @@ import 'reporting/reporting.dart';
 import 'version.dart';
 
 Artifacts? get artifacts => context.get<Artifacts>();
+BuildSystem? get buildSystem => context.get<BuildSystem>();
 Cache get cache => context.get<Cache>()!;
 Config get config => context.get<Config>()!;
 HttpClientFactory? get httpClientFactory => context.get<HttpClientFactory>();

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -35,7 +35,7 @@ import 'convert.dart';
 import 'devfs.dart';
 import 'device.dart';
 import 'features.dart';
-import 'globals.dart' as globals;
+import 'globals_null_migrated.dart' as globals;
 import 'project.dart';
 import 'resident_devtools_handler.dart';
 import 'run_cold.dart';

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -13,7 +13,7 @@ import '../build_system/build_system.dart';
 import '../build_system/targets/web.dart';
 import '../cache.dart';
 import '../flutter_plugins.dart';
-import '../globals.dart' as globals;
+import '../globals_null_migrated.dart' as globals;
 import '../platform_plugins.dart';
 import '../plugins.dart';
 import '../project.dart';

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:file/memory.dart';
@@ -21,15 +19,15 @@ import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
 
 void main() {
-  FileSystem fileSystem;
-  Environment environment;
-  Target fooTarget;
-  Target barTarget;
-  Target fizzTarget;
-  Target sharedTarget;
-  int fooInvocations;
-  int barInvocations;
-  int shared;
+  late FileSystem fileSystem;
+  late Environment environment;
+  late Target fooTarget;
+  late Target barTarget;
+  late Target fizzTarget;
+  late Target sharedTarget;
+  late int fooInvocations;
+  late int barInvocations;
+  late int shared;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -136,7 +134,7 @@ void main() {
 
     expect(stampFile, exists);
 
-    final Map<String, dynamic> stampContents = castStringKeyedMap(
+    final Map<String, Object?>? stampContents = castStringKeyedMap(
       json.decode(stampFile.readAsStringSync()));
 
     expect(stampContents, containsPair('inputs', <Object>['/foo.dart']));
@@ -312,7 +310,7 @@ void main() {
   testWithoutContext('Can describe itself with JSON output', () {
     environment.buildDir.createSync(recursive: true);
 
-    expect(fooTarget.toJson(environment), <String, dynamic>{
+    expect(fooTarget.toJson(environment), <String, Object?>{
       'inputs':  <Object>[
         '/foo.dart',
       ],
@@ -685,7 +683,7 @@ void main() {
 
 }
 
-BuildSystem setUpBuildSystem(FileSystem fileSystem, [FakePlatform platform]) {
+BuildSystem setUpBuildSystem(FileSystem fileSystem, [FakePlatform? platform]) {
   return FlutterBuildSystem(
     fileSystem: fileSystem,
     logger: BufferLogger.test(),
@@ -694,16 +692,17 @@ BuildSystem setUpBuildSystem(FileSystem fileSystem, [FakePlatform platform]) {
 }
 
 class TestTarget extends Target {
-  TestTarget([this._build, this._canSkip]);
+  TestTarget([Future<void> Function(Environment environment)? build, this._canSkip])
+      : _build = build ?? ((Environment environment) async {});
 
   final Future<void> Function(Environment environment) _build;
 
-  final bool Function(Environment environment) _canSkip;
+  final bool Function(Environment environment)? _canSkip;
 
   @override
   bool canSkip(Environment environment) {
     if (_canSkip != null) {
-      return _canSkip(environment);
+      return _canSkip!(environment);
     }
     return super.canSkip(environment);
   }

--- a/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/exceptions_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/build_system/exceptions.dart';
@@ -65,12 +63,8 @@ void main() {
 }
 
 class TestTarget extends Target {
-  TestTarget([this._build]);
-
-  final Future<void> Function(Environment environment) _build;
-
   @override
-  Future<void> build(Environment environment) => _build(environment);
+  Future<void> build(Environment environment) async {}
 
   @override
   List<Target> dependencies = <Target>[];

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -18,7 +18,7 @@ import 'package:flutter_tools/src/commands/build_linux.dart';
 import 'package:flutter_tools/src/commands/build_macos.dart';
 import 'package:flutter_tools/src/commands/build_web.dart';
 import 'package:flutter_tools/src/commands/build_windows.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/src/test_build_system.dart
+++ b/packages/flutter_tools/test/src/test_build_system.dart
@@ -34,7 +34,7 @@ class TestBuildSystem implements BuildSystem {
   @override
   Future<BuildResult> build(Target target, Environment environment, {BuildSystemConfig buildSystemConfig = const BuildSystemConfig()}) async {
     if (_onRun != null) {
-      _onRun!(target, environment);
+      _onRun?.call(target, environment);
     }
     if (_exception != null) {
       throw _exception!;
@@ -51,7 +51,7 @@ class TestBuildSystem implements BuildSystem {
   @override
   Future<BuildResult> buildIncremental(Target target, Environment environment, BuildResult? previousBuild) async {
     if (_onRun != null) {
-      _onRun!(target, environment);
+      _onRun?.call(target, environment);
     }
     if (_exception != null) {
       throw _exception!;

--- a/packages/flutter_tools/test/src/test_build_system.dart
+++ b/packages/flutter_tools/test/src/test_build_system.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_tools/src/build_system/build_system.dart';
@@ -28,21 +26,21 @@ class TestBuildSystem implements BuildSystem {
       _onRun = null;
 
   final List<BuildResult> _results;
-  final BuildResult _singleResult;
-  final dynamic _exception;
-  final void Function(Target target, Environment environment) _onRun;
+  final BuildResult? _singleResult;
+  final Object? _exception;
+  final void Function(Target target, Environment environment)? _onRun;
   int _nextResult = 0;
 
   @override
   Future<BuildResult> build(Target target, Environment environment, {BuildSystemConfig buildSystemConfig = const BuildSystemConfig()}) async {
     if (_onRun != null) {
-      _onRun(target, environment);
+      _onRun!(target, environment);
     }
     if (_exception != null) {
-      throw _exception;
+      throw _exception!;
     }
     if (_singleResult != null) {
-      return _singleResult;
+      return _singleResult!;
     }
     if (_nextResult >= _results.length) {
       throw StateError('Unexpected build request of ${target.name}');
@@ -51,15 +49,15 @@ class TestBuildSystem implements BuildSystem {
   }
 
   @override
-  Future<BuildResult> buildIncremental(Target target, Environment environment, BuildResult previousBuild) async {
+  Future<BuildResult> buildIncremental(Target target, Environment environment, BuildResult? previousBuild) async {
     if (_onRun != null) {
-      _onRun(target, environment);
+      _onRun!(target, environment);
     }
     if (_exception != null) {
-      throw _exception;
+      throw _exception!;
     }
     if (_singleResult != null) {
-      return _singleResult;
+      return _singleResult!;
     }
     if (_nextResult >= _results.length) {
       throw StateError('Unexpected buildIncremental request of ${target.name}');


### PR DESCRIPTION
`build_system`, `exceptions`, and `source` all imported each other, and needed to migrate together.
Move `globals.buildSystem` to `globals_null_migrated`, update imports where possible.

Part of #71511