### PR TITLE
[flutter_tools] fix top web crasher

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -660,37 +660,15 @@ class WebDevFS implements DevFS {
 
   Dwds get dwds => webAssetServer.dwds;
 
-  Future<DebugConnection> _cachedExtensionFuture;
-  StreamSubscription<void> _connectedApps;
+  @visibleForTesting
+  Future<DebugConnection> cachedExtensionFuture;
+
+  @visibleForTesting
+  StreamSubscription<void> connectedApps;
 
   /// Connect and retrieve the [DebugConnection] for the current application.
   Future<ConnectionResult> connect(bool useDebugExtension) {
-    final Completer<ConnectionResult> firstConnection = Completer<ConnectionResult>();
-    _connectedApps = dwds.connectedApps.listen((AppConnection appConnection) async {
-      try {
-        final DebugConnection debugConnection = useDebugExtension
-            ? await (_cachedExtensionFuture ??=
-                dwds.extensionDebugConnections.stream.first)
-            : await dwds.debugConnection(appConnection);
-        if (!firstConnection.isCompleted) {
-          final vm_service.VmService vmService = await createVmServiceDelegate(
-            Uri.parse(debugConnection.uri),
-            logger: globals.logger,
-          );
-          firstConnection.complete(ConnectionResult(appConnection, debugConnection, vmService));
-        }
-      } on Exception catch (error, stackTrace) {
-        if (!firstConnection.isCompleted) {
-          firstConnection.completeError(error, stackTrace);
-        }
-      }
-    }, onError: (dynamic error, StackTrace stackTrace) {
-      globals.printError('Unknown error while waiting for debug connection:$error\n$stackTrace');
-      if (!firstConnection.isCompleted) {
-        firstConnection.completeError(error, stackTrace);
-      }
-    });
-    return firstConnection.future;
+    return connectToApplication(useDebugExtension, this, globals.logger, createVmServiceDelegate);
   }
 
   @override
@@ -745,7 +723,7 @@ class WebDevFS implements DevFS {
   @override
   Future<void> destroy() async {
     await webAssetServer.dispose();
-    await _connectedApps?.cancel();
+    await connectedApps?.cancel();
   }
 
   @override
@@ -1060,3 +1038,35 @@ To serve from a subpath "foo" (i.e. http://localhost:8080/foo/ instead of http:/
 
 For more information, see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 ''';
+
+
+/// Connect and retrieve the [DebugConnection] for the current application.
+@visibleForTesting
+Future<ConnectionResult> connectToApplication(bool useDebugExtension, WebDevFS devFS, Logger logger, Future<vm_service.VmService> Function(Uri, {Logger logger}) createVmService) {
+  final Completer<ConnectionResult> firstConnection = Completer<ConnectionResult>();
+  devFS.connectedApps = devFS.dwds.connectedApps.listen((AppConnection appConnection) async {
+    try {
+      final DebugConnection debugConnection = useDebugExtension
+          ? await (devFS.cachedExtensionFuture ??=
+              devFS.dwds.extensionDebugConnections.stream.first)
+          : await devFS.dwds.debugConnection(appConnection);
+      if (!firstConnection.isCompleted) {
+        final vm_service.VmService vmService = await createVmService(
+          Uri.parse(debugConnection.uri),
+          logger: logger,
+        );
+        firstConnection.complete(ConnectionResult(appConnection, debugConnection, vmService));
+      }
+    } on Exception catch (error, stackTrace) {
+      if (!firstConnection.isCompleted) {
+        firstConnection.completeError(error, stackTrace);
+      }
+    }
+  }, onError: (dynamic error, StackTrace stackTrace) {
+    logger.printError('Unknown error while waiting for debug connection:$error\n$stackTrace');
+    if (!firstConnection.isCompleted) {
+      firstConnection.completeError(error, stackTrace);
+    }
+  });
+  return firstConnection.future;
+}

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -23,12 +23,12 @@ import 'package:flutter_tools/src/web/compile.dart';
 import 'package:package_config/package_config.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/fake.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_vm_services.dart';
 import '../../src/testbed.dart';
-import '../cold_test.dart';
 
 const List<int> kTransparentImage = <int>[
   0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49,
@@ -1163,3 +1163,5 @@ class FakeDebugConnection extends Fake implements DebugConnection {
   @override
   String get uri => '';
 }
+
+class FakeVmService extends Fake implements vm_service.VmService {}


### PR DESCRIPTION
Fixes the error:

StateError: Bad State: cannot add event after closing
at  _streamController.add
at  _StreamSinkWrapper.add
at  AppConnection.runMain

IIRC this was added before we added the isolate start subscription and auto run main in https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart#L601, so it should not be necessary any more