### PR TITLE
Mark new_gallery__crane_perf unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -956,7 +956,6 @@ targets:
 
   - name: linux_new_gallery__crane_perf
     builder: Linux new_gallery__crane_perf
-    bringup: true
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Last 50 runs flaky and failed number is 0.  15 day flake ratio is under 2%.

Marked flaky in https://github.com/flutter/flutter/pull/82754.  See also https://github.com/flutter/flutter/issues/82745