### PR TITLE
Mark linux_large_image_changer_perf_android unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -935,7 +935,6 @@ targets:
 
   - name: linux_large_image_changer_perf_android
     builder: Linux large_image_changer_perf_android
-    bringup: true
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Last 50 runs flaky and failed number is 0.  15 day flake ratio is under 2%.

Marked flaky in https://github.com/flutter/flutter/pull/82754.  Likely fixed by https://github.com/flutter/flutter/pull/82739.  See https://github.com/flutter/flutter/issues/82747.