### PR TITLE
[flutter_tools] throw a tool exit if pub cannot be run

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -148,7 +148,8 @@ class _DefaultPub implements Pub {
        _processUtils = ProcessUtils(
          logger: logger,
          processManager: processManager,
-       );
+       ),
+       _processManager = processManager;
 
   final FileSystem _fileSystem;
   final Logger _logger;
@@ -156,6 +157,7 @@ class _DefaultPub implements Pub {
   final Platform _platform;
   final BotDetector _botDetector;
   final Usage _usage;
+  final ProcessManager _processManager;
 
   @override
   Future<void> get({
@@ -391,11 +393,15 @@ class _DefaultPub implements Pub {
       'cache',
       'dart-sdk',
       'bin',
-      if (_platform.isWindows)
-        'pub.bat'
-      else
-        'pub'
+      'pub',
     ]);
+    if (!_processManager.canRun(sdkPath)) {
+      throwToolExit(
+        'Your Flutter SDK download may be corrupt or missing permissions to run. '
+        'Try re-downloading the Flutter SDK into a directory that has read/write '
+        'permissions for the current user.'
+      );
+    }
     return <String>[sdkPath, ...arguments];
   }
 

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -22,6 +22,31 @@ void main() {
     Cache.flutterRoot = '';
   });
 
+  testWithoutContext('Throws a tool exit if pub cannot be run', () async {
+    final FakeProcessManager processManager = FakeProcessManager.empty();
+    final BufferLogger logger = BufferLogger.test();
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/pub');
+
+    fileSystem.file('pubspec.yaml').createSync();
+
+    final Pub pub = Pub(
+      fileSystem: fileSystem,
+      logger: logger,
+      processManager: processManager,
+      usage: TestUsage(),
+      platform: FakePlatform(
+        environment: const <String, String>{},
+      ),
+      botDetector: const BotDetectorAlwaysNo(),
+    );
+
+    await expectLater(() => pub.get(
+      context: PubContext.pubGet,
+      checkUpToDate: true,
+    ), throwsToolExit(message: 'Your Flutter SDK download may be corrupt or missing permissions to run'));
+  });
+
   testWithoutContext('checkUpToDate skips pub get if the package config is newer than the pubspec '
     'and the current framework version is the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.empty();


### PR DESCRIPTION
The current number one crasher is failing to run pub. Check if it can be run first and throw a tool exit instead.