### PR TITLE
Mark linux_platform_channels_benchmarks unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -967,7 +967,6 @@ targets:
 
   - name: linux_platform_channels_benchmarks
     builder: Linux platform_channels_benchmarks
-    bringup: true
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Last 50 runs flaky and failed number is 0.  15 day flake ratio is under 2%.

Marked flaky in https://github.com/flutter/flutter/pull/82754.  Likely fixed by https://github.com/flutter/flutter/pull/82762.
Fixes https://github.com/flutter/flutter/issues/82743.