### PR TITLE
Mark flutter_gallery_sksl_warmup__transition_perf_e2e as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -890,6 +890,7 @@ targets:
 
   - name: linux_flutter_gallery_sksl_warmup__transition_perf_e2e
     builder: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
+    bringup: true
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Flaky rate 2.67% is above 2% threshold.  Investigation in https://github.com/flutter/flutter/issues/83298.