### PR TITLE
rsync instead of delete and copy Flutter.xcframework for add to app

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -57,6 +57,8 @@ Future<void> main() async {
         );
       });
 
+      checkDirectoryExists(path.join(projectDir.path, '.ios', 'Flutter', 'engine', 'Flutter.xcframework'));
+
       final Directory ephemeralIOSHostApp = Directory(path.join(
         projectDir.path,
         'build',
@@ -89,6 +91,8 @@ Future<void> main() async {
           options: <String>['ios', '--no-codesign', '--profile'],
         );
       });
+
+      checkDirectoryExists(path.join(projectDir.path, '.ios', 'Flutter', 'engine', 'Flutter.xcframework'));
 
       if (!exists(ephemeralIOSHostApp)) {
         return TaskResult.failure('Failed to build ephemeral host .app');
@@ -126,6 +130,7 @@ Future<void> main() async {
       if (!exists(ephemeralSimulatorHostApp)) {
         return TaskResult.failure('Failed to build ephemeral host .app');
       }
+      checkFileExists(path.join(ephemeralSimulatorHostApp.path, 'Frameworks', 'Flutter.framework', 'Flutter'));
 
       if (!exists(File(path.join(
         ephemeralSimulatorHostApp.path,
@@ -170,6 +175,7 @@ Future<void> main() async {
           options: <String>['ios', '--no-codesign', '-v'],
         );
       });
+      checkDirectoryExists(path.join(projectDir.path, '.ios', 'Flutter', 'engine', 'Flutter.xcframework'));
 
       final bool ephemeralHostAppWithCocoaPodsBuilt = exists(ephemeralIOSHostApp);
 
@@ -189,6 +195,7 @@ Future<void> main() async {
       }
 
       checkFileExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'device_info.framework', 'device_info'));
+      checkFileExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'Flutter.framework', 'Flutter'));
 
       // Static, no embedded framework.
       checkDirectoryNotExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'google_sign_in.framework'));

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -144,8 +144,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
 
   # TODO(jmagman): use assemble copied engine in add-to-app.
   if [[ -e "${project_path}/.ios" ]]; then
-    RunCommand rm -rf -- "${derived_dir}/engine/Flutter.framework"
-    RunCommand cp -r -- "${flutter_framework}" "${derived_dir}/engine"
+    RunCommand rsync -av --delete --filter "- .DS_Store" "${flutter_framework}" "${derived_dir}/engine"
   fi
 
   RunCommand pushd "${project_path}" > /dev/null


### PR DESCRIPTION
Instead of deleting and copying the Flutter.xcframework every time the add to app module is built, instead `rsync` so only the updated files are changed (build mode changes, or the artifacts are updated).  This will allow Xcode's incremental compilation to detect there have been no changes, and not call the CocoaPods script that embeds and signs the unchanged framework.

See also https://github.com/flutter/flutter/pull/77756 for similar work.

Building host app time in seconds (subsequent runs match the 3rd time measurements):
|   | master |  this PR |
| ----------- | ----------- | ----------- |
| 1st |  9.0       | 8.7 |
| 2nd |   6.9      |5.5 |
| 3rd |   6.9      |3.3 |


https://github.com/flutter/flutter/issues/82161