### PR TITLE
Remove iOS version override in ios_add2appTests unit tests

### DIFF
--- a/dev/integration_tests/ios_add2app_life_cycle/ios_add2app.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_add2app_life_cycle/ios_add2app.xcodeproj/project.pbxproj
@@ -527,7 +527,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = ios_add2appTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -547,7 +546,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = ios_add2appTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
The `ios_add2app` unit tests should not be overriding the minimum version the app requires.  Remove the override, which will fallback to the project-level 12.0 version requirement.

https://github.com/flutter/flutter/blob/209c6a5deb69993d2885d06c008cf6094b4fc3c7/dev/integration_tests/ios_add2app_life_cycle/ios_add2app.xcodeproj/project.pbxproj#L414