### PR TITLE
Add ability to specify Image widget opacity as an animation

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -360,6 +360,8 @@ void debugFlushLastFrameImageSizeInfo() {
 ///
 ///  * `scale`: The number of image pixels for each logical pixel.
 ///
+///  * `opacity`: The opacity to paint the image onto the canvas with.
+///
 ///  * `colorFilter`: If non-null, the color filter to apply when painting the
 ///    image.
 ///
@@ -420,6 +422,7 @@ void paintImage({
   required ui.Image image,
   String? debugImageLabel,
   double scale = 1.0,
+  double opacity = 1.0,
   ColorFilter? colorFilter,
   BoxFit? fit,
   Alignment alignment = Alignment.center,
@@ -473,6 +476,7 @@ void paintImage({
   final Paint paint = Paint()..isAntiAlias = isAntiAlias;
   if (colorFilter != null)
     paint.colorFilter = colorFilter;
+  paint.color = Color.fromRGBO(0, 0, 0, opacity);
   paint.filterQuality = filterQuality;
   paint.invertColors = invertColors;
   final double halfWidthDelta = (outputSize.width - destinationSize.width) / 2.0;

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -446,7 +446,7 @@ class RenderImage extends RenderBox {
     properties.add(DoubleProperty('height', height, defaultValue: null));
     properties.add(DoubleProperty('scale', scale, defaultValue: 1.0));
     properties.add(ColorProperty('color', color, defaultValue: null));
-    properties.add(DiagnosticsProperty<Animation<double>?>('opacity', opacity));
+    properties.add(DiagnosticsProperty<Animation<double>?>('opacity', opacity, defaultValue: null));
     properties.add(EnumProperty<BlendMode>('colorBlendMode', colorBlendMode, defaultValue: null));
     properties.add(EnumProperty<BoxFit>('fit', fit, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));

--- a/packages/flutter/lib/src/rendering/image.dart
+++ b/packages/flutter/lib/src/rendering/image.dart
@@ -4,6 +4,8 @@
 
 import 'dart:ui' as ui show Image;
 
+import 'package:flutter/animation.dart';
+
 import 'box.dart';
 import 'object.dart';
 
@@ -31,6 +33,7 @@ class RenderImage extends RenderBox {
     double? height,
     double scale = 1.0,
     Color? color,
+    Animation<double>? opacity,
     BlendMode? colorBlendMode,
     BoxFit? fit,
     AlignmentGeometry alignment = Alignment.center,
@@ -52,6 +55,7 @@ class RenderImage extends RenderBox {
        _height = height,
        _scale = scale,
        _color = color,
+       _opacity = opacity,
        _colorBlendMode = colorBlendMode,
        _fit = fit,
        _alignment = alignment,
@@ -161,6 +165,21 @@ class RenderImage extends RenderBox {
     _color = value;
     _updateColorFilter();
     markNeedsPaint();
+  }
+
+  /// If non-null, the value from the [Animation] is multiplied with the opacity
+  /// of each image pixel before painting onto the canvas.
+  Animation<double>? get opacity => _opacity;
+  Animation<double>? _opacity;
+  set opacity(Animation<double>? value) {
+    if (value == _opacity)
+      return;
+
+    if (attached)
+      _opacity?.removeListener(markNeedsPaint);
+    _opacity = value;
+    if (attached)
+      value?.addListener(markNeedsPaint);
   }
 
   /// Used to set the filterQuality of the image
@@ -382,6 +401,18 @@ class RenderImage extends RenderBox {
   }
 
   @override
+  void attach(covariant PipelineOwner owner) {
+    super.attach(owner);
+    _opacity?.addListener(markNeedsPaint);
+  }
+
+  @override
+  void detach() {
+    _opacity?.removeListener(markNeedsPaint);
+    super.detach();
+  }
+
+  @override
   void paint(PaintingContext context, Offset offset) {
     if (_image == null)
       return;
@@ -394,6 +425,7 @@ class RenderImage extends RenderBox {
       image: _image!,
       debugImageLabel: debugImageLabel,
       scale: _scale,
+      opacity: _opacity?.value ?? 1.0,
       colorFilter: _colorFilter,
       fit: _fit,
       alignment: _resolvedAlignment!,
@@ -414,6 +446,7 @@ class RenderImage extends RenderBox {
     properties.add(DoubleProperty('height', height, defaultValue: null));
     properties.add(DoubleProperty('scale', scale, defaultValue: 1.0));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DiagnosticsProperty<Animation<double>?>('opacity', opacity));
     properties.add(EnumProperty<BlendMode>('colorBlendMode', colorBlendMode, defaultValue: null));
     properties.add(EnumProperty<BoxFit>('fit', fit, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui show Image, ImageFilter, TextHeightBehavior;
 
+import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -5915,6 +5916,7 @@ class RawImage extends LeafRenderObjectWidget {
     this.height,
     this.scale = 1.0,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -5960,6 +5962,13 @@ class RawImage extends LeafRenderObjectWidget {
 
   /// If non-null, this color is blended with each image pixel using [colorBlendMode].
   final Color? color;
+
+  /// If non-null, the value from the [Animation] is multiplied with the opacity
+  /// of each image pixel before painting onto the canvas.
+  ///
+  /// This is more efficient that using [FadeTransition] to change the opacity
+  /// of an image.
+  final Animation<double>? opacity;
 
   /// Used to set the filterQuality of the image
   /// Use the "low" quality setting to scale the image, which corresponds to
@@ -6070,6 +6079,7 @@ class RawImage extends LeafRenderObjectWidget {
       height: height,
       scale: scale,
       color: color,
+      opacity: opacity,
       colorBlendMode: colorBlendMode,
       fit: fit,
       alignment: alignment,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6132,6 +6132,7 @@ class RawImage extends LeafRenderObjectWidget {
     properties.add(DoubleProperty('height', height, defaultValue: null));
     properties.add(DoubleProperty('scale', scale, defaultValue: 1.0));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DiagnosticsProperty<Animation<double>?>('opacity', opacity, defaultValue: null));
     properties.add(EnumProperty<BlendMode>('colorBlendMode', colorBlendMode, defaultValue: null));
     properties.add(EnumProperty<BoxFit>('fit', fit, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5966,7 +5966,7 @@ class RawImage extends LeafRenderObjectWidget {
   /// If non-null, the value from the [Animation] is multiplied with the opacity
   /// of each image pixel before painting onto the canvas.
   ///
-  /// This is more efficient that using [FadeTransition] to change the opacity
+  /// This is more efficient than using [FadeTransition] to change the opacity
   /// of an image.
   final Animation<double>? opacity;
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -330,6 +330,7 @@ class Image extends StatefulWidget {
     this.width,
     this.height,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -389,6 +390,7 @@ class Image extends StatefulWidget {
     this.width,
     this.height,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -451,6 +453,7 @@ class Image extends StatefulWidget {
     this.width,
     this.height,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -612,6 +615,7 @@ class Image extends StatefulWidget {
     this.width,
     this.height,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -681,6 +685,7 @@ class Image extends StatefulWidget {
     this.width,
     this.height,
     this.color,
+    this.opacity,
     this.colorBlendMode,
     this.fit,
     this.alignment = Alignment.center,
@@ -921,6 +926,13 @@ class Image extends StatefulWidget {
 
   /// If non-null, this color is blended with each image pixel using [colorBlendMode].
   final Color? color;
+
+  /// If non-null, the value from the [Animation] is multiplied with the opacity
+  /// of each image pixel before painting onto the canvas.
+  ///
+  /// This is more efficient that using [FadeTransition] to change the opacity
+  /// of an image.
+  final Animation<double>? opacity;
 
   /// The rendering quality of the image.
   ///
@@ -1326,6 +1338,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
       height: widget.height,
       scale: _imageInfo?.scale ?? 1.0,
       color: widget.color,
+      opacity: widget.opacity,
       colorBlendMode: widget.colorBlendMode,
       fit: widget.fit,
       alignment: widget.alignment,

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1083,6 +1083,7 @@ class Image extends StatefulWidget {
     properties.add(DoubleProperty('width', width, defaultValue: null));
     properties.add(DoubleProperty('height', height, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DiagnosticsProperty<Animation<double>?>('opacity', opacity, defaultValue: null));
     properties.add(EnumProperty<BlendMode>('colorBlendMode', colorBlendMode, defaultValue: null));
     properties.add(EnumProperty<BoxFit>('fit', fit, defaultValue: null));
     properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -930,8 +930,15 @@ class Image extends StatefulWidget {
   /// If non-null, the value from the [Animation] is multiplied with the opacity
   /// of each image pixel before painting onto the canvas.
   ///
-  /// This is more efficient that using [FadeTransition] to change the opacity
-  /// of an image.
+  /// This is more efficient than using [FadeTransition] to change the opacity
+  /// of an image, since this avoids creating a new composited layer. Composited
+  /// layers may double memory usage as the image is painted onto an offscreen
+  /// render target.
+  ///
+  /// See also:
+  ///
+  ///  * [AlwaysStoppedAnimation], which allows you to create an [Animation]
+  ///    from a single opacity value.
   final Animation<double>? opacity;
 
   /// The rendering quality of the image.

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -43,14 +43,12 @@ class FadeInImageParts {
 }
 
 class FadeInImageElements {
-  const FadeInImageElements(this.rawImageElement, this.fadeTransitionElement);
+  const FadeInImageElements(this.rawImageElement);
 
   final Element rawImageElement;
-  final Element? fadeTransitionElement;
 
   RawImage get rawImage => rawImageElement.widget as RawImage;
-  FadeTransition? get fadeTransition => fadeTransitionElement?.widget as FadeTransition?;
-  double get opacity => fadeTransition == null ? 1 : fadeTransition!.opacity.value;
+  double get opacity => rawImage.opacity?.value ?? 1.0;
 }
 
 class LoadTestImageProvider extends ImageProvider<Object> {
@@ -78,11 +76,8 @@ FadeInImageParts findFadeInImage(WidgetTester tester) {
   final Iterable<Element> rawImageElements = tester.elementList(find.byType(RawImage));
   ComponentElement? fadeInImageElement;
   for (final Element rawImageElement in rawImageElements) {
-    Element? fadeTransitionElement;
     rawImageElement.visitAncestorElements((Element ancestor) {
-      if (ancestor.widget is FadeTransition) {
-        fadeTransitionElement = ancestor;
-      } else if (ancestor.widget is FadeInImage) {
+      if (ancestor.widget is FadeInImage) {
         if (fadeInImageElement == null) {
           fadeInImageElement = ancestor as ComponentElement;
         } else {
@@ -93,7 +88,7 @@ FadeInImageParts findFadeInImage(WidgetTester tester) {
       return true;
     });
     expect(fadeInImageElement, isNotNull);
-    elements.add(FadeInImageElements(rawImageElement, fadeTransitionElement));
+    elements.add(FadeInImageElements(rawImageElement));
   }
   if (elements.length == 2) {
     return FadeInImageParts(fadeInImageElement!, elements.last, elements.first);

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -753,6 +753,19 @@ void main() {
     expect(renderer.colorBlendMode, BlendMode.clear);
   });
 
+  testWidgets('Image opacity parameter', (WidgetTester tester) async {
+    const Animation<double> opacity = AlwaysStoppedAnimation<double>(0.5);
+    await tester.pumpWidget(
+      Image(
+        excludeFromSemantics: true,
+        image: _TestImageProvider(),
+        opacity: opacity,
+      ),
+    );
+    final RenderImage renderer = tester.renderObject<RenderImage>(find.byType(Image));
+    expect(renderer.opacity, opacity);
+  });
+
   testWidgets('Precache', (WidgetTester tester) async {
     final _TestImageProvider provider = _TestImageProvider();
     late Future<void> precache;
@@ -1717,6 +1730,57 @@ void main() {
     (WidgetTester tester) async {
       await _testRotatedImage(tester, true);
       await _testRotatedImage(tester, false);
+    },
+    skip: kIsWeb, // https://github.com/flutter/flutter/issues/54292.
+  );
+
+  testWidgets(
+    'Image opacity',
+    (WidgetTester tester) async {
+      final Key key = UniqueKey();
+      await tester.pumpWidget(RepaintBoundary(
+        key: key,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          textDirection: TextDirection.ltr,
+          children: <Widget>[
+            Image.memory(
+              Uint8List.fromList(kBlueRectPng),
+              opacity: const AlwaysStoppedAnimation<double>(0.25),
+            ),
+            Image.memory(
+              Uint8List.fromList(kBlueRectPng),
+              opacity: const AlwaysStoppedAnimation<double>(0.5),
+            ),
+            Image.memory(
+              Uint8List.fromList(kBlueRectPng),
+              opacity: const AlwaysStoppedAnimation<double>(0.75),
+            ),
+            Image.memory(
+              Uint8List.fromList(kBlueRectPng),
+              opacity: const AlwaysStoppedAnimation<double>(1.0),
+            ),
+          ],
+        ),
+      ));
+
+      // precacheImage is needed, or the image in the golden file will be empty.
+      if (!kIsWeb) {
+        final Finder allImages = find.byType(Image);
+        for (final Element e in allImages.evaluate()) {
+          await tester.runAsync(() async {
+            final Image image = e.widget as Image;
+            await precacheImage(image.image, e);
+          });
+        }
+        await tester.pumpAndSettle();
+      }
+
+      await expectLater(
+        find.byKey(key),
+        matchesGoldenFile('transparent_image.png'),
+      );
     },
     skip: kIsWeb, // https://github.com/flutter/flutter/issues/54292.
   );


### PR DESCRIPTION
This allows image fade in animations to avoid creating a composited layer, which avoids doubling memory usage. In the future, OpacityLayer should be able to avoid creating copies of images and other simple PictureLayers.

#75697 

New Golden image (25%, 50%, 75%, 100% opacity):
![image](https://user-images.githubusercontent.com/2268005/119581999-bcc70800-bd91-11eb-9a81-d05fa3b02943.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
