### PR TITLE
Migrate build system build.dart to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../artifacts.dart';
@@ -20,7 +17,7 @@ class SnapshotType {
   SnapshotType(this.platform, this.mode)
     : assert(mode != null);
 
-  final TargetPlatform platform;
+  final TargetPlatform? platform;
   final BuildMode mode;
 
   @override
@@ -30,9 +27,9 @@ class SnapshotType {
 /// Interface to the gen_snapshot command-line tool.
 class GenSnapshot {
   GenSnapshot({
-    @required Artifacts artifacts,
-    @required ProcessManager processManager,
-    @required Logger logger,
+    required Artifacts artifacts,
+    required ProcessManager processManager,
+    required Logger logger,
   }) : _artifacts = artifacts,
        _processUtils = ProcessUtils(logger: logger, processManager: processManager);
 
@@ -56,10 +53,11 @@ class GenSnapshot {
   };
 
   Future<int> run({
-    @required SnapshotType snapshotType,
-    DarwinArch darwinArch,
+    required SnapshotType snapshotType,
+    DarwinArch? darwinArch,
     Iterable<String> additionalArgs = const <String>[],
   }) {
+    assert(snapshotType.platform != TargetPlatform.ios || darwinArch != null);
     final List<String> args = <String>[
       ...additionalArgs,
     ];
@@ -69,12 +67,12 @@ class GenSnapshot {
     // iOS has a separate gen_snapshot for armv7 and arm64 in the same,
     // directory. So we need to select the right one.
     if (snapshotType.platform == TargetPlatform.ios) {
-      snapshotterPath += '_' + getNameForDarwinArch(darwinArch);
+      snapshotterPath += '_' + getNameForDarwinArch(darwinArch!);
     }
 
     return _processUtils.stream(
       <String>[snapshotterPath, ...args],
-      mapFunction: (String line) =>  kIgnoredWarnings.contains(line) ? null : line,
+      mapFunction: (String line) =>  kIgnoredWarnings.contains(line) ? '' : line,
     );
   }
 }
@@ -82,11 +80,11 @@ class GenSnapshot {
 class AOTSnapshotter {
   AOTSnapshotter({
     this.reportTimings = false,
-    @required Logger logger,
-    @required FileSystem fileSystem,
-    @required Xcode xcode,
-    @required ProcessManager processManager,
-    @required Artifacts artifacts,
+    required Logger logger,
+    required FileSystem fileSystem,
+    required Xcode xcode,
+    required ProcessManager processManager,
+    required Artifacts artifacts,
   }) : _logger = logger,
       _fileSystem = fileSystem,
       _xcode = xcode,
@@ -108,16 +106,16 @@ class AOTSnapshotter {
 
   /// Builds an architecture-specific ahead-of-time compiled snapshot of the specified script.
   Future<int> build({
-    @required TargetPlatform platform,
-    @required BuildMode buildMode,
-    @required String mainPath,
-    @required String outputPath,
-    DarwinArch darwinArch,
-    String sdkRoot,
+    required TargetPlatform platform,
+    required BuildMode buildMode,
+    required String mainPath,
+    required String outputPath,
+    DarwinArch? darwinArch,
+    String? sdkRoot,
     List<String> extraGenSnapshotOptions = const <String>[],
-    @required bool bitcode,
-    @required String splitDebugInfo,
-    @required bool dartObfuscation,
+    required bool bitcode,
+    String? splitDebugInfo,
+    required bool dartObfuscation,
     bool quiet = false,
   }) async {
     assert(platform != TargetPlatform.ios || darwinArch != null);
@@ -197,7 +195,7 @@ class AOTSnapshotter {
       // Faster async/await
       if (shouldSplitDebugInfo) ...<String>[
         '--dwarf-stack-traces',
-        '--save-debugging-info=${_fileSystem.path.join(splitDebugInfo, debugFilename)}'
+        '--save-debugging-info=${_fileSystem.path.join(splitDebugInfo!, debugFilename)}'
       ],
       if (dartObfuscation)
         '--obfuscate',
@@ -220,7 +218,7 @@ class AOTSnapshotter {
     // end-developer can link into their app.
     if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin) {
       final RunResult result = await _buildFramework(
-        appleArch: darwinArch,
+        appleArch: darwinArch!,
         isIOS: platform == TargetPlatform.ios,
         sdkRoot: sdkRoot,
         assemblyPath: assembly,
@@ -238,13 +236,13 @@ class AOTSnapshotter {
   /// Builds an iOS or macOS framework at [outputPath]/App.framework from the assembly
   /// source at [assemblyPath].
   Future<RunResult> _buildFramework({
-    @required DarwinArch appleArch,
-    @required bool isIOS,
-    @required String sdkRoot,
-    @required String assemblyPath,
-    @required String outputPath,
-    @required bool bitcode,
-    @required bool quiet
+    required DarwinArch appleArch,
+    required bool isIOS,
+    String? sdkRoot,
+    required String assemblyPath,
+    required String outputPath,
+    required bool bitcode,
+    required bool quiet
   }) async {
     final String targetArch = getNameForDarwinArch(appleArch);
     if (!quiet) {
@@ -262,7 +260,7 @@ class AOTSnapshotter {
 
     const String embedBitcodeArg = '-fembed-bitcode';
     final String assemblyO = _fileSystem.path.join(outputPath, 'snapshot_assembly.o');
-    List<String> isysrootArgs;
+    List<String>? isysrootArgs;
     if (sdkRoot != null) {
       isysrootArgs = <String>['-isysroot', sdkRoot];
     }

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -72,7 +72,7 @@ class GenSnapshot {
 
     return _processUtils.stream(
       <String>[snapshotterPath, ...args],
-      mapFunction: (String line) =>  kIgnoredWarnings.contains(line) ? '' : line,
+      mapFunction: (String line) =>  kIgnoredWarnings.contains(line) ? null : line,
     );
   }
 }

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -11,7 +11,7 @@ import 'common.dart';
 import 'io.dart';
 import 'logger.dart';
 
-typedef StringConverter = String Function(String string);
+typedef StringConverter = String? Function(String string);
 
 /// A function that will be run before the VM exits.
 typedef ShutdownHook = FutureOr<dynamic> Function();
@@ -452,12 +452,13 @@ class _DefaultProcessUtils implements ProcessUtils {
       .transform<String>(const LineSplitter())
       .where((String line) => filter == null || filter.hasMatch(line))
       .listen((String line) {
+        String? mappedLine = line;
         if (mapFunction != null) {
-          line = mapFunction(line);
+          mappedLine = mapFunction(line);
         }
-        if (line != null) {
-          final String message = '$prefix$line';
-          if (stdoutErrorMatcher?.hasMatch(line) == true) {
+        if (mappedLine != null) {
+          final String message = '$prefix$mappedLine';
+          if (stdoutErrorMatcher?.hasMatch(mappedLine) == true) {
             _logger.printError(message, wrap: false);
           } else if (trace) {
             _logger.printTrace(message);
@@ -471,11 +472,12 @@ class _DefaultProcessUtils implements ProcessUtils {
       .transform<String>(const LineSplitter())
       .where((String line) => filter == null || filter.hasMatch(line))
       .listen((String line) {
+        String? mappedLine = line;
         if (mapFunction != null) {
-          line = mapFunction(line);
+          mappedLine = mapFunction(line);
         }
-        if (line != null) {
-          _logger.printError('$prefix$line', wrap: false);
+        if (mappedLine != null) {
+          _logger.printError('$prefix$mappedLine', wrap: false);
         }
       });
 

--- a/packages/flutter_tools/lib/src/build_system/targets/android.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/android.dart
@@ -9,7 +9,7 @@ import '../../base/build.dart';
 import '../../base/deferred_component.dart';
 import '../../base/file_system.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals show platform, printError, xcode;
+import '../../globals_null_migrated.dart' as globals show platform, printError, xcode;
 import '../../project.dart';
 import '../build_system.dart';
 import '../depfile.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -12,7 +12,7 @@ import '../../base/file_system.dart';
 import '../../build_info.dart';
 import '../../compile.dart';
 import '../../dart/package_map.dart';
-import '../../globals.dart' as globals show xcode;
+import '../../globals_null_migrated.dart' as globals show xcode;
 import '../build_system.dart';
 import '../depfile.dart';
 import '../exceptions.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -12,7 +12,7 @@ import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals show xcode;
+import '../../globals_null_migrated.dart' as globals show xcode;
 import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../build_system.dart';

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -10,7 +10,7 @@ import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/process.dart';
 import '../../build_info.dart';
-import '../../globals.dart' as globals show xcode;
+import '../../globals_null_migrated.dart' as globals show xcode;
 import '../build_system.dart';
 import '../depfile.dart';
 import '../exceptions.dart';

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/build.dart';
@@ -72,22 +70,16 @@ const List<String> kBitcodeClang = <String>[
 
 void main() {
   group('SnapshotType', () {
-    test('throws, if build mode is null', () {
-      expect(
-        () => SnapshotType(TargetPlatform.android_x64, null),
-        throwsA(anything),
-      );
-    });
     test('does not throw, if target platform is null', () {
       expect(() => SnapshotType(null, BuildMode.release), returnsNormally);
     });
   });
 
   group('GenSnapshot', () {
-    GenSnapshot genSnapshot;
-    Artifacts artifacts;
-    FakeProcessManager processManager;
-    BufferLogger logger;
+    late GenSnapshot genSnapshot;
+    late Artifacts artifacts;
+    late FakeProcessManager processManager;
+    late BufferLogger logger;
 
     setUp(() async {
       artifacts = Artifacts.test();
@@ -179,10 +171,10 @@ void main() {
   });
 
   group('AOTSnapshotter', () {
-    MemoryFileSystem fileSystem;
-    AOTSnapshotter snapshotter;
-    Artifacts artifacts;
-    FakeProcessManager processManager;
+    late MemoryFileSystem fileSystem;
+    late AOTSnapshotter snapshotter;
+    late Artifacts artifacts;
+    late FakeProcessManager processManager;
 
     setUp(() async {
       fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -83,6 +83,24 @@ void main() {
       expect(logger.statusText, equals('${testString[0]}\n'));
       expect(logger.errorText, equals('${testString[0]}\n'));
     });
+
+    testWithoutContext('Command output is filtered by mapFunction', () async {
+      processManager.addCommand(const FakeCommand(
+        command: <String>['command'],
+        stdout: 'match\nno match',
+        stderr: 'match\nno match',
+      ));
+
+      await processUtils.stream(<String>['command'], mapFunction: (String line) {
+        if (line == 'match') {
+          return line;
+        }
+        return null;
+      });
+
+      expect(logger.statusText, equals('match\n'));
+      expect(logger.errorText, equals('match\n'));
+    });
   });
 
   group('run', () {


### PR DESCRIPTION
Make build.dart null safe.

Update processUtils.stream to handle a null return from `mapFunction` to indicate no line should be printed, since that's how it's used in a few places.  Add a unit test for this.
https://github.com/flutter/flutter/blob/33b183e6c9874a8936f05defa12129bdc62c8099/packages/flutter_tools/lib/src/android/gradle.dart#L410-L416

Also found a few `globals_null_migrated` imports I missed.

Part of #71511

Closes https://github.com/flutter/flutter/pull/81106