### PR TITLE
fix lint from an improved unnecessary_parenthesis

### DIFF
--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -271,7 +271,7 @@ $factoryDeclaration
     if (languageToLocales[language].length == 1) {
       output.writeln('''
     case '$language':
-      return $generatedClassPrefix${(languageToLocales[language][0]).camelCase()}($factoryArguments);''');
+      return $generatedClassPrefix${languageToLocales[language][0].camelCase()}($factoryArguments);''');
     } else if (!languageToScriptCodes.containsKey(language)) { // Does not distinguish between scripts. Switch on countryCode directly.
       output.writeln('''
     case '$language': {

--- a/packages/flutter/test/painting/alignment_test.dart
+++ b/packages/flutter/test/painting/alignment_test.dart
@@ -45,10 +45,10 @@ void main() {
     expect((topEnd * 0.0).add(topRight * 0.0), center);
     expect(topEnd.add(topRight) * 0.0, (topEnd * 0.0).add(topRight * 0.0));
     expect(topStart.add(topLeft), topLeft.add(topStart));
-    expect((topStart.add(topLeft)).resolve(TextDirection.ltr), (topStart.resolve(TextDirection.ltr)) + topLeft);
-    expect((topStart.add(topLeft)).resolve(TextDirection.rtl), (topStart.resolve(TextDirection.rtl)) + topLeft);
-    expect((topStart.add(topLeft)).resolve(TextDirection.ltr), (topStart.resolve(TextDirection.ltr)).add(topLeft));
-    expect((topStart.add(topLeft)).resolve(TextDirection.rtl), (topStart.resolve(TextDirection.rtl)).add(topLeft));
+    expect(topStart.add(topLeft).resolve(TextDirection.ltr), (topStart.resolve(TextDirection.ltr)) + topLeft);
+    expect(topStart.add(topLeft).resolve(TextDirection.rtl), (topStart.resolve(TextDirection.rtl)) + topLeft);
+    expect(topStart.add(topLeft).resolve(TextDirection.ltr), topStart.resolve(TextDirection.ltr).add(topLeft));
+    expect(topStart.add(topLeft).resolve(TextDirection.rtl), topStart.resolve(TextDirection.rtl).add(topLeft));
     expect(topStart.resolve(TextDirection.ltr), topLeft);
     expect(topStart.resolve(TextDirection.rtl), topRight);
     expect(topEnd * 0.0, center);
@@ -67,8 +67,8 @@ void main() {
     for (final TextDirection x in TextDirection.values) {
       expect((topEnd * 0.0).add(topRight * 0.0).resolve(x), center.add(center).resolve(x));
       expect((topEnd * 0.0).add(topLeft).resolve(x), center.add(topLeft).resolve(x));
-      expect(((topEnd * 0.0).resolve(x)).add(topLeft.resolve(x)), (center.resolve(x)).add(topLeft.resolve(x)));
-      expect(((topEnd * 0.0).resolve(x)).add(topLeft), (center.resolve(x)).add(topLeft));
+      expect((topEnd * 0.0).resolve(x).add(topLeft.resolve(x)), center.resolve(x).add(topLeft.resolve(x)));
+      expect((topEnd * 0.0).resolve(x).add(topLeft), center.resolve(x).add(topLeft));
       expect((topEnd * 0.0).resolve(x), center.resolve(x));
     }
     expect(topStart, isNot(topLeft));

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -380,13 +380,13 @@ void main() {
       bottomStart: Radius.elliptical(120.0, 130.0),
       bottomEnd: Radius.elliptical(140.0, 150.0),
     );
-    expect((a.subtract(b)).resolve(TextDirection.ltr), BorderRadius.only(
+    expect(a.subtract(b).resolve(TextDirection.ltr), BorderRadius.only(
       topLeft: const Radius.elliptical(10.0, 20.0) - Radius.zero,
       topRight: const Radius.elliptical(30.0, 40.0) - const Radius.elliptical(100.0, 110.0),
       bottomLeft: const Radius.elliptical(50.0, 60.0) - const Radius.elliptical(120.0, 130.0),
       bottomRight: Radius.zero - const Radius.elliptical(140.0, 150.0),
     ));
-    expect((a.subtract(b)).resolve(TextDirection.rtl), BorderRadius.only(
+    expect(a.subtract(b).resolve(TextDirection.rtl), BorderRadius.only(
       topLeft: const Radius.elliptical(10.0, 20.0) - const Radius.elliptical(100.0, 110.0),
       topRight: const Radius.elliptical(30.0, 40.0) - Radius.zero,
       bottomLeft: const Radius.elliptical(50.0, 60.0) - const Radius.elliptical(140.0, 150.0),
@@ -405,13 +405,13 @@ void main() {
       bottomStart: Radius.elliptical(120.0, 130.0),
       bottomEnd: Radius.elliptical(140.0, 150.0),
     );
-    expect((a.add(b)).resolve(TextDirection.ltr), BorderRadius.only(
+    expect(a.add(b).resolve(TextDirection.ltr), BorderRadius.only(
       topLeft: const Radius.elliptical(10.0, 20.0) + Radius.zero,
       topRight: const Radius.elliptical(30.0, 40.0) + const Radius.elliptical(100.0, 110.0),
       bottomLeft: const Radius.elliptical(50.0, 60.0) + const Radius.elliptical(120.0, 130.0),
       bottomRight: Radius.zero + const Radius.elliptical(140.0, 150.0),
     ));
-    expect((a.add(b)).resolve(TextDirection.rtl), BorderRadius.only(
+    expect(a.add(b).resolve(TextDirection.rtl), BorderRadius.only(
       topLeft: const Radius.elliptical(10.0, 20.0) + const Radius.elliptical(100.0, 110.0),
       topRight: const Radius.elliptical(30.0, 40.0) + Radius.zero,
       bottomLeft: const Radius.elliptical(50.0, 60.0) + const Radius.elliptical(140.0, 150.0),
@@ -467,8 +467,8 @@ void main() {
       bottomLeft: Radius.elliptical(-3.0, -5.0), // 0 + 0 - bL
       bottomRight: Radius.zero, // 0 + 0 - 0
     );
-    expect((a.add(b.subtract(c))).resolve(TextDirection.ltr), ltr);
-    expect((a.add(b.subtract(c))).resolve(TextDirection.rtl), rtl);
+    expect(a.add(b.subtract(c)).resolve(TextDirection.ltr), ltr);
+    expect(a.add(b.subtract(c)).resolve(TextDirection.rtl), rtl);
   });
 
   test('BorderRadiusGeometry add and subtract, more', () {
@@ -503,8 +503,8 @@ void main() {
       bottomLeft: Radius.elliptical(783.0, 783.0), // bL + bE + bL
       bottomRight: Radius.elliptical(961.0, 961.0), // bR + bS - bR
     );
-    expect((a.add(b.subtract(c))).resolve(TextDirection.ltr), ltr);
-    expect((a.add(b.subtract(c))).resolve(TextDirection.rtl), rtl);
+    expect(a.add(b.subtract(c)).resolve(TextDirection.ltr), ltr);
+    expect(a.add(b.subtract(c)).resolve(TextDirection.rtl), rtl);
   });
 
   test('BorderRadiusGeometry operators', () {
@@ -531,10 +531,10 @@ void main() {
       bottomLeft: Radius.elliptical(95.0, 105.0), // 50,60 -> 140,150
       bottomRight: Radius.elliptical(60.0, 65.0), // 0,0 -> 120,130
     );
-    expect((a.add(b.subtract(a) * 0.5)).resolve(TextDirection.ltr), ltr);
-    expect((a.add(b.subtract(a) * 0.5)).resolve(TextDirection.rtl), rtl);
-    expect((a.add(b.subtract(a) * 0.0)).resolve(TextDirection.ltr), a);
-    expect((a.add(b.subtract(a) * 1.0)).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
+    expect(a.add(b.subtract(a) * 0.5).resolve(TextDirection.ltr), ltr);
+    expect(a.add(b.subtract(a) * 0.5).resolve(TextDirection.rtl), rtl);
+    expect(a.add(b.subtract(a) * 0.0).resolve(TextDirection.ltr), a);
+    expect(a.add(b.subtract(a) * 1.0).resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
   });
 
   test('BorderRadius copyWith, merge, ==, hashCode basics', () {

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -199,8 +199,8 @@ void main() {
     expect(EdgeInsets.zero.toString(), 'EdgeInsets.zero');
     expect(const EdgeInsets.only(top: 1.01, left: 1.01, right: 1.01, bottom: 1.01).toString(), 'EdgeInsets.all(1.0)');
     expect(const EdgeInsetsDirectional.only(start: 1.01, end: 1.01, top: 1.01, bottom: 1.01).toString(), 'EdgeInsetsDirectional(1.0, 1.0, 1.0, 1.0)');
-    expect((const EdgeInsetsDirectional.only(start: 4.0).add(const EdgeInsets.only(top: 3.0))).toString(), 'EdgeInsetsDirectional(4.0, 3.0, 0.0, 0.0)');
-    expect((const EdgeInsetsDirectional.only(top: 4.0).add(const EdgeInsets.only(right: 3.0))).toString(), 'EdgeInsets(0.0, 4.0, 3.0, 0.0)');
-    expect((const EdgeInsetsDirectional.only(start: 4.0).add(const EdgeInsets.only(left: 3.0))).toString(), 'EdgeInsets(3.0, 0.0, 0.0, 0.0) + EdgeInsetsDirectional(4.0, 0.0, 0.0, 0.0)');
+    expect(const EdgeInsetsDirectional.only(start: 4.0).add(const EdgeInsets.only(top: 3.0)).toString(), 'EdgeInsetsDirectional(4.0, 3.0, 0.0, 0.0)');
+    expect(const EdgeInsetsDirectional.only(top: 4.0).add(const EdgeInsets.only(right: 3.0)).toString(), 'EdgeInsets(0.0, 4.0, 3.0, 0.0)');
+    expect(const EdgeInsetsDirectional.only(start: 4.0).add(const EdgeInsets.only(left: 3.0)).toString(), 'EdgeInsets(3.0, 0.0, 0.0, 0.0) + EdgeInsetsDirectional(4.0, 0.0, 0.0, 0.0)');
   });
 }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -3212,11 +3212,11 @@ void main() {
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
 
-      editable.foregroundPainter = (currentPainter = _TestRenderEditablePainter()..repaint = false);
+      editable.foregroundPainter = currentPainter = _TestRenderEditablePainter()..repaint = false;
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 0);
 
-      editable.foregroundPainter = (currentPainter = _TestRenderEditablePainter()..repaint = true);
+      editable.foregroundPainter = currentPainter = _TestRenderEditablePainter()..repaint = true;
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
     });
@@ -3231,11 +3231,11 @@ void main() {
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
 
-      editable.painter = (currentPainter = _TestRenderEditablePainter()..repaint = false);
+      editable.painter = currentPainter = _TestRenderEditablePainter()..repaint = false;
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 0);
 
-      editable.painter = (currentPainter = _TestRenderEditablePainter()..repaint = true);
+      editable.painter = currentPainter = _TestRenderEditablePainter()..repaint = true;
       pumpFrame(phase: EnginePhase.paint);
       expect(currentPainter.paintCount, 1);
     });

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -94,7 +94,7 @@ void main() {
       _testInMemory('treats missing pubspec.yaml as empty', () async {
         final Directory directory = globals.fs.directory('myproject')
           ..createSync(recursive: true);
-        expect((FlutterProject.fromDirectory(directory)).manifest.isEmpty,
+        expect(FlutterProject.fromDirectory(directory).manifest.isEmpty,
           true,
         );
       });


### PR DESCRIPTION
This PR fixes some additional lints (from an upcoming [enhanced unnecessary_parenthesis](https://github.com/dart-lang/linter/pull/2676))