### PR TITLE
Updates override of SemanticsUpdateBuilderSpy to enable soft transition

### DIFF
--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -114,10 +114,18 @@ class SemanticsUpdateBuilderSpy extends ui.SemanticsUpdateBuilder {
     required double thickness,
     required Rect rect,
     required String label,
-    required String hint,
+    // TODO(chunhtai): change the Object? to List<StringAttribute> when engine
+    // change lands.
+    // https://github.com/flutter/flutter/issues/79318.
+    Object? labelAttributes,
     required String value,
+    Object? valueAttributes,
     required String increasedValue,
+    Object? increasedValueAttributes,
     required String decreasedValue,
+    Object? decreasedValueAttributes,
+    required String hint,
+    Object? hintAttributes,
     TextDirection? textDirection,
     required Float64List transform,
     required Int32List childrenInTraversalOrder,

--- a/packages/flutter/test/semantics/semantics_update_test.dart
+++ b/packages/flutter/test/semantics/semantics_update_test.dart
@@ -115,7 +115,7 @@ class SemanticsUpdateBuilderSpy extends ui.SemanticsUpdateBuilder {
     required Rect rect,
     required String label,
     // TODO(chunhtai): change the Object? to List<StringAttribute> when engine
-    // change lands.
+    // pr lands: https://github.com/flutter/engine/pull/25373.
     // https://github.com/flutter/flutter/issues/79318.
     Object? labelAttributes,
     required String value,


### PR DESCRIPTION
This is a temporary patch to soft transition the engine pr: https://github.com/flutter/engine/pull/25373

related https://github.com/flutter/flutter/issues/79318


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
