### PR TITLE
Fix benchmark regression from #83427

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1241,9 +1241,11 @@ class ProjectFileInvalidator {
       final List<Future<void>> waitList = <Future<void>>[];
       for (final Uri uri in urisToScan) {
         waitList.add(pool.withResource<void>(
-          () => _fileSystem
-            .file(uri)
-            .stat()
+          // Calling fs.stat() is more performant than fs.file().stat(), but
+          // uri.toFilePath() does not work with MultiRootFileSystem.
+          () => (uri.hasScheme && uri.scheme != 'file'
+            ?  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows))
+            : _fileSystem.file(uri).stat())
             .then((FileStat stat) {
               final DateTime updatedAt = stat.modified;
               if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
@@ -1255,7 +1257,11 @@ class ProjectFileInvalidator {
       await Future.wait<void>(waitList);
     } else {
       for (final Uri uri in urisToScan) {
-        final DateTime updatedAt = _fileSystem.file(uri).statSync().modified;
+        // Calling fs.statSync() is more performant than fs.file().statSync(), but
+        // uri.toFilePath() does not work with MultiRootFileSystem.
+        final DateTime updatedAt = uri.hasScheme && uri.scheme != 'file'
+          ? _fileSystem.file(uri).statSync().modified
+          : _fileSystem.statSync(uri.toFilePath(windows: _platform.isWindows)).modified;
         if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
           invalidatedFiles.add(uri);
         }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1244,8 +1244,8 @@ class ProjectFileInvalidator {
           // Calling fs.stat() is more performant than fs.file().stat(), but
           // uri.toFilePath() does not work with MultiRootFileSystem.
           () => (uri.hasScheme && uri.scheme != 'file'
-            ?  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows))
-            : _fileSystem.file(uri).stat())
+            ? _fileSystem.file(uri).stat()
+            :  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
             .then((FileStat stat) {
               final DateTime updatedAt = stat.modified;
               if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -4,15 +4,21 @@
 
 // @dart = 2.8
 
+import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/run_hot.dart';
+import 'package:mockito/mockito.dart';
 import 'package:package_config/package_config.dart';
 
 import '../src/common.dart';
+
+class MockFile extends Mock implements File {}
+class MockFileSystem extends Mock implements FileSystem {}
+class MockFileStat extends Mock implements FileStat {}
 
 // assumption: tests have a timeout less than 100 days
 final DateTime inFuture = DateTime.now().add(const Duration(days: 100));
@@ -163,6 +169,56 @@ void main() {
       // The PackagConfig should have been recreated too
       expect(nextInvalidationResult.packageConfig,
         isNot(invalidationResult.packageConfig));
+    });
+
+    testWithoutContext('Uses fs.file().stat() for multischeme URI, and fs.stat() for regular uris, asyncScanning: $asyncScanning', () async {
+      final FileSystem fileSystem = MockFileSystem();
+      final FileStat mockStat = MockFileStat();
+      final File mockFile = MockFile();
+      final ProjectFileInvalidator projectFileInvalidator = ProjectFileInvalidator(
+        fileSystem: fileSystem,
+        platform: FakePlatform(),
+        logger: BufferLogger.test(),
+      );
+
+      when(mockStat.modified).thenReturn(DateTime.now());
+      when(mockFile.stat()).thenAnswer((_) async => mockStat);
+      when(mockFile.statSync()).thenReturn(mockStat);
+
+      when(fileSystem.file(captureAny)).thenReturn(mockFile);
+      when(fileSystem.stat(captureAny)).thenAnswer((_) async => mockStat);
+      when(fileSystem.statSync(captureAny)).thenReturn(mockStat);
+
+      expect(
+        (await projectFileInvalidator.findInvalidated(
+          lastCompiled: inFuture,
+          urisToMonitor: <Uri>[
+            Uri.parse('/normal_path'),
+            Uri.parse('file:///file_path'),
+            Uri.parse('scheme:///scheme_path'),
+          ],
+          packagesPath: '.packages',
+          asyncScanning: asyncScanning,
+          packageConfig: PackageConfig.empty,
+        )).uris,
+        isEmpty,
+      );
+
+      if (asyncScanning) {
+        expect(
+          verify(fileSystem.stat(captureAny)).captured,
+          ['/normal_path', '/file_path'],
+        );
+      } else {
+        expect(
+          verify(fileSystem.statSync(captureAny)).captured,
+          ['/normal_path', '/file_path'],
+        );
+      }
+      expect(
+        verify(fileSystem.file(captureAny)).captured,
+        [Uri.parse('scheme:///scheme_path'), '.packages'],
+      );
     });
   }
 }


### PR DESCRIPTION
Calling fs.stat() is more performant than fs.file().stat(), but
uri.toFilePath() does not work with MultiRootFileSystem. Handle this by
conditionally calling fs.stat() when the uri is not a multiroot uri.
