### PR TITLE
Clean up null assumptions for Xcode and CocoaPods classes

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -397,7 +397,7 @@ enum EnvironmentType {
   simulator,
 }
 
-String? validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String buildNumber, Logger logger) {
+String? validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String? buildNumber, Logger logger) {
   if (buildNumber == null) {
     return null;
   }
@@ -444,7 +444,7 @@ String? validatedBuildNumberForPlatform(TargetPlatform targetPlatform, String bu
   return buildNumber;
 }
 
-String? validatedBuildNameForPlatform(TargetPlatform targetPlatform, String buildName, Logger logger) {
+String? validatedBuildNameForPlatform(TargetPlatform targetPlatform, String? buildName, Logger logger) {
   if (buildName == null) {
     return null;
   }

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -109,7 +109,7 @@ void _updateGeneratedEnvironmentVariablesScript({
 /// Build name parsed and validated from build info and manifest. Used for CFBundleShortVersionString.
 String parsedBuildName({
   @required FlutterManifest manifest,
-  @required BuildInfo buildInfo,
+  BuildInfo buildInfo,
 }) {
   final String buildNameToParse = buildInfo?.buildName ?? manifest.buildName;
   return validatedBuildNameForPlatform(TargetPlatform.ios, buildNameToParse, globals.logger);
@@ -118,7 +118,7 @@ String parsedBuildName({
 /// Build number parsed and validated from build info and manifest. Used for CFBundleVersion.
 String parsedBuildNumber({
   @required FlutterManifest manifest,
-  @required BuildInfo buildInfo,
+  BuildInfo buildInfo,
 }) {
   String buildNumberToParse = buildInfo?.buildNumber ?? manifest.buildNumber;
   final String buildNumber = validatedBuildNumberForPlatform(
@@ -173,8 +173,9 @@ List<String> _xcodeBuildSettingsLines({
   final String buildNumber = parsedBuildNumber(manifest: project.manifest, buildInfo: buildInfo) ?? '1';
   xcodeBuildSettings.add('FLUTTER_BUILD_NUMBER=$buildNumber');
 
-  if (globals.artifacts is LocalEngineArtifacts) {
-    final LocalEngineArtifacts localEngineArtifacts = globals.artifacts as LocalEngineArtifacts;
+  final Artifacts artifacts = globals.artifacts;
+  if (artifacts is LocalEngineArtifacts) {
+    final LocalEngineArtifacts localEngineArtifacts = artifacts;
     final String engineOutPath = localEngineArtifacts.engineOutPath;
     xcodeBuildSettings.add('FLUTTER_ENGINE=${globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath))}');
 

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -389,7 +389,7 @@ class XcodeProjectInfo {
   }
   /// Returns unique scheme matching [buildInfo], or null, if there is no unique
   /// best match.
-  String? schemeFor(BuildInfo buildInfo) {
+  String? schemeFor(BuildInfo? buildInfo) {
     final String expectedScheme = expectedSchemeFor(buildInfo);
     if (schemes.contains(expectedScheme)) {
       return expectedScheme;

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -71,8 +71,8 @@ enum CocoaPodsStatus {
   brokenInstall,
 }
 
-String get cocoaPodsMinimumVersion => '1.9.0';
-String get cocoaPodsRecommendedVersion => '1.10.0';
+const Version cocoaPodsMinimumVersion = Version.withText(1, 9, 0, '1.9.0');
+const Version cocoaPodsRecommendedVersion = Version.withText(1, 10, 0, '1.10.0');
 
 /// Cocoapods is a dependency management solution for iOS and macOS applications.
 ///
@@ -142,10 +142,10 @@ class CocoaPods {
       if (installedVersion == null) {
         return CocoaPodsStatus.unknownVersion;
       }
-      if (installedVersion < Version.parse(cocoaPodsMinimumVersion)) {
+      if (installedVersion < cocoaPodsMinimumVersion) {
         return CocoaPodsStatus.belowMinimumVersion;
       }
-      if (installedVersion < Version.parse(cocoaPodsRecommendedVersion)) {
+      if (installedVersion < cocoaPodsRecommendedVersion) {
         return CocoaPodsStatus.belowRecommendedVersion;
       }
       return CocoaPodsStatus.recommended;

--- a/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods_validator.dart
@@ -52,7 +52,7 @@ class CocoaPodsValidator extends DoctorValidator {
         status = ValidationType.partial;
         final String currentVersionText = await _cocoaPods.cocoaPodsVersionText;
         messages.add(ValidationMessage.hint(
-          _userMessages.cocoaPodsOutdated(currentVersionText, cocoaPodsRecommendedVersion, noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
+          _userMessages.cocoaPodsOutdated(currentVersionText, cocoaPodsRecommendedVersion.toString(), noCocoaPodsConsequence, cocoaPodsInstallInstructions)));
       }
     }
 


### PR DESCRIPTION
I started migrating `project.dart` and all its dependencies, and the diff was huge.
Pull out the cleanup parts in `lib/src/ios` and `lib/src/macos` that can be done without actually migrating to null safety.

Part of #71511