### PR TITLE
Clean up null assumptions for project.dart dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/cmake.dart
+++ b/packages/flutter_tools/lib/src/cmake.dart
@@ -63,10 +63,10 @@ list(APPEND FLUTTER_TOOL_ENVIRONMENT
   "FLUTTER_ROOT=$escapedFlutterRoot"
   "PROJECT_DIR=$escapedProjectDir"
 ''');
-  for (final String key in environment.keys) {
-    final String value = _escapeBackslashes(environment[key]);
-    buffer.writeln('  "$key=$value"');
-  }
+  environment.forEach((String key, String value) {
+    final String configValue = _escapeBackslashes(value);
+    buffer.writeln('  "$key=$configValue"');
+  });
   buffer.writeln(')');
 
   project.generatedCmakeConfigFile

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1093,7 +1093,8 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
         continue;
       }
       // The plugin doesn't implement an interface, verify that it has a default implementation.
-      if (plugin.implementsPackage == null || plugin.implementsPackage.isEmpty) {
+      final String implementsPackage = plugin.implementsPackage;
+      if (implementsPackage == null || implementsPackage.isEmpty) {
         final String defaultImplementation = plugin.defaultPackagePlatforms[platform];
         if (defaultImplementation == null) {
           if (throwOnPluginPubspecError) {
@@ -1124,7 +1125,7 @@ List<PluginInterfaceResolution> resolvePlatformImplementation(
           plugin.pluginDartClassPlatforms[platform] == 'none') {
         continue;
       }
-      final String resolutionKey = '$platform/${plugin.implementsPackage}';
+      final String resolutionKey = '$platform/$implementsPackage';
       if (directDependencyResolutions.containsKey(resolutionKey)) {
         final PluginInterfaceResolution currResolution = directDependencyResolutions[resolutionKey];
         if (currResolution != null && currResolution.plugin.isDirectDependency) {
@@ -1186,12 +1187,12 @@ Future<void> generateMainDartWithPluginRegistrant(
   String currentMainUri,
   File newMainDart,
   File mainFile, {
-  bool throwOnPluginPubspecError,
+  bool throwOnPluginPubspecError = false,
 }) async {
   final List<Plugin> plugins = await findPlugins(rootProject);
   final List<PluginInterfaceResolution> resolutions = resolvePlatformImplementation(
     plugins,
-    throwOnPluginPubspecError: throwOnPluginPubspecError ?? false,
+    throwOnPluginPubspecError: throwOnPluginPubspecError,
   );
   final LanguageVersion entrypointVersion = determineLanguageVersion(
     mainFile,


### PR DESCRIPTION
I started migrating `project.dart` and all its dependencies, and the diff was huge.
Pull out the cleanup parts in project, flutter_plugins, and cmake (kind of a random grouping)  that can be done without actually migrating to null safety.

Part of #71511