### PR TITLE
Add `coldboot` parameter to JSON-RPC interface of daemon

### DIFF
--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -233,6 +233,7 @@ Return a list of all available emulators. The `params` field will be a List; eac
 The `launch()` command allows launching an emulator/simulator by its `id`.
 
 - `emulatorId`: the id of an emulator as returned by `getEmulators`.
+- `coldBoot`: an optional boolean flag which indicates if the emulator should be cold booted. Only supported for android emulators, silently ignored if emulator type is not android.
 
 #### emulator.create
 
@@ -295,6 +296,7 @@ See the [source](https://github.com/flutter/flutter/blob/master/packages/flutter
 
 ## Changelog
 
+- 0.6.1: Added `coldBoot` option to `emulator.lauch` command.
 - 0.6.0: Added `debounce` option to `app.restart` command.
 - 0.5.3: Added `emulatorId` field to device.
 - 0.5.2: Added `platformType` and `category` fields to emulator.

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -32,7 +32,7 @@ import '../runner/flutter_command.dart';
 import '../vmservice.dart';
 import '../web/web_runner.dart';
 
-const String protocolVersion = '0.6.0';
+const String protocolVersion = '0.6.1';
 
 /// A server process command. This command will start up a long-lived server.
 /// It reads JSON-RPC based commands from stdin, executes them, and returns
@@ -1118,6 +1118,7 @@ class EmulatorDomain extends Domain {
 
   Future<void> launch(Map<String, dynamic> args) async {
     final String emulatorId = _getStringArg(args, 'emulatorId', required: true);
+    final bool coldBoot = _getBoolArg(args, 'coldBoot') ?? false;
     final List<Emulator> matches =
         await emulators.getEmulatorsMatching(emulatorId);
     if (matches.isEmpty) {
@@ -1125,7 +1126,7 @@ class EmulatorDomain extends Domain {
     } else if (matches.length > 1) {
       throw "multiple emulators match '$emulatorId'";
     } else {
-      await matches.first.launch();
+      await matches.first.launch(coldBoot: coldBoot);
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -298,6 +298,23 @@ void main() {
       await commands.close();
     });
 
+    testUsingContext('emulator.launch coldboot parameter must be boolean', () async {
+      final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
+      final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();
+      daemon = Daemon(
+        commands.stream,
+        responses.add,
+        notifyingLogger: notifyingLogger,
+      );
+      final Map<String, dynamic> params = <String, dynamic>{'emulatorId': 'device', 'coldBoot': 1};
+      commands.add(<String, dynamic>{'id': 0, 'method': 'emulator.launch', 'params': params});
+      final Map<String, dynamic> response = await responses.stream.firstWhere(_notEvent);
+      expect(response['id'], 0);
+      expect(response['error'], contains('coldBoot is not a bool'));
+      await responses.close();
+      await commands.close();
+    });
+
     testUsingContext('emulator.getEmulators should respond with list', () async {
       final StreamController<Map<String, dynamic>> commands = StreamController<Map<String, dynamic>>();
       final StreamController<Map<String, dynamic>> responses = StreamController<Map<String, dynamic>>();

--- a/packages/flutter_tools/tool/daemon_client.dart
+++ b/packages/flutter_tools/tool/daemon_client.dart
@@ -16,7 +16,7 @@ late Process daemon;
 //   stop: stop a running app
 //   devices: list devices
 //   emulators: list emulators
-//   launch: launch an emulator
+//   emulator-launch: launch an emulator, append the word coldBoot to cold boot the emulator.
 
 Future<void> main() async {
   daemon = await Process.start('dart', <String>['bin/flutter_tools.dart', 'daemon']);
@@ -72,6 +72,8 @@ Future<void> main() async {
         'method': 'emulator.launch',
         'params': <String, dynamic>{
           'emulatorId': words[1],
+          if (words.contains('coldBoot'))
+            'coldBoot': true
         },
       });
     } else if (line == 'enable') {


### PR DESCRIPTION
The coldboot parameter can be used for android based emulators to
force a full boot.

The JSON-RPC interface does not provide means to cold boot android based emulators. This option was recently added using the command line interface. This pull request extends the JSON-RPC interface for cold boot launch.

Note: This PR changes the version of the daemon from 0.6.0 to 0.6.1, the change is fully backwards compatible.

This PR implements the following feature request #83471 

closes #83471

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
