### PR TITLE
Router replaces browser history entry if state changes

### DIFF
--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -67,11 +67,23 @@ class SystemNavigator {
 
   /// Notifies the platform for a route information change.
   ///
-  /// On web, creates a new browser history entry and update URL with the route
-  /// information. Whether the history holds one entry or multiple entries is
-  /// determined by [selectSingleEntryHistory] and [selectMultiEntryHistory].
+  /// On web, this method behaves differently based on the single-entry or
+  /// multiple-entries history mode. Use the [selectSingleEntryHistory] and
+  /// [selectMultiEntryHistory] to toggle between modes.
+  ///
+  /// For single-entry mode, this method replace the current url and state in
+  /// the current history entry. The flag `replace` is ignored.
+  ///
+  /// For multiple-entries mode, this method create a new history entry on top
+  /// of the current entry if the `replace` is true. This means the user will
+  /// be on a new history entry as if the user has visited a new page, and the
+  /// browser back button brings the user back to the previous entry. If the
+  /// `replace` is false, this method only updates the url and the state in the
+  /// current history entry without pushing a new one.
   ///
   /// Currently, this is ignored on other platforms.
+  ///
+  /// The `replace` flag defaults to false.
   static Future<void> routeInformationUpdated({
     required String location,
     Object? state,

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -71,17 +71,17 @@ class SystemNavigator {
   /// multiple-entries history mode. Use the [selectSingleEntryHistory] and
   /// [selectMultiEntryHistory] to toggle between modes.
   ///
-  /// For single-entry mode, this method replace the current url and state in
+  /// For single-entry mode, this method replaces the current url and state in
   /// the current history entry. The flag `replace` is ignored.
   ///
-  /// For multiple-entries mode, this method create a new history entry on top
-  /// of the current entry if the `replace` is true. This means the user will
+  /// For multiple-entries mode, this method creates a new history entry on top
+  /// of the current entry if the `replace` is true, thus the user will
   /// be on a new history entry as if the user has visited a new page, and the
   /// browser back button brings the user back to the previous entry. If the
   /// `replace` is false, this method only updates the url and the state in the
   /// current history entry without pushing a new one.
   ///
-  /// Currently, this is ignored on other platforms.
+  /// This method is ignored on other platforms.
   ///
   /// The `replace` flag defaults to false.
   static Future<void> routeInformationUpdated({

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -75,12 +75,14 @@ class SystemNavigator {
   static Future<void> routeInformationUpdated({
     required String location,
     Object? state,
+    bool replace = false,
   }) {
     return SystemChannels.navigation.invokeMethod<void>(
       'routeInformationUpdated',
       <String, dynamic>{
         'location': location,
         'state': state,
+        'replace': replace,
       },
     );
   }

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -71,14 +71,14 @@ class SystemNavigator {
   /// multiple-entries history mode. Use the [selectSingleEntryHistory] and
   /// [selectMultiEntryHistory] to toggle between modes.
   ///
-  /// For single-entry mode, this method replaces the current url and state in
+  /// For single-entry mode, this method replaces the current URL and state in
   /// the current history entry. The flag `replace` is ignored.
   ///
   /// For multiple-entries mode, this method creates a new history entry on top
-  /// of the current entry if the `replace` is true, thus the user will
+  /// of the current entry if the `replace` is false, thus the user will
   /// be on a new history entry as if the user has visited a new page, and the
-  /// browser back button brings the user back to the previous entry. If the
-  /// `replace` is false, this method only updates the url and the state in the
+  /// browser back button brings the user back to the previous entry. If
+  /// `replace` is true, this method only updates the URL and the state in the
   /// current history entry without pushing a new one.
   ///
   /// This method is ignored on other platforms.

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -510,26 +510,27 @@ class _RouterState<T> extends State<Router<T>> with RestorationMixin {
     _routeInformationReportingTaskScheduled = false;
 
     if (_routeInformation.value != null) {
-      final RouteInformation routeInformation = _routeInformation.value!;
+      final RouteInformation oldRouteInformation = widget.routeInformationProvider!.value;
+      final RouteInformation currentRouteInformation = _routeInformation.value!;
       switch (_currentIntentionToReport) {
         case _IntentionToReportRouteInformation.none:
           assert(false, '_reportRouteInformation must not be called with _IntentionToReportRouteInformation.none');
           return;
         case _IntentionToReportRouteInformation.ignore:
-          if (widget.routeInformationProvider!.value.location != routeInformation.location ||
-              widget.routeInformationProvider!.value.state != routeInformation.state) {
-            widget.routeInformationProvider!.routerUpdatesRouteInformation(routeInformation);
+          if (oldRouteInformation.location != currentRouteInformation.location ||
+              oldRouteInformation.state != currentRouteInformation.state) {
+            widget.routeInformationProvider!.routerUpdatesRouteInformation(currentRouteInformation);
           }
           break;
         case _IntentionToReportRouteInformation.maybe:
-          if (widget.routeInformationProvider!.value.location != routeInformation.location) {
-            widget.routeInformationProvider!.routerReportsNewRouteInformation(routeInformation);
-          } else if (widget.routeInformationProvider!.value.state != routeInformation.state){
-            widget.routeInformationProvider!.routerUpdatesRouteInformation(routeInformation);
+          if (oldRouteInformation.location != currentRouteInformation.location) {
+            widget.routeInformationProvider!.routerReportsNewRouteInformation(currentRouteInformation);
+          } else if (oldRouteInformation.state != currentRouteInformation.state){
+            widget.routeInformationProvider!.routerUpdatesRouteInformation(currentRouteInformation);
           }
           break;
         case _IntentionToReportRouteInformation.must:
-          widget.routeInformationProvider!.routerReportsNewRouteInformation(routeInformation);
+          widget.routeInformationProvider!.routerReportsNewRouteInformation(currentRouteInformation);
           break;
       }
     }

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -392,8 +392,8 @@ class Router<T> extends StatefulWidget {
     return scope?.routerState.widget as Router<T>?;
   }
 
-  /// Forces the [Router] to run the [callback] and reports the route
-  /// information back to the engine.
+  /// Forces the [Router] to run the [callback] and create a new history
+  /// entry in the browser.
   ///
   /// The web application relies on the [Router] to report new route information
   /// in order to create browser history entry. The [Router] will only report
@@ -414,8 +414,8 @@ class Router<T> extends StatefulWidget {
   ///
   ///  * [Router]: see the "URL updates for web applications" section for more
   ///    information about route information reporting.
-  ///  * [neglect]: which forces the [Router] to not report the route
-  ///    information even if location does change.
+  ///  * [neglect]: which forces the [Router] to not create a new history entry
+  ///    even if location does change.
   static void navigate(BuildContext context, VoidCallback callback) {
     final _RouterScope scope = context
       .getElementForInheritedWidgetOfExactType<_RouterScope>()!
@@ -423,24 +423,27 @@ class Router<T> extends StatefulWidget {
     scope.routerState._setStateWithExplicitReportStatus(_IntentionToReportRouteInformation.must, callback);
   }
 
-  /// Forces the [Router] to run the [callback] without reporting the route
-  /// information back to the engine.
-  ///
-  /// Use this method if you don't want the [Router] to report the new route
-  /// information even if it detects changes as a result of running the
-  /// [callback].
+  /// Forces the [Router] to run the [callback] without creating a new history
+  /// entry in the browser.
   ///
   /// The web application relies on the [Router] to report new route information
   /// in order to create browser history entry. The [Router] will report them
-  /// automatically if it detects the [RouteInformation.location] changes. You
-  /// can use this method if you want to navigate to a new route without
-  /// creating the browser history entry.
+  /// automatically if it detects the [RouteInformation.location] changes.
+  ///
+  /// Creating a new route history entry makes users feel they have visited a
+  /// new page, and the browser back button brings them back to previous history
+  /// entry. Use this method if you don't want the [Router] to create a new
+  /// route information even if it detects changes as a result of running the
+  /// [callback].
+  ///
+  /// Note that using this method will still update the current URL and
+  /// browser state.
   ///
   /// See also:
   ///
   ///  * [Router]: see the "URL updates for web applications" section for more
   ///    information about route information reporting.
-  ///  * [navigate]: which forces the [Router] to report the route information
+  ///  * [navigate]: which forces the [Router] to create a new history entry
   ///    even if location does not change.
   static void neglect(BuildContext context, VoidCallback callback) {
     final _RouterScope scope = context

--- a/packages/flutter/test/services/system_navigator_test.dart
+++ b/packages/flutter/test/services/system_navigator_test.dart
@@ -43,11 +43,15 @@ void main() {
     ]);
 
     await verify(() => SystemNavigator.routeInformationUpdated(location: 'a'), <Object>[
-      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': null }),
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': null, 'replace': false }),
     ]);
 
     await verify(() => SystemNavigator.routeInformationUpdated(location: 'a', state: true), <Object>[
-      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': true }),
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': true, 'replace': false }),
+    ]);
+
+    await verify(() => SystemNavigator.routeInformationUpdated(location: 'a', state: true, replace: true), <Object>[
+      isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': true, 'replace': true }),
     ]);
 
     await verify(() => SystemNavigator.routeUpdated(routeName: 'a', previousRouteName: 'b'), <Object>[

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -69,6 +69,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/',
           'state': null,
+          'replace': false,
         },
       ),
     ]);
@@ -86,6 +87,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/A',
           'state': null,
+          'replace': false,
         },
       ),
     );
@@ -103,6 +105,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/',
           'state': null,
+          'replace': false,
         },
       ),
     );
@@ -174,6 +177,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/',
           'state': null,
+          'replace': false,
         },
       ),
     ]);
@@ -191,6 +195,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/A',
           'state': null,
+          'replace': false,
         },
       ),
     );
@@ -208,6 +213,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/B',
           'state': null,
+          'replace': false,
         },
       ),
     );
@@ -243,6 +249,7 @@ void main() {
         arguments: <String, dynamic>{
           'location': '/home',
           'state': null,
+          'replace': false,
         },
       ),
     ]);
@@ -294,6 +301,7 @@ void main() {
       isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{
         'location': 'update',
         'state': 'state',
+        'replace': false,
       }),
     ]);
   });

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -477,11 +477,14 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
 
   testWidgets('router does report URL change correctly', (WidgetTester tester) async {
     RouteInformation? reportedRouteInformation;
+    bool? reportedIsNavigation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
+      onRouterReport: (RouteInformation information, bool isNavigation) {
         // Makes sure we only report once after manually cleaning up.
         expect(reportedRouteInformation, isNull);
+        expect(reportedIsNavigation, isNull);
         reportedRouteInformation = information;
+        reportedIsNavigation = isNavigation;
       },
     );
     final SimpleRouterDelegate delegate = SimpleRouterDelegate(
@@ -519,35 +522,44 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     expect(find.text('initial'), findsNothing);
     expect(find.text('update'), findsOneWidget);
     expect(reportedRouteInformation!.location, 'update');
+    expect(reportedIsNavigation, isTrue);
 
-    // The router should not report if only state changes.
+    // The router should report as non navigation event if only state changes.
     reportedRouteInformation = null;
+    reportedIsNavigation = null;
     delegate.routeInformation = const RouteInformation(
       location: 'update',
       state: 'another state',
     );
     await tester.pump();
     expect(find.text('update'), findsOneWidget);
-    expect(reportedRouteInformation, isNull);
+    expect(reportedRouteInformation!.location, 'update');
+    expect(reportedRouteInformation!.state, 'another state');
+    expect(reportedIsNavigation, isFalse);
 
     reportedRouteInformation = null;
+    reportedIsNavigation = null;
     bool result = false;
     result = await outerDispatcher.invokeCallback(SynchronousFuture<bool>(false));
     expect(result, isTrue);
     await tester.pump();
     expect(find.text('popped'), findsOneWidget);
     expect(reportedRouteInformation!.location, 'popped');
+    expect(reportedIsNavigation, isTrue);
   });
 
   testWidgets('router can be forced to recognize or ignore navigating events', (WidgetTester tester) async {
     RouteInformation? reportedRouteInformation;
+    bool? reportedIsNavigation;
     bool isNavigating = false;
     late RouteInformation nextRouteInformation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
+      onRouterReport: (RouteInformation information, bool isNavigation) {
         // Makes sure we only report once after manually cleaning up.
         expect(reportedRouteInformation, isNull);
+        expect(reportedIsNavigation, isNull);
         reportedRouteInformation = information;
+        reportedIsNavigation = isNavigation;
       },
     );
     provider.value = const RouteInformation(
@@ -592,7 +604,10 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     await tester.pump();
     expect(find.text('initial'), findsNothing);
     expect(find.text('update'), findsOneWidget);
-    expect(reportedRouteInformation, isNull);
+    expect(reportedIsNavigation, isFalse);
+    expect(reportedRouteInformation!.location, 'update');
+    reportedIsNavigation = null;
+    reportedRouteInformation = null;
 
     isNavigating = true;
     // This should not trigger any real navigating event because the
@@ -600,71 +615,19 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     // report a route information because isNavigating = true.
     await tester.tap(find.byType(ElevatedButton));
     await tester.pump();
+    expect(reportedIsNavigation, isTrue);
     expect(reportedRouteInformation!.location, 'update');
+    reportedIsNavigation = null;
+    reportedRouteInformation = null;
   });
 
   testWidgets('router ignore navigating events updates RouteInformationProvider', (WidgetTester tester) async {
     RouteInformation? updatedRouteInformation;
     late RouteInformation nextRouteInformation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
-        // This should never be called
-        expect(true, false);
-      },
-      onRouterUpdate: (RouteInformation information) {
-        // Makes sure we only update once after manually cleaning up.
-        expect(updatedRouteInformation, isNull);
-        updatedRouteInformation = information;
-      },
-    );
-    provider.value = const RouteInformation(
-      location: 'initial',
-    );
-    final SimpleRouterDelegate delegate = SimpleRouterDelegate(reportConfiguration: true);
-    delegate.builder = (BuildContext context, RouteInformation? information) {
-      return ElevatedButton(
-        child: Text(information!.location!),
-        onPressed: () {
-          Router.neglect(context, () {
-            if (delegate.routeInformation != nextRouteInformation)
-              delegate.routeInformation = nextRouteInformation;
-          });
-        },
-      );
-    };
-    final BackButtonDispatcher outerDispatcher = RootBackButtonDispatcher();
-
-    await tester.pumpWidget(buildBoilerPlate(
-      Router<RouteInformation>(
-        backButtonDispatcher: outerDispatcher,
-        routeInformationProvider: provider,
-        routeInformationParser: SimpleRouteInformationParser(),
-        routerDelegate: delegate,
-      ),
-    ));
-    expect(find.text('initial'), findsOneWidget);
-    expect(updatedRouteInformation, isNull);
-
-    nextRouteInformation = const RouteInformation(
-      location: 'update',
-    );
-    await tester.tap(find.byType(ElevatedButton));
-    await tester.pump();
-    expect(find.text('initial'), findsNothing);
-    expect(find.text('update'), findsOneWidget);
-    expect(updatedRouteInformation!.location, 'update');
-  });
-
-  testWidgets('router ignore navigating events updates RouteInformationProvider', (WidgetTester tester) async {
-    RouteInformation? updatedRouteInformation;
-    late RouteInformation nextRouteInformation;
-    final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
-        // This should never be called
-        expect(true, false);
-      },
-      onRouterUpdate: (RouteInformation information) {
-        // Makes sure we only update once after manually cleaning up.
+      onRouterReport: (RouteInformation information, bool isNavigation) {
+        // This should never be a navigation event.
+        expect(isNavigation, false);
         expect(updatedRouteInformation, isNull);
         updatedRouteInformation = information;
       },
@@ -711,12 +674,9 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     RouteInformation? updatedRouteInformation;
     late RouteInformation nextRouteInformation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
-        // This should never be called
-        expect(true, false);
-      },
-      onRouterUpdate: (RouteInformation information) {
-        // Makes sure we only update once after manually cleaning up.
+      onRouterReport: (RouteInformation information, bool isNavigation) {
+        // This should never be a navigation event.
+        expect(isNavigation, false);
         expect(updatedRouteInformation, isNull);
         updatedRouteInformation = information;
       },
@@ -760,7 +720,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
   testWidgets('router does not report when route information is up to date with route information provider', (WidgetTester tester) async {
     RouteInformation? reportedRouteInformation;
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: (RouteInformation information) {
+      onRouterReport: (RouteInformation information, bool isNavigation) {
         reportedRouteInformation = information;
       },
     );
@@ -870,7 +830,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     ]);
 
     log.clear();
-    provider.routerUpdatesRouteInformation(const RouteInformation(location: 'b', state: false));
+    provider.routerReportsNewRouteInformation(const RouteInformation(location: 'b', state: false), isNavigation: false);
     expect(log, <Object>[
       isMethodCall('selectMultiEntryHistory', arguments: null),
       isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'b', 'state': false, 'replace': true }),
@@ -1279,7 +1239,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
   testWidgets('Router reports location if it is different from location given by OS', (WidgetTester tester) async {
     final List<RouteInformation> reportedRouteInformation = <RouteInformation>[];
     final SimpleRouteInformationProvider provider = SimpleRouteInformationProvider(
-      onRouterReport: reportedRouteInformation.add,
+      onRouterReport: (RouteInformation info, bool isNavigation) => reportedRouteInformation.add(info),
     )..value = const RouteInformation(location: '/home');
 
     await tester.pumpWidget(buildBoilerPlate(
@@ -1317,7 +1277,7 @@ Widget buildBoilerPlate(Widget child) {
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation?);
 typedef SimpleRouterDelegatePopRoute = Future<bool> Function();
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result);
-typedef RouterReportRouterInformation = void Function(RouteInformation);
+typedef RouterReportRouterInformation = void Function(RouteInformation, bool);
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {
   SimpleRouteInformationParser();
@@ -1425,11 +1385,9 @@ class SimpleNavigatorRouterDelegate extends RouterDelegate<RouteInformation> wit
 class SimpleRouteInformationProvider extends RouteInformationProvider with ChangeNotifier {
   SimpleRouteInformationProvider({
     this.onRouterReport,
-    this.onRouterUpdate,
   });
 
   RouterReportRouterInformation? onRouterReport;
-  RouterReportRouterInformation? onRouterUpdate;
 
   @override
   RouteInformation get value => _value;
@@ -1440,15 +1398,9 @@ class SimpleRouteInformationProvider extends RouteInformationProvider with Chang
   }
 
   @override
-  void routerReportsNewRouteInformation(RouteInformation routeInformation) {
+  void routerReportsNewRouteInformation(RouteInformation routeInformation, {bool isNavigation = true}) {
     _value = routeInformation;
-    onRouterReport?.call(routeInformation);
-  }
-
-  @override
-  void routerUpdatesRouteInformation(RouteInformation routeInformation) {
-    _value = routeInformation;
-    onRouterUpdate?.call(routeInformation);
+    onRouterReport?.call(routeInformation, isNavigation);
   }
 }
 


### PR DESCRIPTION

require engine pr: https://github.com/flutter/engine/pull/26456

fixes: https://github.com/flutter/flutter/issues/80546

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
