### PR TITLE
[gradle] Unlock all configurations if a local engine is used

### DIFF
--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/benchmarks/macrobenchmarks/android/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/benchmarks/platform_views_layout/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/benchmarks/test_apps/stocks/android/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
+++ b/dev/integration_tests/abstract_method_smoke_test/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/android_semantics_testing/android/build.gradle
+++ b/dev/integration_tests/android_semantics_testing/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/android_views/android/build.gradle
+++ b/dev/integration_tests/android_views/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/channels/android/build.gradle
+++ b/dev/integration_tests/channels/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/external_ui/android/build.gradle
+++ b/dev/integration_tests/external_ui/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/flavors/android/build.gradle
+++ b/dev/integration_tests/flavors/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/flutter_gallery/android/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
+++ b/dev/integration_tests/gradle_deprecated_settings/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/hybrid_android_views/android/build.gradle
+++ b/dev/integration_tests/hybrid_android_views/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/non_nullable/android/build.gradle
+++ b/dev/integration_tests/non_nullable/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/platform_interaction/android/build.gradle
+++ b/dev/integration_tests/platform_interaction/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/release_smoke_test/android/build.gradle
+++ b/dev/integration_tests/release_smoke_test/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/integration_tests/ui/android/build.gradle
+++ b/dev/integration_tests/ui/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/manual_tests/android/build.gradle
+++ b/dev/manual_tests/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/dev/tools/bin/generate_gradle_lockfiles.dart
+++ b/dev/tools/bin/generate_gradle_lockfiles.dart
@@ -161,7 +161,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/flutter_view/android/build.gradle
+++ b/examples/flutter_view/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/hello_world/android/build.gradle
+++ b/examples/hello_world/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/image_list/android/build.gradle
+++ b/examples/image_list/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/layers/android/build.gradle
+++ b/examples/layers/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/platform_channel/android/build.gradle
+++ b/examples/platform_channel/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/examples/platform_view/android/build.gradle
+++ b/examples/platform_view/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 

--- a/packages/integration_test/example/android/build.gradle
+++ b/packages/integration_test/example/android/build.gradle
@@ -39,7 +39,9 @@ subprojects {
     dependencyLocking {
         ignoredDependencies.add('io.flutter:*')
         lockFile = file("${rootProject.projectDir}/project-${project.name}.lockfile")
-        lockAllConfigurations()
+        if (!project.hasProperty('local-engine-repo')) {
+          lockAllConfigurations()
+        }
     }
 }
 


### PR DESCRIPTION
When a local engine is used, only the affected configuration dependencies are added. 
This is problematic when all the dependencies are locked, and the `.lockfile` expects some 
dependencies in the graph.

Fixes https://github.com/flutter/flutter/issues/83617