### PR TITLE
Export shadows to `Icon` API

### DIFF
--- a/packages/flutter/lib/src/cupertino/icon_theme_data.dart
+++ b/packages/flutter/lib/src/cupertino/icon_theme_data.dart
@@ -17,7 +17,8 @@ class CupertinoIconThemeData extends IconThemeData with Diagnosticable {
     Color? color,
     double? opacity,
     double? size,
-  }) : super(color: color, opacity: opacity, size: size);
+    List<Shadow>? shadows,
+  }) : super(color: color, opacity: opacity, size: size, shadows: shadows);
 
   /// Called by [IconTheme.of] to resolve [color] against the given [BuildContext].
   @override
@@ -29,11 +30,12 @@ class CupertinoIconThemeData extends IconThemeData with Diagnosticable {
   /// Creates a copy of this icon theme but with the given fields replaced with
   /// the new values.
   @override
-  CupertinoIconThemeData copyWith({ Color? color, double? opacity, double? size }) {
+  CupertinoIconThemeData copyWith({ Color? color, double? opacity, double? size, List<Shadow>? shadows }) {
     return CupertinoIconThemeData(
       color: color ?? this.color,
       opacity: opacity ?? this.opacity,
       size: size ?? this.size,
+      shadows: shadows ?? this.shadows,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -164,8 +164,7 @@ class Icon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(this.textDirection != null || debugCheckHasDirectionality(context));
-    final TextDirection textDirection =
-        this.textDirection ?? Directionality.of(context);
+    final TextDirection textDirection = this.textDirection ?? Directionality.of(context);
 
     final IconThemeData iconTheme = IconTheme.of(context);
 
@@ -187,8 +186,7 @@ class Icon extends StatelessWidget {
 
     Widget iconWidget = RichText(
       overflow: TextOverflow.visible, // Never clip.
-      textDirection:
-          textDirection, // Since we already fetched it for the assert...
+      textDirection: textDirection, // Since we already fetched it for the assert...
       text: TextSpan(
         text: String.fromCharCode(icon!.codePoint),
         style: TextStyle(

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
@@ -74,6 +75,7 @@ class Icon extends StatelessWidget {
     this.color,
     this.semanticLabel,
     this.textDirection,
+    this.shadows,
   }) : super(key: key);
 
   /// The icon to display. The available icons are described in [Icons].
@@ -150,14 +152,26 @@ class Icon extends StatelessWidget {
   /// specified, either directly using this property or using [Directionality].
   final TextDirection? textDirection;
 
+  /// A list of [Shadow]s that will be painted underneath the icon.
+  ///
+  /// Multiple shadows are supported to replicate lighting from multiple light
+  /// sources.
+  ///
+  /// Shadows must be in the same order for [Icon] to be considered as
+  /// equivalent as order produces differing transparency.
+  final List<Shadow>? shadows;
+
   @override
   Widget build(BuildContext context) {
     assert(this.textDirection != null || debugCheckHasDirectionality(context));
-    final TextDirection textDirection = this.textDirection ?? Directionality.of(context);
+    final TextDirection textDirection =
+        this.textDirection ?? Directionality.of(context);
 
     final IconThemeData iconTheme = IconTheme.of(context);
 
     final double? iconSize = size ?? iconTheme.size;
+
+    final List<Shadow>? iconShadows = shadows ?? iconTheme.shadows;
 
     if (icon == null) {
       return Semantics(
@@ -173,7 +187,8 @@ class Icon extends StatelessWidget {
 
     Widget iconWidget = RichText(
       overflow: TextOverflow.visible, // Never clip.
-      textDirection: textDirection, // Since we already fetched it for the assert...
+      textDirection:
+          textDirection, // Since we already fetched it for the assert...
       text: TextSpan(
         text: String.fromCharCode(icon!.codePoint),
         style: TextStyle(
@@ -182,6 +197,7 @@ class Icon extends StatelessWidget {
           fontSize: iconSize,
           fontFamily: icon!.fontFamily,
           package: icon!.fontPackage,
+          shadows: iconShadows,
         ),
       ),
     );
@@ -221,5 +237,6 @@ class Icon extends StatelessWidget {
     properties.add(IconDataProperty('icon', icon, ifNull: '<empty>', showName: false));
     properties.add(DoubleProperty('size', size, defaultValue: null));
     properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(IterableProperty<Shadow>('shadows', shadows, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/widgets/icon_theme.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme.dart
@@ -75,6 +75,7 @@ class IconTheme extends InheritedTheme {
         size: iconThemeData.size ?? const IconThemeData.fallback().size,
         color: iconThemeData.color ?? const IconThemeData.fallback().color,
         opacity: iconThemeData.opacity ?? const IconThemeData.fallback().opacity,
+        shadows: iconThemeData.shadows ?? const IconThemeData.fallback().shadows,
       );
   }
 

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui' as ui show lerpDouble;
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
@@ -115,11 +114,11 @@ class IconThemeData with Diagnosticable {
         && other.color == color
         && other.opacity == opacity
         && other.size == size
-        && const ListEquality<Shadow>().equals(other.shadows, shadows);
+        && listEquals(other.shadows, shadows);
   }
 
   @override
-  int get hashCode => hashValues(color, opacity, size);
+  int get hashCode => hashValues(color, opacity, size, hashList(shadows));
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -24,8 +24,7 @@ class IconThemeData with Diagnosticable {
   ///
   /// The opacity applies to both explicit and default icon colors. The value
   /// is clamped between 0.0 and 1.0.
-  const IconThemeData({this.color, double? opacity, this.size, this.shadows})
-      : _opacity = opacity;
+  const IconThemeData({this.color, double? opacity, this.size, this.shadows}) : _opacity = opacity;
 
   /// Creates an icon theme with some reasonable default values.
   ///
@@ -51,7 +50,8 @@ class IconThemeData with Diagnosticable {
   /// replaced by the non-null parameters of the given icon theme. If the given
   /// icon theme is null, simply returns this icon theme.
   IconThemeData merge(IconThemeData? other) {
-    if (other == null) return this;
+    if (other == null)
+      return this;
     return copyWith(
       color: other.color,
       opacity: other.opacity,
@@ -109,12 +109,13 @@ class IconThemeData with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType) return false;
-    return other is IconThemeData &&
-        other.color == color &&
-        other.opacity == opacity &&
-        other.size == size &&
-        const ListEquality<Shadow>().equals(other.shadows, shadows);
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is IconThemeData
+        && other.color == color
+        && other.opacity == opacity
+        && other.size == size
+        && const ListEquality<Shadow>().equals(other.shadows, shadows);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui show lerpDouble;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
@@ -23,23 +24,26 @@ class IconThemeData with Diagnosticable {
   ///
   /// The opacity applies to both explicit and default icon colors. The value
   /// is clamped between 0.0 and 1.0.
-  const IconThemeData({this.color, double? opacity, this.size}) : _opacity = opacity;
+  const IconThemeData({this.color, double? opacity, this.size, this.shadows})
+      : _opacity = opacity;
 
   /// Creates an icon theme with some reasonable default values.
   ///
   /// The [color] is black, the [opacity] is 1.0, and the [size] is 24.0.
   const IconThemeData.fallback()
-    : color = const Color(0xFF000000),
-      _opacity = 1.0,
-      size = 24.0;
+      : color = const Color(0xFF000000),
+        _opacity = 1.0,
+        size = 24.0,
+        shadows = null;
 
   /// Creates a copy of this icon theme but with the given fields replaced with
   /// the new values.
-  IconThemeData copyWith({ Color? color, double? opacity, double? size }) {
+  IconThemeData copyWith({Color? color, double? opacity, double? size, List<Shadow>? shadows}) {
     return IconThemeData(
       color: color ?? this.color,
       opacity: opacity ?? this.opacity,
       size: size ?? this.size,
+      shadows: shadows ?? this.shadows,
     );
   }
 
@@ -47,12 +51,12 @@ class IconThemeData with Diagnosticable {
   /// replaced by the non-null parameters of the given icon theme. If the given
   /// icon theme is null, simply returns this icon theme.
   IconThemeData merge(IconThemeData? other) {
-    if (other == null)
-      return this;
+    if (other == null) return this;
     return copyWith(
       color: other.color,
       opacity: other.opacity,
       size: other.size,
+      shadows: other.shadows,
     );
   }
 
@@ -87,6 +91,9 @@ class IconThemeData with Diagnosticable {
   /// The default size for icons.
   final double? size;
 
+  /// The default shadow for icons.
+  final List<Shadow>? shadows;
+
   /// Linearly interpolate between two icon theme data objects.
   ///
   /// {@macro dart.ui.shadow.lerp}
@@ -96,17 +103,18 @@ class IconThemeData with Diagnosticable {
       color: Color.lerp(a?.color, b?.color, t),
       opacity: ui.lerpDouble(a?.opacity, b?.opacity, t),
       size: ui.lerpDouble(a?.size, b?.size, t),
+      shadows: Shadow.lerpList(a?.shadows, b?.shadows, t),
     );
   }
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is IconThemeData
-        && other.color == color
-        && other.opacity == opacity
-        && other.size == size;
+    if (other.runtimeType != runtimeType) return false;
+    return other is IconThemeData &&
+        other.color == color &&
+        other.opacity == opacity &&
+        other.size == size &&
+        const ListEquality<Shadow>().equals(other.shadows, shadows);
   }
 
   @override
@@ -118,5 +126,6 @@ class IconThemeData with Diagnosticable {
     properties.add(ColorProperty('color', color, defaultValue: null));
     properties.add(DoubleProperty('opacity', opacity, defaultValue: null));
     properties.add(DoubleProperty('size', size, defaultValue: null));
+    properties.add(IterableProperty<Shadow>('shadows', shadows, defaultValue: null));
   }
 }

--- a/packages/flutter/test/widgets/icon_theme_data_test.dart
+++ b/packages/flutter/test/widgets/icon_theme_data_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('IconThemeData control test', () {
-    const IconThemeData data = IconThemeData(color: Color(0xAAAAAAAA), opacity: 0.5, size: 16.0);
+    const IconThemeData data = IconThemeData(color: Color(0xAAAAAAAA), opacity: 0.5, size: 16.0, shadows: <Shadow>[Shadow(color: Color(0xAAAAAAAA), blurRadius: 1.0, offset: Offset(1.0, 1.0))]);
 
     expect(data, hasOneLineDescription);
     expect(data, equals(data.copyWith()));
@@ -17,24 +17,27 @@ void main() {
     expect(lerped.color, const Color(0xBF7F7F7F));
     expect(lerped.opacity, 0.625);
     expect(lerped.size, 18.0);
+    expect(lerped.shadows, const <Shadow>[Shadow(color: Color(0xAAAAAAAA), blurRadius: 0.75, offset: Offset(0.75, 0.75))]);
   });
 
   test('IconThemeData lerp with first null', () {
-    const IconThemeData data = IconThemeData(color: Color(0xFFFFFFFF), opacity: 1.0, size: 16.0);
+    const IconThemeData data = IconThemeData(color: Color(0xFFFFFFFF), opacity: 1.0, size: 16.0, shadows: <Shadow>[Shadow(color: Color(0xFFFFFFFF), blurRadius: 1.0, offset: Offset(1.0, 1.0))]);
 
     final IconThemeData lerped = IconThemeData.lerp(null, data, 0.25);
     expect(lerped.color, const Color(0x40FFFFFF));
     expect(lerped.opacity, 0.25);
     expect(lerped.size, 4.0);
+    expect(lerped.shadows, const <Shadow>[Shadow(color: Color(0xFFFFFFFF), blurRadius: 0.25, offset: Offset(0.25, 0.25))]);
   });
 
   test('IconThemeData lerp with second null', () {
-    const IconThemeData data = IconThemeData(color: Color(0xFFFFFFFF), opacity: 1.0, size: 16.0);
+    const IconThemeData data = IconThemeData(color: Color(0xFFFFFFFF), opacity: 1.0, size: 16.0, shadows: <Shadow>[Shadow(color: Color(0xFFFFFFFF), blurRadius: 1.0, offset: Offset(1.0, 1.0))]);
 
     final IconThemeData lerped = IconThemeData.lerp(data, null, 0.25);
     expect(lerped.color, const Color(0xBFFFFFFF));
     expect(lerped.opacity, 0.75);
     expect(lerped.size, 12.0);
+    expect(lerped.shadows, const <Shadow>[Shadow(color: Color(0xFFFFFFFF), blurRadius: 0.75, offset: Offset(0.75, 0.75))]);
   });
 
   test('IconThemeData lerp with both null', () {
@@ -42,5 +45,6 @@ void main() {
     expect(lerped.color, null);
     expect(lerped.opacity, null);
     expect(lerped.size, null);
+    expect(lerped.shadows, null);
   });
 }


### PR DESCRIPTION
Exports the `shadows` parameter from `TextStyle` to `Icon`.

Fixes #79274
Fixes #83637.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
