### PR TITLE
[integration_test] Fix early reporting of results

### DIFF
--- a/packages/integration_test/lib/common.dart
+++ b/packages/integration_test/lib/common.dart
@@ -294,5 +294,8 @@ abstract class IntegrationTestResults {
   Map<String, dynamic>? get reportData;
 
   /// Whether all the test methods completed successfully.
+  ///
+  /// Completes when the tests have finished. The boolean value will be true if
+  /// all tests have passed, and false otherwise.
   Completer<bool> get allTestsPassed;
 }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -40,7 +40,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   IntegrationTestWidgetsFlutterBinding() {
     tearDownAll(() async {
       if (!_allTestsPassed.isCompleted) {
-        _allTestsPassed.complete(true);
+        _allTestsPassed.complete(failureMethodsDetails.isEmpty);
       }
       callbackManager.cleanup();
 
@@ -83,9 +83,6 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     reportTestException =
         (FlutterErrorDetails details, String testDescription) {
       results[testDescription] = Failure(testDescription, details.toString());
-      if (!_allTestsPassed.isCompleted) {
-        _allTestsPassed.complete(false);
-      }
       oldTestExceptionReporter(details, testDescription);
     };
   }
@@ -133,7 +130,7 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   final Completer<bool> _allTestsPassed = Completer<bool>();
 
   @override
-  List<Failure> get failureMethodsDetails => _failures;
+  List<Failure> get failureMethodsDetails => results.values.whereType<Failure>().toList();
 
   /// Similar to [WidgetsFlutterBinding.ensureInitialized].
   ///
@@ -156,8 +153,6 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   /// a [Failure].
   @visibleForTesting
   Map<String, Object> results = <String, Object>{};
-
-  List<Failure> get _failures => results.values.whereType<Failure>().toList();
 
   /// The extra data for the reported result.
   ///

--- a/packages/integration_test/test/binding_fail_test.dart
+++ b/packages/integration_test/test/binding_fail_test.dart
@@ -42,6 +42,14 @@ Future<void> main() async {
       expect(results, containsPair('passing test', equals('success')));
       expect(results, containsPair('failing test', contains(_failureExcerpt)));
     });
+
+    test('when one test fails, then another passes', () async {
+      final Map<String, dynamic>? results = await _runTest(path.join('test', 'data', 'fail_then_pass_test_script.dart'));
+
+      expect(results, hasLength(2));
+      expect(results, containsPair('failing test', contains(_failureExcerpt)));
+      expect(results, containsPair('passing test', equals('success')));
+    });
   });
 }
 

--- a/packages/integration_test/test/data/fail_test_script.dart
+++ b/packages/integration_test/test/data/fail_test_script.dart
@@ -9,6 +9,9 @@ import 'package:integration_test/integration_test.dart';
 
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
+  binding.allTestsPassed.future.then((_) {
+    print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
+  });
 
   testWidgets('failing test 1', (WidgetTester tester) async {
     expect(true, false);
@@ -16,9 +19,5 @@ Future<void> main() async {
 
   testWidgets('failing test 2', (WidgetTester tester) async {
     expect(true, false);
-  });
-
-  tearDownAll(() {
-    print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 }

--- a/packages/integration_test/test/data/fail_then_pass_test_script.dart
+++ b/packages/integration_test/test/data/fail_then_pass_test_script.dart
@@ -13,11 +13,11 @@ Future<void> main() async {
     print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 
-  testWidgets('passing test 1', (WidgetTester tester) async {
-    expect(true, true);
+  testWidgets('failing test', (WidgetTester tester) async {
+    expect(true, false);
   });
 
-  testWidgets('passing test 2', (WidgetTester tester) async {
+  testWidgets('passing test', (WidgetTester tester) async {
     expect(true, true);
   });
 }

--- a/packages/integration_test/test/data/pass_then_fail_test_script.dart
+++ b/packages/integration_test/test/data/pass_then_fail_test_script.dart
@@ -9,6 +9,9 @@ import 'package:integration_test/integration_test.dart';
 
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
+  binding.allTestsPassed.future.then((_) {
+    print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
+  });
 
   testWidgets('passing test', (WidgetTester tester) async {
     expect(true, true);
@@ -16,10 +19,5 @@ Future<void> main() async {
 
   testWidgets('failing test', (WidgetTester tester) async {
     expect(true, false);
-  });
-
-  tearDownAll(() {
-    print(
-        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 }


### PR DESCRIPTION
Fix #75216

The host waits for the `allTestsPassed` completer before exiting the test process. This completer is triggered on the first test failure, which is incorrect. On some platforms, the host driver may stop the running application, which causes the rest of the tests in the same script to not run.

This only applies for running through `flutter drive`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

