### PR TITLE
fix a Scaffold.bottomSheet update bug

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2415,7 +2415,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   // bottom sheet.
   final List<_StandardBottomSheet> _dismissedBottomSheets = <_StandardBottomSheet>[];
   PersistentBottomSheetController<dynamic>? _currentBottomSheet;
-  final GlobalKey _currentBottomSheetKey = GlobalKey();
+  GlobalKey _currentBottomSheetKey = GlobalKey();
 
   void _maybeBuildPersistentBottomSheet() {
     if (widget.bottomSheet != null && _currentBottomSheet == null) {
@@ -2443,8 +2443,14 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         return false;
       }
 
+      // It is possible that the fade-out animation of the sheet has not finished
+      // yet, and the key needs to be regenerated at this time, otherwise, there will
+      // be an exception of duplicate GlobalKey.
+      if (_currentBottomSheetKey.currentState != null)
+        _currentBottomSheetKey = GlobalKey();
       _currentBottomSheet = _buildBottomSheet<void>(
         (BuildContext context) {
+          assert(_currentBottomSheetKey.currentState == null);
           return NotificationListener<DraggableScrollableNotification>(
             onNotification: _persistentBottomSheetExtentChanged,
             child: DraggableScrollableActuator(

--- a/packages/flutter/test/material/persistent_bottom_sheet_test.dart
+++ b/packages/flutter/test/material/persistent_bottom_sheet_test.dart
@@ -501,6 +501,23 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/83668
+  testWidgets('Scaffold.bottomSheet update test', (WidgetTester tester) async {
+    Widget buildFrame(Widget? bottomSheet) {
+      return MaterialApp(
+        home: Scaffold(
+          body: const Placeholder(),
+          bottomSheet: bottomSheet,
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(const Text('I love Flutter!')));
+    await tester.pumpWidget(buildFrame(null));
+    // The disappearing animation has not yet been completed.
+    await tester.pumpWidget(buildFrame(const Text('I love Flutter!')));
+  });
+
   testWidgets('Verify that visual properties are passed through', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     const Color color = Colors.pink;


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/83668

      // It is possible that the fade-out animation of the sheet has not finished
      // yet, and the key needs to be regenerated at this time, otherwise, there will
      // be an exception of duplicate GlobalKey.