### PR TITLE
Support for keyboard navigation of Autocomplete options.

### DIFF
--- a/packages/flutter/lib/src/material/autocomplete.dart
+++ b/packages/flutter/lib/src/material/autocomplete.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'ink_well.dart';

--- a/packages/flutter/lib/src/material/autocomplete.dart
+++ b/packages/flutter/lib/src/material/autocomplete.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'ink_well.dart';
 import 'material.dart';
 import 'text_form_field.dart';
+import 'theme.dart';
 
 /// {@macro flutter.widgets.RawAutocomplete.RawAutocomplete}
 ///
@@ -291,11 +293,13 @@ class _AutocompleteOptions<T extends Object> extends StatelessWidget {
             itemCount: options.length,
             itemBuilder: (BuildContext context, int index) {
               final T option = options.elementAt(index);
+              final bool highlight = AutocompleteHighlightedOption.of(context) == index;
               return InkWell(
                 onTap: () {
                   onSelected(option);
                 },
-                child: Padding(
+                child: Container(
+                  color: highlight ? Theme.of(context).focusColor : null,
                   padding: const EdgeInsets.all(16.0),
                   child: Text(displayStringForOption(option)),
                 ),

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -16,7 +16,7 @@ import 'overlay.dart';
 import 'shortcuts.dart';
 
 /// The type of the [RawAutocomplete] callback which computes the list of
-/// optional completions for the widget's field based on the text the user has
+/// optional completions for the widget's field, based on the text the user has
 /// entered so far.
 ///
 /// See also:
@@ -641,13 +641,13 @@ class RawAutocomplete<T extends Object> extends StatefulWidget {
   /// [CompositedTransformFollower] inside of an [Overlay], not at the same
   /// place in the widget tree as [RawAutocomplete].
   ///
-  /// In order to track what item is highlighted from keyboard navigation, the
+  /// In order to track which item is highlighted by keyboard navigation, the
   /// resulting options will be wrapped in an inherited
   /// [AutocompleteHighlightedOption] widget.
-  /// In the build method of this callback, the index of the highlighted
-  /// option can be obtained from [AutocompleteHighlightedOption.of] to
-  /// display the given option with some visual highlight to indicate it will
-  /// be the option selected from the keyboard.
+  /// Inside this callback, the index of the highlighted option can be obtained
+  /// from [AutocompleteHighlightedOption.of] to display the highlighted option
+  /// with a visual highlight to indicate it will be the option selected from
+  /// the keyboard.
   ///
   /// {@endtemplate}
   final AutocompleteOptionsViewBuilder<T> optionsViewBuilder;
@@ -805,7 +805,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   void _setActionsEnabled(bool enabled) {
     // The enabled state determines whether the action will consume the
     // key shortcut or let it continue on to the underlying text field.
-    // They should only be enabled when the options are showing so they
+    // They should only be enabled when the options are showing so shortcuts
     // can be used to navigate them.
     _previousOptionAction.enabled = enabled;
     _nextOptionAction.enabled = enabled;
@@ -813,8 +813,8 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   // Hide or show the options overlay, if needed.
   void _updateOverlay() {
+    _setActionsEnabled(_shouldShowOptions);
     if (_shouldShowOptions) {
-      _setActionsEnabled(true);
       _floatingOptions?.remove();
       _floatingOptions = OverlayEntry(
         builder: (BuildContext context) {
@@ -834,12 +834,9 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
         },
       );
       Overlay.of(context, rootOverlay: true)!.insert(_floatingOptions!);
-    } else {
-      _setActionsEnabled(false);
-      if (_floatingOptions != null) {
-        _floatingOptions!.remove();
-        _floatingOptions = null;
-      }
+    } else if (_floatingOptions != null) {
+      _floatingOptions!.remove();
+      _floatingOptions = null;
     }
   }
 

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../rendering/mock_canvas.dart';
 
 class User {
   const User({
@@ -397,5 +400,57 @@ void main() {
     final TextFormField field = find.byType(TextFormField).evaluate().first.widget as TextFormField;
     expect(field.controller!.text, 'lemur');
     expect(lastSelection, 'lemur');
+  });
+
+  testWidgets('keyboard navigation of the options properly highlights the option', (WidgetTester tester) async {
+
+    void checkOptionHighlight(String label, Color? color) {
+      final RenderBox renderBox = tester.renderObject(find.ancestor(matching: find.byType(Container), of: find.text(label)));
+      if (color != null) {
+        // Check to see that the container is painted with the highlighted background color.
+        expect(renderBox, paints..rect(color: color));
+      } else {
+        // There should only be a paragraph painted.
+        expect(renderBox, paintsExactlyCountTimes(const Symbol('drawRect'), 0));
+        expect(renderBox, paints..paragraph());
+      }
+    }
+
+    const Color highlightColor = Color(0xFF112233);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light().copyWith(
+          focusColor: highlightColor,
+        ),
+        home: Scaffold(
+          body: Autocomplete<String>(
+            optionsBuilder: (TextEditingValue textEditingValue) {
+              return kOptions.where((String option) {
+                return option.contains(textEditingValue.text.toLowerCase());
+              });
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TextFormField));
+    await tester.enterText(find.byType(TextFormField), 'el');
+    await tester.pump();
+    expect(find.byType(ListView), findsOneWidget);
+    final ListView list = find.byType(ListView).evaluate().first.widget as ListView;
+    expect(list.semanticChildCount, 2);
+
+    // Initially the first option should be highlighted
+    checkOptionHighlight('chameleon', highlightColor);
+    checkOptionHighlight('elephant', null);
+
+    // Move the selection down
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+
+    // Highlight should be moved to the second item
+    checkOptionHighlight('chameleon', null);
+    checkOptionHighlight('elephant', highlightColor);
   });
 }

--- a/packages/flutter/test/material/autocomplete_test.dart
+++ b/packages/flutter/test/material/autocomplete_test.dart
@@ -339,18 +339,18 @@ void main() {
     final Finder listFinder = find.byType(ListView);
     expect(listFinder, findsNothing);
 
-    /// entering `a` returns 9 items(height > `maxOptionsHeight`) from the kOptions
-    /// so height gets restricted to `maxOptionsHeight =250`
+    // Entering `a` returns 9 items(height > `maxOptionsHeight`) from the kOptions
+    // so height gets restricted to `maxOptionsHeight =250`.
     final double nineItemsHeight = await _getDefaultOptionsHeight(tester, 'a');
     expect(nineItemsHeight, equals(maxOptionsHeight));
 
-    /// returns 2 Items (height < `maxOptionsHeight`)
-    /// so options height shrinks to 2 Items combined height
+    // Returns 2 Items (height < `maxOptionsHeight`)
+    // so options height shrinks to 2 Items combined height.
     final double twoItemsHeight = await _getDefaultOptionsHeight(tester, 'el');
     expect(twoItemsHeight, lessThan(maxOptionsHeight));
 
-    /// returns 1 item (height < `maxOptionsHeight`) from `kOptions`
-    /// so options height shrinks to 1 items height
+    // Returns 1 item (height < `maxOptionsHeight`) from `kOptions`
+    // so options height shrinks to 1 items height.
     final double oneItemsHeight = await _getDefaultOptionsHeight(tester, 'elep');
     expect(oneItemsHeight, lessThan(twoItemsHeight));
   });
@@ -405,7 +405,7 @@ void main() {
   testWidgets('keyboard navigation of the options properly highlights the option', (WidgetTester tester) async {
 
     void checkOptionHighlight(String label, Color? color) {
-      final RenderBox renderBox = tester.renderObject(find.ancestor(matching: find.byType(Container), of: find.text(label)));
+      final RenderBox renderBox = tester.renderObject<RenderBox>(find.ancestor(matching: find.byType(Container), of: find.text(label)));
       if (color != null) {
         // Check to see that the container is painted with the highlighted background color.
         expect(renderBox, paints..rect(color: color));


### PR DESCRIPTION
This PR adds support for keyboard navigation to the [Autocomplete](https://master-api.flutter.dev/flutter/material/Autocomplete-class.html) widget:

![Autocomplete-keyboard](https://user-images.githubusercontent.com/19588/120285752-6d417a00-c272-11eb-82c8-6bcb5533aacf.gif)

Specifically it adds new intents `AutocompletePreviousOptionIntent` and `AutocompleteNextOptionIntent` bound to the up arrow  and down arrow keys respectively. These are handled by actions that move a highlight up and down the options list. If the field is submitted (usually with the enter key) it will replace the text with the highlighted option.

If the app provides a custom `optionsViewBuilder` to the `Autocomplete` widget, it will need to manage the display of the highlighted option manually. To do this they can get the index of the highlighted option with the inherited widget `AutocompleteHighlightedOption`. This can be accessed in the builder with:

```dart
final highlightedIndex = AutocompleteHighlightedOption.of(context);
```

Fixes: #82783

I have added several tests to verify the keyboard navigation is working correctly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
