### PR TITLE
Fixed Typo in Editable Text API docs

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -391,7 +391,7 @@ class ToolbarOptions {
 /// [RenderEditable.selectWord], etc. programmatically.
 ///
 /// {@template flutter.widgets.editableText.showCaretOnScreen}
-/// ## Keep the caret visisble when focused
+/// ## Keep the caret visible when focused
 ///
 /// When focused, this widget will make attempts to keep the text area and its
 /// caret (even when [showCursor] is `false`) visible, on these occasions:


### PR DESCRIPTION
>Changed visisble to visible

>While reading the documentation I noticed this typo, so this PR fixes it. It is only a change to the documentation.

> fixes: #83735

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
