### PR TITLE
[flutter_tools] check for empty host in protocol_discovery

### DIFF
--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -128,7 +128,7 @@ class ProtocolDiscovery {
     } on FormatException catch (error, stackTrace) {
       _uriStreamController.addError(error, stackTrace);
     }
-    if (uri == null) {
+    if (uri == null || uri.host.isEmpty) {
       return;
     }
     if (devicePort != null && uri.port != devicePort) {

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -24,7 +24,7 @@ void main() {
         ipv6: false,
         hostPort: null,
         devicePort: null,
-        throttleDuration: const Duration(milliseconds: 200),
+        throttleDuration: const Duration(milliseconds: 5),
         logger: BufferLogger.test(),
       );
     });
@@ -43,6 +43,20 @@ void main() {
         logReader.addLine('HELLO WORLD');
         logReader.addLine('Observatory listening on http://127.0.0.1:9999');
         final Uri uri = await discoverer.uri;
+        expect(uri.port, 9999);
+        expect('$uri', 'http://127.0.0.1:9999');
+      });
+
+      testWithoutContext('does not discover uri with no host', () async {
+        final Future<Uri> pendingUri = discoverer.uri;
+        logReader.addLine('Observatory listening on http12asdasdsd9999');
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        logReader.addLine('Observatory listening on http://127.0.0.1:9999');
+
+        await Future<void>.delayed(Duration.zero);
+
+        final Uri uri = await pendingUri;
+        expect(uri, isNotNull);
         expect(uri.port, 9999);
         expect('$uri', 'http://127.0.0.1:9999');
       });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83838

The protocol discovery regex (and apparently URI) parsing is fairly lenient. Make sure that Uris that are likely not valid internet addresses cannot be connected to, though this does not go as far as allowlisting hosts like http/https/ws/localhost et cetera. I'd be worried about breaking something that may work today