### PR TITLE
Remove globals from android application_package

### DIFF
--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -18,7 +18,6 @@ import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/user_messages.dart';
 import '../build_info.dart';
-import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import 'android_sdk.dart';
 import 'gradle.dart';
@@ -42,6 +41,7 @@ class AndroidApk extends ApplicationPackage {
     @required ProcessManager processManager,
     @required UserMessages userMessages,
     @required Logger logger,
+    @required ProcessUtils processUtils,
   }) {
     final String aaptPath = androidSdk?.latestVersion?.aaptPath;
     if (aaptPath == null || !processManager.canRun(aaptPath)) {
@@ -51,7 +51,7 @@ class AndroidApk extends ApplicationPackage {
 
     String apptStdout;
     try {
-      apptStdout = globals.processUtils.runSync(
+      apptStdout = processUtils.runSync(
         <String>[
           aaptPath,
           'dump',
@@ -62,7 +62,7 @@ class AndroidApk extends ApplicationPackage {
         throwOnError: true,
       ).stdout.trim();
     } on ProcessException catch (error) {
-      globals.printError('Failed to extract manifest from APK: $error.');
+      logger.printError('Failed to extract manifest from APK: $error.');
       return null;
     }
 
@@ -117,6 +117,7 @@ class AndroidApk extends ApplicationPackage {
           processManager: processManager,
           logger: logger,
           userMessages: userMessages,
+          processUtils: processUtils,
         );
       }
       // The .apk hasn't been built yet, so we work with what we have. The run
@@ -209,24 +210,24 @@ class AndroidApk extends ApplicationPackage {
   String get name => file.basename;
 }
 
+abstract class _Entry {
+  const _Entry(this.parent, this.level);
 
-class _Entry {
-  _Element parent;
-  int level;
+  final _Element parent;
+  final int level;
 }
 
 class _Element extends _Entry {
-  _Element.fromLine(String line, _Element parent) {
+  _Element._(this.name, _Element parent, int level) : super(parent, level);
+
+  factory _Element.fromLine(String line, _Element parent) {
     //      E: application (line=29)
     final List<String> parts = line.trimLeft().split(' ');
-    name = parts[1];
-    level = line.length - line.trimLeft().length;
-    this.parent = parent;
-    children = <_Entry>[];
+    return _Element._(parts[1], parent, line.length - line.trimLeft().length);
   }
 
-  List<_Entry> children;
-  String name;
+  final List<_Entry> children = <_Entry>[];
+  final String name;
 
   void addChild(_Entry child) {
     children.add(child);
@@ -252,20 +253,17 @@ class _Element extends _Entry {
 }
 
 class _Attribute extends _Entry {
-  _Attribute.fromLine(String line, _Element parent) {
+  const _Attribute._(this.key, this.value, _Element parent, int level) : super(parent, level);
+
+  factory _Attribute.fromLine(String line, _Element parent) {
     //     A: android:label(0x01010001)="hello_world" (Raw: "hello_world")
     const String attributePrefix = 'A: ';
-    final List<String> keyVal = line
-        .substring(line.indexOf(attributePrefix) + attributePrefix.length)
-        .split('=');
-    key = keyVal[0];
-    value = keyVal[1];
-    level = line.length - line.trimLeft().length;
-    this.parent = parent;
+    final List<String> keyVal = line.substring(line.indexOf(attributePrefix) + attributePrefix.length).split('=');
+    return _Attribute._(keyVal[0], keyVal[1], parent, line.length - line.trimLeft().length);
   }
 
-  String key;
-  String value;
+  final String key;
+  final String value;
 }
 
 class ApkManifestData {
@@ -388,10 +386,13 @@ class ApkManifestData {
       return null;
     }
 
-    final Map<String, Map<String, String>> map = <String, Map<String, String>>{};
-    map['package'] = <String, String>{'name': packageName};
-    map['version-code'] = <String, String>{'name': versionCode.toString()};
-    map['launchable-activity'] = <String, String>{'name': activityName};
+    final Map<String, Map<String, String>> map = <String, Map<String, String>>{
+      if (packageName != null)
+        'package': <String, String>{'name': packageName},
+      'version-code': <String, String>{'name': versionCode.toString()},
+      if (activityName != null)
+        'launchable-activity': <String, String>{'name': activityName},
+    };
 
     return ApkManifestData._(map);
   }

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -77,6 +77,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
           logger: _logger,
           androidSdk: _androidSdk,
           userMessages: _userMessages,
+          processUtils: _processUtils,
         );
       case TargetPlatform.ios:
         return applicationBinary == null

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -122,12 +123,14 @@ void main() {
     testWithoutContext('returns null when failed to extract manifest', () async {
       final AndroidSdkVersion sdkVersion = FakeAndroidSdkVersion();
       sdk.latestVersion = sdkVersion;
+      final Logger logger = BufferLogger.test();
       final AndroidApk androidApk = AndroidApk.fromApk(
         null,
         processManager: fakeProcessManager,
-        logger: BufferLogger.test(),
+        logger: logger,
         userMessages: UserMessages(),
         androidSdk: sdk,
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
       );
 
       expect(androidApk, isNull);


### PR DESCRIPTION
Also clean up `_Entry` and subclasses to use final properties.

Part of #47161.