### PR TITLE
Added `onDismiss` callback to ModalBarrier.

### DIFF
--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -47,7 +47,12 @@ class ModalBarrier extends StatelessWidget {
   ///    [ModalBarrier] built by [ModalRoute] pages.
   final Color? color;
 
-  /// Whether touching the barrier will pop the current route off the [Navigator].
+  /// Specifies if the barrier will be dismissed when the user taps on it.
+  ///
+  /// If true, and [onDismiss] is non-null, [onDismiss] will be called,
+  /// otherwise the current route will be popped from the ambient [Navigator].
+  ///
+  /// If false, tapping on the barrier will do nothing.
   ///
   /// See also:
   ///

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -365,6 +365,60 @@ void main() {
     expect(willPopCalled, isTrue);
   });
 
+  testWidgets('ModalBarrier will call onDismiss callback', (WidgetTester tester) async {
+    bool dismissCallbackCalled = false;
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => const FirstWidget(),
+      '/modal': (BuildContext context) => SecondWidget(onDismiss: () {
+        dismissCallbackCalled = true;
+      }),
+    };
+
+    await tester.pumpWidget(MaterialApp(routes: routes));
+
+    // Initially the barrier is not visible
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+    // Tapping on X routes to the barrier
+    await tester.tap(find.text('X'));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+    expect(find.byKey(const ValueKey<String>('barrier')), findsOneWidget);
+    expect(dismissCallbackCalled, false);
+
+    // Tap on the barrier
+    await tester.tap(find.byKey(const ValueKey<String>('barrier')));
+    await tester.pumpAndSettle(const Duration(seconds: 1)); // end transition
+    expect(dismissCallbackCalled, true);
+  });
+
+  testWidgets('ModalBarrier will not pop when given an onDismiss callback', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => const FirstWidget(),
+      '/modal': (BuildContext context) => SecondWidget(onDismiss: () {}),
+    };
+
+    await tester.pumpWidget(MaterialApp(routes: routes));
+
+    // Initially the barrier is not visible
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+    // Tapping on X routes to the barrier
+    await tester.tap(find.text('X'));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+    expect(find.byKey(const ValueKey<String>('barrier')), findsOneWidget);
+
+    // Tap on the barrier
+    await tester.tap(find.byKey(const ValueKey<String>('barrier')));
+    await tester.pumpAndSettle(const Duration(seconds: 1)); // end transition
+    expect(
+      find.byKey(const ValueKey<String>('barrier')),
+      findsOneWidget,
+      reason: 'The route should not have been dismissed by tapping the barrier, as there was a onDismiss callback given.',
+    );
+  });
+
   testWidgets('Undismissible ModalBarrier hidden in semantic tree', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     await tester.pumpWidget(const ModalBarrier(dismissible: false));
@@ -442,11 +496,16 @@ class FirstWidget extends StatelessWidget {
 }
 
 class SecondWidget extends StatelessWidget {
-  const SecondWidget({ Key? key }) : super(key: key);
+  const SecondWidget({ Key? key, this.onDismiss }) : super(key: key);
+
+  final VoidCallback? onDismiss;
+
   @override
   Widget build(BuildContext context) {
-    return const ModalBarrier(
-      key: ValueKey<String>('barrier'),
+    return ModalBarrier(
+      key: const ValueKey<String>('barrier'),
+      dismissible: true,
+      onDismiss: onDismiss,
     );
   }
 }

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -504,7 +504,6 @@ class SecondWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return ModalBarrier(
       key: const ValueKey<String>('barrier'),
-      dismissible: true,
       onDismiss: onDismiss,
     );
   }


### PR DESCRIPTION
The current `ModalBarrier` only supports dismissing the barrier by popping the current route. However, there are cases like the new Autocomplete widget were we are showing a popup that we want to dismiss by touching outside the popup, but it isn't implemented as a route. 

This PR adds a new `onDismiss` field to the ModalBarrier so that users can override the way the barrier is dismissed. If it is provided, it will be called instead of popping the current route. Otherwise it will behave as it always did.

This will allow us to use this when fixing issue #78184.

I have added a couple of tests that verify that the callback is called if present and only pops the current route if no callback is provided.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
