### PR TITLE
Allows SwitchListTile, CheckboxListTile and RadioListTile to also be able to change horizontalTitleGap, minVerticalPadding, minLeadingWidth

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -278,14 +278,17 @@ class CheckboxListTile extends StatelessWidget {
     this.tristate = false,
     this.shape,
     this.selectedTileColor,
-  }) : assert(tristate != null),
-       assert(tristate || value != null),
-       assert(isThreeLine != null),
-       assert(!isThreeLine || subtitle != null),
-       assert(selected != null),
-       assert(controlAffinity != null),
-       assert(autofocus != null),
-       super(key: key);
+    this.horizontalTitleGap,
+    this.minVerticalPadding,
+    this.minLeadingWidth,
+  })  : assert(tristate != null),
+        assert(tristate || value != null),
+        assert(isThreeLine != null),
+        assert(!isThreeLine || subtitle != null),
+        assert(selected != null),
+        assert(controlAffinity != null),
+        assert(autofocus != null),
+        super(key: key);
 
   /// Whether this checkbox is checked.
   final bool? value;
@@ -395,6 +398,24 @@ class CheckboxListTile extends StatelessWidget {
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.
   final Color? selectedTileColor;
 
+  /// The horizontal gap between the titles and the leading/trailing widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.horizontalTitleGap] is used. If
+  /// that is also null, then a default value of 16 is used.
+  final double? horizontalTitleGap;
+
+  /// The minimum padding on the top and bottom of the title and subtitle widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.minVerticalPadding] is used. If
+  /// that is also null, then a default value of 4 is used.
+  final double? minVerticalPadding;
+
+  /// The minimum width allocated for the [ListTile.leading] widget.
+  ///
+  /// If null, then the value of [ListTileTheme.minLeadingWidth] is used. If
+  /// that is also null, then a default value of 40 is used.
+  final double? minLeadingWidth;
+
   void _handleValueChange() {
     assert(onChanged != null);
     switch (value) {
@@ -451,6 +472,9 @@ class CheckboxListTile extends StatelessWidget {
           shape: shape,
           selectedTileColor: selectedTileColor,
           tileColor: tileColor,
+          horizontalTitleGap: horizontalTitleGap,
+          minVerticalPadding: minVerticalPadding,
+          minLeadingWidth: minLeadingWidth,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -328,13 +328,16 @@ class RadioListTile<T> extends StatelessWidget {
     this.shape,
     this.tileColor,
     this.selectedTileColor,
-  }) : assert(toggleable != null),
-       assert(isThreeLine != null),
-       assert(!isThreeLine || subtitle != null),
-       assert(selected != null),
-       assert(controlAffinity != null),
-       assert(autofocus != null),
-       super(key: key);
+    this.horizontalTitleGap,
+    this.minVerticalPadding,
+    this.minLeadingWidth,
+  })  : assert(toggleable != null),
+        assert(isThreeLine != null),
+        assert(!isThreeLine || subtitle != null),
+        assert(selected != null),
+        assert(controlAffinity != null),
+        assert(autofocus != null),
+        super(key: key);
 
   /// The value represented by this radio button.
   final T value;
@@ -500,6 +503,24 @@ class RadioListTile<T> extends StatelessWidget {
   /// If non-null, defines the background color when [RadioListTile.selected] is true.
   final Color? selectedTileColor;
 
+  /// The horizontal gap between the titles and the leading/trailing widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.horizontalTitleGap] is used. If
+  /// that is also null, then a default value of 16 is used.
+  final double? horizontalTitleGap;
+
+  /// The minimum padding on the top and bottom of the title and subtitle widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.minVerticalPadding] is used. If
+  /// that is also null, then a default value of 4 is used.
+  final double? minVerticalPadding;
+
+  /// The minimum width allocated for the [ListTile.leading] widget.
+  ///
+  /// If null, then the value of [ListTileTheme.minLeadingWidth] is used. If
+  /// that is also null, then a default value of 40 is used.
+  final double? minLeadingWidth;
+
   @override
   Widget build(BuildContext context) {
     final Widget control = Radio<T>(
@@ -537,18 +558,23 @@ class RadioListTile<T> extends StatelessWidget {
           shape: shape,
           tileColor: tileColor,
           selectedTileColor: selectedTileColor,
-          onTap: onChanged != null ? () {
-            if (toggleable && checked) {
-              onChanged!(null);
-              return;
-            }
-            if (!checked) {
-              onChanged!(value);
-            }
-          } : null,
+          onTap: onChanged != null
+              ? () {
+                  if (toggleable && checked) {
+                    onChanged!(null);
+                    return;
+                  }
+                  if (!checked) {
+                    onChanged!(value);
+                  }
+                }
+              : null,
           selected: selected,
           autofocus: autofocus,
           contentPadding: contentPadding,
+          horizontalTitleGap: horizontalTitleGap,
+          minVerticalPadding: minVerticalPadding,
+          minLeadingWidth: minLeadingWidth,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -280,13 +280,16 @@ class SwitchListTile extends StatelessWidget {
     this.controlAffinity = ListTileControlAffinity.platform,
     this.shape,
     this.selectedTileColor,
-  }) : _switchListTileType = _SwitchListTileType.material,
-       assert(value != null),
-       assert(isThreeLine != null),
-       assert(!isThreeLine || subtitle != null),
-       assert(selected != null),
-       assert(autofocus != null),
-       super(key: key);
+    this.horizontalTitleGap,
+    this.minVerticalPadding,
+    this.minLeadingWidth,
+  })  : _switchListTileType = _SwitchListTileType.material,
+        assert(value != null),
+        assert(isThreeLine != null),
+        assert(!isThreeLine || subtitle != null),
+        assert(selected != null),
+        assert(autofocus != null),
+        super(key: key);
 
   /// Creates a Material [ListTile] with an adaptive [Switch], following
   /// Material design's
@@ -322,13 +325,16 @@ class SwitchListTile extends StatelessWidget {
     this.controlAffinity = ListTileControlAffinity.platform,
     this.shape,
     this.selectedTileColor,
-  }) : _switchListTileType = _SwitchListTileType.adaptive,
-       assert(value != null),
-       assert(isThreeLine != null),
-       assert(!isThreeLine || subtitle != null),
-       assert(selected != null),
-       assert(autofocus != null),
-       super(key: key);
+    this.horizontalTitleGap,
+    this.minVerticalPadding,
+    this.minLeadingWidth,
+  })  : _switchListTileType = _SwitchListTileType.adaptive,
+        assert(value != null),
+        assert(isThreeLine != null),
+        assert(!isThreeLine || subtitle != null),
+        assert(selected != null),
+        assert(autofocus != null),
+        super(key: key);
 
   /// Whether this switch is checked.
   ///
@@ -458,6 +464,24 @@ class SwitchListTile extends StatelessWidget {
   /// If non-null, defines the background color when [SwitchListTile.selected] is true.
   final Color? selectedTileColor;
 
+  /// The horizontal gap between the titles and the leading/trailing widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.horizontalTitleGap] is used. If
+  /// that is also null, then a default value of 16 is used.
+  final double? horizontalTitleGap;
+
+  /// The minimum padding on the top and bottom of the title and subtitle widgets.
+  ///
+  /// If null, then the value of [ListTileTheme.minVerticalPadding] is used. If
+  /// that is also null, then a default value of 4 is used.
+  final double? minVerticalPadding;
+
+  /// The minimum width allocated for the [ListTile.leading] widget.
+  ///
+  /// If null, then the value of [ListTileTheme.minLeadingWidth] is used. If
+  /// that is also null, then a default value of 40 is used.
+  final double? minLeadingWidth;
+
   @override
   Widget build(BuildContext context) {
     final Widget control;
@@ -517,12 +541,19 @@ class SwitchListTile extends StatelessWidget {
           dense: dense,
           contentPadding: contentPadding,
           enabled: onChanged != null,
-          onTap: onChanged != null ? () { onChanged!(!value); } : null,
+          onTap: onChanged != null
+              ? () {
+                  onChanged!(!value);
+                }
+              : null,
           selected: selected,
           selectedTileColor: selectedTileColor,
           autofocus: autofocus,
           shape: shape,
           tileColor: tileColor,
+          horizontalTitleGap: horizontalTitleGap,
+          minVerticalPadding: minVerticalPadding,
+          minLeadingWidth: minLeadingWidth,
         ),
       ),
     );


### PR DESCRIPTION
Allow SwitchListTile, CheckboxListTile and RadioListTile to also be able to change horizontalTitleGap, minVerticalPadding, minLeadingWidth like here: #64222

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes #83898

I'm not sure what kind of tests should be made for this, I'm just passing over the values down to the ListTile, and the ListTile already has tests for these properties...

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.



If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
