### PR TITLE
Remove deprecated hasFloatingPlaceholder

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -857,6 +857,67 @@ transforms:
     date: 2020-01-15
     element:
       uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'InputDecorationTheme'
+    oneOf:
+      - if: "hasFloatingPlaceholder == 'true'"
+        changes:
+          - kind: 'addParameter'
+            index: 14
+            name: 'floatingLabelBehavior'
+            style: optional_named
+            argumentValue:
+              expression: '{% FloatingLabelBehavior %}.auto'
+              requiredIf: "hasFloatingPlaceholder == 'true'"
+              variables:
+                FloatingLabelBehavior:
+                  kind: 'import'
+                  uris: [ 'material.dart' ]
+                  name: 'FloatingLabelBehavior'
+          - kind: 'removeParameter'
+            name: 'hasFloatingPlaceholder'
+      - if: "hasFloatingPlaceholder == 'false'"
+        changes:
+          - kind: 'addParameter'
+            index: 14
+            name: 'floatingLabelBehavior'
+            style: optional_named
+            argumentValue:
+              expression: '{% FloatingLabelBehavior %}.never'
+              requiredIf: "hasFloatingPlaceholder == 'false'"
+              variables:
+                FloatingLabelBehavior:
+                  kind: 'import'
+                  uris: [ 'material.dart' ]
+                  name: 'FloatingLabelBehavior'
+          - kind: 'removeParameter'
+            name: 'hasFloatingPlaceholder'
+      - if: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
+        changes:
+          - kind: 'addParameter'
+            index: 14
+            name: 'floatingLabelBehavior'
+            style: optional_named
+            argumentValue:
+              expression: '{% hasFloatingPlaceholder %} ? {% FloatingLabelBehavior %}.auto : {% FloatingLabelBehavior %}.never'
+              requiredIf: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
+              variables:
+                FloatingLabelBehavior:
+                  kind: 'import'
+                  uris: [ 'material.dart' ]
+                  name: 'FloatingLabelBehavior'
+          - kind: 'removeParameter'
+            name: 'hasFloatingPlaceholder'
+    variables:
+      hasFloatingPlaceholder:
+        kind: 'fragment'
+        value: 'arguments[hasFloatingPlaceholder]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/46115
+  - title: "Migrate to 'floatingLabelBehavior'"
+    date: 2020-01-15
+    element:
+      uris: [ 'material.dart' ]
       field: 'hasFloatingPlaceholder'
       inClass: 'InputDecoration'
     changes:

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -279,8 +279,9 @@ class OutlineInputBorder extends InputBorder {
   ///
   /// See also:
   ///
-  ///  * [InputDecoration.hasFloatingPlaceholder], which should be set to false
-  ///    when the [borderSide] is [BorderSide.none]. If let as true, the label
+  ///  * [InputDecoration.floatingLabelBehavior], which should be set to
+  ///    [FloatingLabelBehavior.never] when the [borderSide] is
+  ///    [BorderSide.none]. If let as [FloatingLabelBehavior.auto], the label
   ///    will extend beyond the container as if the border were still being
   ///    drawn.
   const OutlineInputBorder({

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1949,7 +1949,6 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     final bool labelIsInitiallyFloating = widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always
         || (widget.decoration.floatingLabelBehavior != FloatingLabelBehavior.never &&
-            widget.decoration.hasFloatingPlaceholder &&
             widget._labelShouldWithdraw);
 
     _floatingLabelController = AnimationController(
@@ -1997,7 +1996,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   bool get isHovering => widget.isHovering && decoration!.enabled;
   bool get isEmpty => widget.isEmpty;
   bool get _floatingLabelEnabled {
-    return decoration!.hasFloatingPlaceholder && decoration!.floatingLabelBehavior != FloatingLabelBehavior.never;
+    return decoration!.floatingLabelBehavior != FloatingLabelBehavior.never;
   }
 
   @override
@@ -2006,8 +2005,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (widget.decoration != old.decoration)
       _effectiveDecoration = null;
 
-    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior
-        || widget.decoration.hasFloatingPlaceholder != old.decoration.hasFloatingPlaceholder;
+    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
       if (_floatingLabelEnabled
@@ -2537,11 +2535,6 @@ class InputDecoration {
     this.errorText,
     this.errorStyle,
     this.errorMaxLines,
-    @Deprecated(
-      'Use floatingLabelBehavior instead. '
-      'This feature was deprecated after v1.13.2.',
-    )
-    this.hasFloatingPlaceholder = true,
     this.floatingLabelBehavior,
     this.isCollapsed = false,
     this.isDense,
@@ -2584,11 +2577,6 @@ class InputDecoration {
   /// Sets the [isCollapsed] property to true.
   const InputDecoration.collapsed({
     required this.hintText,
-    @Deprecated(
-      'Use floatingLabelBehavior instead. '
-      'This feature was deprecated after v1.13.2.',
-    )
-    this.hasFloatingPlaceholder = true,
     this.floatingLabelBehavior,
     this.hintStyle,
     this.hintTextDirection,
@@ -2599,10 +2587,6 @@ class InputDecoration {
     this.border = InputBorder.none,
     this.enabled = true,
   }) : assert(enabled != null),
-       assert(
-         !(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
-         'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always',
-       ),
        icon = null,
        labelText = null,
        labelStyle = null,
@@ -2759,21 +2743,6 @@ class InputDecoration {
   ///
   ///  * [helperMaxLines], the equivalent but for the [helperText].
   final int? errorMaxLines;
-
-  /// Whether the label floats on focus.
-  ///
-  /// If this is false, the placeholder disappears when the input has focus or
-  /// text has been entered.
-  /// If this is true, the placeholder will rise to the top of the input when
-  /// the input has focus or text has been entered.
-  ///
-  /// Defaults to true.
-  ///
-  @Deprecated(
-    'Use floatingLabelBehavior instead. '
-    'This feature was deprecated after v1.13.2.',
-  )
-  final bool hasFloatingPlaceholder;
 
   /// {@template flutter.material.inputDecoration.floatingLabelBehavior}
   /// Defines how the floating label should be displayed.
@@ -3361,7 +3330,6 @@ class InputDecoration {
     String? errorText,
     TextStyle? errorStyle,
     int? errorMaxLines,
-    bool? hasFloatingPlaceholder,
     FloatingLabelBehavior? floatingLabelBehavior,
     bool? isCollapsed,
     bool? isDense,
@@ -3408,7 +3376,6 @@ class InputDecoration {
       errorText: errorText ?? this.errorText,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
       floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
       isCollapsed: isCollapsed ?? this.isCollapsed,
       isDense: isDense ?? this.isDense,
@@ -3456,7 +3423,6 @@ class InputDecoration {
       hintStyle: hintStyle ?? theme.hintStyle,
       errorStyle: errorStyle ?? theme.errorStyle,
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
-      hasFloatingPlaceholder: hasFloatingPlaceholder,
       floatingLabelBehavior: floatingLabelBehavior ?? theme.floatingLabelBehavior,
       isCollapsed: isCollapsed,
       isDense: isDense ?? theme.isDense,
@@ -3499,7 +3465,6 @@ class InputDecoration {
         && other.errorText == errorText
         && other.errorStyle == errorStyle
         && other.errorMaxLines == errorMaxLines
-        && other.hasFloatingPlaceholder == hasFloatingPlaceholder
         && other.floatingLabelBehavior == floatingLabelBehavior
         && other.isDense == isDense
         && other.contentPadding == contentPadding
@@ -3549,7 +3514,6 @@ class InputDecoration {
       errorText,
       errorStyle,
       errorMaxLines,
-      hasFloatingPlaceholder,
       floatingLabelBehavior,
       isDense,
       contentPadding,
@@ -3599,7 +3563,6 @@ class InputDecoration {
       if (errorText != null) 'errorText: "$errorText"',
       if (errorStyle != null) 'errorStyle: "$errorStyle"',
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
-      if (hasFloatingPlaceholder == false) 'hasFloatingPlaceholder: false',
       if (floatingLabelBehavior != null) 'floatingLabelBehavior: $floatingLabelBehavior',
       if (isDense ?? false) 'isDense: $isDense',
       if (contentPadding != null) 'contentPadding: $contentPadding',
@@ -3659,11 +3622,6 @@ class InputDecorationTheme with Diagnosticable {
     this.hintStyle,
     this.errorStyle,
     this.errorMaxLines,
-    @Deprecated(
-      'Use floatingLabelBehavior instead. '
-      'This feature was deprecated after v1.13.2.',
-    )
-    this.hasFloatingPlaceholder = true,
     this.floatingLabelBehavior = FloatingLabelBehavior.auto,
     this.isDense = false,
     this.contentPadding,
@@ -3686,11 +3644,7 @@ class InputDecorationTheme with Diagnosticable {
   }) : assert(isDense != null),
        assert(isCollapsed != null),
        assert(filled != null),
-       assert(alignLabelWithHint != null),
-       assert(
-         !(!hasFloatingPlaceholder && identical(floatingLabelBehavior, FloatingLabelBehavior.always)),
-         'hasFloatingPlaceholder=false conflicts with FloatingLabelBehavior.always',
-       );
+       assert(alignLabelWithHint != null);
 
   /// The style to use for [InputDecoration.labelText] when the label is
   /// above (i.e., vertically adjacent to) the input field.
@@ -3747,20 +3701,6 @@ class InputDecorationTheme with Diagnosticable {
   ///
   ///  * [helperMaxLines], the equivalent but for the [InputDecoration.helperText].
   final int? errorMaxLines;
-
-  /// Whether the placeholder text floats to become a label on focus.
-  ///
-  /// If this is false, the placeholder disappears when the input has focus or
-  /// text has been entered.
-  /// If this is true, the placeholder will rise to the top of the input when
-  /// the input has focus or text has been entered.
-  ///
-  /// Defaults to true.
-  @Deprecated(
-    'Use floatingLabelBehavior instead. '
-    'This feature was deprecated after v1.13.2.',
-  )
-  final bool hasFloatingPlaceholder;
 
   /// {@macro flutter.material.inputDecoration.floatingLabelBehavior}
   ///
@@ -4030,11 +3970,6 @@ class InputDecorationTheme with Diagnosticable {
     TextStyle? hintStyle,
     TextStyle? errorStyle,
     int? errorMaxLines,
-    @Deprecated(
-      'Use floatingLabelBehavior instead. '
-      'This feature was deprecated after v1.13.2.',
-    )
-    bool? hasFloatingPlaceholder,
     FloatingLabelBehavior? floatingLabelBehavior,
     bool? isDense,
     EdgeInsetsGeometry? contentPadding,
@@ -4062,7 +3997,6 @@ class InputDecorationTheme with Diagnosticable {
       hintStyle: hintStyle ?? this.hintStyle,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      hasFloatingPlaceholder: hasFloatingPlaceholder ?? this.hasFloatingPlaceholder,
       floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
@@ -4094,7 +4028,6 @@ class InputDecorationTheme with Diagnosticable {
       hintStyle,
       errorStyle,
       errorMaxLines,
-      hasFloatingPlaceholder,
       floatingLabelBehavior,
       isDense,
       contentPadding,
@@ -4162,7 +4095,6 @@ class InputDecorationTheme with Diagnosticable {
     properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle, defaultValue: defaultTheme.hintStyle));
     properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
     properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
-    properties.add(DiagnosticsProperty<bool>('hasFloatingPlaceholder', hasFloatingPlaceholder, defaultValue: defaultTheme.hasFloatingPlaceholder));
     properties.add(DiagnosticsProperty<FloatingLabelBehavior>('floatingLabelBehavior', floatingLabelBehavior, defaultValue: defaultTheme.floatingLabelBehavior));
     properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4119,7 +4119,6 @@ void main() {
       'helperMaxLines: 6',
       'hintStyle: TextStyle(<all styles inherited>)',
       'errorMaxLines: 5',
-      'hasFloatingPlaceholder: false',
       'floatingLabelBehavior: FloatingLabelBehavior.never',
       'contentPadding: EdgeInsetsDirectional(40.0, 12.0, 0.0, 12.0)',
       'prefixStyle: TextStyle(<all styles inherited>)',

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2894,7 +2894,7 @@ void main() {
         isEmpty: true,
         decoration: const InputDecoration(
           border: OutlineInputBorder(borderSide: BorderSide.none),
-          hasFloatingPlaceholder: false,
+          floatingLabelBehavior: FloatingLabelBehavior.never,
           labelText: 'label',
         ),
       ),
@@ -2918,7 +2918,7 @@ void main() {
         // isFocused: false (default)
         decoration: const InputDecoration(
           border: OutlineInputBorder(borderSide: BorderSide.none),
-          hasFloatingPlaceholder: false,
+          floatingLabelBehavior: FloatingLabelBehavior.never,
           labelText: 'label',
         ),
       ),
@@ -4094,7 +4094,6 @@ void main() {
       helperMaxLines: 6,
       hintStyle: TextStyle(),
       errorMaxLines: 5,
-      hasFloatingPlaceholder: false,
       floatingLabelBehavior: FloatingLabelBehavior.never,
       contentPadding: EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
       prefixStyle: TextStyle(),

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -194,6 +194,9 @@ void main() {
   InputDecorationTheme(hasFloatingPlaceholder: false);
   InputDecorationTheme();
   inputDecorationTheme.hasFloatingPlaceholder;
+  inputDecorationTheme.copyWith(hasFloatingPlaceholder: false);
+  inputDecorationTheme.copyWith(hasFloatingPlaceholder: true);
+  inputDecorationTheme.copyWith();
 
   // Changes made in https://github.com/flutter/flutter/pull/66482
   ThemeData(textSelectionColor: Colors.red);

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -194,6 +194,9 @@ void main() {
   InputDecorationTheme(floatingLabelBehavior: FloatingLabelBehavior.never);
   InputDecorationTheme();
   inputDecorationTheme.floatingLabelBehavior;
+  inputDecorationTheme.copyWith(floatingLabelBehavior: FloatingLabelBehavior.never);
+  inputDecorationTheme.copyWith(floatingLabelBehavior: FloatingLabelBehavior.auto);
+  inputDecorationTheme.copyWith();
 
   // Changes made in https://github.com/flutter/flutter/pull/66482
   ThemeData(textSelectionTheme: TextSelectionThemeData(selectionColor: Colors.red));


### PR DESCRIPTION
This removes the deprecated `hasFloatingPlaceholder` from `InputDecoration` and `InputDecorationTheme`. 

Flutter/Dart fixes are available to migrate to the new API.

Deprecated in https://github.com/flutter/flutter/pull/46115

This is part of the batch of deprecations slated for removal after the release of 2.2.
[Full list available here.](https://docs.google.com/spreadsheets/d/18VuxojMGFKrFJCeilg3tErAtp23-_tp43XUioC_34To/edit?usp=sharing)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
