### PR TITLE
Mark devicelab test Mac android microbenchmark as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1171,6 +1171,7 @@ targets:
 
   - name: mac_android_microbenchmarks
     builder: Mac_android microbenchmarks
+    bringup: true
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Test mac_android_microbenchmarks is 3.24% flaky for the past 15 days.

Issue: https://github.com/flutter/flutter/issues/83939