### PR TITLE
Fixed TimeOfDay.hourOfPeriod for the noon and midnight cases.

### DIFF
--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -92,6 +92,8 @@ class TimeOfDay {
   DayPeriod get period => hour < hoursPerPeriod ? DayPeriod.am : DayPeriod.pm;
 
   /// Which hour of the current period (e.g., am or pm) this time is.
+  ///
+  /// For 12AM (midnight) and 12PM (noon) this returns 12.
   int get hourOfPeriod => hour == 0 || hour == 12 ? 12 : hour - periodOffset;
 
   /// The hour at which the current period starts.

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -92,7 +92,7 @@ class TimeOfDay {
   DayPeriod get period => hour < hoursPerPeriod ? DayPeriod.am : DayPeriod.pm;
 
   /// Which hour of the current period (e.g., am or pm) this time is.
-  int get hourOfPeriod => hour - periodOffset;
+  int get hourOfPeriod => hour == 0 || hour == 12 ? 12 : hour - periodOffset;
 
   /// The hour at which the current period starts.
   int get periodOffset => period == DayPeriod.am ? 0 : hoursPerPeriod;

--- a/packages/flutter/test/material/time_test.dart
+++ b/packages/flutter/test/material/time_test.dart
@@ -27,6 +27,34 @@ void main() {
     });
   });
 
+  testWidgets('hourOfPeriod returns correct value', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/59158.
+    expect(const TimeOfDay(minute: 0, hour:  0).hourOfPeriod, 12);
+    expect(const TimeOfDay(minute: 0, hour:  1).hourOfPeriod,  1);
+    expect(const TimeOfDay(minute: 0, hour:  2).hourOfPeriod,  2);
+    expect(const TimeOfDay(minute: 0, hour:  3).hourOfPeriod,  3);
+    expect(const TimeOfDay(minute: 0, hour:  4).hourOfPeriod,  4);
+    expect(const TimeOfDay(minute: 0, hour:  5).hourOfPeriod,  5);
+    expect(const TimeOfDay(minute: 0, hour:  6).hourOfPeriod,  6);
+    expect(const TimeOfDay(minute: 0, hour:  7).hourOfPeriod,  7);
+    expect(const TimeOfDay(minute: 0, hour:  8).hourOfPeriod,  8);
+    expect(const TimeOfDay(minute: 0, hour:  9).hourOfPeriod,  9);
+    expect(const TimeOfDay(minute: 0, hour: 10).hourOfPeriod, 10);
+    expect(const TimeOfDay(minute: 0, hour: 11).hourOfPeriod, 11);
+    expect(const TimeOfDay(minute: 0, hour: 12).hourOfPeriod, 12);
+    expect(const TimeOfDay(minute: 0, hour: 13).hourOfPeriod,  1);
+    expect(const TimeOfDay(minute: 0, hour: 14).hourOfPeriod,  2);
+    expect(const TimeOfDay(minute: 0, hour: 15).hourOfPeriod,  3);
+    expect(const TimeOfDay(minute: 0, hour: 16).hourOfPeriod,  4);
+    expect(const TimeOfDay(minute: 0, hour: 17).hourOfPeriod,  5);
+    expect(const TimeOfDay(minute: 0, hour: 18).hourOfPeriod,  6);
+    expect(const TimeOfDay(minute: 0, hour: 19).hourOfPeriod,  7);
+    expect(const TimeOfDay(minute: 0, hour: 20).hourOfPeriod,  8);
+    expect(const TimeOfDay(minute: 0, hour: 21).hourOfPeriod,  9);
+    expect(const TimeOfDay(minute: 0, hour: 22).hourOfPeriod, 10);
+    expect(const TimeOfDay(minute: 0, hour: 23).hourOfPeriod, 11);
+  });
+
   group('RestorableTimeOfDay tests', () {
     testWidgets('value is not accessible when not registered', (WidgetTester tester) async {
       expect(() => RestorableTimeOfDay(const TimeOfDay(hour: 20, minute: 4)).value, throwsAssertionError);


### PR DESCRIPTION
The current `TimeOfDay.hourOfPeriod` returns 0 for both noon and midnight. While it may be argued that technically these are the 0th hour of the period, the common use case is that these should be 12.

This PR fixes this and adds a test to verify that it returns the right value for any hour.

Fixes: #60592, #72480

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
