### PR TITLE
[flutter] dont used cached HttpClient if an HttpOverrides is active

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-import 'dart:_http';
 import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -64,7 +64,16 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
   // We set `autoUncompress` to false to ensure that we can trust the value of
   // the `Content-Length` HTTP header. We automatically uncompress the content
   // in our call to [consolidateHttpClientResponseBytes].
-  static final HttpClient _sharedHttpClient = HttpClient()..autoUncompress = false;
+  //
+  // In order to allow HttpOverrides to be used in different parts of a Flutter
+  // application, use these or the parent zone as a key to look up the client.
+  static final Expando<HttpClient> _sharedClients = Expando<HttpClient>();
+  static HttpClient get _sharedHttpClient {
+    final Object token = HttpOverrides.current ?? Zone.root;
+    HttpClient? cachedClient = _sharedClients[token];
+    cachedClient ??= (_sharedClients[token] = HttpClient()..autoUncompress = false);
+    return cachedClient;
+  }
 
   static HttpClient get _httpClient {
     HttpClient client = _sharedHttpClient;
@@ -85,12 +94,8 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
       assert(key == this);
 
       final Uri resolved = Uri.base.resolve(key.url);
-
       final HttpClientRequest request = await _httpClient.getUrl(resolved);
-
-      headers?.forEach((String name, String value) {
-        request.headers.add(name, value);
-      });
+      headers?.forEach(request.headers.add);
       final HttpClientResponse response = await request.close();
       if (response.statusCode != HttpStatus.ok) {
         // The network may be only temporarily unavailable, or the file will be

--- a/packages/flutter/test/painting/image_provider_network_image_test.dart
+++ b/packages/flutter/test/painting/image_provider_network_image_test.dart
@@ -246,35 +246,6 @@ void main() {
     // configured value.
     await expectError(error2);
   }, skip: isBrowser); // Browser implementation does not use HTTP client but an <img> tag.
-
-  test('Identical zones have the same HttpClients', () async {
-    debugNetworkImageHttpClientProvider = null;
-
-    // assert that a configured fake http client throws the expected error.
-    Future<void> expectError() async {
-      final Completer<Object> completer = Completer<Object>();
-      final ImageStreamListener listener = ImageStreamListener((ImageInfo data, bool syncCall) {
-        // Do nothing.
-      }, onError: (dynamic error, StackTrace? stackTrace) {
-        completer.complete(error);
-      });
-      final ImageProvider imageProvider = NetworkImage(nonconst('testing.url'));
-      final ImageStream stream = imageProvider.resolve(ImageConfiguration.empty);
-      stream.addListener(listener);
-      await completer.future;
-    }
-
-    int created = 0;
-    await HttpOverrides.runZoned(() async {
-      await expectError();
-      await expectError();
-    }, createHttpClient: (SecurityContext? context) {
-      created += 1;
-      return _FakeHttpClient()..thrownError = Object();
-    });
-
-    expect(created, 1);
-  }, skip: isBrowser); // Browser implementation does not use HTTP client but an <img> tag.
 }
 
 class _FakeHttpClient extends Fake implements HttpClient {

--- a/packages/flutter/test/painting/image_provider_network_image_test.dart
+++ b/packages/flutter/test/painting/image_provider_network_image_test.dart
@@ -245,7 +245,7 @@ void main() {
     // Freshly created client should throw the new error instead of the previously
     // configured value.
     await expectError(error2);
-  });
+  }, skip: isBrowser); // Browser implementation does not use HTTP client but an <img> tag.
 
   test('Identical zones have the same HttpClients', () async {
     debugNetworkImageHttpClientProvider = null;
@@ -274,7 +274,7 @@ void main() {
     });
 
     expect(created, 1);
-  });
+  }, skip: isBrowser); // Browser implementation does not use HTTP client but an <img> tag.
 }
 
 class _FakeHttpClient extends Fake implements HttpClient {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83901

Store the http client in an expando on either the root zone or the current http overrides. This allows HttpOverrides to force a new http client creation, without needing to worry about cache invalidation or removing previously created clients.