### PR TITLE
Migrate application_package to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -105,14 +105,17 @@ abstract class IOSApp extends ApplicationPackage {
 }
 
 class BuildableIOSApp extends IOSApp {
-  BuildableIOSApp(this.project, String? projectBundleId, String? hostAppBundleName)
+  BuildableIOSApp(this.project, String projectBundleId, String? hostAppBundleName)
     : _hostAppBundleName = hostAppBundleName,
-      super(projectBundleId: projectBundleId ?? 'com.example.Runner');
+      super(projectBundleId: projectBundleId);
 
-  static Future<BuildableIOSApp> fromProject(IosProject project, BuildInfo buildInfo) async {
+  static Future<BuildableIOSApp?> fromProject(IosProject project, BuildInfo buildInfo) async {
     final String? hostAppBundleName = await project.hostAppBundleName(buildInfo);
     final String? projectBundleId = await project.productBundleIdentifier(buildInfo);
-    return BuildableIOSApp(project, projectBundleId, hostAppBundleName);
+    if (projectBundleId != null) {
+      return BuildableIOSApp(project, projectBundleId, hostAppBundleName);
+    }
+    return null;
   }
 
   final IosProject project;

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:meta/meta.dart';
-
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
@@ -13,15 +9,14 @@ import '../globals_null_migrated.dart' as globals;
 import '../project.dart';
 import 'plist_parser.dart';
 
-
 /// Tests whether a [Directory] is an iOS bundle directory.
 bool _isBundleDirectory(Directory dir) => dir.path.endsWith('.app');
 
 abstract class IOSApp extends ApplicationPackage {
-  IOSApp({@required String projectBundleId}) : super(id: projectBundleId);
+  IOSApp({required String projectBundleId}) : super(id: projectBundleId);
 
   /// Creates a new IOSApp from an existing app bundle or IPA.
-  factory IOSApp.fromPrebuiltApp(FileSystemEntity applicationBinary) {
+  static IOSApp? fromPrebuiltApp(FileSystemEntity applicationBinary) {
     final FileSystemEntityType entityType = globals.fs.typeSync(applicationBinary.path);
     if (entityType == FileSystemEntityType.notFound) {
       globals.printError(
@@ -61,7 +56,7 @@ abstract class IOSApp extends ApplicationPackage {
       globals.printError('Invalid prebuilt iOS app. Does not contain Info.plist.');
       return null;
     }
-    final String id = globals.plistParser.getValueFromFile(
+    final String? id = globals.plistParser.getValueFromFile(
       plistPath,
       PlistParser.kCFBundleIdentifierKey,
     );
@@ -77,7 +72,7 @@ abstract class IOSApp extends ApplicationPackage {
     );
   }
 
-  static Future<IOSApp> fromIosProject(IosProject project, BuildInfo buildInfo) {
+  static Future<IOSApp?> fromIosProject(IosProject project, BuildInfo buildInfo) async {
     if (!globals.platform.isMacOS) {
       return null;
     }
@@ -106,26 +101,26 @@ abstract class IOSApp extends ApplicationPackage {
 
   /// Directory used by ios-deploy to store incremental installation metadata for
   /// faster second installs.
-  Directory get appDeltaDirectory;
+  Directory? get appDeltaDirectory;
 }
 
 class BuildableIOSApp extends IOSApp {
-  BuildableIOSApp(this.project, String projectBundleId, String hostAppBundleName)
+  BuildableIOSApp(this.project, String? projectBundleId, String? hostAppBundleName)
     : _hostAppBundleName = hostAppBundleName,
-      super(projectBundleId: projectBundleId);
+      super(projectBundleId: projectBundleId ?? 'com.example.Runner');
 
   static Future<BuildableIOSApp> fromProject(IosProject project, BuildInfo buildInfo) async {
-    final String projectBundleId = await project.productBundleIdentifier(buildInfo);
-    final String hostAppBundleName = await project.hostAppBundleName(buildInfo);
+    final String? hostAppBundleName = await project.hostAppBundleName(buildInfo);
+    final String? projectBundleId = await project.productBundleIdentifier(buildInfo);
     return BuildableIOSApp(project, projectBundleId, hostAppBundleName);
   }
 
   final IosProject project;
 
-  final String _hostAppBundleName;
+  final String? _hostAppBundleName;
 
   @override
-  String get name => _hostAppBundleName;
+  String? get name => _hostAppBundleName;
 
   @override
   String get simulatorBundlePath => _buildAppPath('iphonesimulator');
@@ -139,8 +134,8 @@ class BuildableIOSApp extends IOSApp {
   // Xcode uses this path for the final archive bundle location,
   // not a top-level output directory.
   // Specifying `build/ios/archive/Runner` will result in `build/ios/archive/Runner.xcarchive`.
-  String get archiveBundlePath
-    => globals.fs.path.join(getIosBuildDirectory(), 'archive', globals.fs.path.withoutExtension(_hostAppBundleName));
+  String get archiveBundlePath => globals.fs.path.join(getIosBuildDirectory(), 'archive',
+      _hostAppBundleName == null ? 'Runner' : globals.fs.path.withoutExtension(_hostAppBundleName!));
 
   // The output xcarchive bundle path `build/ios/archive/Runner.xcarchive`.
   String get archiveBundleOutputPath =>
@@ -156,19 +151,19 @@ class BuildableIOSApp extends IOSApp {
 
 class PrebuiltIOSApp extends IOSApp {
   PrebuiltIOSApp({
-    this.bundleDir,
+    required this.bundleDir,
     this.bundleName,
-    @required String projectBundleId,
+    required String projectBundleId,
   }) : super(projectBundleId: projectBundleId);
 
   final Directory bundleDir;
-  final String bundleName;
+  final String? bundleName;
 
   @override
-  final Directory appDeltaDirectory = null;
+  final Directory? appDeltaDirectory = null;
 
   @override
-  String get name => bundleName;
+  String? get name => bundleName;
 
   @override
   String get simulatorBundlePath => _bundlePath;

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -353,24 +353,6 @@ void main() {
       expect(iosApp.bundleName, 'bundle.app');
     }, overrides: overrides);
 
-    testUsingContext('has expected properties with no product identifier', () async {
-      globals.fs.file('pubspec.yaml').createSync();
-      globals.fs.file('.packages').createSync();
-      final Directory project = globals.fs.directory('ios/Runner.xcodeproj')..createSync(recursive: true);
-      project.childFile('project.pbxproj').createSync();
-      final BuildableIOSApp iosApp = BuildableIOSApp(
-          FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null, null);
-
-      expect(iosApp.id, 'com.example.Runner');
-      expect(iosApp.name, null);
-      expect(iosApp.simulatorBundlePath, 'build/ios/iphonesimulator');
-      expect(iosApp.deviceBundlePath, 'build/ios/iphoneos');
-      expect(iosApp.appDeltaDirectory.path, globals.fs.path.join('build', 'ios', 'app-delta'));
-      expect(iosApp.archiveBundlePath, 'build/ios/archive/Runner');
-      expect(iosApp.archiveBundleOutputPath, 'build/ios/archive/Runner.xcarchive');
-      expect(iosApp.ipaOutputPath, 'build/ios/ipa');
-    }, overrides: overrides);
-
     testUsingContext('returns null when there is no ios or .ios directory', () async {
       globals.fs.file('pubspec.yaml').createSync();
       globals.fs.file('.packages').createSync();
@@ -396,6 +378,17 @@ void main() {
       globals.fs.file('ios/Runner.xcodeproj').createSync(recursive: true);
       final BuildableIOSApp iosApp = await IOSApp.fromIosProject(
         FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null) as BuildableIOSApp;
+
+      expect(iosApp, null);
+    }, overrides: overrides);
+
+    testUsingContext('returns null when there with no product identifier', () async {
+      globals.fs.file('pubspec.yaml').createSync();
+      globals.fs.file('.packages').createSync();
+      final Directory project = globals.fs.directory('ios/Runner.xcodeproj')..createSync(recursive: true);
+      project.childFile('project.pbxproj').createSync();
+      final BuildableIOSApp iosApp = await IOSApp.fromIosProject(
+          FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null) as BuildableIOSApp;
 
       expect(iosApp, null);
     }, overrides: overrides);

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -353,6 +353,24 @@ void main() {
       expect(iosApp.bundleName, 'bundle.app');
     }, overrides: overrides);
 
+    testUsingContext('has expected properties with no product identifier', () async {
+      globals.fs.file('pubspec.yaml').createSync();
+      globals.fs.file('.packages').createSync();
+      final Directory project = globals.fs.directory('ios/Runner.xcodeproj')..createSync(recursive: true);
+      project.childFile('project.pbxproj').createSync();
+      final BuildableIOSApp iosApp = BuildableIOSApp(
+          FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null, null);
+
+      expect(iosApp.id, 'com.example.Runner');
+      expect(iosApp.name, null);
+      expect(iosApp.simulatorBundlePath, 'build/ios/iphonesimulator');
+      expect(iosApp.deviceBundlePath, 'build/ios/iphoneos');
+      expect(iosApp.appDeltaDirectory.path, globals.fs.path.join('build', 'ios', 'app-delta'));
+      expect(iosApp.archiveBundlePath, 'build/ios/archive/Runner');
+      expect(iosApp.archiveBundleOutputPath, 'build/ios/archive/Runner.xcarchive');
+      expect(iosApp.ipaOutputPath, 'build/ios/ipa');
+    }, overrides: overrides);
+
     testUsingContext('returns null when there is no ios or .ios directory', () async {
       globals.fs.file('pubspec.yaml').createSync();
       globals.fs.file('.packages').createSync();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -30,14 +30,17 @@ const Map<String, String> kDyLdLibEntry = <String, String>{
 void main() {
   Artifacts artifacts;
   String iosDeployPath;
+  FileSystem fileSystem;
+  Directory bundleDirectory;
 
   setUp(() {
     artifacts = Artifacts.test();
+    fileSystem = MemoryFileSystem.test();
+    bundleDirectory = fileSystem.directory('bundle');
     iosDeployPath = artifacts.getHostArtifact(HostArtifact.iosDeploy).path;
   });
 
   testWithoutContext('IOSDevice.installApp calls ios-deploy correctly with USB', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleDir: fileSystem.currentDirectory,
@@ -68,7 +71,6 @@ void main() {
   });
 
   testWithoutContext('IOSDevice.installApp calls ios-deploy correctly with network', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleDir: fileSystem.currentDirectory,
@@ -98,7 +100,7 @@ void main() {
   });
 
   testWithoutContext('IOSDevice.uninstallApp calls ios-deploy correctly', () async {
-    final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+    final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         iosDeployPath,
@@ -121,7 +123,7 @@ void main() {
 
   group('isAppInstalled', () {
     testWithoutContext('catches ProcessException from ios-deploy', () async {
-      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: <String>[
           iosDeployPath,
@@ -145,7 +147,7 @@ void main() {
     });
 
     testWithoutContext('returns true when app is installed', () async {
-      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: <String>[
           iosDeployPath,
@@ -169,7 +171,7 @@ void main() {
     });
 
     testWithoutContext('returns false when app is not installed', () async {
-      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: <String>[
           iosDeployPath,
@@ -195,7 +197,7 @@ void main() {
     });
 
     testWithoutContext('returns false on command timeout or other error', () async {
-      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+      final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
       const String stderr = '2020-03-26 17:48:43.484 ios-deploy[21518:5501783] [ !! ] Timed out waiting for device';
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(command: <String>[
@@ -224,7 +226,6 @@ void main() {
   });
 
   testWithoutContext('IOSDevice.installApp catches ProcessException from ios-deploy', () async {
-    final FileSystem fileSystem = MemoryFileSystem.test();
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleDir: fileSystem.currentDirectory,
@@ -249,7 +250,7 @@ void main() {
   });
 
   testWithoutContext('IOSDevice.uninstallApp catches ProcessException from ios-deploy', () async {
-    final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app');
+    final IOSApp iosApp = PrebuiltIOSApp(projectBundleId: 'app', bundleDir: bundleDirectory);
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: <String>[
         iosDeployPath,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -93,6 +93,7 @@ void main() {
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleName: 'Runner',
+      bundleDir: MemoryFileSystem.test().directory('bundle'),
     );
 
     device.portForwarder = devicePortForwarder;


### PR DESCRIPTION
Handle a null product ID in `BuildableIOSApp.fromProject()`, and a test to validate.

Part of #71511