### PR TITLE
Make retry logic more permissive for network errors

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -51,7 +51,7 @@ enum GradleBuildStatus {
 }
 
 /// Returns a simple test function that evaluates to `true` if at least one of
-/// [errorMessages] is contained in the error message.
+/// `errorMessages` is contained in the error message.
 GradleErrorTest _lineMatcher(List<String> errorMessages) {
   return (String line) {
     return errorMessages.any((String errorMessage) => line.contains(errorMessage));

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -50,8 +50,8 @@ enum GradleBuildStatus {
   retryWithAarPlugins,
 }
 
-/// Returns a simple test function that evaluates to [true] if
-/// [errorMessage] is contained in the error message.
+/// Returns a simple test function that evaluates to `true` if at least one of
+/// [errorMessages] is contained in the error message.
 GradleErrorTest _lineMatcher(List<String> errorMessages) {
   return (String line) {
     return errorMessages.any((String errorMessage) => line.contains(errorMessage));
@@ -118,7 +118,7 @@ final GradleHandledError networkErrorHandler = GradleHandledError(
     'javax.net.ssl.SSLHandshakeException: Remote host closed connection during handshake',
     'java.net.SocketException: Connection reset',
     'java.io.FileNotFoundException',
-    'Gateway Time-out'
+    "> Could not get resource 'http",
   ]),
   handler: ({
     required String line,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/19235

The previous matcher string was too narrow - there are a number of ways that gradle can report failing to download in a manner that should be retriable, e.g. that `Remote host closed connection during handshake`, or that `connection timed out`. Rather than looking for a specific reason, just update the string to find the general problem and retry.