### PR TITLE
Delete obsolete TODO

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -56,7 +56,6 @@ Future<void> main(List<String> arguments) async {
   final StringBuffer buf = StringBuffer();
   buf.writeln('name: $kDummyPackageName');
   buf.writeln('homepage: https://flutter.dev');
-  // TODO(dnfield): Re-factor for proper versioning, https://github.com/flutter/flutter/issues/55409
   buf.writeln('version: 0.0.0');
   buf.writeln('environment:');
   buf.writeln("  sdk: '>=2.10.0 <3.0.0'");


### PR DESCRIPTION
Upstream issue closed. There are other ways to resolve this, but we'd still want to do something like it anyway in the end - dartdoc added a feature to suppress the version, but not to dynamically inject it the way we want.