### PR TITLE
Add more analytics for hot reload in flutter_tools.

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -19,7 +19,10 @@ class StopwatchFactory {
   const StopwatchFactory();
 
   /// Create a new [Stopwatch] instance.
-  Stopwatch createStopwatch() => Stopwatch();
+  ///
+  /// The optional [name] parameter is useful in tests when there are multiple
+  /// instances being created.
+  Stopwatch createStopwatch([String name = '']) => Stopwatch();
 }
 
 typedef VoidCallback = void Function();

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -399,18 +399,34 @@ class UpdateFSReport {
     int invalidatedSourcesCount = 0,
     int syncedBytes = 0,
     this.fastReassembleClassName,
+    int scannedSourcesCount = 0,
+    Duration compileDuration = Duration.zero,
+    Duration transferDuration = Duration.zero,
+    Duration findInvalidatedDuration = Duration.zero,
   }) : _success = success,
        _invalidatedSourcesCount = invalidatedSourcesCount,
-       _syncedBytes = syncedBytes;
+       _syncedBytes = syncedBytes,
+       _scannedSourcesCount = scannedSourcesCount,
+       _compileDuration = compileDuration,
+       _transferDuration = transferDuration,
+       _findInvalidatedDuration = findInvalidatedDuration;
 
   bool get success => _success;
   int get invalidatedSourcesCount => _invalidatedSourcesCount;
   int get syncedBytes => _syncedBytes;
+  int get scannedSourcesCount => _scannedSourcesCount;
+  Duration get compileDuration => _compileDuration;
+  Duration get transferDuration => _transferDuration;
+  Duration get findInvalidatedDuration => _findInvalidatedDuration;
 
   bool _success;
   String fastReassembleClassName;
   int _invalidatedSourcesCount;
   int _syncedBytes;
+  int _scannedSourcesCount;
+  Duration _compileDuration;
+  Duration _transferDuration;
+  Duration _findInvalidatedDuration;
 
   void incorporateResults(UpdateFSReport report) {
     if (!report._success) {
@@ -419,6 +435,10 @@ class UpdateFSReport {
     fastReassembleClassName ??= report.fastReassembleClassName;
     _invalidatedSourcesCount += report._invalidatedSourcesCount;
     _syncedBytes += report._syncedBytes;
+    _scannedSourcesCount += report._scannedSourcesCount;
+    _compileDuration += report._compileDuration;
+    _transferDuration += report._transferDuration;
+    _findInvalidatedDuration += report._findInvalidatedDuration;
   }
 }
 
@@ -575,6 +595,7 @@ class DevFS {
 
     // Await the compiler response after checking if the bundle is updated. This allows the file
     // stating to be done while waiting for the frontend_server response.
+    final Stopwatch compileTimer = Stopwatch()..start();
     final Future<CompilerOutput> pendingCompilerOutput = generator.recompile(
       mainUri,
       invalidatedFiles,
@@ -582,7 +603,11 @@ class DevFS {
       fs: _fileSystem,
       projectRootPath: projectRootPath,
       packageConfig: packageConfig,
-    );
+    ).then((CompilerOutput result) {
+      compileTimer.stop();
+      return result;
+    });
+
     if (bundle != null) {
       // The tool writes the assets into the AssetBundle working dir so that they
       // are in the same location in DevFS and the iOS simulator.
@@ -627,15 +652,19 @@ class DevFS {
       }
     }
     _logger.printTrace('Updating files.');
+    final Stopwatch transferTimer = Stopwatch()..start();
     if (dirtyEntries.isNotEmpty) {
       await (devFSWriter ?? _httpWriter).write(dirtyEntries, _baseUri, _httpWriter);
     }
+    transferTimer.stop();
     _logger.printTrace('DevFS: Sync finished');
     return UpdateFSReport(
       success: true,
       syncedBytes: syncedBytes,
       invalidatedSourcesCount: invalidatedFiles.length,
       fastReassembleClassName: _checkIfSingleWidgetReloadApplied(),
+      compileDuration: compileTimer.elapsed,
+      transferDuration: transferTimer.elapsed,
     );
   }
 

--- a/packages/flutter_tools/lib/src/reporting/custom_dimensions.dart
+++ b/packages/flutter_tools/lib/src/reporting/custom_dimensions.dart
@@ -61,6 +61,11 @@ class CustomDimensions {
     this.fastReassemble,
     this.nullSafeMigratedLibraries,
     this.nullSafeTotalLibraries,
+    this.hotEventCompileTimeInMs,
+    this.hotEventFindInvalidatedTimeInMs,
+    this.hotEventScannedSourcesCount,
+    this.hotEventReassembleTimeInMs,
+    this.hotEventReloadVMTimeInMs,
   });
 
   final String? sessionHostOsDetails;  // cd1
@@ -113,6 +118,11 @@ class CustomDimensions {
   final bool? fastReassemble;  // cd48
   final int? nullSafeMigratedLibraries;  // cd49
   final int? nullSafeTotalLibraries;  // cd50
+  final int? hotEventCompileTimeInMs;  // cd 51
+  final int? hotEventFindInvalidatedTimeInMs;  // cd 52
+  final int? hotEventScannedSourcesCount;  // cd 53
+  final int? hotEventReassembleTimeInMs;  // cd 54
+  final int? hotEventReloadVMTimeInMs;  // cd 55
 
   /// Convert to a map that will be used to upload to the analytics backend.
   Map<String, String> toMap() => <String, String>{
@@ -166,6 +176,11 @@ class CustomDimensions {
       if (fastReassemble != null) cdKey(CustomDimensionsEnum.fastReassemble): fastReassemble.toString(),
       if (nullSafeMigratedLibraries != null) cdKey(CustomDimensionsEnum.nullSafeMigratedLibraries): nullSafeMigratedLibraries.toString(),
       if (nullSafeTotalLibraries != null) cdKey(CustomDimensionsEnum.nullSafeTotalLibraries): nullSafeTotalLibraries.toString(),
+      if (hotEventCompileTimeInMs != null) cdKey(CustomDimensionsEnum.hotEventCompileTimeInMs): hotEventCompileTimeInMs.toString(),
+      if (hotEventFindInvalidatedTimeInMs != null) cdKey(CustomDimensionsEnum.hotEventFindInvalidatedTimeInMs): hotEventFindInvalidatedTimeInMs.toString(),
+      if (hotEventScannedSourcesCount != null) cdKey(CustomDimensionsEnum.hotEventScannedSourcesCount): hotEventScannedSourcesCount.toString(),
+      if (hotEventReassembleTimeInMs != null) cdKey(CustomDimensionsEnum.hotEventReassembleTimeInMs): hotEventReassembleTimeInMs.toString(),
+      if (hotEventReloadVMTimeInMs != null) cdKey(CustomDimensionsEnum.hotEventReloadVMTimeInMs): hotEventReloadVMTimeInMs.toString(),
     };
 
   /// Merge the values of two [CustomDimensions] into one. If a value is defined
@@ -226,6 +241,11 @@ class CustomDimensions {
       fastReassemble: other.fastReassemble ?? fastReassemble,
       nullSafeMigratedLibraries: other.nullSafeMigratedLibraries ?? nullSafeMigratedLibraries,
       nullSafeTotalLibraries: other.nullSafeTotalLibraries ?? nullSafeTotalLibraries,
+      hotEventCompileTimeInMs: other.hotEventCompileTimeInMs ?? hotEventCompileTimeInMs,
+      hotEventFindInvalidatedTimeInMs: other.hotEventFindInvalidatedTimeInMs ?? hotEventFindInvalidatedTimeInMs,
+      hotEventScannedSourcesCount: other.hotEventScannedSourcesCount ?? hotEventScannedSourcesCount,
+      hotEventReassembleTimeInMs: other.hotEventReassembleTimeInMs ?? hotEventReassembleTimeInMs,
+      hotEventReloadVMTimeInMs: other.hotEventReloadVMTimeInMs ?? hotEventReloadVMTimeInMs,
     );
   }
 
@@ -280,6 +300,11 @@ class CustomDimensions {
       fastReassemble: _extractBool(map, CustomDimensionsEnum.fastReassemble),
       nullSafeMigratedLibraries: _extractInt(map, CustomDimensionsEnum.nullSafeMigratedLibraries),
       nullSafeTotalLibraries: _extractInt(map, CustomDimensionsEnum.nullSafeTotalLibraries),
+      hotEventCompileTimeInMs: _extractInt(map, CustomDimensionsEnum.hotEventCompileTimeInMs),
+      hotEventFindInvalidatedTimeInMs: _extractInt(map, CustomDimensionsEnum.hotEventFindInvalidatedTimeInMs),
+      hotEventScannedSourcesCount: _extractInt(map, CustomDimensionsEnum.hotEventScannedSourcesCount),
+      hotEventReassembleTimeInMs: _extractInt(map, CustomDimensionsEnum.hotEventReassembleTimeInMs),
+      hotEventReloadVMTimeInMs: _extractInt(map, CustomDimensionsEnum.hotEventReloadVMTimeInMs),
     );
 
   static bool? _extractBool(Map<String, String> map, CustomDimensionsEnum field) =>
@@ -365,6 +390,11 @@ enum CustomDimensionsEnum {
   fastReassemble,  // cd48
   nullSafeMigratedLibraries,  // cd49
   nullSafeTotalLibraries,  // cd50
+  hotEventCompileTimeInMs,  // cd51
+  hotEventFindInvalidatedTimeInMs,  // cd52
+  hotEventScannedSourcesCount,  // cd53
+  hotEventReassembleTimeInMs,  // cd54
+  hotEventReloadVMTimeInMs,  // cd55
 }
 
 String cdKey(CustomDimensionsEnum cd) => 'cd${cd.index + 1}';

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -49,6 +49,11 @@ class HotEvent extends UsageEvent {
     this.invalidatedSourcesCount,
     this.transferTimeInMs,
     this.overallTimeInMs,
+    this.compileTimeInMs,
+    this.findInvalidatedTimeInMs,
+    this.scannedSourcesCount,
+    this.reassembleTimeInMs,
+    this.reloadVMTimeInMs,
   }) : super('hot', parameter, flutterUsage: globals.flutterUsage);
 
   final String? reason;
@@ -65,6 +70,11 @@ class HotEvent extends UsageEvent {
   final int? invalidatedSourcesCount;
   final int? transferTimeInMs;
   final int? overallTimeInMs;
+  final int? compileTimeInMs;
+  final int? findInvalidatedTimeInMs;
+  final int? scannedSourcesCount;
+  final int? reassembleTimeInMs;
+  final int? reloadVMTimeInMs;
 
   @override
   void send() {
@@ -83,6 +93,11 @@ class HotEvent extends UsageEvent {
       hotEventTransferTimeInMs: transferTimeInMs,
       hotEventOverallTimeInMs: overallTimeInMs,
       fastReassemble: fastReassemble,
+      hotEventCompileTimeInMs: compileTimeInMs,
+      hotEventFindInvalidatedTimeInMs: findInvalidatedTimeInMs,
+      hotEventScannedSourcesCount: scannedSourcesCount,
+      hotEventReassembleTimeInMs: reassembleTimeInMs,
+      hotEventReloadVMTimeInMs: reloadVMTimeInMs,
     );
     flutterUsage.sendEvent(category, parameter, parameters: parameters);
   }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1460,7 +1460,7 @@ abstract class ResidentRunner extends ResidentHandlers {
 }
 
 class OperationResult {
-  OperationResult(this.code, this.message, { this.fatal = false });
+  OperationResult(this.code, this.message, { this.fatal = false, this.updateFSReport });
 
   /// The result of the operation; a non-zero code indicates a failure.
   final int code;
@@ -1470,6 +1470,8 @@ class OperationResult {
 
   /// Whether this error should cause the runner to exit.
   final bool fatal;
+
+  final UpdateFSReport updateFSReport;
 
   bool get isOk => code == 0;
 

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -244,7 +244,7 @@ void main() {
       );
       final VerboseLogger verboseLogger = VerboseLogger(
         mockLogger,
-        stopwatchFactory: FakeStopwatchFactory(fakeStopWatch),
+        stopwatchFactory: FakeStopwatchFactory(stopwatch: fakeStopWatch),
       );
 
       verboseLogger.printStatus('Hey Hey Hey Hey');
@@ -266,7 +266,7 @@ void main() {
         outputPreferences: OutputPreferences.test(showColor: true),
       );
       final VerboseLogger verboseLogger = VerboseLogger(
-        mockLogger, stopwatchFactory: FakeStopwatchFactory(fakeStopWatch),
+        mockLogger, stopwatchFactory: FakeStopwatchFactory(stopwatch: fakeStopWatch),
       );
 
       verboseLogger.printStatus('Hey Hey Hey Hey');
@@ -377,7 +377,7 @@ void main() {
       mockStopwatch = FakeStopwatch();
       mockStdio = FakeStdio();
       called = 0;
-      stopwatchFactory = FakeStopwatchFactory(mockStopwatch);
+      stopwatchFactory = FakeStopwatchFactory(stopwatch: mockStopwatch);
     });
 
     List<String> outputStdout() => mockStdio.writtenToStdout.join('').split('\n');
@@ -938,7 +938,7 @@ void main() {
         ),
         stdio: fakeStdio,
         outputPreferences: OutputPreferences.test(showColor: false),
-        stopwatchFactory: FakeStopwatchFactory(fakeStopwatch),
+        stopwatchFactory: FakeStopwatchFactory(stopwatch: fakeStopwatch),
       );
       final Status status = logger.startProgress(
         'Hello',
@@ -1060,53 +1060,6 @@ void main() {
       expect(logger.statusText, 'AAA\nBBB\n');
     });
   });
-}
-
-class FakeStopwatch implements Stopwatch {
-  @override
-  bool get isRunning => _isRunning;
-  bool _isRunning = false;
-
-  @override
-  void start() => _isRunning = true;
-
-  @override
-  void stop() => _isRunning = false;
-
-  @override
-  Duration elapsed = Duration.zero;
-
-  @override
-  int get elapsedMicroseconds => elapsed.inMicroseconds;
-
-  @override
-  int get elapsedMilliseconds => elapsed.inMilliseconds;
-
-  @override
-  int get elapsedTicks => elapsed.inMilliseconds;
-
-  @override
-  int get frequency => 1000;
-
-  @override
-  void reset() {
-    _isRunning = false;
-    elapsed = Duration.zero;
-  }
-
-  @override
-  String toString() => '$runtimeType $elapsed $isRunning';
-}
-
-class FakeStopwatchFactory implements StopwatchFactory {
-  FakeStopwatchFactory([this.stopwatch]);
-
-  Stopwatch stopwatch;
-
-  @override
-  Stopwatch createStopwatch() {
-    return stopwatch ?? FakeStopwatch();
-  }
 }
 
 /// A fake [Logger] that throws the [Invocation] for any method call.

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -7,6 +7,7 @@
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -14,17 +15,20 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_devtools_handler.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/vmservice.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fake_vm_services.dart';
+import '../src/fakes.dart';
 
 final vm_service.Isolate fakeUnpausedIsolate = vm_service.Isolate(
   id: '1',
@@ -146,9 +150,11 @@ void main() {
   group('hotRestart', () {
     final FakeResidentCompiler residentCompiler = FakeResidentCompiler();
     FileSystem fileSystem;
+    TestUsage testUsage;
 
     setUp(() {
       fileSystem = MemoryFileSystem.test();
+      testUsage = TestUsage();
     });
 
     testUsingContext('setup function fails', () async {
@@ -228,6 +234,148 @@ void main() {
         ProcessManager: () => FakeProcessManager.any(),
       });
     });
+
+    testUsingContext('correctly tracks time spent for analytics for hot restart', () async {
+      final FakeDevice device = FakeDevice();
+      final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        fakeFlutterDevice,
+      ];
+
+      fakeFlutterDevice.updateDevFSReport = UpdateFSReport(
+        success: true,
+        invalidatedSourcesCount: 2,
+        syncedBytes: 4,
+        scannedSourcesCount: 8,
+        compileDuration: const Duration(seconds: 16),
+        transferDuration: const Duration(seconds: 32),
+      );
+
+      final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
+        stopwatches: <String, Stopwatch>{
+          'fullRestartHelper': FakeStopwatch()..elapsed = const Duration(seconds: 64),
+          'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 128),
+        },
+      );
+
+      (fakeFlutterDevice.devFS as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+
+      final OperationResult result = await HotRunner(
+        devices,
+        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
+        devtoolsHandler: createNoOpHandler,
+        stopwatchFactory: fakeStopwatchFactory,
+      ).restart(fullRestart: true);
+
+      expect(result.isOk, true);
+      expect(testUsage.events, <TestUsageEvent>[
+        const TestUsageEvent('hot', 'restart', parameters: CustomDimensions(
+          hotEventTargetPlatform: 'flutter-tester',
+          hotEventSdkName: 'Tester',
+          hotEventEmulator: false,
+          hotEventFullRestart: true,
+          hotEventOverallTimeInMs: 64000,
+          hotEventSyncedBytes: 4,
+          hotEventInvalidatedSourcesCount: 2,
+          hotEventTransferTimeInMs: 32000,
+          hotEventCompileTimeInMs: 16000,
+          hotEventFindInvalidatedTimeInMs: 128000,
+          hotEventScannedSourcesCount: 8,
+        )),
+      ]);
+    }, overrides: <Type, Generator>{
+      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
+      Artifacts: () => Artifacts.test(),
+      FileSystem: () => fileSystem,
+      Platform: () => FakePlatform(operatingSystem: 'linux'),
+      ProcessManager: () => FakeProcessManager.any(),
+      Usage: () => testUsage,
+    });
+
+    testUsingContext('correctly tracks time spent for analytics for hot reload', () async {
+      final FakeDevice device = FakeDevice();
+      final FakeFlutterDevice fakeFlutterDevice = FakeFlutterDevice(device);
+      final List<FlutterDevice> devices = <FlutterDevice>[
+        fakeFlutterDevice,
+      ];
+
+      fakeFlutterDevice.updateDevFSReport = UpdateFSReport(
+        success: true,
+        invalidatedSourcesCount: 6,
+        syncedBytes: 8,
+        scannedSourcesCount: 16,
+        compileDuration: const Duration(seconds: 16),
+        transferDuration: const Duration(seconds: 32),
+      );
+
+      final FakeStopwatchFactory fakeStopwatchFactory = FakeStopwatchFactory(
+        stopwatches: <String, Stopwatch>{
+          'updateDevFS': FakeStopwatch()..elapsed = const Duration(seconds: 64),
+          'reloadSources:reload': FakeStopwatch()..elapsed = const Duration(seconds: 128),
+          'reloadSources:reassemble': FakeStopwatch()..elapsed = const Duration(seconds: 256),
+          'reloadSources:vm': FakeStopwatch()..elapsed = const Duration(seconds: 512),
+        },
+      );
+
+      final FakeReloadSourcesHelper fakeReloadSourcesHelper = FakeReloadSourcesHelper(
+        OperationResult.ok,
+        (Map<String, dynamic> firstReloadDetails) {
+          firstReloadDetails['finalLibraryCount'] = 2;
+          firstReloadDetails['receivedLibraryCount'] = 3;
+          firstReloadDetails['receivedClassesCount'] = 4;
+          firstReloadDetails['receivedProceduresCount'] = 5;
+        },
+      );
+
+      final FakeReassembleHelper fakeReassembleHelper = FakeReassembleHelper(ReassembleResult(
+        <FlutterView, FlutterVmService>{null: null},
+        false,
+        true));
+
+      (fakeFlutterDevice.devFS as FakeDevFs).baseUri = Uri.parse('file:///base_uri');
+
+      final OperationResult result = await HotRunner(
+        devices,
+        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        target: 'main.dart',
+        devtoolsHandler: createNoOpHandler,
+        stopwatchFactory: fakeStopwatchFactory,
+        reloadSourcesHelper: fakeReloadSourcesHelper,
+        reassembleHelper: fakeReassembleHelper,
+      ).restart(fullRestart: false);
+
+      expect(result.isOk, true);
+      expect(testUsage.events, <TestUsageEvent>[
+        const TestUsageEvent('hot', 'reload', parameters: CustomDimensions(
+          hotEventFinalLibraryCount: 2,
+          hotEventSyncedLibraryCount: 3,
+          hotEventSyncedClassesCount: 4,
+          hotEventSyncedProceduresCount: 5,
+          hotEventSyncedBytes: 8,
+          hotEventInvalidatedSourcesCount: 6,
+          hotEventTransferTimeInMs: 32000,
+          hotEventOverallTimeInMs: 128000,
+          hotEventTargetPlatform: 'flutter-tester',
+          hotEventSdkName: 'Tester',
+          hotEventEmulator: false,
+          hotEventFullRestart: false,
+          fastReassemble: false,
+          hotEventCompileTimeInMs: 16000,
+          hotEventFindInvalidatedTimeInMs: 64000,
+          hotEventScannedSourcesCount: 16,
+          hotEventReassembleTimeInMs: 256000,
+          hotEventReloadVMTimeInMs: 512000,
+        )),
+      ]);
+    }, overrides: <Type, Generator>{
+      HotRunnerConfig: () => TestHotRunnerConfig(successfulSetup: true),
+      Artifacts: () => Artifacts.test(),
+      FileSystem: () => fileSystem,
+      Platform: () => FakePlatform(operatingSystem: 'linux'),
+      ProcessManager: () => FakeProcessManager.any(),
+      Usage: () => testUsage,
+    });
   });
 
   group('hot attach', () {
@@ -297,8 +445,25 @@ void main() {
 }
 
 class FakeDevFs extends Fake implements DevFS {
+  // UpdateFSReport updateReport;
+
   @override
   Future<void> destroy() async { }
+
+  @override
+  List<Uri> sources = <Uri>[];
+
+  @override
+  DateTime lastCompiled;
+
+  @override
+  PackageConfig lastPackageConfig;
+
+  @override
+  Set<String> assetPathsToEvict = <String>{};
+
+  @override
+  Uri baseUri;
 }
 
 class FakeDevice extends Fake implements Device {
@@ -326,6 +491,9 @@ class FakeDevice extends Fake implements Device {
   Future<bool> get isLocalEmulator async => false;
 
   @override
+  String get name => 'Fake Device';
+
+  @override
   Future<bool> stopApp(
     covariant ApplicationPackage app, {
     String userIdentifier,
@@ -343,6 +511,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   FakeFlutterDevice(this.device);
 
   bool stoppedEchoingDeviceLog = false;
+  UpdateFSReport updateDevFSReport;
 
   @override
   final FakeDevice device;
@@ -354,6 +523,28 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
 
   @override
   DevFS devFS = FakeDevFs();
+
+  @override
+  FlutterVmService get vmService => FakeFlutterVmService();
+
+  @override
+  ResidentCompiler generator;
+
+  @override
+  Future<UpdateFSReport> updateDevFS({
+    Uri mainUri,
+    String target,
+    AssetBundle bundle,
+    DateTime firstBuildTime,
+    bool bundleFirstUpload = false,
+    bool bundleDirty = false,
+    bool fullRestart = false,
+    String projectRootPath,
+    String pathToReload,
+    @required String dillOutputPath,
+    @required List<Uri> invalidatedFiles,
+    @required PackageConfig packageConfig,
+  }) async => updateDevFSReport;
 }
 
 class TestFlutterDevice extends FlutterDevice {
@@ -404,4 +595,61 @@ class TestHotRunnerConfig extends HotRunnerConfig {
 class FakeResidentCompiler extends Fake implements ResidentCompiler {
   @override
   void accept() {}
+}
+
+class FakeFlutterVmService extends Fake implements FlutterVmService {
+  @override
+  vm_service.VmService get service => FakeVmService();
+
+  @override
+  Future<List<FlutterView>> getFlutterViews({bool returnEarly = false, Duration delay = const Duration(milliseconds: 50)}) async {
+    return <FlutterView>[];
+  }
+}
+
+class FakeVmService extends Fake implements vm_service.VmService {
+  @override
+  Future<vm_service.VM> getVM() async => FakeVm();
+}
+
+class FakeVm extends Fake implements vm_service.VM {
+  @override
+  List<vm_service.IsolateRef> get isolates => <vm_service.IsolateRef>[];
+}
+
+class FakeReloadSourcesHelper extends Fake implements ReloadSourcesHelper {
+  FakeReloadSourcesHelper(this.reloadResult, this.reloadCallback);
+
+  final OperationResult reloadResult;
+  void Function(Map<String, dynamic> firstReloadDetails) reloadCallback;
+
+  @override
+  Future<OperationResult> reload(
+    HotRunner hotRunner,
+    List<FlutterDevice> flutterDevices,
+    bool pause,
+    Map<String, dynamic> firstReloadDetails,
+    String targetPlatform,
+    String sdkName,
+    bool emulator,
+    String reason,
+  ) async {
+    reloadCallback(firstReloadDetails);
+    return reloadResult;
+  }
+}
+
+class FakeReassembleHelper extends Fake implements ReassembleHelper {
+  FakeReassembleHelper(this.reassembleResult);
+
+  final ReassembleResult reassembleResult;
+
+  @override
+  Future<ReassembleResult> reassemble(
+    List<FlutterDevice> flutterDevices,
+    Map<FlutterDevice, List<FlutterView>> viewCache,
+    void Function(String message) onSlow,
+    String reloadMessage,
+    String fastReassembleClassName,
+  ) async => reassembleResult;
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -535,3 +535,56 @@ class FakeOperatingSystemUtils extends Fake implements OperatingSystemUtils {
   @override
   Future<int> findFreePort({bool ipv6 = false}) async => 12345;
 }
+
+class FakeStopwatch implements Stopwatch {
+  @override
+  bool get isRunning => _isRunning;
+  bool _isRunning = false;
+
+  @override
+  void start() => _isRunning = true;
+
+  @override
+  void stop() => _isRunning = false;
+
+  @override
+  Duration elapsed = Duration.zero;
+
+  @override
+  int get elapsedMicroseconds => elapsed.inMicroseconds;
+
+  @override
+  int get elapsedMilliseconds => elapsed.inMilliseconds;
+
+  @override
+  int get elapsedTicks => elapsed.inMilliseconds;
+
+  @override
+  int get frequency => 1000;
+
+  @override
+  void reset() {
+    _isRunning = false;
+    elapsed = Duration.zero;
+  }
+
+  @override
+  String toString() => '$runtimeType $elapsed $isRunning';
+}
+
+class FakeStopwatchFactory implements StopwatchFactory {
+  FakeStopwatchFactory({
+    Stopwatch? stopwatch,
+    Map<String, Stopwatch>? stopwatches
+  }) : stopwatches = <String, Stopwatch>{
+         if (stopwatches != null) ...stopwatches,
+         if (stopwatch != null) '': stopwatch,
+       };
+
+  Map<String, Stopwatch> stopwatches;
+
+  @override
+  Stopwatch createStopwatch([String name = '']) {
+    return stopwatches[name] ?? FakeStopwatch();
+  }
+}


### PR DESCRIPTION
## New fields for existing analytics
### Hot reload
* `compileTimeInMs`: Time spent in the resident compiler to compile the changes
* `findInvalidatedTimeInMs`: Time spent in `projectFileInvalidator.findInvalidated`
* `scannedSourcesCount`: Number of source files scanned in `projectFileInvalidator.findInvalidated`
* `reassembleTimeInMs`: Time spent calling `device.vmService.flutterReassemble` or fast reassemble
* `reloadVMTimeInMs`: Time spent calling `device.vmService.service.reloadSources`
* Existing `transferTimeInMs` repurposed to be the actual time spent transferring data onto the device. Previously the stopwatch wasn't stopped so it was the same as `overallTimeInMs`.

### Hot restart (when success)
* `overallTimeInMs`: Total time spent during hot restart
* `syncedBytes`: Total data transferred onto the device
* `scannedSourcesCount`: Number of source files scanned in `projectFileInvalidator.findInvalidated`
* `invalidatedSourcesCount`: Number of source files invalidated
* `findInvalidatedTimeInMs`: Time spent in `projectFileInvalidator.findInvalidated
* `transferTimeInMs`: Time spent transferring data onto the device
* `compileTimeInMs`: Time spent in the resident compiler to compile the changes

## Newly added event
### When hot reload is first ready after flutter_tools is started
* `targetPlatform`: Self explanatory
* `sdkName`: Self explanatory
* `emulator`: Whether the app is running on an emulator
* `overallTimeInMs`: Time from `HotRunner.run()` is called to when hot reload is ready
* `compileTimeInMs`: Time spent initializing the resident compiler
* `transferTimeInMs`: Time spent launching the app on the device (i.e. time spent in `device.runHot`)