### PR TITLE
fix: windows cpu usage too high when process message

### DIFF
--- a/dev/integration_tests/flutter_gallery/windows/runner/run_loop.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/run_loop.cpp
@@ -22,7 +22,7 @@ void RunLoop::Run() {
     MSG message;
     // All pending Windows messages must be processed; MsgWaitForMultipleObjects
     // won't return again for items left in the queue after PeekMessage.
-    while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+    while (::GetMessage(&message, nullptr, 0, 0)) {
       processed_events = true;
       if (message.message == WM_QUIT) {
         keep_running = false;
@@ -35,6 +35,8 @@ void RunLoop::Run() {
       next_flutter_event_time =
           std::min(next_flutter_event_time, ProcessFlutterMessages());
     }
+
+    keep_running = false;
     // If the PeekMessage loop didn't run, process Flutter messages.
     if (!processed_events) {
       next_flutter_event_time =

--- a/dev/manual_tests/windows/runner/run_loop.cpp
+++ b/dev/manual_tests/windows/runner/run_loop.cpp
@@ -22,7 +22,7 @@ void RunLoop::Run() {
     MSG message;
     // All pending Windows messages must be processed; MsgWaitForMultipleObjects
     // won't return again for items left in the queue after PeekMessage.
-    while (::PeekMessage(&message, nullptr, 0, 0, PM_REMOVE)) {
+    while (::GetMessage(&message, nullptr, 0, 0)) {
       processed_events = true;
       if (message.message == WM_QUIT) {
         keep_running = false;
@@ -35,6 +35,8 @@ void RunLoop::Run() {
       next_flutter_event_time =
           std::min(next_flutter_event_time, ProcessFlutterMessages());
     }
+
+    keep_running = false;
     // If the PeekMessage loop didn't run, process Flutter messages.
     if (!processed_events) {
       next_flutter_event_time =


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5308783/120801386-ac721280-c573-11eb-9230-7ac36d3a6648.png)
i find use `PeekMessage` cause windows process cpu useage too hight
i use `GetMessage` replace,  when quit windows `GetMessage`  will not call` if (message.message == WM_QUIT)`, so need set `keep_running = false`; after while{}, all code:
```
while (::GetMessage(&message, nullptr, 0, 0)) {
      processed_events = true;
      if (message.message == WM_QUIT) {
        keep_running = false;
        break;
      }
      ::TranslateMessage(&message);
      ::DispatchMessage(&message);
      // Allow Flutter to process messages each time a Windows message is
      // processed, to prevent starvation.
      next_flutter_event_time =
          std::min(next_flutter_event_time, ProcessFlutterMessages());
    }

    keep_running = false;
```