### PR TITLE
fix `IconThemeData`'s size ignore by `IconButton`

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -328,7 +328,7 @@ class IconButton extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData theme = Theme.of(context);
-    final IconThemeData iconThemeData = IconTheme.of(context);
+    final IconThemeData iconTheme = IconTheme.of(context);
     Color? currentColor;
     if (onPressed != null)
       currentColor = color;
@@ -343,8 +343,7 @@ class IconButton extends StatelessWidget {
     );
     final BoxConstraints adjustedConstraints = effectiveVisualDensity.effectiveConstraints(unadjustedConstraints);
 
-    final IconThemeData iconTheme = iconThemeData.merge(IconThemeData(size: iconSize));
-    final double size = iconTheme.size ?? 24.0;
+    final double size = iconSize ?? iconTheme.size!;
 
     Widget result = ConstrainedBox(
       constraints: adjustedConstraints,

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -141,7 +141,7 @@ class IconButton extends StatelessWidget {
   /// or an [ImageIcon].
   const IconButton({
     Key? key,
-    this.iconSize = 24.0,
+    this.iconSize,
     this.visualDensity,
     this.padding = const EdgeInsets.all(8.0),
     this.alignment = Alignment.center,
@@ -160,8 +160,7 @@ class IconButton extends StatelessWidget {
     this.enableFeedback = true,
     this.constraints,
     required this.icon,
-  }) : assert(iconSize != null),
-       assert(padding != null),
+  }) : assert(padding != null),
        assert(alignment != null),
        assert(splashRadius == null || splashRadius > 0),
        assert(autofocus != null),
@@ -170,7 +169,7 @@ class IconButton extends StatelessWidget {
 
   /// The size of the icon inside the button.
   ///
-  /// This property must not be null. It defaults to 24.0.
+  /// If [iconSize] is null, then it defaults to 24.0.
   ///
   /// The size given here is passed down to the widget in the [icon] property
   /// via an [IconTheme]. Setting the size here instead of in, for example, the
@@ -178,7 +177,7 @@ class IconButton extends StatelessWidget {
   /// fit the [Icon]. If you were to set the size of the [Icon] using
   /// [Icon.size] instead, then the [IconButton] would default to 24.0 and then
   /// the [Icon] itself would likely get clipped.
-  final double iconSize;
+  final double? iconSize;
 
   /// Defines how compact the icon button's layout will be.
   ///
@@ -329,6 +328,7 @@ class IconButton extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ThemeData theme = Theme.of(context);
+    final IconThemeData iconThemeData = IconTheme.of(context);
     Color? currentColor;
     if (onPressed != null)
       currentColor = color;
@@ -343,18 +343,21 @@ class IconButton extends StatelessWidget {
     );
     final BoxConstraints adjustedConstraints = effectiveVisualDensity.effectiveConstraints(unadjustedConstraints);
 
+    final IconThemeData iconTheme = iconThemeData.merge(IconThemeData(size: iconSize));
+    final double size = iconTheme.size ?? 24.0;
+
     Widget result = ConstrainedBox(
       constraints: adjustedConstraints,
       child: Padding(
         padding: padding,
         child: SizedBox(
-          height: iconSize,
-          width: iconSize,
+          height: size,
+          width: size,
           child: Align(
             alignment: alignment,
             child: IconTheme.merge(
               data: IconThemeData(
-                size: iconSize,
+                size: size,
                 color: currentColor,
               ),
               child: icon,
@@ -387,7 +390,7 @@ class IconButton extends StatelessWidget {
         splashColor: splashColor ?? theme.splashColor,
         radius: splashRadius ?? math.max(
           Material.defaultSplashRadius,
-          (iconSize + math.min(padding.horizontal, padding.vertical)) * 0.7,
+          (size + math.min(padding.horizontal, padding.vertical)) * 0.7,
           // x 0.5 for diameter -> radius and + 40% overflow derived from other Material apps.
         ),
         child: result,

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -176,6 +176,27 @@ void main() {
     expect(box.size, const Size(48.0, 600.0));
   });
 
+  testWidgets('Get size from iconButtonTheme', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrap(
+        child: IconTheme(
+          data: const IconThemeData(size: 50),
+          child: IconButton(
+            onPressed: mockOnPressedFunction.handler,
+            icon: const Icon(Icons.link),
+            constraints: const BoxConstraints(),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox iconButton = tester.renderObject(find.byType(IconButton));
+
+    // By default IconButton has a padding of 8.0 on all sides, so both
+    // width and height are 50.0 + 2 * 8.0 = 66.0
+    expect(iconButton.size, const Size(66.0, 66.0));
+  });
+
   testWidgets('test default padding', (WidgetTester tester) async {
     await tester.pumpWidget(
       wrap(
@@ -405,9 +426,9 @@ void main() {
 
     await tester.pumpWidget(
       wrap(
-        child: const IconButton(
+        child: IconButton(
           onPressed: null,
-          icon: Icon(Icons.link, semanticLabel: 'link'),
+          icon: const Icon(Icons.link, semanticLabel: 'link'),
         ),
       ),
     );

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -176,7 +176,7 @@ void main() {
     expect(box.size, const Size(48.0, 600.0));
   });
 
-  testWidgets('Get size from iconButtonTheme', (WidgetTester tester) async {
+  testWidgets('Get size from iconThemeData', (WidgetTester tester) async {
     await tester.pumpWidget(
       wrap(
         child: IconTheme(
@@ -426,9 +426,9 @@ void main() {
 
     await tester.pumpWidget(
       wrap(
-        child: IconButton(
+        child: const IconButton(
           onPressed: null,
-          icon: const Icon(Icons.link, semanticLabel: 'link'),
+          icon: Icon(Icons.link, semanticLabel: 'link'),
         ),
       ),
     );


### PR DESCRIPTION
This pr fixes `IconButton` ignoring size from `IconThemeData`

fix: #77801

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
