### PR TITLE
Mixed null safety in dev/devicelab

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/summarize.dart
+++ b/dev/devicelab/bin/summarize.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/tasks/analyzer_benchmark.dart
+++ b/dev/devicelab/bin/tasks/analyzer_benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/analysis.dart';
 

--- a/dev/devicelab/bin/tasks/android_defines_test.dart
+++ b/dev/devicelab/bin/tasks/android_defines_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
+++ b/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/android_obfuscate_test.dart
+++ b/dev/devicelab/bin/tasks/android_obfuscate_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/android_semantics_integration_test.dart
+++ b/dev/devicelab/bin/tasks/android_semantics_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/android_stack_size_test.dart
+++ b/dev/devicelab/bin/tasks/android_stack_size_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/android_view_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/android_view_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
+++ b/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/animated_placeholder_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/animated_placeholder_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/animation_with_microtasks_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/animation_with_microtasks_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_android__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_win__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_win__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/build_mode_test.dart
+++ b/dev/devicelab/bin/tasks/build_mode_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/channels_integration_test.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/channels_integration_test_ios.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/channels_integration_test_win.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test_win.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_linux.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_linux.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_mac.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_mac.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_win.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_win.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/color_filter_and_fade_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/color_filter_and_fade_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/color_filter_and_fade_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/color_filter_and_fade_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout__start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_android__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_android__scroll_smoothness.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_android__scroll_smoothness.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__devtools_memory.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__devtools_memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_win__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_win__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cull_opacity_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cull_opacity_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cull_opacity_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cull_opacity_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/dart_plugin_registry_test.dart
+++ b/dev/devicelab/bin/tasks/dart_plugin_registry_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/dart_plugin_registry_tests.dart';
 

--- a/dev/devicelab/bin/tasks/dartdocs.dart
+++ b/dev/devicelab/bin/tasks/dartdocs.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/devtools_profile_start_test.dart
+++ b/dev/devicelab/bin/tasks/devtools_profile_start_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
+++ b/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/host_agent.dart';

--- a/dev/devicelab/bin/tasks/embedded_android_views_integration_test.dart
+++ b/dev/devicelab/bin/tasks/embedded_android_views_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/external_ui_integration_test.dart
+++ b/dev/devicelab/bin/tasks/external_ui_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/external_ui_integration_test_ios.dart
+++ b/dev/devicelab/bin/tasks/external_ui_integration_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fast_scroll_heavy_gridview__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_heavy_gridview__memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/flavors_test_ios.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/flavors_test_win.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_win.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_attach_test_fuchsia.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_fuchsia.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/common.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 /// Measure application memory usage after pausing and resuming the app
 /// with the Android back button.
 

--- a/dev/devicelab/bin/tasks/flutter_gallery__image_cache_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__image_cache_memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios32.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios32.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_android__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_win__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_win__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_run_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 // This test runs `flutter test` on the `trivial_widget_test.dart` four times.
 //
 // The first time, the result is ignored, on the basis that it's warming the

--- a/dev/devicelab/bin/tasks/flutter_view__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/frame_policy_delay_test_android.dart
+++ b/dev/devicelab/bin/tasks/frame_policy_delay_test_android.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/common.dart';

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/gradle_non_android_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_non_android_plugin_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/common.dart';

--- a/dev/devicelab/bin/tasks/hello_world__memory.dart
+++ b/dev/devicelab/bin/tasks/hello_world__memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/hello_world_android__compile.dart
+++ b/dev/devicelab/bin/tasks/hello_world_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/hello_world_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/hello_world_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hybrid_android_views_integration_test.dart
+++ b/dev/devicelab/bin/tasks/hybrid_android_views_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/image_list_jit_reported_duration.dart
+++ b/dev/devicelab/bin/tasks/image_list_jit_reported_duration.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/image_list_reported_duration.dart
+++ b/dev/devicelab/bin/tasks/image_list_reported_duration.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_test_test.dart
+++ b/dev/devicelab/bin/tasks/integration_test_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_test_test_ios.dart
+++ b/dev/devicelab/bin/tasks/integration_test_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_driver.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_driver.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_driver.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_driver.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_keyboard_resize.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_keyboard_resize.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_screenshot.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_screenshot.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_textfield.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_textfield.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_keyboard_resize.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_keyboard_resize.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_screenshot.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_screenshot.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_textfield.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_textfield.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/common.dart';

--- a/dev/devicelab/bin/tasks/ios_defines_test.dart
+++ b/dev/devicelab/bin/tasks/ios_defines_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/ios_platform_view_tests.dart
+++ b/dev/devicelab/bin/tasks/ios_platform_view_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/large_image_changer_perf_android.dart
+++ b/dev/devicelab/bin/tasks/large_image_changer_perf_android.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/large_image_changer_perf_ios.dart
+++ b/dev/devicelab/bin/tasks/large_image_changer_perf_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/linux_chrome_dev_mode.dart
+++ b/dev/devicelab/bin/tasks/linux_chrome_dev_mode.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_dev_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/macos_chrome_dev_mode.dart
+++ b/dev/devicelab/bin/tasks/macos_chrome_dev_mode.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_dev_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/microbenchmarks.dart
+++ b/dev/devicelab/bin/tasks/microbenchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/microbenchmarks.dart';

--- a/dev/devicelab/bin/tasks/microbenchmarks_ios.dart
+++ b/dev/devicelab/bin/tasks/microbenchmarks_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/microbenchmarks.dart';

--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
+++ b/dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/dev/devicelab/bin/tasks/multi_widget_construction_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/multi_widget_construction_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/native_ui_tests_ios32.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_ios32.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery__crane_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/new_gallery__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/picture_cache_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/picture_cache_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/picture_cache_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/picture_cache_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_channel_sample_test.dart
+++ b/dev/devicelab/bin/tasks/platform_channel_sample_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_channel_sample_test_ios.dart
+++ b/dev/devicelab/bin/tasks/platform_channel_sample_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_channel_sample_test_swift.dart
+++ b/dev/devicelab/bin/tasks/platform_channel_sample_test_swift.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_channels_benchmarks.dart
+++ b/dev/devicelab/bin/tasks/platform_channels_benchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart'
     show DeviceOperatingSystem;
 import 'package:flutter_devicelab/framework/framework.dart' show task;

--- a/dev/devicelab/bin/tasks/platform_channels_benchmarks_ios.dart
+++ b/dev/devicelab/bin/tasks/platform_channels_benchmarks_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart'
     show DeviceOperatingSystem;
 import 'package:flutter_devicelab/framework/framework.dart' show task;

--- a/dev/devicelab/bin/tasks/platform_interaction_test.dart
+++ b/dev/devicelab/bin/tasks/platform_interaction_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_interaction_test_ios.dart
+++ b/dev/devicelab/bin/tasks/platform_interaction_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_view__start_up.dart
+++ b/dev/devicelab/bin/tasks/platform_view__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/platform_view_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/platform_views_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/platform_views_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/platform_views_scroll_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/platform_views_scroll_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_dependencies_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/plugin_test.dart
+++ b/dev/devicelab/bin/tasks/plugin_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 

--- a/dev/devicelab/bin/tasks/plugin_test_ios.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 

--- a/dev/devicelab/bin/tasks/plugin_test_win.dart
+++ b/dev/devicelab/bin/tasks/plugin_test_win.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/plugin_tests.dart';
 

--- a/dev/devicelab/bin/tasks/post_backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/post_backdrop_filter_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/routing_test.dart
+++ b/dev/devicelab/bin/tasks/routing_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/run_release_test.dart
+++ b/dev/devicelab/bin/tasks/run_release_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/service_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/service_extensions_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/simple_animation_perf_ios.dart
+++ b/dev/devicelab/bin/tasks/simple_animation_perf_ios.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
 
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/smoke_catalina_hot_mode_dev_cycle_ios__benchmark.dart
+++ b/dev/devicelab/bin/tasks/smoke_catalina_hot_mode_dev_cycle_ios__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';

--- a/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
+++ b/dev/devicelab/bin/tasks/smoke_catalina_start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';
 

--- a/dev/devicelab/bin/tasks/smoke_test_build_test.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_build_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/smoke_test_device.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_device.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/smoke_test_failure.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_failure.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/smoke_test_success.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_success.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/smoke_test_throws.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_throws.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 
 /// Smoke test of a task that fails with an exception.

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/tasks/textfield_perf.dart
+++ b/dev/devicelab/bin/tasks/textfield_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/bin/tasks/textfield_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/textfield_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/tiles_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/tiles_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/tiles_scroll_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/tiles_scroll_perf_ios__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/tiles_scroll_perf_iphonexs__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/tiles_scroll_perf_iphonexs__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/adb.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/web_benchmarks_canvaskit.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_canvaskit.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
 

--- a/dev/devicelab/bin/tasks/web_benchmarks_html.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_html.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
 

--- a/dev/devicelab/bin/tasks/web_incremental_test.dart
+++ b/dev/devicelab/bin/tasks/web_incremental_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_dev_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/web_size__compile_test.dart
+++ b/dev/devicelab/bin/tasks/web_size__compile_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';
 

--- a/dev/devicelab/bin/tasks/windows_chrome_dev_mode.dart
+++ b/dev/devicelab/bin/tasks/windows_chrome_dev_mode.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_dev_mode_tests.dart';
 

--- a/dev/devicelab/bin/test_runner.dart
+++ b/dev/devicelab/bin/test_runner.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:args/command_runner.dart';
 
 import 'package:flutter_devicelab/framework/runner.dart';

--- a/dev/devicelab/lib/command/upload_metrics.dart
+++ b/dev/devicelab/lib/command/upload_metrics.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:args/command_runner.dart';
 
 import '../framework/cocoon.dart';

--- a/dev/devicelab/lib/framework/ab.dart
+++ b/dev/devicelab/lib/framework/ab.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:math' as math;
 import 'package:meta/meta.dart';
 

--- a/dev/devicelab/lib/framework/adb.dart
+++ b/dev/devicelab/lib/framework/adb.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert' show json, utf8, LineSplitter, JsonEncoder;
 import 'dart:io' as io;

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert' show Encoding, json;
 import 'dart:io';

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';

--- a/dev/devicelab/lib/framework/host_agent.dart
+++ b/dev/devicelab/lib/framework/host_agent.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:meta/meta.dart';

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 
 import 'utils.dart';

--- a/dev/devicelab/lib/framework/manifest.dart
+++ b/dev/devicelab/lib/framework/manifest.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:meta/meta.dart';

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/framework/running_processes.dart
+++ b/dev/devicelab/lib/framework/running_processes.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:meta/meta.dart';

--- a/dev/devicelab/lib/framework/task_result.dart
+++ b/dev/devicelab/lib/framework/task_result.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/microbenchmarks.dart
+++ b/dev/devicelab/lib/microbenchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/tasks/analysis.dart
+++ b/dev/devicelab/lib/tasks/analysis.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/dev/devicelab/lib/tasks/build_test_task.dart
+++ b/dev/devicelab/lib/tasks/build_test_task.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:args/args.dart';

--- a/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
+++ b/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import '../framework/adb.dart';
 import '../framework/framework.dart';
 import '../framework/host_agent.dart';

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:io';
 

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert' show LineSplitter, json, utf8;
 import 'dart:io';

--- a/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io' show Process, Directory;
 
 import 'package:flutter_devicelab/framework/adb.dart' as adb;

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io' as io;

--- a/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   archive: 3.1.2

--- a/dev/devicelab/test/ab_test.dart
+++ b/dev/devicelab/test/ab_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/ab.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:collection/collection.dart' show ListEquality, MapEquality;
 
 import 'package:flutter_devicelab/framework/adb.dart';

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/test/host_agent_test.dart
+++ b/dev/devicelab/test/host_agent_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_devicelab/framework/host_agent.dart';

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/dev/devicelab/test/running_processes_test.dart
+++ b/dev/devicelab/test/running_processes_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/running_processes.dart';
 import 'common.dart';
 

--- a/dev/devicelab/test/task_result_test.dart
+++ b/dev/devicelab/test/task_result_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/task_result.dart';
 
 import 'common.dart';

--- a/dev/devicelab/test/tasks/build_test_task_test.dart
+++ b/dev/devicelab/test/tasks/build_test_task_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/runner.dart';

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/utils.dart';
 
 import 'common.dart';


### PR DESCRIPTION
Up `dev/devicelab` pubspec sdk to `">=2.12.0-0 <3.0.0"` to opt the package into null safety.  Then add `// @dart = 2.8` to every dart library to opt it out of null safety.

This will allow us to start incrementally migrating packages to null safety, and allows new code to be null safe from its creation.  Matches migration strategy for `flutter_tool` #74832.
