### PR TITLE
Allow Flutter focus to interop with Android view hierarchies

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -893,10 +893,10 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
     if (!isFocused) {
       _controller?.clearFocus();
     }
-   SystemChannels.textInput.invokeMethod<void>(
+    SystemChannels.textInput.invokeMethod<void>(
       'TextInput.setPlatformViewClient',
-      <String, dynamic>{'platformViewId': _id, 'usesVirtualDisplay': false},
-   );
+      <String, dynamic>{'platformViewId': _id},
+    );
   }
 
   void _handlePlatformFocusChanged(bool isFocused){

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -537,7 +537,7 @@ class _AndroidViewState extends State<AndroidView> {
     }
     SystemChannels.textInput.invokeMethod<void>(
       'TextInput.setPlatformViewClient',
-      _id,
+      <String, dynamic>{'platformViewId': _id, 'usesVirtualDisplay': true},
     ).catchError((dynamic e) {
       if (e is MissingPluginException) {
         // We land the framework part of Android platform views keyboard
@@ -893,6 +893,10 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
     if (!isFocused) {
       _controller?.clearFocus();
     }
+   SystemChannels.textInput.invokeMethod<void>(
+      'TextInput.setPlatformViewClient',
+      <String, dynamic>{'platformViewId': _id, 'usesVirtualDisplay': false},
+   );
   }
 
   void _handlePlatformFocusChanged(bool isFocused){

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -119,6 +119,13 @@ class FakeAndroidViewController implements AndroidViewController {
   Future<void> create() async {
     created = true;
   }
+
+  void invokeViewFocused() {
+    final MethodCodec codec = SystemChannels.platform_views.codec;
+    final ByteData data = codec.encodeMethodCall(MethodCall('viewFocused', viewId));
+    ServicesBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData? data) {});
+  }
 }
 
 class FakeAndroidPlatformViewsController {

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -119,13 +119,6 @@ class FakeAndroidViewController implements AndroidViewController {
   Future<void> create() async {
     created = true;
   }
-
-  void invokeViewFocused() {
-    final MethodCodec codec = SystemChannels.platform_views.codec;
-    final ByteData data = codec.encodeMethodCall(MethodCall('viewFocused', viewId));
-    ServicesBinding.instance!.defaultBinaryMessenger
-        .handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData? data) {});
-  }
 }
 
 class FakeAndroidPlatformViewsController {

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1074,10 +1074,10 @@ void main() {
       containerFocusNode.requestFocus();
       await tester.pump();
 
-      late int lastPlatformViewTextClient;
+      late Map<String, dynamic> lastPlatformViewTextClient;
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.textInput, (MethodCall call) {
         if (call.method == 'TextInput.setPlatformViewClient') {
-          lastPlatformViewTextClient = call.arguments as int;
+          lastPlatformViewTextClient = call.arguments as Map<String, dynamic>;
         }
         return null;
       });
@@ -1085,7 +1085,11 @@ void main() {
       viewsController.invokeViewFocused(currentViewId + 1);
       await tester.pump();
 
-      expect(lastPlatformViewTextClient, currentViewId + 1);
+      expect(lastPlatformViewTextClient.containsKey('platformViewId'), true);
+      expect(lastPlatformViewTextClient['platformViewId'], currentViewId + 1);
+
+      expect(lastPlatformViewTextClient.containsKey('usesVirtualDisplay'), true);
+      expect(lastPlatformViewTextClient['usesVirtualDisplay'], true);
     });
 
     testWidgets('AndroidView clears platform focus when unfocused', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2568,6 +2568,7 @@ void main() {
     testWidgets('PlatformViewLink sets a platform view text input client when focused', (WidgetTester tester) async {
       late FakePlatformViewController controller;
       late int viewId;
+
       final PlatformViewLink platformViewLink = PlatformViewLink(
         viewType: 'test',
         onCreatePlatformView: (PlatformViewCreationParams params) {
@@ -2584,15 +2585,18 @@ void main() {
           );
         },
       );
-      await tester.pumpWidget(
-        Center(
-          child: Column(
-            children: <Widget>[
-              SizedBox(width: 300, height: 300, child: platformViewLink),
-            ],
-          ),
+      await tester.pumpWidget(SizedBox(width: 300, height: 300, child: platformViewLink));
+
+      final Focus platformViewFocusWidget = tester.widget(
+        find.descendant(
+          of: find.byType(PlatformViewLink),
+          matching: find.byType(Focus),
         ),
       );
+
+      final FocusNode? focusNode = platformViewFocusWidget.focusNode;
+      expect(focusNode, isNotNull);
+      expect(focusNode!.hasFocus, false);
 
       late Map<String, dynamic> lastPlatformViewTextClient;
       tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.textInput, (MethodCall call) {
@@ -2602,16 +2606,10 @@ void main() {
         return null;
       });
 
-      final Focus platformViewFocusWidget = tester.widget(
-        find.descendant(
-          of: find.byType(PlatformViewLink),
-          matching: find.byType(Focus),
-        ),
-      );
-
       platformViewFocusWidget.focusNode!.requestFocus();
       await tester.pump();
 
+      expect(focusNode.hasFocus, true);
       expect(lastPlatformViewTextClient.containsKey('platformViewId'), true);
       expect(lastPlatformViewTextClient['platformViewId'], viewId);
 


### PR DESCRIPTION
The method `TextInput.setPlatformViewClient` is invoked when a platform view is focused.

HC was missing this called.  Because the implementation in the engine is different for HC, the framework call needs to specify which backend is used.


Engine PR: https://github.com/flutter/engine/pull/26602