### PR TITLE
Add onPlatformViewCreated to HtmlElementView

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -345,6 +345,7 @@ class HtmlElementView extends StatelessWidget {
   const HtmlElementView({
     Key? key,
     required this.viewType,
+    this.onPlatformViewCreated,
   }) : assert(viewType != null),
        assert(kIsWeb, 'HtmlElementView is only available on Flutter Web.'),
        super(key: key);
@@ -353,6 +354,11 @@ class HtmlElementView extends StatelessWidget {
   ///
   /// A PlatformViewFactory for this type must have been registered.
   final String viewType;
+
+  /// Callback to invoke after the platform view has been created.
+  ///
+  /// May be null.
+  final PlatformViewCreatedCallback? onPlatformViewCreated;
 
   @override
   Widget build(BuildContext context) {
@@ -372,7 +378,10 @@ class HtmlElementView extends StatelessWidget {
   /// Creates the controller and kicks off its initialization.
   _HtmlElementViewController _createHtmlElementView(PlatformViewCreationParams params) {
     final _HtmlElementViewController controller = _HtmlElementViewController(params.id, viewType);
-    controller._initialize().then((_) { params.onPlatformViewCreated(params.id); });
+    controller._initialize().then((_) {
+      params.onPlatformViewCreated(params.id);
+      onPlatformViewCreated?.call(params.id);
+    });
     return controller;
   }
 }

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -16,7 +16,8 @@ void main() {
   group('HtmlElementView', () {
     testWidgets('Create HTML view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
       await tester.pumpWidget(
@@ -37,9 +38,42 @@ void main() {
       );
     });
 
+    testWidgets('Create HTML view with PlatformViewCreatedCallback',
+        (WidgetTester tester) async {
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      void onPlatformViewCreatedCallBack(int id) {
+        expect(id >= 0, true);
+      }
+
+      await tester.pumpWidget(
+        Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 100.0,
+            child: HtmlElementView(
+              viewType: 'webview',
+              onPlatformViewCreated: onPlatformViewCreatedCallBack,
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        viewsController.views,
+        unorderedEquals(<FakeHtmlPlatformView>[
+          FakeHtmlPlatformView(currentViewId + 1, 'webview'),
+        ]),
+      );
+    });
+
     testWidgets('Resize HTML view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
         const Center(
@@ -76,7 +110,8 @@ void main() {
 
     testWidgets('Change HTML view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       viewsController.registerViewType('maps');
       await tester.pumpWidget(
@@ -108,7 +143,8 @@ void main() {
     });
 
     testWidgets('Dispose HTML view', (WidgetTester tester) async {
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
         const Center(
@@ -135,9 +171,11 @@ void main() {
       );
     });
 
-    testWidgets('HTML view survives widget tree change', (WidgetTester tester) async {
+    testWidgets('HTML view survives widget tree change',
+        (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(
@@ -168,11 +206,13 @@ void main() {
       );
     });
 
-    testWidgets('HtmlElementView has correct semantics', (WidgetTester tester) async {
+    testWidgets('HtmlElementView has correct semantics',
+        (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       expect(currentViewId, greaterThanOrEqualTo(0));
-      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController =
+          FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
       await tester.pumpWidget(
@@ -195,7 +235,8 @@ void main() {
       await tester.pump();
 
       // The platform view ID is set on the child of the HtmlElementView render object.
-      final SemanticsNode semantics = tester.getSemantics(find.byType(PlatformViewSurface));
+      final SemanticsNode semantics =
+          tester.getSemantics(find.byType(PlatformViewSurface));
 
       expect(semantics.platformViewId, currentViewId + 1);
       expect(semantics.rect, const Rect.fromLTWH(0, 0, 200, 100));

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -42,8 +42,9 @@ void main() {
       final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
+      bool hasPlatformViewCreated = false;
       void onPlatformViewCreatedCallBack(int id) {
-        expect(id >= 0, true);
+        hasPlatformViewCreated = true;
       }
 
       await tester.pumpWidget(
@@ -58,6 +59,9 @@ void main() {
           ),
         ),
       );
+
+      // Check the onPlatformViewCreatedCallBack has been called.
+      expect(hasPlatformViewCreated, true);
 
       expect(
         viewsController.views,

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -16,8 +16,7 @@ void main() {
   group('HtmlElementView', () {
     testWidgets('Create HTML view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
       await tester.pumpWidget(
@@ -38,11 +37,9 @@ void main() {
       );
     });
 
-    testWidgets('Create HTML view with PlatformViewCreatedCallback',
-        (WidgetTester tester) async {
+    testWidgets('Create HTML view with PlatformViewCreatedCallback', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
       void onPlatformViewCreatedCallBack(int id) {
@@ -72,8 +69,7 @@ void main() {
 
     testWidgets('Resize HTML view', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
         const Center(
@@ -110,8 +106,7 @@ void main() {
 
     testWidgets('Change HTML view type', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       viewsController.registerViewType('maps');
       await tester.pumpWidget(
@@ -143,8 +138,7 @@ void main() {
     });
 
     testWidgets('Dispose HTML view', (WidgetTester tester) async {
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       await tester.pumpWidget(
         const Center(
@@ -171,11 +165,9 @@ void main() {
       );
     });
 
-    testWidgets('HTML view survives widget tree change',
-        (WidgetTester tester) async {
+    testWidgets('HTML view survives widget tree change', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(
@@ -206,13 +198,11 @@ void main() {
       );
     });
 
-    testWidgets('HtmlElementView has correct semantics',
-        (WidgetTester tester) async {
+    testWidgets('HtmlElementView has correct semantics', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       expect(currentViewId, greaterThanOrEqualTo(0));
-      final FakeHtmlPlatformViewsController viewsController =
-          FakeHtmlPlatformViewsController();
+      final FakeHtmlPlatformViewsController viewsController = FakeHtmlPlatformViewsController();
       viewsController.registerViewType('webview');
 
       await tester.pumpWidget(
@@ -235,8 +225,7 @@ void main() {
       await tester.pump();
 
       // The platform view ID is set on the child of the HtmlElementView render object.
-      final SemanticsNode semantics =
-          tester.getSemantics(find.byType(PlatformViewSurface));
+      final SemanticsNode semantics = tester.getSemantics(find.byType(PlatformViewSurface));
 
       expect(semantics.platformViewId, currentViewId + 1);
       expect(semantics.rect, const Rect.fromLTWH(0, 0, 200, 100));


### PR DESCRIPTION
## Requirement
`HtmlElementView` has no `onPlatformViewCreated` callback. This callback is primarily important to learn the `viewId` of the created view, for instance, to open the platform channel. The underlying code has its own callback in place but the call doesn't get propagated to the upper level.

## Issue
- [web] HtmlElementView has no onPlatformViewCreated #56181

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
