### PR TITLE
Avoid non-nullable `Future.value()`

### DIFF
--- a/packages/flutter/test/services/default_binary_messenger_test.dart
+++ b/packages/flutter/test/services/default_binary_messenger_test.dart
@@ -51,7 +51,7 @@ void main() {
   });
 
   test('can check the mock handler', () {
-    Future<ByteData> handler(ByteData? call) => Future<ByteData>.value(null);
+    Future<ByteData?> handler(ByteData? call) => Future<ByteData?>.value(null);
     final TestDefaultBinaryMessenger messenger = TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger;
 
     expect(messenger.checkMockMessageHandler('test_channel', null), true);


### PR DESCRIPTION
Using `Future<T>.value()` with a non-nullable `T` is a guaranteed runtime error, which is why I'm [adding an analysis warning](https://dart-review.googlesource.com/c/sdk/+/202622) for it.
Flutter currently has one such usage in a test (the offending constructor does not actually get called).

Closes https://github.com/flutter/flutter/issues/84137

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
