### PR TITLE
Mark Linux web_tool_tests as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -226,6 +226,7 @@ targets:
 
   - name: linux_web_tool_tests
     builder: Linux web_tool_tests
+    bringup: true
     scheduler: luci
     runIf:
       - dev/


### PR DESCRIPTION
Flaky rate 2.29% is above 2% threshold. Investigation in #84134.
