### PR TITLE
Enable drawer color change

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -142,6 +142,7 @@ class Drawer extends StatelessWidget {
     this.elevation = 16.0,
     this.child,
     this.semanticLabel,
+    this.color,
   }) : assert(elevation != null && elevation >= 0.0),
        super(key: key);
 
@@ -171,6 +172,10 @@ class Drawer extends StatelessWidget {
   ///  * [SemanticsConfiguration.namesRoute], for a description of how this
   ///    value is used.
   final String? semanticLabel;
+  /// the color label defines the color of the drawer
+  /// this color will be affected to the Semantics --> Material color
+  /// attribute to provide a custom color to the drawer
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
@@ -196,6 +201,7 @@ class Drawer extends StatelessWidget {
         child: Material(
           elevation: elevation,
           child: child,
+          color: color,
         ),
       ),
     );


### PR DESCRIPTION
With this update, it's now possible to change the color of drawer by precising it in its new color attribute.
Basically, to change the drawer color, we need to wrap all its parts with Containers and set the same colors.
Now, with this update, it's possible to just precise color using the color attribute. Making Flutter easier.


Drawer color can be basically changed.
It's difficult to change the color of a drawer.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
