### PR TITLE
[flutter_tools] switch flutter sdk to dart format

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -160,7 +160,7 @@ List<FlutterCommand> generateCommands({
     platform: globals.platform,
   ),
   EmulatorsCommand(),
-  FormatCommand(),
+  FormatCommand(verboseHelp: verboseHelp),
   GenerateCommand(),
   GenerateLocalizationsCommand(
     fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -45,7 +45,13 @@ class FormatCommand extends FlutterCommand {
       );
       command.add('-h');
     } else {
-      command.addAll(argResults.rest);
+      command.addAll(<String>[
+        for (String arg in argResults.rest)
+          if (arg == '--dry-run')
+            '--output=show'
+          else
+            arg
+      ]);
     }
 
     final int result = await globals.processUtils.stream(command);

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -4,37 +4,21 @@
 
 // @dart = 2.8
 
+import 'package:args/args.dart';
+import 'package:meta/meta.dart';
+
 import '../artifacts.dart';
 import '../base/common.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 
 class FormatCommand extends FlutterCommand {
-  FormatCommand() {
-    argParser.addFlag('dry-run',
-      abbr: 'n',
-      help: 'Show which files would be modified but make no changes.',
-      defaultsTo: false,
-      negatable: false,
-    );
-    argParser.addFlag('set-exit-if-changed',
-      help: 'Return exit code 1 if there are any formatting changes.',
-      defaultsTo: false,
-      negatable: false,
-    );
-    argParser.addFlag('machine',
-      abbr: 'm',
-      help: 'Produce machine-readable JSON output.',
-      defaultsTo: false,
-      negatable: false,
-    );
-    argParser.addOption('line-length',
-      abbr: 'l',
-      help: 'Wrap lines longer than this length.',
-      valueHelp: 'characters',
-      defaultsTo: '80',
-    );
-  }
+  FormatCommand({@required this.verboseHelp});
+
+  @override
+  ArgParser argParser = ArgParser.allowAnything();
+
+  final bool verboseHelp;
 
   @override
   final String name = 'format';
@@ -50,29 +34,19 @@ class FormatCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (argResults.rest.isEmpty) {
-      throwToolExit(
-        'No files specified to be formatted.\n'
-        '\n'
-        'To format all files in the current directory tree:\n'
-        '${runner.executableName} $name .\n'
-        '\n'
-        '$usage'
-      );
-    }
-
-    final String dartSdk = globals.artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path;
     final String dartBinary = globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path;
     final List<String> command = <String>[
       dartBinary,
-      globals.fs.path.join(dartSdk, 'bin', 'snapshots', 'dartfmt.dart.snapshot'),
-      if (boolArg('dry-run')) '-n',
-      if (boolArg('machine')) '-m',
-      if (argResults['line-length'] != null) '-l ${argResults['line-length']}',
-      if (!boolArg('dry-run') && !boolArg('machine')) '-w',
-      if (boolArg('set-exit-if-changed')) '--set-exit-if-changed',
-      ...argResults.rest,
+      'format',
     ];
+    if (argResults.rest.isEmpty) {
+      globals.printError(
+        'No files specified to be formatted.'
+      );
+      command.add('-h');
+    } else {
+      command.addAll(argResults.rest);
+    }
 
     final int result = await globals.processUtils.stream(command);
     if (result != 0) {

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1100,12 +1100,12 @@ void main() {
 
         final Process process = await Process.start(
           globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
-          <String>['format', file.path],
+          <String>['format', '--output=show', file.path],
           workingDirectory: projectDir.path,
         );
         final String formatted = await process.stdout.transform(utf8.decoder).join();
 
-        expect(original, formatted, reason: file.path);
+        expect(formatted, contains(original), reason: file.path);
       }
     }
 
@@ -1202,12 +1202,12 @@ void main() {
 
         final Process process = await Process.start(
           globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
-          <String>['format', file.path],
+          <String>['format', '--output=show', file.path],
           workingDirectory: projectDir.path,
         );
         final String formatted = await process.stdout.transform(utf8.decoder).join();
 
-        expect(original, formatted, reason: file.path);
+        expect(formatted, contains(original), reason: file.path);
       }
     }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1099,11 +1099,8 @@ void main() {
         final String original = file.readAsStringSync();
 
         final Process process = await Process.start(
-          globals.fs.path.join(
-            globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
-            'format',
-          ),
-          <String>[file.path],
+          globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
+          <String>['format', file.path],
           workingDirectory: projectDir.path,
         );
         final String formatted = await process.stdout.transform(utf8.decoder).join();
@@ -1204,11 +1201,8 @@ void main() {
         final String original = file.readAsStringSync();
 
         final Process process = await Process.start(
-          globals.fs.path.join(
-            globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
-            'format',
-          ),
-          <String>[file.path],
+          globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
+          <String>['format', file.path],
           workingDirectory: projectDir.path,
         );
         final String formatted = await process.stdout.transform(utf8.decoder).join();

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1100,9 +1100,8 @@ void main() {
 
         final Process process = await Process.start(
           globals.fs.path.join(
-            globals.artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path,
-            'bin',
-            globals.platform.isWindows ? 'dartfmt.bat' : 'dartfmt',
+            globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
+            'format',
           ),
           <String>[file.path],
           workingDirectory: projectDir.path,
@@ -1206,9 +1205,8 @@ void main() {
 
         final Process process = await Process.start(
           globals.fs.path.join(
-            globals.artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path,
-            'bin',
-            globals.platform.isWindows ? 'dartfmt.bat' : 'dartfmt',
+            globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
+            'format',
           ),
           <String>[file.path],
           workingDirectory: projectDir.path,

--- a/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
@@ -34,7 +34,7 @@ void main() {
       final String original = srcFile.readAsStringSync();
       srcFile.writeAsStringSync(original.replaceFirst('main()', 'main(  )'));
 
-      final FormatCommand command = FormatCommand();
+      final FormatCommand command = FormatCommand(verboseHelp: false);
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['format', srcFile.path]);
 
@@ -51,7 +51,7 @@ void main() {
           'main()', 'main(  )');
       srcFile.writeAsStringSync(nonFormatted);
 
-      final FormatCommand command = FormatCommand();
+      final FormatCommand command = FormatCommand(verboseHelp: false);
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['format', '--dry-run', srcFile.path]);
 
@@ -68,7 +68,7 @@ void main() {
           'main()', 'main(  )');
       srcFile.writeAsStringSync(nonFormatted);
 
-      final FormatCommand command = FormatCommand();
+      final FormatCommand command = FormatCommand(verboseHelp: false);
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       expect(runner.run(<String>[
@@ -92,7 +92,7 @@ void main() {
               'main(anArgument1, anArgument2, anArgument3, anArgument4, anArgument5)'));
 
       final String nonFormattedWithLongLine = srcFile.readAsStringSync();
-      final FormatCommand command = FormatCommand();
+      final FormatCommand command = FormatCommand(verboseHelp: false);
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['format', '--line-length', '$lineLengthLong', srcFile.path]);


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/83822

Also makes flutter format forward everything to dart format without interpretation. 

--dry-run has been replaced with --output=show, work around this by translating the arg on the fly.
