### PR TITLE
Switch sample analysis over to use package:flutter_lints

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -611,13 +611,22 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+
+dev_dependencies:
+  flutter_lints: ^1.0.3
 ''');
 
 
     // Import the analysis options from the Flutter root.
-    final File rootAnalysisOptions = File(path.join(_flutterRoot,'analysis_options.yaml'));
     final File analysisOptions = File(path.join(directory.path, 'analysis_options.yaml'));
-    analysisOptions.writeAsStringSync('include: ${rootAnalysisOptions.absolute.path}');
+    analysisOptions.writeAsStringSync('''
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    # Samples want to print things pretty often.
+    avoid_print: false
+''');
   }
 
   /// Writes out a sample section to the disk and returns the file.

--- a/dev/bots/test/analyze_sample_code_test.dart
+++ b/dev/bots/test/analyze_sample_code_test.dart
@@ -24,22 +24,14 @@ void main() {
       ..removeWhere((String line) => line.startsWith('Analyzer output:') || line.startsWith('Building flutter tool...'));
     expect(process.exitCode, isNot(equals(0)));
     expect(stderrLines, <String>[
-      'In sample starting at dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:117:bool? _visible = true;',
-      '>>> info: Use late for private members with non-nullable type (use_late_for_private_fields_and_variables)',
       'In sample starting at dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:117:      child: Text(title),',
       ">>> error: The final variable 'title' can't be read because it is potentially unassigned at this point (read_potentially_unassigned_final)",
       'dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:30:9: new Opacity(',
       '>>> info: Unnecessary new keyword (unnecessary_new)',
       'dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:62:9: new Opacity(',
       '>>> info: Unnecessary new keyword (unnecessary_new)',
-      "dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:95:9: const text0 = Text('Poor wandering ones!');",
-      '>>> info: Specify type annotations (always_specify_types)',
-      "dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:103:9: const text1 = _Text('Poor wandering ones!');",
-      '>>> info: Specify type annotations (always_specify_types)',
       "dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:111:9: final String? bar = 'Hello';",
       '>>> info: Prefer const over final for declarations (prefer_const_declarations)',
-      "dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:111:23: final String? bar = 'Hello';",
-      '>>> info: Use a non-nullable type for a final variable initialized with a non-nullable value (unnecessary_nullable_for_final_variable_declarations)',
       'dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:112:9: final int foo = null;',
       '>>> info: Prefer const over final for declarations (prefer_const_declarations)',
       'dev/bots/test/analyze-sample-code-test-input/known_broken_documentation.dart:112:25: final int foo = null;',

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -390,8 +390,9 @@ class DataCell {
 ///         (int index) => DataRow(
 ///           color: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
 ///             // All rows will have the same selected color.
-///             if (states.contains(MaterialState.selected))
+///             if (states.contains(MaterialState.selected)) {
 ///               return Theme.of(context).colorScheme.primary.withOpacity(0.08);
+///             }
 ///             // Even rows will have a grey color.
 ///             if (index.isEven) {
 ///               return Colors.grey.withOpacity(0.3);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -260,8 +260,9 @@ typedef DecoderCallback = Future<ui.Codec> Function(Uint8List bytes, {int? cache
 ///   @override
 ///   void didUpdateWidget(MyImage oldWidget) {
 ///     super.didUpdateWidget(oldWidget);
-///     if (widget.imageProvider != oldWidget.imageProvider)
+///     if (widget.imageProvider != oldWidget.imageProvider) {
 ///       _getImage();
+///     }
 ///   }
 ///
 ///   void _getImage() {
@@ -545,8 +546,9 @@ abstract class ImageProvider<T extends Object> {
   ///   void evictImage() {
   ///     final NetworkImage provider = NetworkImage(url);
   ///     provider.evict().then<void>((bool success) {
-  ///       if (success)
+  ///       if (success) {
   ///         debugPrint('removed image!');
+  ///       }
   ///     });
   ///   }
   /// }

--- a/packages/flutter/lib/src/painting/image_resolution.dart
+++ b/packages/flutter/lib/src/painting/image_resolution.dart
@@ -153,8 +153,9 @@ const double _kLowDprLimit = 2.0;
 ///   @override
 ///   void didUpdateWidget(MyImage oldWidget) {
 ///     super.didUpdateWidget(oldWidget);
-///     if (widget.assetImage != oldWidget.assetImage)
+///     if (widget.assetImage != oldWidget.assetImage) {
 ///       _getImage();
+///     }
 ///   }
 ///
 ///   void _getImage() {

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -235,8 +235,9 @@ class _ActiveItem implements Comparable<_ActiveItem> {
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     TextStyle textStyle = Theme.of(context).textTheme.headline4!;
-///     if (selected)
+///     if (selected) {
 ///       textStyle = textStyle.copyWith(color: Colors.lightGreenAccent[400]);
+///     }
 ///     return Padding(
 ///       padding: const EdgeInsets.all(2.0),
 ///       child: SizeTransition(

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6162,8 +6162,9 @@ class RawImage extends LeafRenderObjectWidget {
 /// class TestAssetBundle extends CachingAssetBundle {
 ///   @override
 ///   Future<ByteData> load(String key) async {
-///     if (key == 'resources/test')
+///     if (key == 'resources/test') {
 ///       return ByteData.view(Uint8List.fromList(utf8.encode('Hello World!')).buffer);
+///     }
 ///     return ByteData(0);
 ///   }
 /// }

--- a/packages/flutter/lib/src/widgets/restoration_properties.dart
+++ b/packages/flutter/lib/src/widgets/restoration_properties.dart
@@ -75,8 +75,9 @@ import 'restoration.dart';
 ///
 ///   @override
 ///   void didUpdateValue(Duration? oldValue) {
-///     if (oldValue == null || oldValue.inMicroseconds != value.inMicroseconds)
+///     if (oldValue == null || oldValue.inMicroseconds != value.inMicroseconds) {
 ///       notifyListeners();
+///     }
 ///   }
 ///
 ///   @override


### PR DESCRIPTION
## Description

This switches the sample analysis code to use `package:flutter_lints` instead of the flutter repo analysis options, so that they are compatible with a similar change to DartPad.
