### PR TITLE
Fix wrong reference in deprecated

### DIFF
--- a/packages/flutter_test/lib/src/deprecated.dart
+++ b/packages/flutter_test/lib/src/deprecated.dart
@@ -23,7 +23,7 @@ extension TestBinaryMessengerExtension on BinaryMessenger {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockMessageHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.setMockMessageHandler instead. '
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler instead. '
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )
   void setMockMessageHandler(String channel, MessageHandler? handler) {
@@ -34,7 +34,7 @@ extension TestBinaryMessengerExtension on BinaryMessenger {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.checkMockMessageHandler instead.'
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead.'
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )
   bool checkMockMessageHandler(String channel, Object? handler) {
@@ -55,7 +55,7 @@ extension TestBasicMessageChannelExtension<T> on BasicMessageChannel<T> {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.setMockDecodedMessageHandler instead. '
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler instead. '
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )
   void setMockMessageHandler(Future<T> Function(T? message)? handler) {
@@ -66,7 +66,7 @@ extension TestBasicMessageChannelExtension<T> on BasicMessageChannel<T> {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '
   //   'For the first argument, pass channel.name. '
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )
@@ -88,7 +88,7 @@ extension TestMethodChannelExtension on MethodChannel {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. '
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. '
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )
   void setMockMethodCallHandler(Future<dynamic>? Function(MethodCall call)? handler) {
@@ -99,7 +99,7 @@ extension TestMethodChannelExtension on MethodChannel {
   // HYPERLINK ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // TODO(ianh): deprecate this method: @NotYetDeprecated(
   //   'Use tester.binding.defaultBinaryMessenger.checkMockMessageHandler or '
-  //   'TestDefaultBinaryMessenger.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '
+  //   'TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.checkMockMessageHandler instead. '
   //   'For the first argument, pass channel.name. '
   //   'This feature was deprecated after v2.1.0-10.0.pre.'
   // )


### PR DESCRIPTION
Changed `TestDefaultBinaryMessenger.instance` to `TestDefaultBinaryMessengerBinding.instance`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
