### PR TITLE
[flutter_tools] remove feature for alternative invalidation strategy

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -47,9 +47,6 @@ abstract class FeatureFlags {
   /// Whether fast single widget reloads are enabled.
   bool get isSingleWidgetReloadEnabled => false;
 
-  /// Whether the CFE experimental invalidation strategy is enabled.
-  bool get isExperimentalInvalidationStrategyEnabled => true;
-
   /// Whether the windows UWP embedding is enabled.
   bool get isWindowsUwpEnabled => false;
 
@@ -71,7 +68,6 @@ const List<Feature> allFeatures = <Feature>[
   flutterIOSFeature,
   flutterFuchsiaFeature,
   flutterCustomDevicesFeature,
-  experimentalInvalidationStrategy,
 ];
 
 /// The [Feature] for flutter web.
@@ -267,29 +263,6 @@ const Feature singleWidgetReload = Feature(
   stable: FeatureChannelSetting(
     available: false,
     enabledByDefault: false,
-  ),
-);
-
-/// The CFE experimental invalidation strategy.
-const Feature experimentalInvalidationStrategy = Feature(
-  name: 'Hot reload optimization that reduces incremental artifact size',
-  configSetting: 'experimental-invalidation-strategy',
-  environmentOverride: 'FLUTTER_CFE_EXPERIMENTAL_INVALIDATION',
-  master: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: true,
-  ),
-  dev: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: true,
-  ),
-  beta: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: true,
-  ),
-  stable: FeatureChannelSetting(
-    available: true,
-    enabledByDefault: true,
   ),
 );
 

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -48,9 +48,6 @@ class FlutterFeatureFlags implements FeatureFlags {
   bool get isSingleWidgetReloadEnabled => isEnabled(singleWidgetReload);
 
   @override
-  bool get isExperimentalInvalidationStrategyEnabled => isEnabled(experimentalInvalidationStrategy);
-
-  @override
   bool get isWindowsUwpEnabled => isEnabled(windowsUwpEmbedding);
 
   @override

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -151,8 +151,7 @@ class FlutterDevice {
       extraFrontEndOptions = <String>[
         if (featureFlags.isSingleWidgetReloadEnabled)
          '--flutter-widget-cache',
-        if (featureFlags.isExperimentalInvalidationStrategyEnabled)
-          '--enable-experiment=alternative-invalidation-strategy',
+        '--enable-experiment=alternative-invalidation-strategy',
         ...?extraFrontEndOptions,
       ];
       generator = ResidentCompiler(

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2037,7 +2037,7 @@ void main() {
     FeatureFlags: () => TestFeatureFlags(isSingleWidgetReloadEnabled: true)
   });
 
-   testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag when feature is enabled', () async {
+   testUsingContext('FlutterDevice passes alternative-invalidation-strategy flag', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice mockDevice = FakeDevice(targetPlatform: TargetPlatform.android_arm);
 
@@ -2059,7 +2059,6 @@ void main() {
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
-    FeatureFlags: () => TestFeatureFlags(isExperimentalInvalidationStrategyEnabled: true)
   });
 
    testUsingContext('FlutterDevice passes initializeFromDill parameter if specified', () async {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -415,7 +415,6 @@ class TestFeatureFlags implements FeatureFlags {
     this.isIOSEnabled = true,
     this.isFuchsiaEnabled = false,
     this.areCustomDevicesEnabled = false,
-    this.isExperimentalInvalidationStrategyEnabled = false,
     this.isWindowsUwpEnabled = false,
   });
 
@@ -447,9 +446,6 @@ class TestFeatureFlags implements FeatureFlags {
   final bool areCustomDevicesEnabled;
 
   @override
-  final bool isExperimentalInvalidationStrategyEnabled;
-
-  @override
   final bool isWindowsUwpEnabled;
 
   @override
@@ -473,8 +469,6 @@ class TestFeatureFlags implements FeatureFlags {
         return isFuchsiaEnabled;
       case flutterCustomDevicesFeature:
         return areCustomDevicesEnabled;
-      case experimentalInvalidationStrategy:
-        return isExperimentalInvalidationStrategyEnabled;
       case windowsUwpEmbedding:
         return isWindowsUwpEnabled;
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84355

This feature is rolled out to stable and resulted in a ~30% average improvement to hot reload times.