### PR TITLE
Fix assemble iOS codesign flag to support --no-sound-null-safety

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -187,7 +187,7 @@ is set to release or run \"flutter build ios --release\", then re-run Archive fr
     -dTrackWidgetCreation="${TRACK_WIDGET_CREATION}"                      \
     -dDartObfuscation="${DART_OBFUSCATION}"                               \
     -dEnableBitcode="${bitcode_flag}"                                     \
-    "${codesign_identity_flag}"                                           \
+    ${codesign_identity_flag}                                             \
     ${bundle_sksl_path}                                                   \
     ${code_size_directory}                                                \
     --ExtraGenSnapshotOptions="${EXTRA_GEN_SNAPSHOT_OPTIONS}"             \

--- a/packages/flutter_tools/test/integration.shard/flutter_build_null_unsafe_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_null_unsafe_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  Directory tempDir;
+  Directory projectRoot;
+  String flutterBin;
+  final List<String> targetPlatforms = <String>[
+    'apk',
+    'web',
+    if (platform.isWindows) 'windows',
+    if (platform.isMacOS) ...<String>['macos', 'ios'],
+  ];
+
+  setUpAll(() {
+    tempDir = createResolvedTempDirectorySync('build_null_unsafe_test.');
+    flutterBin = fileSystem.path.join(
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
+    processManager.runSync(<String>[
+      flutterBin,
+      'config',
+      '--enable-macos-desktop',
+      '--enable-windows-desktop',
+      '--enable-web',
+    ]);
+
+    processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      'hello',
+    ], workingDirectory: tempDir.path);
+
+    projectRoot = tempDir.childDirectory('hello');
+    writeFile(fileSystem.path.join(projectRoot.path, 'pubspec.yaml'), '''
+name: hello
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+''');
+    writeFile(fileSystem.path.join(projectRoot.path, 'lib', 'main.dart'), '''
+import 'unsafe.dart';
+void main() {
+  print(unsafeString);
+}
+''');
+    writeFile(fileSystem.path.join(projectRoot.path, 'lib', 'unsafe.dart'), '''
+// @dart=2.9
+String unsafeString = null;
+''');
+  });
+
+  tearDownAll(() {
+    tryToDelete(tempDir);
+  });
+
+  for (final String targetPlatform in targetPlatforms) {
+    testWithoutContext('flutter build $targetPlatform --no-sound-null-safety', () {
+      print(tempDir);
+      final ProcessResult result = processManager.runSync(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'build',
+        targetPlatform,
+        '--no-pub',
+        '--no-sound-null-safety',
+        if (targetPlatform == 'ios') '--no-codesign',
+      ], workingDirectory: projectRoot.path);
+      expect(result.exitCode, 0);
+    }, timeout: const Timeout(Duration(minutes: 3)));
+  }
+}


### PR DESCRIPTION
`codesign_identity_flag` in xcode_backend needs to handle an empty string, so shouldn't be avoid word splitting with quotes.  This matches `bundle_sksl_path` and `code_size_directory` flags right after it.

Added a `--no-sound-null-safety` integration test that fails for iOS on master, but passes on this PR.

Fixes https://github.com/flutter/flutter/issues/77912