### PR TITLE
ReorderableListView should treat fuchsia as a mobile platform.

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -421,7 +421,6 @@ class _ReorderableListViewState extends State<ReorderableListView> {
 
     if (widget.buildDefaultDragHandles) {
       switch (Theme.of(context).platform) {
-        case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
         case TargetPlatform.macOS:
@@ -470,6 +469,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
 
         case TargetPlatform.iOS:
         case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
           return ReorderableDelayedDragStartListener(
             key: itemGlobalKey,
             index: index,

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -1366,6 +1366,20 @@ void main() {
     });
     // TODO(djshuckerow): figure out how to write a test for scrolling the list.
 
+    testWidgets('ReorderableListView on desktop platforms should have drag handles', (WidgetTester tester) async {
+      await tester.pumpWidget(build());
+      // All four items should have drag handles and not delayed listeners.
+      expect(find.byIcon(Icons.drag_handle), findsNWidgets(4));
+      expect(find.byType(ReorderableDelayedDragStartListener), findsNothing);
+    }, variant: TargetPlatformVariant.desktop());
+
+    testWidgets('ReorderableListView on mobile platforms should not have drag handles', (WidgetTester tester) async {
+      await tester.pumpWidget(build());
+      // All four items should have delayed listeners and not drag handles.
+      expect(find.byType(ReorderableDelayedDragStartListener), findsNWidgets(4));
+      expect(find.byIcon(Icons.drag_handle), findsNothing);
+    }, variant: TargetPlatformVariant.mobile());
+
     testWidgets('Vertical list renders drag handle in correct position', (WidgetTester tester) async {
       await tester.pumpWidget(build(platform: TargetPlatform.macOS));
       final Finder listView = find.byType(ReorderableListView);


### PR DESCRIPTION
Currently the `ReorderableListView` treats `TargetPlatform.fuchsia` as a desktop platform and gives it drag handles by default. As the rest of Flutter usually treats Fuchsia as a mobile platform (see `TargetPlatformVariant.mobile`), this list view should as well to be consistent.

I also added a couple of lists that verify the presence of drag handles or delayed touch listeners for each platform.

Fixes https://github.com/flutter/flutter/issues/84376

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
