### PR TITLE
CupertinoNavigationBar leading is too high

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1088,15 +1088,19 @@ class _NavigationBarStaticComponents {
 
     return KeyedSubtree(
       key: leadingKey,
-      child: Padding(
-        padding: EdgeInsetsDirectional.only(
-          start: padding?.start ?? _kNavBarEdgePadding,
-        ),
-        child: IconTheme.merge(
-          data: const IconThemeData(
-            size: 32.0,
+      child: Align(
+        widthFactor: 1.0,
+        alignment: Alignment.center,
+        child: Padding(
+          padding: EdgeInsetsDirectional.only(
+            start: padding?.start ?? _kNavBarEdgePadding,
           ),
-          child: leadingContent,
+          child: IconTheme.merge(
+            data: const IconThemeData(
+              size: 32.0,
+            ),
+            child: leadingContent,
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -1359,6 +1359,25 @@ void main() {
     expect(find.text('Page 1'), findsOneWidget);
     expect(find.text('Page 2'), findsNothing);
   });
+
+  testWidgets(
+       'Leading positon of the text in CupertinoNavigationBar should be centered vertically',
+       (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(
+            leading: Text('lead'),
+            middle: Text('Title'),
+            trailing: Text('Trailing')),
+            child: Center(child: Text('Test!')),
+        ),
+      ),
+    );
+
+    // 44 is the standard height of the nav bar.
+    expect(tester.getCenter(find.text('lead')).dy, 22.0);
+  });
 }
 
 class _ExpectStyles extends StatelessWidget {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/18536


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
