### PR TITLE
[flutter_tools] dont try to reassemble isolates without ext.flutter.reassemble

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -25,6 +25,7 @@ const String kRunInViewMethod = '_flutter.runInView';
 const String kListViewsMethod = '_flutter.listViews';
 const String kScreenshotSkpMethod = '_flutter.screenshotSkp';
 const String kScreenshotMethod = '_flutter.screenshot';
+const String kReassembleMethod = 'ext.flutter.reassemble';
 
 /// The error response code from an unrecoverable compilation failure.
 const int kIsolateReloadBarred = 1005;
@@ -647,7 +648,7 @@ class FlutterVmService {
     @required String isolateId,
   }) {
     return invokeFlutterExtensionRpcRaw(
-      'ext.flutter.reassemble',
+      kReassembleMethod,
       isolateId: isolateId,
     );
   }


### PR DESCRIPTION
Might fix https://github.com/flutter/flutter/issues/84347

Background isolates are created as flutter views with a ui isolate attached, so the flutter tool will attempt to hot reload them. We have some reports of the reassemble future hanging instead of finishing with null due to a missing method.

Since we already have the isolate and all registered extensions before we call the reassemble future, we can first check if it was registered and then no-op if it is missing.