### PR TITLE
wip: fix: exploratory fix for stepper builder flicker bug

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,6 +15,18 @@
 version: 1
 transforms:
 
+  # Changes made in https://github.com/flutter/flutter/pull/84467
+  - title: "Migrate to 'detailedControlsBuilder'"
+    date: 2021-07-22
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'Stepper'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'controlsBuilder',
+        newName: 'detailedControlsBuilder'
+
   # Changes made in https://github.com/flutter/flutter/pull/81336
   - title: "Remove 'buttonColor'"
     date: 2021-04-30

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -92,12 +92,16 @@ class ControlsDetails {
 
 /// A builder that creates a widget given a ControlsDetails object.
 ///
-/// Used by [Stepper.indexedControlsBuilder].
+/// Used by [Stepper.detailedControlsBuilder].
 ///
 /// See also:
 ///
 ///  * [WidgetBuilder], which is similar but only takes a [BuildContext].
-typedef IndexedControlsBuilder = Widget Function(BuildContext context, { required ControlsDetails details });
+typedef DetailedControlsBuilder = Widget Function(
+  BuildContext context, {
+    required ControlsDetails details
+  }
+);
 
 const TextStyle _kStepStyle = TextStyle(
   fontSize: 12.0,
@@ -229,11 +233,11 @@ class Stepper extends StatefulWidget {
     this.onStepContinue,
     this.onStepCancel,
     @Deprecated(
-      'Migrate to indexedControlsBuilder. '
+      'Migrate to detailedControlsBuilder. '
       'This feature was deprecated after v2.4.0-1.0.pre.126.',
     )
     this.controlsBuilder,
-    this.indexedControlsBuilder,
+    this.detailedControlsBuilder,
     this.elevation,
   }) : assert(steps != null),
        assert(type != null),
@@ -329,7 +333,7 @@ class Stepper extends StatefulWidget {
   /// ```
   /// {@end-tool}
   @Deprecated(
-    'Use indexedControlsBuilder instead. '
+    'Use detailedControlsBuilder instead. '
     'This feature was deprecated after v2.4.0-1.0.pre.126.',
   )
   final ControlsWidgetBuilder? controlsBuilder;
@@ -350,8 +354,8 @@ class Stepper extends StatefulWidget {
   /// ```dart
   /// Widget build(BuildContext context) {
   ///   return Stepper(
-  ///     indexedControlsBuilder:
-  ///       (BuildContext context, { ControlsDetails details }) {
+  ///     detailedControlsBuilder:
+  ///       (BuildContext context, { required ControlsDetails details }) {
   ///          return Row(
   ///            children: <Widget>[
   ///              TextButton(
@@ -385,7 +389,7 @@ class Stepper extends StatefulWidget {
   /// }
   /// ```
   /// {@end-tool}
-  final IndexedControlsBuilder? indexedControlsBuilder;
+  final DetailedControlsBuilder? detailedControlsBuilder;
 
   /// The elevation of this stepper's [Material] when [type] is [StepperType.horizontal].
   final double? elevation;
@@ -542,8 +546,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   }
 
   Widget _buildVerticalControls(int stepIndex) {
-    if (widget.indexedControlsBuilder != null)
-      return widget.indexedControlsBuilder!(
+    if (widget.detailedControlsBuilder != null)
+      return widget.detailedControlsBuilder!(
         context,
         details: ControlsDetails(
           currentStep: widget.currentStep,
@@ -555,7 +559,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
 
     // TODO(craiglabenz): Remove this after the deprecation period.
     if (widget.controlsBuilder != null)
-      return widget.controlsBuilder!(context, onStepContinue: widget.onStepContinue, onStepCancel: widget.onStepCancel);
+      return widget.controlsBuilder!(
+        context,
+        onStepContinue: widget.onStepContinue,
+        onStepCancel: widget.onStepCancel,
+      );
 
     final Color cancelColor;
     switch (Theme.of(context).brightness) {

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -55,7 +55,7 @@ enum StepperType {
   horizontal,
 }
 
-/// Container for all the information necessary to build a Stepper widget's 
+/// Container for all the information necessary to build a Stepper widget's
 /// foward and backward controls for any given step.
 @immutable
 class ControlsDetails {
@@ -70,7 +70,7 @@ class ControlsDetails {
   /// different from [stepIndex] if the user has just changed steps and we are
   /// currently animating toward that step.
   final int currentStep;
-  
+
   /// Index of the step for which these controls are being built. This is
   /// not necessarily the active index, if the user has just changed steps and
   /// this step is animating away.
@@ -230,7 +230,7 @@ class Stepper extends StatefulWidget {
     this.onStepCancel,
     @Deprecated(
       'Migrate to indexedControlsBuilder. '
-      'This builder was deprecated after v2.4.0-1.0.pre.126.',
+      'This feature was deprecated after v2.4.0-1.0.pre.126.',
     )
     this.controlsBuilder,
     this.indexedControlsBuilder,
@@ -329,8 +329,8 @@ class Stepper extends StatefulWidget {
   /// ```
   /// {@end-tool}
   @Deprecated(
-    'Migrate to indexedControlsBuilder. '
-    'This builder was deprecated after v2.4.0-1.0.pre.126.',
+    'Use indexedControlsBuilder instead. '
+    'This feature was deprecated after v2.4.0-1.0.pre.126.',
   )
   final ControlsWidgetBuilder? controlsBuilder;
 

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -435,9 +435,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     }
   }
 
-  Widget _buildVerticalControls() {
+  Widget _buildVerticalControls(int stepIndex) {
     if (widget.controlsBuilder != null)
-      return widget.controlsBuilder!(context, onStepContinue: widget.onStepContinue, onStepCancel: widget.onStepCancel);
+      return widget.controlsBuilder!(context, stepIndex: stepIndex, onStepContinue: widget.onStepContinue, onStepCancel: widget.onStepCancel);
 
     final Color cancelColor;
     switch (Theme.of(context).brightness) {
@@ -619,7 +619,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             child: Column(
               children: <Widget>[
                 widget.steps[index].content,
-                _buildVerticalControls(),
+                _buildVerticalControls(index),
               ],
             ),
           ),
@@ -719,7 +719,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
                 duration: kThemeAnimationDuration,
                 child: widget.steps[widget.currentStep].content,
               ),
-              _buildVerticalControls(),
+              _buildVerticalControls(widget.currentStep),
             ],
           ),
         ),

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4612,7 +4612,7 @@ typedef TransitionBuilder = Widget Function(BuildContext context, Widget? child)
 /// See also:
 ///
 ///  * [WidgetBuilder], which is similar but only takes a [BuildContext].
-typedef ControlsWidgetBuilder = Widget Function(BuildContext context, { VoidCallback? onStepContinue, VoidCallback? onStepCancel });
+typedef ControlsWidgetBuilder = Widget Function(BuildContext context, { required int stepIndex, VoidCallback? onStepContinue, VoidCallback? onStepCancel, });
 
 /// An [Element] that composes other [Element]s.
 ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4612,7 +4612,8 @@ typedef TransitionBuilder = Widget Function(BuildContext context, Widget? child)
 /// See also:
 ///
 ///  * [WidgetBuilder], which is similar but only takes a [BuildContext].
-typedef ControlsWidgetBuilder = Widget Function(BuildContext context, { required int stepIndex, VoidCallback? onStepContinue, VoidCallback? onStepCancel, });
+
+typedef ControlsWidgetBuilder = Widget Function(BuildContext context, { VoidCallback? onStepContinue, VoidCallback? onStepCancel, });
 
 /// An [Element] that composes other [Element]s.
 ///

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -380,7 +380,7 @@ void main() {
       canceledPressed = true;
     }
 
-    Widget builder(BuildContext context, { required int stepIndex, VoidCallback? onStepContinue, VoidCallback? onStepCancel }) {
+    Widget builder(BuildContext context, { VoidCallback? onStepContinue, VoidCallback? onStepCancel }) {
       return Container(
         margin: const EdgeInsets.only(top: 16.0),
         child: ConstrainedBox(
@@ -446,6 +446,100 @@ void main() {
 
     expect(canceledPressed, isTrue);
     expect(continuePressed, isTrue);
+  });
+
+  testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async {
+    
+    int currentStep = 0;
+    void setContinue() {
+      currentStep += 1;
+    }
+
+    void setCanceled() {
+      currentStep -= 1;
+    }
+
+    Widget builder(BuildContext context, { required ControlsDetails details }) {
+      // For the purposes of testing, only render something for the active
+      // step.
+      if (!details.isActive)
+        return Container();
+      
+      return Container(
+        margin: const EdgeInsets.only(top: 16.0),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints.tightFor(height: 48.0),
+          child: Row(
+            children: <Widget>[
+              TextButton(
+                onPressed: details.onStepContinue,
+                child: Text('Continue to ${details.stepIndex + 1}'),
+              ),
+              Container(
+                margin: const EdgeInsetsDirectional.only(start: 8.0),
+                child: TextButton(
+                  onPressed: details.onStepCancel,
+                  child: Text('Return to ${details.stepIndex - 1}'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: Material(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return Stepper(
+                  currentStep: currentStep,
+                  indexedControlsBuilder: builder,
+                  onStepCancel: () => setState(setCanceled),
+                  onStepContinue: () => setState(setContinue),
+                  steps: const <Step>[
+                    Step(
+                      title: Text('A'),
+                      state: StepState.complete,
+                      content: SizedBox(
+                        width: 100.0,
+                        height: 100.0,
+                      ),
+                    ),
+                    Step(
+                      title: Text('C'),
+                      content: SizedBox(
+                        width: 100.0,
+                        height: 100.0,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Never mind that there is no Step -1 or Step 2 -- actual build method
+    // implementations would make those checks.
+    expect(find.text('Return to -1'), findsNWidgets(1));
+    expect(find.text('Continue to 1'), findsNWidgets(1));
+    expect(find.text('Return to 0'), findsNWidgets(0));
+    expect(find.text('Continue to 2'), findsNWidgets(0));
+
+    await tester.tap(find.text('Continue to 1').first);
+    await tester.pumpAndSettle();
+
+    // Never mind that there is no Step -1 or Step 2 -- actual build method
+    // implementations would make those checks.
+    expect(find.text('Return to -1'), findsNWidgets(0));
+    expect(find.text('Continue to 1'), findsNWidgets(0));
+    expect(find.text('Return to 0'), findsNWidgets(1));
+    expect(find.text('Continue to 2'), findsNWidgets(1));
   });
 
   testWidgets('Stepper error test', (WidgetTester tester) async {

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -449,7 +449,7 @@ void main() {
   });
 
   testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async {
-    
+
     int currentStep = 0;
     void setContinue() {
       currentStep += 1;
@@ -464,7 +464,7 @@ void main() {
       // step.
       if (!details.isActive)
         return Container();
-      
+
       return Container(
         margin: const EdgeInsets.only(top: 16.0),
         child: ConstrainedBox(

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -380,7 +380,7 @@ void main() {
       canceledPressed = true;
     }
 
-    Widget builder(BuildContext context, { VoidCallback? onStepContinue, VoidCallback? onStepCancel }) {
+    Widget builder(BuildContext context, { required int stepIndex, VoidCallback? onStepContinue, VoidCallback? onStepCancel }) {
       return Container(
         margin: const EdgeInsets.only(top: 16.0),
         child: ConstrainedBox(


### PR DESCRIPTION
### Behavior

Previously, use of the `Stepper.controlsBuilder` method has the potential to create a brief flicker as the controls in the vanishing step quickly rebuild with the new `activeIndex`. An example widget using the Stepper might look like so:

```dart

/// This is updated by setState() shenanigans.
int _activeIndex = 0;

Widget build(BuildContext context) {
  return Stepper(
    controlsBuilder: (BuildContext context, {VoidCallback? onStepContinue, VoidCallback? onStepCancel}) {
      return Row(
        children: <Widget>[
          TextButton(
            onPressed: onStepContinue,
            child: Text('NEXT ${_activeIndex}'),
          ),
          TextButton(
            onPressed: onStepCancel,
            child: Text('CANCEL ${stepIndex - 1}'),
          ),
        ],
      );
    },
    steps: [...],
  );
}
```


This behavior is represented by this slowed-down gif:

<img src="https://user-images.githubusercontent.com/855034/121750329-079a8c80-cac1-11eb-8506-5cd4b6c6a5ca.gif" height="400"/>

---

With this fix, an alternate builder (currently named `detailedControlsBuilder`) is available, and controls built with it can make use of the new `ControlsDetails` parameter to know who _they_ are, not which step is replacing them. An example widget using the Stepper could be refactored like so:

```dart

/// This is updated by setState() shenanigans.
int _activeIndex = 0;

Widget build(BuildContext context) {
  return Stepper(
    // A new `ControlsDetails` parameter appears!
    controlsBuilder: (BuildContext context, {required ControlsDetails details }) {
      return Row(
        children: <Widget>[
          TextButton(
            onPressed: details.onStepContinue,
            // Use `stepIndex` instead of `_activeIndex`
            child: Text('NEXT ${details.stepIndex}'),
          ),
          TextButton(
            onPressed: details.onStepCancel,
            // Use `stepIndex` instead of `_activeIndex`
            child: Text('CANCEL ${details.stepIndex - 1}'),
          ),
        ],
      );
    },
    steps: [...],
  );
}
```

Rewriting such methods in this way fixes this flicker, as captured in this slowed-down gif:

<img src="https://user-images.githubusercontent.com/855034/121750623-96a7a480-cac1-11eb-853e-664ebf530fb4.gif" height="400"/>


### Risks

This deprecates an existing builder method, which will introduce some churn for developers. However, nothing is breaking, at least :)


Fixes #78119