### PR TITLE
Fix watchOS build when  companion app is configured with xcode variable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@ Seongyun Kim <helloworld@cau.ac.kr>
 Ludwik Trammer <ludwik@gmail.com>
 Marian Triebe <m.triebe@live.de>
 Alexis Rouillard <contact@arouillard.fr>
+Mirko Mucaria <skogsfrae@gmail.com>

--- a/dev/integration_tests/ios_app_with_extensions/ios/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/ios_app_with_extensions/ios/Runner.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_BUNDLE_IDENTIFIER = io.flutter.extensionTest;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -828,6 +829,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_BUNDLE_IDENTIFIER = io.flutter.extensionTest;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -883,6 +885,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_BUNDLE_IDENTIFIER = io.flutter.extensionTest;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/dev/integration_tests/ios_app_with_extensions/ios/watch Extension/Info.plist
+++ b/dev/integration_tests/ios_app_with_extensions/ios/watch Extension/Info.plist
@@ -25,7 +25,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>io.flutter.extensionTest.watchkitapp</string>
+			<string>$(APP_BUNDLE_IDENTIFIER).watchkitapp</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/dev/integration_tests/ios_app_with_extensions/ios/watch/Info.plist
+++ b/dev/integration_tests/ios_app_with_extensions/ios/watch/Info.plist
@@ -26,7 +26,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>io.flutter.extensionTest</string>
+	<string>$(APP_BUNDLE_IDENTIFIER)</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -694,18 +694,18 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
         if (bundleIdentifier == fromPlist) {
           return true;
         }
-        
+
         // The key WKCompanionAppBundleIdentifier might contain an xcode variable
         // that needs to be substituted before comparing it with bundle id
         if (fromPlist != null && fromPlist.contains(r'$')) {
           final Map<String, String>? allBuildSettings = await buildSettingsForBuildInfo(buildInfo);
           if (allBuildSettings != null) {
-            final String substituedVariable = substituteXcodeVariables(fromPlist, allBuildSettings); 
+            final String substituedVariable = substituteXcodeVariables(fromPlist, allBuildSettings);
             if (substituedVariable == bundleIdentifier) {
               return true;
             }
           }
-        } 
+        }
       }
     }
     return false;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -689,8 +689,23 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
       final File infoFile = hostAppRoot.childDirectory(target).childFile('Info.plist');
       // The Info.plist file of a target contains the key WKCompanionAppBundleIdentifier,
       // if it is a watchOS companion app.
-      if (infoFile.existsSync() && globals.plistParser.getValueFromFile(infoFile.path, 'WKCompanionAppBundleIdentifier') == bundleIdentifier) {
-        return true;
+      if (infoFile.existsSync()) {
+        final String? fromPlist = globals.plistParser.getValueFromFile(infoFile.path, 'WKCompanionAppBundleIdentifier');
+        if (bundleIdentifier == fromPlist) {
+          return true;
+        }
+        
+        // The key WKCompanionAppBundleIdentifier might contain an xcode variable
+        // that needs to be substituted before comparing it with bundle id
+        if (fromPlist != null && fromPlist.contains(r'$')) {
+          final Map<String, String>? allBuildSettings = await buildSettingsForBuildInfo(buildInfo);
+          if (allBuildSettings != null) {
+            final String substituedVariable = substituteXcodeVariables(fromPlist, allBuildSettings); 
+            if (substituedVariable == bundleIdentifier) {
+              return true;
+            }
+          }
+        } 
       }
     }
     return false;

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -697,6 +697,24 @@ apply plugin: 'kotlin-android'
         XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
         FlutterProjectFactory: () => flutterProjectFactory,
       });
+
+      testUsingContext('has watch companion with build settings', () async {
+        final FlutterProject project = await someProject();
+        project.ios.xcodeProject.createSync();
+        mockXcodeProjectInterpreter.buildSettings = <String, String>{
+          'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
+        };
+        project.ios.hostAppRoot.childDirectory('WatchTarget').childFile('Info.plist').createSync(recursive: true);
+        testPlistParser.setProperty('WKCompanionAppBundleIdentifier', r'$(PRODUCT_BUNDLE_IDENTIFIER)');
+
+        expect(await project.ios.containsWatchCompanion(<String>['WatchTarget'], null), isTrue);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        PlistParser: () => testPlistParser,
+        XcodeProjectInterpreter: () => mockXcodeProjectInterpreter,
+        FlutterProjectFactory: () => flutterProjectFactory,
+      });
     });
   });
 }


### PR DESCRIPTION
This PR fixes an issue in flutter tools that caused the watchOS build to fail when the `WKCompanionAppBundleIdentifier` parameter in `Info.plist` is configured with an xcode variable.

Fixes #77244  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
