### PR TITLE
[devicelab] Check for Android device battery level

### DIFF
--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -50,6 +50,18 @@ void main() {
       });
     });
 
+    group('batteryLevel', () {
+      test('has enough battery', () async {
+        FakeDevice.pretendHasEnoughBattery();
+        expect(await device.hasLowBatteryLevel(), isFalse);
+      });
+
+      test('has not enough battery', () async {
+        FakeDevice.pretendHasNotEnoughBattery();
+        expect(await device.hasLowBatteryLevel(), isTrue);
+      });
+    });
+
     group('togglePower', () {
       test('sends power event', () async {
         await device.togglePower();
@@ -197,6 +209,18 @@ class FakeDevice extends AndroidDevice {
   static void pretendAsleep() {
     output = '''
       mWakefulness=Asleep
+    ''';
+  }
+
+  static void pretendHasNotEnoughBattery() {
+    output = '''
+      level: 15
+    ''';
+  }
+
+  static void pretendHasEnoughBattery() {
+    output = '''
+      level: 20
     ''';
   }
 


### PR DESCRIPTION
This PR adds checks for battery level as mentioned in the TODOs of @yjbanov.
It will filter out and warn about Android devices with low battery level (smaller than or equal to 15%).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
