### PR TITLE
feature: add pod-install flag

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -42,6 +42,7 @@ class BuildInfo {
     this.androidGradleDaemon = true,
     this.packageConfig = PackageConfig.empty,
     this.initializeFromDill,
+    this.shouldPodInstall = true,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
        fileSystemRoots = fileSystemRoots ?? const <String>[],
@@ -158,6 +159,10 @@ class BuildInfo {
   ///
   /// If this is null, it will be initialized from the default cached location.
   final String? initializeFromDill;
+
+  /// Whether `pod install` should be executed when related changes detected.
+  final bool shouldPodInstall;
+
 
   static const BuildInfo debug = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
   static const BuildInfo profile = BuildInfo(BuildMode.profile, null, treeShakeIcons: kIconTreeShakerEnabledDefault);

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -200,6 +200,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     usesAnalyzeSizeFlag();
+    addXcodeSpecificBuildOptions();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -50,6 +50,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     addEnableExperimentation(hide: !verboseHelp);
+    addXcodeSpecificBuildOptions();
 
     argParser
       ..addFlag('debug',
@@ -201,7 +202,9 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
           buildInfo, modeDirectory, iPhoneBuildOutput, simulatorBuildOutput);
 
       // Build and copy plugins.
-      await processPodsIfNeeded(_project.ios, getIosBuildDirectory(), buildInfo.mode);
+      if (buildInfo.shouldPodInstall) {
+        await processPodsIfNeeded(_project.ios, getIosBuildDirectory(), buildInfo.mode);
+      }
       if (hasPlugins(_project)) {
         await _producePlugins(buildInfo.mode, xcodeBuildConfiguration, iPhoneBuildOutput, simulatorBuildOutput, modeDirectory, outputDirectory);
       }

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -23,6 +23,7 @@ class BuildMacosCommand extends BuildSubCommand {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
     usesBuildNumberOption();
     usesBuildNameOption();
+    addXcodeSpecificBuildOptions();
   }
 
   @override

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -153,6 +153,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     addDdsOptions(verboseHelp: verboseHelp);
     addDevToolsOptions(verboseHelp: verboseHelp);
     addAndroidSpecificBuildOptions(hide: !verboseHelp);
+    addXcodeSpecificBuildOptions();
   }
 
   bool get traceStartup => boolArg('trace-startup');

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -198,7 +198,9 @@ Future<XcodeBuildResult> buildXcodeProject({
     targetOverride: targetOverride,
     buildInfo: buildInfo,
   );
-  await processPodsIfNeeded(project.ios, getIosBuildDirectory(), buildInfo.mode);
+  if (buildInfo.shouldPodInstall) {
+    await processPodsIfNeeded(project.ios, getIosBuildDirectory(), buildInfo.mode);
+  }
   if (configOnly) {
     return XcodeBuildResult(success: true);
   }

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -63,7 +63,9 @@ Future<void> buildMacOS({
     targetOverride: targetOverride,
     useMacOSConfig: true,
   );
-  await processPodsIfNeeded(flutterProject.macos, getMacOSBuildDirectory(), buildInfo.mode);
+  if (buildInfo.shouldPodInstall) {
+    await processPodsIfNeeded(flutterProject.macos, getMacOSBuildDirectory(), buildInfo.mode);
+  }
   // If the xcfilelists do not exist, create empty version.
   if (!flutterProject.macos.inputFileList.existsSync()) {
     flutterProject.macos.inputFileList.createSync(recursive: true);

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -120,6 +120,7 @@ class FlutterOptions {
   static const String kDeferredComponents = 'deferred-components';
   static const String kAndroidProjectArgs = 'android-project-arg';
   static const String kInitializeFromDill = 'initialize-from-dill';
+  static const String kPodInstall = 'pod-install';
 }
 
 abstract class FlutterCommand extends Command<void> {
@@ -795,6 +796,13 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  void addXcodeSpecificBuildOptions({ bool hide = false }) {
+    argParser.addFlag(FlutterOptions.kPodInstall,
+      defaultsTo: true,
+      help: 'Install pods if changes are detected.',
+    );
+  }
+
   void addNativeNullAssertions({ bool hide = false }) {
     argParser.addFlag('native-null-assertions',
       defaultsTo: true,
@@ -1008,6 +1016,9 @@ abstract class FlutterCommand extends Command<void> {
       ? stringsArg(FlutterOptions.kAndroidProjectArgs)
       : <String>[];
 
+    final bool shouldPodInstall = !argParser.options.containsKey(FlutterOptions.kPodInstall)
+      || boolArg(FlutterOptions.kPodInstall);
+
     if (dartObfuscation && (splitDebugInfoPath == null || splitDebugInfoPath.isEmpty)) {
       throwToolExit(
         '"--${FlutterOptions.kDartObfuscationOption}" can only be used in '
@@ -1079,6 +1090,7 @@ abstract class FlutterCommand extends Command<void> {
       initializeFromDill: argParser.options.containsKey(FlutterOptions.kInitializeFromDill)
           ? stringArg(FlutterOptions.kInitializeFromDill)
           : null,
+      shouldPodInstall: shouldPodInstall,
     );
   }
 


### PR DESCRIPTION
Added `--[no]-pod-install` flag so that you can force the` pod install` step to be skipped.

closes: #53781
also partially solves #40135 since it would be possible to explicitly run `bundle exec pod install` and disable `pod install` call from `flutter_tools`

This is only the first step, but it already gives ability to:
- manage pods installation as you want
- share Pods directory as-is with very thin wrapper:
  `./tools/manage_deps.sh`
  ```bash
  PODS_PATH="$(pwd)/ios/Pods"

  FLUTTER_SDK_PATH="$(
    cd "$(dirname "$(command -v flutter)")/.." >/dev/null 2>&1
    pwd -P
  )"
  # fix path to engine artifacts
  sed -i '' -E 's|(.*)/Users(.*)bin/cache/artifacts/engine(.*)|\1'"$FLUTTER_SDK_PATH"'/bin/cache/artifacts/engine\3|g' "$PODS_PATH/Pods.xcodeproj/project.pbxproj"
  # fix path to plugins in .pub-cache
  sed -i '' -E 's|(.*)path = "(.*)/.pub-cache(.*)|\1path = "'"$HOME"'/.pub-cache\3|g' "$PODS_PATH/Pods.xcodeproj/project.pbxproj"

  ruby ./ios/manage_deps_helper.rb
  ```

  `./ios/manage_deps_helper.rb` - to generate `ios/.symlinks` and other files generated during `pod install` with default `Podfile`
  ```ruby
  # ignore pod commands
  def pod(*rest)
  end
  
  
  # everything else is copy-pasted from ios/Podfile
  def flutter_root
    generated_xcode_build_settings_path = File.expand_path(File.join('ios', 'Flutter', 'Generated.xcconfig'), __FILE__)
    unless File.exist?(generated_xcode_build_settings_path)
      raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
    end
  
    File.foreach(generated_xcode_build_settings_path) do |line|
      matches = line.match(/FLUTTER_ROOT\=(.*)/)
      return matches[1].strip if matches
    end
    raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
  end
  
  require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
  
  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
  ```


## tests TBD

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
