### PR TITLE
Fix scrollbar error message and test

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1048,8 +1048,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     final ScrollController? scrollController = widget.controller ?? PrimaryScrollController.of(context);
     final bool tryPrimary = widget.controller == null;
     final String controllerForError = tryPrimary
-      ? 'provided ScrollController'
-      : 'PrimaryScrollController';
+      ? 'PrimaryScrollController'
+      : 'provided ScrollController';
 
     String when = '';
     if (showScrollbar) {


### PR DESCRIPTION
This PR fixes some if/else logic in the creation of the Scrollbar error messages and improves an existing test that wasn't testing properly that code. More information in the linked issue.

Fixes: https://github.com/flutter/flutter/issues/84569

@Piinks That if/else and original test got introduced in this PR https://github.com/flutter/flutter/pull/77107 

On the same note, while testing the merged code in https://github.com/flutter/flutter/pull/81278 I think we could make an even better error message if it actually told which Scrollbar is throwing the error. RIght now the error shows as follows, but it's impossible to tell which scrollbar is incorrect. This could catch off guard people with a big codebase when this gets into stable.
![image](https://user-images.githubusercontent.com/22084723/121910786-6ebd7880-cd2f-11eb-8705-966c1d8cb0df.png)

I've asked in the hackers Discord what would be the best way to tackle this. 
https://discord.com/channels/608014603317936148/608021234516754444/853999114018750484

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
