### PR TITLE
Deflake demo

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
@@ -49,10 +49,6 @@ Future<void> runDemos(List<String> demos, WidgetController controller) async {
     }
     currentDemoCategory = demoCategory;
 
-    final Finder demoItem = find.text(demoName);
-    await controller.scrollUntilVisible(demoItem, 48.0);
-    await controller.pumpAndSettle();
-
     Future<void> pageBack() {
       Finder backButton = find.byTooltip('Back');
       if (backButton.evaluate().isEmpty) {
@@ -62,6 +58,9 @@ Future<void> runDemos(List<String> demos, WidgetController controller) async {
     }
 
     for (int i = 0; i < 2; i += 1) {
+      final Finder demoItem = find.text(demoName);
+      await controller.scrollUntilVisible(demoItem, 48.0);
+      await controller.pumpAndSettle();
       await controller.tap(demoItem); // Launch the demo
 
       if (kUnsynchronizedDemos.contains(demo)) {


### PR DESCRIPTION
This seems to occasionally flake on a second iteration, with an error that indicates that the demo it wants to tap isn't found on the screen.

If we make sure the demo is visible in every iteration it should work just fine.

Intended to fix https://github.com/flutter/flutter/issues/83298