### PR TITLE
Feat(cupertino): [date_picker] Date order parameter

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -190,6 +190,8 @@ enum _PickerColumnType {
 /// The class will display its children as consecutive columns. Its children
 /// order is based on internationalization.
 ///
+/// The default order can be overridden by using the [dateOrder] property.
+///
 /// Example of the picker in date mode:
 ///
 ///  * US-English: `| July | 13 | 2012 |`
@@ -245,6 +247,8 @@ class CupertinoDatePicker extends StatefulWidget {
   /// positive integer factor of 60.
   ///
   /// [use24hFormat] decides whether 24 hour format is used. Defaults to false.
+  ///
+  /// [dateOrder] is the date-picker date order. Defaults to localizations.datePickerDateOrder.
   CupertinoDatePicker({
     Key? key,
     this.mode = CupertinoDatePickerMode.dateAndTime,
@@ -256,6 +260,7 @@ class CupertinoDatePicker extends StatefulWidget {
     this.maximumYear,
     this.minuteInterval = 1,
     this.use24hFormat = false,
+    this.dateOrder,
     this.backgroundColor,
   }) : initialDateTime = initialDateTime ?? DateTime.now(),
        assert(mode != null),
@@ -355,6 +360,9 @@ class CupertinoDatePicker extends StatefulWidget {
   /// Whether to use 24 hour format. Defaults to false.
   final bool use24hFormat;
 
+  /// Date-picker date order. Defaults to localizations.datePickerDateOrder.
+  final DatePickerDateOrder? dateOrder;
+
   /// Callback called when the selected date and/or time changes. If the new
   /// selected [DateTime] is not valid, or is not in the [minimumDate] through
   /// [maximumDate] range, this callback will not be called.
@@ -378,7 +386,7 @@ class CupertinoDatePicker extends StatefulWidget {
       case CupertinoDatePickerMode.dateAndTime:
         return _CupertinoDatePickerDateTimeState();
       case CupertinoDatePickerMode.date:
-        return _CupertinoDatePickerDateState();
+        return _CupertinoDatePickerDateState(dateOrder: dateOrder);
     }
   }
 
@@ -1049,6 +1057,13 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
 }
 
 class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
+
+  _CupertinoDatePickerDateState({
+    required this.dateOrder,
+  });
+
+  final DatePickerDateOrder? dateOrder;
+
   late int textDirectionFactor;
   late CupertinoLocalizations localizations;
 
@@ -1331,7 +1346,10 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
     List<_ColumnBuilder> pickerBuilders = <_ColumnBuilder>[];
     List<double> columnWidths = <double>[];
 
-    switch (localizations.datePickerDateOrder) {
+    final DatePickerDateOrder datePickerDateOrder =
+        dateOrder ?? localizations.datePickerDateOrder;
+
+    switch (datePickerDateOrder) {
       case DatePickerDateOrder.mdy:
         pickerBuilders = <_ColumnBuilder>[_buildMonthPicker, _buildDayPicker, _buildYearPicker];
         columnWidths = <double>[

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -188,9 +188,7 @@ enum _PickerColumnType {
 /// There are several modes of the date picker listed in [CupertinoDatePickerMode].
 ///
 /// The class will display its children as consecutive columns. Its children
-/// order is based on internationalization.
-///
-/// The default order can be overridden by using the [dateOrder] property.
+/// order is based on internationalization, or the [dateOrder] property if specified.
 ///
 /// Example of the picker in date mode:
 ///
@@ -248,7 +246,8 @@ class CupertinoDatePicker extends StatefulWidget {
   ///
   /// [use24hFormat] decides whether 24 hour format is used. Defaults to false.
   ///
-  /// [dateOrder] is the date-picker date order. Defaults to localizations.datePickerDateOrder.
+  /// [dateOrder] determines the order of the columns inside [CupertinoDatePicker] in date mode.
+  /// Defaults to the locale's default date format/order.
   CupertinoDatePicker({
     Key? key,
     this.mode = CupertinoDatePickerMode.dateAndTime,
@@ -360,7 +359,8 @@ class CupertinoDatePicker extends StatefulWidget {
   /// Whether to use 24 hour format. Defaults to false.
   final bool use24hFormat;
 
-  /// Date-picker date order. Defaults to localizations.datePickerDateOrder.
+  /// Determines the order of the columns inside [CupertinoDatePicker] in date mode.
+  /// Defaults to the locale's default date format/order.
   final DatePickerDateOrder? dateOrder;
 
   /// Callback called when the selected date and/or time changes. If the new

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1239,12 +1239,15 @@ void main() {
         ),
       );
 
-      Offset lastOffset = tester.getTopLeft(find.text('2018'));
+      expect(
+        tester.getTopLeft(find.text('2018')).dx,
+        lessThan(tester.getTopLeft(find.text('14')).dx),
+      );
 
-      expect(tester.getTopLeft(find.text('14')).dx > lastOffset.dx, true);
-      lastOffset = tester.getTopLeft(find.text('14'));
-
-      expect(tester.getTopLeft(find.text('January')).dx > lastOffset.dx, true);
+      expect(
+        tester.getTopLeft(find.text('14')).dx,
+        lessThan(tester.getTopLeft(find.text('January')).dx),
+      );
     });
 
     testWidgets('DatePicker displays hours and minutes correctly in RTL', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1221,6 +1221,32 @@ void main() {
       );
     });
 
+    testWidgets('DatePicker displays the date in correct order', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: SizedBox(
+              height: 400.0,
+              width: 400.0,
+              child: CupertinoDatePicker(
+                dateOrder: DatePickerDateOrder.ydm,
+                mode: CupertinoDatePickerMode.date,
+                onDateTimeChanged: (DateTime newDate) {},
+                initialDateTime: DateTime(2018, 1, 14, 10, 30),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      Offset lastOffset = tester.getTopLeft(find.text('2018'));
+
+      expect(tester.getTopLeft(find.text('14')).dx > lastOffset.dx, true);
+      lastOffset = tester.getTopLeft(find.text('14'));
+
+      expect(tester.getTopLeft(find.text('January')).dx > lastOffset.dx, true);
+    });
+
     testWidgets('DatePicker displays hours and minutes correctly in RTL', (WidgetTester tester) async {
       await tester.pumpWidget(
         CupertinoApp(


### PR DESCRIPTION
Closes #84550 

This PR adds a new `dateOrder` parameter to  `CupertinoDatePicker` to define the order of the columns in date mode which overrides the default order value defined by `localizations.datePickerDateOrder`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
