### PR TITLE
Fix integration_test podspecs warnings

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -18,6 +18,46 @@ Future<void> main() async {
 
     final Directory tempDir = Directory.systemTemp.createTempSync('flutter_plugin_test.');
     try {
+      section('Lint integration_test');
+
+      await inDirectory(tempDir, () async {
+        // Relative to this script.
+        final String flutterRoot = path.dirname(path.dirname(path.dirname(path.dirname(path.dirname(path.fromUri(Platform.script))))));
+        print('Flutter root at $flutterRoot');
+        final String integrationTestPackage = path.join(flutterRoot, 'packages', 'integration_test');
+        final String iosintegrationTestPodspec = path.join(integrationTestPackage, 'ios', 'integration_test.podspec');
+
+        await exec(
+          'pod',
+          <String>[
+            'lib',
+            'lint',
+            iosintegrationTestPodspec,
+            '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
+            '--use-libraries',
+            '--verbose',
+          ],
+          environment: <String, String>{
+            'LANG': 'en_US.UTF-8',
+          },
+        );
+
+        final String macosintegrationTestPodspec = path.join(integrationTestPackage, 'integration_test_macos', 'macos', 'integration_test_macos.podspec');
+        await exec(
+          'pod',
+          <String>[
+            'lib',
+            'lint',
+            macosintegrationTestPodspec,
+            '--configuration=Debug', // Release targets unsupported arm64 Apple Silicon. Use Debug to only build against targeted x86_64 macOS.
+            '--verbose',
+          ],
+          environment: <String, String>{
+            'LANG': 'en_US.UTF-8',
+          },
+        );
+      });
+
       section('Create Objective-C plugin');
 
       const String objcPluginName = 'test_plugin_objc';

--- a/packages/integration_test/integration_test_macos/macos/integration_test_macos.podspec
+++ b/packages/integration_test/integration_test_macos/macos/integration_test_macos.podspec
@@ -8,13 +8,17 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Runs tests that use the flutter_test API as integration tests on macOS.
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/integration_test/integration_test_macos'
-  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.homepage         = 'https://github.com/flutter/flutter/tree/master/packages/integration_test/integration_test_macos'
+  s.license          = { :type => 'BSD', :text => <<-LICENSE
+Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+LICENSE
+   }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/integration_test' }
+  s.source           = { :http => 'https://github.com/flutter/flutter/tree/master/packages/integration_test/integration_test_macos' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'
+  s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/packages/integration_test/ios/integration_test.podspec
+++ b/packages/integration_test/ios/integration_test.podspec
@@ -8,10 +8,13 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Runs tests that use the flutter_test API as integration tests.
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/integration_test'
-  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.homepage         = 'https://github.com/flutter/flutter/tree/master/packages/integration_test'
+  s.license          = { :type => 'BSD', :text => <<-LICENSE
+Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+LICENSE
+   }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/integration_test' }
+  s.source           = { :http => 'https://github.com/flutter/flutter/tree/master/packages/integration_test' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
Fix warnings that license files didn't exist.  Update URLs to flutter/flutter instead of plugins repo.

Add test to avoid future regressions: https://ci.chromium.org/p/flutter/builders/try/Mac%20plugin_lint_mac/5370?

Fixes https://github.com/flutter/flutter/issues/72989