### PR TITLE
[WIP] Refactor redundant interactive logic in CupertinoSwitch

### DIFF
--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -149,8 +149,6 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   late AnimationController _reactionController;
   late Animation<double> _reaction;
 
-  bool get isInteractive => widget.onChanged != null;
-
   // A non-null boolean value that changes to true at the end of a drag if the
   // switch must be animated to the position indicated by the widget's value.
   bool needsPositionAnimation = false;
@@ -216,52 +214,42 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   }
 
   void _handleTapDown(TapDownDetails details) {
-    if (isInteractive)
-      needsPositionAnimation = false;
-      _reactionController.forward();
+    needsPositionAnimation = false;
+    _reactionController.forward();
   }
 
   void _handleTap() {
-    if (isInteractive) {
-      widget.onChanged!(!widget.value);
-      _emitVibration();
-    }
+    widget.onChanged!(!widget.value);
+    _emitVibration();
   }
 
   void _handleTapUp(TapUpDetails details) {
-    if (isInteractive) {
-      needsPositionAnimation = false;
-      _reactionController.reverse();
-    }
+    needsPositionAnimation = false;
+    _reactionController.reverse();
   }
 
   void _handleTapCancel() {
-    if (isInteractive)
-      _reactionController.reverse();
+    _reactionController.reverse();
   }
 
   void _handleDragStart(DragStartDetails details) {
-    if (isInteractive) {
-      needsPositionAnimation = false;
-      _reactionController.forward();
-      _emitVibration();
-    }
+    needsPositionAnimation = false;
+    _reactionController.forward();
+    _emitVibration();
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
-    if (isInteractive) {
-      position
-        ..curve = Curves.linear
-        ..reverseCurve = Curves.linear;
-      final double delta = details.primaryDelta! / _kTrackInnerLength;
-      switch (Directionality.of(context)) {
-        case TextDirection.rtl:
-          _positionController.value -= delta;
-          break;
-        case TextDirection.ltr:
-          _positionController.value += delta;
-          break;
-      }
+    position
+      ..curve = Curves.linear
+      ..reverseCurve = Curves.linear;
+    final double delta = details.primaryDelta! / _kTrackInnerLength;
+    switch (Directionality.of(context)) {
+      case TextDirection.rtl:
+        _positionController.value -= delta;
+        break;
+      case TextDirection.ltr:
+        _positionController.value += delta;
+        break;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84390

Originally found in https://github.com/flutter/flutter/pull/84374#discussion_r649510333

There appeared to be a bug in `CupertinoSwitch` due to an indentation error. When trying to write a test for the fix, I found that you could never actually reach it since gestures are not enabled if the switch is disabled. So I refactored instead to remove the redundant `isInteractive` logic. All existing test pass.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
