### PR TITLE
Re-add liblzma as an explicit dependancy on Linux

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -235,6 +235,8 @@ class UserMessages {
   String pkgConfigTooOld(String minimumVersion) => 'pkg-config $minimumVersion or later is required.';
   String get gtkLibrariesMissing => 'GTK 3.0 development libraries are required for Linux development.\n'
       'They are likely available from your distribution (e.g.: apt install libgtk-3-dev)';
+  String get lzmaLibraryMissing => 'The lzma development library is required for Linux development.\n'
+       'It is likely available from your distribution (e.g.: apt install liblzma-dev)';
 
   // Messages used in FlutterCommand
   String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -236,7 +236,7 @@ class UserMessages {
   String get gtkLibrariesMissing => 'GTK 3.0 development libraries are required for Linux development.\n'
       'They are likely available from your distribution (e.g.: apt install libgtk-3-dev)';
   String get lzmaLibraryMissing => 'The lzma development library is required for Linux development.\n'
-       'It is likely available from your distribution (e.g.: apt install liblzma-dev)';
+      'It is likely available from your distribution (e.g.: apt install liblzma-dev)';
 
   // Messages used in FlutterCommand
   String flutterElapsedTime(String name, String elapsedTime) => '"flutter $name" took $elapsedTime.';

--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -152,6 +152,10 @@ class LinuxDoctorValidator extends DoctorValidator {
         messages.add(ValidationMessage.error(_userMessages.gtkLibrariesMissing));
       }
     }
+    if (!await _libraryIsPresent('liblzma')) {
+      validationType = ValidationType.missing;
+      messages.add(ValidationMessage.error(_userMessages.lzmaLibraryMissing));
+    }
 
     return ValidationResult(validationType, messages);
   }

--- a/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app/linux.tmpl/flutter/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+pkg_check_modules(LZMA REQUIRED IMPORTED_TARGET liblzma)
 
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
 
@@ -65,6 +66,7 @@ target_link_libraries(flutter INTERFACE
   PkgConfig::GTK
   PkgConfig::GLIB
   PkgConfig::GIO
+  PkgConfig::LZMA
 )
 add_dependencies(flutter flutter_assemble)
 

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -98,6 +98,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,
@@ -121,6 +122,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,
@@ -145,6 +147,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,
@@ -169,6 +172,7 @@ void main() {
       _ninjaPresentCommand('0.8.1'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,
@@ -193,6 +197,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.27.0'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,
@@ -217,6 +222,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -241,6 +247,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -265,6 +272,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -289,6 +297,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -313,6 +322,7 @@ void main() {
       _missingBinaryCommand('ninja'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -337,6 +347,7 @@ void main() {
       _ninjaPresentCommand('bogus'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -361,6 +372,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _missingBinaryCommand('pkg-config'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -385,6 +397,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('bogus'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -409,6 +422,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesMissingCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final UserMessages userMessages = UserMessages();
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
@@ -427,6 +441,32 @@ void main() {
     ]);
   });
 
+  testWithoutContext('Missing validation when liblzma is not available', () async {
+    final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      _clangPresentCommand('4.0.1'),
+      _cmakePresentCommand('3.16.3'),
+      _ninjaPresentCommand('1.10.0'),
+      _pkgConfigPresentCommand('0.29'),
+      ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma', exists: false),
+    ]);
+    final UserMessages userMessages = UserMessages();
+    final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
+      processManager: processManager,
+      userMessages: userMessages,
+    );
+    final ValidationResult result = await linuxDoctorValidator.validate();
+
+    expect(result.type, ValidationType.missing);
+    expect(result.messages, <ValidationMessage>[
+      const ValidationMessage('clang version 4.0.1-6+build1'),
+      const ValidationMessage('cmake version 3.16.3'),
+      const ValidationMessage('ninja version 1.10.0'),
+      const ValidationMessage('pkg-config version 0.29'),
+      ValidationMessage.error(userMessages.lzmaLibraryMissing),
+    ]);
+  });
+
   testWithoutContext('Missing validation when multiple dependencies are not available', () async {
     final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       _missingBinaryCommand('clang++'),
@@ -434,6 +474,7 @@ void main() {
       _ninjaPresentCommand('1.10.0'),
       _pkgConfigPresentCommand('0.29'),
       ..._gtkLibrariesPresentCommands(),
+      _libraryCheckCommand('liblzma'),
     ]);
     final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
       processManager: processManager,


### PR DESCRIPTION
(**NOTE:** This was fixed before, but was incorrectly reverted in https://github.com/flutter/flutter/pull/78415)

## Description

If this library is missing, builds fail with:

`//lib64/liblzma.so.5: undefined reference to 'pthread_sigmask@GLIBC_2.32'`

**NOTE:** Some distros have this library installed by default (such as Ubuntu), and some do not (such as Fedora 33+).

## Related Issues

Resolves: https://github.com/canonical/flutter-snap/issues/17

## Tests

I've updated the relative flutter-doctor tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
