### PR TITLE
Use TOOL_COMMAND to find flutter root if available

### DIFF
--- a/dev/snippets/lib/snippets.dart
+++ b/dev/snippets/lib/snippets.dart
@@ -32,7 +32,7 @@ class SnippetGenerator {
       : configuration = configuration ??
             // Flutter's root is four directories up from this script.
             Configuration(flutterRoot: Directory(Platform.environment['FLUTTER_ROOT']
-                ?? path.canonicalize(path.join(path.dirname(path.fromUri(Platform.script)), '..', '..', '..')))) {
+                ?? path.canonicalize(path.join(path.dirname(path.fromUri(Platform.environment['TOOL_COMMAND'] ?? Platform.script)), '..', '..', '..')))) {
     this.configuration.createOutputDirectory();
   }
 


### PR DESCRIPTION
If FLUTTER_ROOT is not set and dartdoc runs the snippet tool via snapshot, autodetecting FLUTTER_ROOT will not work properly without this change.