### PR TITLE
Fixed an issue with overflow exceptions with nested lists inside a reorderable list item.

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -12,6 +12,7 @@ import 'basic.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'inherited_theme.dart';
+import 'media_query.dart';
 import 'overlay.dart';
 import 'scroll_controller.dart';
 import 'scroll_physics.dart';
@@ -1283,7 +1284,11 @@ class _DragItemProxy extends StatelessWidget {
     final Widget proxyChild = proxyDecorator?.call(child, index, animation.view) ?? child;
     final Offset overlayOrigin = _overlayOrigin(context);
 
-    return AnimatedBuilder(
+    return MediaQuery(
+      // Remove the top padding so that any nested list views in the item
+      // won't pick up the scaffold's padding in the overlay.
+      data: MediaQuery.of(context).removePadding(removeTop: true),
+      child: AnimatedBuilder(
         animation: animation,
         builder: (BuildContext context, Widget? child) {
           Offset effectivePosition = position;
@@ -1302,6 +1307,7 @@ class _DragItemProxy extends StatelessWidget {
           );
         },
         child: proxyChild,
+      ),
     );
   }
 }

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -268,6 +268,114 @@ void main() {
     expect(getItemFadeTransition(), findsNothing);
   });
 
+  testWidgets('ReorderableList supports items with nested list views without throwing layout exception.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return MediaQuery(
+            // Ensure there is always a top padding to simulate a phone with
+            // safe area at the top. If the nested list doesn't have the
+            // padding removed before it is put into the overlay it will
+            // overflow the layout by the top padding.
+            data: MediaQuery.of(context).copyWith(padding: const EdgeInsets.only(top: 50)),
+            child: child!,
+          );
+        },
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Nested Lists')),
+          body: ReorderableList(
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return ReorderableDragStartListener(
+                index: index,
+                key: ValueKey<int>(index),
+                child: Column(
+                  children: <Widget>[
+                    ListView(
+                      shrinkWrap: true,
+                      physics: const ClampingScrollPhysics(),
+                      children: const <Widget>[
+                        Text('Other data'),
+                        Text('Other data'),
+                        Text('Other data'),
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            },
+            onReorder: (int oldIndex, int newIndex) {},
+          ),
+        ),
+      ),
+    );
+
+    // Start gesture on first item
+    final TestGesture drag = await tester.startGesture(tester.getCenter(find.byKey(const ValueKey<int>(0))));
+    await tester.pump(kPressTimeout);
+
+    // Drag enough for move to start
+    await drag.moveBy(const Offset(0, 50));
+    await tester.pumpAndSettle();
+
+    // There shouldn't be a layout overflow exception.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ReorderableList supports items with nested list views without throwing layout exception.', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return MediaQuery(
+            // Ensure there is always a top padding to simulate a phone with
+            // safe area at the top. If the nested list doesn't have the
+            // padding removed before it is put into the overlay it will
+            // overflow the layout by the top padding.
+            data: MediaQuery.of(context).copyWith(padding: const EdgeInsets.only(top: 50)),
+            child: child!,
+          );
+        },
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Nested Lists')),
+          body: ReorderableList(
+            itemCount: 10,
+            itemBuilder: (BuildContext context, int index) {
+              return ReorderableDragStartListener(
+                index: index,
+                key: ValueKey<int>(index),
+                child: Column(
+                  children: <Widget>[
+                    ListView(
+                      shrinkWrap: true,
+                      physics: const ClampingScrollPhysics(),
+                      children: const <Widget>[
+                        Text('Other data'),
+                        Text('Other data'),
+                        Text('Other data'),
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            },
+            onReorder: (int oldIndex, int newIndex) {},
+          ),
+        ),
+      ),
+    );
+
+    // Start gesture on first item
+    final TestGesture drag = await tester.startGesture(tester.getCenter(find.byKey(const ValueKey<int>(0))));
+    await tester.pump(kPressTimeout);
+
+    // Drag enough for move to start
+    await drag.moveBy(const Offset(0, 50));
+    await tester.pumpAndSettle();
+
+    // There shouldn't be a layout overflow exception.
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('SliverReorderableList - properly animates the drop at starting position in a reversed list', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/84625
     final List<int> items = List<int>.generate(8, (int index) => index);

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -323,6 +323,7 @@ void main() {
   });
 
   testWidgets('ReorderableList supports items with nested list views without throwing layout exception.', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/83224.
     await tester.pumpWidget(
       MaterialApp(
         builder: (BuildContext context, Widget? child) {
@@ -364,11 +365,11 @@ void main() {
       ),
     );
 
-    // Start gesture on first item
+    // Start gesture on first item.
     final TestGesture drag = await tester.startGesture(tester.getCenter(find.byKey(const ValueKey<int>(0))));
     await tester.pump(kPressTimeout);
 
-    // Drag enough for move to start
+    // Drag enough for move to start.
     await drag.moveBy(const Offset(0, 50));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
Fixes #83224.

The issue is caused by the nested list picking up the outer scaffold top padding when it is moved to the overlay. The parent `ReorderableList` normally deals with that so that any nested list views won't see the padding. However, when the item is moved to the overlay, it is now a top level list and picks up the padding which causes it to overflow the size of the list item.  This PR fixes this by removing any top padding from the  `MediaQueryData` that wraps the child.

Added a new test to ensure this doesn't break again.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
