### PR TITLE
Reland: Add optional param to useRootNavigator when showSearch

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -35,6 +35,12 @@ import 'theme.dart';
 /// call. Call [SearchDelegate.close] before re-using the same delegate instance
 /// for another [showSearch] call.
 ///
+/// The `useRootNavigator` argument is used to determine whether to push the
+/// search page to the [Navigator] furthest from or nearest to the given
+/// `context`. By default, `useRootNavigator` is `false` and the search page
+/// route created by this method is pushed to the nearest navigator to the
+/// given `context`. It can not be `null`.
+///
 /// The transition to the search page triggered by this method looks best if the
 /// screen triggering the transition contains an [AppBar] at the top and the
 /// transition is called from an [IconButton] that's part of [AppBar.actions].
@@ -54,12 +60,14 @@ Future<T?> showSearch<T>({
   required BuildContext context,
   required SearchDelegate<T> delegate,
   String? query = '',
+  bool useRootNavigator = false,
 }) {
   assert(delegate != null);
   assert(context != null);
+  assert(useRootNavigator != null);
   delegate.query = query ?? delegate.query;
   delegate._currentBody = _SearchBody.suggestions;
-  return Navigator.of(context).push(_SearchPageRoute<T>(
+  return Navigator.of(context, rootNavigator: useRootNavigator).push(_SearchPageRoute<T>(
     delegate: delegate,
   ));
 }

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -841,6 +841,66 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
     expect(selectedResults, <String>['Result']);
   });
+
+  testWidgets('showSearch with useRootNavigator', (WidgetTester tester) async {
+    final _MyNavigatorObserver rootObserver = _MyNavigatorObserver();
+    final _MyNavigatorObserver localObserver = _MyNavigatorObserver();
+
+    final _TestEmptySearchDelegate delegate = _TestEmptySearchDelegate(
+      result: 'Result',
+      suggestions: 'Suggestions',
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      navigatorObservers: <NavigatorObserver>[rootObserver],
+      home: Navigator(
+        observers: <NavigatorObserver>[localObserver],
+        onGenerateRoute: (RouteSettings settings) {
+          if (settings.name == 'nested') {
+            return MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) => Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  TextButton(
+                      onPressed: () async {
+                        await showSearch(context: context, delegate: delegate, useRootNavigator: true);
+                      },
+                      child: const Text('showSearchRootNavigator')),
+                  TextButton(
+                      onPressed: () async {
+                        await showSearch(context: context, delegate: delegate);
+                      },
+                      child: const Text('showSearchLocalNavigator')),
+                ],
+              ),
+              settings: settings,
+            );
+          }
+          throw UnimplementedError();
+        },
+        initialRoute: 'nested',
+      ),
+    ));
+
+    expect(rootObserver.pushCount, 0);
+    expect(localObserver.pushCount, 0);
+
+    // showSearch normal and back
+    await tester.tap(find.text('showSearchLocalNavigator'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    expect(rootObserver.pushCount, 0);
+    expect(localObserver.pushCount, 1);
+
+    // showSearch with rootNavigator
+    await tester.tap(find.text('showSearchRootNavigator'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    expect(rootObserver.pushCount, 1);
+    expect(localObserver.pushCount, 1);
+  });
 }
 
 class TestHomePage extends StatelessWidget {
@@ -1024,5 +1084,18 @@ class _TestEmptySearchDelegate extends SearchDelegate<String> {
         },
       ),
     );
+  }
+}
+
+class _MyNavigatorObserver extends NavigatorObserver {
+  int pushCount = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    // don't count the root route
+    if (<String>['nested', '/'].contains(route.settings.name)) {
+      return;
+    }
+    pushCount++;
   }
 }


### PR DESCRIPTION
I added the optional parameter `useRootNavigator` to choose which navigator it push to.

*issue* [61288](https://github.com/flutter/flutter/issues/61288)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
