### PR TITLE
Add GC events to transitions perf test for gallery

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -196,6 +196,7 @@ void main([List<String> args = const <String>[]]) {
         streams: const <TimelineStream>[
           TimelineStream.dart,
           TimelineStream.embedder,
+          TimelineStream.gc,
         ],
       );
 


### PR DESCRIPTION
This will give us metrics on number of GCs run in that test.
