### PR TITLE
[WIP] Placeholder/WidgetSpan plainText representation support and WidgetSpan in SelectableText

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -579,9 +579,6 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
-    assert(() {
-      return _controller._textSpan.visitChildren((InlineSpan span) => span.runtimeType == TextSpan);
-    }(), 'SelectableText only supports TextSpan; Other type of InlineSpan is not allowed');
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
     assert(

--- a/packages/flutter/lib/src/painting/placeholder_span.dart
+++ b/packages/flutter/lib/src/painting/placeholder_span.dart
@@ -16,9 +16,14 @@ import 'text_style.dart';
 /// An immutable placeholder that is embedded inline within text.
 ///
 /// [PlaceholderSpan] represents a placeholder that acts as a stand-in for other
-/// content. A [PlaceholderSpan] by itself does not contain useful
-/// information to change a [TextSpan]. Instead, this class must be extended
-/// to define contents.
+/// content.
+///
+/// A [PlaceholderSpan] by itself does not change the text layout visually
+/// but can be used to insert invisible codepoint indexes into the text to
+/// account for rich or dynamic content that requires plaintext metadata to
+/// properly represent in a [TextEditingValue]. For example, a raw placeholder
+/// can be inserted to account for a `<b>` bold tag. The caret would properly
+/// skip over 3 indexes to account for the non-rendered bold tag string.
 ///
 /// [WidgetSpan] from the widgets library extends [PlaceholderSpan] and may be
 /// used instead to specify a widget as the contents of the placeholder.
@@ -30,7 +35,7 @@ import 'text_style.dart';
 ///  * [Text], a widget for showing uniformly-styled text.
 ///  * [RichText], a widget for finer control of text rendering.
 ///  * [TextPainter], a class for painting [TextSpan] objects on a [Canvas].
-abstract class PlaceholderSpan extends InlineSpan {
+class PlaceholderSpan extends InlineSpan {
   /// Creates a [PlaceholderSpan] with the given values.
   ///
   /// A [TextStyle] may be provided with the [style] property, but only the
@@ -53,6 +58,12 @@ abstract class PlaceholderSpan extends InlineSpan {
   /// This is ignored when using other alignment modes.
   final TextBaseline? baseline;
 
+  /// The plaintext respresentation of the placeholder.
+  ///
+  /// The placeholder will occupy the same number of codepoint indexes in the
+  /// laid out text as the length of this String.
+  ///
+  /// This is typically the String content this placeholder is replacing.
   final String plainText;
 
   /// [PlaceholderSpan]s are flattened to a `0xFFFC` object replacement character in the

--- a/packages/flutter/lib/src/painting/placeholder_span.dart
+++ b/packages/flutter/lib/src/painting/placeholder_span.dart
@@ -39,6 +39,7 @@ abstract class PlaceholderSpan extends InlineSpan {
     this.alignment = ui.PlaceholderAlignment.bottom,
     this.baseline,
     TextStyle? style,
+    this.plainText = '\uFFFC',
   }) : super(style: style);
 
   /// How the placeholder aligns vertically with the text.
@@ -52,12 +53,14 @@ abstract class PlaceholderSpan extends InlineSpan {
   /// This is ignored when using other alignment modes.
   final TextBaseline? baseline;
 
+  final String plainText;
+
   /// [PlaceholderSpan]s are flattened to a `0xFFFC` object replacement character in the
   /// plain text representation when `includePlaceholders` is true.
   @override
   void computeToPlainText(StringBuffer buffer, {bool includeSemanticsLabels = true, bool includePlaceholders = true}) {
     if (includePlaceholders) {
-      buffer.write('\uFFFC');
+      buffer.write(plainText);
     }
   }
 

--- a/packages/flutter/lib/src/painting/placeholder_span.dart
+++ b/packages/flutter/lib/src/painting/placeholder_span.dart
@@ -117,9 +117,9 @@ class PlaceholderSpan extends InlineSpan {
       return RenderComparison.identical;
     if (other.runtimeType != runtimeType)
       return RenderComparison.layout;
-    final WidgetSpan typedOther = other as PlaceholderSpan;
-    if (child != typedOther.child ||
-        alignment != typedOther.alignment ||
+    final PlaceholderSpan typedOther = other as PlaceholderSpan;
+    if (alignment != typedOther.alignment ||
+        baseline != typedOther.baseline ||
         plainText != typedOther.plainText) {
       return RenderComparison.layout;
     }

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -8,7 +8,7 @@ import 'package:flutter/painting.dart';
 
 import 'framework.dart';
 
-typedef WidgetSpanPlainTextGenerator = String Function(Widget);
+typedef WidgetSpanPlainTextGenerator = String Function(Widget, ui.PlaceholderAlignment, TextBaseline?, TextStyle?);
 
 /// An immutable widget that is embedded inline within text.
 ///
@@ -71,12 +71,12 @@ class WidgetSpan extends PlaceholderSpan {
   ///
   /// A [TextStyle] may be provided with the [style] property, but only the
   /// decoration, foreground, background, and spacing options will be used.
-  const WidgetSpan({
+  WidgetSpan({
     required this.child,
     ui.PlaceholderAlignment alignment = ui.PlaceholderAlignment.bottom,
     TextBaseline? baseline,
     TextStyle? style,
-    this.plainTextGenerator,
+    WidgetSpanPlainTextGenerator? plainTextGenerator,
   }) : assert(child != null),
        assert(
          baseline != null || !(
@@ -89,13 +89,11 @@ class WidgetSpan extends PlaceholderSpan {
          alignment: alignment,
          baseline: baseline,
          style: style,
+         plainText: plainTextGenerator!(child, alignment, baseline, style),
        );
 
   /// The widget to embed inline within text.
   final Widget child;
-
-  ///
-  final WidgetSpanPlainTextGenerator? plainTextGenerator;
 
   /// Adds a placeholder box to the paragraph builder if a size has been
   /// calculated for the widget.
@@ -122,20 +120,10 @@ class WidgetSpan extends PlaceholderSpan {
       scale: textScaleFactor,
       baseline: currentDimensions.baseline,
       baselineOffset: currentDimensions.baselineOffset,
+      codepointLength: plainText.length,
     );
     if (hasStyle) {
       builder.pop();
-    }
-  }
-
-  @override
-  void computeToPlainText(StringBuffer buffer, {bool includeSemanticsLabels = true, bool includePlaceholders = true}) {
-    if (includePlaceholders) {
-      if (plainTextGenerator != null) {
-        buffer.write(plainTextGenerator!(child));
-      } else {
-        buffer.write('\uFFFC');
-      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -8,6 +8,15 @@ import 'package:flutter/painting.dart';
 
 import 'framework.dart';
 
+/// A function that generates a plain text String to represent the WidgetSpan.
+///
+/// WidgetSpans used in Editable text fields and SelectableText should be
+/// represented in the TextEditingValue by a String. This function is called
+/// to generate the plaintext representation that is expected to be found in
+/// place of the widget.
+///
+/// This function is only needed if proper caret and clipboard behavior is
+/// expected.
 typedef WidgetSpanPlainTextGenerator = String Function(Widget, ui.PlaceholderAlignment, TextBaseline?, TextStyle?);
 
 /// An immutable widget that is embedded inline within text.
@@ -156,7 +165,9 @@ class WidgetSpan extends PlaceholderSpan {
     if ((style == null) != (other.style == null))
       return RenderComparison.layout;
     final WidgetSpan typedOther = other as WidgetSpan;
-    if (child != typedOther.child || alignment != typedOther.alignment) {
+    if (child != typedOther.child ||
+        alignment != typedOther.alignment ||
+        plainTextGenerator != typedOther.plainTextGenerator) {
       return RenderComparison.layout;
     }
     RenderComparison result = RenderComparison.identical;

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -136,21 +136,6 @@ class WidgetSpan extends PlaceholderSpan {
     }
   }
 
-  /// Calls `visitor` on this [WidgetSpan]. There are no children spans to walk.
-  @override
-  bool visitChildren(InlineSpanVisitor visitor) {
-    return visitor(this);
-  }
-
-  @override
-  InlineSpan? getSpanForPositionVisitor(TextPosition position, Accumulator offset) {
-    if (position.offset == offset.value) {
-      return this;
-    }
-    offset.increment(1);
-    return null;
-  }
-
   @override
   int? codeUnitAtVisitor(int index, Accumulator offset) {
     return null;
@@ -167,7 +152,7 @@ class WidgetSpan extends PlaceholderSpan {
     final WidgetSpan typedOther = other as WidgetSpan;
     if (child != typedOther.child ||
         alignment != typedOther.alignment ||
-        plainTextGenerator != typedOther.plainTextGenerator) {
+        plainText != typedOther.plainText) {
       return RenderComparison.layout;
     }
     RenderComparison result = RenderComparison.identical;

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -8,6 +8,8 @@ import 'package:flutter/painting.dart';
 
 import 'framework.dart';
 
+typedef WidgetSpanPlainTextGenerator = String Function(Widget);
+
 /// An immutable widget that is embedded inline within text.
 ///
 /// The [child] property is the widget that will be embedded. Children are
@@ -74,6 +76,7 @@ class WidgetSpan extends PlaceholderSpan {
     ui.PlaceholderAlignment alignment = ui.PlaceholderAlignment.bottom,
     TextBaseline? baseline,
     TextStyle? style,
+    this.plainTextGenerator,
   }) : assert(child != null),
        assert(
          baseline != null || !(
@@ -90,6 +93,9 @@ class WidgetSpan extends PlaceholderSpan {
 
   /// The widget to embed inline within text.
   final Widget child;
+
+  ///
+  final WidgetSpanPlainTextGenerator? plainTextGenerator;
 
   /// Adds a placeholder box to the paragraph builder if a size has been
   /// calculated for the widget.
@@ -119,6 +125,17 @@ class WidgetSpan extends PlaceholderSpan {
     );
     if (hasStyle) {
       builder.pop();
+    }
+  }
+
+  @override
+  void computeToPlainText(StringBuffer buffer, {bool includeSemanticsLabels = true, bool includePlaceholders = true}) {
+    if (includePlaceholders) {
+      if (plainTextGenerator != null) {
+        buffer.write(plainTextGenerator!(child));
+      } else {
+        buffer.write('\uFFFC');
+      }
     }
   }
 

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -8,17 +8,6 @@ import 'package:flutter/painting.dart';
 
 import 'framework.dart';
 
-/// A function that generates a plain text String to represent the WidgetSpan.
-///
-/// WidgetSpans used in Editable text fields and SelectableText should be
-/// represented in the TextEditingValue by a String. This function is called
-/// to generate the plaintext representation that is expected to be found in
-/// place of the widget.
-///
-/// This function is only needed if proper caret and clipboard behavior is
-/// expected.
-typedef WidgetSpanPlainTextGenerator = String Function(Widget, ui.PlaceholderAlignment, TextBaseline?, TextStyle?);
-
 /// An immutable widget that is embedded inline within text.
 ///
 /// The [child] property is the widget that will be embedded. Children are
@@ -80,12 +69,12 @@ class WidgetSpan extends PlaceholderSpan {
   ///
   /// A [TextStyle] may be provided with the [style] property, but only the
   /// decoration, foreground, background, and spacing options will be used.
-  WidgetSpan({
+  const WidgetSpan({
     required this.child,
     ui.PlaceholderAlignment alignment = ui.PlaceholderAlignment.bottom,
     TextBaseline? baseline,
     TextStyle? style,
-    WidgetSpanPlainTextGenerator? plainTextGenerator,
+    String? plainText,
   }) : assert(child != null),
        assert(
          baseline != null || !(
@@ -98,7 +87,7 @@ class WidgetSpan extends PlaceholderSpan {
          alignment: alignment,
          baseline: baseline,
          style: style,
-         plainText: plainTextGenerator!(child, alignment, baseline, style),
+         plainText: plainText,
        );
 
   /// The widget to embed inline within text.

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -69,12 +69,18 @@ class WidgetSpan extends PlaceholderSpan {
   ///
   /// A [TextStyle] may be provided with the [style] property, but only the
   /// decoration, foreground, background, and spacing options will be used.
+  ///
+  /// The [plainText] parameter specifies how the WidgetSpan is respresented as
+  /// a plaintext String. This String's length is also used by the text selection and
+  /// caret to properly navigate the [TextEditingValue.text].
+  ///
+  /// The default plainText is a object replacement character (0xFFFC). 
   const WidgetSpan({
     required this.child,
     ui.PlaceholderAlignment alignment = ui.PlaceholderAlignment.bottom,
     TextBaseline? baseline,
     TextStyle? style,
-    String? plainText,
+    String plainText = '\uFFFC',
   }) : assert(child != null),
        assert(
          baseline != null || !(


### PR DESCRIPTION
Adds support for WidgetSpan rendering in SelectableText and adds API for customizable clipboard behavior.

Placeholder is changed to be instantiable to allow insertion of zero-size multi-codepoint placeholders to allow indexing of carets to work when using placeholders as a replacement for non-rendered metadata plaintext.

Will require text layout engine support for WidgetSpans representing n-length strings to properly handle clipboard and indexing. PR: https://github.com/flutter/engine/pull/27010
