### PR TITLE
remove deprecated `author` fields

### DIFF
--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -1,5 +1,4 @@
 name: flutter_devicelab
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 

--- a/dev/snippets/pubspec.yaml
+++ b/dev/snippets/pubspec.yaml
@@ -1,6 +1,5 @@
 name: snippets
 version: 0.1.0
-author: Flutter Team <flutter-dev@googlegroups.com>
 description: A code snippet dartdoc extension for Flutter API docs.
 homepage: https://github.com/flutter/flutter
 

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -2,7 +2,6 @@ name: vitool
 description: A tool for generating Dart vector animation code from SVG sequences.
 version: 0.0.1
 homepage: https://flutter.dev
-author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,5 +1,4 @@
 name: flutter
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 

--- a/packages/flutter/test_private/pubspec.yaml
+++ b/packages/flutter/test_private/pubspec.yaml
@@ -1,5 +1,4 @@
 name: flutter_test_private
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Tests private interfaces of the flutter
 
 environment:

--- a/packages/flutter/test_private/test/pubspec.yaml
+++ b/packages/flutter/test_private/test/pubspec.yaml
@@ -1,5 +1,4 @@
 name: animated_icons_private_test
-author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -1,7 +1,6 @@
 name: flutter_driver
 description: Integration and performance test API for Flutter applications
 homepage: http://flutter.dev
-author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -1,7 +1,6 @@
 name: flutter_tools
 description: Tools for building Flutter applications
 homepage: https://flutter.dev
-author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/flutter_web_plugins/pubspec.yaml
+++ b/packages/flutter_web_plugins/pubspec.yaml
@@ -1,6 +1,5 @@
 name: flutter_web_plugins
 description: Library to register Flutter Web plugins
-author: Flutter Authors <flutter-dev@googlegroups.com>
 homepage: http://flutter.dev
 
 environment:

--- a/packages/integration_test/integration_test_macos/pubspec.yaml
+++ b/packages/integration_test/integration_test_macos/pubspec.yaml
@@ -1,7 +1,6 @@
 name: integration_test_macos
 description: Desktop implementation of integration_test plugin
 version: 0.0.1+1
-author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test/integration_test_macos
 
 flutter:


### PR DESCRIPTION
Removes deprecated `author` field sections that will break on an upcoming SDK release.

See: https://dart-review.googlesource.com/c/sdk/+/204420

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
