### PR TITLE
[gen_l10n] Make plural handling of zero, one and two more flexible in arb files

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -186,10 +186,40 @@ String _generatePluralMethod(Message message, String translationForMessage) {
   }
 
   final Placeholder countPlaceholder = message.getCountPlaceholder();
-  const Map<String, String> pluralIds = <String, String>{
+
+  // Only either the numerical representation ('=0') or the English word ('zero')
+  // should be present. Both cannot simultaneously be defined. Prefer
+  // the use of the English representation.
+  const Map<String, String> pluralChecks = <String, String>{
     '=0': 'zero',
     '=1': 'one',
     '=2': 'two',
+  };
+
+  for (final String numericalVersion in pluralChecks.keys) {
+    final String englishVersion = pluralChecks[numericalVersion]!;
+
+    final RegExp numericalExpRE = RegExp('($numericalVersion)\\s*{([^}]+)}');
+    final RegExpMatch? numericalMatch = numericalExpRE.firstMatch(easyMessage);
+    final RegExp wordExpRE = RegExp('($englishVersion)\\s*{([^}]+)}');
+    final RegExpMatch? wordMatch = wordExpRE.firstMatch(easyMessage);
+
+    if (numericalMatch != null && numericalMatch.groupCount == 2 && wordMatch != null && wordMatch.groupCount == 2) {
+      throw L10nException('''
+Both the numerical representation '$numericalVersion' or the English
+word '$englishVersion' are defined, but both cannot simultaneously be defined.
+Prefer the use of the English representation '$englishVersion'.
+''');
+    }
+  }
+
+  const Map<String, String> pluralIds = <String, String>{
+    '=0': 'zero',
+    'zero': 'zero',
+    '=1': 'one',
+    'one': 'one',
+    '=2': 'two',
+    'two': 'two',
     'few': 'few',
     'many': 'many',
     'other': 'other',

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1853,10 +1853,8 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   }
 }''';
 
-      l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
-        ..createSync(recursive: true);
       l10nDirectory.childFile(defaultTemplateArbFileName)
-        .writeAsStringSync(pluralMessageWithDuplicateZeroRepresentation);
+        .writeAsStringSync(pluralMessageWithDuplicateOneRepresentation);
 
       try {
         LocalizationsGenerator(
@@ -1884,10 +1882,8 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   }
 }''';
 
-      l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
-        ..createSync(recursive: true);
       l10nDirectory.childFile(defaultTemplateArbFileName)
-        .writeAsStringSync(pluralMessageWithDuplicateZeroRepresentation);
+        .writeAsStringSync(pluralMessageWithDuplicateTwoRepresentation);
 
       try {
         LocalizationsGenerator(

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1812,6 +1812,101 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
       });
     });
 
+    testWithoutContext('should throw attempting to generate a plural message with both number and english representations defined for zero, one, or two', () {
+      const String pluralMessageWithDuplicateZeroRepresentation = '''
+{
+  "helloWorlds": "{count,plural, =0{zero}zero{other zero}other{Hello other {count} worlds}}",
+  "@helloWorlds": {
+    "description": "Cannot have both =0 and zero.",
+    "placeholders": {}
+  }
+}''';
+
+      Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+        ..createSync(recursive: true);
+      l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(pluralMessageWithDuplicateZeroRepresentation);
+
+      try {
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+      } on L10nException catch (e) {
+        e.message.contains('both cannot simultaneously be defined.');
+        e.message.contains('=0');
+        e.message.contains('zero');
+      }
+
+      const String pluralMessageWithDuplicateOneRepresentation = '''
+{
+  "helloWorlds": "{count,plural, =1{one}one{other one}other{Hello other {count} worlds}}",
+  "@helloWorlds": {
+    "description": "Cannot have both =1 and one.",
+    "placeholders": {}
+  }
+}''';
+
+      l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+        ..createSync(recursive: true);
+      l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(pluralMessageWithDuplicateZeroRepresentation);
+
+      try {
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+      } on L10nException catch (e) {
+        e.message.contains('both cannot simultaneously be defined.');
+        e.message.contains('=1');
+        e.message.contains('one');
+      }
+
+      const String pluralMessageWithDuplicateTwoRepresentation = '''
+{
+  "helloWorlds": "{count,plural, =2{zero}two{other zero}other{Hello other {count} worlds}}",
+  "@helloWorlds": {
+    "description": "Cannot have both =2 and two.",
+    "placeholders": {}
+  }
+}''';
+
+      l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+        ..createSync(recursive: true);
+      l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(pluralMessageWithDuplicateZeroRepresentation);
+
+      try {
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+      } on L10nException catch (e) {
+        e.message.contains('both cannot simultaneously be defined.');
+        e.message.contains('=2');
+        e.message.contains('two');
+      }
+    });
+
     testWithoutContext('intl package import should be omitted in subclass files when no plurals are included', () {
       fs.currentDirectory.childDirectory('lib').childDirectory('l10n')..createSync(recursive: true)
         ..childFile(defaultTemplateArbFileName).writeAsStringSync(singleMessageArbFileString)


### PR DESCRIPTION
Addresses part of https://github.com/flutter/flutter/issues/84291.

This change allows `gen-l10n` to handle plurals in arb files as both numerical and english word representations. For example, both 'zero' and '=0' will be accepted as the same thing. This also introduces a check to make sure both are not simultaneously defined. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
