### PR TITLE
remove deprecated `author` pubspec section

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1511,7 +1511,6 @@ environment:
     ..writeAsStringSync('''
 name: sky_engine
 version: 0.0.99
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Dart SDK extensions for dart:ui
 homepage: http://flutter.io
 # sky_engine requires sdk_ext support in the analyzer which was added in 1.11.x

--- a/packages/flutter_tools/test/general.shard/update_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/update_packages_test.dart
@@ -15,7 +15,6 @@ import '../src/common.dart';
 // An example pubspec.yaml from flutter, not necessary for it to be up to date.
 const String kFlutterPubspecYaml = r'''
 name: flutter
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 
@@ -50,7 +49,6 @@ dev_dependencies:
 
 const String kExtraPubspecYaml = r'''
 name: nodeps
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A dummy pubspec with no dependencies
 homepage: http://flutter.dev
 
@@ -60,7 +58,6 @@ environment:
 
 const String kInvalidGitPubspec = '''
 name: flutter
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 


### PR DESCRIPTION
Work to prepare for landing a new diagnostic for deprecated `author` sections in pubspecs.

I'm hoping this will address the breakage reported here: 

```
▌21:25:04▐ RUNNING: cd packages/flutter/test_private; ../../../bin/cache/dart-sdk/bin/pub run --sound-null-safety test_private.dart
Found manifest /b/s/w/ir/cache/builder/flutter/packages/flutter/test_private/test/animated_icons_private_test.json
Analyzing test case animated_icons_private_test
Running "/b/s/w/ir/cache/builder/flutter/bin/flutter analyze --current-package --pub --congratulate ." in /b/s/w/ir/x/t/flutter_package.BEMBPZ/animated_icons_private_test.
Building flutter tool...
Running "flutter pub get" in animated_icons_private_test...      1,262ms
Analyzing animated_icons_private_test...                        

warning • The 'author' field is no longer used and may be removed • pubspec.yaml:2:1 • deprecated_field
```

(Full log: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8843770644483238544/+/u/flutter_test_framework_tests/stdout)

See also: #84997 and https://dart-review.googlesource.com/c/sdk/+/204420.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
