### PR TITLE
Try to dump app again for run_demos.dart

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/run_demos.dart
@@ -61,16 +61,15 @@ Future<void> runDemos(List<String> demos, WidgetController controller) async {
       final Finder demoItem = find.text(demoName);
       await controller.scrollUntilVisible(demoItem, 48.0);
       await controller.pumpAndSettle();
-      try {
-        await controller.tap(demoItem); // Launch the demo
-      } catch (e) {
+      if (demoItem.evaluate().isEmpty) {
         print('Failed to find $demoItem');
         print('All available elements:');
-        print(controller.allElements.toList());
+        print(controller.allElements.toList().join('\n'));
         print('App structure:');
         debugDumpApp();
-        rethrow;
+        throw TestFailure('Failed to find element');
       }
+      await controller.tap(demoItem); // Launch the demo
 
       if (kUnsynchronizedDemos.contains(demo)) {
         // These tests have animation, pumpAndSettle cannot be used.


### PR DESCRIPTION
Previous attempt at #84996 was not catching the exception. This instead tests the condition that causes the exception when calling .tap

@zanderso 

For https://github.com/flutter/flutter/issues/83298