### PR TITLE
macOS unzip then rsync to delete stale artifacts

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -427,6 +427,44 @@ class _MacOSUtils extends _PosixUtils {
     }
     return _hostPlatform!;
   }
+
+  // unzip, then rsync
+  @override
+  void unzip(File file, Directory targetDirectory) {
+    if (!_processManager.canRun('unzip')) {
+      // unzip is not available. this error message is modeled after the download
+      // error in bin/internal/update_dart_sdk.sh
+      throwToolExit('Missing "unzip" tool. Unable to extract ${file.path}.\nConsider running "brew install unzip".');
+    }
+    if (_processManager.canRun('rsync')) {
+      final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync('flutter_${file.basename}.');
+      try {
+        // Unzip to a temporary directory.
+        _processUtils.runSync(
+          <String>['unzip', '-o', '-q', file.path, '-d', tempDirectory.path],
+          throwOnError: true,
+          verboseExceptions: true,
+        );
+        for (final FileSystemEntity unzippedFile in tempDirectory.listSync(followLinks: false)) {
+          // rsync --delete the unzipped files so files removed from the archive are also removed from the target.
+          _processUtils.runSync(
+            <String>['rsync', '-av', '--delete', unzippedFile.path, targetDirectory.path],
+            throwOnError: true,
+            verboseExceptions: true,
+          );
+        }
+      } finally {
+        tempDirectory.deleteSync(recursive: true);
+      }
+    } else {
+      // Fall back to unzipping directly.
+      _processUtils.runSync(
+        <String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path],
+        throwOnError: true,
+        verboseExceptions: true,
+      );
+    }
+  }
 }
 
 class _WindowsUtils extends OperatingSystemUtils {

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -457,7 +457,8 @@ class _MacOSUtils extends _PosixUtils {
         tempDirectory.deleteSync(recursive: true);
       }
     } else {
-      // Fall back to unzipping directly.
+      // Fall back to just unzipping.
+      _logger.printTrace('Unable to find rsync, falling back to direct unzipping.');
       _processUtils.runSync(
         <String>['unzip', '-o', '-q', file.path, '-d', targetDirectory.path],
         throwOnError: true,

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
@@ -534,6 +535,77 @@ void main() {
       () => osUtils.unzip(bar, foo),
       throwsProcessException(message: exceptionMessage),
     );
+  });
+
+  group('unzip on macOS', () {
+    testWithoutContext('falls back to unzip when rsync cannot run', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+      fakeProcessManager.excludedExecutables.add('rsync');
+
+      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'macos'),
+        processManager: fakeProcessManager,
+      );
+
+      final Directory targetDirectory = fileSystem.currentDirectory;
+      fakeProcessManager.addCommand(FakeCommand(
+        command: <String>['unzip', '-o', '-q', 'foo.zip', '-d', targetDirectory.path],
+      ));
+
+      macOSUtils.unzip(fileSystem.file('foo.zip'), targetDirectory);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+    });
+
+    testWithoutContext('unzip and rsyncs', () {
+      final FileSystem fileSystem = MemoryFileSystem.test();
+
+      final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        platform: FakePlatform(operatingSystem: 'macos'),
+        processManager: fakeProcessManager,
+      );
+
+      final Directory targetDirectory = fileSystem.currentDirectory;
+      final Directory tempDirectory = fileSystem.systemTempDirectory.childDirectory('flutter_foo.zip.rand0');
+      fakeProcessManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            'unzip',
+            '-o',
+            '-q',
+            'foo.zip',
+            '-d',
+            tempDirectory.path,
+          ],
+          onRun: () {
+            expect(tempDirectory, exists);
+            tempDirectory.childDirectory('dirA').childFile('fileA').createSync(recursive: true);
+            tempDirectory.childDirectory('dirB').childFile('fileB').createSync(recursive: true);
+          },
+        ),
+        FakeCommand(command: <String>[
+          'rsync',
+          '-av',
+          '--delete',
+          tempDirectory.childDirectory('dirA').path,
+          targetDirectory.path,
+        ]),
+        FakeCommand(command: <String>[
+          'rsync',
+          '-av',
+          '--delete',
+          tempDirectory.childDirectory('dirB').path,
+          targetDirectory.path,
+        ]),
+      ]);
+
+      macOSUtils.unzip(fileSystem.file('foo.zip'), fileSystem.currentDirectory);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(tempDirectory, isNot(exists));
+    });
   });
 
   group('display an install message when unzip cannot be run', () {

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -542,9 +542,10 @@ void main() {
       final FileSystem fileSystem = MemoryFileSystem.test();
       fakeProcessManager.excludedExecutables.add('rsync');
 
+      final BufferLogger logger = BufferLogger.test();
       final OperatingSystemUtils macOSUtils = OperatingSystemUtils(
         fileSystem: fileSystem,
-        logger: BufferLogger.test(),
+        logger: logger,
         platform: FakePlatform(operatingSystem: 'macos'),
         processManager: fakeProcessManager,
       );
@@ -556,6 +557,7 @@ void main() {
 
       macOSUtils.unzip(fileSystem.file('foo.zip'), targetDirectory);
       expect(fakeProcessManager, hasNoRemainingExpectations);
+      expect(logger.traceText, contains('Unable to find rsync'));
     });
 
     testWithoutContext('unzip and rsyncs', () {


### PR DESCRIPTION
On macOS only, when unzipping, first unzip to a temp directory, then `rsync` with the `--delete` flag so stale files that aren't in the target directory are deleted, and files continue to only be updated as needed.  This adds an extra I/O copy step to unzipping, but will make sure deleted archive files are actually deleted.  This applies for downloading cached artifacts as well as unzipping prebuilt macOS and iOS app bundles.

Confirmed that the stale xcframework architecture triple directories are removed on this PR (more details in https://github.com/flutter/flutter/issues/85062)

Fixes https://github.com/flutter/flutter/issues/85062

There was a previous attempt to do this at https://github.com/flutter/flutter/pull/74818 but that only seems to delete `flutter/bin/cache/artifacts/engine/ios/artifacts` (which doesn't exist), not `flutter/bin/cache/artifacts/engine/ios/*`