### PR TITLE
Avoid iOS app with extension checks that fail on M1 ARM Macs

### DIFF
--- a/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/ios_app_with_extensions_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 Future<void> main() async {
@@ -68,8 +67,8 @@ Future<void> main() async {
       );
 
       checkDirectoryExists(appBundle);
-      await _checkFlutterFrameworkArchs(appFrameworkPath, isSimulator: false);
-      await _checkFlutterFrameworkArchs(flutterFrameworkPath, isSimulator: false);
+      await _checkFlutterFrameworkArchs(appFrameworkPath);
+      await _checkFlutterFrameworkArchs(flutterFrameworkPath);
 
       // Check the watch extension framework added in the Podfile
       // is in place with the expected watch archs.
@@ -101,8 +100,8 @@ Future<void> main() async {
       });
 
       checkDirectoryExists(appBundle);
-      await _checkFlutterFrameworkArchs(appFrameworkPath, isSimulator: false);
-      await _checkFlutterFrameworkArchs(flutterFrameworkPath, isSimulator: false);
+      await _checkFlutterFrameworkArchs(appFrameworkPath);
+      await _checkFlutterFrameworkArchs(flutterFrameworkPath);
       unawaited(_checkWatchExtensionFrameworkArchs(watchExtensionFrameworkPath));
 
       section('Clean build');
@@ -252,22 +251,18 @@ Future<void> main() async {
       )).path;
 
       checkDirectoryExists(simulatorAppBundle);
-
-      final String simulatorAppFrameworkPath = path.join(
+      checkFileExists(path.join(
         simulatorAppBundle,
         'Frameworks',
         'App.framework',
         'App',
-      );
-      final String simulatorFlutterFrameworkPath = path.join(
+      ));
+      checkFileExists(path.join(
         simulatorAppBundle,
         'Frameworks',
         'Flutter.framework',
         'Flutter',
-      );
-
-      await _checkFlutterFrameworkArchs(simulatorAppFrameworkPath, isSimulator: true);
-      await _checkFlutterFrameworkArchs(simulatorFlutterFrameworkPath, isSimulator: true);
+      ));
 
       return TaskResult.success(null);
     } catch (e) {
@@ -307,23 +302,16 @@ Future<void> main() async {
   });
 }
 
-Future<void> _checkFlutterFrameworkArchs(String frameworkPath, {
-  @required bool isSimulator
-}) async {
+Future<void> _checkFlutterFrameworkArchs(String frameworkPath) async {
   checkFileExists(frameworkPath);
 
   final String archs = await fileType(frameworkPath);
-  if (isSimulator == archs.contains('armv7')) {
-    throw TaskResult.failure('$frameworkPath armv7 architecture unexpected');
+  if (!archs.contains('arm64')) {
+    throw TaskResult.failure('$frameworkPath arm64 architecture missing');
   }
 
-  if (isSimulator == archs.contains('arm64')) {
-    throw TaskResult.failure('$frameworkPath arm64 architecture unexpected');
-  }
-
-  if (isSimulator != archs.contains('x86_64')) {
-    throw TaskResult.failure(
-        '$frameworkPath x86_64 architecture unexpected');
+  if (archs.contains('x86_64')) {
+    throw TaskResult.failure('$frameworkPath x86_64 architecture unexpectedly present');
   }
 }
 


### PR DESCRIPTION
Xcode has slightly different build settings for an iOS app with a watch companion on an ARM Mac than on x86_64 Mac.  The simulator is already being validated by running unit tests, so stick with validating architectures for physical devices.

Fixes https://github.com/flutter/flutter/issues/82402