### PR TITLE
Remove tests checking Xcode 11 naming conventions

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -113,69 +113,20 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
 
   final String outputPath = path.join(projectDir.path, outputDirectoryName);
 
-  // Xcode changed the name of this generated directory in Xcode 12.
-  const String xcode11ArmDirectoryName = 'ios-armv7_arm64';
-  const String xcode12ArmDirectoryName = 'ios-arm64_armv7';
-
-  final String xcode11AppFrameworkDirectory = path.join(
-    outputPath,
-    'Debug',
-    'App.xcframework',
-    xcode11ArmDirectoryName,
-    'App.framework',
-    'App',
-  );
-  final String xcode12AppFrameworkDirectory = path.join(
-    outputPath,
-    'Debug',
-    'App.xcframework',
-    xcode12ArmDirectoryName,
-    'App.framework',
-    'App',
-  );
-
-  // Based on the locally installed version of Xcode.
-  String localXcodeArmDirectoryName;
-  if (exists(File(xcode11AppFrameworkDirectory))) {
-    localXcodeArmDirectoryName = xcode11ArmDirectoryName;
-  } else if (exists(File(xcode12AppFrameworkDirectory))) {
-    localXcodeArmDirectoryName = xcode12ArmDirectoryName;
-  } else {
-    throw const FileSystemException('Expected App.framework binary to exist.');
-  }
-
-  final String xcode11FlutterFrameworkDirectory = path.join(
+  checkFileExists(path.join(
     outputPath,
     'Debug',
     'Flutter.xcframework',
-    xcode11ArmDirectoryName,
+    'ios-arm64_armv7',
     'Flutter.framework',
     'Flutter',
-  );
-  final String xcode12FlutterFrameworkDirectory = path.join(
-    outputPath,
-    'Debug',
-    'Flutter.xcframework',
-    xcode12ArmDirectoryName,
-    'Flutter.framework',
-    'Flutter',
-  );
-
-  // Based on the version of Xcode installed on the engine builder.
-  String builderXcodeArmDirectoryName;
-  if (exists(File(xcode11FlutterFrameworkDirectory))) {
-    builderXcodeArmDirectoryName = xcode11ArmDirectoryName;
-  } else if (exists(File(xcode12FlutterFrameworkDirectory))) {
-    builderXcodeArmDirectoryName = xcode12ArmDirectoryName;
-  } else {
-    throw const FileSystemException('Expected Flutter.framework binary to exist.');
-  }
+  ));
 
   final String debugAppFrameworkPath = path.join(
     outputPath,
     'Debug',
     'App.xcframework',
-    localXcodeArmDirectoryName,
+    'ios-arm64_armv7',
     'App.framework',
     'App',
   );
@@ -223,7 +174,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'App.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'App.framework',
       'App',
     );
@@ -240,7 +191,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'App.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'App.framework',
       'flutter_assets',
       'vm_snapshot_data',
@@ -263,7 +214,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'Flutter.xcframework',
-      builderXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'Flutter.framework',
       'Flutter',
     );
@@ -309,7 +260,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'device_info.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'device_info.framework',
       'device_info',
     );
@@ -322,7 +273,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'Reachability.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'Reachability.framework',
       'Reachability',
     );
@@ -334,7 +285,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'device_info.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'device_info.framework',
       'Headers',
       'DeviceInfoPlugin.h',
@@ -345,7 +296,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
         outputPath,
         mode,
         'device_info.xcframework',
-        localXcodeArmDirectoryName,
+        'ios-arm64_armv7',
         'dSYMs',
         'device_info.framework.dSYM',
       ));
@@ -378,7 +329,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
     outputPath,
     'Release',
     'device_info.xcframework',
-    localXcodeArmDirectoryName,
+    'ios-arm64_armv7',
     'BCSymbolMaps',
   ));
 
@@ -392,7 +343,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'FlutterPluginRegistrant.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'FlutterPluginRegistrant.framework',
       'FlutterPluginRegistrant',
     );
@@ -402,7 +353,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
       outputPath,
       mode,
       'FlutterPluginRegistrant.xcframework',
-      localXcodeArmDirectoryName,
+      'ios-arm64_armv7',
       'FlutterPluginRegistrant.framework',
       'Headers',
       'GeneratedPluginRegistrant.h',


### PR DESCRIPTION
Xcode 11 named these files `ios-armv7_arm64` and Xcode 12 names them `ios-arm64_armv7`.  The Xcode 11 name checks in this test are no longer necessary now that the [engine builders are on Xcode 12](https://github.com/flutter/infra/pull/473).