### PR TITLE
[integration_test] Support collecting of SkSL

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -215,6 +215,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
               'as a multiplier of the default timeout (e.g. "2x"), '
               'or as the string "none" to disable the timeout entirely.',
         defaultsTo: '30s',
+      )
+      ..addOption('write-sksl-on-exit',
+        help: 'Attempts to write an SkSL file when the test process is finished '
+              'to the provided file, overwriting it if necessary. This is only '
+              'supported when running Integration Tests.',
       );
       addDdsOptions(verboseHelp: verboseHelp);
   }
@@ -386,6 +391,16 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       watcher = collector;
     }
 
+    final File writeSkslOnExit = stringArg('write-sksl-on-exit') != null
+        ? globals.fs.file(stringArg('write-sksl-on-exit'))
+        : null;
+    if (!_isIntegrationTest && argResults.wasParsed('write-sksl-on-exit')) {
+      globals.logger.printStatus(
+        '--write-sksl-on-exit was parsed but will be ignored, this is only '
+        'supported for Integration Tests.'
+      );
+    }
+
     final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
       buildInfo,
       startPaused: startPaused,
@@ -394,6 +409,8 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       disablePortPublication: true,
       enableDds: enableDds,
       nullAssertions: boolArg(FlutterOptions.kNullAssertions),
+      cacheSkSL: writeSkslOnExit != null,
+      purgePersistentCache: writeSkslOnExit != null,
     );
 
     Device integrationTestDevice;
@@ -452,6 +469,9 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       totalShards: totalShards,
       integrationTestDevice: integrationTestDevice,
       integrationTestUserIdentifier: stringArg(FlutterOptions.kDeviceUser),
+      integrationTestWriteSkslOnExit: stringArg('write-sksl-on-exit') != null
+        ? globals.fs.file(stringArg('write-sksl-on-exit'))
+        : null,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -63,6 +63,7 @@ FlutterPlatform installHook({
   PlatformPluginRegistration platformPluginRegistration,
   Device integrationTestDevice,
   String integrationTestUserIdentifier,
+  File integrationTestWriteSkslOnExit,
 }) {
   assert(testWrapper != null);
   assert(enableObservatory || (!debuggingOptions.startPaused && debuggingOptions.hostVmServicePort == null));
@@ -92,6 +93,7 @@ FlutterPlatform installHook({
     icudtlPath: icudtlPath,
     integrationTestDevice: integrationTestDevice,
     integrationTestUserIdentifier: integrationTestUserIdentifier,
+    integrationTestWriteSkslOnExit: integrationTestWriteSkslOnExit,
   );
   platformPluginRegistration(platform);
   return platform;
@@ -286,6 +288,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.icudtlPath,
     this.integrationTestDevice,
     this.integrationTestUserIdentifier,
+    this.integrationTestWriteSkslOnExit
   }) : assert(shellPath != null);
 
   final String shellPath;
@@ -310,6 +313,7 @@ class FlutterPlatform extends PlatformPlugin {
   bool get _isIntegrationTest => integrationTestDevice != null;
 
   final String integrationTestUserIdentifier;
+  final File integrationTestWriteSkslOnExit;
 
   final FontConfigManager _fontConfigManager = FontConfigManager();
 
@@ -407,6 +411,7 @@ class FlutterPlatform extends PlatformPlugin {
         debuggingOptions: debuggingOptions,
         device: integrationTestDevice,
         userIdentifier: integrationTestUserIdentifier,
+        writeSkslOnExit: integrationTestWriteSkslOnExit,
       );
     }
     return FlutterTesterTestDevice(

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -55,6 +55,7 @@ abstract class FlutterTestRunner {
     int totalShards,
     Device integrationTestDevice,
     String integrationTestUserIdentifier,
+    File integrationTestWriteSkslOnExit,
   });
 }
 
@@ -91,6 +92,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     int totalShards,
     Device integrationTestDevice,
     String integrationTestUserIdentifier,
+    File integrationTestWriteSkslOnExit,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
@@ -209,6 +211,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       icudtlPath: icudtlPath,
       integrationTestDevice: integrationTestDevice,
       integrationTestUserIdentifier: integrationTestUserIdentifier,
+      integrationTestWriteSkslOnExit: integrationTestWriteSkslOnExit,
     );
 
     try {

--- a/packages/flutter_tools/test/src/fake_vm_services.dart
+++ b/packages/flutter_tools/test/src/fake_vm_services.dart
@@ -22,7 +22,7 @@ class FakeVmServiceHost {
     @required List<VmServiceExpectation> requests,
     Uri httpAddress,
     Uri wsAddress,
-  }) : _requests = requests {
+  }) : _requests = <VmServiceExpectation>[...requests] {
     _vmService = FlutterVmService(vm_service.VmService(
       _input.stream,
       _output.add,


### PR DESCRIPTION
Passing `--write-sksl-on-exit=sksl.json` to `flutter test` when running in Integration Test mode will collect shaders to the specified file.

- Slightly pushes back when `IntegrationTestDevice.observatoryUrl` completes, so that we avoid duplication of state and keep one instance variable that tracks both the observatory and the vm service
- Modified `FakeVmService` to copy the `requests` list since it will be mutated and is unexpected when reusing the `requests` list over multiple fakes

TODO:
- Verify that the collected shaders actually work
- Multiple tests will generate multiple shader files, probably want to only run this when one test file is specified



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
