### PR TITLE
Revert "Remove per-test timeouts from integration tests"

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/measure_scroll_smoothness_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/measure_scroll_smoothness_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
+  timeout: const Duration(minutes: 5),
   responseDataCallback: (Map<String, dynamic>? data) async {
     await driver.writeResponseData(
       data,

--- a/dev/benchmarks/macrobenchmarks/test/cull_opacity_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/cull_opacity_perf_e2e.dart
@@ -15,5 +15,6 @@ Future<void> main() async {
     kCullOpacityRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/multi_widget_construction_perf_e2e.dart
@@ -12,5 +12,6 @@ void main() {
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -15,6 +15,7 @@ void macroPerfTestE2E(
   String routeName, {
   Duration pageDelay,
   Duration duration = const Duration(seconds: 3),
+  Duration timeout = const Duration(seconds: 30),
   ControlCallback body,
   ControlCallback setup,
 }) {
@@ -62,5 +63,5 @@ void macroPerfTestE2E(
       }
       await durationFuture;
     });
-  }, semanticsEnabled: false);
+  }, semanticsEnabled: false, timeout: Timeout(timeout));
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/cull_opacity_perf_test.dart
@@ -12,5 +12,6 @@ void main() {
     kCullOpacityRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
+    timeout: const Duration(minutes: 2),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/e2e_test.dart
@@ -5,6 +5,7 @@
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
+  timeout: const Duration(minutes: 5),
   responseDataCallback: (Map<String, dynamic> data) async {
     await driver.writeResponseData(
       data['performance'] as Map<String, dynamic>,

--- a/dev/benchmarks/macrobenchmarks/test_driver/frame_policy_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/frame_policy_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
+  timeout: const Duration(minutes: 1),
   responseDataCallback: (Map<String, dynamic> data) async {
     final Map<String, dynamic> benchmarkLiveResult =
         data['benchmarkLive'] as Map<String,dynamic>;

--- a/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/multi_widget_construction_perf_test.dart
@@ -12,5 +12,6 @@ void main() {
     kMultiWidgetConstructionRouteName,
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 45),
   );
 }

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
@@ -11,6 +11,7 @@ void main() {
   macroPerfTest(
     'picture_cache_perf',
     kPictureCacheRouteName,
+    timeout: const Duration(seconds: 60),
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
       final SerializableFinder tabBarView = find.byValueKey('tabbar_view');

--- a/dev/benchmarks/macrobenchmarks/test_driver/stack_size_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/stack_size_perf_test.dart
@@ -30,7 +30,7 @@ void main() {
     await file.writeAsString(_encodeJson(<String, dynamic>{
       'stack_size': stackSizeInBytes,
     }));
-  });
+  }, timeout: const Timeout(kTimeout));
 }
 
 String _encodeJson(Map<String, dynamic> jsonObject) {

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -6,6 +6,8 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:macrobenchmarks/common.dart';
 import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 
+const Duration kTimeout = Duration(seconds: 30);
+
 typedef DriverTestCallBack = Future<void> Function(FlutterDriver driver);
 
 Future<void> runDriverTestForRoute(String routeName, DriverTestCallBack body) async {
@@ -32,13 +34,14 @@ Future<void> runDriverTestForRoute(String routeName, DriverTestCallBack body) as
 }
 
 void macroPerfTest(
-  String testName,
-  String routeName, {
-  Duration pageDelay,
-  Duration duration = const Duration(seconds: 3),
-  Future<void> Function(FlutterDriver driver) driverOps,
-  Future<void> Function(FlutterDriver driver) setupOps,
-}) {
+    String testName,
+    String routeName,
+    { Duration pageDelay,
+      Duration duration = const Duration(seconds: 3),
+      Duration timeout = kTimeout,
+      Future<void> Function(FlutterDriver driver) driverOps,
+      Future<void> Function(FlutterDriver driver) setupOps,
+    }) {
   test(testName, () async {
     Timeline timeline;
     await runDriverTestForRoute(routeName, (FlutterDriver driver) async {
@@ -64,5 +67,5 @@ void macroPerfTest(
 
     final TimelineSummary summary = TimelineSummary.summarize(timeline);
     await summary.writeTimelineToFile(testName, pretty: true);
-  });
+  }, timeout: Timeout(timeout));
 }

--- a/dev/benchmarks/test_apps/stocks/test_driver/stock_view_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test_driver/stock_view_test.dart
@@ -36,7 +36,8 @@ void main() {
 
       final SerializableFinder stockOption =
           find.byValueKey('AAPL_symbol_name');
-      final String symbol = await driver.getText(stockOption);
+      final String symbol = await driver.getText(stockOption,
+          timeout: const Duration(milliseconds: 500));
 
       expect(symbol, 'AAPL');
     }, skip: 'Needs to be fixed on Fuchsia.');

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -59,6 +59,7 @@ Future<void> main() async {
       await driver.tap(tapWindow);
       final String windowClickCount = await driver.getText(
         find.byValueKey('WindowClickCount'),
+        timeout: const Duration(seconds: 5),
       );
       expect(windowClickCount, 'Click count: 1');
     });

--- a/dev/integration_tests/channels/test_driver/main_test.dart
+++ b/dev/integration_tests/channels/test_driver/main_test.dart
@@ -25,7 +25,7 @@ void main() {
       if (status != 'complete') {
         fail('Failed at step $step with status $status');
       }
-    });
+    }, timeout: const Timeout(Duration(minutes: 1)));
 
     tearDownAll(() async {
       driver.close();

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e.dart
@@ -48,6 +48,7 @@ void main([List<String> args = const <String>[]]) {
           ..removeAll(kProfiledDemos);
         await runDemos(unprofiledDemos.toList(), tester);
       },
+      timeout: const Timeout(Duration(minutes: 5)),
       semanticsEnabled: withSemantics,
     );
   });

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_e2e_test.dart
@@ -5,6 +5,7 @@
 import 'package:integration_test/integration_test_driver.dart' as driver;
 
 Future<void> main() => driver.integrationDriver(
+  timeout: const Duration(minutes: 5),
   responseDataCallback: (Map<String, dynamic>? data) async {
     await driver.writeResponseData(
       data!['performance'] as Map<String, dynamic>,

--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -130,6 +130,7 @@ Future<void> runDemos(List<String> demos, FlutterDriver driver) async {
     await driver.scrollUntilVisible(demoList, demoItem,
       dyScroll: -48.0,
       alignment: 0.5,
+      timeout: const Duration(seconds: 30),
     );
 
     for (int i = 0; i < 2; i += 1) {
@@ -217,6 +218,6 @@ void main([List<String> args = const <String>[]]) {
         await runDemos(unprofiledDemos.toList(), driver);
       }
 
-    });
+    }, timeout: const Timeout(Duration(minutes: 5)));
   });
 }

--- a/dev/integration_tests/ui/test_driver/commands_none_test.dart
+++ b/dev/integration_tests/ui/test_driver/commands_none_test.dart
@@ -18,6 +18,6 @@ void main() {
 
   test('check that we are in normal mode', () async {
     expect(await driver.requestData('status'), 'log: paint');
-    await driver.waitForAbsent(find.byType('PerformanceOverlay'));
+    await driver.waitForAbsent(find.byType('PerformanceOverlay'), timeout: Duration.zero);
   });
 }

--- a/dev/integration_tests/ui/test_driver/commands_performance_overlay_test.dart
+++ b/dev/integration_tests/ui/test_driver/commands_performance_overlay_test.dart
@@ -18,6 +18,6 @@ void main() {
 
   test('check that we are showing the performance overlay', () async {
     await driver.requestData('status'); // force a reassemble
-    await driver.waitFor(find.byType('PerformanceOverlay'));
+    await driver.waitFor(find.byType('PerformanceOverlay'), timeout: Duration.zero);
   });
 }

--- a/dev/integration_tests/ui/test_driver/empty_test.dart
+++ b/dev/integration_tests/ui/test_driver/empty_test.dart
@@ -18,6 +18,6 @@ void main() {
       await driver.close();
     });
 
-    test('empty', () async {});
+    test('empty', () async {}, timeout: const Timeout(Duration(minutes: 1)));
   });
 }

--- a/dev/integration_tests/ui/test_driver/screenshot_test.dart
+++ b/dev/integration_tests/ui/test_driver/screenshot_test.dart
@@ -48,6 +48,6 @@ void main() {
 
         imageBefore = imageAfter;
       }
-    });
+    }, timeout: const Timeout(Duration(minutes: 2)));
   });
 }

--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -64,7 +64,7 @@ Future<void> writeResponseData(
 ///
 /// ```
 Future<void> integrationDriver({
-  Duration timeout = const Duration(minutes: 20),
+  Duration timeout = const Duration(minutes: 1),
   ResponseDataCallback? responseDataCallback = writeResponseData,
 }) async {
   final FlutterDriver driver = await FlutterDriver.connect();


### PR DESCRIPTION
Reverts flutter/flutter#85098

Unintentionally reduced timeouts on some tests.