### PR TITLE
Revert "Mark Linux large_image_changer_perf_android as flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -937,7 +937,6 @@ targets:
 
   - name: linux_large_image_changer_perf_android
     builder: Linux large_image_changer_perf_android
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/85078
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
Reverts flutter/flutter#85079

Timeouts that let this flake have been eliminated with https://github.com/flutter/flutter/pull/85141

Reduces severity of #85078 