### PR TITLE
[flutter_tools] convert devtools URL to a better format

### DIFF
--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -291,7 +291,6 @@ class NoOpDevtoolsHandler implements ResidentDevtoolsHandler {
 
 /// Convert a [URI] with query parameters into a display format instead
 /// of the default URI encoding.
-@visibleForTesting
 String urlToDisplayString(Uri uri) {
   final StringBuffer base = StringBuffer(uri.replace(
     queryParameters: <String, String>{},

--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -288,3 +288,21 @@ class NoOpDevtoolsHandler implements ResidentDevtoolsHandler {
     return;
   }
 }
+
+/// Convert a [URI] with query parameters into a display format instead
+/// of the default URI encoding.
+@visibleForTesting
+String urlToDisplayString(Uri uri) {
+  final StringBuffer base = StringBuffer(uri.replace(
+    queryParameters: <String, String>{},
+  ).toString());
+  String fencepost = '';
+  for (final MapEntry<String, String> entry in uri.queryParameters.entries) {
+    base.write(fencepost);
+    base.write(entry.key);
+    base.write('=');
+    base.write(entry.value);
+    fencepost = '&';
+  }
+  return base.toString();
+}

--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -296,13 +296,6 @@ String urlToDisplayString(Uri uri) {
   final StringBuffer base = StringBuffer(uri.replace(
     queryParameters: <String, String>{},
   ).toString());
-  String fencepost = '';
-  for (final MapEntry<String, String> entry in uri.queryParameters.entries) {
-    base.write(fencepost);
-    base.write(entry.key);
-    base.write('=');
-    base.write(entry.value);
-    fencepost = '&';
-  }
+  base.write(uri.queryParameters.keys.map((String key) => '$key=${uri.queryParameters[key]}').join('&'));
   return base.toString();
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1409,7 +1409,7 @@ abstract class ResidentRunner extends ResidentHandlers {
         if (uri != null) {
           globals.printStatus(
             'The Flutter DevTools debugger and profiler '
-            'on ${device.device.name} is available at: $uri',
+            'on ${device.device.name} is available at: ${urlToDisplayString(uri)}',
           );
         }
       }

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -427,6 +427,13 @@ void main() {
     expect(handler.launchDevToolsInBrowser(flutterDevices: <FlutterDevice>[]), isTrue);
     expect(handler.launchedInBrowser, isTrue);
   });
+
+  testWithoutContext('Converts a VmService URI with a query parameter to a pretty display string', () {
+    final String value = 'http://127.0.0.1:9100?uri=http%3A%2F%2F127.0.0.1%3A57922%2F_MXpzytpH20%3D%2F';
+    final Uri uri = Uri.parse(value);
+
+    expect(urlToDisplayString(uri), 'http://127.0.0.1:9100?uri=http://127.0.0.1:57922/_MXpzytpH20=/');
+  });
 }
 
 class FakeDevtoolsLauncher extends Fake implements DevtoolsLauncher {

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -429,7 +429,7 @@ void main() {
   });
 
   testWithoutContext('Converts a VmService URI with a query parameter to a pretty display string', () {
-    final String value = 'http://127.0.0.1:9100?uri=http%3A%2F%2F127.0.0.1%3A57922%2F_MXpzytpH20%3D%2F';
+    const String value = 'http://127.0.0.1:9100?uri=http%3A%2F%2F127.0.0.1%3A57922%2F_MXpzytpH20%3D%2F';
     final Uri uri = Uri.parse(value);
 
     expect(urlToDisplayString(uri), 'http://127.0.0.1:9100?uri=http://127.0.0.1:57922/_MXpzytpH20=/');


### PR DESCRIPTION
Prevents URI escaping from being run over the address in the query parameter.

https://github.com/flutter/devtools/issues/3158