### PR TITLE
[flutter_tools] well known device ids

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -195,4 +195,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
       }
     }
   }
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -191,7 +191,6 @@ Future<T> runInContext<T>(
         artifacts: globals.artifacts,
         flutterVersion: globals.flutterVersion,
         androidWorkflow: androidWorkflow,
-        config: globals.config,
         fuchsiaWorkflow: fuchsiaWorkflow,
         xcDevice: globals.xcdevice,
         userMessages: globals.userMessages,

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -767,4 +767,7 @@ class CustomDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async => const <String>[];
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -344,7 +344,7 @@ abstract class DeviceDiscovery {
   /// devices (will be an empty list if there are no issues).
   Future<List<String>> getDiagnostics() => Future<List<String>>.value(<String>[]);
 
-  /// The well-known device IDs that the discoverer can produce.
+  /// Hard-coded device IDs that the discoverer can produce.
   ///
   /// These values are used by the device discovery to determine if it can
   /// short-circuit the other detectors if a specific ID is provided. If a

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -110,29 +110,36 @@ abstract class DeviceManager {
 
     // Some discoverers have hard-coded device IDs and return quickly, and others
     // shell out to other processes and can take longer.
+    // If an ID was specified, first check if it was a "well-known" device id.
+    final Set<String> wellKnownIds = _platformDiscoverers
+      .expand((DeviceDiscovery discovery) => discovery.wellKnownIds)
+      .toSet();
+    final bool hasWellKnownId = hasSpecifiedDeviceId && wellKnownIds.contains(specifiedDeviceId);
+
     // Process discoverers as they can return results, so if an exact match is
     // found quickly, we don't wait for all the discoverers to complete.
     final List<Device> prefixMatches = <Device>[];
     final Completer<Device> exactMatchCompleter = Completer<Device>();
     final List<Future<List<Device>>> futureDevices = <Future<List<Device>>>[
       for (final DeviceDiscovery discoverer in _platformDiscoverers)
-        discoverer
-        .devices
-        .then((List<Device> devices) {
-          for (final Device device in devices) {
-            if (exactlyMatchesDeviceId(device)) {
-              exactMatchCompleter.complete(device);
-              return null;
+        if (!hasWellKnownId || discoverer.wellKnownIds.contains(specifiedDeviceId))
+          discoverer
+          .devices
+          .then((List<Device> devices) {
+            for (final Device device in devices) {
+              if (exactlyMatchesDeviceId(device)) {
+                exactMatchCompleter.complete(device);
+                return null;
+              }
+              if (startsWithDeviceId(device)) {
+                prefixMatches.add(device);
+              }
             }
-            if (startsWithDeviceId(device)) {
-              prefixMatches.add(device);
-            }
-          }
-          return null;
-        }, onError: (dynamic error, StackTrace stackTrace) {
-          // Return matches from other discoverers even if one fails.
-          _logger.printTrace('Ignored error discovering $deviceId: $error');
-        })
+            return null;
+          }, onError: (dynamic error, StackTrace stackTrace) {
+            // Return matches from other discoverers even if one fails.
+            _logger.printTrace('Ignored error discovering $deviceId: $error');
+          })
     ];
 
     // Wait for an exact match, or for all discoverers to return results.
@@ -336,6 +343,15 @@ abstract class DeviceDiscovery {
   /// Gets a list of diagnostic messages pertaining to issues with any connected
   /// devices (will be an empty list if there are no issues).
   Future<List<String>> getDiagnostics() => Future<List<String>>.value(<String>[]);
+
+  /// The well-known device IDs that the discoverer can produce.
+  ///
+  /// These values are used by the device discovery to determine if it can
+  /// short-circuit the other detectors if a specific ID is provided. If a
+  /// discoverer has no valid fixed IDs, these should be left empty.
+  ///
+  /// For example, 'windows' or 'linux'.
+  List<String> get wellKnownIds;
 }
 
 /// A [DeviceDiscovery] implementation that uses polling to discover device adds

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -11,7 +11,6 @@ import 'android/android_device_discovery.dart';
 import 'android/android_sdk.dart';
 import 'android/android_workflow.dart';
 import 'artifacts.dart';
-import 'base/config.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/os.dart';
@@ -55,7 +54,6 @@ class FlutterDeviceManager extends DeviceManager {
     @required IOSWorkflow iosWorkflow,
     @required FuchsiaWorkflow fuchsiaWorkflow,
     @required FlutterVersion flutterVersion,
-    @required Config config,
     @required Artifacts artifacts,
     @required MacOSWorkflow macOSWorkflow,
     @required UserMessages userMessages,
@@ -93,7 +91,6 @@ class FlutterDeviceManager extends DeviceManager {
       fileSystem: fileSystem,
       flutterVersion: flutterVersion,
       processManager: processManager,
-      config: config,
       logger: logger,
       artifacts: artifacts,
       operatingSystemUtils: operatingSystemUtils,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -231,6 +231,9 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
     }
     return FuchsiaDevice(resolvedHost, name: name);
   }
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }
 
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -133,6 +133,9 @@ class IOSDevices extends PollingDeviceDiscovery {
 
     return _xcdevice.getDiagnostics();
   }
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }
 
 enum IOSDeviceInterface {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -48,6 +48,9 @@ class IOSSimulators extends PollingDeviceDiscovery {
 
   @override
   Future<List<Device>> pollingGetDevices({ Duration timeout }) async => _iosSimulatorUtils.getAttachedDevices();
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }
 
 class IOSSimulatorUtils {

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -135,4 +135,7 @@ class LinuxDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async => const <String>[];
+
+  @override
+  List<String> get wellKnownIds => const <String>['linux'];
 }

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -148,4 +148,7 @@ class MacOSDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async => const <String>[];
+
+  @override
+  List<String> get wellKnownIds => const <String>['macos'];
 }

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -146,5 +146,5 @@ class MacOSDesignedForIPadDevices extends PollingDeviceDiscovery {
   Future<List<String>> getDiagnostics() async => const <String>[];
 
   @override
-  List<String> get wellKnownIds => const <String>[];
+  List<String> get wellKnownIds => const <String>['designed-for-ipad'];
 }

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -144,4 +144,7 @@ class MacOSDesignedForIPadDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async => const <String>[];
+
+  @override
+  List<String> get wellKnownIds => const <String>[];
 }

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -11,7 +11,6 @@ import 'package:process/process.dart';
 
 import '../application_package.dart';
 import '../artifacts.dart';
-import '../base/config.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -268,9 +267,6 @@ class FlutterTesterDevices extends PollingDeviceDiscovery {
     @required ProcessManager processManager,
     @required Logger logger,
     @required FlutterVersion flutterVersion,
-    // TODO(jonahwilliams): remove after flutter rolls
-    // ignore: avoid_unused_constructor_parameters
-    Config config,
     @required OperatingSystemUtils operatingSystemUtils,
   }) : _testerDevice = FlutterTesterDevice(
         kTesterDeviceId,
@@ -299,4 +295,7 @@ class FlutterTesterDevices extends PollingDeviceDiscovery {
   Future<List<Device>> pollingGetDevices({ Duration timeout }) async {
     return showFlutterTesterDevice ? <Device>[_testerDevice] : <Device>[];
   }
+
+  @override
+  List<String> get wellKnownIds => const <String>[kTesterDeviceId];
 }

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -362,6 +362,9 @@ class WebDevices extends PollingDeviceDiscovery {
 
   @override
   bool get supportsPlatform =>  _featureFlags.isWebEnabled;
+
+  @override
+  List<String> get wellKnownIds => const <String>['chrome', 'web-server', 'edge'];
 }
 
 @visibleForTesting

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -454,4 +454,7 @@ class WindowsDevices extends PollingDeviceDiscovery {
 
   @override
   Future<List<String>> getDiagnostics() async => const <String>[];
+
+  @override
+  List<String> get wellKnownIds => const <String>['windows', 'winuwp'];
 }

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -96,6 +96,17 @@ void main() {
     ).devices, hasLength(1));
   });
 
+  testWithoutContext('LinuxDevice has well known id "linux"', () async {
+    expect(LinuxDevices(
+      fileSystem: MemoryFileSystem.test(),
+      platform: linux,
+      featureFlags: TestFeatureFlags(isLinuxEnabled: true),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.any(),
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+    ).wellKnownIds, <String>['linux']);
+  });
+
   testWithoutContext('LinuxDevice: discoverDevices', () async {
     // Timeout ignored.
     final List<Device> devices = await LinuxDevices(

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -132,6 +132,22 @@ void main() {
     expect(await macOSDevices.devices, hasLength(1));
   });
 
+  testWithoutContext('has a well known device id macos', () async {
+    final MacOSDevices macOSDevices = MacOSDevices(
+      fileSystem: MemoryFileSystem.test(),
+      processManager: FakeProcessManager.any(),
+      logger: BufferLogger.test(),
+      platform: macOS,
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+      macOSWorkflow: MacOSWorkflow(
+        featureFlags: TestFeatureFlags(isMacOSEnabled: true),
+        platform: macOS,
+      ),
+    );
+
+    expect(macOSDevices.wellKnownIds, <String>['macos']);
+  });
+
   testWithoutContext('can discover devices with a provided timeout', () async {
     final MacOSDevices macOSDevices = MacOSDevices(
       fileSystem: MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -181,7 +180,6 @@ FlutterTesterDevices setUpFlutterTesterDevices() {
     artifacts: Artifacts.test(),
     processManager: FakeProcessManager.any(),
     fileSystem: MemoryFileSystem.test(),
-    config: Config.test(),
     flutterVersion: FakeFlutterVersion(),
     operatingSystemUtils: FakeOperatingSystemUtils(),
   );

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -124,6 +124,21 @@ void main() {
       contains(isA<GoogleChromeDevice>()));
   });
 
+  testWithoutContext('Has well known device ids chrome, edge, and web-server', () async {
+    final WebDevices webDevices = WebDevices(
+      featureFlags: TestFeatureFlags(isWebEnabled: true),
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      platform: FakePlatform(
+        operatingSystem: 'linux',
+        environment: <String, String>{}
+      ),
+      processManager:  FakeProcessManager.any(),
+    );
+
+    expect(webDevices.wellKnownIds, <String>['chrome', 'web-server', 'edge']);
+  });
+
   testWithoutContext('Chrome device is not listed when Chrome cannot be run', () async {
     final FakeProcessManager processManager = FakeProcessManager.empty();
     processManager.excludedExecutables = <String>{kLinuxExecutable};

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -116,6 +116,22 @@ void main() {
     ).devices, hasLength(2));
   });
 
+  testWithoutContext('WindowsDevices has windows and winuwp well known devices', () async {
+    final FeatureFlags featureFlags = TestFeatureFlags(isWindowsEnabled: true, isWindowsUwpEnabled: true);
+    expect(WindowsDevices(
+      windowsWorkflow: WindowsWorkflow(
+        featureFlags: featureFlags,
+        platform: FakePlatform(operatingSystem: 'windows')
+      ),
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+      logger: BufferLogger.test(),
+      processManager: FakeProcessManager.any(),
+      fileSystem: MemoryFileSystem.test(),
+      featureFlags: featureFlags,
+      uwptool: FakeUwpTool(),
+    ).wellKnownIds, <String>['windows', 'winuwp']);
+  });
+
   testWithoutContext('WindowsDevices ignores the timeout provided to discoverDevices', () async {
     final WindowsDevices windowsDevices = WindowsDevices(
       windowsWorkflow: WindowsWorkflow(

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -175,6 +175,9 @@ class FakePollingDeviceDiscovery extends PollingDeviceDiscovery {
 
   @override
   Stream<Device> get onRemoved => _onRemovedController.stream;
+
+  @override
+  List<String> wellKnownIds = <String>[];
 }
 
 /// A fake implementation of the [DeviceLogReader].


### PR DESCRIPTION
Currently the flutter tool will always run all device discovery code, even if the id provided corresponds to a "well-known" device such as "chrome" or "windows". While the device discovery is stopped as soon as a device is identified, this still leaves room for extra logs and the potential for errors in device discovery to leak out.

Instead, allow each device discoverer to declare a list of identifiers that are treated as "well known". Then, if the device discovery was provided a specific id and that id is contained in the set, only run discovery once.

This does not apply in the reverse direction; since there is almost no cost to device discovery for the "well known" devices, skipping it when a not well known identifier is provided does not buy much.

Fixes https://github.com/flutter/flutter/issues/83115