### PR TITLE
Remove incorrect text about web renderer default

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -167,7 +167,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         defaultsTo: 'tester',
         help: 'Selects the test backend.',
         allowedHelp: <String, String>{
-          'tester': 'Run tests using the default VM-based test environment.',
+          'tester': 'Run tests using the VM-based test environment.',
           'chrome': '(deprecated) Run tests using the Google Chrome web browser. '
                     'This value is intended for testing the Flutter framework '
                     'itself and may be removed at any time.',

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -563,7 +563,7 @@ abstract class FlutterCommand extends Command<void> {
       allowed: <String>['auto', 'canvaskit', 'html'],
       help: 'The renderer implementation to use when building for the web.',
       allowedHelp: <String, String>{
-        'html': 'Always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL. This is the default.',
+        'html': 'Always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL.',
         'canvaskit': 'Always use the CanvasKit renderer. This renderer uses WebGL and WebAssembly to render graphics.',
         'auto': 'Use the HTML renderer on mobile devices, and CanvasKit on desktop devices.',
       }

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -86,6 +86,16 @@ void verifyOptions(String command, Iterable<Option> options) {
     expect(option.help, isNot(matches(_questionablePatterns)), reason: '${_header}Help for $target--${option.name}" may have a typo. (If it does not you may have to update args_test.dart, sorry. Search for "_questionablePatterns")');
     if (option.defaultsTo != null) {
       expect(option.help, isNot(contains('Default')), reason: '${_header}Help for $target--${option.name}" mentions the default value but that is redundant with the defaultsTo option which is also specified (and preferred).');
+
+      if (option.allowedHelp != null) {
+        for (final String allowedValue in option.allowedHelp.keys) {
+          expect(
+            option.allowedHelp[allowedValue],
+            isNot(anyOf(contains('default'), contains('Default'))),
+            reason: '${_header}Help for $target--${option.name} $allowedValue" mentions the default value but that is redundant with the defaultsTo option which is also specified (and preferred).',
+          );
+        }
+      }
     }
     expect(option.help, isNot(matches(_bannedArgumentReferencePatterns)), reason: '${_header}Help for $target--${option.name}" contains the string "--" in an unexpected way. If it\'s trying to mention another argument, it should be quoted, as in "--foo".');
     for (final String line in option.help.split('\n')) {

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
-import 'package:args/src/option.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/error_handling_io.dart';
@@ -49,69 +48,10 @@ void main() {
       Cache.enableLocking();
     });
 
-    group('help text', () {
-      testUsingContext('contains global options', () {
-        final FakeDeprecatedCommand fake = FakeDeprecatedCommand();
-        createTestCommandRunner(fake);
-        expect(fake.usage, contains('Global options:\n'));
-      });
-
-      testUsingContext('options do not mention defaults in descriptive texts', () async {
-        /// Helper to check options for any flags added by [addFlags].
-        ///
-        /// All flags can't be added to the same flutterCommand as many of the
-        /// addFoo/useFoo methods overlap and throw if called together.
-        void check(void Function(FlutterCommand) addFlags) {
-          final DummyFlutterCommand flutterCommand = DummyFlutterCommand();
-          addFlags(flutterCommand);
-          for (final Option option in flutterCommand.argParser.options.values) {
-            // option.help is not checked as some options legitimately contain
-            // the word default (for example Gradle daemon).
-            expect(option.valueHelp, isNot(contains('default')));
-            if (option.allowedHelp != null) {
-              for (final String allowedValueHelp in option.allowedHelp.values) {
-                expect(allowedValueHelp, isNot(contains('default')));
-              }
-            }
-          }
-        }
-
-        // For convenience, all addFoo and useFoo methods are tested. Those that
-        // do not have help text for options are skipped in the [check] method.
-        check((FlutterCommand command) => command.addAndroidSpecificBuildOptions());
-        check((FlutterCommand command) => command.addBuildModeFlags(verboseHelp: true));
-        check((FlutterCommand command) => command.addBuildPerformanceFile());
-        check((FlutterCommand command) => command.addBundleSkSLPathOption(hide: false));
-        check((FlutterCommand command) => command.addCommonDesktopBuildOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.addDartObfuscationOption());
-        check((FlutterCommand command) => command.addDdsOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.addDevToolsOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.addEnableExperimentation(hide: false));
-        check((FlutterCommand command) => command.addNativeNullAssertions());
-        check((FlutterCommand command) => command.addNullSafetyModeOptions(hide: false));
-        check((FlutterCommand command) => command.addPublishPort());
-        check((FlutterCommand command) => command.addShrinkingFlag(verboseHelp: true));
-        check((FlutterCommand command) => command.addSplitDebugInfoOption());
-        check((FlutterCommand command) => command.addTreeShakeIconsFlag());
-        check((FlutterCommand command) => command.usesAnalyzeSizeFlag());
-        check((FlutterCommand command) => command.usesBuildNameOption());
-        check((FlutterCommand command) => command.usesBuildNumberOption());
-        check((FlutterCommand command) => command.usesDartDefineOption());
-        check((FlutterCommand command) => command.usesDeviceTimeoutOption());
-        check((FlutterCommand command) => command.usesDeviceUserOption());
-        check((FlutterCommand command) => command.usesExtraDartFlagOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.usesFilesystemOptions(hide: false));
-        check((FlutterCommand command) => command.usesFlavorOption());
-        check((FlutterCommand command) => command.usesFuchsiaOptions());
-        check((FlutterCommand command) => command.usesInitializeFromDillOption(hide: false));
-        check((FlutterCommand command) => command.usesIpv6Flag(verboseHelp: true));
-        check((FlutterCommand command) => command.usesPortOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.usesPubOption());
-        check((FlutterCommand command) => command.usesTargetOption());
-        check((FlutterCommand command) => command.usesTrackWidgetCreation(verboseHelp: true));
-        check((FlutterCommand command) => command.usesWebOptions(verboseHelp: true));
-        check((FlutterCommand command) => command.usesWebRendererOption());
-      });
+    testUsingContext('help text contains global options', () {
+      final FakeDeprecatedCommand fake = FakeDeprecatedCommand();
+      createTestCommandRunner(fake);
+      expect(fake.usage, contains('Global options:\n'));
     });
 
     testUsingContext('honors shouldUpdateCache false', () async {


### PR DESCRIPTION
The output of `flutter run --help` currently includes this:

```
    --web-renderer                                The renderer implementation to use when building for the web.

          [auto] (default)                        Use the HTML renderer on mobile devices, and CanvasKit on desktop devices.
          [canvaskit]                             Always use the CanvasKit renderer. This renderer uses WebGL and WebAssembly to render graphics.
          [html]                                  Always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL. This
                                                  is the default.
```

It says `default` next to `auto` but also `"This is the default"` on `html`.

It appears that `auto` is the real default (see line 562), and it seems superfluous to include this also in the description (especially if it can get out of sync like this).