### PR TITLE
move autofocus process to postFrame phase

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'focus_manager.dart';
@@ -614,8 +615,13 @@ class _FocusState extends State<Focus> {
 
   void _handleAutofocus() {
     if (!_didAutofocus && widget.autofocus) {
-      FocusScope.of(context).autofocus(focusNode);
       _didAutofocus = true;
+      // Waiting for inactive nodes to be disposed.
+      SchedulerBinding.instance!.addPostFrameCallback((_) {
+        if (mounted) {
+          FocusScope.of(context).autofocus(focusNode);
+        }
+      });
     }
   }
 

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -148,6 +148,28 @@ void main() {
       expect(find.text('B FOCUSED'), findsOneWidget);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/84845
+    testWidgets('autofocus test - previously focused child is about to unmount.', (WidgetTester tester) async {
+      final FocusNode focusNodeA = FocusNode(debugLabel: 'Test Node A');
+      final FocusNode focusNodeB = FocusNode(debugLabel: 'Test Node B');
+      final Widget autofocusA = Focus(
+        focusNode: focusNodeA,
+        autofocus: true,
+        child: const Placeholder(),
+      );
+
+      final Widget autofocusB = Focus(
+        focusNode: focusNodeB,
+        autofocus: true,
+        child: const Placeholder(),
+      );
+
+      await tester.pumpWidget(FocusScope(child: autofocusA));
+      expect(focusNodeA.hasFocus, true);
+      await tester.pumpWidget(FocusScope(child: SizedBox(child: autofocusB)));
+      expect(focusNodeB.hasFocus, true);
+    });
+
     testWidgets('Can have multiple focused children and they update accordingly', (WidgetTester tester) async {
       final GlobalKey<TestFocusState> keyA = GlobalKey();
       final GlobalKey<TestFocusState> keyB = GlobalKey();


### PR DESCRIPTION
Fixes #84845 

There is a similar logic in  https://github.com/flutter/flutter/blob/64401fb8dfce47bb0b31f9d513adb10a61c5451c/packages/flutter/lib/src/widgets/editable_text.dart#L1610