### PR TITLE
Add dart fix for AndroidViewController.id

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,6 +15,28 @@
 version: 1
 transforms:
 
+  # Changes made in https://github.com/flutter/flutter/pull/60320
+  - title: "Migrate to 'viewId'"
+    date: 2020-07-05
+    element:
+      uris: [ 'services.dart' ]
+      getter: id
+      inClass: 'TextureAndroidViewController'
+    changes:
+      - kind: 'rename'
+        newName: 'viewId'
+
+  # Changes made in https://github.com/flutter/flutter/pull/60320
+  - title: "Migrate to 'viewId'"
+    date: 2020-07-05
+    element:
+      uris: [ 'services.dart' ]
+      getter: id
+      inClass: 'SurfaceAndroidViewController'
+    changes:
+      - kind: 'rename'
+        newName: 'viewId'
+
   # Changes made in https://github.com/flutter/flutter/pull/81858
   - title: "Migrate to 'supportedDevices'"
     date: 2021-05-04

--- a/packages/flutter/test_fixes/services.dart
+++ b/packages/flutter/test_fixes/services.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/60320
+  final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
+      viewId: 10,
+      viewType: 'FixTester',
+      layoutDirection: TextDirection.ltr,
+  );
+  int viewId = surfaceController.id;
+  final TextureAndroidViewController textureController = TextureAndroidViewController(
+    viewId: 10,
+    viewType: 'FixTester',
+    layoutDirection: TextDirection.ltr,
+  );
+  viewId = textureController.id;
+}

--- a/packages/flutter/test_fixes/services.dart.expect
+++ b/packages/flutter/test_fixes/services.dart.expect
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/60320
+  final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
+      viewId: 10,
+      viewType: 'FixTester',
+      layoutDirection: TextDirection.ltr,
+  );
+  int viewId = surfaceController.viewId;
+  final TextureAndroidViewController textureController = TextureAndroidViewController(
+    viewId: 10,
+    viewType: 'FixTester',
+    layoutDirection: TextDirection.ltr,
+  );
+  viewId = textureController.viewId;
+}


### PR DESCRIPTION
This adds a dart/flutter fix for the deprecated AndroidViewController.id. This affects the implementing classes of `SurfaceAndroidViewController` and `TextureAndroidViewController`.

Deprecated in https://github.com/flutter/flutter/pull/60320

Part of https://github.com/flutter/flutter/issues/74908

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
