### PR TITLE
[devicelab] Remove hot reload benchmark file iff it exists

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -33,7 +33,9 @@ TaskFunction createHotModeTest({String deviceIdOverride, Map<String, String> env
       deviceIdOverride = device.deviceId;
     }
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
-    rm(benchmarkFile);
+    if (benchmarkFile.existsSync()) {
+      rm(benchmarkFile);
+    }
     final List<String> options = <String>[
       '--hot', '-d', deviceIdOverride, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--no-publish-port', '--verbose',
     ];


### PR DESCRIPTION
We're seeing this fail on Dart HHH runs - https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8843541475255812785/+/u/run_hot_mode_dev_cycle_linux__benchmark/stderr. Not sure if we're missing something, but my assumption this is safe to ignore if it doesn't exist.

https://github.com/flutter/flutter/issues/85249

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

