### PR TITLE
[flutter_tools] ensure kernel paths match between init from dill and persist

### DIFF
--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -33,7 +33,7 @@ String getDefaultCachedKernelPath({
 }) {
   final StringBuffer buffer = StringBuffer();
    final List<String> cacheFrontEndOptions = extraFrontEndOptions.toList()
-    ..removeWhere((String arg) => arg.startsWith('--enable-experiment=') || arg == '--flutter-widget-cache');
+     ..removeWhere((String arg) => arg.startsWith('--enable-experiment=') || arg == '--flutter-widget-cache');
   buffer.writeAll(dartDefines);
   buffer.writeAll(cacheFrontEndOptions);
   String buildPrefix = '';

--- a/packages/flutter_tools/lib/src/bundle.dart
+++ b/packages/flutter_tools/lib/src/bundle.dart
@@ -32,8 +32,10 @@ String getDefaultCachedKernelPath({
   Config? config,
 }) {
   final StringBuffer buffer = StringBuffer();
+   final List<String> cacheFrontEndOptions = extraFrontEndOptions.toList()
+    ..removeWhere((String arg) => arg.startsWith('--enable-experiment=') || arg == '--flutter-widget-cache');
   buffer.writeAll(dartDefines);
-  buffer.writeAll(extraFrontEndOptions);
+  buffer.writeAll(cacheFrontEndOptions);
   String buildPrefix = '';
   if (buffer.isNotEmpty) {
     final String output = buffer.toString();

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -5,9 +5,11 @@
 // @dart = 2.8
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/bundle_builder.dart';
 import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
@@ -116,5 +118,42 @@ void main() {
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testWithoutContext('--flutter-widget-cache and --enable-experiment are removed from getDefaultCachedKernelPath hash', () {
+    final FileSystem fileSystem = MemoryFileSystem.test();
+    final Config config = Config.test();
+
+    expect(getDefaultCachedKernelPath(
+      trackWidgetCreation: true,
+      dartDefines: <String>[],
+      extraFrontEndOptions: <String>['--enable-experiment=foo', '--flutter-widget-cache'],
+      fileSystem: fileSystem,
+      config: config,
+    ), 'build/cache.dill.track.dill');
+
+    expect(getDefaultCachedKernelPath(
+      trackWidgetCreation: true,
+      dartDefines: <String>['foo=bar'],
+      extraFrontEndOptions: <String>['--enable-experiment=foo', '--flutter-widget-cache'],
+      fileSystem: fileSystem,
+      config: config,
+    ), 'build/06ad47d8e64bd28de537b62ff85357c4.cache.dill.track.dill');
+
+    expect(getDefaultCachedKernelPath(
+      trackWidgetCreation: false,
+      dartDefines: <String>[],
+      extraFrontEndOptions: <String>['--enable-experiment=foo', '--flutter-widget-cache'],
+      fileSystem: fileSystem,
+      config: config,
+    ), 'build/cache.dill');
+
+    expect(getDefaultCachedKernelPath(
+      trackWidgetCreation: true,
+      dartDefines: <String>[],
+      extraFrontEndOptions: <String>['--enable-experiment=foo', '--flutter-widget-cache', '--foo=bar'],
+      fileSystem: fileSystem,
+      config: config,
+    ), 'build/95b595cca01caa5f0ca0a690339dd7f6.cache.dill.track.dill');
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1555,7 +1555,7 @@ void main() {
           BuildMode.debug,
           '',
           treeShakeIcons: false,
-          extraFrontEndOptions: <String>['--enable-experiment=non-nullable>']
+          extraFrontEndOptions: <String>['--enable-experiment=non-nullable']
         )
       ),
       target: 'main.dart',
@@ -1566,7 +1566,7 @@ void main() {
     await residentRunner.run(enableDevTools: true);
 
     expect(await globals.fs.file(globals.fs.path.join(
-      'build', '3416d3007730479552122f01c01e326d.cache.dill')).readAsString(), 'ABC');
+      'build', 'cache.dill')).readAsString(), 'ABC');
   }));
 
   testUsingContext('HotRunner does not copy app.dill if a dillOutputPath is given', () => testbed.run(() async {
@@ -1735,7 +1735,7 @@ void main() {
     )).generator as DefaultResidentCompiler;
 
     expect(residentCompiler.initializeFromDill,
-      globals.fs.path.join(getBuildDirectory(), '825b8f791aa86c5057fff6f064542c54.cache.dill'));
+      globals.fs.path.join(getBuildDirectory(), '80b1a4cf4e7b90e1ab5f72022a0bc624.cache.dill'));
     expect(residentCompiler.librariesSpec,
       globals.fs.file(globals.artifacts.getHostArtifact(HostArtifact.flutterWebLibrariesJson))
         .uri.toString());


### PR DESCRIPTION
The usage of --flutter-widget-cache only in the initialize from dill argument would cause the dill caching to get out of sync. Filter out experiments and the widget cache option when computing the location for the dill cache file - as these do not affect the dill contents.