### PR TITLE
Check ios-arm64_x86_64-simulator directory when validating codesigning entitlement

### DIFF
--- a/dev/conductor/lib/codesign.dart
+++ b/dev/conductor/lib/codesign.dart
@@ -180,11 +180,11 @@ class CodesignCommand extends Command<void> {
       'artifacts/engine/darwin-x64/FlutterMacOS.framework/Versions/A/FlutterMacOS',
       'artifacts/engine/darwin-x64/font-subset',
       'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64_armv7/Flutter.framework/Flutter',
-      'artifacts/engine/ios-profile/Flutter.xcframework/ios-x86_64-simulator/Flutter.framework/Flutter',
+      'artifacts/engine/ios-profile/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_armv7/Flutter.framework/Flutter',
-      'artifacts/engine/ios-release/Flutter.xcframework/ios-x86_64-simulator/Flutter.framework/Flutter',
+      'artifacts/engine/ios-release/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'artifacts/engine/ios/Flutter.xcframework/ios-arm64_armv7/Flutter.framework/Flutter',
-      'artifacts/engine/ios/Flutter.xcframework/ios-x86_64-simulator/Flutter.framework/Flutter',
+      'artifacts/engine/ios/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'artifacts/ios-deploy/ios-deploy',
     ]
         .map((String relativePath) =>

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -84,7 +84,7 @@ void main() {
 
       fileSystem
           .directory(xcframeworkPath)
-          .childDirectory('ios-x86_64-simulator')
+          .childDirectory('ios-arm64_x86_64-simulator')
           .childDirectory('Flutter.framework')
           .createSync(recursive: true);
       fileSystem
@@ -98,7 +98,7 @@ void main() {
             mode: BuildMode.release,
             environmentType: EnvironmentType.simulator),
         fileSystem.path
-            .join(xcframeworkPath, 'ios-x86_64-simulator', 'Flutter.framework'),
+            .join(xcframeworkPath, 'ios-arm64_x86_64-simulator', 'Flutter.framework'),
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterFramework,
@@ -249,7 +249,7 @@ void main() {
 
       fileSystem
           .directory(xcframeworkPath)
-          .childDirectory('ios-x86_64-simulator')
+          .childDirectory('ios-arm64_x86_64-simulator')
           .childDirectory('Flutter.framework')
           .createSync(recursive: true);
       fileSystem
@@ -265,7 +265,7 @@ void main() {
           environmentType: EnvironmentType.simulator,
         ),
         fileSystem.path
-            .join(xcframeworkPath, 'ios-x86_64-simulator', 'Flutter.framework'),
+            .join(xcframeworkPath, 'ios-arm64_x86_64-simulator', 'Flutter.framework'),
       );
       expect(
         artifacts.getArtifactPath(


### PR DESCRIPTION
The engine Flutter frameworks are now building for arm64 iOS simulator as of recipe change https://flutter-review.googlesource.com/c/recipes/+/14780.  Change the codesigning script to match the new path names.

See https://github.com/flutter/flutter/pull/85053 for similar fix.