### PR TITLE
Make sure that the asset directory on devfs always exist.

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -480,6 +480,8 @@ class DevFS {
   final Directory rootDirectory;
   final Set<String> assetPathsToEvict = <String>{};
 
+  static const String kAssetDirectoryPlaceholderFilename = '.__dummy_flutter_asset';
+
   List<Uri> sources = <Uri>[];
   DateTime lastCompiled;
   DateTime _previousCompiled;
@@ -635,7 +637,7 @@ class DevFS {
       // When the bundle is first uploaded, include a dummy file to make sure
       // that the assets directory on DevFS is created.
       if (bundleFirstUpload) {
-        final Uri deviceUri = _fileSystem.path.toUri(_fileSystem.path.join(assetDirectory, '.__dummy_flutter_asset'));
+        final Uri deviceUri = _fileSystem.path.toUri(_fileSystem.path.join(assetDirectory, kAssetDirectoryPlaceholderFilename));
         dirtyEntries[deviceUri] = DevFSByteContent(<int>[]);
       }
     }

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -631,6 +631,13 @@ class DevFS {
           assetPathsToEvict.add(archivePath);
         }
       });
+
+      // When the bundle is first uploaded, include a dummy file to make sure
+      // that the assets directory on DevFS is created.
+      if (bundleFirstUpload) {
+        final Uri deviceUri = _fileSystem.path.toUri(_fileSystem.path.join(assetDirectory, '.__dummy_flutter_asset'));
+        dirtyEntries[deviceUri] = DevFSByteContent(<int>[]);
+      }
     }
     final CompilerOutput compilerOutput = await pendingCompilerOutput;
     if (compilerOutput == null || compilerOutput.errorCount > 0) {

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -428,7 +429,6 @@ void main() {
 
   testWithoutContext('DevFS correctly records the elapsed time', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
-    // final FakeDevFSWriter writer = FakeDevFSWriter();
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[createDevFSRequest],
       httpAddress: Uri.parse('http://localhost'),
@@ -470,6 +470,115 @@ void main() {
     expect(report.compileDuration, const Duration(seconds: 3));
     expect(report.transferDuration, const Duration(seconds: 5));
   });
+
+  group('DevFS with AssetBundle', () {
+    FileSystem fileSystem;
+    FakeDevFSWriter writer;
+    DevFS devFS;
+    FakeResidentCompiler residentCompiler;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem.test();
+      writer = FakeDevFSWriter();
+      final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+        requests: <VmServiceExpectation>[createDevFSRequest],
+      );
+
+      devFS = DevFS(
+        fakeVmServiceHost.vmService,
+        'test',
+        fileSystem.currentDirectory,
+        fileSystem: fileSystem,
+        logger: BufferLogger.test(),
+        osUtils: FakeOperatingSystemUtils(),
+        httpClient: FakeHttpClient.any(),
+      );
+
+      residentCompiler = FakeResidentCompiler()
+        ..onRecompile = (Uri mainUri, List<Uri> invalidatedFiles) async {
+          fileSystem.file('example').createSync();
+          return const CompilerOutput('lib/foo.txt.dill', 0, <Uri>[]);
+        };
+    });
+
+    testUsingContext('skip uploading assets when bundleFirstUpload', () async {
+      final FakeAssetBundle fakeAssetBundle = FakeAssetBundle(<String, DevFSContent>{
+        'assets/modified.png': FakeDevFSByteContent(
+          bytes: <int>[0],
+          isModified: true,
+        ),
+        'assets/not_modified.png': FakeDevFSByteContent(
+          bytes: <int>[0],
+          isModified: false,
+        ),
+      });
+
+      await devFS.create();
+
+      expect(writer.written, false);
+
+      final UpdateFSReport report = await devFS.update(
+        mainUri: Uri.parse('lib/main.dart'),
+        generator: residentCompiler,
+        dillOutputPath: 'lib/foo.dill',
+        pathToReload: 'lib/foo.txt.dill',
+        trackWidgetCreation: false,
+        invalidatedFiles: <Uri>[],
+        packageConfig: PackageConfig.empty,
+        devFSWriter: writer,
+        bundle: fakeAssetBundle,
+        bundleFirstUpload: true,
+      );
+
+      expect(report.success, true);
+      expect(writer.written, true);
+      expect(writer.lastWrittenEntries.keys, <Uri>[
+        Uri.parse('build/flutter_assets/.__dummy_flutter_asset'),
+      ]);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+
+    testUsingContext('uploads updated assets when bundleFirstUpload', () async {
+      final FakeAssetBundle fakeAssetBundle = FakeAssetBundle(<String, DevFSContent>{
+        'assets/modified.png': FakeDevFSByteContent(
+          bytes: <int>[0],
+          isModified: true,
+        ),
+        'assets/not_modified.png': FakeDevFSByteContent(
+          bytes: <int>[0],
+          isModified: false,
+        ),
+      });
+      await devFS.create();
+
+      expect(writer.written, false);
+
+      final UpdateFSReport report = await devFS.update(
+        mainUri: Uri.parse('lib/main.dart'),
+        generator: residentCompiler,
+        dillOutputPath: 'lib/foo.dill',
+        pathToReload: 'lib/foo.txt.dill',
+        trackWidgetCreation: false,
+        invalidatedFiles: <Uri>[],
+        packageConfig: PackageConfig.empty,
+        devFSWriter: writer,
+        bundle: fakeAssetBundle,
+        bundleFirstUpload: false,
+      );
+
+      expect(report.success, true);
+      expect(writer.written, true);
+      expect(writer.lastWrittenEntries.keys, <Uri>[
+        Uri.parse('build/flutter_assets/assets/modified.png'),
+        Uri.parse('lib/foo.txt.dill'),
+      ]);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
 }
 
 class FakeResidentCompiler extends Fake implements ResidentCompiler {
@@ -484,9 +593,34 @@ class FakeResidentCompiler extends Fake implements ResidentCompiler {
 
 class FakeDevFSWriter implements DevFSWriter {
   bool written = false;
+  Map<Uri, DevFSContent> lastWrittenEntries;
 
   @override
   Future<void> write(Map<Uri, DevFSContent> entries, Uri baseUri, DevFSWriter parent) async {
     written = true;
+    lastWrittenEntries = entries;
   }
+}
+
+class FakeAssetBundle extends Fake implements AssetBundle {
+  FakeAssetBundle(this.entries);
+
+  @override
+  Map<String, DevFSContent> entries;
+}
+
+class FakeDevFSByteContent extends Fake implements DevFSByteContent {
+  FakeDevFSByteContent({
+    this.bytes,
+    this.isModified,
+  });
+
+  @override
+  List<int> bytes;
+
+  @override
+  bool isModified;
+
+  @override
+  int get size => bytes.length;
 }

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -533,7 +533,7 @@ void main() {
       expect(report.success, true);
       expect(writer.written, true);
       expect(writer.lastWrittenEntries.keys, <Uri>[
-        Uri.parse('build/flutter_assets/.__dummy_flutter_asset'),
+        Uri.parse('build/flutter_assets/${DevFS.kAssetDirectoryPlaceholderFilename}'),
       ]);
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,


### PR DESCRIPTION
Fixes the problem where hot reloading assets only works after a hot
restart.

When the bundle is being uploaded for the first time, the files in the
assets are all skipped, therefore the assets directory are not created
on DevFS. Then flutter_tools calls `setAssetDirectory` on the vm
service, which failed because the directory doesn't exist, and the
`DirectoryAssetBundle` is not valid. So asset_manager only has one
resolver, which is the `ApkAssetProvider` on Android, and never sees
updated asset files.

The problem is only corrected after a hot restart.

This PR fixes this issue by uploading a dummy file on firstBundleUpload
to make sure that the directory is properly created.

---

I can't find any github issues describing this, so here's the repro steps:

1. Launch an app with asset
2. Replace the asset file with a new image, then hot reload.
3. The image on screen should be updated, but isn't.
4. Then hot restart, and the image is updated.
5. Update the image again and hot reload. Now the image on screen is correctly updated.