### PR TITLE
[flutter_tools] dont use SETLOCAL ENABLEDELAYEDEXPANSION unnecessarily

### DIFF
--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -11,8 +11,6 @@ REM work across all platforms!
 REM
 REM --------------------------------------------------------------------------
 
-SETLOCAL ENABLEDELAYEDEXPANSION
-
 FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 
 REM Include shared scripts in shared.bat

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -11,8 +11,6 @@ REM work across all platforms!
 REM
 REM --------------------------------------------------------------------------
 
-SETLOCAL ENABLEDELAYEDEXPANSION
-
 FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 
 REM If available, add location of bundled mingit to PATH

--- a/packages/flutter_tools/test/integration.shard/variable_expansion_windows.dart
+++ b/packages/flutter_tools/test/integration.shard/variable_expansion_windows.dart
@@ -1,0 +1,8 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Not a test file, invoked by `variable_expansion_windows_test.dart`.
+void main(List<String> args) {
+  print('args: $args');
+}

--- a/packages/flutter_tools/test/integration.shard/variable_expansion_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/variable_expansion_windows_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/84270 .
+  testWithoutContext('dart command will expand variables on windows', () async {
+    final ProcessResult result = await processManager.run(<String>[
+      fileSystem.path.join(getFlutterRoot(), 'bin', 'dart'),
+      fileSystem.path.join(getFlutterRoot(), 'packages', 'flutter_tools', 'test', 'integration.shard', 'variable_expansion_windows.dart'),
+      '"^(?!Golden).+"',
+    ]);
+    expect(result.stdout, contains('args: ["(?!Golden).+"]'));
+  }, skip: !platform.isWindows);
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84270


`SETLOCAL ENABLEDELAYEDEXPANSION` is not needed in the entrypoint scripts, all of the "interesting" work was moved to shared.bat. Nevertheless, this causes problems when passing quoted values through the flutter or dart since they get expanded immediately because of this.

Remove the setting.