### PR TITLE
WIP - Reland "Override MediaQuery for WidgetsApp (#81295)"

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -170,6 +170,7 @@ class CupertinoApp extends StatefulWidget {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
+    this.useInheritedMediaQuery = false,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -210,6 +211,7 @@ class CupertinoApp extends StatefulWidget {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
+    this.useInheritedMediaQuery = false,
   }) : assert(title != null),
        assert(showPerformanceOverlay != null),
        assert(checkerboardRasterCacheImages != null),
@@ -407,6 +409,9 @@ class CupertinoApp extends StatefulWidget {
   ///    in a subtree.
   final ScrollBehavior? scrollBehavior;
 
+  /// {@macro flutter.widgets.widgetsApp.useInheritedMediaQuery}
+  final bool useInheritedMediaQuery;
+
   @override
   State<CupertinoApp> createState() => _CupertinoAppState();
 
@@ -530,6 +535,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
         shortcuts: widget.shortcuts,
         actions: widget.actions,
         restorationScopeId: widget.restorationScopeId,
+        useInheritedMediaQuery: widget.useInheritedMediaQuery,
       );
     }
     return WidgetsApp(
@@ -564,6 +570,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
       shortcuts: widget.shortcuts,
       actions: widget.actions,
       restorationScopeId: widget.restorationScopeId,
+      useInheritedMediaQuery: widget.useInheritedMediaQuery,
     );
   }
 

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -200,6 +200,7 @@ class MaterialApp extends StatefulWidget {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
+    this.useInheritedMediaQuery = false,
   }) : assert(routes != null),
        assert(navigatorObservers != null),
        assert(title != null),
@@ -247,6 +248,7 @@ class MaterialApp extends StatefulWidget {
     this.actions,
     this.restorationScopeId,
     this.scrollBehavior,
+    this.useInheritedMediaQuery = false,
   }) : assert(routeInformationParser != null),
        assert(routerDelegate != null),
        assert(title != null),
@@ -665,6 +667,9 @@ class MaterialApp extends StatefulWidget {
   ///  * <https://material.io/design/layout/spacing-methods.html>
   final bool debugShowMaterialGrid;
 
+  /// {@macro flutter.widgets.widgetsApp.useInheritedMediaQuery}
+  final bool useInheritedMediaQuery;
+
   @override
   State<MaterialApp> createState() => _MaterialAppState();
 
@@ -858,6 +863,7 @@ class _MaterialAppState extends State<MaterialApp> {
         shortcuts: widget.shortcuts,
         actions: widget.actions,
         restorationScopeId: widget.restorationScopeId,
+        useInheritedMediaQuery: widget.useInheritedMediaQuery,
       );
     }
 
@@ -893,6 +899,7 @@ class _MaterialAppState extends State<MaterialApp> {
       shortcuts: widget.shortcuts,
       actions: widget.actions,
       restorationScopeId: widget.restorationScopeId,
+      useInheritedMediaQuery: widget.useInheritedMediaQuery,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -236,6 +236,9 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 /// It is used by both [MaterialApp] and [CupertinoApp] to implement base
 /// functionality for an app.
 ///
+/// If a [MediaQuery] is not available above [WidgetsApp], a [MediaQuery] is
+/// built using [MediaQuery.fromWindow].
+///
 /// Find references to many of the widgets that [WidgetsApp] wraps in the "See
 /// also" section.
 ///
@@ -247,6 +250,8 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 ///    without an explicit style.
 ///  * [MediaQuery], which establishes a subtree in which media queries resolve
 ///    to a [MediaQueryData].
+///  * [MediaQuery.fromWindow], which builds a [MediaQuery] with data derived
+///    from [WidgetsBinding.window].
 ///  * [Localizations], which defines the [Locale] for its `child`.
 ///  * [Title], a widget that describes this app in the operating system.
 ///  * [Navigator], a widget that manages a set of child widgets with a stack
@@ -1635,6 +1640,19 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
 
     assert(_debugCheckLocalizations(appLocale));
 
+    Widget child = Localizations(
+      locale: appLocale,
+      delegates: _localizationsDelegates.toList(),
+      child: title,
+    );
+
+    final MediaQueryData? data = MediaQuery.maybeOf(context);
+    if (data == null) {
+      child = MediaQuery.fromWindow(
+        child: child,
+      );
+    }
+
     return RootRestorationScope(
       restorationId: widget.restorationScopeId,
       child: Shortcuts(
@@ -1648,96 +1666,12 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
             child: DefaultTextEditingActions(
               child: FocusTraversalGroup(
                 policy: ReadingOrderTraversalPolicy(),
-                child: _MediaQueryFromWindow(
-                  child: Localizations(
-                    locale: appLocale,
-                    delegates: _localizationsDelegates.toList(),
-                    child: title,
-                  ),
-                ),
+                child: child,
               ),
             ),
           ),
         ),
       ),
     );
-  }
-}
-
-/// Builds [MediaQuery] from `window` by listening to [WidgetsBinding].
-///
-/// It is performed in a standalone widget to rebuild **only** [MediaQuery] and
-/// its dependents when `window` changes, instead of rebuilding the entire widget tree.
-class _MediaQueryFromWindow extends StatefulWidget {
-  const _MediaQueryFromWindow({Key? key, required this.child}) : super(key: key);
-
-  final Widget child;
-
-  @override
-  _MediaQueryFromWindowsState createState() => _MediaQueryFromWindowsState();
-}
-
-class _MediaQueryFromWindowsState extends State<_MediaQueryFromWindow> with WidgetsBindingObserver {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance!.addObserver(this);
-  }
-
-  // ACCESSIBILITY
-
-  @override
-  void didChangeAccessibilityFeatures() {
-    setState(() {
-      // The properties of window have changed. We use them in our build
-      // function, so we need setState(), but we don't cache anything locally.
-    });
-  }
-
-  // METRICS
-
-  @override
-  void didChangeMetrics() {
-    setState(() {
-      // The properties of window have changed. We use them in our build
-      // function, so we need setState(), but we don't cache anything locally.
-    });
-  }
-
-  @override
-  void didChangeTextScaleFactor() {
-    setState(() {
-      // The textScaleFactor property of window has changed. We reference
-      // window in our build function, so we need to call setState(), but
-      // we don't need to cache anything locally.
-    });
-  }
-
-  // RENDERING
-  @override
-  void didChangePlatformBrightness() {
-    setState(() {
-      // The platformBrightness property of window has changed. We reference
-      // window in our build function, so we need to call setState(), but
-      // we don't need to cache anything locally.
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance!.window);
-    if (!kReleaseMode) {
-      data = data.copyWith(platformBrightness: debugBrightnessOverride);
-    }
-    return MediaQuery(
-      data: data,
-      child: widget.child,
-    );
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
-    super.dispose();
   }
 }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -237,7 +237,7 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 /// functionality for an app.
 ///
 /// Builds a [MediaQuery] using [MediaQuery.fromWindow]. To use an inherited
-/// [MediaQuery] instead, set [useExistingMediaQuery] to true.
+/// [MediaQuery] instead, set [useInheritedMediaQuery] to true.
 ///
 /// Find references to many of the widgets that [WidgetsApp] wraps in the "See
 /// also" section.
@@ -332,7 +332,7 @@ class WidgetsApp extends StatefulWidget {
     this.shortcuts,
     this.actions,
     this.restorationScopeId,
-    this.useExistingMediaQuery = false,
+    this.useInheritedMediaQuery = false,
   }) : assert(navigatorObservers != null),
        assert(routes != null),
        assert(
@@ -429,7 +429,7 @@ class WidgetsApp extends StatefulWidget {
     this.shortcuts,
     this.actions,
     this.restorationScopeId,
-    this.useExistingMediaQuery = false,
+    this.useInheritedMediaQuery = false,
   }) : assert(
          routeInformationParser != null &&
          routerDelegate != null,
@@ -1121,7 +1121,7 @@ class WidgetsApp extends StatefulWidget {
   /// If true, an inherited MediaQuery will be used. If one if not available, or this is false, one will be built from the window.
   ///
   /// Cannot be null, defaults to false.
-  final bool useExistingMediaQuery;
+  final bool useInheritedMediaQuery;
 
   /// If true, forces the performance overlay to be visible in all instances.
   ///
@@ -1654,7 +1654,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     );
 
     final MediaQueryData? data = MediaQuery.maybeOf(context);
-    if (!widget.useExistingMediaQuery || data == null) {
+    if (!widget.useInheritedMediaQuery || data == null) {
       child = MediaQuery.fromWindow(
         child: child,
       );

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1118,8 +1118,7 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final String? restorationScopeId;
 
-  /// If true, only builds a [MediaQuery] if none is available above the
-  /// [WidgetsApp].
+  /// If true, an inherited MediaQuery will be used. If one if not available, or this is false, one will be built from the window.
   ///
   /// If set to false [WidgetsApp] build a [MediaQuery] using
   /// [MediaQuery.fromWindow].

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -236,8 +236,8 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 /// It is used by both [MaterialApp] and [CupertinoApp] to implement base
 /// functionality for an app.
 ///
-/// If a [MediaQuery] is not available above [WidgetsApp], a [MediaQuery] is
-/// built using [MediaQuery.fromWindow].
+/// Builds a [MediaQuery] using [MediaQuery.fromWindow], reuse an existing
+/// [MediaQuery] by setting the [useExistingMediaQuery] to true.
 ///
 /// Find references to many of the widgets that [WidgetsApp] wraps in the "See
 /// also" section.
@@ -332,6 +332,7 @@ class WidgetsApp extends StatefulWidget {
     this.shortcuts,
     this.actions,
     this.restorationScopeId,
+    this.useExistingMediaQuery = false,
   }) : assert(navigatorObservers != null),
        assert(routes != null),
        assert(
@@ -428,6 +429,7 @@ class WidgetsApp extends StatefulWidget {
     this.shortcuts,
     this.actions,
     this.restorationScopeId,
+    this.useExistingMediaQuery = false,
   }) : assert(
          routeInformationParser != null &&
          routerDelegate != null,
@@ -1116,6 +1118,13 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final String? restorationScopeId;
 
+  /// If true, only builds a [MediaQuery] if none is available above the
+  /// [WidgetsApp].
+  ///
+  /// If set to false [WidgetsApp] build a [MediaQuery] using
+  /// [MediaQuery.fromWindow].
+  final bool useExistingMediaQuery;
+
   /// If true, forces the performance overlay to be visible in all instances.
   ///
   /// Used by the `showPerformanceOverlay` observatory extension.
@@ -1647,7 +1656,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     );
 
     final MediaQueryData? data = MediaQuery.maybeOf(context);
-    if (data == null) {
+    if (!widget.useExistingMediaQuery || data == null) {
       child = MediaQuery.fromWindow(
         child: child,
       );

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1118,10 +1118,12 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final String? restorationScopeId;
 
+  /// {@template flutter.widgets.widgetsApp.useInheritedMediaQuery}
   /// If true, an inherited MediaQuery will be used. If one is not available,
   /// or this is false, one will be built from the window.
   ///
   /// Cannot be null, defaults to false.
+  /// {@endtemplate}
   final bool useInheritedMediaQuery;
 
   /// If true, forces the performance overlay to be visible in all instances.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -236,8 +236,8 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 /// It is used by both [MaterialApp] and [CupertinoApp] to implement base
 /// functionality for an app.
 ///
-/// Builds a [MediaQuery] using [MediaQuery.fromWindow], reuse an existing
-/// [MediaQuery] by setting the [useExistingMediaQuery] to true.
+/// Builds a [MediaQuery] using [MediaQuery.fromWindow]. To use an inherited
+/// [MediaQuery] instead, set [useExistingMediaQuery] to true.
 ///
 /// Find references to many of the widgets that [WidgetsApp] wraps in the "See
 /// also" section.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1120,8 +1120,7 @@ class WidgetsApp extends StatefulWidget {
 
   /// If true, an inherited MediaQuery will be used. If one if not available, or this is false, one will be built from the window.
   ///
-  /// If set to false [WidgetsApp] build a [MediaQuery] using
-  /// [MediaQuery.fromWindow].
+  /// Cannot be null, defaults to false.
   final bool useExistingMediaQuery;
 
   /// If true, forces the performance overlay to be visible in all instances.

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1118,7 +1118,8 @@ class WidgetsApp extends StatefulWidget {
   /// {@endtemplate}
   final String? restorationScopeId;
 
-  /// If true, an inherited MediaQuery will be used. If one if not available, or this is false, one will be built from the window.
+  /// If true, an inherited MediaQuery will be used. If one is not available,
+  /// or this is false, one will be built from the window.
   ///
   /// Cannot be null, defaults to false.
   final bool useInheritedMediaQuery;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -9,6 +9,7 @@ import 'dart:ui' show Brightness;
 import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
+import 'binding.dart';
 import 'debug.dart';
 import 'framework.dart';
 
@@ -787,6 +788,32 @@ class MediaQuery extends InheritedWidget {
     );
   }
 
+  /// Creates a [_MediaQueryFromWindow] which builds and updates a
+  /// [MediaQuery] using the latest [WidgetsBinding.window] values.
+  ///
+  /// The [MediaQuery] is wrapped in a separate widget to ensure that only it
+  /// and its dependents are updated when `window` changes, instead of
+  /// rebuilding the whole widget tree.
+  ///
+  /// This should be inserted into the widget tree when the [MediaQuery] view
+  /// padding is consumed by a widget in such a way that the view padding is no
+  /// longer exposed to the widget's descendants or siblings.
+  ///
+  /// The [child] argument is required and must not be null.
+  ///
+  /// See also:
+  ///
+  ///  * [_MediaQueryFromWindow], the underlying widget.
+  static Widget fromWindow({
+    Key? key,
+    required Widget child,
+  }) {
+    return _MediaQueryFromWindow(
+      key: key,
+      child: child,
+    );
+  }
+
   /// Contains information about the current media.
   ///
   /// For example, the [MediaQueryData.size] property contains the width and
@@ -921,4 +948,101 @@ enum NavigationMode {
   /// controls will retain focus when disabled, and will be able to receive
   /// focus (although they remain disabled) when traversed.
   directional,
+}
+
+/// Provides a [MediaQuery] which is built and updated using the latest
+/// [WidgetsBinding.window] values.
+///
+/// Receives `window` updates by listening to [WidgetsBinding].
+///
+/// The standalone widget ensures that it rebuilds **only** [MediaQuery] and
+/// its dependents when `window` changes, instead of rebuilding the entire
+/// widget tree.
+///
+/// It is used by [WidgetsApp] if no other [MediaQuery] is available above it.
+///
+/// See also:
+///
+///  * [MediaQuery], which establishes a subtree in which media queries resolve
+///    to a [MediaQueryData].
+class _MediaQueryFromWindow extends StatefulWidget {
+  /// Creates a [_MediaQueryFromWindow] that provides a [MediaQuery] to its
+  /// descendants using the `window` to keep [MediaQueryData] up to date.
+  ///
+  /// The [child] must not be null.
+  const _MediaQueryFromWindow({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  @override
+  State<_MediaQueryFromWindow> createState() => _MediaQueryFromWindowState();
+}
+
+class _MediaQueryFromWindowState extends State<_MediaQueryFromWindow> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance!.addObserver(this);
+  }
+
+  // ACCESSIBILITY
+
+  @override
+  void didChangeAccessibilityFeatures() {
+    setState(() {
+      // The properties of window have changed. We use them in our build
+      // function, so we need setState(), but we don't cache anything locally.
+    });
+  }
+
+  // METRICS
+
+  @override
+  void didChangeMetrics() {
+    setState(() {
+      // The properties of window have changed. We use them in our build
+      // function, so we need setState(), but we don't cache anything locally.
+    });
+  }
+
+  @override
+  void didChangeTextScaleFactor() {
+    setState(() {
+      // The textScaleFactor property of window has changed. We reference
+      // window in our build function, so we need to call setState(), but
+      // we don't need to cache anything locally.
+    });
+  }
+
+  // RENDERING
+  @override
+  void didChangePlatformBrightness() {
+    setState(() {
+      // The platformBrightness property of window has changed. We reference
+      // window in our build function, so we need to call setState(), but
+      // we don't need to cache anything locally.
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance!.window);
+    if (!kReleaseMode) {
+      data = data.copyWith(platformBrightness: debugBrightnessOverride);
+    }
+    return MediaQuery(
+      data: data,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance!.removeObserver(this);
+    super.dispose();
+  }
 }

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -788,8 +788,8 @@ class MediaQuery extends InheritedWidget {
     );
   }
 
-  /// Creates a [_MediaQueryFromWindow] which builds and updates a
-  /// [MediaQuery] using the latest [WidgetsBinding.window] values.
+  /// Provides a [MediaQuery] which is built and updated using the latest
+  /// [WidgetsBinding.window] values.
   ///
   /// The [MediaQuery] is wrapped in a separate widget to ensure that only it
   /// and its dependents are updated when `window` changes, instead of
@@ -800,10 +800,6 @@ class MediaQuery extends InheritedWidget {
   /// longer exposed to the widget's descendants or siblings.
   ///
   /// The [child] argument is required and must not be null.
-  ///
-  /// See also:
-  ///
-  ///  * [_MediaQueryFromWindow], the underlying widget.
   static Widget fromWindow({
     Key? key,
     required Widget child,

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -209,7 +209,7 @@ void main() {
     expect(scrollBehavior.getScrollPhysics(capturedContext).runtimeType, NeverScrollableScrollPhysics);
   });
 
-  testWidgets('When `useExistingMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
+  testWidgets('When `useInheritedMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     final UniqueKey uniqueKey = UniqueKey();
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -208,6 +208,26 @@ void main() {
     expect(scrollBehavior.runtimeType, MockScrollBehavior);
     expect(scrollBehavior.getScrollPhysics(capturedContext).runtimeType, NeverScrollableScrollPhysics);
   });
+
+  testWidgets('When `useExistingMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
+    late BuildContext capturedContext;
+    final UniqueKey uniqueKey = UniqueKey();
+    await tester.pumpWidget(
+      MediaQuery(
+        key: uniqueKey,
+        data: const MediaQueryData(),
+        child: CupertinoApp(
+          useInheritedMediaQuery: true,
+          builder: (BuildContext context, Widget? child) {
+            capturedContext = context;
+            return const Placeholder();
+          },
+          color: const Color(0xFF123456),
+        ),
+      ),
+    );
+    expect(capturedContext.dependOnInheritedWidgetOfExactType<MediaQuery>()?.key, uniqueKey);
+  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1063,6 +1063,26 @@ void main() {
     expect(scrollBehavior.runtimeType, MockScrollBehavior);
     expect(scrollBehavior.getScrollPhysics(capturedContext).runtimeType, NeverScrollableScrollPhysics);
   });
+
+  testWidgets('When `useExistingMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
+    late BuildContext capturedContext;
+    final UniqueKey uniqueKey = UniqueKey();
+    await tester.pumpWidget(
+      MediaQuery(
+        key: uniqueKey,
+        data: const MediaQueryData(),
+        child: MaterialApp(
+          useInheritedMediaQuery: true,
+          builder: (BuildContext context, Widget? child) {
+            capturedContext = context;
+            return const Placeholder();
+          },
+          color: const Color(0xFF123456),
+        ),
+      ),
+    );
+    expect(capturedContext.dependOnInheritedWidgetOfExactType<MediaQuery>()?.key, uniqueKey);
+  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -1064,7 +1064,7 @@ void main() {
     expect(scrollBehavior.getScrollPhysics(capturedContext).runtimeType, NeverScrollableScrollPhysics);
   });
 
-  testWidgets('When `useExistingMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
+  testWidgets('When `useInheritedMediaQuery` is true an existing MediaQuery is used if one is available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     final UniqueKey uniqueKey = UniqueKey();
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -455,6 +455,39 @@ void main() {
       const Locale('zh'),
     );
   });
+
+  testWidgets('WidgetsApp creates a MediaQuery', (WidgetTester tester) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      WidgetsApp(
+        builder: (BuildContext context, Widget? child) {
+          capturedContext = context;
+          return const Placeholder();
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    expect(MediaQuery.of(capturedContext), isNotNull);
+  });
+
+  testWidgets('WidgetsApp does not create MediaQuery if one is already available', (WidgetTester tester) async {
+    late BuildContext capturedContext;
+    final UniqueKey uniqueKey = UniqueKey();
+    await tester.pumpWidget(
+      MediaQuery(
+      key: uniqueKey,
+        data: const MediaQueryData(),
+        child: WidgetsApp(
+          builder: (BuildContext context, Widget? child) {
+            capturedContext = context;
+            return const Placeholder();
+          },
+          color: const Color(0xFF123456),
+        ),
+      ),
+    );
+    expect(capturedContext.dependOnInheritedWidgetOfExactType<MediaQuery>()?.key, uniqueKey);
+  });
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -460,7 +460,7 @@ void main() {
     late BuildContext capturedContext;
     await tester.pumpWidget(
       WidgetsApp(
-        useExistingMediaQuery: false,
+        useInheritedMediaQuery: false,
         builder: (BuildContext context, Widget? child) {
           capturedContext = context;
           return const Placeholder();
@@ -471,7 +471,7 @@ void main() {
     expect(MediaQuery.of(capturedContext), isNotNull);
   });
 
-  testWidgets('WidgetsApp does not create MediaQuery if `useExistingMediaQuery` is set to true and one is already available', (WidgetTester tester) async {
+  testWidgets('WidgetsApp does not create MediaQuery if `useExistingMediaQuery` is set to true and one is available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     final UniqueKey uniqueKey = UniqueKey();
     await tester.pumpWidget(
@@ -479,7 +479,7 @@ void main() {
       key: uniqueKey,
         data: const MediaQueryData(),
         child: WidgetsApp(
-          useExistingMediaQuery: true,
+          useInheritedMediaQuery: true,
           builder: (BuildContext context, Widget? child) {
             capturedContext = context;
             return const Placeholder();
@@ -495,7 +495,7 @@ void main() {
     late BuildContext capturedContext;
     await tester.pumpWidget(
       WidgetsApp(
-        useExistingMediaQuery: true,
+        useInheritedMediaQuery: true,
         builder: (BuildContext context, Widget? child) {
           capturedContext = context;
           return const Placeholder();

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -456,7 +456,7 @@ void main() {
     );
   });
 
-  testWidgets('WidgetsApp creates a MediaQuery if `useExistingMediaQuery` is set to false', (WidgetTester tester) async {
+  testWidgets('WidgetsApp creates a MediaQuery if `useInheritedMediaQuery` is set to false', (WidgetTester tester) async {
     late BuildContext capturedContext;
     await tester.pumpWidget(
       WidgetsApp(
@@ -471,7 +471,7 @@ void main() {
     expect(MediaQuery.of(capturedContext), isNotNull);
   });
 
-  testWidgets('WidgetsApp does not create MediaQuery if `useExistingMediaQuery` is set to true and one is available', (WidgetTester tester) async {
+  testWidgets('WidgetsApp does not create MediaQuery if `useInheritedMediaQuery` is set to true and one is available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     final UniqueKey uniqueKey = UniqueKey();
     await tester.pumpWidget(
@@ -491,7 +491,7 @@ void main() {
     expect(capturedContext.dependOnInheritedWidgetOfExactType<MediaQuery>()?.key, uniqueKey);
   });
 
-  testWidgets('WidgetsApp does create a MediaQuery if `useExistingMediaQuery` is set to true and none is available', (WidgetTester tester) async {
+  testWidgets('WidgetsApp does create a MediaQuery if `useInheritedMediaQuery` is set to true and none is available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     await tester.pumpWidget(
       WidgetsApp(

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -456,10 +456,11 @@ void main() {
     );
   });
 
-  testWidgets('WidgetsApp creates a MediaQuery', (WidgetTester tester) async {
+  testWidgets('WidgetsApp creates a MediaQuery if `useExistingMediaQuery` is set to false', (WidgetTester tester) async {
     late BuildContext capturedContext;
     await tester.pumpWidget(
       WidgetsApp(
+        useExistingMediaQuery: false,
         builder: (BuildContext context, Widget? child) {
           capturedContext = context;
           return const Placeholder();
@@ -470,7 +471,7 @@ void main() {
     expect(MediaQuery.of(capturedContext), isNotNull);
   });
 
-  testWidgets('WidgetsApp does not create MediaQuery if one is already available', (WidgetTester tester) async {
+  testWidgets('WidgetsApp does not create MediaQuery if `useExistingMediaQuery` is set to true and one is already available', (WidgetTester tester) async {
     late BuildContext capturedContext;
     final UniqueKey uniqueKey = UniqueKey();
     await tester.pumpWidget(
@@ -478,6 +479,7 @@ void main() {
       key: uniqueKey,
         data: const MediaQueryData(),
         child: WidgetsApp(
+          useExistingMediaQuery: true,
           builder: (BuildContext context, Widget? child) {
             capturedContext = context;
             return const Placeholder();
@@ -487,6 +489,21 @@ void main() {
       ),
     );
     expect(capturedContext.dependOnInheritedWidgetOfExactType<MediaQuery>()?.key, uniqueKey);
+  });
+
+  testWidgets('WidgetsApp does create a MediaQuery if `useExistingMediaQuery` is set to true and none is available', (WidgetTester tester) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      WidgetsApp(
+        useExistingMediaQuery: true,
+        builder: (BuildContext context, Widget? child) {
+          capturedContext = context;
+          return const Placeholder();
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    expect(MediaQuery.of(capturedContext), isNotNull);
   });
 }
 

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -627,4 +627,49 @@ void main() {
     expect(outsideBoldTextOverride, false);
     expect(insideBoldTextOverride, true);
   });
+
+  testWidgets('MediaQuery.fromWindow creates a MediaQuery', (WidgetTester tester) async {
+    bool hasMediaQueryAsParentOutside = false;
+    bool hasMediaQueryAsParentInside = false;
+
+    await tester.pumpWidget(
+      Builder(
+        builder: (BuildContext context) {
+          hasMediaQueryAsParentOutside =
+              context.findAncestorWidgetOfExactType<MediaQuery>() != null;
+          return MediaQuery.fromWindow(
+            child: Builder(
+              builder: (BuildContext context) {
+                hasMediaQueryAsParentInside =
+                    context.findAncestorWidgetOfExactType<MediaQuery>() != null;
+                return const SizedBox();
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(hasMediaQueryAsParentOutside, false);
+    expect(hasMediaQueryAsParentInside, true);
+  });
+
+  testWidgets('MediaQueryData.fromWindow is created using window values', (WidgetTester tester)
+  async {
+    final MediaQueryData windowData = MediaQueryData.fromWindow(WidgetsBinding.instance!.window);
+    late MediaQueryData fromWindowData;
+
+    await tester.pumpWidget(
+      MediaQuery.fromWindow(
+        child: Builder(
+          builder: (BuildContext context) {
+            fromWindowData = MediaQuery.of(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    expect(windowData, equals(fromWindowData));
+  });
 }


### PR DESCRIPTION
## Description

Reland #81295, which enables WidgetsApp to reuse an already existing MediaQuery if there is one. (Motivation described in #81293.)

#81295 was breaking internal tests: `test/OCL:380874320:BASE:381245548:1624543113950:7fda35d8` and was reverted in #85223.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
