### PR TITLE
Expose minThumbLength, crossAxisMargin, and minOverscrollLength on RawScrollbar

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1060,8 +1060,8 @@ class RawScrollbar extends StatefulWidget {
   /// [minOverscrollLength] is `double.infinity`, it will not be respected if
   /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
   ///
-  /// The value is less than or equal to [minLength] and greater than or equal to 0.
-  /// If unspecified or set to null, it will default to the value of [minLength].
+  /// The value is less than or equal to [minThumbLength] and greater than or equal to 0.
+  /// If unspecified or set to null, it will default to the value of [minThumbLength].
   double get minOverscrollLength => _minOverscrollLength;
   final double _minOverscrollLength;
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -253,8 +253,8 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// `double.infinity`, it will not be respected if
   /// [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
   ///
-  /// Mustn't be null and the value has to be within the range of 0 to
-  /// [minOverscrollLength], inclusive. Defaults to 18.0.
+  /// Mustn't be null and the value has to be greater or equal to
+  /// [minOverscrollLength], which in turn is >= 0. Defaults to 18.0.
   double get minLength => _minLength;
   double _minLength;
   set minLength(double value) {
@@ -275,7 +275,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
   ///
   /// The value is less than or equal to [minLength] and greater than or equal to 0.
-  /// If unspecified or set to null, it will defaults to the value of [minLength].
+  /// If unspecified or set to null, it will default to the value of [minLength].
   double get minOverscrollLength => _minOverscrollLength;
   double _minOverscrollLength;
   set minOverscrollLength(double value) {
@@ -857,6 +857,7 @@ class RawScrollbar extends StatefulWidget {
     this.radius,
     this.thickness,
     this.thumbColor,
+    this.minThumbLength = _kMinThumbExtent,
     this.fadeDuration = _kScrollbarFadeDuration,
     this.timeToFade = _kScrollbarTimeToFade,
     this.pressDuration = Duration.zero,
@@ -864,11 +865,15 @@ class RawScrollbar extends StatefulWidget {
     this.interactive,
     this.scrollbarOrientation,
     this.mainAxisMargin = 0.0,
+    this.crossAxisMargin = 0.0
   }) : assert(child != null),
+       assert(minThumbLength != null),
+       assert(minThumbLength >= 0),
        assert(fadeDuration != null),
        assert(timeToFade != null),
        assert(pressDuration != null),
        assert(mainAxisMargin != null),
+       assert(crossAxisMargin != null),
        super(key: key);
 
   /// {@template flutter.widgets.Scrollbar.child}
@@ -1030,6 +1035,19 @@ class RawScrollbar extends StatefulWidget {
   /// If null, defaults to Color(0x66BCBCBC).
   final Color? thumbColor;
 
+  /// The preferred smallest size the scrollbar can shrink to when the total
+  /// scrollable extent is large, the current visible viewport is small, and the
+  /// viewport is not overscrolled.
+  ///
+  /// The size of the scrollbar may shrink to a smaller size than [minThumbLength] to
+  /// fit in the available paint area. E.g., when [minThumbLength] is
+  /// `double.infinity`, it will not be respected if
+  /// [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
+  ///
+  /// Mustn't be null and the value has to be greater or equal to
+  /// [minOverscrollLength], which in turn is >= 0. Defaults to 18.0.
+  final double minThumbLength;
+
   /// The [Duration] of the fade animation.
   ///
   /// Cannot be null, defaults to a [Duration] of 300 milliseconds.
@@ -1084,6 +1102,11 @@ class RawScrollbar extends StatefulWidget {
   ///
   /// Mustn't be null and defaults to 0.
   final double mainAxisMargin;
+
+  /// Distance from the scrollbar's side to the nearest edge in logical pixels.
+  ///
+  /// Must not be null and defaults to 0.
+  final double crossAxisMargin;
 
   @override
   RawScrollbarState<RawScrollbar> createState() => RawScrollbarState<RawScrollbar>();
@@ -1154,10 +1177,12 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     );
     scrollbarPainter = ScrollbarPainter(
       color: widget.thumbColor ?? const Color(0x66BCBCBC),
+      minLength: widget.minThumbLength,
       thickness: widget.thickness ?? _kScrollbarThickness,
       fadeoutOpacityAnimation: _fadeoutOpacityAnimation,
       scrollbarOrientation: widget.scrollbarOrientation,
       mainAxisMargin: widget.mainAxisMargin,
+      crossAxisMargin: widget.crossAxisMargin
     );
   }
 
@@ -1294,7 +1319,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..radius = widget.radius
       ..padding = MediaQuery.of(context).padding
       ..scrollbarOrientation = widget.scrollbarOrientation
-      ..mainAxisMargin = widget.mainAxisMargin;
+      ..mainAxisMargin = widget.mainAxisMargin
+      ..crossAxisMargin = widget.crossAxisMargin
+      ..minLength = widget.minThumbLength;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -872,7 +872,7 @@ class RawScrollbar extends StatefulWidget {
        assert(minThumbLength >= 0),
        assert(minOverscrollLength == null || minOverscrollLength <= minThumbLength),
        assert(minOverscrollLength == null || minOverscrollLength >= 0),
-       _minOverscrollLength = minOverscrollLength ?? minThumbLength,
+       minOverscrollLength = minOverscrollLength ?? minThumbLength,
        assert(fadeDuration != null),
        assert(timeToFade != null),
        assert(pressDuration != null),
@@ -1066,8 +1066,7 @@ class RawScrollbar extends StatefulWidget {
   ///
   /// The value is less than or equal to [minThumbLength] and greater than or equal to 0.
   /// If unspecified or set to null, it will default to the value of [minThumbLength].
-  double get minOverscrollLength => _minOverscrollLength;
-  final double _minOverscrollLength;
+  final double minOverscrollLength;
 
   /// The [Duration] of the fade animation.
   ///

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -196,7 +196,8 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     notifyListeners();
   }
 
-  /// Distance from the scrollbar's side to the nearest edge in logical pixels.
+  /// Distance from the scrollbar thumb to the nearest cross axis edge
+  /// in logical pixels.
   ///
   /// Must not be null and defaults to 0.
   double get crossAxisMargin => _crossAxisMargin;
@@ -244,7 +245,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   }
 
 
-  /// The preferred smallest size the scrollbar can shrink to when the total
+  /// The preferred smallest size the scrollbar thumb can shrink to when the total
   /// scrollable extent is large, the current visible viewport is small, and the
   /// viewport is not overscrolled.
   ///
@@ -266,7 +267,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     notifyListeners();
   }
 
-  /// The preferred smallest size the scrollbar can shrink to when viewport is
+  /// The preferred smallest size the scrollbar thumb can shrink to when viewport is
   /// overscrolled.
   ///
   /// When overscrolling, the size of the scrollbar may shrink to a smaller size
@@ -275,7 +276,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
   /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
   ///
   /// The value is less than or equal to [minLength] and greater than or equal to 0.
-  /// If unspecified or set to null, it will default to the value of [minLength].
+  /// When null, it will default to the value of [minLength].
   double get minOverscrollLength => _minOverscrollLength;
   double _minOverscrollLength;
   set minOverscrollLength(double value) {
@@ -1038,33 +1039,32 @@ class RawScrollbar extends StatefulWidget {
   /// If null, defaults to Color(0x66BCBCBC).
   final Color? thumbColor;
 
-  /// The preferred smallest size the scrollbar can shrink to when the total
+  /// The preferred smallest size the scrollbar thumb can shrink to when the total
   /// scrollable extent is large, the current visible viewport is small, and the
   /// viewport is not overscrolled.
   ///
-  /// The size of the scrollbar may shrink to a smaller size than [minThumbLength] to
-  /// fit in the available paint area. E.g., when [minThumbLength] is
-  /// `double.infinity`, it will not be respected if
-  /// [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
+  /// The size of the scrollbar's thumb may shrink to a smaller size than [minThumbLength]
+  /// to fit in the available paint area (e.g., when [minThumbLength] is greater
+  /// than [ScrollMetrics.viewportDimension] and [mainAxisMargin] combined).
   ///
   /// Mustn't be null and the value has to be greater or equal to
   /// [minOverscrollLength], which in turn is >= 0. Defaults to 18.0.
   final double minThumbLength;
 
-  /// The preferred smallest size the scrollbar can shrink to when viewport is
+  /// The preferred smallest size the scrollbar thumb can shrink to when viewport is
   /// overscrolled.
   ///
-  /// When overscrolling, the size of the scrollbar may shrink to a smaller size
-  /// than [minOverscrollLength] to fit in the available paint area. E.g., when
-  /// [minOverscrollLength] is `double.infinity`, it will not be respected if
-  /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
+  /// When overscrolling, the size of the scrollbar's thumb may shrink to a smaller size
+  /// than [minOverscrollLength] to fit in the available paint area (e.g., when
+  /// [minOverscrollLength] is greater than [ScrollMetrics.viewportDimension] and
+  /// [mainAxisMargin] combined).
   ///
   /// Overscrolling can be made possible by setting the `physics` property
   /// of the `child` Widget to a `BouncingScrollPhysics`, which is a special
   /// `ScrollPhysics` that allows overscrolling.
   ///
   /// The value is less than or equal to [minThumbLength] and greater than or equal to 0.
-  /// If unspecified or set to null, it will default to the value of [minThumbLength].
+  /// When null, it will default to the value of [minThumbLength].
   final double? minOverscrollLength;
 
   /// The [Duration] of the fade animation.
@@ -1122,7 +1122,8 @@ class RawScrollbar extends StatefulWidget {
   /// Mustn't be null and defaults to 0.
   final double mainAxisMargin;
 
-  /// Distance from the scrollbar's side to the nearest edge in logical pixels.
+  /// Distance from the scrollbar thumb side to the nearest cross axis edge
+  /// in logical pixels.
   ///
   /// Must not be null and defaults to 0.
   final double crossAxisMargin;

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1060,6 +1060,10 @@ class RawScrollbar extends StatefulWidget {
   /// [minOverscrollLength] is `double.infinity`, it will not be respected if
   /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
   ///
+  /// Overscrolling can be made possible by setting the `physics` property
+  /// of the `child` Widget to a `BouncingScrollPhysics`, which is a special
+  /// `ScrollPhysics` that allows overscrolling.
+  ///
   /// The value is less than or equal to [minThumbLength] and greater than or equal to 0.
   /// If unspecified or set to null, it will default to the value of [minThumbLength].
   double get minOverscrollLength => _minOverscrollLength;

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -858,6 +858,7 @@ class RawScrollbar extends StatefulWidget {
     this.thickness,
     this.thumbColor,
     this.minThumbLength = _kMinThumbExtent,
+    double? minOverscrollLength,
     this.fadeDuration = _kScrollbarFadeDuration,
     this.timeToFade = _kScrollbarTimeToFade,
     this.pressDuration = Duration.zero,
@@ -869,6 +870,9 @@ class RawScrollbar extends StatefulWidget {
   }) : assert(child != null),
        assert(minThumbLength != null),
        assert(minThumbLength >= 0),
+       assert(minOverscrollLength == null || minOverscrollLength <= minThumbLength),
+       assert(minOverscrollLength == null || minOverscrollLength >= 0),
+       _minOverscrollLength = minOverscrollLength ?? minThumbLength,
        assert(fadeDuration != null),
        assert(timeToFade != null),
        assert(pressDuration != null),
@@ -1048,6 +1052,19 @@ class RawScrollbar extends StatefulWidget {
   /// [minOverscrollLength], which in turn is >= 0. Defaults to 18.0.
   final double minThumbLength;
 
+  /// The preferred smallest size the scrollbar can shrink to when viewport is
+  /// overscrolled.
+  ///
+  /// When overscrolling, the size of the scrollbar may shrink to a smaller size
+  /// than [minOverscrollLength] to fit in the available paint area. E.g., when
+  /// [minOverscrollLength] is `double.infinity`, it will not be respected if
+  /// the [ScrollMetrics.viewportDimension] and [mainAxisMargin] are finite.
+  ///
+  /// The value is less than or equal to [minLength] and greater than or equal to 0.
+  /// If unspecified or set to null, it will default to the value of [minLength].
+  double get minOverscrollLength => _minOverscrollLength;
+  final double _minOverscrollLength;
+
   /// The [Duration] of the fade animation.
   ///
   /// Cannot be null, defaults to a [Duration] of 300 milliseconds.
@@ -1178,6 +1195,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     scrollbarPainter = ScrollbarPainter(
       color: widget.thumbColor ?? const Color(0x66BCBCBC),
       minLength: widget.minThumbLength,
+      minOverscrollLength: widget.minOverscrollLength,
       thickness: widget.thickness ?? _kScrollbarThickness,
       fadeoutOpacityAnimation: _fadeoutOpacityAnimation,
       scrollbarOrientation: widget.scrollbarOrientation,
@@ -1321,7 +1339,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..mainAxisMargin = widget.mainAxisMargin
       ..crossAxisMargin = widget.crossAxisMargin
-      ..minLength = widget.minThumbLength;
+      ..minLength = widget.minThumbLength
+      ..minOverscrollLength = widget.minOverscrollLength;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -858,7 +858,7 @@ class RawScrollbar extends StatefulWidget {
     this.thickness,
     this.thumbColor,
     this.minThumbLength = _kMinThumbExtent,
-    double? minOverscrollLength,
+    this.minOverscrollLength,
     this.fadeDuration = _kScrollbarFadeDuration,
     this.timeToFade = _kScrollbarTimeToFade,
     this.pressDuration = Duration.zero,
@@ -872,7 +872,6 @@ class RawScrollbar extends StatefulWidget {
        assert(minThumbLength >= 0),
        assert(minOverscrollLength == null || minOverscrollLength <= minThumbLength),
        assert(minOverscrollLength == null || minOverscrollLength >= 0),
-       minOverscrollLength = minOverscrollLength ?? minThumbLength,
        assert(fadeDuration != null),
        assert(timeToFade != null),
        assert(pressDuration != null),
@@ -1066,7 +1065,7 @@ class RawScrollbar extends StatefulWidget {
   ///
   /// The value is less than or equal to [minThumbLength] and greater than or equal to 0.
   /// If unspecified or set to null, it will default to the value of [minThumbLength].
-  final double minOverscrollLength;
+  final double? minOverscrollLength;
 
   /// The [Duration] of the fade animation.
   ///
@@ -1198,7 +1197,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     scrollbarPainter = ScrollbarPainter(
       color: widget.thumbColor ?? const Color(0x66BCBCBC),
       minLength: widget.minThumbLength,
-      minOverscrollLength: widget.minOverscrollLength,
+      minOverscrollLength: widget.minOverscrollLength ?? widget.minThumbLength,
       thickness: widget.thickness ?? _kScrollbarThickness,
       fadeoutOpacityAnimation: _fadeoutOpacityAnimation,
       scrollbarOrientation: widget.scrollbarOrientation,
@@ -1343,7 +1342,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..mainAxisMargin = widget.mainAxisMargin
       ..crossAxisMargin = widget.crossAxisMargin
       ..minLength = widget.minThumbLength
-      ..minOverscrollLength = widget.minOverscrollLength;
+      ..minOverscrollLength = widget.minOverscrollLength ?? widget.minThumbLength;
   }
 
   @override

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1492,6 +1492,7 @@ void main() {
           child: RawScrollbar(
             controller: scrollController,
             minThumbLength: 21,
+            minOverscrollLength: 8,
             isAlwaysShown: true,
             child: SingleChildScrollView(
               controller: scrollController,

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1482,4 +1482,53 @@ void main() {
         ..rect(rect: const Rect.fromLTRB(794.0, 10.0, 800.0, 358.0))
     );
   });
+  testWidgets('minThumbLength property of RawScrollbar is respected', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: RawScrollbar(
+            controller: scrollController,
+            minThumbLength: 21,
+            isAlwaysShown: true,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(width: 1000.0, height: 50000.0),
+            ),
+          ),
+        )));
+    await tester.pumpAndSettle();
+    expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0)) // track
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 21.0))); // thumb
+  });
+
+  testWidgets('crossAxisMargin property of RawScrollbar is respected', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: RawScrollbar(
+            controller: scrollController,
+            crossAxisMargin: 30,
+            isAlwaysShown: true,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(width: 1000.0, height: 1000.0),
+            ),
+          ),
+        )));
+    await tester.pumpAndSettle();
+    expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(734.0, 0.0, 800.0, 600.0))
+          ..rect(rect: const Rect.fromLTRB(764.0, 0.0, 770.0, 360.0)));
+  });
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1532,4 +1532,37 @@ void main() {
           ..rect(rect: const Rect.fromLTRB(734.0, 0.0, 800.0, 600.0))
           ..rect(rect: const Rect.fromLTRB(764.0, 0.0, 770.0, 360.0)));
   });
+
+  testWidgets('minOverscrollLength property of RawScrollbar is respected', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: RawScrollbar(
+            controller: scrollController,
+            isAlwaysShown: true,
+            minOverscrollLength: 8.0,
+            minThumbLength: 36.0,
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              controller: scrollController,
+              child: const SizedBox(height: 10000),
+            )
+          ),
+        )
+      )
+    );
+    await tester.pumpAndSettle();
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(RawScrollbar)));
+    await gesture.moveBy(const Offset(0, 1000));
+    await tester.pump();
+    expect(
+        find.byType(RawScrollbar),
+        paints
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
+          ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 8.0)));
+  });
+  
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1564,5 +1564,5 @@ void main() {
           ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
           ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 8.0)));
   });
-  
+
 }


### PR DESCRIPTION
This PR finishes off #84793 by exposing the properties minThumbLength, crossAxisMargin, and minOverscrollLength on the RawScrollbar Widget.

I've also fixed a mistake in the documentation of `minLength` in the `ScrollbarPainter` class (it states that `minLength` must be in the range [0, `minOverscrollLength`], and at the same time states that `minOverscrollLength` is at most `minLength`).

Fixes #84793

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.