### PR TITLE
[fuchsia] pm serve should not use the device address

### DIFF
--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -312,7 +312,7 @@ class FuchsiaDevice extends Device {
     }
     // Stop the app if it's currently running.
     await stopApp(package);
-    final String host = await hostAddress;
+
     // Find out who the device thinks we are.
     final int port = await globals.os.findFreePort();
     if (port == 0) {
@@ -357,7 +357,7 @@ class FuchsiaDevice extends Device {
       // Start up a package server.
       const String packageServerName = FuchsiaPackageServer.toolHost;
       fuchsiaPackageServer = FuchsiaPackageServer(
-          packageRepo.path, packageServerName, host, port);
+          packageRepo.path, packageServerName, '', port);
       if (!await fuchsiaPackageServer.start()) {
         globals.printError('Failed to start the Fuchsia package server');
         return LaunchResult.failed();

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_start_test.dart
@@ -229,14 +229,13 @@ void main() {
       Artifacts: () => artifacts,
       FileSystem: () => memoryFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      FuchsiaDeviceTools: () => fuchsiaDeviceTools,
       FuchsiaArtifacts: () => FuchsiaArtifacts(sshConfig: null),
       OperatingSystemUtils: () => osUtils,
     });
 
     testUsingContext('fail when cant get host address', () async {
       expect(() async =>
-        setupAndStartApp(prebuilt: true, mode: BuildMode.release),
+          FuchsiaDeviceWithFakeDiscovery('123').hostAddress,
           throwsToolExit(message: 'Failed to get local address, aborting.'));
     }, overrides: <Type, Generator>{
       Artifacts: () => artifacts,


### PR DESCRIPTION
BUG: fxbug.dev/77566
BUG: https://github.com/flutter/flutter/issues/83609

When building for fuchsia the `pm serve` command was attempting to serve with the devices address but it needs to be listening on the host machine. This change just calls `pm serve :port` which will cause the device to serve packages from the host machine. In the future we may want to allow users to serve from a different machine but that is not needed right now.

Note: to test this you will need to be running the terminal product instead of the workstation product because the flutter tool uses tiles_ctl to launch applications which does not work in the workstation product.
