### PR TITLE
Make _kDebugFocus into a global that can be set (debugFocusChanges)

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -15,12 +15,15 @@ import 'focus_scope.dart';
 import 'focus_traversal.dart';
 import 'framework.dart';
 
-// Used for debugging focus code. Set to true to see highly verbose debug output
-// when focus changes occur.
-const bool _kDebugFocus = false;
+/// Setting to true will cause extensive logging to occur when focus changes occur.
+///
+/// Can be used to debug focus issues: each time the focus changes, the focus
+/// tree will be printed and requests for focus and other focus operations will
+/// be logged.
+bool debugFocusChanges = false;
 
 bool _focusDebug(String message, [Iterable<String>? details]) {
-  if (_kDebugFocus) {
+  if (debugFocusChanges) {
     debugPrint('FOCUS: $message');
     if (details != null && details.isNotEmpty) {
       for (final String detail in details) {
@@ -28,6 +31,7 @@ bool _focusDebug(String message, [Iterable<String>? details]) {
       }
     }
   }
+  // Return true so that it can be easily used inside of an assert.
   return true;
 }
 
@@ -1789,7 +1793,7 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
       notifyListeners();
     }
     assert(() {
-      if (_kDebugFocus) {
+      if (debugFocusChanges) {
         debugDumpFocusTree();
       }
       return true;


### PR DESCRIPTION
## Description

This removes the `_kDebugFocus` private global and replaces it with a global `debugFocusChanges` 

## Tests

- Added a test making sure that debug output happens when the focus changes.