### PR TITLE
Update stack_trace.dart

### DIFF
--- a/dev/integration_tests/web/lib/stack_trace.dart
+++ b/dev/integration_tests/web/lib/stack_trace.dart
@@ -152,7 +152,7 @@ class StackFrameEquality implements Equality<StackFrame> {
   }
 
   @override
-  int hash(StackFrame e) {
+  int hash(StackFrame e) { // ignore: avoid_renaming_method_parameters
     return hashValues(e.number, e.packageScheme, e.package, e.packagePath, e.line, e.column, e.className, e.method);
   }
 

--- a/dev/integration_tests/web/lib/stack_trace.dart
+++ b/dev/integration_tests/web/lib/stack_trace.dart
@@ -151,6 +151,7 @@ class StackFrameEquality implements Equality<StackFrame> {
            e1.method == e2.method;
   }
 
+  // TODO(dnfield): This ignore shouldn't be necessary, see https://github.com/dart-lang/sdk/issues/46477
   @override
   int hash(StackFrame e) { // ignore: avoid_renaming_method_parameters
     return hashValues(e.number, e.packageScheme, e.package, e.packagePath, e.line, e.column, e.className, e.method);


### PR DESCRIPTION
Dart roll containing Object.hash is messing this up.

This seems like a bug in the analyzer - @bwilkerson or @pq might know