### PR TITLE
Clean up old integration test TODOs

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_gesture_transformable.dart
@@ -175,8 +175,8 @@ class _GestureTransformableState extends State<GestureTransformable> with Ticker
   }
 
   // Get the offset of the current widget from the global screen coordinates.
-  // TODO(justinmc): Protect against calling this during first build.
   static Offset getOffset(BuildContext context) {
+    assert(context.findRenderObject() != null, 'The given context must have a renderObject, such as after the first build has completed.');
     final RenderBox renderObject = context.findRenderObject()! as RenderBox;
     return renderObject.localToGlobal(Offset.zero);
   }
@@ -334,8 +334,6 @@ class _GestureTransformableState extends State<GestureTransformable> with Ticker
       Offset(nextTranslation.dx, nextTranslation.dy),
     );
     if (!inBoundaries) {
-      // TODO(justinmc): Instead of canceling translation when it goes out of
-      // bounds, stop translation at boundary.
       return matrix;
     }
 

--- a/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_inertial_motion.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/transformations/transformations_demo_inertial_motion.dart
@@ -9,7 +9,6 @@ import 'package:vector_math/vector_math.dart' show Vector2;
 // Provides calculations for an object moving with inertia and friction using
 // the equation of motion from physics.
 // https://en.wikipedia.org/wiki/Equations_of_motion#Constant_translational_acceleration_in_a_straight_line
-// TODO(justinmc): Can this be replaced with friction_simulation.dart?
 @immutable
 class InertialMotion {
   const InertialMotion(this._initialVelocity, this._initialPosition);
@@ -30,7 +29,6 @@ class InertialMotion {
 
   // The acceleration opposing the initial velocity in x and y components.
   Vector2 get _acceleration {
-    // TODO(justinmc): Find actual velocity instead of summing?
     final double velocityTotal = _initialVelocity.pixelsPerSecond.dx.abs()
       + _initialVelocity.pixelsPerSecond.dy.abs();
     final double vRatioX = _initialVelocity.pixelsPerSecond.dx / velocityTotal;


### PR DESCRIPTION
Cleaning up my old TODOs without issue links.  In this case, these are part of an old version of my InteractiveViewer demo that are still used as integration tests, even though there is a newer version in the gallery repo.  I've removed most of them as irrelevant.

A part of https://github.com/flutter/flutter/issues/85342