### PR TITLE
Remved ButtonBar references from material tests

### DIFF
--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -47,8 +47,8 @@ RenderParagraph _getTextRenderObjectFromDialog(WidgetTester tester, String text)
 }
 
 // What was the AlertDialog's ButtonBar when many of these tests were written,
-// is now a Container with an OverflowBar child. The Container's size and location
-// match the original ButtonBar's size and location.
+// is now a Padding widget with an OverflowBar child. The Padding widget's size
+// and location  match the original ButtonBar's size and location.
 Finder _findButtonBar() {
   return find.ancestor(of: find.byType(OverflowBar), matching: find.byType(Padding)).first;
 }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -493,8 +493,10 @@ void main() {
         ),
       ),
     );
-    expect(tester.getBottomLeft(_findButtonBar()), const Offset(10.0, 560.0));
-    expect(tester.getBottomRight(_findButtonBar()), const Offset(770.0, 560.0));
+
+    final Finder buttonsBar = find.ancestor(of: find.byType(OverflowBar), matching: find.byType(Padding)).first;
+    expect(tester.getBottomLeft(buttonsBar), const Offset(10.0, 560.0));
+    expect(tester.getBottomRight(buttonsBar), const Offset(770.0, 560.0));
   });
 
   testWidgets('Persistent bottom buttons bottom padding is not consumed by viewInsets', (WidgetTester tester) async {
@@ -2370,11 +2372,4 @@ class _CustomPageRoute<T> extends PageRoute<T> {
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     return child;
   }
-}
-
-// What was the Scaffold's ButtonBar when many of these tests were written,
-// is now a Container with an OverflowBar child. The Container's size and location
-// match the original ButtonBar's size and location.
-Finder _findButtonBar() {
-  return find.ancestor(of: find.byType(OverflowBar), matching: find.byType(Container)).first;
 }

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -744,7 +744,6 @@ void main() {
       popupMenuTheme: const PopupMenuThemeData(color: Colors.black),
       bannerTheme: const MaterialBannerThemeData(backgroundColor: Colors.black),
       dividerTheme: const DividerThemeData(color: Colors.black),
-      buttonBarTheme: const ButtonBarThemeData(alignment: MainAxisAlignment.start),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(type: BottomNavigationBarType.fixed),
       timePickerTheme: const TimePickerThemeData(backgroundColor: Colors.black),
       textButtonTheme: TextButtonThemeData(style: TextButton.styleFrom(primary: Colors.red)),


### PR DESCRIPTION
ButtonBar's semantics and implementation are problematic (see https://github.com/flutter/flutter/issues/53378); removing the last vestiges of it form tests: https://github.com/flutter/flutter/issues/53378