### PR TITLE
Fix three additional cases where doc references are not conforming to new lookup code restrictions

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -215,8 +215,9 @@ class NavigationRail extends StatefulWidget {
 
   /// The rail's elevation or z-coordinate.
   ///
-  /// If [Directionality] is [TextDirection.LTR], the inner side is the right
-  /// side, and if [Directionality] is [TextDirection.RTL], it is the left side.
+  /// If [Directionality] is [intl.TextDirection.LTR], the inner side is the
+  /// right side, and if [Directionality] is [intl.TextDirection.RTL], it is
+  /// the left side.
   ///
   /// The default value is 0.
   final double? elevation;

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -979,9 +979,10 @@ abstract class WidgetController {
   /// soft keyboard.
   ///
   /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type
-  /// of system. Defaults to "web" on web, and "android" everywhere else. Must not be
-  /// null. Some platforms (e.g. Windows, iOS) are not yet supported.
+  /// [platform.Platform.operatingSystem] to make the event appear to be from
+  /// that type of system. Defaults to "web" on web, and "android" everywhere
+  /// else. Must not be null. Some platforms (e.g. Windows, iOS) are not yet
+  /// supported.
   ///
   /// Keys that are down when the test completes are cleared after each test.
   ///
@@ -1009,9 +1010,10 @@ abstract class WidgetController {
   /// from a soft keyboard.
   ///
   /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type
-  /// of system. Defaults to "web" on web, and "android" everywhere else. Must not be
-  /// null. Some platforms (e.g. Windows, iOS) are not yet supported.
+  /// [platform.Platform.operatingSystem] to make the event appear to be from
+  /// that type of system. Defaults to "web" on web, and "android" everywhere
+  /// else. Must not be null. Some platforms (e.g. Windows, iOS) are not yet
+  /// supported.
   ///
   /// Keys that are down when the test completes are cleared after each test.
   ///
@@ -1033,8 +1035,9 @@ abstract class WidgetController {
   /// not from a soft keyboard.
   ///
   /// Specify `platform` as one of the platforms allowed in
-  /// [Platform.operatingSystem] to make the event appear to be from that type of
-  /// system. Defaults to "web" on web, and "android" everywhere else. May not be null.
+  /// [platform.Platform.operatingSystem] to make the event appear to be from
+  /// that type of system. Defaults to "web" on web, and "android" everywhere
+  /// else. May not be null.
   ///
   /// Returns true if the key event was handled by the framework.
   ///


### PR DESCRIPTION
Similar to #85412, fix more cases where the new dartdoc lookup will not work.

I didn't discover these because the handling of ambiguous cases had a bug where resolution was not fully stable and could vary between runs.  This will be fixed with dart-lang/dartdoc#2712.