### PR TITLE
Removed PaginatedDataTable ButtonBar special case

### DIFF
--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/widgets.dart';
 
-import 'button_bar.dart';
 import 'card.dart';
 import 'constants.dart';
 import 'data_table.dart';
@@ -372,17 +371,8 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     // HEADER
     final List<Widget> headerWidgets = <Widget>[];
-    double startPadding = 24.0;
     if (_selectedRowCount == 0 && widget.header != null) {
       headerWidgets.add(Expanded(child: widget.header!));
-      if (widget.header is ButtonBar) {
-        // We adjust the padding when a button bar is present, because the
-        // ButtonBar introduces 2 pixels of outside padding, plus 2 pixels
-        // around each button on each side, and the button itself will have 8
-        // pixels internally on each side, yet we want the left edge of the
-        // inside of the button to line up with the 24.0 left inset.
-        startPadding = 12.0;
-      }
     } else if (widget.header != null) {
       headerWidgets.add(Expanded(
         child: Text(localizations.selectedRowCountTitle(_selectedRowCount)),
@@ -501,7 +491,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                         height: 64.0,
                         color: _selectedRowCount > 0 ? themeData.secondaryHeaderColor : null,
                         child: Padding(
-                          padding: EdgeInsetsDirectional.only(start: startPadding, end: 14.0),
+                          padding: EdgeInsetsDirectional.only(start: 24, end: 14.0),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: headerWidgets,

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -491,7 +491,7 @@ class PaginatedDataTableState extends State<PaginatedDataTable> {
                         height: 64.0,
                         color: _selectedRowCount > 0 ? themeData.secondaryHeaderColor : null,
                         child: Padding(
-                          padding: EdgeInsetsDirectional.only(start: 24, end: 14.0),
+                          padding: const EdgeInsetsDirectional.only(start: 24, end: 14.0),
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: headerWidgets,

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1006,4 +1006,32 @@ void main() {
     expect(icons.elementAt(2).color, arrowHeadColor);
     expect(icons.elementAt(3).color, arrowHeadColor);
   });
+
+  testWidgets('OverflowBar header left alignment', (WidgetTester tester) async {
+    // Test an old special case that tried to align the first child of a ButtonBar
+    // and the left edge of a Text header widget. Still possible with OverflowBar
+    // albeit without any special case in the implementation's build method.
+    Widget buildFrame(Widget header) {
+      return MaterialApp(
+        home: PaginatedDataTable(
+          header: header,
+          rowsPerPage: 2,
+          source: TestDataSource(),
+          columns: const <DataColumn>[
+            DataColumn(label: Text('Name')),
+            DataColumn(label: Text('Calories'), numeric: true),
+            DataColumn(label: Text('Generation')),
+          ],
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(const Text('HEADER')));
+    final double headerX = tester.getTopLeft(find.text('HEADER')).dx;
+    final Widget overflowBar = OverflowBar(
+      children: <Widget>[ElevatedButton(onPressed: () {}, child: const Text('BUTTON'))],
+    );
+    await tester.pumpWidget(buildFrame(overflowBar));
+    expect(headerX, tester.getTopLeft(find.byType(ElevatedButton)).dx);
+  });
 }


### PR DESCRIPTION
ButtonBar's semantics and implementation are problematic (see #53378). The only remaining framework dependency was a special case in PaginatedDataTable for which there was no test case, no customer test coverage, and no internal (Google) app dependency. The special case adjusted the horizontal inset for headers whose value was a ButtonBar, to try and align the button bar's first child with where the left edge of the header was expected. This is still possible by using an OverflowBar instead of a ButtonBar, without a special case.

The original special case didn't actually seem to work in general and checking the type of a widget is of dubious value, since Flutter is based on composition. For example `header: Container(color: Colors.red, child: ButtonBar(...))` would not have triggered the special case.

