### PR TITLE
[integration_test] Fix example link in the README

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -78,7 +78,7 @@ To run the `integration_test/foo_test.dart` test with the
 flutter drive \
   --driver=test_driver/integration_test.dart \
   --target=integration_test/foo_test.dart
-``` d
+```
 
 ### Web
 

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -65,7 +65,7 @@ test_driver/
   integration_test.dart
 ```
 
-[Example](https://github.com/flutter/plugins/tree/master/packages/integration_test/example)
+[Example](https://github.com/flutter/flutter/tree/master/packages/integration_test/example)
 
 ## Using Flutter Driver to Run Tests
 
@@ -78,7 +78,7 @@ To run the `integration_test/foo_test.dart` test with the
 flutter drive \
   --driver=test_driver/integration_test.dart \
   --target=integration_test/foo_test.dart
-```
+``` d
 
 ### Web
 


### PR DESCRIPTION
Currently, the Example link points to the plugins repository example, which is now removed.
Updated example link to point to flutter/packages/integration_test example location.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
