### PR TITLE
[ci.yaml] Set targets names equal to builder

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -814,7 +814,7 @@ targets:
     scheduler: luci
 
   - name: Linux docs_test
-    builder: Linux docs_test
+    builder: Linux docs_test # Flaky https://github.com/flutter/flutter/issues/84609
     bringup: true
     presubmit: false
     scheduler: luci
@@ -856,7 +856,7 @@ targets:
 
   - name: Linux flutter_gallery__transition_perf_e2e
     builder: Linux flutter_gallery__transition_perf_e2e
-    bringup: true
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
     presubmit: false
     scheduler: luci
 
@@ -882,7 +882,7 @@ targets:
 
   - name: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
     builder: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
-    bringup: true
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
     presubmit: false
     scheduler: luci
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -9,11 +9,11 @@ enabled_branches:
   - master
 
 targets:
-  - name: linux_analyze
+  - name: Linux analyze
     builder: Linux analyze
     scheduler: luci
 
-  - name: linux_build_aar_module_test
+  - name: Linux build_aar_module_test
     builder: Linux build_aar_module_test
     scheduler: luci
     runIf:
@@ -21,19 +21,19 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_customer_testing
+  - name: Linux customer_testing
     builder: Linux customer_testing
     scheduler: luci
 
-  - name: linux_build_tests_1_2
+  - name: Linux build_tests_1_2
     builder: Linux build_tests_1_2
     scheduler: luci
 
-  - name: linux_build_tests_2_2
+  - name: Linux build_tests_2_2
     builder: Linux build_tests_2_2
     scheduler: luci
 
-  - name: linux_docs
+  - name: Linux docs
     builder: Linux docs
     postsubmit: false
     scheduler: luci
@@ -45,7 +45,7 @@ targets:
       - packages/flutter_localizations/
       - bin/
 
-  - name: linux_framework_tests_libraries
+  - name: Linux framework_tests_libraries
     builder: Linux framework_tests_libraries
     scheduler: luci
     runIf:
@@ -60,7 +60,7 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: linux_framework_tests_misc
+  - name: Linux framework_tests_misc
     builder: Linux framework_tests_misc
     scheduler: luci
     runIf:
@@ -75,7 +75,7 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: linux_framework_tests_widgets
+  - name: Linux framework_tests_widgets
     builder: Linux framework_tests_widgets
     scheduler: luci
     runIf:
@@ -90,44 +90,44 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: linux_firebase_abstract_method_smoke_test
+  - name: Linux firebase_abstract_method_smoke_test
     builder: Linux firebase_abstract_method_smoke_test
     scheduler: luci
 
-  - name: linux_firebase_android_embedding_v2_smoke_test
+  - name: Linux firebase_android_embedding_v2_smoke_test
     builder: Linux firebase_android_embedding_v2_smoke_test
     scheduler: luci
 
-  - name: linux_firebase_release_smoke_test
+  - name: Linux firebase_release_smoke_test
     builder: Linux firebase_release_smoke_test
     scheduler: luci
 
-  - name: linux_fuchsia_precache
+  - name: Linux fuchsia_precache
     builder: Linux fuchsia_precache
     scheduler: luci
 
-  - name: linux_gradle_desugar_classes_test
+  - name: Linux gradle_desugar_classes_test
     builder: Linux gradle_desugar_classes_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: linux_gradle_plugin_bundle_test
+  - name: Linux gradle_plugin_bundle_test
     builder: Linux gradle_plugin_bundle_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: linux_gradle_plugin_fat_apk_test
+  - name: Linux gradle_plugin_fat_apk_test
     builder: Linux gradle_plugin_fat_apk_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: linux_gradle_plugin_light_apk_test
+  - name: Linux gradle_plugin_light_apk_test
     builder: Linux gradle_plugin_light_apk_test
     postsubmit: false
     scheduler: luci
@@ -135,7 +135,7 @@ targets:
       - dev/**
       - bin/**
 
-  - name: linux_module_host_with_custom_build_test
+  - name: Linux module_host_with_custom_build_test
     builder: Linux module_host_with_custom_build_test
     scheduler: luci
     runIf:
@@ -143,7 +143,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_module_custom_host_app_name_test
+  - name: Linux module_custom_host_app_name_test
     builder: Linux module_custom_host_app_name_test
     scheduler: luci
     runIf:
@@ -151,7 +151,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_module_test
+  - name: Linux module_test
     builder: Linux module_test
     scheduler: luci
     runIf:
@@ -159,7 +159,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_plugin_test
+  - name: Linux plugin_test
     builder: Linux plugin_test
     scheduler: luci
     runIf:
@@ -167,7 +167,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_skp_generator
+  - name: Linux skp_generator
     builder: Linux skp_generator
     scheduler: luci
     runIf:
@@ -176,7 +176,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_tests_general
+  - name: Linux tool_tests_general
     builder: Linux tool_tests_general
     scheduler: luci
     runIf:
@@ -184,7 +184,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_tests_commands
+  - name: Linux tool_tests_commands
     builder: Linux tool_tests_commands
     scheduler: luci
     runIf:
@@ -192,7 +192,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_integration_tests_1_4
+  - name: Linux tool_integration_tests_1_4
     builder: Linux tool_integration_tests_1_4
     scheduler: luci
     runIf:
@@ -200,7 +200,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_integration_tests_2_4
+  - name: Linux tool_integration_tests_2_4
     builder: Linux tool_integration_tests_2_4
     scheduler: luci
     runIf:
@@ -208,7 +208,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_integration_tests_3_4
+  - name: Linux tool_integration_tests_3_4
     builder: Linux tool_integration_tests_3_4
     scheduler: luci
     runIf:
@@ -216,7 +216,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_tool_integration_tests_4_4
+  - name: Linux tool_integration_tests_4_4
     builder: Linux tool_integration_tests_4_4
     scheduler: luci
     runIf:
@@ -224,7 +224,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_web_tool_tests
+  - name: Linux web_tool_tests
     builder: Linux web_tool_tests
     scheduler: luci
     runIf:
@@ -232,14 +232,14 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: linux_web_benchmarks_html
+  - name: Linux web_benchmarks_html
     builder: Linux web_benchmarks_html
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: linux_web_tests_0
+  - name: Linux web_tests_0
     builder: Linux web_tests_0
     scheduler: luci
     runIf:
@@ -247,7 +247,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_1
+  - name: Linux web_tests_1
     builder: Linux web_tests_1
     scheduler: luci
     runIf:
@@ -255,7 +255,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_2
+  - name: Linux web_tests_2
     builder: Linux web_tests_2
     scheduler: luci
     runIf:
@@ -263,7 +263,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_3
+  - name: Linux web_tests_3
     builder: Linux web_tests_3
     scheduler: luci
     runIf:
@@ -271,7 +271,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_4
+  - name: Linux web_tests_4
     builder: Linux web_tests_4
     scheduler: luci
     runIf:
@@ -279,7 +279,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_5
+  - name: Linux web_tests_5
     builder: Linux web_tests_5
     scheduler: luci
     runIf:
@@ -287,7 +287,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_6
+  - name: Linux web_tests_6
     builder: Linux web_tests_6
     scheduler: luci
     runIf:
@@ -295,7 +295,7 @@ targets:
       - packages/
       - bin/
 
-  - name: linux_web_tests_7_last
+  - name: Linux web_tests_7_last
     builder: Linux web_tests_7_last
     scheduler: luci
     runIf:
@@ -303,7 +303,7 @@ targets:
       - packages/
       - bin/
 
-  - name: web_long_running_tests_1_5
+  - name: Linux web_long_running_tests_1_5
     builder: Linux web_long_running_tests_1_5
     postsubmit: false
     scheduler: luci
@@ -312,7 +312,7 @@ targets:
       - packages/
       - bin/
 
-  - name: web_long_running_tests_2_5
+  - name: Linux web_long_running_tests_2_5
     builder: Linux web_long_running_tests_2_5
     postsubmit: false
     scheduler: luci
@@ -321,7 +321,7 @@ targets:
       - packages/
       - bin/
 
-  - name: web_long_running_tests_3_5
+  - name: Linux web_long_running_tests_3_5
     builder: Linux web_long_running_tests_3_5
     postsubmit: false
     scheduler: luci
@@ -330,7 +330,7 @@ targets:
       - packages/
       - bin/
 
-  - name: web_long_running_tests_4_5
+  - name: Linux web_long_running_tests_4_5
     builder: Linux web_long_running_tests_4_5
     postsubmit: false
     scheduler: luci
@@ -339,7 +339,7 @@ targets:
       - packages/
       - bin/
 
-  - name: web_long_running_tests_5_5
+  - name: Linux web_long_running_tests_5_5
     builder: Linux web_long_running_tests_5_5
     postsubmit: false
     scheduler: luci
@@ -348,11 +348,11 @@ targets:
       - packages/
       - bin/
 
-  - name: flutter_plugins
+  - name: Linux flutter_plugins
     builder: Linux flutter_plugins
     scheduler: luci
 
-  - name: mac_build_aar_module_test
+  - name: Mac build_aar_module_test
     builder: Mac build_aar_module_test
     scheduler: luci
     runIf:
@@ -360,7 +360,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_build_ios_framework_module_test
+  - name: Mac build_ios_framework_module_test
     builder: Mac build_ios_framework_module_test
     scheduler: luci
     runIf:
@@ -368,27 +368,27 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_build_tests_1_4
+  - name: Mac build_tests_1_4
     builder: Mac build_tests_1_4
     scheduler: luci
 
-  - name: mac_build_tests_2_4
+  - name: Mac build_tests_2_4
     builder: Mac build_tests_2_4
     scheduler: luci
 
-  - name: mac_build_tests_3_4
+  - name: Mac build_tests_3_4
     builder: Mac build_tests_3_4
     scheduler: luci
 
-  - name: mac_build_tests_4_4
+  - name: Mac build_tests_4_4
     builder: Mac build_tests_4_4
     scheduler: luci
 
-  - name: mac_customer_testing
+  - name: Mac customer_testing
     builder: Mac customer_testing
     scheduler: luci
 
-  - name: mac_framework_tests_libraries
+  - name: Mac framework_tests_libraries
     builder: Mac framework_tests_libraries
     postsubmit: false
     scheduler: luci
@@ -404,7 +404,7 @@ targets:
       - packages/flutter_tools/lib/src/test/**
       - bin/**
 
-  - name: mac_framework_tests_misc
+  - name: Mac framework_tests_misc
     builder: Mac framework_tests_misc
     scheduler: luci
     runIf:
@@ -419,7 +419,7 @@ targets:
       - packages/flutter_tools/lib/src/test/**
       - bin/**
 
-  - name: mac_framework_tests_widgets
+  - name: Mac framework_tests_widgets
     builder: Mac framework_tests_widgets
     scheduler: luci
     runIf:
@@ -434,28 +434,28 @@ targets:
       - packages/flutter_tools/lib/src/test/**
       - bin/**
 
-  - name: mac_gradle_plugin_bundle_test
+  - name: Mac gradle_plugin_bundle_test
     builder: Mac gradle_plugin_bundle_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: mac_gradle_plugin_fat_apk_test
+  - name: Mac gradle_plugin_fat_apk_test
     builder: Mac gradle_plugin_fat_apk_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: mac_gradle_plugin_light_apk_test
+  - name: Mac gradle_plugin_light_apk_test
     builder: Mac gradle_plugin_light_apk_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: mac_module_custom_host_app_name_test
+  - name: Mac module_custom_host_app_name_test
     builder: Mac module_custom_host_app_name_test
     scheduler: luci
     runIf:
@@ -463,7 +463,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_module_host_with_custom_build_test
+  - name: Mac module_host_with_custom_build_test
     builder: Mac module_host_with_custom_build_test
     scheduler: luci
     runIf:
@@ -471,7 +471,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_module_test
+  - name: Mac module_test
     builder: Mac module_test
     scheduler: luci
     runIf:
@@ -479,22 +479,23 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_module_test_ios
+  - name: Mac module_test_ios
     builder: Mac module_test_ios
+    bringup: true
     scheduler: luci
     runIf:
       - dev/**
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_plugin_lint_mac
+  - name: Mac plugin_lint_mac
     builder: Mac plugin_lint_mac
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: mac_plugin_test
+  - name: Mac plugin_test
     builder: Mac plugin_test
     scheduler: luci
     runIf:
@@ -502,7 +503,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: dart_plugin_registry_test
+  - name: Mac dart_plugin_registry_test
     builder: Mac dart_plugin_registry_test
     scheduler: luci
     runIf:
@@ -510,7 +511,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_tool_tests_general
+  - name: Mac tool_tests_general
     builder: Mac tool_tests_general
     scheduler: luci
     runIf:
@@ -518,7 +519,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: tool_tests_commands
+  - name: Windows tool_tests_commands
     builder: Windows tool_tests_commands
     postsubmit: false
     scheduler: luci
@@ -527,7 +528,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_tool_integration_tests_1_4
+  - name: Mac tool_integration_tests_1_4
     builder: Mac tool_integration_tests_1_4
     scheduler: luci
     runIf:
@@ -535,7 +536,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_tool_integration_tests_2_4
+  - name: Mac tool_integration_tests_2_4
     builder: Mac tool_integration_tests_2_4
     scheduler: luci
     runIf:
@@ -543,7 +544,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_tool_integration_tests_3_4
+  - name: Mac tool_integration_tests_3_4
     builder: Mac tool_integration_tests_3_4
     scheduler: luci
     runIf:
@@ -551,7 +552,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_tool_integration_tests_4_4
+  - name: Mac tool_integration_tests_4_4
     builder: Mac tool_integration_tests_4_4
     scheduler: luci
     runIf:
@@ -559,7 +560,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: mac_web_tool_tests
+  - name: Mac web_tool_tests
     builder: Mac web_tool_tests
     postsubmit: false
     scheduler: luci
@@ -568,7 +569,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_build_aar_module_test
+  - name: Windows build_aar_module_test
     builder: Windows build_aar_module_test
     scheduler: luci
     runIf:
@@ -576,23 +577,23 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_build_tests_1_3
+  - name: Windows build_tests_1_3
     builder: Windows build_tests_1_3
     scheduler: luci
 
-  - name: win_build_tests_2_3
+  - name: Windows build_tests_2_3
     builder: Windows build_tests_2_3
     scheduler: luci
 
-  - name: win_build_tests_3_3
+  - name: Windows build_tests_3_3
     builder: Windows build_tests_3_3
     scheduler: luci
 
-  - name: win_customer_testing
+  - name: Windows customer_testing
     builder: Windows customer_testing
     scheduler: luci
 
-  - name: win_framework_tests_libraries
+  - name: Windows framework_tests_libraries
     builder: Windows framework_tests_libraries
     scheduler: luci
     runIf:
@@ -607,7 +608,7 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: framework_tests_misc
+  - name: Windows framework_tests_misc
     builder: Windows framework_tests_misc
     postsubmit: false
     scheduler: luci
@@ -623,7 +624,7 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: framework_tests_widgets
+  - name: Windows framework_tests_widgets
     builder: Windows framework_tests_widgets
     postsubmit: false
     scheduler: luci
@@ -639,21 +640,21 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: win_gradle_plugin_bundle_test
+  - name: Windows gradle_plugin_bundle_test
     builder: Windows gradle_plugin_bundle_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: win_gradle_plugin_light_apk_test
+  - name: Windows gradle_plugin_light_apk_test
     builder: Windows gradle_plugin_light_apk_test
     scheduler: luci
     runIf:
       - dev/**
       - bin/**
 
-  - name: win_module_custom_host_app_name_test
+  - name: Windows module_custom_host_app_name_test
     builder: Windows module_custom_host_app_name_test
     scheduler: luci
     runIf:
@@ -661,7 +662,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_module_test
+  - name: Windows module_test
     builder: Windows module_test
     scheduler: luci
     runIf:
@@ -669,7 +670,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_module_host_with_custom_build_test
+  - name: Windows module_host_with_custom_build_test
     builder: Windows module_host_with_custom_build_test
     scheduler: luci
     runIf:
@@ -677,7 +678,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_plugin_test
+  - name: Windows plugin_test
     builder: Windows plugin_test
     scheduler: luci
     runIf:
@@ -685,7 +686,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: tool_tests_general
+  - name: Windows tool_tests_general
     builder: Windows tool_tests_general
     postsubmit: false
     scheduler: luci
@@ -694,7 +695,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_tool_integration_tests_1_5
+  - name: Windows tool_integration_tests_1_5
     builder: Windows tool_integration_tests_1_5
     scheduler: luci
     runIf:
@@ -702,7 +703,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_tool_integration_tests_2_5
+  - name: Windows tool_integration_tests_2_5
     builder: Windows tool_integration_tests_2_5
     scheduler: luci
     runIf:
@@ -710,7 +711,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_tool_integration_tests_3_5
+  - name: Windows tool_integration_tests_3_5
     builder: Windows tool_integration_tests_3_5
     scheduler: luci
     runIf:
@@ -718,7 +719,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_tool_integration_tests_4_5
+  - name: Windows tool_integration_tests_4_5
     builder: Windows tool_integration_tests_4_5
     scheduler: luci
     runIf:
@@ -726,7 +727,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_tool_integration_tests_5_5
+  - name: Windows tool_integration_tests_5_5
     builder: Windows tool_integration_tests_5_5
     scheduler: luci
     runIf:
@@ -734,7 +735,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: win_web_tool_tests
+  - name: Windows web_tool_tests
     builder: Windows web_tool_tests
     scheduler: luci
     runIf:
@@ -742,758 +743,759 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: linux_analyzer_benchmark
+  - name: Linux analyzer_benchmark
     builder: Linux analyzer_benchmark
     presubmit: false
     scheduler: luci
 
-  - name: linux_android_defines_test
+  - name: Linux android_defines_test
     builder: Linux android_defines_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_android_obfuscate_test
+  - name: Linux android_obfuscate_test
     builder: Linux android_obfuscate_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_android_stack_size_test
+  - name: Linux android_stack_size_test
     builder: Linux android_stack_size_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_android_view_scroll_perf__timeline_summary
+  - name: Linux android_view_scroll_perf__timeline_summary
     builder: Linux android_view_scroll_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_animated_placeholder_perf__e2e_summary
+  - name: Linux animated_placeholder_perf__e2e_summary
     builder: Linux animated_placeholder_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_backdrop_filter_perf__e2e_summary
+  - name: Linux backdrop_filter_perf__e2e_summary
     builder: Linux backdrop_filter_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_basic_material_app_android__compile
+  - name: Linux basic_material_app_android__compile
     builder: Linux basic_material_app_android__compile
     presubmit: false
     scheduler: luci
 
-  - name: linux_color_filter_and_fade_perf__e2e_summary
+  - name: Linux color_filter_and_fade_perf__e2e_summary
     builder: Linux color_filter_and_fade_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_complex_layout_android__compile
+  - name: Linux complex_layout_android__compile
     builder: Linux complex_layout_android__compile
     presubmit: false
     scheduler: luci
 
-  - name: linux_complex_layout_android__scroll_smoothness
+  - name: Linux complex_layout_android__scroll_smoothness
     builder: Linux complex_layout_android__scroll_smoothness
     presubmit: false
     scheduler: luci
 
-  - name: linux_complex_layout_scroll_perf__devtools_memory
+  - name: Linux complex_layout_scroll_perf__devtools_memory
     builder: Linux complex_layout_scroll_perf__devtools_memory
     presubmit: false
     scheduler: luci
 
-  - name: linux_complex_layout_semantics_perf
+  - name: Linux complex_layout_semantics_perf
     builder: Linux complex_layout_semantics_perf
     presubmit: false
     scheduler: luci
 
-  - name: linux_cubic_bezier_perf__e2e_summary
+  - name: Linux cubic_bezier_perf__e2e_summary
     builder: Linux cubic_bezier_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_cubic_bezier_perf_sksl_warmup__e2e_summary
+  - name: Linux cubic_bezier_perf_sksl_warmup__e2e_summary
     builder: Linux cubic_bezier_perf_sksl_warmup__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_cull_opacity_perf__e2e_summary
+  - name: Linux cull_opacity_perf__e2e_summary
     builder: Linux cull_opacity_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_docs_test
+  - name: Linux docs_test
     builder: Linux docs_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/84609
+    bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: linux_docs_publish
+  - name: Linux docs_publish
     builder: Linux docs_publish
     presubmit: false
     scheduler: luci
 
-  - name: linux_fast_scroll_heavy_gridview__memory
+  - name: Linux fast_scroll_heavy_gridview__memory
     builder: Linux fast_scroll_heavy_gridview__memory
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_engine_group_performance
+  - name: Linux flutter_engine_group_performance
     builder: Linux flutter_engine_group_performance
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__back_button_memory
+  - name: Linux flutter_gallery__back_button_memory
     builder: Linux flutter_gallery__back_button_memory
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__image_cache_memory
+  - name: Linux flutter_gallery__image_cache_memory
     builder: Linux flutter_gallery__image_cache_memory
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__memory_nav
+  - name: Linux flutter_gallery__memory_nav
     builder: Linux flutter_gallery__memory_nav
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__start_up
+  - name: Linux flutter_gallery__start_up
     builder: Linux flutter_gallery__start_up
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__transition_perf_e2e
+  - name: Linux flutter_gallery__transition_perf_e2e
     builder: Linux flutter_gallery__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+    bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__transition_perf_hybrid
+  - name: Linux flutter_gallery__transition_perf_hybrid
     builder: Linux flutter_gallery__transition_perf_hybrid
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__transition_perf_with_semantics
+  - name: Linux flutter_gallery__transition_perf_with_semantics
     builder: Linux flutter_gallery__transition_perf_with_semantics
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery__transition_perf
+  - name: Linux flutter_gallery__transition_perf
     builder: Linux flutter_gallery__transition_perf
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery_android__compile
+  - name: Linux flutter_gallery_android__compile
     builder: Linux flutter_gallery_android__compile
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery_sksl_warmup__transition_perf_e2e
+  - name: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
     builder: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+    bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery_sksl_warmup__transition_perf
+  - name: Linux flutter_gallery_sksl_warmup__transition_perf
     builder: Linux flutter_gallery_sksl_warmup__transition_perf
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery_v2_chrome_run_test
+  - name: Linux flutter_gallery_v2_chrome_run_test
     builder: Linux flutter_gallery_v2_chrome_run_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_gallery_v2_web_compile_test
+  - name: Linux flutter_gallery_v2_web_compile_test
     builder: Linux flutter_gallery_v2_web_compile_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_flutter_test_performance
+  - name: Linux flutter_test_performance
     builder: Linux flutter_test_performance
     presubmit: false
     scheduler: luci
 
-  - name: linux_frame_policy_delay_test_android
+  - name: Linux frame_policy_delay_test_android
     builder: Linux frame_policy_delay_test_android
     presubmit: false
     scheduler: luci
 
-  - name: linux_hot_mode_dev_cycle_linux__benchmark
+  - name: Linux hot_mode_dev_cycle_linux__benchmark
     builder: Linux hot_mode_dev_cycle_linux__benchmark
     presubmit: false
     scheduler: luci
 
-  - name: linux_image_list_jit_reported_duration
+  - name: Linux image_list_jit_reported_duration
     builder: Linux image_list_jit_reported_duration
     presubmit: false
     scheduler: luci
 
-  - name: linux_image_list_reported_duration
+  - name: Linux image_list_reported_duration
     builder: Linux image_list_reported_duration
     presubmit: false
     scheduler: luci
 
-  - name: linux_large_image_changer_perf_android
+  - name: Linux large_image_changer_perf_android
     builder: Linux large_image_changer_perf_android
     presubmit: false
     scheduler: luci
 
-  - name: animated_image_gc_perf
+  - name: Linux animated_image_gc_perf
     builder: Linux animated_image_gc_perf
     presubmit: false
     scheduler: luci
 
-  - name: linux_linux_chrome_dev_mode
+  - name: Linux linux_chrome_dev_mode
     builder: Linux linux_chrome_dev_mode
     presubmit: false
     scheduler: luci
 
-  - name: linux_multi_widget_construction_perf__e2e_summary
+  - name: Linux multi_widget_construction_perf__e2e_summary
     builder: Linux multi_widget_construction_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_new_gallery__crane_perf
+  - name: Linux new_gallery__crane_perf
     builder: Linux new_gallery__crane_perf
     presubmit: false
     scheduler: luci
 
-  - name: linux_picture_cache_perf__e2e_summary
+  - name: Linux picture_cache_perf__e2e_summary
     builder: Linux picture_cache_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_platform_channels_benchmarks
+  - name: Linux platform_channels_benchmarks
     builder: Linux platform_channels_benchmarks
     presubmit: false
     scheduler: luci
 
-  - name: linux_platform_views_scroll_perf__timeline_summary
+  - name: Linux platform_views_scroll_perf__timeline_summary
     builder: Linux platform_views_scroll_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_routing_test
+  - name: Linux routing_test
     builder: Linux routing_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_technical_debt__cost
+  - name: Linux technical_debt__cost
     builder: Linux technical_debt__cost
     presubmit: false
     scheduler: luci
 
-  - name: linux_textfield_perf__e2e_summary
+  - name: Linux textfield_perf__e2e_summary
     builder: Linux textfield_perf__e2e_summary
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_benchmarks_canvaskit
+  - name: Linux web_benchmarks_canvaskit
     builder: Linux web_benchmarks_canvaskit
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_size__compile_test
+  - name: Linux web_size__compile_test
     builder: Linux web_size__compile_test
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_long_running_tests_1_5
+  - name: Linux web_long_running_tests_1_5
     builder: Linux web_long_running_tests_1_5
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_long_running_tests_2_5
+  - name: Linux web_long_running_tests_2_5
     builder: Linux web_long_running_tests_2_5
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_long_running_tests_3_5
+  - name: Linux web_long_running_tests_3_5
     builder: Linux web_long_running_tests_3_5
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_long_running_tests_4_5
+  - name: Linux web_long_running_tests_4_5
     builder: Linux web_long_running_tests_4_5
     presubmit: false
     scheduler: luci
 
-  - name: linux_web_long_running_tests_5_5
+  - name: Linux web_long_running_tests_5_5
     builder: Linux web_long_running_tests_5_5
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_android_semantics_integration_test
+  - name: Mac_android android_semantics_integration_test
     builder: Mac_android android_semantics_integration_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_backdrop_filter_perf__timeline_summary
+  - name: Mac_android backdrop_filter_perf__timeline_summary
     builder: Mac_android backdrop_filter_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_channels_integration_test
+  - name: Mac_android channels_integration_test
     builder: Mac_android channels_integration_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_color_filter_and_fade_perf__timeline_summary
+  - name: Mac_android color_filter_and_fade_perf__timeline_summary
     builder: Mac_android color_filter_and_fade_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_complex_layout__start_up
+  - name: Mac_android complex_layout__start_up
     builder: Mac_android complex_layout__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_complex_layout_scroll_perf__memory
+  - name: Mac_android complex_layout_scroll_perf__memory
     builder: Mac_android complex_layout_scroll_perf__memory
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_complex_layout_scroll_perf__timeline_summary
+  - name: Mac_android complex_layout_scroll_perf__timeline_summary
     builder: Mac_android complex_layout_scroll_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_cubic_bezier_perf__timeline_summary
+  - name: Mac_android cubic_bezier_perf__timeline_summary
     builder: Mac_android cubic_bezier_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_cubic_bezier_perf_sksl_warmup__timeline_summary
+  - name: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
     builder: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_cull_opacity_perf__timeline_summary
+  - name: Mac_android cull_opacity_perf__timeline_summary
     builder: Mac_android cull_opacity_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_drive_perf_debug_warning
+  - name: Mac_android drive_perf_debug_warning
     builder: Mac_android drive_perf_debug_warning
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_embedded_android_views_integration_test
+  - name: Mac_android embedded_android_views_integration_test
     builder: Mac_android embedded_android_views_integration_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_external_ui_integration_test
+  - name: Mac_android external_ui_integration_test
     builder: Mac_android external_ui_integration_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_fading_child_animation_perf__timeline_summary
+  - name: Mac_android fading_child_animation_perf__timeline_summary
     builder: Mac_android fading_child_animation_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_fast_scroll_large_images__memory
+  - name: Mac_android fast_scroll_large_images__memory
     builder: Mac_android fast_scroll_large_images__memory
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_flavors_test
+  - name: Mac_android flavors_test
     builder: Mac_android flavors_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_flutter_view__start_up
+  - name: Mac_android flutter_view__start_up
     builder: Mac_android flutter_view__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_fullscreen_textfield_perf__timeline_summary
+  - name: Mac_android fullscreen_textfield_perf__timeline_summary
     builder: Mac_android fullscreen_textfield_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_hello_world__memory
+  - name: Mac_android hello_world__memory
     builder: Mac_android hello_world__memory
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_hello_world_android__compile
+  - name: Mac_android hello_world_android__compile
     builder: Mac_android hello_world_android__compile
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_home_scroll_perf__timeline_summary
+  - name: Mac_android home_scroll_perf__timeline_summary
     builder: Mac_android home_scroll_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_hot_mode_dev_cycle__benchmark
+  - name: Mac_android hot_mode_dev_cycle__benchmark
     builder: Mac_android hot_mode_dev_cycle__benchmark
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_hybrid_android_views_integration_test
+  - name: Mac_android hybrid_android_views_integration_test
     builder: Mac_android hybrid_android_views_integration_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_imagefiltered_transform_animation_perf__timeline_summary
+  - name: Mac_android imagefiltered_transform_animation_perf__timeline_summary
     builder: Mac_android imagefiltered_transform_animation_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_integration_ui_driver
+  - name: Mac_android integration_ui_driver
     builder: Mac_android integration_ui_driver
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_integration_ui_keyboard_resize
+  - name: Mac_android integration_ui_keyboard_resize
     builder: Mac_android integration_ui_keyboard_resize
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_integration_ui_screenshot
+  - name: Mac_android integration_ui_screenshot
     builder: Mac_android integration_ui_screenshot
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_integration_ui_textfield
+  - name: Mac_android integration_ui_textfield
     builder: Mac_android integration_ui_textfield
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_integration_test_test
+  - name: Mac_android integration_test_test
     builder: Mac_android integration_test_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_microbenchmarks
+  - name: Mac_android microbenchmarks
     builder: Mac_android microbenchmarks
     bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_new_gallery__transition_perf
+  - name: Mac_android new_gallery__transition_perf
     builder: Mac_android new_gallery__transition_perf
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_picture_cache_perf__timeline_summary
+  - name: Mac_android picture_cache_perf__timeline_summary
     builder: Mac_android picture_cache_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_platform_channel_sample_test
+  - name: Mac_android platform_channel_sample_test
     builder: Mac_android platform_channel_sample_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_platform_interaction_test
+  - name: Mac_android platform_interaction_test
     builder: Mac_android platform_interaction_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_platform_view__start_up
+  - name: Mac_android platform_view__start_up
     builder: Mac_android platform_view__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_run_release_test
+  - name: Mac_android run_release_test
     builder: Mac_android run_release_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_service_extensions_test
+  - name: Mac_android service_extensions_test
     builder: Mac_android service_extensions_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_smoke_catalina_start_up
+  - name: Mac_android smoke_catalina_start_up
     builder: Mac_android smoke_catalina_start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_textfield_perf__timeline_summary
+  - name: Mac_android textfield_perf__timeline_summary
     builder: Mac_android textfield_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_android_tiles_scroll_perf__timeline_summary
+  - name: Mac_android tiles_scroll_perf__timeline_summary
     builder: Mac_android tiles_scroll_perf__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_framework_testslibraries
+  - name: Mac framework_tests_libraries
     builder: Mac framework_tests_libraries
     presubmit: false
     scheduler: luci
 
-  - name: mac_tool_tests_commands
+  - name: Mac tool_tests_commands
     builder: Mac tool_tests_commands
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_backdrop_filter_perf_ios__timeline_summary
+  - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
     builder: Mac_ios backdrop_filter_perf_ios__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_basic_material_app_ios__compile
+  - name: Mac_ios basic_material_app_ios__compile
     builder: Mac_ios basic_material_app_ios__compile
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_channels_integration_test_ios
+  - name: Mac_ios channels_integration_test_ios
     builder: Mac_ios channels_integration_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_complex_layout_ios__compile
+  - name: Mac_ios complex_layout_ios__compile
     builder: Mac_ios complex_layout_ios__compile
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_complex_layout_ios__start_up
+  - name: Mac_ios complex_layout_ios__start_up
     builder: Mac_ios complex_layout_ios__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_complex_layout_scroll_perf_ios__timeline_summary
+  - name: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
     builder: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_external_ui_integration_test_ios
+  - name: Mac_ios external_ui_integration_test_ios
     builder: Mac_ios external_ui_integration_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flavors_test_ios
+  - name: Mac_ios flavors_test_ios
     builder: Mac_ios flavors_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_gallery__transition_perf_e2e_ios
+  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
     builder: Mac_ios flutter_gallery__transition_perf_e2e_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_gallery__transition_perf_e2e_ios32
+  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios32
     builder: Mac_ios flutter_gallery__transition_perf_e2e_ios32
     bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_gallery_ios__compile
+  - name: Mac_ios flutter_gallery_ios__compile
     builder: Mac_ios flutter_gallery_ios__compile
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_gallery_ios__start_up
+  - name: Mac_ios flutter_gallery_ios__start_up
     builder: Mac_ios flutter_gallery_ios__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_gallery_ios__transition_perf
+  - name: Mac_ios flutter_gallery_ios__transition_perf
     builder: Mac_ios flutter_gallery_ios__transition_perf
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_flutter_view_ios__start_up
+  - name: Mac_ios flutter_view_ios__start_up
     builder: Mac_ios flutter_view_ios__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_hello_world_ios__compile
+  - name: Mac_ios hello_world_ios__compile
     builder: Mac_ios hello_world_ios__compile
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_hot_mode_dev_cycle_macos_target__benchmark
+  - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
     builder: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_integration_ui_ios_driver
+  - name: Mac_ios integration_ui_ios_driver
     builder: Mac_ios integration_ui_ios_driver
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_integration_ui_ios_keyboard_resize
+  - name: Mac_ios integration_ui_ios_keyboard_resize
     builder: Mac_ios integration_ui_ios_keyboard_resize
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_integration_ui_ios_screenshot
+  - name: Mac_ios integration_ui_ios_screenshot
     builder: Mac_ios integration_ui_ios_screenshot
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_integration_ui_ios_textfield
+  - name: Mac_ios integration_ui_ios_textfield
     builder: Mac_ios integration_ui_ios_textfield
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_integration_test_test_ios
+  - name: Mac_ios integration_test_test_ios
     builder: Mac_ios integration_test_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_ios_app_with_extensions_test
+  - name: Mac_ios ios_app_with_extensions_test
     builder: Mac_ios ios_app_with_extensions_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_ios_content_validation_test
+  - name: Mac_ios ios_content_validation_test
     builder: Mac_ios ios_content_validation_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_ios_defines_test
+  - name: Mac_ios ios_defines_test
     builder: Mac_ios ios_defines_test
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_ios_platform_view_tests
+  - name: Mac_ios ios_platform_view_tests
     builder: Mac_ios ios_platform_view_tests
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_large_image_changer_perf_ios
+  - name: Mac_ios large_image_changer_perf_ios
     builder: Mac_ios large_image_changer_perf_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_macos_chrome_dev_mode
+  - name: Mac_ios macos_chrome_dev_mode
     builder: Mac_ios macos_chrome_dev_mode
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_microbenchmarks_ios
+  - name: Mac_ios microbenchmarks_ios
     builder: Mac_ios microbenchmarks_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_native_ui_tests_ios32
+  - name: Mac_ios native_ui_tests_ios32
     builder: Mac_ios native_ui_tests_ios32
     bringup: true
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_new_gallery_ios__transition_perf
+  - name: Mac_ios new_gallery_ios__transition_perf
     builder: Mac_ios new_gallery_ios__transition_perf
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_channel_sample_test_ios
+  - name: Mac_ios platform_channel_sample_test_ios
     builder: Mac_ios platform_channel_sample_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_channel_sample_test_swift
+  - name: Mac_ios platform_channel_sample_test_swift
     builder: Mac_ios platform_channel_sample_test_swift
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_channels_benchmarks_ios
+  - name: Mac_ios platform_channels_benchmarks_ios
     builder: Mac_ios platform_channels_benchmarks_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_interaction_test_ios
+  - name: Mac_ios platform_interaction_test_ios
     builder: Mac_ios platform_interaction_test_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_view_ios__start_up
+  - name: Mac_ios platform_view_ios__start_up
     builder: Mac_ios platform_view_ios__start_up
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_platform_views_scroll_perf_ios__timeline_summary
+  - name: Mac_ios platform_views_scroll_perf_ios__timeline_summary
     builder: Mac_ios platform_views_scroll_perf_ios__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_post_backdrop_filter_perf_ios__timeline_summary
+  - name: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
     builder: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_simple_animation_perf_ios
+  - name: Mac_ios simple_animation_perf_ios
     builder: Mac_ios simple_animation_perf_ios
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_smoke_catalina_hot_mode_dev_cycle_ios__benchmark
+  - name: Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark
     builder: Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark
     presubmit: false
     scheduler: luci
 
-  - name: mac_ios_tiles_scroll_perf_ios__timeline_summary
+  - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
     builder: Mac_ios tiles_scroll_perf_ios__timeline_summary
     presubmit: false
     scheduler: luci
 
-  - name: win_framework_tests_misc
+  - name: Windows framework_tests_misc
     builder: Windows framework_tests_misc
     presubmit: false
     scheduler: luci
 
-  - name: win_framework_tests_widgets
+  - name: Windows framework_tests_widgets
     builder: Windows framework_tests_widgets
     presubmit: false
     scheduler: luci
 
-  - name: win_gradle_plugin_fat_apk_test
+  - name: Windows gradle_plugin_fat_apk_test
     builder: Windows gradle_plugin_fat_apk_test
     presubmit: false
     scheduler: luci
 
-  - name: win_tool_tests_general
+  - name: Windows tool_tests_general
     builder: Windows tool_tests_general
     presubmit: false
     scheduler: luci
 
-  - name: win_tool_tests_commands
+  - name: Windows tool_tests_commands
     builder: Windows tool_tests_commands
     presubmit: false
     scheduler: luci
 
-  - name: complex_layout_win__compile
+  - name: Windows_android complex_layout_win__compile
     builder: Windows_android complex_layout_win__compile
     presubmit: false
     scheduler: luci
 
-  - name: basic_material_app_win__compile
+  - name: Windows_android basic_material_app_win__compile
     builder: Windows_android basic_material_app_win__compile
     presubmit: false
     scheduler: luci
 
-  - name: flutter_gallery_win__compile
+  - name: Windows_android flutter_gallery_win__compile
     builder: Windows_android flutter_gallery_win__compile
     presubmit: false
     scheduler: luci
 
-  - name: windows_chrome_dev_mode
+  - name: Windows_android windows_chrome_dev_mode
     builder: Windows_android windows_chrome_dev_mode
     presubmit: false
     scheduler: luci
 
-  - name: flavors_test_win
+  - name: Windows_android flavors_test_win
     builder: Windows_android flavors_test_win
     presubmit: false
     scheduler: luci
 
-  - name: channels_integration_test_win
+  - name: Windows_android channels_integration_test_win
     builder: Windows_android channels_integration_test_win
     presubmit: false
     scheduler: luci
 
-  - name: hot_mode_dev_cycle_win__benchmark
+  - name: Windows_android hot_mode_dev_cycle_win__benchmark
     builder: Windows_android hot_mode_dev_cycle_win__benchmark
     presubmit: false
     scheduler: luci
+

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -814,8 +814,8 @@ targets:
     scheduler: luci
 
   - name: Linux docs_test
-    builder: Linux docs_test # Flaky https://github.com/flutter/flutter/issues/84609
-    bringup: true
+    builder: Linux docs_test
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/84609
     presubmit: false
     scheduler: luci
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1438,4 +1438,3 @@ targets:
     builder: Windows_android hot_mode_dev_cycle_win__benchmark
     presubmit: false
     scheduler: luci
-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -305,7 +305,6 @@ targets:
 
   - name: Linux web_long_running_tests_1_5
     builder: Linux web_long_running_tests_1_5
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -314,7 +313,6 @@ targets:
 
   - name: Linux web_long_running_tests_2_5
     builder: Linux web_long_running_tests_2_5
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -323,7 +321,6 @@ targets:
 
   - name: Linux web_long_running_tests_3_5
     builder: Linux web_long_running_tests_3_5
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -332,7 +329,6 @@ targets:
 
   - name: Linux web_long_running_tests_4_5
     builder: Linux web_long_running_tests_4_5
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -341,7 +337,6 @@ targets:
 
   - name: Linux web_long_running_tests_5_5
     builder: Linux web_long_running_tests_5_5
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -390,7 +385,6 @@ targets:
 
   - name: Mac framework_tests_libraries
     builder: Mac framework_tests_libraries
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/**
@@ -521,7 +515,6 @@ targets:
 
   - name: Windows tool_tests_commands
     builder: Windows tool_tests_commands
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/**
@@ -610,7 +603,6 @@ targets:
 
   - name: Windows framework_tests_misc
     builder: Windows framework_tests_misc
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -626,7 +618,6 @@ targets:
 
   - name: Windows framework_tests_widgets
     builder: Windows framework_tests_widgets
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/
@@ -688,7 +679,6 @@ targets:
 
   - name: Windows tool_tests_general
     builder: Windows tool_tests_general
-    postsubmit: false
     scheduler: luci
     runIf:
       - dev/**
@@ -1001,31 +991,6 @@ targets:
     presubmit: false
     scheduler: luci
 
-  - name: Linux web_long_running_tests_1_5
-    builder: Linux web_long_running_tests_1_5
-    presubmit: false
-    scheduler: luci
-
-  - name: Linux web_long_running_tests_2_5
-    builder: Linux web_long_running_tests_2_5
-    presubmit: false
-    scheduler: luci
-
-  - name: Linux web_long_running_tests_3_5
-    builder: Linux web_long_running_tests_3_5
-    presubmit: false
-    scheduler: luci
-
-  - name: Linux web_long_running_tests_4_5
-    builder: Linux web_long_running_tests_4_5
-    presubmit: false
-    scheduler: luci
-
-  - name: Linux web_long_running_tests_5_5
-    builder: Linux web_long_running_tests_5_5
-    presubmit: false
-    scheduler: luci
-
   - name: Mac_android android_semantics_integration_test
     builder: Mac_android android_semantics_integration_test
     presubmit: false
@@ -1224,11 +1189,6 @@ targets:
 
   - name: Mac_android tiles_scroll_perf__timeline_summary
     builder: Mac_android tiles_scroll_perf__timeline_summary
-    presubmit: false
-    scheduler: luci
-
-  - name: Mac framework_tests_libraries
-    builder: Mac framework_tests_libraries
     presubmit: false
     scheduler: luci
 
@@ -1439,28 +1399,8 @@ targets:
     presubmit: false
     scheduler: luci
 
-  - name: Windows framework_tests_misc
-    builder: Windows framework_tests_misc
-    presubmit: false
-    scheduler: luci
-
-  - name: Windows framework_tests_widgets
-    builder: Windows framework_tests_widgets
-    presubmit: false
-    scheduler: luci
-
   - name: Windows gradle_plugin_fat_apk_test
     builder: Windows gradle_plugin_fat_apk_test
-    presubmit: false
-    scheduler: luci
-
-  - name: Windows tool_tests_general
-    builder: Windows tool_tests_general
-    presubmit: false
-    scheduler: luci
-
-  - name: Windows tool_tests_commands
-    builder: Windows tool_tests_commands
     presubmit: false
     scheduler: luci
 


### PR DESCRIPTION
This is to deduplicate the builder field as it's no longer necessary.

Fixed some issues where there were duplicate targets for both presubmit and postsubmit.

https://github.com/flutter/flutter/issues/84998

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
