### PR TITLE
[web] Remove the part directive from the web key map template

### DIFF
--- a/dev/tools/gen_keycodes/data/web_key_map_dart.tmpl
+++ b/dev/tools/gen_keycodes/data/web_key_map_dart.tmpl
@@ -9,8 +9,6 @@
 // Edit the template dev/tools/gen_keycodes/data/web_key_map_dart.tmpl instead.
 // See dev/tools/gen_keycodes/README.md for more information.
 
-part of engine;
-
 /// Maps Web KeyboardEvent codes to the matching LogicalKeyboardKey id.
 const Map<String, int> kWebToLogicalKey = <String, int>{
 @@@WEB_LOGICAL_KEY_CODE_MAP@@@


### PR DESCRIPTION
In this engine [PR](https://github.com/flutter/engine/pull/26917), I updated the web's `key_map.dart` which is supposed to be auto-generated. So here's the PR to update the template that generates the file.

https://github.com/flutter/flutter/issues/80755