### PR TITLE
Wait for iOS UI buttons to exist before tapping

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -17,7 +17,9 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
-    [app.buttons[@"Full Screen (Cold)"] tap];
+    XCUIElement *coldButton = app.buttons[@"Full Screen (Cold)"];
+    XCTAssertTrue([coldButton waitForExistenceWithTimeout:60.0]);
+    [coldButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
@@ -32,7 +34,9 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
-    [app.buttons[@"Full Screen (Warm)"] tap];
+    XCUIElement *warmButton = app.buttons[@"Full Screen (Warm)"];
+    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
@@ -47,7 +51,9 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
-    [app.buttons[@"Flutter View (Warm)"] tap];
+    XCUIElement *warmButton = app.buttons[@"Flutter View (Warm)"];
+    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     [app.otherElements[@"Increment via Flutter"] tap];
@@ -62,7 +68,9 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
-    [app.buttons[@"Hybrid View (Warm)"] tap];
+    XCUIElement *warmButton = app.buttons[@"Hybrid View (Warm)"];
+    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
@@ -87,8 +95,9 @@
     [app.buttons[@"Dual Flutter View (Cold)"] tap];
 
     // There are two marquees.
-    XCTAssertTrue([app.staticTexts[@"This is Marquee"] waitForExistenceWithTimeout:60.0]);
-    XCTAssertEqual([app.staticTexts matchingType:XCUIElementTypeStaticText identifier:@"This is Marquee"].count, 2);
+    XCUIElementQuery *marqueeQuery = [app.staticTexts matchingIdentifier:@"This is Marquee"];
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"count = 2"] evaluatedWithObject:marqueeQuery handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
 
     // Back navigation.
     [app.navigationBars[@"Dual Flutter Views"].buttons[@"Flutter iOS Demos Home"] tap];


### PR DESCRIPTION
1. Wait for buttons to exist before attempting to tap on them.
2. Validate the 2 marquee texts in dual Flutter views by waiting for both of them instead of waiting for one and validating two exist.

Fixes https://github.com/flutter/flutter/issues/85578