### PR TITLE
Specify rasterFinishWallTime

### DIFF
--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -143,6 +143,7 @@ void main() {
       buildFinish: 15000,
       rasterStart: 16000,
       rasterFinish: 20000,
+      rasterFinishWallTime: 20010,
       frameNumber: 1991
     )]);
 

--- a/packages/flutter_test/test/frame_timing_summarizer_test.dart
+++ b/packages/flutter_test/test/frame_timing_summarizer_test.dart
@@ -29,6 +29,9 @@ void main() {
           buildFinish: buildTimes[i],
           rasterStart: 500,
           rasterFinish: rasterTimes[i],
+          // Wall time should not be used in any profiling metrics.
+          // It is primarily to correlate with external tools' measurement.
+          rasterFinishWallTime: 0,
         ),
     ];
 


### PR DESCRIPTION
This is to transition `rasterFinishWallTime` to a required field in `dart:ui`.
