### PR TITLE
Scale selection handles for rich text on iOS

### DIFF
--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -67,13 +67,13 @@ class _CupertinoDesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphheight, double? endGlyphHeight]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
     return Offset.zero;
   }
 }

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -67,7 +67,7 @@ class _CupertinoDesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphheight, double? endGlyphHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     return const SizedBox.shrink();
   }
 

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -67,13 +67,13 @@ class _CupertinoDesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
     return Offset.zero;
   }
 }

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -67,13 +67,13 @@ class _CupertinoDesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     return Offset.zero;
   }
 }

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -254,7 +254,7 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // padding in every direction that will constitute the selection drag area.
     final Size desiredSize = getHandleSize(textLineHeight);
 
-    final Widget leftHandle = SizedBox.fromSize(
+    final Widget handle = SizedBox.fromSize(
       size: desiredSize,
       child: CustomPaint(painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor)),
     );
@@ -264,14 +264,14 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // on top of the text selection endpoints.
     switch (type) {
       case TextSelectionHandleType.left:
-        return leftHandle;
+        return handle;
       case TextSelectionHandleType.right:
         return Transform(
           transform: Matrix4.identity()
             ..translate(desiredSize.width / 2, desiredSize.height / 2)
             ..rotateZ(math.pi)
             ..translate(-desiredSize.width / 2, -desiredSize.height / 2),
-          child: leftHandle,
+          child: handle,
         );
       // iOS doesn't draw anything for collapsed selections.
       case TextSelectionHandleType.collapsed:

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -247,18 +247,19 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
   /// Builder for iOS text selection edges.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     // iOS selection handles do not respond to taps.
 
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
-    final Size desiredSize = getHandleSize(textLineHeight);
+    startGlyphHeight = startGlyphHeight ?? textLineHeight;
+    endGlyphHeight = endGlyphHeight ?? textLineHeight;
 
-    final Widget handle = SizedBox.fromSize(
-      size: desiredSize,
-      child: CustomPaint(
-        painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
-      ),
+    final Size desiredSize;
+    final Widget handle;
+
+    final Widget customPaint = CustomPaint(
+      painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
     );
 
     // [buildHandle]'s widget is positioned at the selection cursor's bottom
@@ -266,8 +267,18 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // on top of the text selection endpoints.
     switch (type) {
       case TextSelectionHandleType.left:
+        desiredSize = getHandleSize(startGlyphHeight);
+        handle = SizedBox.fromSize(
+          size: desiredSize,
+          child: customPaint,
+        );
         return handle;
       case TextSelectionHandleType.right:
+        desiredSize = getHandleSize(endGlyphHeight);
+        handle = SizedBox.fromSize(
+          size: desiredSize,
+          child: customPaint,
+        );
         return Transform(
           transform: Matrix4.identity()
             ..translate(desiredSize.width / 2, desiredSize.height / 2)
@@ -285,12 +296,17 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
-    final Size handleSize = getHandleSize(textLineHeight);
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
+    startGlyphHeight = startGlyphHeight ?? textLineHeight;
+    endGlyphHeight = endGlyphHeight ?? textLineHeight;
+
+    final Size handleSize;
+
     switch (type) {
       // The circle is at the top for the left handle, and the anchor point is
       // all the way at the bottom of the line.
       case TextSelectionHandleType.left:
+        handleSize = getHandleSize(startGlyphHeight);
         return Offset(
           handleSize.width / 2,
           handleSize.height,
@@ -298,12 +314,14 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
       // The right handle is vertically flipped, and the anchor point is near
       // the top of the circle to give slight overlap.
       case TextSelectionHandleType.right:
+        handleSize = getHandleSize(endGlyphHeight);
         return Offset(
           handleSize.width / 2,
           handleSize.height - 2 * _kSelectionHandleRadius + _kSelectionHandleOverlap,
         );
       // A collapsed handle anchors itself so that it's centered.
       case TextSelectionHandleType.collapsed:
+        handleSize = getHandleSize(textLineHeight);
         return Offset(
           handleSize.width / 2,
           textLineHeight + (handleSize.height - textLineHeight) / 2,

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -256,7 +256,9 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
     final Widget handle = SizedBox.fromSize(
       size: desiredSize,
-      child: CustomPaint(painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor)),
+      child: CustomPaint(
+        painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
+      ),
     );
 
     // [buildHandle]'s widget is positioned at the selection cursor's bottom
@@ -285,7 +287,6 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   @override
   Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     final Size handleSize = getHandleSize(textLineHeight);
-
     switch (type) {
       // The circle is at the top for the left handle, and the anchor point is
       // all the way at the bottom of the line.

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -247,15 +247,28 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
   /// Builder for iOS text selection edges.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     // iOS selection handles do not respond to taps.
 
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
+    print(secondaryLineHeight);
+    if(secondaryLineHeight == null)
+      secondaryLineHeight = textLineHeight;
+
     final Size desiredSize = getHandleSize(textLineHeight);
 
-    final Widget handle = SizedBox.fromSize(
+    final Widget leftHandle = SizedBox.fromSize(
       size: desiredSize,
+      child: CustomPaint(
+        painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
+      ),
+    );
+
+    final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
+
+    final Widget rightHandle = SizedBox.fromSize(
+      size: desiredSizeRight,
       child: CustomPaint(
         painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
       ),
@@ -266,15 +279,15 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // on top of the text selection endpoints.
     switch (type) {
       case TextSelectionHandleType.left:
-        return handle;
+        return leftHandle;
       case TextSelectionHandleType.right:
         // Right handle is a vertical mirror of the left.
         return Transform(
           transform: Matrix4.identity()
-            ..translate(desiredSize.width / 2, desiredSize.height / 2)
+            ..translate(desiredSizeRight.width / 2, desiredSizeRight.height / 2)
             ..rotateZ(math.pi)
-            ..translate(-desiredSize.width / 2, -desiredSize.height / 2),
-          child: handle,
+            ..translate(-desiredSizeRight.width / 2, -desiredSizeRight.height / 2),
+          child: rightHandle,
         );
       // iOS doesn't draw anything for collapsed selections.
       case TextSelectionHandleType.collapsed:
@@ -286,28 +299,33 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
-    final Size handleSize = getHandleSize(textLineHeight);
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+    if(secondaryLineHeight == null)
+      secondaryLineHeight = textLineHeight;
+
+    final Size leftHandleSize = getHandleSize(textLineHeight);
+    final Size rightHandleSize = getHandleSize(secondaryLineHeight);
+
     switch (type) {
       // The circle is at the top for the left handle, and the anchor point is
       // all the way at the bottom of the line.
       case TextSelectionHandleType.left:
         return Offset(
-          handleSize.width / 2,
-          handleSize.height,
+          leftHandleSize.width / 2,
+          leftHandleSize.height,
         );
       // The right handle is vertically flipped, and the anchor point is near
       // the top of the circle to give slight overlap.
       case TextSelectionHandleType.right:
         return Offset(
-          handleSize.width / 2,
-          handleSize.height - 2 * _kSelectionHandleRadius + _kSelectionHandleOverlap,
+          rightHandleSize.width / 2,
+          rightHandleSize.height - 2 * _kSelectionHandleRadius + _kSelectionHandleOverlap,
         );
       // A collapsed handle anchors itself so that it's centered.
       case TextSelectionHandleType.collapsed:
         return Offset(
-          handleSize.width / 2,
-          textLineHeight + (handleSize.height - textLineHeight) / 2,
+          leftHandleSize.width / 2,
+          textLineHeight + (leftHandleSize.height - textLineHeight) / 2,
         );
     }
   }

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -252,11 +252,11 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
-    print(secondaryLineHeight);
     if(secondaryLineHeight == null)
       secondaryLineHeight = textLineHeight;
 
     final Size desiredSize = getHandleSize(textLineHeight);
+    final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
 
     final Widget customPaint = CustomPaint(
       painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
@@ -266,8 +266,6 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
       size: desiredSize,
       child: customPaint,
     );
-
-    final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
 
     final Widget rightHandle = SizedBox.fromSize(
       size: desiredSizeRight,
@@ -279,15 +277,8 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // on top of the text selection endpoints.
     switch (type) {
       case TextSelectionHandleType.left:
-        print('left ' + desiredSize.height.toString());
-        print('left textline' + textLineHeight.toString());
         return leftHandle;
       case TextSelectionHandleType.right:
-        // Right handle is a vertical mirror of the left.
-        // Right handle is a vertical mirror of the left.
-        print('right secondary ' + secondaryLineHeight.toString());
-        print('right ' + desiredSizeRight.height.toString());
-        // return rightHandle;
         return Transform(
           transform: Matrix4.identity()
             ..translate(desiredSizeRight.width / 2, desiredSizeRight.height / 2)

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -252,8 +252,7 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
-    if(secondaryLineHeight == null)
-      secondaryLineHeight = textLineHeight;
+    secondaryLineHeight = secondaryLineHeight?? textLineHeight;
 
     final Size desiredSize = getHandleSize(textLineHeight);
     final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
@@ -297,8 +296,7 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   /// See [TextSelectionControls.getHandleAnchor].
   @override
   Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
-    if(secondaryLineHeight == null)
-      secondaryLineHeight = textLineHeight;
+    secondaryLineHeight = secondaryLineHeight?? textLineHeight;
 
     final Size leftHandleSize = getHandleSize(textLineHeight);
     final Size rightHandleSize = getHandleSize(secondaryLineHeight);

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -247,28 +247,16 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
   /// Builder for iOS text selection edges.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     // iOS selection handles do not respond to taps.
 
     // We want a size that's a vertical line the height of the text plus a 18.0
     // padding in every direction that will constitute the selection drag area.
-    secondaryLineHeight = secondaryLineHeight?? textLineHeight;
-
     final Size desiredSize = getHandleSize(textLineHeight);
-    final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
-
-    final Widget customPaint = CustomPaint(
-      painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
-    );
 
     final Widget leftHandle = SizedBox.fromSize(
       size: desiredSize,
-      child: customPaint,
-    );
-
-    final Widget rightHandle = SizedBox.fromSize(
-      size: desiredSizeRight,
-      child: customPaint,
+      child: CustomPaint(painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor)),
     );
 
     // [buildHandle]'s widget is positioned at the selection cursor's bottom
@@ -280,10 +268,10 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
       case TextSelectionHandleType.right:
         return Transform(
           transform: Matrix4.identity()
-            ..translate(desiredSizeRight.width / 2, desiredSizeRight.height / 2)
+            ..translate(desiredSize.width / 2, desiredSize.height / 2)
             ..rotateZ(math.pi)
-            ..translate(-desiredSizeRight.width / 2, -desiredSizeRight.height / 2),
-          child: rightHandle,
+            ..translate(-desiredSize.width / 2, -desiredSize.height / 2),
+          child: leftHandle,
         );
       // iOS doesn't draw anything for collapsed selections.
       case TextSelectionHandleType.collapsed:
@@ -295,32 +283,29 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
-    secondaryLineHeight = secondaryLineHeight?? textLineHeight;
-
-    final Size leftHandleSize = getHandleSize(textLineHeight);
-    final Size rightHandleSize = getHandleSize(secondaryLineHeight);
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+    final Size handleSize = getHandleSize(textLineHeight);
 
     switch (type) {
       // The circle is at the top for the left handle, and the anchor point is
       // all the way at the bottom of the line.
       case TextSelectionHandleType.left:
         return Offset(
-          leftHandleSize.width / 2,
-          leftHandleSize.height,
+          handleSize.width / 2,
+          handleSize.height,
         );
       // The right handle is vertically flipped, and the anchor point is near
       // the top of the circle to give slight overlap.
       case TextSelectionHandleType.right:
         return Offset(
-          rightHandleSize.width / 2,
-          rightHandleSize.height - 2 * _kSelectionHandleRadius + _kSelectionHandleOverlap,
+          handleSize.width / 2,
+          handleSize.height - 2 * _kSelectionHandleRadius + _kSelectionHandleOverlap,
         );
       // A collapsed handle anchors itself so that it's centered.
       case TextSelectionHandleType.collapsed:
         return Offset(
-          leftHandleSize.width / 2,
-          textLineHeight + (leftHandleSize.height - textLineHeight) / 2,
+          handleSize.width / 2,
+          textLineHeight + (handleSize.height - textLineHeight) / 2,
         );
     }
   }

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -258,20 +258,20 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
 
     final Size desiredSize = getHandleSize(textLineHeight);
 
+    final Widget customPaint = CustomPaint(
+      painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
+    );
+
     final Widget leftHandle = SizedBox.fromSize(
       size: desiredSize,
-      child: CustomPaint(
-        painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
-      ),
+      child: customPaint,
     );
 
     final Size desiredSizeRight = getHandleSize(secondaryLineHeight);
 
     final Widget rightHandle = SizedBox.fromSize(
       size: desiredSizeRight,
-      child: CustomPaint(
-        painter: _TextSelectionHandlePainter(CupertinoTheme.of(context).primaryColor),
-      ),
+      child: customPaint,
     );
 
     // [buildHandle]'s widget is positioned at the selection cursor's bottom
@@ -279,9 +279,15 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     // on top of the text selection endpoints.
     switch (type) {
       case TextSelectionHandleType.left:
+        print('left ' + desiredSize.height.toString());
+        print('left textline' + textLineHeight.toString());
         return leftHandle;
       case TextSelectionHandleType.right:
         // Right handle is a vertical mirror of the left.
+        // Right handle is a vertical mirror of the left.
+        print('right secondary ' + secondaryLineHeight.toString());
+        print('right ' + desiredSizeRight.height.toString());
+        // return rightHandle;
         return Transform(
           transform: Matrix4.identity()
             ..translate(desiredSizeRight.width / 2, desiredSizeRight.height / 2)

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -53,13 +53,13 @@ class _DesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
     return Offset.zero;
   }
 

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -53,13 +53,13 @@ class _DesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     return Offset.zero;
   }
 

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -53,13 +53,13 @@ class _DesktopTextSelectionControls extends TextSelectionControls {
 
   /// Builds the text selection handles, but desktop has none.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     return const SizedBox.shrink();
   }
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
     return Offset.zero;
   }
 

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -54,7 +54,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
 
   /// Builder for material-style text selection handles.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     final ThemeData theme = Theme.of(context);
     final Color handleColor = TextSelectionTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary;
     final Widget handle = SizedBox(
@@ -94,7 +94,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
     switch (type) {
       case TextSelectionHandleType.left:
         return const Offset(_kHandleSize, 0);

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -54,7 +54,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
 
   /// Builder for material-style text selection handles.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     final ThemeData theme = Theme.of(context);
     final Color handleColor = TextSelectionTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary;
     final Widget handle = SizedBox(
@@ -94,7 +94,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
     switch (type) {
       case TextSelectionHandleType.left:
         return const Offset(_kHandleSize, 0);

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -54,7 +54,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
 
   /// Builder for material-style text selection handles.
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textHeight, [VoidCallback? onTap]) {
     final ThemeData theme = Theme.of(context);
     final Color handleColor = TextSelectionTheme.of(context).selectionHandleColor ?? theme.colorScheme.primary;
     final Widget handle = SizedBox(
@@ -94,7 +94,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     switch (type) {
       case TextSelectionHandleType.left:
         return const Offset(_kHandleSize, 0);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3111,8 +3111,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// on iOS.
   ///
   /// Returns null if [TextRange.isValid] is false for the given `range`, or the
-  /// given `range` is collapsed, or if the given range is not valid for the
-  /// current text.
+  /// given `range` is collapsed.
   Rect? getRectForComposingRange(TextRange range) {
     if(range.start == -1 && range.end == -1){
       print('what');

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3113,7 +3113,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// Returns null if [TextRange.isValid] is false for the given `range`, or the
   /// given `range` is collapsed.
   Rect? getRectForComposingRange(TextRange range) {
-    if (!range.isValid || range.isCollapsed)
+    if (!range.isValid || range.isCollapsed || (range.end > _plainText.length || range.end < 0 || range.start < 0))
       return null;
     _computeTextMetricsIfNeeded();
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3088,7 +3088,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     final Offset paintOffset = _paintOffset;
 
     final List<ui.TextBox> boxes = selection.isCollapsed ?
-        <ui.TextBox>[] : _textPainter.getBoxesForSelection(selection);
+        <ui.TextBox>[] : _textPainter.getBoxesForSelection(selection, boxHeightStyle: selectionHeightStyle, boxWidthStyle: selectionWidthStyle);
     if (boxes.isEmpty) {
       // TODO(mpcomplete): This doesn't work well at an RTL/LTR boundary.
       final Offset caretOffset = _textPainter.getOffsetForCaret(selection.extent, _caretPrototype);

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3113,9 +3113,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// Returns null if [TextRange.isValid] is false for the given `range`, or the
   /// given `range` is collapsed.
   Rect? getRectForComposingRange(TextRange range) {
-    if(range.start == -1 && range.end == -1){
-      print('what');
-    }
     if (!range.isValid || range.isCollapsed)
       return null;
     _computeTextMetricsIfNeeded();

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3111,9 +3111,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// on iOS.
   ///
   /// Returns null if [TextRange.isValid] is false for the given `range`, or the
-  /// given `range` is collapsed.
+  /// given `range` is collapsed, or if the given range is not valid for the
+  /// current text.
   Rect? getRectForComposingRange(TextRange range) {
-    if (!range.isValid || range.isCollapsed || (range.end > _plainText.length || range.end < 0 || range.start < 0))
+    if(range.start == -1 && range.end == -1){
+      print('what');
+    }
+    if (!range.isValid || range.isCollapsed)
       return null;
     _computeTextMetricsIfNeeded();
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -4097,7 +4097,6 @@ class _TextHighlightPainter extends RenderEditablePainter {
 
   Color? get highlightColor => _highlightColor;
   Color? _highlightColor;
-
   set highlightColor(Color? newValue) {
     if (newValue == _highlightColor)
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -4112,6 +4112,7 @@ class _TextHighlightPainter extends RenderEditablePainter {
 
   Color? get highlightColor => _highlightColor;
   Color? _highlightColor;
+
   set highlightColor(Color? newValue) {
     if (newValue == _highlightColor)
       return;
@@ -4169,8 +4170,11 @@ class _TextHighlightPainter extends RenderEditablePainter {
       boxWidthStyle: selectionWidthStyle,
     );
 
-    for (final TextBox box in boxes)
-      canvas.drawRect(box.toRect().shift(renderEditable._paintOffset), highlightPaint);
+    for (final TextBox box in boxes) {
+      print('highlight height ' + box.toRect().height.toString());
+      canvas.drawRect(
+          box.toRect().shift(renderEditable._paintOffset), highlightPaint);
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3127,6 +3127,23 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     )?.shift(_paintOffset);
   }
 
+  Rect? getRectForRange(TextRange range) {
+    if (!range.isValid || range.isCollapsed)
+      return null;
+    _computeTextMetricsIfNeeded();
+
+    final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(
+      TextSelection(baseOffset: range.start, extentOffset: range.end),
+      boxHeightStyle: selectionHeightStyle,
+      boxWidthStyle: selectionWidthStyle,
+    );
+
+    return boxes.fold(
+      null,
+          (Rect? accum, TextBox incoming) => accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
+    )?.shift(_paintOffset);
+  }
+
   /// Returns the position in the text for the given global coordinate.
   ///
   /// See also:

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -3119,28 +3119,13 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
 
     final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(
       TextSelection(baseOffset: range.start, extentOffset: range.end),
-    );
-
-    return boxes.fold(
-      null,
-      (Rect? accum, TextBox incoming) => accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
-    )?.shift(_paintOffset);
-  }
-
-  Rect? getRectForRange(TextRange range) {
-    if (!range.isValid || range.isCollapsed)
-      return null;
-    _computeTextMetricsIfNeeded();
-
-    final List<ui.TextBox> boxes = _textPainter.getBoxesForSelection(
-      TextSelection(baseOffset: range.start, extentOffset: range.end),
       boxHeightStyle: selectionHeightStyle,
       boxWidthStyle: selectionWidthStyle,
     );
 
     return boxes.fold(
       null,
-          (Rect? accum, TextBox incoming) => accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
+      (Rect? accum, TextBox incoming) => accum?.expandToInclude(incoming.toRect()) ?? incoming.toRect(),
     )?.shift(_paintOffset);
   }
 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -4170,11 +4170,8 @@ class _TextHighlightPainter extends RenderEditablePainter {
       boxWidthStyle: selectionWidthStyle,
     );
 
-    for (final TextBox box in boxes) {
-      print('highlight height ' + box.toRect().height.toString());
-      canvas.drawRect(
-          box.toRect().shift(renderEditable._paintOffset), highlightPaint);
-    }
+    for (final TextBox box in boxes)
+      canvas.drawRect(box.toRect().shift(renderEditable._paintOffset), highlightPaint);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -824,9 +824,10 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
+    // On iOS we want to calculate the start and end handles separately so they
+    // scale for the selected content.
     late final Rect? startHandleRect;
     late final Rect? endHandleRect;
-
     startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
     endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -839,7 +839,12 @@ class _TextSelectionHandleOverlayState
     final int lastSelectedGraphemeExtent;
     final TextSelection? selection = widget.renderObject.selection;
 
-    if (selection == null || selection.isValid || selection.isCollapsed) {
+    if (selection != null && selection.isValid && !selection.isCollapsed) {
+      final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
+      firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
+      lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
+      assert(firstSelectedGraphemeExtent <= selectedGraphemes.length && lastSelectedGraphemeExtent <= selectedGraphemes.length);
+    } else {
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given text is empty, so fall back to first/last character
       // range in this case.
@@ -848,11 +853,6 @@ class _TextSelectionHandleOverlayState
       // for a collapsed selection, fall back to this case when that happens.
       firstSelectedGraphemeExtent = 0;
       lastSelectedGraphemeExtent = 0;
-    } else {
-      final String selectedGraphemes = selection.textInside(text);
-      firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
-      lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
-      assert(firstSelectedGraphemeExtent <= selectedGraphemes.length && lastSelectedGraphemeExtent <= selectedGraphemes.length);
     }
 
     final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -840,7 +840,7 @@ class _TextSelectionHandleOverlayState
     final TextSelection? selection = widget.renderObject.selection;
 
     if (selection != null && selection.isValid && !selection.isCollapsed) {
-      final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
+      final String selectedGraphemes = selection.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
       assert(firstSelectedGraphemeExtent <= selectedGraphemes.length && lastSelectedGraphemeExtent <= selectedGraphemes.length);

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -851,7 +851,7 @@ class _TextSelectionHandleOverlayState
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
     }
-    
+
     final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
     final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end - lastSelectedGraphemeExtent, end: widget.selection.end));
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -828,13 +828,8 @@ class _TextSelectionHandleOverlayState
     late final Rect? startHandleRect;
     late final Rect? endHandleRect;
 
-    if(widget.renderObject.selectionHeightStyle == ui.BoxHeightStyle.tight){
-      startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-      endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    }else{
-      startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-      endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    }
+    startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 
     late double preferredLineHeight;
 
@@ -859,7 +854,7 @@ class _TextSelectionHandleOverlayState
       preferredLineHeight,
     );
     final Size handleSize = widget.selectionControls.getHandleSize(
-      widget.renderObject.preferredLineHeight,
+      preferredLineHeight,
     );
 
     final Rect handleRect = Rect.fromLTWH(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -837,7 +837,7 @@ class _TextSelectionHandleOverlayState
     final String text = span.toPlainText();
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    if(text.isEmpty || widget.selection.isCollapsed){
+    if (text.isEmpty || widget.selection.isCollapsed) {
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given string is empty, so fall back to first/last character
       // range in this case.
@@ -846,7 +846,7 @@ class _TextSelectionHandleOverlayState
       // for a collapsed selection, fall back to this case when that happens.
       firstSelectedGraphemeExtent = 1;
       lastSelectedGraphemeExtent = 1;
-    }else{
+    } else {
       final String selectedGraphemes = widget.selection.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -858,10 +858,8 @@ class _TextSelectionHandleOverlayState
     final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
     final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end - lastSelectedGraphemeExtent, end: widget.selection.end));
 
-    if (firstSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed)
-      assert(startHandleRect != null);
-    if (lastSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed)
-      assert(endHandleRect != null);
+    assert(!(firstSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed) || startHandleRect != null);
+    assert(!(lastSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed) || endHandleRect != null);
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -858,7 +858,6 @@ class _TextSelectionHandleOverlayState
       type,
       preferredLineHeight,
     );
-
     final Size handleSize = widget.selectionControls.getHandleSize(
       widget.renderObject.preferredLineHeight,
     );

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -836,10 +836,10 @@ class _TextSelectionHandleOverlayState
     if(defaultTargetPlatform == TargetPlatform.iOS){
       switch(type){
         case TextSelectionHandleType.left:
-          preferredLineHeight = widget.renderObject.preferredLineHeight;
+          preferredLineHeight = startHandleRect?.height ?? widget.renderObject.preferredLineHeight;
           break;
         case TextSelectionHandleType.right:
-          preferredLineHeight = widget.renderObject.preferredLineHeight;
+          preferredLineHeight = endHandleRect?.height ?? widget.renderObject.preferredLineHeight;
           break;
         case TextSelectionHandleType.collapsed:
           preferredLineHeight = widget.renderObject.preferredLineHeight;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -853,7 +853,7 @@ class _TextSelectionHandleOverlayState
     }
 
     final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
-    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - lastSelectedGraphemeExtent));
+    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end - lastSelectedGraphemeExtent, end: widget.selection.end));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' as ui show BoxHeightStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -836,10 +835,10 @@ class _TextSelectionHandleOverlayState
     if(defaultTargetPlatform == TargetPlatform.iOS){
       switch(type){
         case TextSelectionHandleType.left:
-          preferredLineHeight = startHandleRect?.height ?? widget.renderObject.preferredLineHeight;
+          preferredLineHeight = widget.renderObject.preferredLineHeight;
           break;
         case TextSelectionHandleType.right:
-          preferredLineHeight = endHandleRect?.height ?? widget.renderObject.preferredLineHeight;
+          preferredLineHeight = widget.renderObject.preferredLineHeight;
           break;
         case TextSelectionHandleType.collapsed:
           preferredLineHeight = widget.renderObject.preferredLineHeight;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -837,7 +837,6 @@ class _TextSelectionHandleOverlayState
     final String text = span.toPlainText();
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    
     if(text.isEmpty || widget.selection.isCollapsed){
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given string is empty, so fall back to first/last character

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -855,8 +855,8 @@ class _TextSelectionHandleOverlayState
     }
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
-        type,
-        preferredLineHeight,
+      type,
+      preferredLineHeight,
     );
 
     final Size handleSize = widget.selectionControls.getHandleSize(
@@ -876,7 +876,7 @@ class _TextSelectionHandleOverlayState
     );
     final RelativeRect padding = RelativeRect.fromLTRB(
       math.max((interactiveRect.width - handleRect.width) / 2, 0),
-      math.max((interactiveRect.height - handleRect.height) / 2, 0),//
+      math.max((interactiveRect.height - handleRect.height) / 2, 0),
       math.max((interactiveRect.width - handleRect.width) / 2, 0),
       math.max((interactiveRect.height - handleRect.height) / 2, 0),
     );

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -851,13 +851,13 @@ class _TextSelectionHandleOverlayState
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
     }
+    
+    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
+    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end - lastSelectedGraphemeExtent, end: widget.selection.end));
 
-    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.renderObject.selection!.start, end: widget.renderObject.selection!.start + firstSelectedGraphemeExtent));
-    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.renderObject.selection!.end - lastSelectedGraphemeExtent, end: widget.renderObject.selection!.end));
-
-    if (firstSelectedGraphemeExtent > 0)
+    if (firstSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed)
       assert(startHandleRect != null);
-    if (lastSelectedGraphemeExtent > 0)
+    if (lastSelectedGraphemeExtent > 0 && widget.selection.isValid && !widget.selection.isCollapsed)
       assert(endHandleRect != null);
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -827,13 +828,26 @@ class _TextSelectionHandleOverlayState
     // On some platforms we may want to calculate the start and end handles
     // separately so they scale for the selected content.
     //
-    // For the start handle we compute the rectangles that encompass the beginning
-    // of the selection.
+    // For the start handle we compute the rectangles that encompass the range
+    // of the first full selected grapheme cluster at the beginning of the selection.
     //
-    // For the end handle we compute the rectangles that encompass the end of
-    // the selection.
-    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    // For the end handle we compute the rectangles that encompass the range
+    // of the last full selected grapheme cluster at the end of the selection.
+    final InlineSpan span = widget.renderObject.text!;
+    final String text = span.toPlainText();
+    final String selectedGraphemes = widget.selection.textInside(text);
+    final int firstSelectedGraphemeExtent;
+    final int lastSelectedGraphemeExtent;
+    if(selectedGraphemes.length == 0){
+      firstSelectedGraphemeExtent = 1;
+      lastSelectedGraphemeExtent = 1;
+    }else{
+      firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
+      lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
+    }
+
+    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
+    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - lastSelectedGraphemeExtent));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -837,9 +837,10 @@ class _TextSelectionHandleOverlayState
     final String text = span.toPlainText();
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    if (text.isEmpty || widget.renderObject.selection == null || !widget.renderObject.selection!.isValid || widget.renderObject.selection!.isCollapsed) {
+
+    if (widget.renderObject.selection == null || !widget.renderObject.selection!.isValid || widget.renderObject.selection!.isCollapsed) {
       // The call to selectedGraphemes.characters.first/last will throw a state
-      // error if the given string is empty, so fall back to first/last character
+      // error if the given text is empty, so fall back to first/last character
       // range in this case.
       //
       // The call to widget.selection.textInside(text) will return a RangeError
@@ -850,6 +851,7 @@ class _TextSelectionHandleOverlayState
       final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
+      assert(firstSelectedGraphemeExtent <= selectedGraphemes.length && lastSelectedGraphemeExtent <= selectedGraphemes.length);
     }
 
     final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -838,7 +838,10 @@ class _TextSelectionHandleOverlayState
     final String selectedGraphemes = widget.selection.textInside(text);
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    if(selectedGraphemes.length == 0){
+    if(selectedGraphemes.isEmpty){
+      // The call to selectedGraphemes.characters.first/last will throw a state
+      // error if the given string is empty, so fall back to first/last character
+      // range in this case.
       firstSelectedGraphemeExtent = 1;
       lastSelectedGraphemeExtent = 1;
     }else{

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -837,23 +837,28 @@ class _TextSelectionHandleOverlayState
     final String text = span.toPlainText();
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    if (text.isEmpty || widget.selection.isCollapsed) {
+    if (text.isEmpty || widget.renderObject.selection == null || !widget.renderObject.selection!.isValid || widget.renderObject.selection!.isCollapsed) {
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given string is empty, so fall back to first/last character
       // range in this case.
       //
       // The call to widget.selection.textInside(text) will return a RangeError
       // for a collapsed selection, fall back to this case when that happens.
-      firstSelectedGraphemeExtent = 1;
-      lastSelectedGraphemeExtent = 1;
+      firstSelectedGraphemeExtent = 0;
+      lastSelectedGraphemeExtent = 0;
     } else {
       final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
     }
 
-    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + firstSelectedGraphemeExtent));
-    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end - lastSelectedGraphemeExtent, end: widget.selection.end));
+    final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.renderObject.selection!.start, end: widget.renderObject.selection!.start + firstSelectedGraphemeExtent));
+    final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.renderObject.selection!.end - lastSelectedGraphemeExtent, end: widget.renderObject.selection!.end));
+
+    if (firstSelectedGraphemeExtent > 0)
+      assert(startHandleRect != null);
+    if (lastSelectedGraphemeExtent > 0)
+      assert(endHandleRect != null);
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -847,7 +847,7 @@ class _TextSelectionHandleOverlayState
       firstSelectedGraphemeExtent = 1;
       lastSelectedGraphemeExtent = 1;
     } else {
-      final String selectedGraphemes = widget.selection.textInside(text);
+      final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -837,8 +837,9 @@ class _TextSelectionHandleOverlayState
     final String text = span.toPlainText();
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
+    final TextSelection? selection = widget.renderObject.selection;
 
-    if (widget.renderObject.selection == null || !widget.renderObject.selection!.isValid || widget.renderObject.selection!.isCollapsed) {
+    if (selection == null || selection.isValid || selection.isCollapsed) {
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given text is empty, so fall back to first/last character
       // range in this case.
@@ -848,7 +849,7 @@ class _TextSelectionHandleOverlayState
       firstSelectedGraphemeExtent = 0;
       lastSelectedGraphemeExtent = 0;
     } else {
-      final String selectedGraphemes = widget.renderObject.selection!.textInside(text);
+      final String selectedGraphemes = selection.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
       assert(firstSelectedGraphemeExtent <= selectedGraphemes.length && lastSelectedGraphemeExtent <= selectedGraphemes.length);

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -835,16 +835,20 @@ class _TextSelectionHandleOverlayState
     // of the last full selected grapheme cluster at the end of the selection.
     final InlineSpan span = widget.renderObject.text!;
     final String text = span.toPlainText();
-    final String selectedGraphemes = widget.selection.textInside(text);
     final int firstSelectedGraphemeExtent;
     final int lastSelectedGraphemeExtent;
-    if(selectedGraphemes.isEmpty){
+    
+    if(text.isEmpty || widget.selection.isCollapsed){
       // The call to selectedGraphemes.characters.first/last will throw a state
       // error if the given string is empty, so fall back to first/last character
       // range in this case.
+      //
+      // The call to widget.selection.textInside(text) will return a RangeError
+      // for a collapsed selection, fall back to this case when that happens.
       firstSelectedGraphemeExtent = 1;
       lastSelectedGraphemeExtent = 1;
     }else{
+      final String selectedGraphemes = widget.selection.textInside(text);
       firstSelectedGraphemeExtent = selectedGraphemes.characters.first.length;
       lastSelectedGraphemeExtent = selectedGraphemes.characters.last.length;
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -824,28 +824,31 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
+    final double preferredLineHeight;
+
     // On iOS we want to calculate the start and end handles separately so they
     // scale for the selected content.
-    late final Rect? startHandleRect;
-    late final Rect? endHandleRect;
-    startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-
-    late double preferredLineHeight;
-
-    if(defaultTargetPlatform == TargetPlatform.iOS){
-      switch(type){
+    //
+    // For the start handle we compute the rectangles that encompass the beginning
+    // of the selection.
+    //
+    // For the end handle we compute the rectangles that encompass the end of
+    // the selection.
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      switch (type) {
         case TextSelectionHandleType.left:
-          preferredLineHeight = startHandleRect?.height ?? widget.renderObject.preferredLineHeight;
+          final Rect? startHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+          preferredLineHeight = startHandleRect!.height;
           break;
         case TextSelectionHandleType.right:
-          preferredLineHeight = endHandleRect?.height ?? widget.renderObject.preferredLineHeight;
+          final Rect? endHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+          preferredLineHeight = endHandleRect!.height;
           break;
         case TextSelectionHandleType.collapsed:
           preferredLineHeight = widget.renderObject.preferredLineHeight;
           break;
       }
-    }else{
+    } else {
       preferredLineHeight = widget.renderObject.preferredLineHeight;
     }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -825,39 +825,17 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
-    // final min_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.end));
-    // final text_val = widget.renderObject.text!.toPlainText();
-    // // print(text_val);
-    // // print(widget.selection.textInside(text_val));
-    // late Rect? left_rect;
-    // late Rect? right_rect;
-    //
-    // if(widget.renderObject.selectionHeightStyle == ui.BoxHeightStyle.tight){
-    //   //Left handle, smallest rec that can surround the first word after the handle
-    //   left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    //
-    //   //Right handle, smallest rec that can surround the first word before the handle
-    //   right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    // }else{
-    //   //Left handle, smallest rec that fits entire selection
-    //   left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    //
-    //   //Right handle, smallest rec that fits the range containing the last line
-    //   right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    // }
-
-    final left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    final right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    final leftHandleRect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    final rightHandleRect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,
-      left_rect?.height ?? widget.renderObject.preferredLineHeight,
-      defaultTargetPlatform == TargetPlatform.iOS? right_rect?.height: null
-      // widget.renderObject.preferredLineHeight,
+      leftHandleRect?.height ?? widget.renderObject.preferredLineHeight,
+      defaultTargetPlatform == TargetPlatform.iOS? rightHandleRect?.height: null
     );
+
     final Size handleSize = widget.selectionControls.getHandleSize(
-      right_rect?.height ?? widget.renderObject.preferredLineHeight,
-      // widget.renderObject.preferredLineHeight,
+      rightHandleRect?.height ?? widget.renderObject.preferredLineHeight,
     );
 
     final Rect handleRect = Rect.fromLTWH(
@@ -903,10 +881,9 @@ class _TextSelectionHandleOverlayState
               child: widget.selectionControls.buildHandle(
                 context,
                 type,
-                left_rect?.height ?? widget.renderObject.preferredLineHeight,
-                // widget.renderObject.preferredLineHeight,
+                leftHandleRect?.height ?? widget.renderObject.preferredLineHeight,
                 widget.onSelectionHandleTapped,
-                defaultTargetPlatform == TargetPlatform.iOS? right_rect?.height: null,
+                defaultTargetPlatform == TargetPlatform.iOS? rightHandleRect?.height: null,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -825,26 +825,29 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
-    final min_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.end));
-    final text_val = widget.renderObject.text!.toPlainText();
-    // print(text_val);
-    print(widget.selection.textInside(text_val));
-    late Rect? left_rect;
-    late Rect? right_rect;
+    // final min_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.end));
+    // final text_val = widget.renderObject.text!.toPlainText();
+    // // print(text_val);
+    // // print(widget.selection.textInside(text_val));
+    // late Rect? left_rect;
+    // late Rect? right_rect;
+    //
+    // if(widget.renderObject.selectionHeightStyle == ui.BoxHeightStyle.tight){
+    //   //Left handle, smallest rec that can surround the first word after the handle
+    //   left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    //
+    //   //Right handle, smallest rec that can surround the first word before the handle
+    //   right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    // }else{
+    //   //Left handle, smallest rec that fits entire selection
+    //   left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    //
+    //   //Right handle, smallest rec that fits the range containing the last line
+    //   right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    // }
 
-    if(widget.renderObject.selectionHeightStyle == ui.BoxHeightStyle.tight){
-      //Left handle, smallest rec that can surround the first word after the handle
-      left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-
-      //Right handle, smallest rec that can surround the first word before the handle
-      right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    }else{
-      //Left handle, smallest rec that fits entire selection
-      left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.end));
-
-      //Right handle, smallest rec that fits the range containing the last line
-      right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
-    }
+    final left_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    final right_rect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,
@@ -853,7 +856,8 @@ class _TextSelectionHandleOverlayState
       // widget.renderObject.preferredLineHeight,
     );
     final Size handleSize = widget.selectionControls.getHandleSize(
-      widget.renderObject.preferredLineHeight,
+      right_rect?.height ?? widget.renderObject.preferredLineHeight,
+      // widget.renderObject.preferredLineHeight,
     );
 
     final Rect handleRect = Rect.fromLTWH(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -835,7 +835,7 @@ class _TextSelectionHandleOverlayState
     );
 
     final Size handleSize = widget.selectionControls.getHandleSize(
-      rightHandleRect?.height ?? widget.renderObject.preferredLineHeight,
+      widget.renderObject.preferredLineHeight,
     );
 
     final Rect handleRect = Rect.fromLTWH(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -825,8 +825,8 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
-    final leftHandleRect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    final rightHandleRect = widget.renderObject.getRectForRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    final leftHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    final rightHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -825,8 +824,8 @@ class _TextSelectionHandleOverlayState
         break;
     }
 
-    final leftHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
-    final rightHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
+    final Rect? leftHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.start, end: widget.selection.start + 1));
+    final Rect? rightHandleRect = widget.renderObject.getRectForComposingRange(TextRange(start: widget.selection.end, end: widget.selection.end - 1));
 
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       type,

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -35,7 +35,7 @@ class MockClipboard {
 
 class MockTextSelectionControls extends TextSelectionControls {
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     throw UnimplementedError();
   }
 
@@ -54,7 +54,7 @@ class MockTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -35,7 +35,7 @@ class MockClipboard {
 
 class MockTextSelectionControls extends TextSelectionControls {
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     throw UnimplementedError();
   }
 
@@ -54,7 +54,7 @@ class MockTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -35,7 +35,7 @@ class MockClipboard {
 
 class MockTextSelectionControls extends TextSelectionControls {
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     throw UnimplementedError();
   }
 
@@ -54,7 +54,7 @@ class MockTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -782,4 +782,85 @@ void main() {
     skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
+
+  testWidgets('iOS selection handles scale with rich text (grapheme clusters)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: SelectableText.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+                TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+                TextSpan(text: '👨‍👩‍👦 ', style: TextStyle(fontSize: 35.0)),
+                TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
+    final EditableTextState editableTextState = tester.state(find.byType(EditableText));
+    final TextEditingController controller = editableTextWidget.controller;
+
+    // Double tap to select the second word.
+    const int index = 4;
+    await tester.tapAt(textOffsetToPosition(tester, index));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, index));
+    await tester.pumpAndSettle();
+    expect(editableTextState.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
+
+    // Drag the right handle 2 letters to the right. Placing the end handle on
+    // the third word. We use a small offset because the endpoint is on the very
+    // corner of the handle.
+    final TextSelection selection = controller.selection;
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
+
+    final Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
+    final Offset newHandlePos = textOffsetToPosition(tester, 16);
+    final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    await tester.pump();
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 16);
+
+    // Find start and end handles and verify their sizes.
+    expect(find.byType(Overlay), findsOneWidget);
+    expect(find.descendant(
+      of: find.byType(Overlay),
+      matching: find.byType(CustomPaint),
+    ), findsNWidgets(2));
+
+    final Iterable<RenderBox> handles = tester.renderObjectList(find.descendant(
+      of: find.byType(Overlay),
+      matching: find.byType(CustomPaint),
+    ));
+
+    // The handle height is determined by the formula:
+    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap .
+    // The text line height will be the value of the fontSize.
+    // The constant _kSelectionHandleRadius has the value of 6.
+    // The constant _kSelectionHandleOverlap has the value of 1.5.
+    // In the case of the end handle, which is located on the grapheme cluster '👨‍👩‍👦',
+    // 35.0 + 6 * 2 - 1.5 = 45.5 .
+    expect(handles.first.size.height, 60.5);
+    expect(handles.last.size.height, 45.5);
+  },
+    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
 }

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../widgets/editable_text_utils.dart' show textOffsetToPosition;
+import '../widgets/editable_text_utils.dart' show textOffsetToPosition, findRenderEditable;
 
 class MockClipboard {
   Object _clipboardData = <String, dynamic>{
@@ -81,24 +81,6 @@ void main() {
     );
     // Disabled buttons have no opacity change when pressed.
     return button.pressedOpacity! < 1.0;
-  }
-
-  // Returns the first RenderEditable.
-  RenderEditable findRenderEditable(WidgetTester tester) {
-    final RenderObject root = tester.renderObject(find.byType(EditableText));
-    expect(root, isNotNull);
-
-    late RenderEditable renderEditable;
-    void recursiveFinder(RenderObject child) {
-      if (child is RenderEditable) {
-        renderEditable = child;
-        return;
-      }
-      child.visitChildren(recursiveFinder);
-    }
-    root.visitChildren(recursiveFinder);
-    expect(renderEditable, isNotNull);
-    return renderEditable;
   }
 
   List<TextSelectionPoint> globalize(Iterable<TextSelectionPoint> points, RenderBox box) {

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -728,7 +728,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
     await tester.tapAt(textOffsetToPosition(tester, index));
     await tester.pumpAndSettle();
-    expect(controller.selection.isCollapsed, isFalse);
     expect(editableTextState.selectionOverlay!.handlesAreVisible, isTrue);
     expect(controller.selection.baseOffset, 4);
     expect(controller.selection.extentOffset, 7);

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -617,7 +619,7 @@ void main() {
     );
   });
 
-  testWidgets('iOS selection handles scale with rich text', (WidgetTester tester) async {
+  testWidgets('iOS selection handles scale with rich text (selection style 1)', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: Center(
@@ -693,6 +695,88 @@ void main() {
     // 50.0 + 6 * 2 - 1.5 = 60.5 .
     expect(handles.first.size.height, 60.5);
     expect(handles.last.size.height, 35.5);
+  },
+    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
+  );
+
+  testWidgets('iOS selection handles scale with rich text (selection style 2)', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: SelectableText.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(text: 'abc ', style: TextStyle(fontSize: 100.0)),
+                TextSpan(text: 'def ', style: TextStyle(fontSize: 50.0)),
+                TextSpan(text: 'hij', style: TextStyle(fontSize: 25.0)),
+              ],
+            ),
+            selectionHeightStyle: ui.BoxHeightStyle.max,
+          ),
+        ),
+      ),
+    );
+
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
+    final EditableTextState editableTextState = tester.state(find.byType(EditableText));
+    final TextEditingController controller = editableTextWidget.controller;
+
+    // Double tap to select the second word.
+    const int index = 4;
+    await tester.tapAt(textOffsetToPosition(tester, index));
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tapAt(textOffsetToPosition(tester, index));
+    await tester.pumpAndSettle();
+    expect(controller.selection.isCollapsed, isFalse);
+    expect(editableTextState.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 7);
+
+    // Drag the right handle 2 letters to the right. Placing the end handle on
+    // the third word. We use a small offset because the endpoint is on the very
+    // corner of the handle.
+    final TextSelection selection = controller.selection;
+    final RenderEditable renderEditable = findRenderEditable(tester);
+    final List<TextSelectionPoint> endpoints = globalize(
+      renderEditable.getEndpointsForSelection(selection),
+      renderEditable,
+    );
+    expect(endpoints.length, 2);
+
+    Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
+    Offset newHandlePos = textOffsetToPosition(tester, 11);
+    TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    await tester.pump();
+    await gesture.moveTo(newHandlePos);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.extentOffset, 11);
+
+    // Find start and end handles and verify their sizes.
+    expect(find.byType(Overlay), findsOneWidget);
+    expect(find.descendant(
+      of: find.byType(Overlay),
+      matching: find.byType(CustomPaint),
+    ), findsNWidgets(2));
+
+    final Iterable<RenderBox> handles = tester.renderObjectList(find.descendant(
+      of: find.byType(Overlay),
+      matching: find.byType(CustomPaint),
+    ));
+
+    // The handle height is determined by the formula:
+    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap
+    // The text line height will be the value of the fontSize.
+    // The constant _kSelectionHandleRadius has the value of 6.
+    // The constant _kSelectionHandleOverlap has the value of 1.5.
+    // In the case of the start handle, which is located on the word 'def',
+    // 50.0 + 6 * 2 - 1.5 = 60.5 .
+    expect(handles.first.size.height, 110.5);
+    expect(handles.last.size.height, 110.5);
   },
     skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -774,6 +774,9 @@ void main() {
     // The constant _kSelectionHandleOverlap has the value of 1.5.
     // In the case of the start handle, which is located on the word 'def',
     // 100 + 6 * 2 - 1.5 = 110.5 .
+    // In this case both selection handles are the same size because the selection
+    // height style is set to BoxHeightStyle.max which means that the height of
+    // the selection highlight will be the height of the largest word on the line.
     expect(handles.first.size.height, 110.5);
     expect(handles.last.size.height, 110.5);
   },

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -646,7 +646,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
     await tester.tapAt(textOffsetToPosition(tester, index));
     await tester.pumpAndSettle();
-    expect(controller.selection.isCollapsed, isFalse);
     expect(editableTextState.selectionOverlay!.handlesAreVisible, isTrue);
     expect(controller.selection.baseOffset, 4);
     expect(controller.selection.extentOffset, 7);

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -687,7 +687,7 @@ void main() {
     ));
 
     // The handle height is determined by the formula:
-    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap
+    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap .
     // The text line height will be the value of the fontSize.
     // The constant _kSelectionHandleRadius has the value of 6.
     // The constant _kSelectionHandleOverlap has the value of 1.5.
@@ -769,12 +769,12 @@ void main() {
     ));
 
     // The handle height is determined by the formula:
-    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap
-    // The text line height will be the value of the fontSize.
+    // textLineHeight + _kSelectionHandleRadius * 2 - _kSelectionHandleOverlap .
+    // The text line height will be the value of the fontSize, of the largest word on the line.
     // The constant _kSelectionHandleRadius has the value of 6.
     // The constant _kSelectionHandleOverlap has the value of 1.5.
     // In the case of the start handle, which is located on the word 'def',
-    // 50.0 + 6 * 2 - 1.5 = 60.5 .
+    // 100 + 6 * 2 - 1.5 = 110.5 .
     expect(handles.first.size.height, 110.5);
     expect(handles.last.size.height, 110.5);
   },

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
+import 'dart:ui' as ui show BoxHeightStyle;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/editable_text_utils.dart' show textOffsetToPosition;
@@ -662,9 +662,9 @@ void main() {
     );
     expect(endpoints.length, 2);
 
-    Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
-    Offset newHandlePos = textOffsetToPosition(tester, 11);
-    TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    final Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
+    final Offset newHandlePos = textOffsetToPosition(tester, 11);
+    final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
     await tester.pump();
     await gesture.moveTo(newHandlePos);
     await tester.pump();
@@ -744,9 +744,9 @@ void main() {
     );
     expect(endpoints.length, 2);
 
-    Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
-    Offset newHandlePos = textOffsetToPosition(tester, 11);
-    TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
+    final Offset handlePos = endpoints[1].point + const Offset(1.0, 1.0);
+    final Offset newHandlePos = textOffsetToPosition(tester, 11);
+    final TestGesture gesture = await tester.startGesture(handlePos, pointer: 7);
     await tester.pump();
     await gesture.moveTo(newHandlePos);
     await tester.pump();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -846,10 +846,10 @@ void main() {
     expect(controller.selection.extentOffset, 7);
 
     // Use toolbar to select all text.
-    if(isContextMenuProvidedByPlatform){
+    if (isContextMenuProvidedByPlatform) {
       controller.selection = TextSelection(baseOffset: 0, extentOffset: controller.text.length);
       expect(controller.selection.extentOffset, controller.text.length);
-    }else {
+    } else {
       await tester.tap(find.text('Select all'));
       await tester.pump();
       expect(controller.selection.baseOffset, 0);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -846,10 +846,15 @@ void main() {
     expect(controller.selection.extentOffset, 7);
 
     // Use toolbar to select all text.
-    await tester.tap(find.text('Select all'));
-    await tester.pump();
-    expect(controller.selection.baseOffset, 0);
-    expect(controller.selection.extentOffset, controller.text.length);
+    if(isContextMenuProvidedByPlatform){
+      controller.selection = TextSelection(baseOffset: 0, extentOffset: controller.text.length);
+      expect(controller.selection.extentOffset, controller.text.length);
+    }else {
+      await tester.tap(find.text('Select all'));
+      await tester.pump();
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, controller.text.length);
+    }
 
     await expectLater(
       find.byType(MaterialApp),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -834,12 +834,24 @@ void main() {
       ),
     );
 
-    final Offset textfieldStart = tester.getTopLeft(find.byKey(const Key('field0')));
+    final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
+    final EditableTextState editableTextState = tester.state(find.byType(EditableText));
 
-    await tester.longPressAt(textfieldStart + const Offset(50.0, 2.0));
+    // Double tap to select the first word.
+    const int index = 4;
+    await tester.tapAt(textOffsetToPosition(tester, index));
     await tester.pump(const Duration(milliseconds: 50));
-    await tester.tapAt(textfieldStart + const Offset(100.0, 107.0));
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tapAt(textOffsetToPosition(tester, index));
+    await tester.pumpAndSettle();
+    expect(editableTextState.selectionOverlay!.handlesAreVisible, isTrue);
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, 7);
+
+    // Use toolbar to select all text.
+    await tester.tap(find.text('Select all'));
+    await tester.pump();
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, controller.text.length);
 
     await expectLater(
       find.byType(MaterialApp),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -833,8 +833,7 @@ void main() {
         ),
       ),
     );
-
-    final EditableText editableTextWidget = tester.widget(find.byType(EditableText));
+    
     final EditableTextState editableTextState = tester.state(find.byType(EditableText));
 
     // Double tap to select the first word.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -833,7 +833,6 @@ void main() {
         ),
       ),
     );
-    
     final EditableTextState editableTextState = tester.state(find.byType(EditableText));
 
     // Double tap to select the first word.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7797,7 +7797,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? startGlyphHeight, double? endGlyphHeight]) {
     return Container();
   }
 
@@ -7807,7 +7807,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? startGlyphHeight, double? endGlyphHeight]) {
     return Offset.zero;
   }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7797,7 +7797,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     return Container();
   }
 
@@ -7807,7 +7807,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
     return Offset.zero;
   }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7797,7 +7797,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
+  Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap, double? secondaryLineHeight]) {
     return Container();
   }
 
@@ -7807,7 +7807,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight, [double? secondaryLineHeight]) {
     return Offset.zero;
   }
 


### PR DESCRIPTION
## Description
Check out the [design doc](https://docs.google.com/document/d/1XuvdYUzZQAxCLYT2H1DNtOi1s6fGmFE-cgmweaijfe4/edit?usp=sharing) for more details.

On iOS the selection handles should scale with the font size for rich text. The value used in calculating the handle anchor and handle size is `widget.renderObject.preferredLineHeight`. The value `preferredLineHeight` is defined as not always being the height of every line of the given text. On iOS we want the `preferredLineHeight` to pertain to the current selection so the handles can scale. To achieve this I calculate two new values `startHandleRect` and `endHandleRect` using the `renderObjects` `getRectForComposingRange`. These new values are then used to calculate the handle anchor and handle size depending on the `TextSelectionHandleType`.

Before|After
---|---
![Screen Shot 2021-07-07 at 1 07 02 PM](https://user-images.githubusercontent.com/948037/124822029-4424a100-df24-11eb-9ce9-3574f524ebf8.png)|![Screen Shot 2021-07-07 at 1 06 38 PM](https://user-images.githubusercontent.com/948037/124822044-4981eb80-df24-11eb-93c9-307d3826d653.png)

## Related Issues
Fixes #79303

## Tests
I added the following tests:
* cupertino/text_selection_test.dart
  * Widget test to verify selection handles scale correctly when selection height style is `BoxHeightStyle.tight` (this is the default).
  * Widget test to verify selection handle scale correctly when selection height style is `BoxHeightStyle.max`.

Updated goldens:
* material/text_field_test.dart TextSelectionStyle 1

Before|After
---|---
![material text_field_golden TextSelectionStyle 1_masterImage](https://user-images.githubusercontent.com/948037/126704737-b8545f0c-e602-457c-bfd1-0735370d3fa6.png)|![material text_field_golden TextSelectionStyle 1_testImage](https://user-images.githubusercontent.com/948037/126704746-d9e8e29c-66d6-4614-809c-61c4ca100f02.png)

* material/text_field_test.dart TextSelectionStyle 2

Before|After
---|---
![material text_field_golden TextSelectionStyle 2_masterImage](https://user-images.githubusercontent.com/948037/126704767-df3747b8-24fa-4c40-b5b1-885a57512c91.png)|![material text_field_golden TextSelectionStyle 2_testImage](https://user-images.githubusercontent.com/948037/126704781-724eda9f-3c34-494f-b530-c2c0df6a3ca2.png)

The selection endpoints have shifted down to match the selection style. This is expected.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.