### PR TITLE
Assert disposed layers are not reused

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -148,8 +148,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
     }());
     return disposed;
   }
-  // TODO(dnfield): https://github.com/flutter/flutter/issues/85066
-  final bool _debugDisposed = false;
+  bool _debugDisposed = false;
 
   /// Set when this layer is appended to a [ContainerLayer], and
   /// unset when it is removed.
@@ -220,8 +219,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
         'Do not directly call dispose on a $runtimeType. Instead, '
         'use createHandle and LayerHandle.dispose.',
       );
-      // TODO(dnfield): enable this. https://github.com/flutter/flutter/issues/85066
-      // _debugDisposed = true;
+      _debugDisposed = true;
       return true;
     }());
     _engineLayer?.dispose();

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -602,13 +602,11 @@ void main() {
     parent.buildScene(SceneBuilder());
   }, skip: isBrowser); // TODO(yjbanov): `toImage` doesn't work on the Web: https://github.com/flutter/flutter/issues/42767
 
-  // TODO(dnfield): remove this when https://github.com/flutter/flutter/issues/85066 is resolved.
-  const bool bug85066 = true;
   test('PictureLayer does not let you call dispose unless refcount is 0', () {
     PictureLayer layer = PictureLayer(Rect.zero);
     expect(layer.debugHandleCount, 0);
     layer.dispose();
-    expect(layer.debugDisposed, true, skip: bug85066);
+    expect(layer.debugDisposed, true);
 
     layer = PictureLayer(Rect.zero);
     final LayerHandle<PictureLayer> handle = LayerHandle<PictureLayer>(layer);
@@ -616,8 +614,8 @@ void main() {
     expect(() => layer.dispose(), throwsAssertionError);
     handle.layer = null;
     expect(layer.debugHandleCount, 0);
-    expect(layer.debugDisposed, true, skip: bug85066);
-    expect(() => layer.dispose(), throwsAssertionError, skip: bug85066); // already disposed.
+    expect(layer.debugDisposed, true);
+    expect(() => layer.dispose(), throwsAssertionError); // already disposed.
   });
 
   test('Layer append/remove increases/decreases handle count', () {
@@ -632,7 +630,7 @@ void main() {
 
     layer.remove();
     expect(layer.debugHandleCount, 0);
-    expect(layer.debugDisposed, true, skip: bug85066);
+    expect(layer.debugDisposed, true);
   });
 
   test('Layer.dispose disposes the engineLayer', () {
@@ -693,17 +691,17 @@ void main() {
 
     holder.layer = layer2;
     expect(layer.debugHandleCount, 0);
-    expect(layer.debugDisposed, true, skip: bug85066);
+    expect(layer.debugDisposed, true);
     expect(layer2.debugHandleCount, 1);
     expect(layer2.debugDisposed, false);
 
     holder.layer = null;
     expect(layer.debugHandleCount, 0);
-    expect(layer.debugDisposed, true, skip: bug85066);
+    expect(layer.debugDisposed, true);
     expect(layer2.debugHandleCount, 0);
-    expect(layer2.debugDisposed, true, skip: bug85066);
+    expect(layer2.debugDisposed, true);
 
-    expect(() => holder.layer = layer, throwsAssertionError, skip: bug85066);
+    expect(() => holder.layer = layer, throwsAssertionError);
   });
 }
 

--- a/packages/flutter/test/rendering/object_paint_dispose_test.dart
+++ b/packages/flutter/test/rendering/object_paint_dispose_test.dart
@@ -7,8 +7,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // TODO(dnfield): remove when https://github.com/flutter/flutter/issues/85066 is resolved.
-  const bool bug85066 = true;
   testWidgets('Tracks picture layers accurately when painting is interleaved with a pushLayer', (WidgetTester tester) async {
     // Creates a RenderObject that will paint into multiple picture layers.
     // Asserts that both layers get a handle, and that all layers get correctly
@@ -34,7 +32,7 @@ void main() {
     await tester.pumpWidget(const SizedBox());
 
     for (final Layer layer in layers) {
-      expect(layer.debugDisposed, true, skip: bug85066);
+      expect(layer.debugDisposed, true);
     }
     expect(renderObject.debugDisposed, true);
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85066

Must not be landed before cl/382767924