### PR TITLE
Don't lose composing region when dragging handle in a word

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -675,7 +675,7 @@ class TextSelectionOverlay {
         break;
     }
     selectionDelegate!.userUpdateTextEditingValue(
-      _value.copyWith(selection: newSelection, composing: TextRange.empty),
+      _value.copyWith(selection: newSelection),
       SelectionChangedCause.drag,
     );
     selectionDelegate!.bringIntoView(textPosition);


### PR DESCRIPTION
We were resetting the composing region when selection changed, but that's not how native behaves.  For example, when the current word is being composed, the user should be able to move the caret around inside of the composing region to modify it.

### Flutter Before

https://user-images.githubusercontent.com/389558/124324128-51621a00-db37-11eb-8c08-93b92d53e396.mov



### Flutter After

https://user-images.githubusercontent.com/389558/124324190-68087100-db37-11eb-9e60-b704f0611562.mov



### Native Android
https://user-images.githubusercontent.com/389558/124323943-f5979100-db36-11eb-8f9e-0c1252204a1b.mov


## References

Partial fix for https://github.com/flutter/flutter/issues/84849

This is not a full fix because, as you can see in the "Flutter After" video, the handle disappears when moving beyond the current word.  It seems to me that that has a different cause, which I'll add some notes about in the issue.