### PR TITLE
Fix the Interactive App for the MaterialStateOutlinedBorder class

### DIFF
--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -437,15 +437,17 @@ class _MaterialStateBorderSide extends MaterialStateBorderSide {
 ///
 /// @override
 /// Widget build(BuildContext context) {
-///   return FilterChip(
-///     label: const Text('Select chip'),
-///     selected: isSelected,
-///     onSelected: (bool value) {
-///       setState(() {
-///         isSelected = value;
-///       });
-///     },
-///     shape: SelectedBorder(),
+///   return Material(
+///     child: FilterChip(
+///       label: const Text('Select chip'),
+///       selected: isSelected,
+///       onSelected: (bool value) {
+///         setState(() {
+///           isSelected = value;
+///         });
+///       },
+///       shape: SelectedBorder(),
+///     ),
 ///   );
 /// }
 /// ```


### PR DESCRIPTION
Currently, the interactive app on https://api.flutter.dev/flutter/material/MaterialStateOutlinedBorder-class.html does not work, because `FilterChip` here: https://github.com/flutter/flutter/blob/ef5e7e6f889e711bc863d1b0508fc59b252aa608/packages/flutter/lib/src/material/material_state.dart#L440 needs a `Material` widget ancestor. This PR wraps this `FilterChip` inside a `Material` widget.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.