### PR TITLE
[new feature] Add a borderRadius property to TableBorder

### DIFF
--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -23,6 +23,7 @@ class TableBorder {
     this.left = BorderSide.none,
     this.horizontalInside = BorderSide.none,
     this.verticalInside = BorderSide.none,
+    this.borderRadius = BorderRadius.zero,
   });
 
   /// A uniform border with all sides the same color and width.
@@ -32,9 +33,10 @@ class TableBorder {
     Color color = const Color(0xFF000000),
     double width = 1.0,
     BorderStyle style = BorderStyle.solid,
+    BorderRadius borderRadius = BorderRadius.zero,
   }) {
     final BorderSide side = BorderSide(color: color, width: width, style: style);
-    return TableBorder(top: side, right: side, bottom: side, left: side, horizontalInside: side, verticalInside: side);
+    return TableBorder(top: side, right: side, bottom: side, left: side, horizontalInside: side, verticalInside: side, borderRadius: borderRadius);
   }
 
   /// Creates a border for a table where all the interior sides use the same
@@ -70,6 +72,9 @@ class TableBorder {
 
   /// The vertical interior sides of this border.
   final BorderSide verticalInside;
+
+  /// The [BorderRadius] to use when painting the corners of this border.
+  final BorderRadius borderRadius;
 
   /// The widths of the sides of this border represented as an [EdgeInsets].
   ///
@@ -256,7 +261,14 @@ class TableBorder {
         }
       }
     }
-    paintBorder(canvas, rect, top: top, right: right, bottom: bottom, left: left);
+    if(!isUniform || borderRadius == BorderRadius.zero)
+      paintBorder(canvas, rect, top: top, right: right, bottom: bottom, left: left);
+    else {
+      final RRect outer = borderRadius.toRRect(rect);
+      final RRect inner = outer.deflate(top.width);
+      final Paint paint = Paint()..color = top.color;
+      canvas.drawDRRect(outer, inner, paint);
+    }
   }
 
   @override
@@ -271,12 +283,13 @@ class TableBorder {
         && other.bottom == bottom
         && other.left == left
         && other.horizontalInside == horizontalInside
-        && other.verticalInside == verticalInside;
+        && other.verticalInside == verticalInside
+        && other.borderRadius == borderRadius;
   }
 
   @override
-  int get hashCode => hashValues(top, right, bottom, left, horizontalInside, verticalInside);
+  int get hashCode => hashValues(top, right, bottom, left, horizontalInside, verticalInside, borderRadius);
 
   @override
-  String toString() => 'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside)';
+  String toString() => 'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside, $borderRadius)';
 }

--- a/packages/flutter/test/rendering/table_border_test.dart
+++ b/packages/flutter/test/rendering/table_border_test.dart
@@ -124,6 +124,13 @@ void main() {
 
   test('TableBorder Object API', () {
     final String none = BorderSide.none.toString();
-    expect(const TableBorder().toString(), 'TableBorder($none, $none, $none, $none, $none, $none)');
+    final String zeroRadius = BorderRadius.zero.toString();
+    expect(const TableBorder().toString(), 'TableBorder($none, $none, $none, $none, $none, $none, $zeroRadius)');
   });
+
+  test('TableBorder.all with a borderRadius', () {
+    final TableBorder tableA = TableBorder.all(borderRadius: BorderRadius.circular(8.0));
+    expect(tableA.borderRadius, BorderRadius.circular(8.0));
+  });
+
 }

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -253,4 +253,26 @@ void main() {
     layout(table, constraints: BoxConstraints.tight(const Size(800.0, 600.0)));
     expect(table.hasSize, true);
   });
+
+  test('Table paints a borderRadius', () {
+    final RenderTable table = RenderTable(
+      textDirection: TextDirection.ltr,
+      border: TableBorder.all(borderRadius: BorderRadius.circular(8.0)),
+    );
+    layout(table);
+    table.setFlatChildren(2, <RenderBox>[
+      RenderPositionedBox(), RenderPositionedBox(),
+      RenderPositionedBox(), RenderPositionedBox(),
+    ]);
+    pumpFrame();
+    expect(table, paints
+      ..path()
+      ..path()
+      ..drrect(
+        outer: RRect.fromLTRBR(0.0, 0.0, 800.0, 0.0, const Radius.circular(8.0)),
+        inner: RRect.fromLTRBR(1.0, 1.0, 799.0, -1.0, const Radius.circular(7.0)),
+      )
+    );
+  });
+
 }


### PR DESCRIPTION
This PR adds a `borderRadius` property to `TableBorder`. Any `BorderRadius` can be used as long as the borders used on the table (inside & out) are all identical ("uniform").

The `borderRadius` property can be used to draw borders such as:

<div>
<img src="https://user-images.githubusercontent.com/52705497/124559848-d2295a80-de44-11eb-8bbd-c9b60b3dc8e8.jpg" width="200" height="200" style="float:left;">
&nbsp; &nbsp; &nbsp; &nbsp;
<img src="https://user-images.githubusercontent.com/52705497/124560082-17e62300-de45-11eb-9428-dbfc27fb6991.jpg" width="200" height="200">
<p>&nbsp;</p>
</div>

Fixes #58486.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.