### PR TITLE
Timepicker to handle localized numbers in input mode

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart' as intl;
 
 import 'color_scheme.dart';
 import 'colors.dart';
@@ -1350,12 +1351,23 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     registerForRestoration(minuteHasError, 'minute_has_error');
   }
 
-  int? _parseHour(String? value) {
+  int? _toLocalizedNumber(String? value) {
     if (value == null) {
       return null;
     }
 
-    int? newHour = int.tryParse(value);
+    try {
+      final String locale = Localizations.localeOf(context).toString();
+      final intl.NumberFormat format = intl.NumberFormat('#0', locale);
+      return format.parse(value).toInt();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  int? _parseHour(String? value) {
+    int? newHour = _toLocalizedNumber(value);
+
     if (newHour == null) {
       return null;
     }
@@ -1377,11 +1389,8 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   }
 
   int? _parseMinute(String? value) {
-    if (value == null) {
-      return null;
-    }
+    final int? newMinute = _toLocalizedNumber(value);
 
-    final int? newMinute = int.tryParse(value);
     if (newMinute == null) {
       return null;
     }
@@ -1411,7 +1420,10 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   void _handleMinuteSavedSubmitted(String? value) {
     final int? newMinute = _parseMinute(value);
     if (newMinute != null) {
-      _selectedTime.value = TimeOfDay(hour: _selectedTime.value.hour, minute: int.parse(value!));
+      _selectedTime.value = TimeOfDay(
+          hour: _selectedTime.value.hour,
+          minute: _toLocalizedNumber(value)!
+      );
       widget.onChanged(_selectedTime.value);
     }
   }

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   vector_math: 2.1.0
   sky_engine:
     sdk: flutter
+  intl: 0.17.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_localizations/test/material/time_picker_test.dart
+++ b/packages/flutter_localizations/test/material/time_picker_test.dart
@@ -277,6 +277,9 @@ void main() {
         expect(dayPeriodControlFinder, findsNothing);
       }
       await finishPicker(tester);
+
+      expect(() => tester.firstWidget(find.byType(TimePickerDialog)),
+          throwsA(const TypeMatcher<StateError>()));
     }
   });
 


### PR DESCRIPTION
This PR adds `intl` dependency to `flutter`

Fixes #85527

#### The root cause

When a non-ASCII numbers are used, they were sent to `int.tryParse` and they fail.

#### The solution

`NumberFormat` is used to transform the string according to the current locale, before parsing it.


#### The test

Tests were there to open a dialog already, however it didn't check if dialog is closed or not. I tried to get the internal state of the dialog (to know about `hourHasError` and `minuteHasError`), but it seem not directly possible.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
