### PR TITLE
Update devtools_launcher.dart comment

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -16,10 +16,8 @@ import 'convert.dart';
 import 'persistent_tool_state.dart';
 import 'resident_runner.dart';
 
-/// An implementation of the devtools launcher that uses the server package.
-///
-/// This is implemented in `isolated/` to prevent the flutter_tool from needing
-/// a devtools dependency in google3.
+/// An implementation of the devtools launcher that uses `pub global activate` to
+/// start a server instance.
 class DevtoolsServerLauncher extends DevtoolsLauncher {
   DevtoolsServerLauncher({
     @required Platform platform,


### PR DESCRIPTION
We no longer directly depend on devtools, correct the doc comment to describe the current mechanism.
