### PR TITLE
Migrate devicelab tasks a-f to null safety.

### DIFF
--- a/dev/devicelab/bin/tasks/analyzer_benchmark.dart
+++ b/dev/devicelab/bin/tasks/analyzer_benchmark.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/analysis.dart';
 

--- a/dev/devicelab/bin/tasks/android_defines_test.dart
+++ b/dev/devicelab/bin/tasks/android_defines_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
+++ b/dev/devicelab/bin/tasks/android_engine_dependency_proxy_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';
@@ -20,7 +18,7 @@ Future<void> main() async {
   await task(() async {
     section('Find Java');
 
-    final String javaHome = await findJavaHome();
+    final String? javaHome = await findJavaHome();
     if (javaHome == null)
       return TaskResult.failure('Could not find Java');
     print('\nUsing JAVA_HOME=$javaHome');

--- a/dev/devicelab/bin/tasks/android_obfuscate_test.dart
+++ b/dev/devicelab/bin/tasks/android_obfuscate_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/android_semantics_integration_test.dart
+++ b/dev/devicelab/bin/tasks/android_semantics_integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/android_stack_size_test.dart
+++ b/dev/devicelab/bin/tasks/android_stack_size_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/android_view_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/android_view_scroll_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
+++ b/dev/devicelab/bin/tasks/animated_image_gc_perf.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/animated_placeholder_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/animated_placeholder_perf__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/animation_with_microtasks_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/animation_with_microtasks_perf_ios__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/backdrop_filter_perf_ios__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_android__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_android__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_ios__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/basic_material_app_win__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_win__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/build_aar_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_module_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';
@@ -24,7 +22,7 @@ Future<void> main() async {
 
     section('Find Java');
 
-    final String javaHome = await findJavaHome();
+    final String? javaHome = await findJavaHome();
     if (javaHome == null)
       return TaskResult.failure('Could not find Java');
     print('\nUsing JAVA_HOME=$javaHome');

--- a/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/build_aar_plugin_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';
@@ -20,7 +18,7 @@ Future<void> main() async {
 
     section('Find Java');
 
-    final String javaHome = await findJavaHome();
+    final String? javaHome = await findJavaHome();
     if (javaHome == null)
       return TaskResult.failure('Could not find Java');
     print('\nUsing JAVA_HOME=$javaHome');

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/build_mode_test.dart
+++ b/dev/devicelab/bin/tasks/build_mode_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -25,7 +23,7 @@ Future<String> runFlutterAndQuit(List<String> args, Device device) async {
   );
   final List<String> stdout = <String>[];
   final List<String> stderr = <String>[];
-  int runExitCode;
+  int? runExitCode;
   run.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen(
     (String line) {
       print('run:stdout: $line');

--- a/dev/devicelab/bin/tasks/channels_integration_test.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/channels_integration_test_ios.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test_ios.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/channels_integration_test_win.dart
+++ b/dev/devicelab/bin/tasks/channels_integration_test_win.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_linux.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_linux.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_mac.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_mac.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/codegen_integration_win.dart
+++ b/dev/devicelab/bin/tasks/codegen_integration_win.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/color_filter_and_fade_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/color_filter_and_fade_perf__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/color_filter_and_fade_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/color_filter_and_fade_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout__start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout__start_up.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_android__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_android__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_android__scroll_smoothness.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_android__scroll_smoothness.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_ios__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_ios__start_up.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__devtools_memory.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__devtools_memory.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__memory.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf_ios__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf_ios__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_semantics_perf.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/complex_layout_win__compile.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_win__compile.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cubic_bezier_perf_sksl_warmup__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cull_opacity_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/cull_opacity_perf__e2e_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/cull_opacity_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/cull_opacity_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/dart_plugin_registry_test.dart
+++ b/dev/devicelab/bin/tasks/dart_plugin_registry_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/dart_plugin_registry_tests.dart';
 

--- a/dev/devicelab/bin/tasks/dartdocs.dart
+++ b/dev/devicelab/bin/tasks/dartdocs.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/devtools_profile_start_test.dart
+++ b/dev/devicelab/bin/tasks/devtools_profile_start_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';

--- a/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
+++ b/dev/devicelab/bin/tasks/drive_perf_debug_warning.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/embedded_android_views_integration_test.dart
+++ b/dev/devicelab/bin/tasks/embedded_android_views_integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/external_ui_integration_test.dart
+++ b/dev/devicelab/bin/tasks/external_ui_integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/external_ui_integration_test_ios.dart
+++ b/dev/devicelab/bin/tasks/external_ui_integration_test_ios.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fast_scroll_heavy_gridview__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_heavy_gridview__memory.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
@@ -20,7 +18,7 @@ class FastScrollHeavyGridViewMemoryTest extends MemoryTest {
         );
 
   @override
-  AndroidDevice get device => super.device as AndroidDevice;
+  AndroidDevice? get device => super.device as AndroidDevice?;
 
   @override
   int get iterationCount => 5;
@@ -29,11 +27,11 @@ class FastScrollHeavyGridViewMemoryTest extends MemoryTest {
   Future<void> useMemory() async {
     await launchApp();
     await recordStart();
-    await device.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
+    await device!.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
     await Future<void>.delayed(const Duration(milliseconds: 1500));
-    await device.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
+    await device!.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
     await Future<void>.delayed(const Duration(milliseconds: 1500));
-    await device.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
+    await device!.shellExec('input', <String>['swipe', '50 1500 50 50 50']);
     await Future<void>.delayed(const Duration(milliseconds: 1500));
     await recordEnd();
   }

--- a/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
+++ b/dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
@@ -20,7 +18,7 @@ class FastScrollLargeImagesMemoryTest extends MemoryTest {
         );
 
   @override
-  AndroidDevice get device => super.device as AndroidDevice;
+  AndroidDevice? get device => super.device as AndroidDevice?;
 
   @override
   int get iterationCount => 5;
@@ -29,7 +27,7 @@ class FastScrollLargeImagesMemoryTest extends MemoryTest {
   Future<void> useMemory() async {
     await launchApp();
     await recordStart();
-    await device.shellExec('input', <String>['swipe', '0 1500 0 0 50']);
+    await device!.shellExec('input', <String>['swipe', '0 1500 0 0 50']);
     await Future<void>.delayed(const Duration(milliseconds: 15000));
     await recordEnd();
   }

--- a/dev/devicelab/bin/tasks/flavors_test.dart
+++ b/dev/devicelab/bin/tasks/flavors_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/flavors_test_ios.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_ios.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/flavors_test_win.dart
+++ b/dev/devicelab/bin/tasks/flavors_test_win.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';


### PR DESCRIPTION
Part of #85995.

Migrate the first 3rd of the devicelab tasks to null safety.

This will require the core framework migration #85993 to land first in order for the tests to pass.