### PR TITLE
Migrate devicelab tests and test runners to null safety.

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -21,7 +21,7 @@ List<String> _taskNames = <String>[];
 String? deviceId;
 
 /// The git branch being tested on.
-late String gitBranch;
+String? gitBranch;
 
 /// The build of the local engine to use.
 ///
@@ -68,7 +68,7 @@ Future<void> main(List<String> rawArgs) async {
 
   deviceId = args['device-id'] as String?;
   exitOnFirstTestFailure = (args['exit'] as bool?) ?? false;
-  gitBranch = args['git-branch'] as String;
+  gitBranch = args['git-branch'] as String?;
   localEngine = args['local-engine'] as String?;
   localEngineSrcPath = args['local-engine-src-path'] as String?;
   luciBuilder = args['luci-builder'] as String?;

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -313,7 +313,6 @@ final ArgParser _argParser = ArgParser()
   )
   ..addOption(
     'git-branch',
-    mandatory: true,
     help: '[Flutter infrastructure] Git branch of the current commit. LUCI\n'
           'checkouts run in detached HEAD state, so the branch must be passed.',
   )

--- a/dev/devicelab/bin/summarize.dart
+++ b/dev/devicelab/bin/summarize.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:convert';
 import 'dart:io';
 

--- a/dev/devicelab/bin/test_runner.dart
+++ b/dev/devicelab/bin/test_runner.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/dev/devicelab/test/ab_test.dart
+++ b/dev/devicelab/test/ab_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/ab.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:collection/collection.dart' show ListEquality, MapEquality;
 
 import 'package:flutter_devicelab/framework/devices.dart';
@@ -13,12 +11,11 @@ import 'common.dart';
 
 void main() {
   group('device', () {
-    Device device;
+    late Device device;
 
     setUp(() {
       FakeDevice.resetLog();
-      device = null;
-      device = FakeDevice();
+      device = FakeDevice(deviceId: 'fakeDeviceId');
     });
 
     tearDown(() {
@@ -131,9 +128,9 @@ void expectLog(List<CommandArgs> log) {
 }
 
 CommandArgs cmd({
-  String command,
-  List<String> arguments,
-  Map<String, String> environment,
+  required String command,
+  List<String>? arguments,
+  Map<String, String>? environment,
 }) {
   return CommandArgs(
     command: command,
@@ -146,11 +143,11 @@ typedef ExitErrorFactory = dynamic Function();
 
 @immutable
 class CommandArgs {
-  const CommandArgs({ this.command, this.arguments, this.environment });
+  const CommandArgs({ required this.command, this.arguments, this.environment });
 
   final String command;
-  final List<String> arguments;
-  final Map<String, String> environment;
+  final List<String>? arguments;
+  final Map<String, String>? environment;
 
   @override
   String toString() => 'CommandArgs(command: $command, arguments: $arguments, environment: $environment)';
@@ -177,7 +174,7 @@ class CommandArgs {
 }
 
 class FakeDevice extends AndroidDevice {
-  FakeDevice({String deviceId}) : super(deviceId: deviceId);
+  FakeDevice({required String deviceId}) : super(deviceId: deviceId);
 
   static String output = '';
 
@@ -206,7 +203,7 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
-  Future<String> shellEval(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) async {
+  Future<String> shellEval(String command, List<String> arguments, { Map<String, String>? environment, bool silent = false }) async {
     commandLog.add(CommandArgs(
       command: command,
       arguments: arguments,
@@ -216,7 +213,7 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
-  Future<void> shellExec(String command, List<String> arguments, { Map<String, String> environment, bool silent = false }) async {
+  Future<void> shellExec(String command, List<String> arguments, { Map<String, String>? environment, bool silent = false }) async {
     commandLog.add(CommandArgs(
       command: command,
       arguments: arguments,

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:convert';
 import 'dart:io';
 
@@ -17,14 +15,14 @@ import 'package:http/testing.dart';
 import 'common.dart';
 
 void main() {
-  ProcessResult _processResult;
+  late ProcessResult _processResult;
   ProcessResult runSyncStub(String executable, List<String> args,
-          {Map<String, String> environment,
-          bool includeParentEnvironment,
-          bool runInShell,
-          Encoding stderrEncoding,
-          Encoding stdoutEncoding,
-          String workingDirectory}) =>
+          {Map<String, String>? environment,
+          bool includeParentEnvironment = true,
+          bool runInShell = false,
+          Encoding? stderrEncoding,
+          Encoding? stdoutEncoding,
+          String? workingDirectory}) =>
       _processResult;
 
   // Expected test values.
@@ -33,9 +31,9 @@ void main() {
   const String serviceAccountToken = 'test_token';
 
   group('Cocoon', () {
-    Client mockClient;
-    Cocoon cocoon;
-    FileSystem fs;
+    late Client mockClient;
+    late Cocoon cocoon;
+    late FileSystem fs;
 
     setUp(() {
       fs = MemoryFileSystem();
@@ -183,7 +181,7 @@ void main() {
   });
 
   group('AuthenticatedCocoonClient', () {
-    FileSystem fs;
+    late FileSystem fs;
 
     setUp(() {
       fs = MemoryFileSystem();

--- a/dev/devicelab/test/host_agent_test.dart
+++ b/dev/devicelab/test/host_agent_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_devicelab/framework/host_agent.dart';
@@ -12,7 +10,7 @@ import 'package:platform/platform.dart';
 import 'common.dart';
 
 void main() {
-  FileSystem fs;
+  late FileSystem fs;
   setUp(() {
     fs = MemoryFileSystem();
     hostAgent.resetDumpDirectory();
@@ -31,8 +29,8 @@ void main() {
       );
       final HostAgent agent = HostAgent(platform: fakePlatform, fileSystem: fs);
 
-      expect(agent.dumpDirectory.existsSync(), isTrue);
-      expect(agent.dumpDirectory.path, environmentDir.path);
+      expect(agent.dumpDirectory!.existsSync(), isTrue);
+      expect(agent.dumpDirectory!.path, environmentDir.path);
     });
 
     test('not set by environment', () async {

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -31,7 +29,7 @@ void main() {
     Future<void> expectScriptResult(
         List<String> testNames,
         int expectedExitCode,
-        {String deviceId}
+        {String? deviceId}
       ) async {
       final ProcessResult result = await runScript(testNames, <String>[
         if (deviceId != null) ...<String>['-d', deviceId],

--- a/dev/devicelab/test/running_processes_test.dart
+++ b/dev/devicelab/test/running_processes_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/running_processes.dart';
 import 'common.dart';
 

--- a/dev/devicelab/test/task_result_test.dart
+++ b/dev/devicelab/test/task_result_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/task_result.dart';
 
 import 'common.dart';

--- a/dev/devicelab/test/tasks/build_test_task_test.dart
+++ b/dev/devicelab/test/tasks/build_test_task_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/runner.dart';
@@ -24,7 +22,7 @@ void main() {
       deviceId: 'FAKE_SUCCESS',
       isolateParams: isolateParams,
     );
-    expect(result.data['benchmark'], 'data');
+    expect(result.data!['benchmark'], 'data');
   });
 
   test('runs build only when build arg is given', () async {
@@ -44,7 +42,7 @@ void main() {
       deviceId: 'FAKE_SUCCESS',
       isolateParams: isolateParams,
     );
-    expect(result.data['benchmark'], 'data');
+    expect(result.data!['benchmark'], 'data');
   });
 
   test('sets environment', () async {

--- a/dev/devicelab/test/utils_test.dart
+++ b/dev/devicelab/test/utils_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_devicelab/framework/utils.dart';
 
 import 'common.dart';


### PR DESCRIPTION
Part of #84014.

This migrates the devicelab tests and test runners to null safety. With this everything in the device lab should be running with null safety turned on.
