### PR TITLE
Add CallbackShortcuts widget

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1249,6 +1249,17 @@ class CallbackShortcuts extends StatelessWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
+  // A helper function to make the stack trace more useful if the callback
+  // throws, by providing the activator and event as arguments that will appear
+  // in the stack trace.
+  bool _applyKeyBinding(ShortcutActivator activator, RawKeyEvent event) {
+    if (activator.accepts(event, RawKeyboard.instance)) {
+      bindings[activator]!.call();
+      return true;
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Focus(
@@ -1258,10 +1269,7 @@ class CallbackShortcuts extends StatelessWidget {
         KeyEventResult result = KeyEventResult.ignored;
         // Activates all key bindings that match, returns "handled" if any handle it.
         for (final ShortcutActivator activator in bindings.keys) {
-          if (activator.accepts(event, RawKeyboard.instance)) {
-            bindings[activator]!.call();
-            result = KeyEventResult.handled;
-          }
+          result = _applyKeyBinding(activator, event) ? KeyEventResult.handled : result;
         }
         return result;
       },

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1217,7 +1217,16 @@ class _ShortcutsMarker extends InheritedNotifier<ShortcutManager> {
 /// [Shortcuts] and [Actions] mechanism is overkill, and this widget is here for
 /// those apps.
 ///
-/// [Shortcuts] and [CallbackShortcuts] can both be used in the same app.
+/// [Shortcuts] and [CallbackShortcuts] can both be used in the same app. As
+/// with any key handling widget, if this widget handles a key event then
+/// widgets above it in the focus chain will not receive the event. This means
+/// that if this widget handles a key, then an ancestor [Shortcuts] widget (or
+/// any other key handling widget) will not receive that key, and similarly, if
+/// a descendant of this widget handles the key, then the key event will not
+/// reach this widget for handling.
+///
+/// See also:
+///  * [Focus], a widget that defines which widgets can receive keyboard focus.
 class CallbackShortcuts extends StatelessWidget {
   /// Creates a const [CallbackShortcuts] widget.
   const CallbackShortcuts({

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1077,4 +1077,167 @@ void main() {
       invoked = 0;
     });
   });
+  group('CallbackShortcuts', () {
+    testWidgets('trigger on key events', (WidgetTester tester) async {
+      int invoked = 0;
+      await tester.pumpWidget(
+        CallbackShortcuts(
+          bindings: <ShortcutActivator, VoidCallback>{
+            const SingleActivator(LogicalKeyboardKey.keyA): () {
+              invoked++;
+            },
+          },
+          child: const Focus(
+            autofocus: true,
+            child: Placeholder(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      expect(invoked, equals(1));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      expect(invoked, equals(1));
+    });
+    testWidgets('nested CallbackShortcuts stop propagation', (WidgetTester tester) async {
+      int invokedOuter = 0;
+      int invokedInner = 0;
+      await tester.pumpWidget(
+        CallbackShortcuts(
+          bindings: <ShortcutActivator, VoidCallback>{
+            const SingleActivator(LogicalKeyboardKey.keyA): () {
+              invokedOuter++;
+            },
+          },
+          child: CallbackShortcuts(
+            bindings: <ShortcutActivator, VoidCallback>{
+              const SingleActivator(LogicalKeyboardKey.keyA): () {
+                invokedInner++;
+              },
+            },
+            child: const Focus(
+              autofocus: true,
+              child: Placeholder(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      expect(invokedOuter, equals(0));
+      expect(invokedInner, equals(1));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      expect(invokedOuter, equals(0));
+      expect(invokedInner, equals(1));
+    });
+    testWidgets('non-overlapping nested CallbackShortcuts fire appropriately', (WidgetTester tester) async {
+      int invokedOuter = 0;
+      int invokedInner = 0;
+      await tester.pumpWidget(
+        CallbackShortcuts(
+          bindings: <ShortcutActivator, VoidCallback>{
+            const CharacterActivator('b'): () {
+              invokedOuter++;
+            },
+          },
+          child: CallbackShortcuts(
+            bindings: <ShortcutActivator, VoidCallback>{
+              const CharacterActivator('a'): () {
+                invokedInner++;
+              },
+            },
+            child: const Focus(
+              autofocus: true,
+              child: Placeholder(),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      expect(invokedOuter, equals(0));
+      expect(invokedInner, equals(1));
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyB);
+      expect(invokedOuter, equals(1));
+      expect(invokedInner, equals(1));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyB);
+      expect(invokedOuter, equals(1));
+      expect(invokedInner, equals(1));
+    });
+    testWidgets('Works correctly with Shortcuts too', (WidgetTester tester) async {
+      int invokedCallbackA = 0;
+      int invokedCallbackB = 0;
+      int invokedActionA = 0;
+      int invokedActionB = 0;
+
+      void clear() {
+        invokedCallbackA = 0;
+        invokedCallbackB = 0;
+        invokedActionA = 0;
+        invokedActionB = 0;
+      }
+
+      await tester.pumpWidget(
+        Actions(
+          actions: <Type, Action<Intent>>{
+            TestIntent: TestAction(
+              onInvoke: (Intent intent) {
+                invokedActionA++;
+                return true;
+              },
+            ),
+            TestIntent2: TestAction(
+              onInvoke: (Intent intent) {
+                invokedActionB++;
+                return true;
+              },
+            ),
+          },
+          child: CallbackShortcuts(
+            bindings: <ShortcutActivator, VoidCallback>{
+              const CharacterActivator('b'): () {
+                invokedCallbackB++;
+              },
+            },
+            child: Shortcuts(
+              shortcuts: <LogicalKeySet, Intent>{
+                LogicalKeySet(LogicalKeyboardKey.keyA): const TestIntent(),
+                LogicalKeySet(LogicalKeyboardKey.keyB): const TestIntent2(),
+              },
+              child: CallbackShortcuts(
+                bindings: <ShortcutActivator, VoidCallback>{
+                  const CharacterActivator('a'): () {
+                    invokedCallbackA++;
+                  },
+                },
+                child: const Focus(
+                  autofocus: true,
+                  child: Placeholder(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      expect(invokedCallbackA, equals(1));
+      expect(invokedCallbackB, equals(0));
+      expect(invokedActionA, equals(0));
+      expect(invokedActionB, equals(0));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      clear();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyB);
+      expect(invokedCallbackA, equals(0));
+      expect(invokedCallbackB, equals(0));
+      expect(invokedActionA, equals(0));
+      expect(invokedActionB, equals(1));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyB);
+    });
+  });
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1084,7 +1084,7 @@ void main() {
         CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
             const SingleActivator(LogicalKeyboardKey.keyA): () {
-              invoked++;
+              invoked += 1;
             },
           },
           child: const Focus(
@@ -1107,13 +1107,13 @@ void main() {
         CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
             const SingleActivator(LogicalKeyboardKey.keyA): () {
-              invokedOuter++;
+              invokedOuter += 1;
             },
           },
           child: CallbackShortcuts(
             bindings: <ShortcutActivator, VoidCallback>{
               const SingleActivator(LogicalKeyboardKey.keyA): () {
-                invokedInner++;
+                invokedInner += 1;
               },
             },
             child: const Focus(
@@ -1139,13 +1139,13 @@ void main() {
         CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
             const CharacterActivator('b'): () {
-              invokedOuter++;
+              invokedOuter += 1;
             },
           },
           child: CallbackShortcuts(
             bindings: <ShortcutActivator, VoidCallback>{
               const CharacterActivator('a'): () {
-                invokedInner++;
+                invokedInner += 1;
               },
             },
             child: const Focus(
@@ -1186,13 +1186,13 @@ void main() {
           actions: <Type, Action<Intent>>{
             TestIntent: TestAction(
               onInvoke: (Intent intent) {
-                invokedActionA++;
+                invokedActionA += 1;
                 return true;
               },
             ),
             TestIntent2: TestAction(
               onInvoke: (Intent intent) {
-                invokedActionB++;
+                invokedActionB += 1;
                 return true;
               },
             ),
@@ -1200,7 +1200,7 @@ void main() {
           child: CallbackShortcuts(
             bindings: <ShortcutActivator, VoidCallback>{
               const CharacterActivator('b'): () {
-                invokedCallbackB++;
+                invokedCallbackB += 1;
               },
             },
             child: Shortcuts(
@@ -1211,7 +1211,7 @@ void main() {
               child: CallbackShortcuts(
                 bindings: <ShortcutActivator, VoidCallback>{
                   const CharacterActivator('a'): () {
-                    invokedCallbackA++;
+                    invokedCallbackA += 1;
                   },
                 },
                 child: const Focus(

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1077,6 +1077,7 @@ void main() {
       invoked = 0;
     });
   });
+
   group('CallbackShortcuts', () {
     testWidgets('trigger on key events', (WidgetTester tester) async {
       int invoked = 0;
@@ -1100,6 +1101,7 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
       expect(invoked, equals(1));
     });
+
     testWidgets('nested CallbackShortcuts stop propagation', (WidgetTester tester) async {
       int invokedOuter = 0;
       int invokedInner = 0;
@@ -1132,6 +1134,7 @@ void main() {
       expect(invokedOuter, equals(0));
       expect(invokedInner, equals(1));
     });
+
     testWidgets('non-overlapping nested CallbackShortcuts fire appropriately', (WidgetTester tester) async {
       int invokedOuter = 0;
       int invokedInner = 0;
@@ -1168,6 +1171,7 @@ void main() {
       expect(invokedOuter, equals(1));
       expect(invokedInner, equals(1));
     });
+
     testWidgets('Works correctly with Shortcuts too', (WidgetTester tester) async {
       int invokedCallbackA = 0;
       int invokedCallbackB = 0;


### PR DESCRIPTION
## Description

This adds a simpler way to describe shortcuts that just maps a key combination to a callback, instead of involving the actions and intents of the `Shortcuts` widget.  It doesn't share any implementation or data with that system, but you can combine the two in the same app.

It's basically just a wrapper around a `Focus` widget with an `onKey` handler.

## Tests

- Added tests for individual event triggering, as well as nested situations.
- Still adding tests to make sure this and `Shortcuts` interoperate.