### PR TITLE
Switch drive_service from using deprecated version of --record-memory-profile flag

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -261,7 +261,7 @@ class FlutterDriverService extends DriverService {
     if (profileMemory != null) {
       unawaited(_devtoolsLauncher.launch(
         Uri.parse(_vmServiceUri),
-        additionalArguments: <String>['--profile-memory=$profileMemory'],
+        additionalArguments: <String>['--record-memory-profile=$profileMemory'],
       ));
       // When profiling memory the original launch future will never complete.
       await _devtoolsLauncher.processStart;


### PR DESCRIPTION
The deprecated version was removed from DevTools in version 2.4.0 breaking flutter_tools tests.