### PR TITLE
[flutter_tool] Pin DevTools to 2.4.0

### DIFF
--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -178,6 +178,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
         'global',
         'activate',
         'devtools',
+        '2.4.0',
       ]);
       if (_devToolsActivateProcess.exitCode != 0) {
         _logger.printError(

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -178,7 +178,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.6',
+          stdout: 'devtools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -186,8 +186,9 @@ void main() {
             'global',
             'activate',
             'devtools',
+            '2.4.0',
           ],
-          stdout: 'Activated DevTools 0.9.6',
+          stdout: 'Activated DevTools 2.4.0',
         ),
         FakeCommand(
           command: const <String>[
@@ -231,8 +232,9 @@ void main() {
             'global',
             'activate',
             'devtools',
+            '2.4.0'
           ],
-          stdout: 'Activated DevTools 0.9.5',
+          stdout: 'Activated DevTools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -240,7 +242,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.5',
+          stdout: 'devtools 2.4.0',
         ),
         FakeCommand(
           command: const <String>[
@@ -276,7 +278,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.5',
+          stdout: 'devtools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -284,8 +286,9 @@ void main() {
             'global',
             'activate',
             'devtools',
+            '2.4.0'
           ],
-          stdout: 'Activated DevTools 0.9.5',
+          stdout: 'Activated DevTools 2.4.0',
         ),
         FakeCommand(
           command: const <String>[
@@ -326,7 +329,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.6',
+          stdout: 'devtools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -353,7 +356,7 @@ void main() {
           'global',
           'list',
         ],
-        stdout: 'devtools 0.9.6',
+        stdout: 'devtools 2.4.0',
       ),
       const FakeCommand(
         command: <String>[
@@ -397,7 +400,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.6',
+          stdout: 'devtools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -405,6 +408,7 @@ void main() {
             'global',
             'activate',
             'devtools',
+            '2.4.0',
           ],
           stderr: 'Error - could not activate devtools',
           exitCode: 1,
@@ -442,7 +446,7 @@ void main() {
             'global',
             'list',
           ],
-          stdout: 'devtools 0.9.5',
+          stdout: 'devtools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[
@@ -450,8 +454,9 @@ void main() {
             'global',
             'activate',
             'devtools',
+            '2.4.0'
           ],
-          stdout: 'Activated DevTools 0.9.6',
+          stdout: 'Activated DevTools 2.4.0',
         ),
         const FakeCommand(
           command: <String>[

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -450,7 +450,7 @@ void main() {
     // Ensure that DevTools is activated.
     final ProcessResult pubResult = await processManager.run(<String>[
       fileSystem.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart'),
-      'pub', 'global', 'activate', 'devtools',
+      'pub', 'global', 'activate', 'devtools', '2.4.0',
     ], workingDirectory: testDirectory).timeout(const Duration(seconds: 20));
     if (pubResult.exitCode != 0) {
       print('Unable to activate devtools:\n${pubResult.stderr}');


### PR DESCRIPTION
Currently, DevTools can be updated out of band, which can close the tree on an unrelated commit in a way that is difficult for the gardener to diagnose. See https://github.com/flutter/flutter/issues/86121. This PR pins DevTools to avoid this issue.