### PR TITLE
[Documentation] Fix AppBarTheme toolbarTextStyle and titleTextStyle documentation

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -655,6 +655,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [ThemeData.appBarTheme] is used. If that is also null, the default
   /// value is a copy of the overall theme's [TextTheme.bodyText2]
   /// [TextStyle], with color set to the app bar's [foregroundColor].
+  /// 
+  /// If this property is specified, then [backwardsCompatibility] should be false.
   /// {@endtemplate}
   ///
   /// See also:
@@ -671,6 +673,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [ThemeData.appBarTheme] is used. If that is also null, the default
   /// value is a copy of the overall theme's [TextTheme.headline6]
   /// [TextStyle], with color set to the app bar's [foregroundColor].
+  /// 
+  /// If this property is specified, then [backwardsCompatibility] should be false.
   /// {@endtemplate}
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -154,10 +154,10 @@ class AppBarTheme with Diagnosticable {
   ///    height of an AppBar widget, taking this value into account.
   final double? toolbarHeight;
 
-  /// Overrides the default value for the obsolete [AppBar.toolbarTextStyle]
+  /// Overrides the default value of [AppBar.toolbarTextStyle]
   /// property in all descendant [AppBar] widgets.
   ///
-  /// If this property is specified, then [backwardsCompatibility] should be true.
+  /// If this property is specified, then [backwardsCompatibility] should be false.
   ///
   /// See also:
   ///
@@ -168,7 +168,7 @@ class AppBarTheme with Diagnosticable {
   /// Overrides the default value of [AppBar.titleTextStyle]
   /// property in all descendant [AppBar] widgets.
   ///
-  /// If this property is specified, then [backwardsCompatibility] should be true.
+  /// If this property is specified, then [backwardsCompatibility] should be false.
   ///
   /// See also:
   ///


### PR DESCRIPTION
- Fixed the documentation regarding to the `backwardsCompatibility` flag in `AppBarTheme` introduced in #82344
- Fixed a comment saying that `toolbarTextStyle` is outdated
- Added the same `backwardsCompatibility` documentation to `AppBar`

More details in the issue:
- fixes #86127

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
