### PR TITLE
[flutter] tab navigation does not notify the focus scope node

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2011,11 +2011,8 @@ class _FocusTrap extends SingleChildRenderObjectWidget {
 }
 
 class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
-  _RenderFocusTrap(this._focusScopeNode) {
-    focusScopeNode.addListener(_currentFocusListener);
-  }
+  _RenderFocusTrap(this._focusScopeNode);
 
-  FocusNode? currentFocus;
   Rect? currentFocusRect;
   Expando<BoxHitTestResult> cachedResults = Expando<BoxHitTestResult>();
 
@@ -2024,13 +2021,7 @@ class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
   set focusScopeNode(FocusScopeNode value) {
     if (focusScopeNode == value)
       return;
-    focusScopeNode.removeListener(_currentFocusListener);
     _focusScopeNode = value;
-    focusScopeNode.addListener(_currentFocusListener);
-  }
-
-  void _currentFocusListener() {
-    currentFocus = focusScopeNode.focusedChild;
   }
 
   @override
@@ -2069,11 +2060,11 @@ class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
       || event.buttons != kPrimaryButton
       || event.kind != PointerDeviceKind.mouse
       || _shouldIgnoreEvents
-      || currentFocus == null) {
+      || _focusScopeNode.focusedChild == null) {
       return;
     }
     final BoxHitTestResult? result = cachedResults[entry];
-    final FocusNode? focusNode = currentFocus;
+    final FocusNode? focusNode = _focusScopeNode.focusedChild;
     if (focusNode == null || result == null)
       return;
 


### PR DESCRIPTION
Discovered while working on https://github.com/flutter/flutter/pull/86041, it seems like tab navigation does not cause a notifaction on the focus scope node, which means that the cached focus node is out of date.

I'm not sure if this is intentional or not, but since we don't actually need the listener I can work around it here. Attached test case fails without this change.