### PR TITLE
[flutter_tools] fix -n workaround

### DIFF
--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -48,7 +48,7 @@ class FormatCommand extends FlutterCommand {
       command.addAll(<String>[
         for (String arg in argResults.rest)
           if (arg == '--dry-run' || arg == '-n')
-            '--output=show'
+            '--output=none'
           else
             arg
       ]);

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -47,7 +47,7 @@ class FormatCommand extends FlutterCommand {
     } else {
       command.addAll(<String>[
         for (String arg in argResults.rest)
-          if (arg == '--dry-run')
+          if (arg == '--dry-run' || arg == '-n')
             '--output=show'
           else
             arg

--- a/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
@@ -59,6 +59,23 @@ void main() {
       expect(shouldNotFormatted, nonFormatted);
     });
 
+    testUsingContext('dry-run with -n', () async {
+      final String projectPath = await createProject(tempDir);
+
+      final File srcFile = globals.fs.file(
+          globals.fs.path.join(projectPath, 'lib', 'main.dart'));
+      final String nonFormatted = srcFile.readAsStringSync().replaceFirst(
+          'main()', 'main(  )');
+      srcFile.writeAsStringSync(nonFormatted);
+
+      final FormatCommand command = FormatCommand(verboseHelp: false);
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      await runner.run(<String>['format', '-n', srcFile.path]);
+
+      final String shouldNotFormatted = srcFile.readAsStringSync();
+      expect(shouldNotFormatted, nonFormatted);
+    });
+
     testUsingContext('dry-run with set-exit-if-changed', () async {
       final String projectPath = await createProject(tempDir);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/86140

While I added a workaround for `--dry-run` I forgot the workaround for `-n`. @RedBrogdon 