### PR TITLE
Reland [flutter_tools] show only supported sub commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -24,25 +24,31 @@ import 'build_winuwp.dart';
 
 class BuildCommand extends FlutterCommand {
   BuildCommand({ bool verboseHelp = false }) {
-    addSubcommand(BuildAarCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildIOSCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildIOSFrameworkCommand(
+    _addSubcommand(BuildAarCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildApkCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildAppBundleCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildIOSCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildIOSFrameworkCommand(
       buildSystem: globals.buildSystem,
       verboseHelp: verboseHelp,
     ));
-    addSubcommand(BuildIOSArchiveCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildWebCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildMacosCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildLinuxCommand(
+    _addSubcommand(BuildIOSArchiveCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildBundleCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildWebCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildMacosCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildLinuxCommand(
       operatingSystemUtils: globals.os,
       verboseHelp: verboseHelp
     ));
-    addSubcommand(BuildWindowsCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildWindowsUwpCommand(verboseHelp: verboseHelp));
-    addSubcommand(BuildFuchsiaCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildWindowsCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildWindowsUwpCommand(verboseHelp: verboseHelp));
+    _addSubcommand(BuildFuchsiaCommand(verboseHelp: verboseHelp));
+  }
+
+  void _addSubcommand(BuildSubCommand command) {
+    if (command.supported) {
+      addSubcommand(command);
+    }
   }
 
   @override
@@ -62,6 +68,8 @@ abstract class BuildSubCommand extends FlutterCommand {
 
   @override
   bool get reportNullSafety => true;
+
+  bool get supported => true;
 
   /// Display a message describing the current null safety runtime mode
   /// that was selected.

--- a/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
+++ b/packages/flutter_tools/lib/src/commands/build_fuchsia.dart
@@ -59,6 +59,9 @@ class BuildFuchsiaCommand extends BuildSubCommand {
   String get description => 'Build the Fuchsia target (Experimental).';
 
   @override
+  bool get supported => globals.platform.isLinux || globals.platform.isMacOS;
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     if (!featureFlags.isFuchsiaEnabled) {
       throwToolExit(
@@ -68,7 +71,7 @@ class BuildFuchsiaCommand extends BuildSubCommand {
     }
     final BuildInfo buildInfo = await getBuildInfo();
     final FlutterProject flutterProject = FlutterProject.current();
-    if (!globals.platform.isLinux && !globals.platform.isMacOS) {
+    if (!supported) {
       throwToolExit('"build fuchsia" is only supported on Linux and MacOS hosts.');
     }
     if (!flutterProject.fuchsia.existsSync()) {

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -225,11 +225,14 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   Directory _outputAppDirectory(String xcodeResultOutput);
 
   @override
+  bool get supported => globals.platform.isMacOS;
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     defaultBuildMode = forSimulator ? BuildMode.debug : BuildMode.release;
     final BuildInfo buildInfo = await getBuildInfo();
 
-    if (!globals.platform.isMacOS) {
+    if (!supported) {
       throwToolExit('Building for iOS is only supported on macOS.');
     }
     if (forSimulator && !buildInfo.supportsSimulator) {

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -142,10 +142,13 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   }
 
   @override
+  bool get supported => _platform.isMacOS;
+
+  @override
   Future<void> validateCommand() async {
     await super.validateCommand();
     _project = FlutterProject.current();
-    if (!_platform.isMacOS) {
+    if (!supported) {
       throwToolExit('Building frameworks for iOS is only supported on the Mac.');
     }
 

--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -40,13 +40,16 @@ class BuildMacosCommand extends BuildSubCommand {
   String get description => 'Build a macOS desktop application.';
 
   @override
+  bool get supported => globals.platform.isMacOS;
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     final BuildInfo buildInfo = await getBuildInfo();
     final FlutterProject flutterProject = FlutterProject.current();
     if (!featureFlags.isMacOSEnabled) {
       throwToolExit('"build macos" is not currently supported. To enable, run "flutter config --enable-macos-desktop".');
     }
-    if (!globals.platform.isMacOS) {
+    if (!supported) {
       throwToolExit('"build macos" only supported on macOS hosts.');
     }
     displayNullSafetyMode(buildInfo);

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -111,7 +112,7 @@ void main() {
 
       expect(
         createTestCommandRunner(command).run(const <String>['build', 'fuchsia']),
-        throwsToolExit(),
+        throwsA(isA<UsageException>()),
       );
     }, overrides: <Type, Generator>{
       Platform: () => windowsPlatform,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_fuchsia_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_fuchsia.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_kernel_compiler.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_pm.dart';
@@ -110,9 +111,10 @@ void main() {
       final File pubspecFile = fileSystem.file('pubspec.yaml')..createSync();
       pubspecFile.writeAsStringSync('name: $appName');
 
+      final bool supported = BuildFuchsiaCommand(verboseHelp: false).supported;
       expect(
         createTestCommandRunner(command).run(const <String>['build', 'fuchsia']),
-        throwsA(isA<UsageException>()),
+        supported ? throwsToolExit() : throwsA(isA<UsageException>()),
       );
     }, overrides: <Type, Generator>{
       Platform: () => windowsPlatform,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -162,7 +163,7 @@ void main() {
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'ios', '--no-pub']
-    ), throwsToolExit());
+    ), throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_ios.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 
@@ -161,9 +162,10 @@ void main() {
     fileSystem.file(fileSystem.path.join('lib', 'main.dart'))
       .createSync(recursive: true);
 
+    final bool supported = BuildIOSCommand(verboseHelp: false).supported;
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'ios', '--no-pub']
-    ), throwsA(isA<UsageException>()));
+    ), supported ? throwsToolExit() : throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.8
 
+import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -157,7 +158,7 @@ void main() {
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'ipa', '--no-pub']
-    ), throwsToolExit());
+    ), throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/build_ios.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 
@@ -156,9 +157,10 @@ void main() {
     fileSystem.file(fileSystem.path.join('lib', 'main.dart'))
       .createSync(recursive: true);
 
+    final bool supported = BuildIOSArchiveCommand(verboseHelp: false).supported;
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'ipa', '--no-pub']
-    ), throwsA(isA<UsageException>()));
+    ), supported ? throwsToolExit() : throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -149,7 +149,7 @@ void main() {
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'macos', '--no-pub']
-    ), throwsToolExit(message: '"build macos" only supported on macOS hosts.'));
+    ), throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     Platform: () => notMacosPlatform,
     FileSystem: () => fileSystem,
@@ -391,7 +391,7 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
     expect(() => runner.run(<String>['build', 'macos', '--no-pub']),
-      throwsToolExit());
+      throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -390,8 +390,9 @@ void main() {
   testUsingContext('Refuses to build for macOS when feature is disabled', () {
     final CommandRunner<void> runner = createTestCommandRunner(BuildCommand());
 
+    final bool supported = BuildMacosCommand(verboseHelp: false).supported;
     expect(() => runner.run(<String>['build', 'macos', '--no-pub']),
-      throwsA(isA<UsageException>()));
+      supported ? throwsToolExit() : throwsA(isA<UsageException>()));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isMacOSEnabled: false),
   });

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -5,6 +5,7 @@
 // @dart = 2.8
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
 import 'package:flutter_tools/src/commands/build.dart';
@@ -74,6 +75,13 @@ void main() {
     testLogger.clear();
     FakeBuildSubCommand().test(sound);
     expect(testLogger.statusText, contains('💪 Building with sound null safety 💪'));
+  });
+
+  testUsingContext('Include only supported sub commands', () {
+    final BuildCommand command = BuildCommand();
+    for (final Command<void> x in command.subcommands.values) {
+      expect((x as BuildSubCommand).supported, isTrue);
+    }
   });
 }
 


### PR DESCRIPTION
This is the second try of https://github.com/flutter/flutter/pull/85125, reverted in https://github.com/flutter/flutter/pull/86131.

Since I don't have a macOS, and it seems the PR tests don't use it, except after actually merging. The tests expectations were done blindly based on results [here](https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20tool_tests_commands/1431/overview).

The last commit has the difference against the reverted PR.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
