### PR TITLE
AppBar.backwardsCompatibility now default false, deprecated

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
@@ -341,7 +341,6 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
   @override
   Widget build(BuildContext context) {
     final AppBar appBar = AppBar(
-      brightness: Brightness.light,
       elevation: 0.0,
       titleSpacing: 0.0,
       title: _BackdropTitle(

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
@@ -29,7 +29,6 @@ class _LoginPageState extends State<LoginPage> {
       appBar: AppBar(
         elevation: 0.0,
         backgroundColor: Colors.white,
-        brightness: Brightness.light,
         leading: IconButton(
           icon: const BackButtonIcon(),
           tooltip: MaterialLocalizations.of(context).backButtonTooltip,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -240,6 +240,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.brightness,
     this.iconTheme,
     this.actionsIconTheme,
+    @Deprecated(
+      'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     this.textTheme,
     this.primary = true,
     this.centerTitle,
@@ -595,6 +599,9 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final IconThemeData? actionsIconTheme;
 
   /// {@template flutter.material.appbar.textTheme}
+  /// This property is deprecated, please use [toolbarTextStyle] and
+  /// [titleTextStyle] instead.
+  ///
   /// The typographic styles to use for text in the app bar. Typically this is
   /// set along with [backgroundColor], [iconTheme].
   ///
@@ -602,6 +609,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [ThemeData.appBarTheme] is used. If that is also null, then
   /// [ThemeData.primaryTextTheme] is used.
   /// {@endtemplate}
+  @Deprecated(
+    'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+    'This feature was deprecated after v2.4.0-0.0.pre.',
+  )
   final TextTheme? textTheme;
 
   /// {@template flutter.material.appbar.primary}
@@ -1536,6 +1547,10 @@ class SliverAppBar extends StatefulWidget {
     this.brightness,
     this.iconTheme,
     this.actionsIconTheme,
+    @Deprecated(
+      'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     this.textTheme,
     this.primary = true,
     this.centerTitle,
@@ -1652,6 +1667,10 @@ class SliverAppBar extends StatefulWidget {
   /// {@macro flutter.material.appbar.textTheme}
   ///
   /// This property is used to configure an [AppBar].
+  @Deprecated(
+    'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+    'This feature was deprecated after v2.4.0-0.0.pre.',
+  )
   final TextTheme? textTheme;
 
   /// {@macro flutter.material.appbar.primary}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -848,7 +848,7 @@ class _AppBarState extends State<AppBar> {
     final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
     final double toolbarHeight = widget.toolbarHeight ?? appBarTheme.toolbarHeight ?? kToolbarHeight;
-    final bool backwardsCompatibility = widget.backwardsCompatibility ?? appBarTheme.backwardsCompatibility ?? true;
+    final bool backwardsCompatibility = widget.backwardsCompatibility ?? appBarTheme.backwardsCompatibility ?? false;
 
     final Color backgroundColor = backwardsCompatibility
       ? widget.backgroundColor

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -233,6 +233,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.shape,
     this.backgroundColor,
     this.foregroundColor,
+    @Deprecated(
+      'This property is no longer used, please use systemOverlayStyle instead. '
+      'This feature was deprecated after 2.4.0-0.0.pre.',
+    )
     this.brightness,
     this.iconTheme,
     this.actionsIconTheme,
@@ -245,6 +249,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.bottomOpacity = 1.0,
     this.toolbarHeight,
     this.leadingWidth,
+    @Deprecated(
+      'This property is obsolete and is false by default. '
+      'This feature was deprecated after 2.4.0-0.0.pre.',
+    )
     this.backwardsCompatibility,
     this.toolbarTextStyle,
     this.titleTextStyle,
@@ -523,7 +531,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final Color? foregroundColor;
 
   /// {@template flutter.material.appbar.brightness}
-  /// This property is obsolete, please use [systemOverlayStyle] instead.
+  /// This property is deprecated, please use [systemOverlayStyle] instead.
   ///
   /// Determines the brightness of the [SystemUiOverlayStyle]: for
   /// [Brightness.dark], [SystemUiOverlayStyle.light] is used and fo
@@ -548,6 +556,10 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    is light or dark.
   ///  * [backwardsCompatibility], which forces AppBar to use this
   ///    obsolete property.
+  @Deprecated(
+    'This property is no longer used, please use systemOverlayStyle instead. '
+    'This feature was deprecated after 2.4.0-0.0.pre.',
+  )
   final Brightness? brightness;
 
   /// {@template flutter.material.appbar.iconTheme}
@@ -584,7 +596,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// {@template flutter.material.appbar.textTheme}
   /// The typographic styles to use for text in the app bar. Typically this is
-  /// set along with [brightness] [backgroundColor], [iconTheme].
+  /// set along with [backgroundColor], [iconTheme].
   ///
   /// If this property is null, then [AppBarTheme.textTheme] of
   /// [ThemeData.appBarTheme] is used. If that is also null, then
@@ -674,21 +686,25 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final double? leadingWidth;
 
   /// {@template flutter.material.appbar.backwardsCompatibility}
+  /// This property is deprecated and is false by default.
+  ///
   /// If true, preserves the original defaults for the [backgroundColor],
   /// [iconTheme], [actionsIconTheme] properties, and the original use of
   /// the [textTheme] and [brightness] properties.
   ///
   /// If this property is null, then [AppBarTheme.backwardsCompatibility] of
   /// [ThemeData.appBarTheme] is used. If that is also null, the default
-  /// value is true.
+  /// value is false.
   ///
-  /// This is a temporary property. When setting it to false is no
-  /// longer considered a breaking change, it will be deprecated and
-  /// its default value will be changed to false. App developers are
-  /// encouraged to opt into the new features by setting it to false
-  /// and using the [foregroundColor] and [systemOverlayStyle]
-  /// properties as needed.
+  /// This is a temporary property and it has been deprecated. App
+  /// developers are encouraged to opt into the new features by
+  /// setting it to false and using the [foregroundColor] and
+  /// [systemOverlayStyle] properties as needed.
   /// {@endtemplate}
+  @Deprecated(
+    'This property is obsolete and is false by default. '
+    'This feature was deprecated after 2.4.0-0.0.pre.',
+  )
   final bool? backwardsCompatibility;
 
   /// {@template flutter.material.appbar.toolbarTextStyle}
@@ -1513,6 +1529,10 @@ class SliverAppBar extends StatefulWidget {
     this.forceElevated = false,
     this.backgroundColor,
     this.foregroundColor,
+    @Deprecated(
+      'This property is no longer used, please use systemOverlayStyle instead. '
+      'This feature was deprecated after 2.4.0-0.0.pre.',
+    )
     this.brightness,
     this.iconTheme,
     this.actionsIconTheme,
@@ -1613,6 +1633,10 @@ class SliverAppBar extends StatefulWidget {
   /// {@macro flutter.material.appbar.brightness}
   ///
   /// This property is used to configure an [AppBar].
+  @Deprecated(
+    'This property is no longer used, please use systemOverlayStyle instead. '
+    'This feature was deprecated after 2.4.0-0.0.pre.',
+  )
   final Brightness? brightness;
 
   /// {@macro flutter.material.appbar.iconTheme}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -745,7 +745,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@template flutter.material.appbar.systemOverlayStyle}
   /// Specifies the style to use for the system overlays that overlap the AppBar.
   ///
-  /// This property is only used if [backwardsCompatibility] is set to false.
+  /// This property is only used if [backwardsCompatibility] is false (the default).
   ///
   /// If this property is null, then [AppBarTheme.systemOverlayStyle] of
   /// [ThemeData.appBarTheme] is used. If that is also null, an appropriate

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -235,7 +235,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.foregroundColor,
     @Deprecated(
       'This property is no longer used, please use systemOverlayStyle instead. '
-      'This feature was deprecated after 2.4.0-0.0.pre.',
+      'This feature was deprecated after v2.4.0-0.0.pre.',
     )
     this.brightness,
     this.iconTheme,
@@ -251,7 +251,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.leadingWidth,
     @Deprecated(
       'This property is obsolete and is false by default. '
-      'This feature was deprecated after 2.4.0-0.0.pre.',
+      'This feature was deprecated after v2.4.0-0.0.pre.',
     )
     this.backwardsCompatibility,
     this.toolbarTextStyle,
@@ -558,7 +558,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    obsolete property.
   @Deprecated(
     'This property is no longer used, please use systemOverlayStyle instead. '
-    'This feature was deprecated after 2.4.0-0.0.pre.',
+    'This feature was deprecated after v2.4.0-0.0.pre.',
   )
   final Brightness? brightness;
 
@@ -698,12 +698,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// This is a temporary property and it has been deprecated. App
   /// developers are encouraged to opt into the new features by
-  /// setting it to false and using the [foregroundColor] and
+  /// leaving it default (false) and using the [foregroundColor] and
   /// [systemOverlayStyle] properties as needed.
   /// {@endtemplate}
   @Deprecated(
     'This property is obsolete and is false by default. '
-    'This feature was deprecated after 2.4.0-0.0.pre.',
+    'This feature was deprecated after v2.4.0-0.0.pre.',
   )
   final bool? backwardsCompatibility;
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1531,7 +1531,7 @@ class SliverAppBar extends StatefulWidget {
     this.foregroundColor,
     @Deprecated(
       'This property is no longer used, please use systemOverlayStyle instead. '
-      'This feature was deprecated after 2.4.0-0.0.pre.',
+      'This feature was deprecated after v2.4.0-0.0.pre.',
     )
     this.brightness,
     this.iconTheme,
@@ -1635,7 +1635,7 @@ class SliverAppBar extends StatefulWidget {
   /// This property is used to configure an [AppBar].
   @Deprecated(
     'This property is no longer used, please use systemOverlayStyle instead. '
-    'This feature was deprecated after 2.4.0-0.0.pre.',
+    'This feature was deprecated after v2.4.0-0.0.pre.',
   )
   final Brightness? brightness;
 

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -28,6 +28,10 @@ import 'theme.dart';
 class AppBarTheme with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.appBarTheme].
   const AppBarTheme({
+    @Deprecated(
+      'This property is no longer used, please use systemOverlayStyle instead. '
+      'This feature was deprecated after 2.4.0-0.0.pre.',
+    )
     this.brightness,
     Color? color,
     Color? backgroundColor,
@@ -43,6 +47,10 @@ class AppBarTheme with Diagnosticable {
     this.toolbarTextStyle,
     this.titleTextStyle,
     this.systemOverlayStyle,
+    @Deprecated(
+      'This property is obsolete and is false by default. '
+      'This feature was deprecated after 2.4.0-0.0.pre.',
+    )
     this.backwardsCompatibility,
   }) : assert(
          color == null || backgroundColor == null,
@@ -50,7 +58,7 @@ class AppBarTheme with Diagnosticable {
        ),
        backgroundColor = backgroundColor ?? color;
 
-  /// This property is obsolete, please use [systemOverlayStyle] instead.
+  /// This property is deprecated, please use [systemOverlayStyle] instead.
   ///
   /// Overrides the default value of the obsolete [AppBar.brightness]
   /// property which implicitly defines [AppBar.systemOverlayStyle] in
@@ -62,6 +70,10 @@ class AppBarTheme with Diagnosticable {
   ///    [AppBar.systemOverlayStyle] in all descendant [AppBar] widgets.
   ///  * [AppBar.backwardsCompatibility], which forces [AppBar] to depend
   ///    on this obsolete property.
+  @Deprecated(
+    'This property is no longer used, please use systemOverlayStyle instead. '
+    'This feature was deprecated after 2.4.0-0.0.pre.',
+  )
   final Brightness? brightness;
 
   /// Obsolete property that overrides the default value of
@@ -182,6 +194,10 @@ class AppBarTheme with Diagnosticable {
 
   /// Overrides the default value of [AppBar.backwardsCompatibility]
   /// property in all descendant [AppBar] widgets.
+  @Deprecated(
+    'This property is obsolete and is false by default. '
+    'This feature was deprecated after 2.4.0-0.0.pre.',
+  )
   final bool? backwardsCompatibility;
 
   /// Creates a copy of this object with the given fields replaced with the

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -40,6 +40,10 @@ class AppBarTheme with Diagnosticable {
     this.shadowColor,
     this.iconTheme,
     this.actionsIconTheme,
+    @Deprecated(
+      'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     this.textTheme,
     this.centerTitle,
     this.titleSpacing,
@@ -142,6 +146,9 @@ class AppBarTheme with Diagnosticable {
   ///    [AppBar.foregroundColor] in all descendant widgets.
   final IconThemeData? actionsIconTheme;
 
+  /// This property is deprecated, please use [toolbarTextStyle] and
+  /// [titleTextStyle] instead.
+  ///
   /// Overrides the default value of the obsolete [AppBar.textTheme]
   /// property in all descendant [AppBar] widgets.
   ///
@@ -151,6 +158,10 @@ class AppBarTheme with Diagnosticable {
   ///    [AppBar.toolbarTextStyle in all descendant [AppBar] widgets.
   ///  * [titleTextStyle], which overrides the default value for
   ///    [AppBar.titleTextStyle in all descendant [AppBar] widgets.
+  @Deprecated(
+    'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+    'This feature was deprecated after v2.4.0-0.0.pre.',
+  )
   final TextTheme? textTheme;
 
   /// Overrides the default value for [AppBar.centerTitle].

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -76,6 +76,8 @@ class AppBarTheme with Diagnosticable {
   )
   final Brightness? brightness;
 
+  /// This property is deprecated, please use [backgroundColor] instead.
+  ///
   /// Obsolete property that overrides the default value of
   /// [AppBar.backgroundColor] in all descendant [AppBar] widgets.
   ///
@@ -86,6 +88,10 @@ class AppBarTheme with Diagnosticable {
   ///    [AppBar.backgroundColor].
   ///  * [AppBar.backwardsCompatibility], which forces [AppBar] to depend
   ///    on this obsolete property.
+  @Deprecated(
+    'This property is no longer used, please use backgroundColor instead. '
+    'This feature was deprecated after v2.4.0-0.0.pre.',
+  )
   Color? get color => backgroundColor;
 
   /// Overrides the default value of [AppBar.backgroundColor] in all
@@ -169,7 +175,8 @@ class AppBarTheme with Diagnosticable {
   /// Overrides the default value for the obsolete [AppBar.toolbarTextStyle]
   /// property in all descendant [AppBar] widgets.
   ///
-  /// If this property is specified, then [backwardsCompatibility] should be true.
+  /// If this property is specified, then [backwardsCompatibility]
+  /// should be false (the default).
   ///
   /// See also:
   ///
@@ -180,7 +187,8 @@ class AppBarTheme with Diagnosticable {
   /// Overrides the default value of [AppBar.titleTextStyle]
   /// property in all descendant [AppBar] widgets.
   ///
-  /// If this property is specified, then [backwardsCompatibility] should be true.
+  /// If this property is specified, then [backwardsCompatibility]
+  /// should be false (the default).
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -30,7 +30,7 @@ class AppBarTheme with Diagnosticable {
   const AppBarTheme({
     @Deprecated(
       'This property is no longer used, please use systemOverlayStyle instead. '
-      'This feature was deprecated after 2.4.0-0.0.pre.',
+      'This feature was deprecated after v2.4.0-0.0.pre.',
     )
     this.brightness,
     Color? color,
@@ -49,7 +49,7 @@ class AppBarTheme with Diagnosticable {
     this.systemOverlayStyle,
     @Deprecated(
       'This property is obsolete and is false by default. '
-      'This feature was deprecated after 2.4.0-0.0.pre.',
+      'This feature was deprecated after v2.4.0-0.0.pre.',
     )
     this.backwardsCompatibility,
   }) : assert(
@@ -72,7 +72,7 @@ class AppBarTheme with Diagnosticable {
   ///    on this obsolete property.
   @Deprecated(
     'This property is no longer used, please use systemOverlayStyle instead. '
-    'This feature was deprecated after 2.4.0-0.0.pre.',
+    'This feature was deprecated after v2.4.0-0.0.pre.',
   )
   final Brightness? brightness;
 
@@ -196,7 +196,7 @@ class AppBarTheme with Diagnosticable {
   /// property in all descendant [AppBar] widgets.
   @Deprecated(
     'This property is obsolete and is false by default. '
-    'This feature was deprecated after 2.4.0-0.0.pre.',
+    'This feature was deprecated after v2.4.0-0.0.pre.',
   )
   final bool? backwardsCompatibility;
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -27,7 +27,6 @@ Widget buildSliverAppBarApp({
           primary: true,
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               title: const Text('AppBar Title'),
               floating: floating,
               pinned: pinned,
@@ -73,7 +72,6 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('X'),
           ),
         ),
@@ -94,7 +92,6 @@ void main() {
           theme: ThemeData(platform: platform),
           home: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               title: const Text('X'),
             ),
           ),
@@ -113,7 +110,6 @@ void main() {
           theme: ThemeData(platform: platform),
           home: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               title: const Text('X'),
               actions: const <Widget>[
                 Icon(Icons.thumb_up),
@@ -135,7 +131,6 @@ void main() {
           theme: ThemeData(platform: platform),
           home: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               title: const Text('X'),
               actions: const <Widget>[
                 Icon(Icons.thumb_up),
@@ -158,7 +153,6 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             centerTitle: true,
             title: const Text('X'),
           ),
@@ -178,7 +172,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             centerTitle: false,
             title: const Placeholder(key: Key('X')),
           ),
@@ -198,7 +191,6 @@ void main() {
           textDirection: TextDirection.rtl,
           child: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               centerTitle: false,
               title: const Placeholder(key: Key('X')),
             ),
@@ -217,7 +209,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             centerTitle: false,
             titleSpacing: 32.0,
             title: const Placeholder(key: Key('X')),
@@ -238,7 +229,6 @@ void main() {
           textDirection: TextDirection.rtl,
           child: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               centerTitle: false,
               titleSpacing: 32.0,
               title: const Placeholder(key: Key('X')),
@@ -260,7 +250,6 @@ void main() {
         MaterialApp(
           home: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               centerTitle: false,
               title: const Text('X'),
             ),
@@ -283,7 +272,6 @@ void main() {
             textDirection: TextDirection.rtl,
             child: Scaffold(
               appBar: AppBar(
-                backwardsCompatibility: false,
                 centerTitle: false,
                 title: const Text('X'),
               ),
@@ -310,7 +298,6 @@ void main() {
       return MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             leading: leading,
             centerTitle: false,
             title: Container(
@@ -374,7 +361,6 @@ void main() {
       return MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             leading: leading,
             centerTitle: true,
             title: Container(
@@ -429,7 +415,6 @@ void main() {
           textDirection: TextDirection.rtl,
           child: Scaffold(
             appBar: AppBar(
-              backwardsCompatibility: false,
               leading: leading,
               centerTitle: true,
               title: Container(
@@ -475,7 +460,6 @@ void main() {
         home: SizedBox(
           height: kToolbarHeight,
           child: AppBar(
-            backwardsCompatibility: false,
             leading: const Text('L'),
             title: const Text('No Scaffold'),
             actions: const <Widget>[Text('A1'), Text('A2')],
@@ -499,7 +483,6 @@ void main() {
             width: 0.0,
             child: Scaffold(
               appBar: AppBar(
-                backwardsCompatibility: false,
                 title: const Text('X'),
               ),
             ),
@@ -523,7 +506,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             key: appBarKey,
             leading: SizedBox(key: leadingKey, height: 50.0),
             title: SizedBox(key: titleKey, height: 40.0),
@@ -623,7 +605,6 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('X'),
           ),
           drawer: Column(), // Doesn't really matter. Triggers a hamburger regardless.
@@ -642,7 +623,7 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
+
             title: const Text('X'),
             actions: const <Widget> [
               IconButton(
@@ -1012,7 +993,6 @@ void main() {
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               title: const Text('Title'),
               forceElevated: forceElevated,
               elevation: elevation,
@@ -1096,7 +1076,6 @@ void main() {
             child: Scaffold(
               primary: true,
               appBar: AppBar(
-                backwardsCompatibility: false,
                 title: const Text('title'),
               ),
             ),
@@ -1122,7 +1101,6 @@ void main() {
             child: Scaffold(
               primary: false,
               appBar: AppBar(
-                backwardsCompatibility: false,
                 bottom: PreferredSize(
                   preferredSize: const Size.fromHeight(200.0),
                   child: Container(),
@@ -1150,7 +1128,6 @@ void main() {
             child: Scaffold(
               primary: true,
               appBar: AppBar(
-                backwardsCompatibility: false,
                 bottom: PreferredSize(
                   preferredSize: const Size.fromHeight(200.0),
                   child: Container(),
@@ -1176,7 +1153,6 @@ void main() {
           child: MediaQuery(
             data: topPadding100,
             child: AppBar(
-              backwardsCompatibility: false,
               primary: false,
               title: const Text('title'),
             ),
@@ -1206,7 +1182,6 @@ void main() {
               body: Column(
                 children: <Widget>[
                   AppBar(
-                    backwardsCompatibility: false,
                     title: const Text('title'),
                   ),
                 ],
@@ -1246,7 +1221,6 @@ void main() {
         home: Scaffold(
           drawer: const Drawer(),
           appBar: AppBar(
-            backwardsCompatibility: false,
             automaticallyImplyLeading: false,
           ),
         ),
@@ -1353,7 +1327,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             title: const Text('Abc'),
             actions: <Widget>[
               IconButton(
@@ -1395,7 +1368,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: Placeholder(key: key),
             title: const Text('Abc'),
             actions: const <Widget>[
@@ -1417,7 +1389,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: Placeholder(key: key),
             title: const Text('Abc'),
             actions: const <Widget>[
@@ -1448,7 +1419,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: Placeholder(key: key),
             title: const Text('Abc'),
             actions: const <Widget>[
@@ -1490,7 +1460,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: Placeholder(key: key),
             title: const Text('Abc'),
             actions: const <Widget>[
@@ -1538,7 +1507,6 @@ void main() {
             child: Scaffold(
               primary: false,
               appBar: AppBar(
-                backwardsCompatibility: false,
                 leading: Placeholder(key: leadingKey), // Forced to 56x56, see _kLeadingWidth in app_bar.dart.
                 title: Placeholder(key: titleKey, fallbackHeight: kToolbarHeight),
                 actions: <Widget>[ Placeholder(key: trailingKey, fallbackWidth: 10) ],
@@ -1584,7 +1552,6 @@ void main() {
               primary: true,
               slivers: <Widget>[
                 SliverAppBar(
-                  backwardsCompatibility: false,
                   leading: Placeholder(key: leadingKey),
                   title: Placeholder(key: titleKey, fallbackHeight: kToolbarHeight),
                   actions: <Widget>[ Placeholder(key: trailingKey) ],
@@ -1623,7 +1590,6 @@ void main() {
               primary: true,
               slivers: <Widget>[
                 SliverAppBar(
-                  backwardsCompatibility: false,
                   leading: Placeholder(key: leadingKey),
                   title: Placeholder(key: titleKey),
                   actions: <Widget>[ Placeholder(key: trailingKey) ],
@@ -1646,7 +1612,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: const Text('Leading'),
             title: const Text('Title'),
             actions: const <Widget>[
@@ -1732,7 +1697,6 @@ void main() {
             textDirection: TextDirection.rtl,
             child: Center(
               child: AppBar(
-                backwardsCompatibility: false,
                 leading: const Text('Leading'),
                 title: const Text('Title'),
                 actions: const <Widget>[
@@ -1821,7 +1785,6 @@ void main() {
       MaterialApp(
         home: Center(
           child: AppBar(
-            backwardsCompatibility: false,
             leading: const Text('Leading'),
             title: const ExcludeSemantics(child: Text('Title')),
             excludeHeaderSemantics: true,
@@ -1879,7 +1842,6 @@ void main() {
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               leading: Text('Leading'),
               flexibleSpace: ExcludeSemantics(child: Text('Title')),
               actions: <Widget>[Text('Action 1')],
@@ -1950,7 +1912,6 @@ void main() {
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               leading: Text('Leading'),
               flexibleSpace: Text('Flexible space'),
               actions: <Widget>[Text('Action 1')],
@@ -2025,7 +1986,6 @@ void main() {
       theme: darkTheme,
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('test'),
         ),
       ),
@@ -2046,7 +2006,6 @@ void main() {
         theme: lightTheme,
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('test'),
           ),
         ),
@@ -2067,7 +2026,6 @@ void main() {
       theme: lightTheme,
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('test'),
         ),
       ),
@@ -2088,7 +2046,6 @@ void main() {
         theme: darkTheme,
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('test'),
           ),
         ),
@@ -2116,7 +2073,6 @@ void main() {
               body: CustomScrollView(
                 slivers: <Widget>[
                   SliverAppBar(
-                    backwardsCompatibility: false,
                     expandedHeight: appBarHeight,
                     pinned: false,
                     floating: true,
@@ -2170,7 +2126,6 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: AppBar(
-          backwardsCompatibility: false,
           leading: const Text('L'),
           title: const Text('No Scaffold'),
           actions: const <Widget>[Text('A1'), Text('A2')],
@@ -2194,7 +2149,6 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: AppBar(
-          backwardsCompatibility: false,
           leading: const Text('L'),
           title: const Text('No Scaffold'),
           actions: const <Widget>[Text('A1'), Text('A2')],
@@ -2218,7 +2172,6 @@ void main() {
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               leading: Text('L'),
               title: Text('No Scaffold'),
               actions: <Widget>[Text('A1'), Text('A2')],
@@ -2246,7 +2199,6 @@ void main() {
         home: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
-              backwardsCompatibility: false,
               leading: Text('L'),
               title: Text('No Scaffold'),
               actions: <Widget>[Text('A1'), Text('A2')],
@@ -2277,7 +2229,6 @@ void main() {
               data: MediaQuery.of(context).copyWith(textScaleFactor: textScaleFactor),
               child: Scaffold(
                 appBar: AppBar(
-                  backwardsCompatibility: false,
                   centerTitle: false,
                   title: const Text('Jumbo', style: TextStyle(fontSize: 18)),
                 ),
@@ -2318,7 +2269,6 @@ void main() {
                 builder: (BuildContext context) {
                   return Scaffold(
                     appBar: AppBar(
-                      backwardsCompatibility: false,
                       centerTitle: centerTitle,
                       title: MediaQuery(
                         data: MediaQuery.of(context).copyWith(textScaleFactor: textScaleFactor),
@@ -2379,7 +2329,6 @@ void main() {
           home: CustomScrollView(
             slivers: <Widget>[
               SliverAppBar(
-                backwardsCompatibility: false,
                 title: const Text('Jumbo'),
                 pinned: pinned,
                 floating: floating,
@@ -2413,7 +2362,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('Title'),
             toolbarHeight: 48,
           ),
@@ -2491,7 +2439,6 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           leading: const Placeholder(key: key),
           leadingWidth: 100,
           title: const Text('Title'),
@@ -2509,7 +2456,6 @@ void main() {
       home: CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
-            backwardsCompatibility: false,
             leading: Placeholder(key: key),
             leadingWidth: 100,
             title: Text('Title'),
@@ -2572,7 +2518,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             foregroundColor: foregroundColor,
             backgroundColor: backgroundColor,
             leading: Icon(Icons.add_circle, key: leadingIconKey),
@@ -2659,7 +2604,6 @@ void main() {
           body: CustomScrollView(
             slivers: <Widget>[
               SliverAppBar(
-                backwardsCompatibility: false,
                 elevation: 0,
                 backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
                   return states.contains(MaterialState.scrolledUnder) ? scrolledColor : defaultColor;
@@ -2720,7 +2664,6 @@ void main() {
           body: CustomScrollView(
             slivers: <Widget>[
               SliverAppBar(
-                backwardsCompatibility: false,
                 elevation: 0,
                 backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
                   return states.contains(MaterialState.scrolledUnder) ? scrolledColor : defaultColor;
@@ -2782,7 +2725,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             elevation: 0,
             backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
               return states.contains(MaterialState.scrolledUnder) ? scrolledColor : defaultColor;
@@ -2834,7 +2776,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             elevation: 0,
             backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
               return states.contains(MaterialState.scrolledUnder) ? scrolledColor : defaultColor;
@@ -2890,7 +2831,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('AppBar'),
           ),
           body: Scrollbar(
@@ -2918,7 +2858,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             elevation: 0,
             backgroundColor: MaterialStateColor.resolveWith((Set<MaterialState> states) {
               return states.contains(MaterialState.scrolledUnder) ? scrolledColor : defaultColor;

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -623,7 +623,6 @@ void main() {
         theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
-
             title: const Text('X'),
             actions: const <Widget> [
               IconButton(

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -19,7 +19,6 @@ void main() {
       MaterialApp(
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             actions: <Widget>[
               IconButton(icon: const Icon(Icons.share), onPressed: () { }),
             ],
@@ -54,7 +53,6 @@ void main() {
         theme: ThemeData(appBarTheme: appBarTheme),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             title: const Text('App Bar Title'),
             actions: <Widget>[
               IconButton(icon: const Icon(Icons.share), onPressed: () { }),
@@ -143,7 +141,6 @@ void main() {
         theme: ThemeData.from(colorScheme: const ColorScheme.light()),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             backgroundColor: color,
             brightness: brightness,
             systemOverlayStyle: systemOverlayStyle,
@@ -185,7 +182,6 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData.from(colorScheme: const ColorScheme.light()),
       home: Scaffold(appBar: AppBar(
-        backwardsCompatibility: false,
         iconTheme: iconThemeData,
         actionsIconTheme: actionsIconThemeData,
         actions: <Widget>[
@@ -207,7 +203,6 @@ void main() {
           .copyWith(appBarTheme: _appBarTheme()),
         home: Scaffold(
           appBar: AppBar(
-            backwardsCompatibility: false,
             actions: <Widget>[
               IconButton(icon: const Icon(Icons.share), onPressed: () { }),
             ],
@@ -244,7 +239,6 @@ void main() {
             theme = Theme.of(context);
             return Scaffold(
               appBar: AppBar(
-                backwardsCompatibility: false,
                 actions: <Widget>[
                   IconButton(icon: const Icon(Icons.share), onPressed: () { }),
                 ],
@@ -321,7 +315,6 @@ void main() {
             builder: (BuildContext context) {
               return Scaffold(
                 appBar: AppBar(
-                  backwardsCompatibility: false,
                   iconTheme: IconThemeData(color: appBarIconColor),
                   actions: <Widget>[
                     IconButton(icon: const Icon(Icons.share), onPressed: () { }),
@@ -355,7 +348,6 @@ void main() {
       theme: ThemeData(appBarTheme: const AppBarTheme(centerTitle: true)),
       home: Scaffold(appBar: AppBar(
         title: const Text('Title'),
-        backwardsCompatibility: false,
       )),
     ));
 
@@ -368,7 +360,6 @@ void main() {
       theme: ThemeData(appBarTheme: const AppBarTheme(centerTitle: true)),
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('Title'),
           centerTitle: false,
         ),
@@ -384,7 +375,6 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData(platform: TargetPlatform.iOS),
       home: Scaffold(appBar: AppBar(
-        backwardsCompatibility: false,
         title: const Text('Title'),
       )),
     ));
@@ -400,7 +390,6 @@ void main() {
       theme: ThemeData(appBarTheme: const AppBarTheme(shadowColor: Colors.red)),
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('Title'),
           shadowColor: Colors.yellow,
         ),
@@ -418,7 +407,6 @@ void main() {
       theme: ThemeData(appBarTheme: const AppBarTheme(titleSpacing: kTitleSpacing)),
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('Title'),
         ),
       ),
@@ -434,7 +422,6 @@ void main() {
       theme: ThemeData(appBarTheme: const AppBarTheme(titleSpacing: kTitleSpacing)),
       home: Scaffold(
         appBar: AppBar(
-          backwardsCompatibility: false,
           title: const Text('Title'),
           titleSpacing: 40,
         ),
@@ -452,7 +439,6 @@ void main() {
       home: const CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
-            backwardsCompatibility: false,
             title: Text('Title'),
           ),
         ],
@@ -470,7 +456,6 @@ void main() {
       home: const CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
-            backwardsCompatibility: false,
             title: Text('Title'),
             titleSpacing: 40,
           ),
@@ -497,7 +482,6 @@ void main() {
   testWidgets('AppBarTheme implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const AppBarTheme(
-      backwardsCompatibility: false,
       brightness: Brightness.dark,
       backgroundColor: Color(0xff000001),
       elevation: 8.0,
@@ -518,7 +502,6 @@ void main() {
       'shadowColor: Color(0xff000002)',
       'centerTitle: true',
       'titleSpacing: 40.0',
-      'backwardsCompatibility: false',
     ]);
 
     // On the web, Dart doubles and ints are backed by the same kind of object because


### PR DESCRIPTION
Deprecate AppBar.brightness, AppBar.backwardsCompatibility, SliverAppBar.brightness, SliverAppBar.backwardsCompatibility, AppBarTheme.brightness, AppBarTheme.backwardsCompatibility, and AppBarTheme.textTheme. The default value of AppBar.backwardsCompatibility is now false.

This is a follow-on to https://github.com/flutter/flutter/pull/71184 which substantially revised AppBar and added the backwardsCompatibility flag to give developers time to migrate.

Fixes https://github.com/flutter/flutter/issues/86127