### PR TITLE
Revert "Migrate devicelab tasks f-i to null safety."

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_attach_test_fuchsia.dart
+++ b/dev/devicelab/bin/tasks/flutter_attach_test_fuchsia.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -114,8 +116,8 @@ void main() {
         'sentinel-${random.nextInt(1<<32)}': Completer<void>(),
       };
 
-      late Process runProcess;
-      late Process logsProcess;
+      Process runProcess;
+      Process logsProcess;
 
       try {
         section('Creating lib/fuchsia_main.dart');
@@ -156,12 +158,12 @@ void main() {
             print('logs:stdout: $log');
             for (final String sentinel in sentinelMessage.keys) {
               if (log.contains(sentinel)) {
-                if (sentinelMessage[sentinel]!.isCompleted) {
+                if (sentinelMessage[sentinel].isCompleted) {
                   throw Exception(
                     'Expected a single `$sentinel` message in the device log, but found more than one'
                   );
                 }
-                sentinelMessage[sentinel]!.complete();
+                sentinelMessage[sentinel].complete();
                 break;
               }
             }
@@ -228,7 +230,7 @@ void main() {
       }
 
       for (final String sentinel in sentinelMessage.keys) {
-        if (!sentinelMessage[sentinel]!.isCompleted) {
+        if (!sentinelMessage[sentinel].isCompleted) {
           throw Exception('Expected $sentinel in the device logs.');
         }
       }

--- a/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';
@@ -71,7 +73,7 @@ Future<TaskResult> _doTest() async {
     final String apkPath = path.join(multipleFluttersPath, 'android', 'app',
         'build', 'outputs', 'apk', 'release', 'app-release.apk');
 
-    TaskResult? result;
+    TaskResult result;
     await _withApkInstall(apkPath, _bundleName, (AndroidDevice device) async {
       final List<int> totalMemorySamples = <int>[];
       for (int i = 0; i < _numberOfIterations; ++i) {

--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 /// Measure application memory usage after pausing and resuming the app
 /// with the Android back button.
 
@@ -17,7 +19,7 @@ class BackButtonMemoryTest extends MemoryTest {
   BackButtonMemoryTest() : super('${flutterDirectory.path}/dev/integration_tests/flutter_gallery', 'test_memory/back_button.dart', packageName);
 
   @override
-  AndroidDevice? get device => super.device as AndroidDevice?;
+  AndroidDevice get device => super.device as AndroidDevice;
 
   @override
   int get iterationCount => 5;
@@ -32,7 +34,7 @@ class BackButtonMemoryTest extends MemoryTest {
 
       // Push back button, wait for it to be seen by the Flutter app.
       prepareForNextMessage('AppLifecycleState.paused');
-      await device!.shellExec('input', <String>['keyevent', 'KEYCODE_BACK']);
+      await device.shellExec('input', <String>['keyevent', 'KEYCODE_BACK']);
       await receivedNextMessage;
 
       // Give Android time to settle (e.g. run GCs) after closing the app.
@@ -40,7 +42,7 @@ class BackButtonMemoryTest extends MemoryTest {
 
       // Relaunch the app, wait for it to launch.
       prepareForNextMessage('READY');
-      final String output = await device!.shellEval('am', <String>['start', '-n', '$packageName/$activityName']);
+      final String output = await device.shellEval('am', <String>['start', '-n', '$packageName/$activityName']);
       print('adb shell am start: $output');
       if (output.contains('Error'))
         fail('unable to launch activity');

--- a/dev/devicelab/bin/tasks/flutter_gallery__image_cache_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__image_cache_memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios32.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e_ios32.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
@@ -12,13 +14,11 @@ Future<void> main() async {
   await task(() async {
     final TaskResult withoutSemantics = await createGalleryTransitionTest()();
     final TaskResult withSemantics = await createGalleryTransitionTest(semanticsEnabled: true)();
-    final bool withSemanticsDataMissing = withSemantics.benchmarkScoreKeys == null || withSemantics.benchmarkScoreKeys!.isEmpty;
-    final bool withoutSemanticsDataMissing = withoutSemantics.benchmarkScoreKeys == null || withoutSemantics.benchmarkScoreKeys!.isEmpty;
-    if (withSemanticsDataMissing || withoutSemanticsDataMissing) {
+    if (withSemantics.benchmarkScoreKeys.isEmpty || withoutSemantics.benchmarkScoreKeys.isEmpty) {
       String message = 'Lack of data';
-      if (withSemanticsDataMissing) {
+      if (withSemantics.benchmarkScoreKeys.isEmpty) {
         message += ' for test with semantics';
-        if (withoutSemanticsDataMissing) {
+        if (withoutSemantics.benchmarkScoreKeys.isEmpty) {
           message += ' and without semantics';
         }
       } else {
@@ -29,11 +29,11 @@ Future<void> main() async {
 
     final List<String> benchmarkScoreKeys = <String>[];
     final Map<String, dynamic> data = <String, dynamic>{};
-    for (final String key in withSemantics.benchmarkScoreKeys!) {
+    for (final String key in withSemantics.benchmarkScoreKeys) {
       final String deltaKey = 'delta_$key';
-      data[deltaKey] = (withSemantics.data![key] as num) - (withoutSemantics.data![key] as num);
-      data['semantics_$key'] = withSemantics.data![key];
-      data[key] = withoutSemantics.data![key];
+      data[deltaKey] = (withSemantics.data[key] as num) - (withoutSemantics.data[key] as num);
+      data['semantics_$key'] = withSemantics.data[key];
+      data[key] = withoutSemantics.data[key];
       benchmarkScoreKeys.add(deltaKey);
     }
 

--- a/dev/devicelab/bin/tasks/flutter_gallery_android__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_instrumentation_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/devices.dart';
@@ -25,11 +27,9 @@ Future<void> main() async {
       await flutter('packages', options: <String>['get']);
       await flutter('clean');
       await flutter('build', options: <String>['apk', '--target', 'test/live_smoketest.dart']);
-      final String? javaHome = await findJavaHome();
-      final Map<String, String>? environment = javaHome != null
-        ? <String, String>{ 'JAVA_HOME': javaHome }
-        : null;
-      await exec('./tool/run_instrumentation_test.sh', <String>[], environment: environment);
+      await exec('./tool/run_instrumentation_test.sh', <String>[], environment: <String, String>{
+        'JAVA_HOME': await findJavaHome(),
+      });
     });
 
     return TaskResult.success(null);

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_ios__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_ios__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_sksl_warmup__transition_perf_e2e.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';

--- a/dev/devicelab/bin/tasks/flutter_gallery_win__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_win__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_run_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 // This test runs `flutter test` on the `trivial_widget_test.dart` four times.
 //
 // The first time, the result is ignored, on the basis that it's warming the
@@ -65,11 +67,11 @@ Future<int> runTest({bool coverage = false, bool noPub = false}) async {
       // we have a blank line at the start
       step = TestStep.testWritesFirstCarriageReturn;
     } else {
-      final Match? match = testOutputPattern.matchAsPrefix(entry);
+      final Match match = testOutputPattern.matchAsPrefix(entry);
       if (match == null) {
         badLines += 1;
       } else {
-        if (step.index >= TestStep.testWritesFirstCarriageReturn.index && step.index <= TestStep.testLoading.index && match.group(1)!.startsWith('loading ')) {
+        if (step.index >= TestStep.testWritesFirstCarriageReturn.index && step.index <= TestStep.testLoading.index && match.group(1).startsWith('loading ')) {
           // first the test loads
           step = TestStep.testLoading;
         } else if (step.index <= TestStep.testRunning.index && match.group(1) == 'A trivial widget test') {

--- a/dev/devicelab/bin/tasks/flutter_view__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_ios__start_up.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/frame_policy_delay_test_android.dart
+++ b/dev/devicelab/bin/tasks/frame_policy_delay_test_android.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf__e2e_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:flutter_devicelab/framework/devices.dart';

--- a/dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_desugar_classes_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_java8_compile_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_migrate_settings_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/framework.dart';
@@ -18,7 +20,7 @@ Future<void> main() async {
 
     section('Find Java');
 
-    final String? javaHome = await findJavaHome();
+    final String javaHome = await findJavaHome();
     if (javaHome == null)
       return TaskResult.failure('Could not find Java');
     print('\nUsing JAVA_HOME=$javaHome');
@@ -41,7 +43,7 @@ Future<void> main() async {
 
       section('Build APK');
 
-      late String stdout;
+      String stdout;
       await inDirectory(projectDir, () async {
         stdout = await evalFlutter(
           'build',

--- a/dev/devicelab/bin/tasks/gradle_non_android_plugin_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_non_android_plugin_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 

--- a/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/apk_utils.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';

--- a/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';

--- a/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
+++ b/dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:io';
 
 import 'package:flutter_devicelab/framework/apk_utils.dart';
@@ -175,7 +177,7 @@ Future<void> main() async {
             ],
           );
         });
-        final String? errorMessage = validateSnapshotDependency(project, 'kernel_blob.bin');
+        final String errorMessage = validateSnapshotDependency(project, 'kernel_blob.bin');
         if (errorMessage != null) {
           throw TaskResult.failure(errorMessage);
         }

--- a/dev/devicelab/bin/tasks/hello_world__memory.dart
+++ b/dev/devicelab/bin/tasks/hello_world__memory.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';
@@ -22,7 +24,7 @@ class HelloWorldMemoryTest extends MemoryTest {
       '--verbose',
       '--release',
       '--no-resident',
-      '-d', device!.deviceId,
+      '-d', device.deviceId,
       test,
     ]);
     await Future<void>.delayed(const Duration(milliseconds: 1500));

--- a/dev/devicelab/bin/tasks/hello_world_android__compile.dart
+++ b/dev/devicelab/bin/tasks/hello_world_android__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/hello_world_ios__compile.dart
+++ b/dev/devicelab/bin/tasks/hello_world_ios__compile.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/home_scroll_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 

--- a/dev/devicelab/bin/tasks/hybrid_android_views_integration_test.dart
+++ b/dev/devicelab/bin/tasks/hybrid_android_views_integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/image_list_jit_reported_duration.dart
+++ b/dev/devicelab/bin/tasks/image_list_jit_reported_duration.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/image_list_reported_duration.dart
+++ b/dev/devicelab/bin/tasks/image_list_reported_duration.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/imagefiltered_transform_animation_perf__timeline_summary.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_test_test.dart
+++ b/dev/devicelab/bin/tasks/integration_test_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_test_test_ios.dart
+++ b/dev/devicelab/bin/tasks/integration_test_test_ios.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_driver.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_driver.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_driver.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_driver.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_keyboard_resize.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_keyboard_resize.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_screenshot.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_screenshot.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_ios_textfield.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_ios_textfield.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_keyboard_resize.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_keyboard_resize.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_screenshot.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_screenshot.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';

--- a/dev/devicelab/bin/tasks/integration_ui_textfield.dart
+++ b/dev/devicelab/bin/tasks/integration_ui_textfield.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';


### PR DESCRIPTION
Reverts flutter/flutter#85997

Cast error at https://github.com/flutter/flutter/blob/master/dev/devicelab/lib/tasks/hot_mode_tests.dart#L248

https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20hot_mode_dev_cycle__benchmark/1810/overview
