### PR TITLE
InputDecoration: Text should use hintStyle when inline

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2203,8 +2203,8 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     // Setting TextStyle.height to 1 ensures that the label's height will equal
     // its font size.
     final TextStyle inlineLabelStyle = themeData.fixTextFieldOutlineLabel
-      ? inlineStyle.merge(decoration!.labelStyle).copyWith(height: 1)
-      : inlineStyle.merge(decoration!.labelStyle);
+      ? inlineStyle.merge(decoration!.hintStyle).copyWith(height: 1)
+      : inlineStyle.merge(decoration!.hintStyle);
     final Widget? label = decoration!.labelText == null ? null : _Shaker(
       animation: _shakingLabelController.view,
       child: AnimatedOpacity(

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3016,6 +3016,15 @@ void main() {
     expect(getBorderWeight(tester), 1.0);
   });
 
+  TextStyle _getLabelStyle(WidgetTester tester) {
+    return tester.firstWidget<AnimatedDefaultTextStyle>(
+      find.ancestor(
+        of: find.text('label'),
+        matching: find.byType(AnimatedDefaultTextStyle),
+      ),
+    ).style;
+  }
+
   testWidgets('InputDecorationTheme style overrides', (WidgetTester tester) async {
     const TextStyle style16 = TextStyle(fontFamily: 'Ahem', fontSize: 16.0);
     final TextStyle labelStyle = style16.merge(const TextStyle(color: Colors.red));
@@ -3078,18 +3087,10 @@ void main() {
     expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
     expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
 
-    TextStyle getLabelStyle() {
-      return tester.firstWidget<AnimatedDefaultTextStyle>(
-        find.ancestor(
-          of: find.text('label'),
-          matching: find.byType(AnimatedDefaultTextStyle),
-        ),
-      ).style;
-    }
     // label has the hintStyle because labelText is on top of input field
     // (i.e., at the same location on the screen where
     // text may be entered in the child)
-    expect(getLabelStyle().color, hintStyle.color);
+    expect(_getLabelStyle(tester).color, hintStyle.color);
   });
 
   testWidgets('InputDecorationTheme style overrides focused', (WidgetTester tester) async {
@@ -3134,15 +3135,7 @@ void main() {
     expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
     expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
 
-    TextStyle getLabelStyle() {
-      return tester.firstWidget<AnimatedDefaultTextStyle>(
-        find.ancestor(
-          of: find.text('label'),
-          matching: find.byType(AnimatedDefaultTextStyle),
-        ),
-      ).style;
-    }
-    expect(getLabelStyle().color, labelStyle.color);
+    expect(_getLabelStyle(tester).color, labelStyle.color);
   });
 
   testWidgets('InputDecorator.toString()', (WidgetTester tester) async {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -132,6 +132,15 @@ double getOpacity(WidgetTester tester, String textValue) {
   return opacityWidget.opacity.value;
 }
 
+TextStyle getLabelStyle(WidgetTester tester) {
+  return tester.firstWidget<AnimatedDefaultTextStyle>(
+    find.ancestor(
+      of: find.text('label'),
+      matching: find.byType(AnimatedDefaultTextStyle),
+    ),
+  ).style;
+}
+
 void main() {
   testWidgets('InputDecorator input/label layout', (WidgetTester tester) async {
     // The label appears above the input text
@@ -3016,15 +3025,6 @@ void main() {
     expect(getBorderWeight(tester), 1.0);
   });
 
-  TextStyle _getLabelStyle(WidgetTester tester) {
-    return tester.firstWidget<AnimatedDefaultTextStyle>(
-      find.ancestor(
-        of: find.text('label'),
-        matching: find.byType(AnimatedDefaultTextStyle),
-      ),
-    ).style;
-  }
-
   testWidgets('InputDecorationTheme style overrides', (WidgetTester tester) async {
     const TextStyle style16 = TextStyle(fontFamily: 'Ahem', fontSize: 16.0);
     final TextStyle labelStyle = style16.merge(const TextStyle(color: Colors.red));
@@ -3081,16 +3081,15 @@ void main() {
     expect(tester.getTopLeft(find.text('helper')), const Offset(0.0, 64.0));
     expect(tester.getTopRight(find.text('counter')), const Offset(800.0, 64.0));
 
-    // Verify that the styles were passed along
+    // Verify that the styles were passed along.
     expect(tester.widget<Text>(find.text('prefix')).style!.color, prefixStyle.color);
     expect(tester.widget<Text>(find.text('suffix')).style!.color, suffixStyle.color);
     expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
     expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
 
-    // label has the hintStyle because labelText is on top of input field
-    // (i.e., at the same location on the screen where
-    // text may be entered in the child)
-    expect(_getLabelStyle(tester).color, hintStyle.color);
+    // Label has the hintStyle because labelText is on top of the input field
+    // (i.e., at the same location on the screen where text may be entered in the child).
+    expect(getLabelStyle(tester).color, hintStyle.color);
   });
 
   testWidgets('InputDecorationTheme style overrides focused', (WidgetTester tester) async {
@@ -3128,14 +3127,14 @@ void main() {
       ),
     );
 
-    // Verify that the styles were passed along
+    // Verify that the styles were passed along.
     expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);
     expect(tester.widget<Text>(find.text('prefix')).style!.color, prefixStyle.color);
     expect(tester.widget<Text>(find.text('suffix')).style!.color, suffixStyle.color);
     expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
     expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
 
-    expect(_getLabelStyle(tester).color, labelStyle.color);
+    expect(getLabelStyle(tester).color, labelStyle.color);
   });
 
   testWidgets('InputDecorator.toString()', (WidgetTester tester) async {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3086,6 +3086,62 @@ void main() {
         ),
       ).style;
     }
+    // label has the hintStyle because labelText is on top of input field
+    // (i.e., at the same location on the screen where
+    // text may be entered in the child)
+    expect(getLabelStyle().color, hintStyle.color);
+  });
+
+  testWidgets('InputDecorationTheme style overrides focused', (WidgetTester tester) async {
+    const TextStyle style16 = TextStyle(fontFamily: 'Ahem', fontSize: 16.0);
+    final TextStyle labelStyle = style16.merge(const TextStyle(color: Colors.red));
+    final TextStyle hintStyle = style16.merge(const TextStyle(color: Colors.green));
+    final TextStyle prefixStyle = style16.merge(const TextStyle(color: Colors.blue));
+    final TextStyle suffixStyle = style16.merge(const TextStyle(color: Colors.purple));
+
+    const TextStyle style12 = TextStyle(fontFamily: 'Ahem', fontSize: 12.0);
+    final TextStyle helperStyle = style12.merge(const TextStyle(color: Colors.orange));
+    final TextStyle counterStyle = style12.merge(const TextStyle(color: Colors.orange));
+
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true, // label appears, vertically centered
+        isFocused: true, // hintText is visible
+        inputDecorationTheme: InputDecorationTheme(
+          labelStyle: labelStyle,
+          hintStyle: hintStyle,
+          prefixStyle: prefixStyle,
+          suffixStyle: suffixStyle,
+          helperStyle: helperStyle,
+          counterStyle: counterStyle,
+          // filled: false (default) - don't pad by left/right 12dps
+        ),
+        decoration: const InputDecoration(
+          labelText: 'label',
+          hintText: 'hint',
+          prefixText: 'prefix',
+          suffixText: 'suffix',
+          helperText: 'helper',
+          counterText: 'counter',
+        ),
+      ),
+    );
+
+    // Verify that the styles were passed along
+    expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);
+    expect(tester.widget<Text>(find.text('prefix')).style!.color, prefixStyle.color);
+    expect(tester.widget<Text>(find.text('suffix')).style!.color, suffixStyle.color);
+    expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
+    expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
+
+    TextStyle getLabelStyle() {
+      return tester.firstWidget<AnimatedDefaultTextStyle>(
+        find.ancestor(
+          of: find.text('label'),
+          matching: find.byType(AnimatedDefaultTextStyle),
+        ),
+      ).style;
+    }
     expect(getLabelStyle().color, labelStyle.color);
   });
 


### PR DESCRIPTION
Fixes #21385

`labelText` should use `hintStyle` instead of `labelStyle` when inline (displayed on top of the input field (i.e. at the same location on the screen where text may be entered in `child`)).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
