### PR TITLE
Dart Fixes for clipBehavior breaks

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -71,7 +71,7 @@ transforms:
     changes:
     - kind: 'rename'
       newName: 'clipBehavior'
-  
+
   # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
   - title: "Migrate to 'clipBehavior'"
     date: 2020-08-20

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,6 +15,225 @@
 version: 1
 transforms:
 
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'rendering.dart' ]
+      field: 'clipToSize'
+      inClass: 'RenderListWheelViewport'
+    changes:
+      - kind: 'rename'
+        newName: 'clipBehavior'
+
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'rendering.dart' ]
+      constructor: ''
+      inClass: 'RenderListWheelViewport'
+    oneOf:
+    - if: "clipToSize == 'true'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.hardEdge'
+            requiredIf: "clipToSize == 'true'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    - if: "clipToSize == 'false'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.none'
+            requiredIf: "clipToSize == 'false'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    variables:
+      clipToSize:
+        kind: 'fragment'
+        value: 'arguments[clipToSize]'
+
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      field: 'clipToSize'
+      inClass: 'ListWheelViewport'
+    changes:
+    - kind: 'rename'
+      newName: 'clipBehavior'
+  
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'ListWheelViewport'
+    oneOf:
+    - if: "clipToSize == 'true'"
+      changes:
+      - kind: 'addParameter'
+        index: 13
+        name: 'clipBehavior'
+        style: optional_named
+        argumentValue:
+          expression: 'Clip.hardEdge'
+          requiredIf: "clipToSize == 'true'"
+      - kind: 'removeParameter'
+        name: 'clipToSize'
+    - if: "clipToSize == 'false'"
+      changes:
+      - kind: 'addParameter'
+        index: 13
+        name: 'clipBehavior'
+        style: optional_named
+        argumentValue:
+          expression: 'Clip.none'
+          requiredIf: "clipToSize == 'false'"
+      - kind: 'removeParameter'
+        name: 'clipToSize'
+    variables:
+      clipToSize:
+        kind: 'fragment'
+        value: 'arguments[clipToSize]'
+
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: 'useDelegate'
+      inClass: 'ListWheelScrollView'
+    oneOf:
+    - if: "clipToSize == 'true'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.hardEdge'
+            requiredIf: "clipToSize == 'true'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    - if: "clipToSize == 'false'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.none'
+            requiredIf: "clipToSize == 'false'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    variables:
+      clipToSize:
+        kind: 'fragment'
+        value: 'arguments[clipToSize]'
+
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      field: 'clipToSize'
+      inClass: 'ListWheelScrollView'
+    changes:
+      - kind: 'rename'
+        newName: 'clipBehavior'
+
+  # Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-08-20
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: ''
+      inClass: 'ListWheelScrollView'
+    oneOf:
+    - if: "clipToSize == 'true'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.hardEdge'
+            requiredIf: "clipToSize == 'true'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    - if: "clipToSize == 'false'"
+      changes:
+        - kind: 'addParameter'
+          index: 13
+          name: 'clipBehavior'
+          style: optional_named
+          argumentValue:
+            expression: 'Clip.none'
+            requiredIf: "clipToSize == 'false'"
+        - kind: 'removeParameter'
+          name: 'clipToSize'
+    variables:
+      clipToSize:
+        kind: 'fragment'
+        value: 'arguments[clipToSize]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/66305
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-09-22
+    element:
+      uris: [ 'rendering.dart' ]
+      field: 'overflow'
+      inClass: 'RenderStack'
+    changes:
+      - kind: 'rename'
+        newName: 'clipBehavior'
+
+  # Changes made in https://github.com/flutter/flutter/pull/66305
+  - title: "Migrate to 'clipBehavior'"
+    date: 2020-09-22
+    element:
+      uris: [ 'rendering.dart' ]
+      constructor: ''
+      inClass: 'RenderStack'
+    oneOf:
+      - if: "overflow == 'Overflow.clip'"
+        changes:
+          - kind: 'addParameter'
+            index: 0
+            name: 'clipBehavior'
+            style: optional_named
+            argumentValue:
+              expression: 'Clip.hardEdge'
+              requiredIf: "overflow == 'Overflow.clip'"
+          - kind: 'removeParameter'
+            name: 'overflow'
+      - if: "overflow == 'Overflow.visible'"
+        changes:
+          - kind: 'addParameter'
+            index: 0
+            name: 'clipBehavior'
+            style: optional_named
+            argumentValue:
+              expression: 'Clip.none'
+              requiredIf: "overflow == 'Overflow.visible'"
+          - kind: 'removeParameter'
+            name: 'overflow'
+    variables:
+      overflow:
+        kind: 'fragment'
+        value: 'arguments[overflow]'
+
   # Changes made in https://github.com/flutter/flutter/pull/81303
   - title: "Migrate to 'setEnabledSystemUIMode'"
     date: 2021-06-08

--- a/packages/flutter/test_fixes/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino.dart
@@ -168,4 +168,17 @@ void main() {
   renderObjectToWidgetElement.insertChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.moveChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.removeChildRenderObject(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
+  listWheelScrollView.clipToSize;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipToSize: true);
+  listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport.clipToSize;
 }

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -168,4 +168,17 @@ void main() {
   renderObjectToWidgetElement.insertRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.moveRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.removeRenderObjectChild(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
+  listWheelScrollView.clipBehavior;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport.clipBehavior;
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -330,4 +330,17 @@ void main() {
   renderObjectToWidgetElement.insertChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.moveChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.removeChildRenderObject(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
+  listWheelScrollView.clipToSize;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipToSize: true);
+  listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport.clipToSize;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -302,4 +302,17 @@ void main() {
   renderObjectToWidgetElement.insertRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.moveRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.removeRenderObjectChild(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
+  listWheelScrollView.clipBehavior;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport.clipBehavior;
 }

--- a/packages/flutter/test_fixes/rendering.dart
+++ b/packages/flutter/test_fixes/rendering.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  RenderStack renderStack = RenderStack();
+  renderStack = RenderStack(overflow: Overflow.visible);
+  renderStack = RenderStack(overflow: Overflow.clip);
+  renderStack.overflow;
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  RenderListWheelViewport renderListWheelViewport = RenderListWheelViewport();
+  renderListWheelViewport = RenderListWheelViewport(clipToSize: true);
+  renderListWheelViewport = RenderListWheelViewport(clipToSize: false);
+  renderListWheelViewport.clipToSize;
+}

--- a/packages/flutter/test_fixes/rendering.dart.expect
+++ b/packages/flutter/test_fixes/rendering.dart.expect
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/66305
+  RenderStack renderStack = RenderStack();
+  renderStack = RenderStack(clipBehavior: Clip.none);
+  renderStack = RenderStack(clipBehavior: Clip.hardEdge);
+  renderStack.clipBehavior;
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  RenderListWheelViewport renderListWheelViewport = RenderListWheelViewport();
+  renderListWheelViewport = RenderListWheelViewport(clipBehavior: Clip.hardEdge);
+  renderListWheelViewport = RenderListWheelViewport(clipBehavior: Clip.none);
+  renderListWheelViewport.clipBehavior;
+}

--- a/packages/flutter/test_fixes/widgets.dart
+++ b/packages/flutter/test_fixes/widgets.dart
@@ -136,4 +136,17 @@ void main() {
   renderObjectToWidgetElement.insertChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.moveChildRenderObject(renderObject, object);
   renderObjectToWidgetElement.removeChildRenderObject(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
+  listWheelScrollView.clipToSize;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipToSize: true);
+  listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport.clipToSize;
 }

--- a/packages/flutter/test_fixes/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets.dart.expect
@@ -136,4 +136,17 @@ void main() {
   renderObjectToWidgetElement.insertRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.moveRenderObjectChild(renderObject, object);
   renderObjectToWidgetElement.removeRenderObjectChild(renderObject);
+
+  // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
+  ListWheelScrollView listWheelScrollView = ListWheelScrollView();
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView.useDelegate();
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
+  listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
+  listWheelScrollView.clipBehavior;
+  ListWheelViewport listWheelViewport = ListWheelViewport();
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
+  listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport.clipBehavior;
 }


### PR DESCRIPTION
This adds flutter fixes for the clipBehavior breaks. This is not the last of them as previously thought, updating the bug to reflect new breaks that need fixes.


Part of https://github.com/flutter/flutter/issues/74908

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
