### PR TITLE
[flutter_tools] Improve toolexit error messages for `flutter upgrade`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -17,6 +17,9 @@ import '../globals_null_migrated.dart' as globals;
 import '../runner/flutter_command.dart';
 import '../version.dart';
 
+// The official docs to install Flutter.
+String get _flutterInstallDocs => 'https://flutter.dev/docs/get-started/install';
+
 class UpgradeCommand extends FlutterCommand {
   UpgradeCommand({
     @required bool verboseHelp,
@@ -224,7 +227,7 @@ class UpgradeCommandRunner {
 
   /// Returns the remote HEAD flutter version.
   ///
-  /// Exits tool if there is no upstream.
+  /// Exits tool if HEAD isn't pointing to a branch, or there is no upstream.
   Future<FlutterVersion> fetchLatestVersion() async {
     String revision;
     try {
@@ -245,16 +248,17 @@ class UpgradeCommandRunner {
       final String errorString = e.toString();
       if (errorString.contains('fatal: HEAD does not point to a branch')) {
         throwToolExit(
-          'You are not currently on a release branch. Use git to '
-          "check out an official branch ('stable', 'beta', 'dev', or 'master') "
-          'and retry, for example:\n'
-          '  git checkout stable'
+          'Unable to upgrade Flutter: HEAD does not point to a branch (Are you '
+          'in a detached HEAD state?).\n'
+          'Use "flutter channel" to switch to an official channel, and retry. '
+          'Alternatively, re-install Flutter by going to $_flutterInstallDocs.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         throwToolExit(
-          'Unable to upgrade Flutter: no origin repository configured. '
-          "Run 'git remote add origin "
-          "https://github.com/flutter/flutter' in $workingDirectory");
+          'Unable to upgrade Flutter: No upstream repository configured (The current '
+          'branch may not be tracking a remote repository).\n'
+          'Re-install Flutter by going to $_flutterInstallDocs.'
+        );
       } else {
         throwToolExit(errorString);
       }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -248,15 +248,15 @@ class UpgradeCommandRunner {
       final String errorString = e.toString();
       if (errorString.contains('fatal: HEAD does not point to a branch')) {
         throwToolExit(
-          'Unable to upgrade Flutter: HEAD does not point to a branch (Are you '
-          'in a detached HEAD state?).\n'
+          'Unable to upgrade Flutter: Your Flutter checkout is currently not '
+          'on a release branch.\n'
           'Use "flutter channel" to switch to an official channel, and retry. '
           'Alternatively, re-install Flutter by going to $_flutterInstallDocs.'
         );
       } else if (errorString.contains('fatal: no upstream configured for branch')) {
         throwToolExit(
-          'Unable to upgrade Flutter: No upstream repository configured (The current '
-          'branch may not be tracking a remote repository).\n'
+          'Unable to upgrade Flutter: The current Flutter branch/channel is '
+          'not tracking any remote repository.\n'
           'Re-install Flutter by going to $_flutterInstallDocs.'
         );
       } else {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -18,7 +18,7 @@ import '../runner/flutter_command.dart';
 import '../version.dart';
 
 // The official docs to install Flutter.
-String get _flutterInstallDocs => 'https://flutter.dev/docs/get-started/install';
+const String _flutterInstallDocs = 'https://flutter.dev/docs/get-started/install';
 
 class UpgradeCommand extends FlutterCommand {
   UpgradeCommand({

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -200,8 +200,8 @@ void main() {
 
       await expectLater(
         () async => realCommandRunner.fetchLatestVersion(),
-        throwsToolExit(message: 'Unable to upgrade Flutter: HEAD does not point '
-          'to a branch (Are you in a detached HEAD state?).\n'
+        throwsToolExit(message: 'Unable to upgrade Flutter: Your Flutter checkout '
+          'is currently not on a release branch.\n'
           'Use "flutter channel" to switch to an official channel, and retry. '
           'Alternatively, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
         ),
@@ -229,8 +229,8 @@ void main() {
 
       await expectLater(
         () async => realCommandRunner.fetchLatestVersion(),
-        throwsToolExit(message: 'Unable to upgrade Flutter: No upstream repository '
-          'configured (The current branch may not be tracking a remote repository).\n'
+        throwsToolExit(message: 'Unable to upgrade Flutter: The current Flutter '
+          'branch/channel is not tracking any remote repository.\n'
           'Re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/upgrade_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-import 'package:flutter_tools/src/base/common.dart' show ToolExit;
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -199,17 +198,14 @@ void main() {
         ),
       ]);
 
-      ToolExit err;
-      try {
-        await realCommandRunner.fetchLatestVersion();
-      } on ToolExit catch (e) {
-        err = e;
-      }
-
-      expect(err, isNotNull);
-      expect(err.toString(), contains('Unable to upgrade Flutter: HEAD does not point to a branch'));
-      expect(err.toString(), contains('Use "flutter channel" to switch to an official channel, and retry'));
-      expect(err.toString(), contains('re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+      await expectLater(
+        () async => realCommandRunner.fetchLatestVersion(),
+        throwsToolExit(message: 'Unable to upgrade Flutter: HEAD does not point '
+          'to a branch (Are you in a detached HEAD state?).\n'
+          'Use "flutter channel" to switch to an official channel, and retry. '
+          'Alternatively, re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
+        ),
+      );
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,
@@ -231,16 +227,13 @@ void main() {
         ),
       ]);
 
-      ToolExit err;
-      try {
-        await realCommandRunner.fetchLatestVersion();
-      } on ToolExit catch (e) {
-        err = e;
-      }
-
-      expect(err, isNotNull);
-      expect(err.toString(), contains('Unable to upgrade Flutter: No upstream repository configured'));
-      expect(err.toString(), contains('Re-install Flutter by going to https://flutter.dev/docs/get-started/install'));
+      await expectLater(
+        () async => realCommandRunner.fetchLatestVersion(),
+        throwsToolExit(message: 'Unable to upgrade Flutter: No upstream repository '
+          'configured (The current branch may not be tracking a remote repository).\n'
+          'Re-install Flutter by going to https://flutter.dev/docs/get-started/install.'
+        ),
+      );
       expect(processManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => processManager,


### PR DESCRIPTION
This PR updates the toolexit error messages displayed when one runs `flutter upgrade` with either the `HEAD` not pointing to a branch, or the current branch lacking an upstream.

More specifically, this removes any `git` commands from the error messages. and replaces them with an equivalent from the flutter sub commands, if any.

Also adds a link to the official Flutter install docs(https://flutter.dev/docs/get-started/install) for further help.

This change was originally a part of #79372, which was reverted in #83423.

Fixes #49713.
Fixes #79366.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
