### PR TITLE
[web] use resident resident runner in flutter drive

### DIFF
--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -46,6 +46,7 @@ class FlutterDriverFactory {
   DriverService createDriverService(bool web) {
     if (web) {
       return WebDriverService(
+        logger: _logger,
         processUtils: _processUtils,
         dartSdkPath: _dartSdkPath,
       );

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1376,7 +1376,7 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   Future<void> exitApp() async {
     final List<Future<void>> futures = <Future<void>>[
-      for (final FlutterDevice device in flutterDevices)  device.exitApps(),
+      for (final FlutterDevice device in flutterDevices) device.exitApps(),
     ];
     await Future.wait(futures);
     appFinished();

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -460,6 +460,7 @@ void main() {
   testWithoutContext('WebDriver error message includes link to documentation', () async {
     const String link = 'https://flutter.dev/docs/testing/integration-tests#running-in-a-browser';
     final DriverService driverService = WebDriverService(
+      logger: BufferLogger.test(),
       dartSdkPath: 'dart',
       processUtils: ProcessUtils(
         processManager: FakeProcessManager.empty(),

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -4,10 +4,26 @@
 
 // @dart = 2.8
 
+import 'dart:async';
+
+import 'package:file/src/interface/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/net.dart';
+import 'package:flutter_tools/src/base/process.dart';
+import 'package:flutter_tools/src/base/time.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/drive/web_driver_service.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:flutter_tools/src/resident_runner.dart';
+import 'package:flutter_tools/src/web/web_runner.dart';
+import 'package:test/fake.dart';
 import 'package:webdriver/sync_io.dart' as sync_io;
 
 import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fake_vm_services.dart';
 
 void main() {
   testWithoutContext('getDesiredCapabilities Chrome with headless on', () {
@@ -165,4 +181,113 @@ void main() {
 
     expect(getDesiredCapabilities(Browser.androidChrome, false), expected);
   });
+
+  testUsingContext('WebDriverService starts and stops an app', () async {
+    final WebDriverService service = setUpDriverService();
+    final FakeDevice device = FakeDevice();
+    await service.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile), true);
+    await service.stop();
+    expect(FakeResidentRunner.instance.callLog, <String>[
+      'run',
+      'exitApp',
+      'cleanupAtFinish',
+    ]);
+  }, overrides: <Type, Generator>{
+    WebRunnerFactory: () => FakeWebRunnerFactory(),
+  });
+
+  testUsingContext('WebDriverService forwards exception when run future fails before app starts', () async {
+    final WebDriverService service = setUpDriverService();
+    final Device device = FakeDevice();
+    await expectLater(
+      service.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile), true),
+      throwsA('This is a test error'),
+    );
+  }, overrides: <Type, Generator>{
+    WebRunnerFactory: () => FakeWebRunnerFactory(
+      doResolveToError: true,
+    ),
+  });
+}
+
+class FakeWebRunnerFactory implements WebRunnerFactory {
+  FakeWebRunnerFactory({
+    this.doResolveToError = false,
+  });
+
+  final bool doResolveToError;
+
+  @override
+  ResidentRunner createWebRunner(FlutterDevice device, {String target, bool stayResident, FlutterProject flutterProject, bool ipv6, DebuggingOptions debuggingOptions, UrlTunneller urlTunneller, Logger logger, FileSystem fileSystem, SystemClock systemClock, Usage usage, bool machine = false}) {
+    expect(stayResident, isTrue);
+    return FakeResidentRunner(
+      doResolveToError: doResolveToError,
+    );
+  }
+}
+
+class FakeResidentRunner extends Fake implements ResidentRunner {
+  FakeResidentRunner({
+    this.doResolveToError,
+  }) {
+    instance = this;
+  }
+
+  static FakeResidentRunner instance;
+
+  final bool doResolveToError;
+  final Completer<int> _exitCompleter = Completer<int>();
+  final List<String> callLog = <String>[];
+
+  @override
+  Uri get uri => Uri();
+
+  @override
+  Future<int> run({
+    Completer<DebugConnectionInfo> connectionInfoCompleter,
+    Completer<void> appStartedCompleter,
+    bool enableDevTools = false,
+    String route,
+  }) async {
+    callLog.add('run');
+
+    if (doResolveToError) {
+      return Future<int>.error('This is a test error');
+    }
+
+    appStartedCompleter.complete();
+    // Emulate stayResident by completing after exitApp is called.
+    return _exitCompleter.future;
+  }
+
+  @override
+  Future<void> exitApp() async {
+    callLog.add('exitApp');
+    _exitCompleter.complete();
+  }
+
+  @override
+  Future<void> cleanupAtFinish() async {
+    callLog.add('cleanupAtFinish');
+  }
+}
+
+WebDriverService setUpDriverService() {
+  final BufferLogger logger = BufferLogger.test();
+  return WebDriverService(
+    logger: logger,
+    processUtils: ProcessUtils(
+      logger: logger,
+      processManager: FakeProcessManager.any(),
+    ),
+    dartSdkPath: 'dart',
+  );
+}
+
+class FakeDevice extends Fake implements Device {
+  @override
+  final PlatformType platformType = PlatformType.web;
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;
 }


### PR DESCRIPTION
...as opposed to a non-resident resident runner. This way the runner doesn't try to quit the app before the test is done testing. I'm not sure how it even worked before, but at the very least we should now see the "Application finished" message _after_ the test, and not before it. Hopefully this will also provide more logging as we'll continue to be connected to the app during the test, which may shed some light on what's going on in https://github.com/flutter/flutter/issues/86375.
