### PR TITLE
Fixed a cast issue with host_mode_tests.dart.

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -245,7 +245,7 @@ Future<Map<String, dynamic>> captureReloadData(
 
   await Future.wait<void>(<Future<void>>[stdoutDone.future, stderrDone.future]);
   await process.exitCode;
-  final Map<String, Object> result = json.decode(benchmarkFile.readAsStringSync()) as Map<String, Object>;
+  final Map<String, dynamic> result = json.decode(benchmarkFile.readAsStringSync()) as Map<String, dynamic>;
   benchmarkFile.deleteSync();
   return result;
 }


### PR DESCRIPTION
This should fix a cast failure for some device lab tests:

```
Task result:
{
  "success": false,
  "reason": "Task failed: type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Object>' in type cast"
}
```
