### PR TITLE
Always write devicelab test results to a file if the resultsPath option is present

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -42,7 +42,7 @@ Future<void> runTasks(
     print(const JsonEncoder.withIndent('  ').convert(result));
     section('Finished task "$taskName"');
 
-    if (resultsPath != null && gitBranch != null) {
+    if (resultsPath != null) {
       final Cocoon cocoon = Cocoon();
       await cocoon.writeTaskResultToFile(
         builderName: luciBuilder,


### PR DESCRIPTION
Some runs of DeviceLab performance tests are run without a gitBranch option, but
still must save their results to a local file.  They stopped writing this file after #86325
was landed, which added a check that gitBranch was not null.
