### PR TITLE
Rerun devicelab task from test runner

### DIFF
--- a/dev/devicelab/README.md
+++ b/dev/devicelab/README.md
@@ -27,7 +27,9 @@ When a device in the lab is free, it will pickup tasks that need to be completed
 
 1. If the task succeeds, the test runner reports the success and uploads its performance metrics to Flutter's infrastructure. Not
 all tasks record performance metrics.
-2. If the task fails, the test runner reports the failure to Flutter's infrastructure and no performance metrics are collected
+2. If task fails, an auto rerun happens. Whenever the last run succeeds, the task will be reported as a success. For this case,
+a flake will be flagged and populated to the test result.
+3. If the task fails in all reruns, the test runner reports the failure to Flutter's infrastructure and no performance metrics are collected
 
 ## Running tests locally
 

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -114,7 +114,6 @@ Future<void> main(List<String> rawArgs) async {
       gitBranch: gitBranch,
       luciBuilder: luciBuilder,
       resultsPath: resultsPath,
-      print: print,
     );
   }
 }

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -114,6 +114,7 @@ Future<void> main(List<String> rawArgs) async {
       gitBranch: gitBranch,
       luciBuilder: luciBuilder,
       resultsPath: resultsPath,
+      print: print,
     );
   }
 }

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -47,6 +47,9 @@ class Cocoon {
   /// Url used to send results to.
   static const String baseCocoonApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
+  /// Threshold to auto retry a failed test.
+  static const int retry = 2;
+
   /// Underlying [FileSystem] to use.
   final FileSystem fs;
 

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -48,7 +48,7 @@ class Cocoon {
   static const String baseCocoonApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
   /// Threshold to auto retry a failed test.
-  static const int retry = 2;
+  static const int retryNumber = 2;
 
   /// Underlying [FileSystem] to use.
   final FileSystem fs;

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -38,7 +38,7 @@ Future<void> runTasks(
   String? resultsPath,
   List<String>? taskArgs,
   @visibleForTesting Map<String, String>? isolateParams,
-  @visibleForTesting Function(String)? print,
+  @visibleForTesting Function(String) print = print,
   @visibleForTesting List<String>? logs,
 }) async {
   for (final String taskName in taskNames) {
@@ -63,10 +63,10 @@ Future<void> runTasks(
         retry++;
       } else {
         if (retry > 0) {
-          print!('Total ${retry+1} executions: $retry failures and 1 success');
+          print('Total ${retry+1} executions: $retry failures and 1 success');
           print('flaky: true');
         } else {
-          print!('Total ${retry+1} executions: 1 success');
+          print('Total ${retry+1} executions: 1 success');
           print('flaky: false');
         }
         break;
@@ -74,7 +74,7 @@ Future<void> runTasks(
     }
 
     if (!result.succeeded) {
-      print!('Total $retry executions: 0 success');
+      print('Total $retry executions: 0 success');
       print('flaky: false');
       exitCode = 1;
       if (exitOnFirstTestFailure) {

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -30,7 +30,7 @@ Future<void> runTasks(
   for (final String taskName in taskNames) {
     TaskResult result;
     int retry = 0;
-    while (retry <= Cocoon.retry) {
+    while (retry <= Cocoon.retryNumber) {
       result = await rerunTask(
         taskName,
         deviceId: deviceId,

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -17,14 +17,14 @@ import 'task_result.dart';
 import 'utils.dart';
 
 /// Run a list of tasks.
-/// 
+///
 /// For each task, an auto rerun will be triggered when task fails.
-/// 
+///
 /// If the task succeeds the first time, it will be recorded as successful.
-/// 
+///
 /// If the task fails first, but gets passed in the end, the
 /// test will be recorded as successful but with a flake flag.
-/// 
+///
 /// If the task fails all reruns, it will be recorded as failed.
 Future<void> runTasks(
   List<String> taskNames, {
@@ -85,7 +85,7 @@ Future<void> runTasks(
 }
 
 /// A rerun wrapper for `runTask`.
-/// 
+///
 /// This separates reruns in separate sections.
 Future<TaskResult> rerunTask(
   String taskName, {

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -47,7 +47,9 @@ Future<void> runTasks(
         retry++;
       } else {
         if (retry > 0) {
-          print('Flaky: true');
+          section('Flaky status for "$taskName"');
+          print('Total ${retry+1} executions: $retry failures and 1 success');
+          print('flaky: true');
         }
         break;
       }

--- a/dev/devicelab/test/runner_test.dart
+++ b/dev/devicelab/test/runner_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:flutter_devicelab/framework/runner.dart';
+
+import 'common.dart';
+
+void main() {
+  final Map<String, String> isolateParams = <String, String>{
+    'runFlutterConfig': 'false',
+    'runProcessCleanup': 'false',
+    'timeoutInMinutes': '1',
+  };
+  List<String> printLog;
+  void print(String s) => printLog.add(s);
+
+  group('run.dart script', () {
+    test('Reruns - Test passes the first time.', () async {
+      printLog = <String>[];
+      await runTasks(
+        <String>['smoke_test_success'],
+        isolateParams: isolateParams,
+        print: print,
+        logs: printLog,
+      );
+      expect(printLog.length, 2);
+      expect(printLog[0], 'Total 1 executions: 1 success');
+      expect(printLog[1], 'flaky: false');
+    });
+
+    test('Reruns - Test fails all reruns.', () async {
+      printLog = <String>[];
+      await runTasks(
+        <String>['smoke_test_failure'],
+        isolateParams: isolateParams,
+        print: print,
+        logs: printLog,
+      );
+      expect(printLog.length, 2);
+      expect(printLog[0], 'Total 3 executions: 0 success');
+      expect(printLog[1], 'flaky: false');
+    });
+  });
+}


### PR DESCRIPTION
This is part of https://github.com/flutter/flutter/issues/86324: rerun task for up to 2 times if failed.

With https://flutter-review.googlesource.com/c/recipes/+/15363, recipe side takes care of flakiness from test runner retry. This way, we will not miss any flaky case.