### PR TITLE
add AnimatedSlide widget

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1687,14 +1687,6 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 /// up or down by the amount of it's height with each press of the corresponding button.
 ///
 /// ```dart
-/// class LogoSlide extends StatefulWidget {
-///   const LogoSlide({Key? key}) : super(key: key);
-///
-///   @override
-///   State<LogoSlide> createState() => LogoSlideState();
-/// }
-///
-/// class LogoSlideState extends State<LogoSlide> {
 ///  Offset offset = Offset(0, 0);
 ///
 ///  void _slideUp() {
@@ -1730,7 +1722,6 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///      ],
 ///    );
 ///  }
-/// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1681,7 +1681,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 /// example, an [Offset] with a `dx` of 0.25 will result in a horizontal
 /// translation of one quarter the width of the child.
 ///
-/// {@tool snippet}
+/// {@tool dartpad --template=stateful_widget_scaffold}
 ///
 /// This code defines a widget that uses [AnimatedSlide] to translate a [FlutterLogo]
 /// up or down by the amount of it's height with each press of the corresponding button.

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1687,14 +1687,14 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 /// up or down by the amount of it's height with each press of the corresponding button.
 ///
 /// ```dart
-///  Offset offset = Offset(0, 0);
+///  Offset offset = Offset.zero;
 ///
 ///  void _slideUp() {
-///    setState(() => offset -= Offset(0, 1));
+///    setState(() => offset -= const Offset(0, 1));
 ///  }
 ///
 ///  void _slideDown() {
-///    setState(() => offset += Offset(0, 1));
+///    setState(() => offset += const Offset(0, 1));
 ///  }
 ///
 ///  @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -36,7 +36,8 @@ class BoxConstraintsTween extends Tween<BoxConstraints> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as a tight constraint of zero size.
-  BoxConstraintsTween({ BoxConstraints? begin, BoxConstraints? end }) : super(begin: begin, end: end);
+  BoxConstraintsTween({BoxConstraints? begin, BoxConstraints? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -67,7 +68,8 @@ class DecorationTween extends Tween<Decoration> {
   /// result is always null. If [end] is not null, then its lerping logic is
   /// used (via [Decoration.lerpTo]). Otherwise, [begin]'s lerping logic is used
   /// (via [Decoration.lerpFrom]).
-  DecorationTween({ Decoration? begin, Decoration? end }) : super(begin: begin, end: end);
+  DecorationTween({Decoration? begin, Decoration? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -90,7 +92,8 @@ class EdgeInsetsTween extends Tween<EdgeInsets> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as an [EdgeInsets] with no inset.
-  EdgeInsetsTween({ EdgeInsets? begin, EdgeInsets? end }) : super(begin: begin, end: end);
+  EdgeInsetsTween({EdgeInsets? begin, EdgeInsets? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -112,7 +115,8 @@ class EdgeInsetsGeometryTween extends Tween<EdgeInsetsGeometry> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as an [EdgeInsetsGeometry] with no inset.
-  EdgeInsetsGeometryTween({ EdgeInsetsGeometry? begin, EdgeInsetsGeometry? end }) : super(begin: begin, end: end);
+  EdgeInsetsGeometryTween({EdgeInsetsGeometry? begin, EdgeInsetsGeometry? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -130,7 +134,8 @@ class BorderRadiusTween extends Tween<BorderRadius?> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as a right angle (no radius).
-  BorderRadiusTween({ BorderRadius? begin, BorderRadius? end }) : super(begin: begin, end: end);
+  BorderRadiusTween({BorderRadius? begin, BorderRadius? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -148,7 +153,7 @@ class BorderTween extends Tween<Border?> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as having no border.
-  BorderTween({ Border? begin, Border? end }) : super(begin: begin, end: end);
+  BorderTween({Border? begin, Border? end}) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -169,7 +174,7 @@ class Matrix4Tween extends Tween<Matrix4> {
   /// The [begin] and [end] properties must be non-null before the tween is
   /// first used, but the arguments can be null if the values are going to be
   /// filled in later.
-  Matrix4Tween({ Matrix4? begin, Matrix4? end }) : super(begin: begin, end: end);
+  Matrix4Tween({Matrix4? begin, Matrix4? end}) : super(begin: begin, end: end);
 
   @override
   Matrix4 lerp(double t) {
@@ -207,7 +212,8 @@ class TextStyleTween extends Tween<TextStyle> {
   /// The [begin] and [end] properties must be non-null before the tween is
   /// first used, but the arguments can be null if the values are going to be
   /// filled in later.
-  TextStyleTween({ TextStyle? begin, TextStyle? end }) : super(begin: begin, end: end);
+  TextStyleTween({TextStyle? begin, TextStyle? end})
+      : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -257,7 +263,7 @@ class TextStyleTween extends Tween<TextStyle> {
 ///    [DefaultTextStyle].
 ///  * [AnimatedScale], which is an implicitly animated version of [Transform.scale].
 ///  * [AnimatedRotation], which is an implicitly animated version of [Transform.rotate].
-///  * [AnimatedOffset], which is an implicitly animated version of [Transform.translate].
+///  * [AnimatedSlide], which implicitly animates the position of a widget relative to its normal position.
 ///  * [AnimatedOpacity], which is an implicitly animated version of [Opacity].
 ///  * [AnimatedPadding], which is an implicitly animated version of [Padding].
 ///  * [AnimatedPhysicalModel], which is an implicitly animated version of
@@ -281,9 +287,9 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
     this.curve = Curves.linear,
     required this.duration,
     this.onEnd,
-  }) : assert(curve != null),
-       assert(duration != null),
-       super(key: key);
+  })  : assert(curve != null),
+        assert(duration != null),
+        super(key: key);
 
   /// The curve to apply when animating the parameters of this container.
   final Curve curve;
@@ -298,12 +304,14 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
   final VoidCallback? onEnd;
 
   @override
-  ImplicitlyAnimatedWidgetState<ImplicitlyAnimatedWidget> createState(); // ignore: no_logic_in_create_state, https://github.com/dart-lang/linter/issues/2345
+  ImplicitlyAnimatedWidgetState<ImplicitlyAnimatedWidget>
+      createState(); // ignore: no_logic_in_create_state, https://github.com/dart-lang/linter/issues/2345
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(IntProperty('duration', duration.inMilliseconds, unit: 'ms'));
+    properties
+        .add(IntProperty('duration', duration.inMilliseconds, unit: 'ms'));
   }
 }
 
@@ -337,7 +345,8 @@ typedef TweenConstructor<T extends Object> = Tween<T> Function(T targetValue);
 /// of this visitor.
 ///
 /// The `<T>` parameter specifies the type of value that's being animated.
-typedef TweenVisitor<T extends Object> = Tween<T>? Function(Tween<T>? tween, T targetValue, TweenConstructor<T> constructor);
+typedef TweenVisitor<T extends Object> = Tween<T>? Function(
+    Tween<T>? tween, T targetValue, TweenConstructor<T> constructor);
 
 /// A base class for the `State` of widgets with implicit animations.
 ///
@@ -349,7 +358,8 @@ typedef TweenVisitor<T extends Object> = Tween<T>? Function(Tween<T>? tween, T t
 /// instances. Subclasses must implement the [forEachTween] method to allow
 /// [ImplicitlyAnimatedWidgetState] to iterate through the widget's fields and
 /// animate them.
-abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin<T> {
+abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
+    extends State<T> with SingleTickerProviderStateMixin<T> {
   /// The animation controller driving this widget's implicit animations.
   @protected
   AnimationController get controller => _controller;
@@ -389,7 +399,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
     }
     _controller.duration = widget.duration;
     if (_constructTweens()) {
-      forEachTween((Tween<dynamic>? tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
+      forEachTween((Tween<dynamic>? tween, dynamic targetValue,
+          TweenConstructor<dynamic> constructor) {
         _updateTween(tween, targetValue);
         return tween;
       });
@@ -416,8 +427,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   }
 
   void _updateTween(Tween<dynamic>? tween, dynamic targetValue) {
-    if (tween == null)
-      return;
+    if (tween == null) return;
     tween
       ..begin = tween.evaluate(_animation)
       ..end = targetValue;
@@ -425,7 +435,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 
   bool _constructTweens() {
     bool shouldStartAnimation = false;
-    forEachTween((Tween<dynamic>? tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
+    forEachTween((Tween<dynamic>? tween, dynamic targetValue,
+        TweenConstructor<dynamic> constructor) {
       if (targetValue != null) {
         tween ??= constructor(targetValue);
         if (_shouldAnimateTween(tween, targetValue))
@@ -535,7 +546,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   ///     an evaluation of the tween against the current [animation], and the
   ///     [Tween.end] value for each tween will be the target value.
   @protected
-  void didUpdateTweens() { }
+  void didUpdateTweens() {}
 }
 
 /// A base class for widgets with implicit animations that need to rebuild their
@@ -548,7 +559,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 /// Subclasses must implement the [forEachTween] method to allow
 /// [AnimatedWidgetBaseState] to iterate through the subclasses' widget's fields
 /// and animate them.
-abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends ImplicitlyAnimatedWidgetState<T> {
+abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget>
+    extends ImplicitlyAnimatedWidgetState<T> {
   @override
   void initState() {
     super.initState();
@@ -556,7 +568,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
   }
 
   void _handleAnimationChanged() {
-    setState(() { /* The animation ticked. Rebuild with new animation value */ });
+    setState(() {/* The animation ticked. Rebuild with new animation value */});
   }
 }
 
@@ -642,21 +654,22 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(margin == null || margin.isNonNegative),
-       assert(padding == null || padding.isNonNegative),
-       assert(decoration == null || decoration.debugAssertIsValid()),
-       assert(constraints == null || constraints.debugAssertIsValid()),
-       assert(color == null || decoration == null,
-         'Cannot provide both a color and a decoration\n'
-         'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".',
-       ),
-       decoration = decoration ?? (color != null ? BoxDecoration(color: color) : null),
-       constraints =
-        (width != null || height != null)
-          ? constraints?.tighten(width: width, height: height)
-            ?? BoxConstraints.tightFor(width: width, height: height)
-          : constraints,
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(margin == null || margin.isNonNegative),
+        assert(padding == null || padding.isNonNegative),
+        assert(decoration == null || decoration.debugAssertIsValid()),
+        assert(constraints == null || constraints.debugAssertIsValid()),
+        assert(
+          color == null || decoration == null,
+          'Cannot provide both a color and a decoration\n'
+          'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".',
+        ),
+        decoration =
+            decoration ?? (color != null ? BoxDecoration(color: color) : null),
+        constraints = (width != null || height != null)
+            ? constraints?.tighten(width: width, height: height) ??
+                BoxConstraints.tightFor(width: width, height: height)
+            : constraints,
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The [child] contained by the container.
   ///
@@ -735,24 +748,36 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   final Clip clipBehavior;
 
   @override
-  AnimatedWidgetBaseState<AnimatedContainer> createState() => _AnimatedContainerState();
+  AnimatedWidgetBaseState<AnimatedContainer> createState() =>
+      _AnimatedContainerState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, showName: false, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
-    properties.add(DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
-    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration, defaultValue: null));
-    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null, showName: false));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>(
+        'alignment', alignment,
+        showName: false, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
+        defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<BoxConstraints>(
+        'constraints', constraints,
+        defaultValue: null, showName: false));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin,
+        defaultValue: null));
     properties.add(ObjectFlagProperty<Matrix4>.has('transform', transform));
-    properties.add(DiagnosticsProperty<AlignmentGeometry>('transformAlignment', transformAlignment, defaultValue: null));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>(
+        'transformAlignment', transformAlignment,
+        defaultValue: null));
     properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior));
   }
 }
 
-class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer> {
+class _AnimatedContainerState
+    extends AnimatedWidgetBaseState<AnimatedContainer> {
   AlignmentGeometryTween? _alignment;
   EdgeInsetsGeometryTween? _padding;
   DecorationTween? _decoration;
@@ -764,14 +789,47 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
-    _padding = visitor(_padding, widget.padding, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
-    _decoration = visitor(_decoration, widget.decoration, (dynamic value) => DecorationTween(begin: value as Decoration)) as DecorationTween?;
-    _foregroundDecoration = visitor(_foregroundDecoration, widget.foregroundDecoration, (dynamic value) => DecorationTween(begin: value as Decoration)) as DecorationTween?;
-    _constraints = visitor(_constraints, widget.constraints, (dynamic value) => BoxConstraintsTween(begin: value as BoxConstraints)) as BoxConstraintsTween?;
-    _margin = visitor(_margin, widget.margin, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
-    _transform = visitor(_transform, widget.transform, (dynamic value) => Matrix4Tween(begin: value as Matrix4)) as Matrix4Tween?;
-    _transformAlignment = visitor(_transformAlignment, widget.transformAlignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
+    _alignment = visitor(
+            _alignment,
+            widget.alignment,
+            (dynamic value) =>
+                AlignmentGeometryTween(begin: value as AlignmentGeometry))
+        as AlignmentGeometryTween?;
+    _padding = visitor(
+            _padding,
+            widget.padding,
+            (dynamic value) =>
+                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
+        as EdgeInsetsGeometryTween?;
+    _decoration = visitor(_decoration, widget.decoration,
+            (dynamic value) => DecorationTween(begin: value as Decoration))
+        as DecorationTween?;
+    _foregroundDecoration = visitor(
+            _foregroundDecoration,
+            widget.foregroundDecoration,
+            (dynamic value) => DecorationTween(begin: value as Decoration))
+        as DecorationTween?;
+    _constraints = visitor(
+            _constraints,
+            widget.constraints,
+            (dynamic value) =>
+                BoxConstraintsTween(begin: value as BoxConstraints))
+        as BoxConstraintsTween?;
+    _margin = visitor(
+            _margin,
+            widget.margin,
+            (dynamic value) =>
+                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
+        as EdgeInsetsGeometryTween?;
+    _transform = visitor(_transform, widget.transform,
+            (dynamic value) => Matrix4Tween(begin: value as Matrix4))
+        as Matrix4Tween?;
+    _transformAlignment = visitor(
+            _transformAlignment,
+            widget.transformAlignment,
+            (dynamic value) =>
+                AlignmentGeometryTween(begin: value as AlignmentGeometry))
+        as AlignmentGeometryTween?;
   }
 
   @override
@@ -794,14 +852,28 @@ class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer>
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, showName: false, defaultValue: null));
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('padding', _padding, defaultValue: null));
-    description.add(DiagnosticsProperty<DecorationTween>('bg', _decoration, defaultValue: null));
-    description.add(DiagnosticsProperty<DecorationTween>('fg', _foregroundDecoration, defaultValue: null));
-    description.add(DiagnosticsProperty<BoxConstraintsTween>('constraints', _constraints, showName: false, defaultValue: null));
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('margin', _margin, defaultValue: null));
-    description.add(ObjectFlagProperty<Matrix4Tween>.has('transform', _transform));
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>('transformAlignment', _transformAlignment, defaultValue: null));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
+        'alignment', _alignment,
+        showName: false, defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
+        'padding', _padding,
+        defaultValue: null));
+    description.add(DiagnosticsProperty<DecorationTween>('bg', _decoration,
+        defaultValue: null));
+    description.add(DiagnosticsProperty<DecorationTween>(
+        'fg', _foregroundDecoration,
+        defaultValue: null));
+    description.add(DiagnosticsProperty<BoxConstraintsTween>(
+        'constraints', _constraints,
+        showName: false, defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
+        'margin', _margin,
+        defaultValue: null));
+    description
+        .add(ObjectFlagProperty<Matrix4Tween>.has('transform', _transform));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
+        'transformAlignment', _transformAlignment,
+        defaultValue: null));
   }
 }
 
@@ -873,9 +945,9 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(padding != null),
-       assert(padding.isNonNegative),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(padding != null),
+        assert(padding.isNonNegative),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The amount of space by which to inset the child.
   final EdgeInsetsGeometry padding;
@@ -886,7 +958,8 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
   final Widget? child;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPadding> createState() => _AnimatedPaddingState();
+  AnimatedWidgetBaseState<AnimatedPadding> createState() =>
+      _AnimatedPaddingState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -900,15 +973,20 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _padding = visitor(_padding, widget.padding, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
+    _padding = visitor(
+            _padding,
+            widget.padding,
+            (dynamic value) =>
+                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
+        as EdgeInsetsGeometryTween?;
   }
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: _padding!
-        .evaluate(animation)
-        .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
+          .evaluate(animation)
+          .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
       child: widget.child,
     );
   }
@@ -916,7 +994,9 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('padding', _padding, defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
+        'padding', _padding,
+        defaultValue: null));
   }
 }
 
@@ -974,7 +1054,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedPadding], which can animate the padding instead of the
 ///    alignment.
-///  * [AnimatedOffset], which can animate the translation of child by a given offset relative to its size.
+///  * [AnimatedSlide], which can animate the translation of child relative to its normal position by a given offset.
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
@@ -992,10 +1072,10 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(alignment != null),
-       assert(widthFactor == null || widthFactor >= 0.0),
-       assert(heightFactor == null || heightFactor >= 0.0),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(alignment != null),
+        assert(widthFactor == null || widthFactor >= 0.0),
+        assert(heightFactor == null || heightFactor >= 0.0),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// How to align the child.
   ///
@@ -1036,7 +1116,8 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
+    properties
+        .add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
   }
 }
 
@@ -1047,12 +1128,21 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
-    if(widget.heightFactor != null) {
-      _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _alignment = visitor(
+            _alignment,
+            widget.alignment,
+            (dynamic value) =>
+                AlignmentGeometryTween(begin: value as AlignmentGeometry))
+        as AlignmentGeometryTween?;
+    if (widget.heightFactor != null) {
+      _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor,
+              (dynamic value) => Tween<double>(begin: value as double))
+          as Tween<double>?;
     }
-    if(widget.widthFactor != null) {
-      _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    if (widget.widthFactor != null) {
+      _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor,
+              (dynamic value) => Tween<double>(begin: value as double))
+          as Tween<double>?;
     }
   }
 
@@ -1069,9 +1159,15 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, defaultValue: null));
-    description.add(DiagnosticsProperty<Tween<double>>('widthFactor', _widthFactorTween, defaultValue: null));
-    description.add(DiagnosticsProperty<Tween<double>>('heightFactor', _heightFactorTween, defaultValue: null));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
+        'alignment', _alignment,
+        defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>(
+        'widthFactor', _widthFactorTween,
+        defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>(
+        'heightFactor', _heightFactorTween,
+        defaultValue: null));
   }
 }
 
@@ -1168,9 +1264,9 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(left == null || right == null || width == null),
-       assert(top == null || bottom == null || height == null),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(left == null || right == null || width == null),
+        assert(top == null || bottom == null || height == null),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// Creates a widget that animates the rectangle it occupies implicitly.
   ///
@@ -1182,13 +1278,13 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : left = rect.left,
-       top = rect.top,
-       width = rect.width,
-       height = rect.height,
-       right = null,
-       bottom = null,
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : left = rect.left,
+        top = rect.top,
+        width = rect.width,
+        height = rect.height,
+        right = null,
+        bottom = null,
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1220,7 +1316,8 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPositioned> createState() => _AnimatedPositionedState();
+  AnimatedWidgetBaseState<AnimatedPositioned> createState() =>
+      _AnimatedPositionedState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1234,7 +1331,8 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedPositionedState extends AnimatedWidgetBaseState<AnimatedPositioned> {
+class _AnimatedPositionedState
+    extends AnimatedWidgetBaseState<AnimatedPositioned> {
   Tween<double>? _left;
   Tween<double>? _top;
   Tween<double>? _right;
@@ -1244,12 +1342,24 @@ class _AnimatedPositionedState extends AnimatedWidgetBaseState<AnimatedPositione
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _left = visitor(_left, widget.left, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _top = visitor(_top, widget.top, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _right = visitor(_right, widget.right, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _bottom = visitor(_bottom, widget.bottom, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _width = visitor(_width, widget.width, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _height = visitor(_height, widget.height, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _left = visitor(_left, widget.left,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _top = visitor(_top, widget.top,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _right = visitor(_right, widget.right,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _bottom = visitor(_bottom, widget.bottom,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _width = visitor(_width, widget.width,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _height = visitor(_height, widget.height,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -1321,9 +1431,9 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(start == null || end == null || width == null),
-       assert(top == null || bottom == null || height == null),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(start == null || end == null || width == null),
+        assert(top == null || bottom == null || height == null),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1355,7 +1465,8 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPositionedDirectional> createState() => _AnimatedPositionedDirectionalState();
+  AnimatedWidgetBaseState<AnimatedPositionedDirectional> createState() =>
+      _AnimatedPositionedDirectionalState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1369,7 +1480,8 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<AnimatedPositionedDirectional> {
+class _AnimatedPositionedDirectionalState
+    extends AnimatedWidgetBaseState<AnimatedPositionedDirectional> {
   Tween<double>? _start;
   Tween<double>? _top;
   Tween<double>? _end;
@@ -1379,12 +1491,24 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _start = visitor(_start, widget.start, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _top = visitor(_top, widget.top, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _end = visitor(_end, widget.end, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _bottom = visitor(_bottom, widget.bottom, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _width = visitor(_width, widget.width, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _height = visitor(_height, widget.height, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _start = visitor(_start, widget.start,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _top = visitor(_top, widget.top,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _end = visitor(_end, widget.end,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _bottom = visitor(_bottom, widget.bottom,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _width = visitor(_width, widget.width,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _height = visitor(_height, widget.height,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -1466,7 +1590,7 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///  * [AnimatedRotation], for animating the rotation of a child.
 ///  * [AnimatedSize], for animating the resize of a child based on changes
 ///    in layout.
-///  * [AnimatedOffset], for animating the translation of a child by given offset.
+///  * [AnimatedSlide], for animating the translation of a child by given offset relative to its normal position.
 ///  * [ScaleTransition], an explicitly animated version of this widget, where
 ///    an [Animation] is provided by the caller instead of being built in.
 class AnimatedScale extends ImplicitlyAnimatedWidget {
@@ -1483,8 +1607,8 @@ class AnimatedScale extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(scale != null),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(scale != null),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1509,14 +1633,17 @@ class AnimatedScale extends ImplicitlyAnimatedWidget {
   final FilterQuality? filterQuality;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedScale> createState() => _AnimatedScaleState();
+  ImplicitlyAnimatedWidgetState<AnimatedScale> createState() =>
+      _AnimatedScaleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('scale', scale));
-    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment, defaultValue: Alignment.center));
-    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality, defaultValue: null));
+    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment,
+        defaultValue: Alignment.center));
+    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality,
+        defaultValue: null));
   }
 }
 
@@ -1526,7 +1653,9 @@ class _AnimatedScaleState extends ImplicitlyAnimatedWidgetState<AnimatedScale> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _scale = visitor(_scale, widget.scale, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _scale = visitor(_scale, widget.scale,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -1611,7 +1740,7 @@ class AnimatedRotation extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(turns != null),
+  })  : assert(turns != null),
         super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
@@ -1638,24 +1767,30 @@ class AnimatedRotation extends ImplicitlyAnimatedWidget {
   final FilterQuality? filterQuality;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedRotation> createState() => _AnimatedRotationState();
+  ImplicitlyAnimatedWidgetState<AnimatedRotation> createState() =>
+      _AnimatedRotationState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('turns', turns));
-    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment, defaultValue: Alignment.center));
-    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality, defaultValue: null));
+    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment,
+        defaultValue: Alignment.center));
+    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality,
+        defaultValue: null));
   }
 }
 
-class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotation> {
+class _AnimatedRotationState
+    extends ImplicitlyAnimatedWidgetState<AnimatedRotation> {
   Tween<double>? _turns;
   late Animation<double> _turnsAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _turns = visitor(_turns, widget.turns, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _turns = visitor(_turns, widget.turns,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -1674,7 +1809,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
   }
 }
 
-/// Animated version of [Transform.translate] which automatically transitions the child's
+/// Widget which automatically transitions the child's
 /// offset relative to its normal position whenever the given offset changes.
 ///
 /// The translation is expressed as an [Offset] scaled to the child's size. For
@@ -1683,25 +1818,25 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///
 /// {@tool snippet}
 ///
-/// This code defines a widget that uses [AnimatedOffset] to translate a [FlutterLogo]
+/// This code defines a widget that uses [AnimatedSlide] to translate a [FlutterLogo]
 /// up or down by the amount of it's height with each press of the corresponding button.
 ///
 /// ```dart
-/// class LogoTranslate extends StatefulWidget {
-///   const LogoTranslate({Key? key}) : super(key: key);
+/// class LogoSlide extends StatefulWidget {
+///   const LogoSlide({Key? key}) : super(key: key);
 ///
 ///   @override
-///   State<LogoTranslate> createState() => LogoTranslateState();
+///   State<LogoSlide> createState() => LogoSlideState();
 /// }
 ///
-/// class LogoTranslateState extends State<LogoTranslate> {
+/// class LogoSlideState extends State<LogoSlide> {
 ///  Offset offset = Offset(0, 0);
 ///
-///  void _moveUp() {
+///  void _slideUp() {
 ///    setState(() => offset -= Offset(0, 1));
 ///  }
-/// 
-///  void _moveDown() {
+///
+///  void _slideDown() {
 ///    setState(() => offset += Offset(0, 1));
 ///  }
 ///
@@ -1711,16 +1846,16 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///      mainAxisSize: MainAxisSize.min,
 ///      children: <Widget>[
 ///        ElevatedButton(
-///          child: const Text('Translate up'),
-///          onPressed: _moveUp,
+///          child: const Text('Slide up'),
+///          onPressed: _slideUp,
 ///        ),
 ///        ElevatedButton(
-///          child: const Text('Translate down'),
-///          onPressed: _moveDown,
+///          child: const Text('Slide down'),
+///          onPressed: _slideDown,
 ///        ),
 ///        Padding(
 ///          padding: const EdgeInsets.all(50),
-///          child: AnimatedOffset(
+///          child: AnimatedSlide(
 ///            offset: offset,
 ///            duration: const Duration(milliseconds: 500),
 ///            curve: Curves.easeInOut,
@@ -1741,47 +1876,49 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
 ///    position over a given duration whenever the given [alignment] changes.
-class AnimatedOffset extends ImplicitlyAnimatedWidget {
+class AnimatedSlide extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its offset translation implicitly.
   ///
   /// The [offset] and [duration] arguments must not be null.
-  const AnimatedOffset({
+  const AnimatedSlide({
     Key? key,
     this.child,
     required this.offset,
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) :
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
-  /// The target offset. 
+  /// The target offset.
   /// The child will be translated horizontally by `width * dx` and vertically by `height * dy`
   ///
   /// The offset must not be null.
   final Offset offset;
 
   @override
-  _AnimatedOffsetState createState() => _AnimatedOffsetState();
+  _AnimatedSlideState createState() => _AnimatedSlideState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DoubleProperty('offset', offset));
   }
 }
 
-class _AnimatedOffsetState extends ImplicitlyAnimatedWidgetState<AnimatedOffset> {
+class _AnimatedSlideState extends ImplicitlyAnimatedWidgetState<AnimatedSlide> {
   Tween<Offset>? _offset;
   late Animation<Offset> _offsetAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _offset = visitor(_offset, widget.offset, (dynamic value) => Tween<Offset>(begin: value as Offset)) as Tween<Offset>?;
+    _offset = visitor(_offset, widget.offset,
+            (dynamic value) => Tween<Offset>(begin: value as Offset))
+        as Tween<Offset>?;
   }
 
   @override
@@ -1869,8 +2006,8 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
     required Duration duration,
     VoidCallback? onEnd,
     this.alwaysIncludeSemantics = false,
-  }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1896,7 +2033,8 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedOpacity> createState() => _AnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<AnimatedOpacity> createState() =>
+      _AnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1905,13 +2043,16 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacity> {
+class _AnimatedOpacityState
+    extends ImplicitlyAnimatedWidgetState<AnimatedOpacity> {
   Tween<double>? _opacity;
   late Animation<double> _opacityAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _opacity = visitor(_opacity, widget.opacity, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _opacity = visitor(_opacity, widget.opacity,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -2005,8 +2146,8 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
     required Duration duration,
     VoidCallback? onEnd,
     this.alwaysIncludeSemantics = false,
-  }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-      super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The sliver below this widget in the tree.
   final Widget? sliver;
@@ -2030,7 +2171,8 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> createState() => _SliverAnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> createState() =>
+      _SliverAnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -2039,13 +2181,16 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _SliverAnimatedOpacityState extends ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> {
+class _SliverAnimatedOpacityState
+    extends ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> {
   Tween<double>? _opacity;
   late Animation<double> _opacityAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _opacity = visitor(_opacity, widget.opacity, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _opacity = visitor(_opacity, widget.opacity,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
   }
 
   @override
@@ -2101,13 +2246,13 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(style != null),
-       assert(child != null),
-       assert(softWrap != null),
-       assert(overflow != null),
-       assert(maxLines == null || maxLines > 0),
-       assert(textWidthBasis != null),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(style != null),
+        assert(child != null),
+        assert(softWrap != null),
+        assert(overflow != null),
+        assert(maxLines == null || maxLines > 0),
+        assert(textWidthBasis != null),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -2154,27 +2299,41 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
   final ui.TextHeightBehavior? textHeightBehavior;
 
   @override
-  AnimatedWidgetBaseState<AnimatedDefaultTextStyle> createState() => _AnimatedDefaultTextStyleState();
+  AnimatedWidgetBaseState<AnimatedDefaultTextStyle> createState() =>
+      _AnimatedDefaultTextStyleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     style.debugFillProperties(properties);
-    properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
-    properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
-    properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
+    properties.add(
+        EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
+    properties.add(FlagProperty('softWrap',
+        value: softWrap,
+        ifTrue: 'wrapping at box width',
+        ifFalse: 'no wrapping except at line break characters',
+        showName: true));
+    properties.add(
+        EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
-    properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));
-    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));
+    properties.add(EnumProperty<TextWidthBasis>(
+        'textWidthBasis', textWidthBasis,
+        defaultValue: TextWidthBasis.parent));
+    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>(
+        'textHeightBehavior', textHeightBehavior,
+        defaultValue: null));
   }
 }
 
-class _AnimatedDefaultTextStyleState extends AnimatedWidgetBaseState<AnimatedDefaultTextStyle> {
+class _AnimatedDefaultTextStyleState
+    extends AnimatedWidgetBaseState<AnimatedDefaultTextStyle> {
   TextStyleTween? _style;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _style = visitor(_style, widget.style, (dynamic value) => TextStyleTween(begin: value as TextStyle)) as TextStyleTween?;
+    _style = visitor(_style, widget.style,
+            (dynamic value) => TextStyleTween(begin: value as TextStyle))
+        as TextStyleTween?;
   }
 
   @override
@@ -2230,16 +2389,16 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : assert(child != null),
-       assert(shape != null),
-       assert(clipBehavior != null),
-       assert(borderRadius != null),
-       assert(elevation != null && elevation >= 0.0),
-       assert(color != null),
-       assert(shadowColor != null),
-       assert(animateColor != null),
-       assert(animateShadowColor != null),
-       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  })  : assert(child != null),
+        assert(shape != null),
+        assert(clipBehavior != null),
+        assert(borderRadius != null),
+        assert(elevation != null && elevation >= 0.0),
+        assert(color != null),
+        assert(shadowColor != null),
+        assert(animateColor != null),
+        assert(animateShadowColor != null),
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -2278,22 +2437,26 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
   final bool animateShadowColor;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPhysicalModel> createState() => _AnimatedPhysicalModelState();
+  AnimatedWidgetBaseState<AnimatedPhysicalModel> createState() =>
+      _AnimatedPhysicalModelState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(EnumProperty<BoxShape>('shape', shape));
-    properties.add(DiagnosticsProperty<BorderRadius>('borderRadius', borderRadius));
+    properties
+        .add(DiagnosticsProperty<BorderRadius>('borderRadius', borderRadius));
     properties.add(DoubleProperty('elevation', elevation));
     properties.add(ColorProperty('color', color));
     properties.add(DiagnosticsProperty<bool>('animateColor', animateColor));
     properties.add(ColorProperty('shadowColor', shadowColor));
-    properties.add(DiagnosticsProperty<bool>('animateShadowColor', animateShadowColor));
+    properties.add(
+        DiagnosticsProperty<bool>('animateShadowColor', animateShadowColor));
   }
 }
 
-class _AnimatedPhysicalModelState extends AnimatedWidgetBaseState<AnimatedPhysicalModel> {
+class _AnimatedPhysicalModelState
+    extends AnimatedWidgetBaseState<AnimatedPhysicalModel> {
   BorderRadiusTween? _borderRadius;
   Tween<double>? _elevation;
   ColorTween? _color;
@@ -2301,10 +2464,16 @@ class _AnimatedPhysicalModelState extends AnimatedWidgetBaseState<AnimatedPhysic
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _borderRadius = visitor(_borderRadius, widget.borderRadius, (dynamic value) => BorderRadiusTween(begin: value as BorderRadius)) as BorderRadiusTween?;
-    _elevation = visitor(_elevation, widget.elevation, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
-    _color = visitor(_color, widget.color, (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
-    _shadowColor = visitor(_shadowColor, widget.shadowColor, (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
+    _borderRadius = visitor(_borderRadius, widget.borderRadius,
+            (dynamic value) => BorderRadiusTween(begin: value as BorderRadius))
+        as BorderRadiusTween?;
+    _elevation = visitor(_elevation, widget.elevation,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _color = visitor(_color, widget.color,
+        (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
+    _shadowColor = visitor(_shadowColor, widget.shadowColor,
+        (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -257,7 +257,7 @@ class TextStyleTween extends Tween<TextStyle> {
 ///    [DefaultTextStyle].
 ///  * [AnimatedScale], which is an implicitly animated version of [Transform.scale].
 ///  * [AnimatedRotation], which is an implicitly animated version of [Transform.rotate].
-///  * [AnimatedOffset], which is an implicitly animated version of [Transform.translate].
+///  * [AnimatedSlide], which implicitly animates the position of a widget relative to its normal position.
 ///  * [AnimatedOpacity], which is an implicitly animated version of [Opacity].
 ///  * [AnimatedPadding], which is an implicitly animated version of [Padding].
 ///  * [AnimatedPhysicalModel], which is an implicitly animated version of
@@ -974,7 +974,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedPadding], which can animate the padding instead of the
 ///    alignment.
-///  * [AnimatedOffset], which can animate the translation of child by a given offset relative to its size.
+///  * [AnimatedSlide], which can animate the translation of child by a given offset relative to its size.
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
@@ -1466,7 +1466,7 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///  * [AnimatedRotation], for animating the rotation of a child.
 ///  * [AnimatedSize], for animating the resize of a child based on changes
 ///    in layout.
-///  * [AnimatedOffset], for animating the translation of a child by given offset.
+///  * [AnimatedSlide], for animating the translation of a child by a given offset relative to its size.
 ///  * [ScaleTransition], an explicitly animated version of this widget, where
 ///    an [Animation] is provided by the caller instead of being built in.
 class AnimatedScale extends ImplicitlyAnimatedWidget {
@@ -1674,7 +1674,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
   }
 }
 
-/// Animated version of [Transform.translate] which automatically transitions the child's
+/// Widget which automatically transitions the child's
 /// offset relative to its normal position whenever the given offset changes.
 ///
 /// The translation is expressed as an [Offset] scaled to the child's size. For
@@ -1683,25 +1683,25 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///
 /// {@tool snippet}
 ///
-/// This code defines a widget that uses [AnimatedOffset] to translate a [FlutterLogo]
+/// This code defines a widget that uses [AnimatedSlide] to translate a [FlutterLogo]
 /// up or down by the amount of it's height with each press of the corresponding button.
 ///
 /// ```dart
-/// class LogoTranslate extends StatefulWidget {
-///   const LogoTranslate({Key? key}) : super(key: key);
+/// class LogoSlide extends StatefulWidget {
+///   const LogoSlide({Key? key}) : super(key: key);
 ///
 ///   @override
-///   State<LogoTranslate> createState() => LogoTranslateState();
+///   State<LogoSlide> createState() => LogoSlideState();
 /// }
 ///
-/// class LogoTranslateState extends State<LogoTranslate> {
+/// class LogoSlideState extends State<LogoSlide> {
 ///  Offset offset = Offset(0, 0);
 ///
-///  void _moveUp() {
+///  void _slideUp() {
 ///    setState(() => offset -= Offset(0, 1));
 ///  }
 /// 
-///  void _moveDown() {
+///  void _slideDown() {
 ///    setState(() => offset += Offset(0, 1));
 ///  }
 ///
@@ -1711,16 +1711,16 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///      mainAxisSize: MainAxisSize.min,
 ///      children: <Widget>[
 ///        ElevatedButton(
-///          child: const Text('Translate up'),
-///          onPressed: _moveUp,
+///          child: const Text('Slide up'),
+///          onPressed: _slideUp,
 ///        ),
 ///        ElevatedButton(
-///          child: const Text('Translate down'),
-///          onPressed: _moveDown,
+///          child: const Text('Slide down'),
+///          onPressed: _slideDown,
 ///        ),
 ///        Padding(
 ///          padding: const EdgeInsets.all(50),
-///          child: AnimatedOffset(
+///          child: AnimatedSlide(
 ///            offset: offset,
 ///            duration: const Duration(milliseconds: 500),
 ///            curve: Curves.easeInOut,
@@ -1741,11 +1741,11 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
 ///    position over a given duration whenever the given [alignment] changes.
-class AnimatedOffset extends ImplicitlyAnimatedWidget {
+class AnimatedSlide extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its offset translation implicitly.
   ///
   /// The [offset] and [duration] arguments must not be null.
-  const AnimatedOffset({
+  const AnimatedSlide({
     Key? key,
     this.child,
     required this.offset,
@@ -1767,15 +1767,16 @@ class AnimatedOffset extends ImplicitlyAnimatedWidget {
   final Offset offset;
 
   @override
-  _AnimatedOffsetState createState() => _AnimatedOffsetState();
+  _AnimatedSlideState createState() => _AnimatedSlideState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(DoubleProperty('offset', offset));
   }
 }
 
-class _AnimatedOffsetState extends ImplicitlyAnimatedWidgetState<AnimatedOffset> {
+class _AnimatedSlideState extends ImplicitlyAnimatedWidgetState<AnimatedSlide> {
   Tween<Offset>? _offset;
   late Animation<Offset> _offsetAnimation;
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1731,7 +1731,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
-///    position over a given duration whenever the given [alignment] changes.
+///    position over a given duration whenever the given alignment changes.
 class AnimatedSlide extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its offset translation implicitly.
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1752,8 +1752,7 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) :
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -257,7 +257,7 @@ class TextStyleTween extends Tween<TextStyle> {
 ///    [DefaultTextStyle].
 ///  * [AnimatedScale], which is an implicitly animated version of [Transform.scale].
 ///  * [AnimatedRotation], which is an implicitly animated version of [Transform.rotate].
-///  * [AnimatedSlide], which implicitly animates the position of a widget relative to its normal position.
+///  * [AnimatedOffset], which is an implicitly animated version of [Transform.translate].
 ///  * [AnimatedOpacity], which is an implicitly animated version of [Opacity].
 ///  * [AnimatedPadding], which is an implicitly animated version of [Padding].
 ///  * [AnimatedPhysicalModel], which is an implicitly animated version of
@@ -974,7 +974,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedPadding], which can animate the padding instead of the
 ///    alignment.
-///  * [AnimatedSlide], which can animate the translation of child by a given offset relative to its size.
+///  * [AnimatedOffset], which can animate the translation of child by a given offset relative to its size.
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
@@ -1466,7 +1466,7 @@ class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<Animat
 ///  * [AnimatedRotation], for animating the rotation of a child.
 ///  * [AnimatedSize], for animating the resize of a child based on changes
 ///    in layout.
-///  * [AnimatedSlide], for animating the translation of a child by a given offset relative to its size.
+///  * [AnimatedOffset], for animating the translation of a child by given offset.
 ///  * [ScaleTransition], an explicitly animated version of this widget, where
 ///    an [Animation] is provided by the caller instead of being built in.
 class AnimatedScale extends ImplicitlyAnimatedWidget {
@@ -1674,7 +1674,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
   }
 }
 
-/// Widget which automatically transitions the child's
+/// Animated version of [Transform.translate] which automatically transitions the child's
 /// offset relative to its normal position whenever the given offset changes.
 ///
 /// The translation is expressed as an [Offset] scaled to the child's size. For
@@ -1683,25 +1683,25 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///
 /// {@tool snippet}
 ///
-/// This code defines a widget that uses [AnimatedSlide] to translate a [FlutterLogo]
+/// This code defines a widget that uses [AnimatedOffset] to translate a [FlutterLogo]
 /// up or down by the amount of it's height with each press of the corresponding button.
 ///
 /// ```dart
-/// class LogoSlide extends StatefulWidget {
-///   const LogoSlide({Key? key}) : super(key: key);
+/// class LogoTranslate extends StatefulWidget {
+///   const LogoTranslate({Key? key}) : super(key: key);
 ///
 ///   @override
-///   State<LogoSlide> createState() => LogoSlideState();
+///   State<LogoTranslate> createState() => LogoTranslateState();
 /// }
 ///
-/// class LogoSlideState extends State<LogoSlide> {
+/// class LogoTranslateState extends State<LogoTranslate> {
 ///  Offset offset = Offset(0, 0);
 ///
-///  void _slideUp() {
+///  void _moveUp() {
 ///    setState(() => offset -= Offset(0, 1));
 ///  }
 /// 
-///  void _slideDown() {
+///  void _moveDown() {
 ///    setState(() => offset += Offset(0, 1));
 ///  }
 ///
@@ -1711,16 +1711,16 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///      mainAxisSize: MainAxisSize.min,
 ///      children: <Widget>[
 ///        ElevatedButton(
-///          child: const Text('Slide up'),
-///          onPressed: _slideUp,
+///          child: const Text('Translate up'),
+///          onPressed: _moveUp,
 ///        ),
 ///        ElevatedButton(
-///          child: const Text('Slide down'),
-///          onPressed: _slideDown,
+///          child: const Text('Translate down'),
+///          onPressed: _moveDown,
 ///        ),
 ///        Padding(
 ///          padding: const EdgeInsets.all(50),
-///          child: AnimatedSlide(
+///          child: AnimatedOffset(
 ///            offset: offset,
 ///            duration: const Duration(milliseconds: 500),
 ///            curve: Curves.easeInOut,
@@ -1741,11 +1741,11 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
 ///    position over a given duration whenever the given [alignment] changes.
-class AnimatedSlide extends ImplicitlyAnimatedWidget {
+class AnimatedOffset extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its offset translation implicitly.
   ///
   /// The [offset] and [duration] arguments must not be null.
-  const AnimatedSlide({
+  const AnimatedOffset({
     Key? key,
     this.child,
     required this.offset,
@@ -1767,16 +1767,15 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
   final Offset offset;
 
   @override
-  _AnimatedSlideState createState() => _AnimatedSlideState();
+  _AnimatedOffsetState createState() => _AnimatedOffsetState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DoubleProperty('offset', offset));
   }
 }
 
-class _AnimatedSlideState extends ImplicitlyAnimatedWidgetState<AnimatedSlide> {
+class _AnimatedOffsetState extends ImplicitlyAnimatedWidgetState<AnimatedOffset> {
   Tween<Offset>? _offset;
   late Animation<Offset> _offsetAnimation;
 

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -617,7 +617,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> exten
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
-///    position over a given duration whenever the given [alignment] changes.
+///    position over a given duration whenever the given [AnimatedAlign.alignment] changes.
 ///  * [AnimatedSwitcher], which switches out a child for a new one with a customizable transition.
 ///  * [AnimatedCrossFade], which fades between two children and interpolates their sizes.
 class AnimatedContainer extends ImplicitlyAnimatedWidget {
@@ -1731,7 +1731,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
 ///  * [AnimatedAlign], which automatically transitions its child's
-///    position over a given duration whenever the given alignment changes.
+///    position over a given duration whenever the given [AnimatedAlign.alignment] changes.
 class AnimatedSlide extends ImplicitlyAnimatedWidget {
   /// Creates a widget that animates its offset translation implicitly.
   ///

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1700,7 +1700,7 @@ class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotat
 ///  void _slideUp() {
 ///    setState(() => offset -= Offset(0, 1));
 ///  }
-/// 
+///
 ///  void _slideDown() {
 ///    setState(() => offset += Offset(0, 1));
 ///  }
@@ -1760,7 +1760,7 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
-  /// The target offset. 
+  /// The target offset.
   /// The child will be translated horizontally by `width * dx` and vertically by `height * dy`
   ///
   /// The offset must not be null.

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1766,7 +1766,7 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
   final Offset offset;
 
   @override
-  _AnimatedSlideState createState() => _AnimatedSlideState();
+  ImplicitlyAnimatedWidgetState<AnimatedSlide> createState() => _AnimatedSlideState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -974,7 +974,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedPadding], which can animate the padding instead of the
 ///    alignment.
-///  * [AnimatedOffset], which can animate the translation of child by a given offset.
+///  * [AnimatedOffset], which can animate the translation of child by a given offset relative to its size.
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -36,8 +36,7 @@ class BoxConstraintsTween extends Tween<BoxConstraints> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as a tight constraint of zero size.
-  BoxConstraintsTween({BoxConstraints? begin, BoxConstraints? end})
-      : super(begin: begin, end: end);
+  BoxConstraintsTween({ BoxConstraints? begin, BoxConstraints? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -68,8 +67,7 @@ class DecorationTween extends Tween<Decoration> {
   /// result is always null. If [end] is not null, then its lerping logic is
   /// used (via [Decoration.lerpTo]). Otherwise, [begin]'s lerping logic is used
   /// (via [Decoration.lerpFrom]).
-  DecorationTween({Decoration? begin, Decoration? end})
-      : super(begin: begin, end: end);
+  DecorationTween({ Decoration? begin, Decoration? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -92,8 +90,7 @@ class EdgeInsetsTween extends Tween<EdgeInsets> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as an [EdgeInsets] with no inset.
-  EdgeInsetsTween({EdgeInsets? begin, EdgeInsets? end})
-      : super(begin: begin, end: end);
+  EdgeInsetsTween({ EdgeInsets? begin, EdgeInsets? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -115,8 +112,7 @@ class EdgeInsetsGeometryTween extends Tween<EdgeInsetsGeometry> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as an [EdgeInsetsGeometry] with no inset.
-  EdgeInsetsGeometryTween({EdgeInsetsGeometry? begin, EdgeInsetsGeometry? end})
-      : super(begin: begin, end: end);
+  EdgeInsetsGeometryTween({ EdgeInsetsGeometry? begin, EdgeInsetsGeometry? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -134,8 +130,7 @@ class BorderRadiusTween extends Tween<BorderRadius?> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as a right angle (no radius).
-  BorderRadiusTween({BorderRadius? begin, BorderRadius? end})
-      : super(begin: begin, end: end);
+  BorderRadiusTween({ BorderRadius? begin, BorderRadius? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -153,7 +148,7 @@ class BorderTween extends Tween<Border?> {
   ///
   /// The [begin] and [end] properties may be null; the null value
   /// is treated as having no border.
-  BorderTween({Border? begin, Border? end}) : super(begin: begin, end: end);
+  BorderTween({ Border? begin, Border? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -174,7 +169,7 @@ class Matrix4Tween extends Tween<Matrix4> {
   /// The [begin] and [end] properties must be non-null before the tween is
   /// first used, but the arguments can be null if the values are going to be
   /// filled in later.
-  Matrix4Tween({Matrix4? begin, Matrix4? end}) : super(begin: begin, end: end);
+  Matrix4Tween({ Matrix4? begin, Matrix4? end }) : super(begin: begin, end: end);
 
   @override
   Matrix4 lerp(double t) {
@@ -212,8 +207,7 @@ class TextStyleTween extends Tween<TextStyle> {
   /// The [begin] and [end] properties must be non-null before the tween is
   /// first used, but the arguments can be null if the values are going to be
   /// filled in later.
-  TextStyleTween({TextStyle? begin, TextStyle? end})
-      : super(begin: begin, end: end);
+  TextStyleTween({ TextStyle? begin, TextStyle? end }) : super(begin: begin, end: end);
 
   /// Returns the value this variable has at the given animation clock value.
   @override
@@ -287,9 +281,9 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
     this.curve = Curves.linear,
     required this.duration,
     this.onEnd,
-  })  : assert(curve != null),
-        assert(duration != null),
-        super(key: key);
+  }) : assert(curve != null),
+       assert(duration != null),
+       super(key: key);
 
   /// The curve to apply when animating the parameters of this container.
   final Curve curve;
@@ -304,14 +298,12 @@ abstract class ImplicitlyAnimatedWidget extends StatefulWidget {
   final VoidCallback? onEnd;
 
   @override
-  ImplicitlyAnimatedWidgetState<ImplicitlyAnimatedWidget>
-      createState(); // ignore: no_logic_in_create_state, https://github.com/dart-lang/linter/issues/2345
+  ImplicitlyAnimatedWidgetState<ImplicitlyAnimatedWidget> createState(); // ignore: no_logic_in_create_state, https://github.com/dart-lang/linter/issues/2345
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(IntProperty('duration', duration.inMilliseconds, unit: 'ms'));
+    properties.add(IntProperty('duration', duration.inMilliseconds, unit: 'ms'));
   }
 }
 
@@ -345,8 +337,7 @@ typedef TweenConstructor<T extends Object> = Tween<T> Function(T targetValue);
 /// of this visitor.
 ///
 /// The `<T>` parameter specifies the type of value that's being animated.
-typedef TweenVisitor<T extends Object> = Tween<T>? Function(
-    Tween<T>? tween, T targetValue, TweenConstructor<T> constructor);
+typedef TweenVisitor<T extends Object> = Tween<T>? Function(Tween<T>? tween, T targetValue, TweenConstructor<T> constructor);
 
 /// A base class for the `State` of widgets with implicit animations.
 ///
@@ -358,8 +349,7 @@ typedef TweenVisitor<T extends Object> = Tween<T>? Function(
 /// instances. Subclasses must implement the [forEachTween] method to allow
 /// [ImplicitlyAnimatedWidgetState] to iterate through the widget's fields and
 /// animate them.
-abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
-    extends State<T> with SingleTickerProviderStateMixin<T> {
+abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget> extends State<T> with SingleTickerProviderStateMixin<T> {
   /// The animation controller driving this widget's implicit animations.
   @protected
   AnimationController get controller => _controller;
@@ -399,8 +389,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
     }
     _controller.duration = widget.duration;
     if (_constructTweens()) {
-      forEachTween((Tween<dynamic>? tween, dynamic targetValue,
-          TweenConstructor<dynamic> constructor) {
+      forEachTween((Tween<dynamic>? tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
         _updateTween(tween, targetValue);
         return tween;
       });
@@ -427,7 +416,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   }
 
   void _updateTween(Tween<dynamic>? tween, dynamic targetValue) {
-    if (tween == null) return;
+    if (tween == null)
+      return;
     tween
       ..begin = tween.evaluate(_animation)
       ..end = targetValue;
@@ -435,8 +425,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 
   bool _constructTweens() {
     bool shouldStartAnimation = false;
-    forEachTween((Tween<dynamic>? tween, dynamic targetValue,
-        TweenConstructor<dynamic> constructor) {
+    forEachTween((Tween<dynamic>? tween, dynamic targetValue, TweenConstructor<dynamic> constructor) {
       if (targetValue != null) {
         tween ??= constructor(targetValue);
         if (_shouldAnimateTween(tween, targetValue))
@@ -546,7 +535,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
   ///     an evaluation of the tween against the current [animation], and the
   ///     [Tween.end] value for each tween will be the target value.
   @protected
-  void didUpdateTweens() {}
+  void didUpdateTweens() { }
 }
 
 /// A base class for widgets with implicit animations that need to rebuild their
@@ -559,8 +548,7 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
 /// Subclasses must implement the [forEachTween] method to allow
 /// [AnimatedWidgetBaseState] to iterate through the subclasses' widget's fields
 /// and animate them.
-abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget>
-    extends ImplicitlyAnimatedWidgetState<T> {
+abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget> extends ImplicitlyAnimatedWidgetState<T> {
   @override
   void initState() {
     super.initState();
@@ -568,7 +556,7 @@ abstract class AnimatedWidgetBaseState<T extends ImplicitlyAnimatedWidget>
   }
 
   void _handleAnimationChanged() {
-    setState(() {/* The animation ticked. Rebuild with new animation value */});
+    setState(() { /* The animation ticked. Rebuild with new animation value */ });
   }
 }
 
@@ -654,22 +642,21 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(margin == null || margin.isNonNegative),
-        assert(padding == null || padding.isNonNegative),
-        assert(decoration == null || decoration.debugAssertIsValid()),
-        assert(constraints == null || constraints.debugAssertIsValid()),
-        assert(
-          color == null || decoration == null,
-          'Cannot provide both a color and a decoration\n'
-          'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".',
-        ),
-        decoration =
-            decoration ?? (color != null ? BoxDecoration(color: color) : null),
-        constraints = (width != null || height != null)
-            ? constraints?.tighten(width: width, height: height) ??
-                BoxConstraints.tightFor(width: width, height: height)
-            : constraints,
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(margin == null || margin.isNonNegative),
+       assert(padding == null || padding.isNonNegative),
+       assert(decoration == null || decoration.debugAssertIsValid()),
+       assert(constraints == null || constraints.debugAssertIsValid()),
+       assert(color == null || decoration == null,
+         'Cannot provide both a color and a decoration\n'
+         'The color argument is just a shorthand for "decoration: BoxDecoration(color: color)".',
+       ),
+       decoration = decoration ?? (color != null ? BoxDecoration(color: color) : null),
+       constraints =
+        (width != null || height != null)
+          ? constraints?.tighten(width: width, height: height)
+            ?? BoxConstraints.tightFor(width: width, height: height)
+          : constraints,
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The [child] contained by the container.
   ///
@@ -748,36 +735,24 @@ class AnimatedContainer extends ImplicitlyAnimatedWidget {
   final Clip clipBehavior;
 
   @override
-  AnimatedWidgetBaseState<AnimatedContainer> createState() =>
-      _AnimatedContainerState();
+  AnimatedWidgetBaseState<AnimatedContainer> createState() => _AnimatedContainerState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<AlignmentGeometry>(
-        'alignment', alignment,
-        showName: false, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
-        defaultValue: null));
-    properties.add(
-        DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
-    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty<BoxConstraints>(
-        'constraints', constraints,
-        defaultValue: null, showName: false));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment, showName: false, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('fg', foregroundDecoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: null, showName: false));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
     properties.add(ObjectFlagProperty<Matrix4>.has('transform', transform));
-    properties.add(DiagnosticsProperty<AlignmentGeometry>(
-        'transformAlignment', transformAlignment,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('transformAlignment', transformAlignment, defaultValue: null));
     properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior));
   }
 }
 
-class _AnimatedContainerState
-    extends AnimatedWidgetBaseState<AnimatedContainer> {
+class _AnimatedContainerState extends AnimatedWidgetBaseState<AnimatedContainer> {
   AlignmentGeometryTween? _alignment;
   EdgeInsetsGeometryTween? _padding;
   DecorationTween? _decoration;
@@ -789,47 +764,14 @@ class _AnimatedContainerState
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _alignment = visitor(
-            _alignment,
-            widget.alignment,
-            (dynamic value) =>
-                AlignmentGeometryTween(begin: value as AlignmentGeometry))
-        as AlignmentGeometryTween?;
-    _padding = visitor(
-            _padding,
-            widget.padding,
-            (dynamic value) =>
-                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
-        as EdgeInsetsGeometryTween?;
-    _decoration = visitor(_decoration, widget.decoration,
-            (dynamic value) => DecorationTween(begin: value as Decoration))
-        as DecorationTween?;
-    _foregroundDecoration = visitor(
-            _foregroundDecoration,
-            widget.foregroundDecoration,
-            (dynamic value) => DecorationTween(begin: value as Decoration))
-        as DecorationTween?;
-    _constraints = visitor(
-            _constraints,
-            widget.constraints,
-            (dynamic value) =>
-                BoxConstraintsTween(begin: value as BoxConstraints))
-        as BoxConstraintsTween?;
-    _margin = visitor(
-            _margin,
-            widget.margin,
-            (dynamic value) =>
-                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
-        as EdgeInsetsGeometryTween?;
-    _transform = visitor(_transform, widget.transform,
-            (dynamic value) => Matrix4Tween(begin: value as Matrix4))
-        as Matrix4Tween?;
-    _transformAlignment = visitor(
-            _transformAlignment,
-            widget.transformAlignment,
-            (dynamic value) =>
-                AlignmentGeometryTween(begin: value as AlignmentGeometry))
-        as AlignmentGeometryTween?;
+    _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
+    _padding = visitor(_padding, widget.padding, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
+    _decoration = visitor(_decoration, widget.decoration, (dynamic value) => DecorationTween(begin: value as Decoration)) as DecorationTween?;
+    _foregroundDecoration = visitor(_foregroundDecoration, widget.foregroundDecoration, (dynamic value) => DecorationTween(begin: value as Decoration)) as DecorationTween?;
+    _constraints = visitor(_constraints, widget.constraints, (dynamic value) => BoxConstraintsTween(begin: value as BoxConstraints)) as BoxConstraintsTween?;
+    _margin = visitor(_margin, widget.margin, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
+    _transform = visitor(_transform, widget.transform, (dynamic value) => Matrix4Tween(begin: value as Matrix4)) as Matrix4Tween?;
+    _transformAlignment = visitor(_transformAlignment, widget.transformAlignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
   }
 
   @override
@@ -852,28 +794,14 @@ class _AnimatedContainerState
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
-        'alignment', _alignment,
-        showName: false, defaultValue: null));
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
-        'padding', _padding,
-        defaultValue: null));
-    description.add(DiagnosticsProperty<DecorationTween>('bg', _decoration,
-        defaultValue: null));
-    description.add(DiagnosticsProperty<DecorationTween>(
-        'fg', _foregroundDecoration,
-        defaultValue: null));
-    description.add(DiagnosticsProperty<BoxConstraintsTween>(
-        'constraints', _constraints,
-        showName: false, defaultValue: null));
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
-        'margin', _margin,
-        defaultValue: null));
-    description
-        .add(ObjectFlagProperty<Matrix4Tween>.has('transform', _transform));
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
-        'transformAlignment', _transformAlignment,
-        defaultValue: null));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, showName: false, defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('padding', _padding, defaultValue: null));
+    description.add(DiagnosticsProperty<DecorationTween>('bg', _decoration, defaultValue: null));
+    description.add(DiagnosticsProperty<DecorationTween>('fg', _foregroundDecoration, defaultValue: null));
+    description.add(DiagnosticsProperty<BoxConstraintsTween>('constraints', _constraints, showName: false, defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('margin', _margin, defaultValue: null));
+    description.add(ObjectFlagProperty<Matrix4Tween>.has('transform', _transform));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>('transformAlignment', _transformAlignment, defaultValue: null));
   }
 }
 
@@ -945,9 +873,9 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(padding != null),
-        assert(padding.isNonNegative),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(padding != null),
+       assert(padding.isNonNegative),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The amount of space by which to inset the child.
   final EdgeInsetsGeometry padding;
@@ -958,8 +886,7 @@ class AnimatedPadding extends ImplicitlyAnimatedWidget {
   final Widget? child;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPadding> createState() =>
-      _AnimatedPaddingState();
+  AnimatedWidgetBaseState<AnimatedPadding> createState() => _AnimatedPaddingState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -973,20 +900,15 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _padding = visitor(
-            _padding,
-            widget.padding,
-            (dynamic value) =>
-                EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry))
-        as EdgeInsetsGeometryTween?;
+    _padding = visitor(_padding, widget.padding, (dynamic value) => EdgeInsetsGeometryTween(begin: value as EdgeInsetsGeometry)) as EdgeInsetsGeometryTween?;
   }
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: _padding!
-          .evaluate(animation)
-          .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
+        .evaluate(animation)
+        .clamp(EdgeInsets.zero, EdgeInsetsGeometry.infinity),
       child: widget.child,
     );
   }
@@ -994,9 +916,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>(
-        'padding', _padding,
-        defaultValue: null));
+    description.add(DiagnosticsProperty<EdgeInsetsGeometryTween>('padding', _padding, defaultValue: null));
   }
 }
 
@@ -1054,7 +974,7 @@ class _AnimatedPaddingState extends AnimatedWidgetBaseState<AnimatedPadding> {
 ///  * [AnimatedContainer], which can transition more values at once.
 ///  * [AnimatedPadding], which can animate the padding instead of the
 ///    alignment.
-///  * [AnimatedSlide], which can animate the translation of child relative to its normal position by a given offset.
+///  * [AnimatedSlide], which can animate the translation of child by a given offset relative to its size.
 ///  * [AnimatedPositioned], which, as a child of a [Stack], automatically
 ///    transitions its child's position over a given duration whenever the given
 ///    position changes.
@@ -1072,10 +992,10 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(alignment != null),
-        assert(widthFactor == null || widthFactor >= 0.0),
-        assert(heightFactor == null || heightFactor >= 0.0),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(alignment != null),
+       assert(widthFactor == null || widthFactor >= 0.0),
+       assert(heightFactor == null || heightFactor >= 0.0),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// How to align the child.
   ///
@@ -1116,8 +1036,7 @@ class AnimatedAlign extends ImplicitlyAnimatedWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
+    properties.add(DiagnosticsProperty<AlignmentGeometry>('alignment', alignment));
   }
 }
 
@@ -1128,21 +1047,12 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _alignment = visitor(
-            _alignment,
-            widget.alignment,
-            (dynamic value) =>
-                AlignmentGeometryTween(begin: value as AlignmentGeometry))
-        as AlignmentGeometryTween?;
-    if (widget.heightFactor != null) {
-      _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor,
-              (dynamic value) => Tween<double>(begin: value as double))
-          as Tween<double>?;
+    _alignment = visitor(_alignment, widget.alignment, (dynamic value) => AlignmentGeometryTween(begin: value as AlignmentGeometry)) as AlignmentGeometryTween?;
+    if(widget.heightFactor != null) {
+      _heightFactorTween = visitor(_heightFactorTween, widget.heightFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
     }
-    if (widget.widthFactor != null) {
-      _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor,
-              (dynamic value) => Tween<double>(begin: value as double))
-          as Tween<double>?;
+    if(widget.widthFactor != null) {
+      _widthFactorTween = visitor(_widthFactorTween, widget.widthFactor, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
     }
   }
 
@@ -1159,15 +1069,9 @@ class _AnimatedAlignState extends AnimatedWidgetBaseState<AnimatedAlign> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
-        'alignment', _alignment,
-        defaultValue: null));
-    description.add(DiagnosticsProperty<Tween<double>>(
-        'widthFactor', _widthFactorTween,
-        defaultValue: null));
-    description.add(DiagnosticsProperty<Tween<double>>(
-        'heightFactor', _heightFactorTween,
-        defaultValue: null));
+    description.add(DiagnosticsProperty<AlignmentGeometryTween>('alignment', _alignment, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>('widthFactor', _widthFactorTween, defaultValue: null));
+    description.add(DiagnosticsProperty<Tween<double>>('heightFactor', _heightFactorTween, defaultValue: null));
   }
 }
 
@@ -1264,9 +1168,9 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(left == null || right == null || width == null),
-        assert(top == null || bottom == null || height == null),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(left == null || right == null || width == null),
+       assert(top == null || bottom == null || height == null),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// Creates a widget that animates the rectangle it occupies implicitly.
   ///
@@ -1278,13 +1182,13 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : left = rect.left,
-        top = rect.top,
-        width = rect.width,
-        height = rect.height,
-        right = null,
-        bottom = null,
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : left = rect.left,
+       top = rect.top,
+       width = rect.width,
+       height = rect.height,
+       right = null,
+       bottom = null,
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1316,8 +1220,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPositioned> createState() =>
-      _AnimatedPositionedState();
+  AnimatedWidgetBaseState<AnimatedPositioned> createState() => _AnimatedPositionedState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1331,8 +1234,7 @@ class AnimatedPositioned extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedPositionedState
-    extends AnimatedWidgetBaseState<AnimatedPositioned> {
+class _AnimatedPositionedState extends AnimatedWidgetBaseState<AnimatedPositioned> {
   Tween<double>? _left;
   Tween<double>? _top;
   Tween<double>? _right;
@@ -1342,24 +1244,12 @@ class _AnimatedPositionedState
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _left = visitor(_left, widget.left,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _top = visitor(_top, widget.top,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _right = visitor(_right, widget.right,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _bottom = visitor(_bottom, widget.bottom,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _width = visitor(_width, widget.width,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _height = visitor(_height, widget.height,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _left = visitor(_left, widget.left, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _top = visitor(_top, widget.top, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _right = visitor(_right, widget.right, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _bottom = visitor(_bottom, widget.bottom, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _width = visitor(_width, widget.width, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _height = visitor(_height, widget.height, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -1431,9 +1321,9 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(start == null || end == null || width == null),
-        assert(top == null || bottom == null || height == null),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(start == null || end == null || width == null),
+       assert(top == null || bottom == null || height == null),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1465,8 +1355,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   final double? height;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPositionedDirectional> createState() =>
-      _AnimatedPositionedDirectionalState();
+  AnimatedWidgetBaseState<AnimatedPositionedDirectional> createState() => _AnimatedPositionedDirectionalState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -1480,8 +1369,7 @@ class AnimatedPositionedDirectional extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedPositionedDirectionalState
-    extends AnimatedWidgetBaseState<AnimatedPositionedDirectional> {
+class _AnimatedPositionedDirectionalState extends AnimatedWidgetBaseState<AnimatedPositionedDirectional> {
   Tween<double>? _start;
   Tween<double>? _top;
   Tween<double>? _end;
@@ -1491,24 +1379,12 @@ class _AnimatedPositionedDirectionalState
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _start = visitor(_start, widget.start,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _top = visitor(_top, widget.top,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _end = visitor(_end, widget.end,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _bottom = visitor(_bottom, widget.bottom,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _width = visitor(_width, widget.width,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _height = visitor(_height, widget.height,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _start = visitor(_start, widget.start, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _top = visitor(_top, widget.top, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _end = visitor(_end, widget.end, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _bottom = visitor(_bottom, widget.bottom, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _width = visitor(_width, widget.width, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _height = visitor(_height, widget.height, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -1590,7 +1466,7 @@ class _AnimatedPositionedDirectionalState
 ///  * [AnimatedRotation], for animating the rotation of a child.
 ///  * [AnimatedSize], for animating the resize of a child based on changes
 ///    in layout.
-///  * [AnimatedSlide], for animating the translation of a child by given offset relative to its normal position.
+///  * [AnimatedSlide], for animating the translation of a child by a given offset relative to its size.
 ///  * [ScaleTransition], an explicitly animated version of this widget, where
 ///    an [Animation] is provided by the caller instead of being built in.
 class AnimatedScale extends ImplicitlyAnimatedWidget {
@@ -1607,8 +1483,8 @@ class AnimatedScale extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(scale != null),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(scale != null),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -1633,17 +1509,14 @@ class AnimatedScale extends ImplicitlyAnimatedWidget {
   final FilterQuality? filterQuality;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedScale> createState() =>
-      _AnimatedScaleState();
+  ImplicitlyAnimatedWidgetState<AnimatedScale> createState() => _AnimatedScaleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('scale', scale));
-    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment,
-        defaultValue: Alignment.center));
-    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment, defaultValue: Alignment.center));
+    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality, defaultValue: null));
   }
 }
 
@@ -1653,9 +1526,7 @@ class _AnimatedScaleState extends ImplicitlyAnimatedWidgetState<AnimatedScale> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _scale = visitor(_scale, widget.scale,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _scale = visitor(_scale, widget.scale, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -1740,7 +1611,7 @@ class AnimatedRotation extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(turns != null),
+  }) : assert(turns != null),
         super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
@@ -1767,30 +1638,24 @@ class AnimatedRotation extends ImplicitlyAnimatedWidget {
   final FilterQuality? filterQuality;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedRotation> createState() =>
-      _AnimatedRotationState();
+  ImplicitlyAnimatedWidgetState<AnimatedRotation> createState() => _AnimatedRotationState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('turns', turns));
-    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment,
-        defaultValue: Alignment.center));
-    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<Alignment>('alignment', alignment, defaultValue: Alignment.center));
+    properties.add(EnumProperty<FilterQuality>('filterQuality', filterQuality, defaultValue: null));
   }
 }
 
-class _AnimatedRotationState
-    extends ImplicitlyAnimatedWidgetState<AnimatedRotation> {
+class _AnimatedRotationState extends ImplicitlyAnimatedWidgetState<AnimatedRotation> {
   Tween<double>? _turns;
   late Animation<double> _turnsAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _turns = visitor(_turns, widget.turns,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _turns = visitor(_turns, widget.turns, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -1835,7 +1700,7 @@ class _AnimatedRotationState
 ///  void _slideUp() {
 ///    setState(() => offset -= Offset(0, 1));
 ///  }
-///
+/// 
 ///  void _slideDown() {
 ///    setState(() => offset += Offset(0, 1));
 ///  }
@@ -1887,14 +1752,15 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  }) : super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) :
+        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget? child;
 
-  /// The target offset.
+  /// The target offset. 
   /// The child will be translated horizontally by `width * dx` and vertically by `height * dy`
   ///
   /// The offset must not be null.
@@ -1916,9 +1782,7 @@ class _AnimatedSlideState extends ImplicitlyAnimatedWidgetState<AnimatedSlide> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _offset = visitor(_offset, widget.offset,
-            (dynamic value) => Tween<Offset>(begin: value as Offset))
-        as Tween<Offset>?;
+    _offset = visitor(_offset, widget.offset, (dynamic value) => Tween<Offset>(begin: value as Offset)) as Tween<Offset>?;
   }
 
   @override
@@ -2006,8 +1870,8 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
     required Duration duration,
     VoidCallback? onEnd,
     this.alwaysIncludeSemantics = false,
-  })  : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -2033,8 +1897,7 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  ImplicitlyAnimatedWidgetState<AnimatedOpacity> createState() =>
-      _AnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<AnimatedOpacity> createState() => _AnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -2043,16 +1906,13 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _AnimatedOpacityState
-    extends ImplicitlyAnimatedWidgetState<AnimatedOpacity> {
+class _AnimatedOpacityState extends ImplicitlyAnimatedWidgetState<AnimatedOpacity> {
   Tween<double>? _opacity;
   late Animation<double> _opacityAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _opacity = visitor(_opacity, widget.opacity,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _opacity = visitor(_opacity, widget.opacity, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -2146,8 +2006,8 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
     required Duration duration,
     VoidCallback? onEnd,
     this.alwaysIncludeSemantics = false,
-  })  : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
+      super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The sliver below this widget in the tree.
   final Widget? sliver;
@@ -2171,8 +2031,7 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   final bool alwaysIncludeSemantics;
 
   @override
-  ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> createState() =>
-      _SliverAnimatedOpacityState();
+  ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> createState() => _SliverAnimatedOpacityState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -2181,16 +2040,13 @@ class SliverAnimatedOpacity extends ImplicitlyAnimatedWidget {
   }
 }
 
-class _SliverAnimatedOpacityState
-    extends ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> {
+class _SliverAnimatedOpacityState extends ImplicitlyAnimatedWidgetState<SliverAnimatedOpacity> {
   Tween<double>? _opacity;
   late Animation<double> _opacityAnimation;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _opacity = visitor(_opacity, widget.opacity,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _opacity = visitor(_opacity, widget.opacity, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
   }
 
   @override
@@ -2246,13 +2102,13 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(style != null),
-        assert(child != null),
-        assert(softWrap != null),
-        assert(overflow != null),
-        assert(maxLines == null || maxLines > 0),
-        assert(textWidthBasis != null),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(style != null),
+       assert(child != null),
+       assert(softWrap != null),
+       assert(overflow != null),
+       assert(maxLines == null || maxLines > 0),
+       assert(textWidthBasis != null),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -2299,41 +2155,27 @@ class AnimatedDefaultTextStyle extends ImplicitlyAnimatedWidget {
   final ui.TextHeightBehavior? textHeightBehavior;
 
   @override
-  AnimatedWidgetBaseState<AnimatedDefaultTextStyle> createState() =>
-      _AnimatedDefaultTextStyleState();
+  AnimatedWidgetBaseState<AnimatedDefaultTextStyle> createState() => _AnimatedDefaultTextStyleState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     style.debugFillProperties(properties);
-    properties.add(
-        EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
-    properties.add(FlagProperty('softWrap',
-        value: softWrap,
-        ifTrue: 'wrapping at box width',
-        ifFalse: 'no wrapping except at line break characters',
-        showName: true));
-    properties.add(
-        EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
+    properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
+    properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
+    properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
-    properties.add(EnumProperty<TextWidthBasis>(
-        'textWidthBasis', textWidthBasis,
-        defaultValue: TextWidthBasis.parent));
-    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>(
-        'textHeightBehavior', textHeightBehavior,
-        defaultValue: null));
+    properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));
+    properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));
   }
 }
 
-class _AnimatedDefaultTextStyleState
-    extends AnimatedWidgetBaseState<AnimatedDefaultTextStyle> {
+class _AnimatedDefaultTextStyleState extends AnimatedWidgetBaseState<AnimatedDefaultTextStyle> {
   TextStyleTween? _style;
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _style = visitor(_style, widget.style,
-            (dynamic value) => TextStyleTween(begin: value as TextStyle))
-        as TextStyleTween?;
+    _style = visitor(_style, widget.style, (dynamic value) => TextStyleTween(begin: value as TextStyle)) as TextStyleTween?;
   }
 
   @override
@@ -2389,16 +2231,16 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
     Curve curve = Curves.linear,
     required Duration duration,
     VoidCallback? onEnd,
-  })  : assert(child != null),
-        assert(shape != null),
-        assert(clipBehavior != null),
-        assert(borderRadius != null),
-        assert(elevation != null && elevation >= 0.0),
-        assert(color != null),
-        assert(shadowColor != null),
-        assert(animateColor != null),
-        assert(animateShadowColor != null),
-        super(key: key, curve: curve, duration: duration, onEnd: onEnd);
+  }) : assert(child != null),
+       assert(shape != null),
+       assert(clipBehavior != null),
+       assert(borderRadius != null),
+       assert(elevation != null && elevation >= 0.0),
+       assert(color != null),
+       assert(shadowColor != null),
+       assert(animateColor != null),
+       assert(animateShadowColor != null),
+       super(key: key, curve: curve, duration: duration, onEnd: onEnd);
 
   /// The widget below this widget in the tree.
   ///
@@ -2437,26 +2279,22 @@ class AnimatedPhysicalModel extends ImplicitlyAnimatedWidget {
   final bool animateShadowColor;
 
   @override
-  AnimatedWidgetBaseState<AnimatedPhysicalModel> createState() =>
-      _AnimatedPhysicalModelState();
+  AnimatedWidgetBaseState<AnimatedPhysicalModel> createState() => _AnimatedPhysicalModelState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(EnumProperty<BoxShape>('shape', shape));
-    properties
-        .add(DiagnosticsProperty<BorderRadius>('borderRadius', borderRadius));
+    properties.add(DiagnosticsProperty<BorderRadius>('borderRadius', borderRadius));
     properties.add(DoubleProperty('elevation', elevation));
     properties.add(ColorProperty('color', color));
     properties.add(DiagnosticsProperty<bool>('animateColor', animateColor));
     properties.add(ColorProperty('shadowColor', shadowColor));
-    properties.add(
-        DiagnosticsProperty<bool>('animateShadowColor', animateShadowColor));
+    properties.add(DiagnosticsProperty<bool>('animateShadowColor', animateShadowColor));
   }
 }
 
-class _AnimatedPhysicalModelState
-    extends AnimatedWidgetBaseState<AnimatedPhysicalModel> {
+class _AnimatedPhysicalModelState extends AnimatedWidgetBaseState<AnimatedPhysicalModel> {
   BorderRadiusTween? _borderRadius;
   Tween<double>? _elevation;
   ColorTween? _color;
@@ -2464,16 +2302,10 @@ class _AnimatedPhysicalModelState
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _borderRadius = visitor(_borderRadius, widget.borderRadius,
-            (dynamic value) => BorderRadiusTween(begin: value as BorderRadius))
-        as BorderRadiusTween?;
-    _elevation = visitor(_elevation, widget.elevation,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _color = visitor(_color, widget.color,
-        (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
-    _shadowColor = visitor(_shadowColor, widget.shadowColor,
-        (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
+    _borderRadius = visitor(_borderRadius, widget.borderRadius, (dynamic value) => BorderRadiusTween(begin: value as BorderRadius)) as BorderRadiusTween?;
+    _elevation = visitor(_elevation, widget.elevation, (dynamic value) => Tween<double>(begin: value as double)) as Tween<double>?;
+    _color = visitor(_color, widget.color, (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
+    _shadowColor = visitor(_shadowColor, widget.shadowColor, (dynamic value) => ColorTween(begin: value as Color)) as ColorTween?;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1772,7 +1772,7 @@ class AnimatedSlide extends ImplicitlyAnimatedWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DoubleProperty('offset', offset));
+    properties.add(DiagnosticsProperty<Offset>('offset', offset));
   }
 }
 

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -215,7 +215,7 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(slideWidget.position.value, equals(const Offset(0,0)));
+    expect(slideWidget.position.value, equals(Offset.zero));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
@@ -724,7 +724,7 @@ class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
     return AnimatedSlide(
       duration: duration,
       onEnd: widget.callback,
-      offset: toggle ? const Offset(1,1) : const Offset(0,0),
+      offset: toggle ? const Offset(1,1) : Offset.zero,
       child: child,
     );
   }

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -171,12 +171,12 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-   testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
+   testWidgets('AnimatedOffset onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
         switchKey: switchKey,
-        state: _TestAnimatedSlideWidgetState(),
+        state: _TestAnimatedOffsetWidgetState(),
       ),
     ));
 
@@ -191,11 +191,11 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
   
-  testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
+  testWidgets('AnimatedOffset transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         switchKey: switchKey,
-        state: _TestAnimatedSlideWidgetState(),
+        state: _TestAnimatedOffsetWidgetState(),
       ),
     ));
 
@@ -718,10 +718,10 @@ class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetS
   }
 }
 
-class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
+class _TestAnimatedOffsetWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
-    return AnimatedSlide(
+    return AnimatedOffset(
       duration: duration,
       onEnd: widget.callback,
       offset: toggle ? Offset(1,1) : Offset(0,0),
@@ -860,4 +860,4 @@ class _TestAnimatedThemeWidgetState extends _TestAnimatedWidgetState {
       child: child,
     );
   }
-}
+} 

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -203,7 +203,7 @@ void main() {
       find.byType(TestAnimatedWidget)
     ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
-    final SlideTransition offsetWidget = tester.widget<SlideTransition>(
+    final SlideTransition slideWidget = tester.widget<SlideTransition>(
       find.ancestor(
         of: find.byType(Placeholder),
         matching: find.byType(SlideTransition),
@@ -215,17 +215,17 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(offsetWidget.position.value, equals(Offset(0,0)));
+    expect(slideWidget.position.value, equals(const Offset(0,0)));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(offsetWidget.position.value, equals(Offset(0.5,0.5)));
+    expect(slideWidget.position.value, equals(const Offset(0.5,0.5)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(0.75,0.75)));
+    expect(slideWidget.position.value, equals(const Offset(0.75,0.75)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(1,1)));
+    expect(slideWidget.position.value, equals(const Offset(1,1)));
     expect(state.builds, equals(2));
   });
 
@@ -724,7 +724,7 @@ class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
     return AnimatedSlide(
       duration: duration,
       onEnd: widget.callback,
-      offset: toggle ? Offset(1,1) : Offset(0,0),
+      offset: toggle ? const Offset(1,1) : const Offset(0,0),
       child: child,
     );
   }

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -171,12 +171,12 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-   testWidgets('AnimatedOffset onEnd callback test', (WidgetTester tester) async {
+   testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
         switchKey: switchKey,
-        state: _TestAnimatedOffsetWidgetState(),
+        state: _TestAnimatedSlideWidgetState(),
       ),
     ));
 
@@ -191,11 +191,11 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
   
-  testWidgets('AnimatedOffset transition test', (WidgetTester tester) async {
+  testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         switchKey: switchKey,
-        state: _TestAnimatedOffsetWidgetState(),
+        state: _TestAnimatedSlideWidgetState(),
       ),
     ));
 
@@ -718,10 +718,10 @@ class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetS
   }
 }
 
-class _TestAnimatedOffsetWidgetState extends _TestAnimatedWidgetState {
+class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
-    return AnimatedOffset(
+    return AnimatedSlide(
       duration: duration,
       onEnd: widget.callback,
       offset: toggle ? Offset(1,1) : Offset(0,0),
@@ -860,4 +860,4 @@ class _TestAnimatedThemeWidgetState extends _TestAnimatedWidgetState {
       child: child,
     );
   }
-} 
+}

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -190,7 +190,7 @@ void main() {
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
   });
-  
+
   testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -171,6 +171,64 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
+   testWidgets('AnimatedOffset onEnd callback test', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(
+      child: TestAnimatedWidget(
+        callback: mockOnEndFunction.handler,
+        switchKey: switchKey,
+        state: _TestAnimatedOffsetWidgetState(),
+      ),
+    ));
+
+    final Finder widgetFinder = find.byKey(switchKey);
+
+    await tester.tap(widgetFinder);
+    await tester.pump();
+    expect(mockOnEndFunction.called, 0);
+    await tester.pump(animationDuration);
+    expect(mockOnEndFunction.called, 0);
+    await tester.pump(additionalDelay);
+    expect(mockOnEndFunction.called, 1);
+  });
+  
+  testWidgets('AnimatedOffset transition test', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(
+      child: TestAnimatedWidget(
+        switchKey: switchKey,
+        state: _TestAnimatedOffsetWidgetState(),
+      ),
+    ));
+
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+      find.byType(TestAnimatedWidget)
+    ).rebuildState!;
+    final Finder switchFinder = find.byKey(switchKey);
+    final SlideTransition offsetWidget = tester.widget<SlideTransition>(
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(SlideTransition),
+      ).first,
+    );
+
+    expect(state.builds, equals(1));
+
+    await tester.tap(switchFinder);
+    expect(state.builds, equals(1));
+    await tester.pump();
+    expect(offsetWidget.position.value, equals(Offset(0,0)));
+    expect(state.builds, equals(2));
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(offsetWidget.position.value, equals(Offset(0.5,0.5)));
+    expect(state.builds, equals(2));
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(offsetWidget.position.value, equals(Offset(0.75,0.75)));
+    expect(state.builds, equals(2));
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(offsetWidget.position.value, equals(Offset(1,1)));
+    expect(state.builds, equals(2));
+  });
+
   testWidgets('AnimatedScale onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
@@ -660,6 +718,18 @@ class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetS
   }
 }
 
+class _TestAnimatedOffsetWidgetState extends _TestAnimatedWidgetState {
+  @override
+  Widget getAnimatedWidget() {
+    return AnimatedOffset(
+      duration: duration,
+      onEnd: widget.callback,
+      offset: toggle ? Offset(1,1) : Offset(0,0),
+      child: child,
+    );
+  }
+}
+
 class _TestAnimatedScaleWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
@@ -790,4 +860,4 @@ class _TestAnimatedThemeWidgetState extends _TestAnimatedWidgetState {
       child: child,
     );
   }
-}
+} 

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -13,8 +13,8 @@ class MockOnEndFunction {
   }
 }
 
-const Duration animationDuration = Duration(milliseconds:1000);
-const Duration additionalDelay = Duration(milliseconds:1);
+const Duration animationDuration = Duration(milliseconds: 1000);
+const Duration additionalDelay = Duration(milliseconds: 1);
 
 void main() {
   late MockOnEndFunction mockOnEndFunction;
@@ -66,7 +66,8 @@ void main() {
     expect(result, equals(Matrix4.translationValues(11.0, 21.0, 31.0)));
   });
 
-  testWidgets('AnimatedContainer onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedContainer onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -87,7 +88,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPadding onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedPadding onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -129,7 +131,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPositioned onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -150,7 +153,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPositionedDirectional onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -171,12 +175,12 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-   testWidgets('AnimatedOffset onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
         switchKey: switchKey,
-        state: _TestAnimatedOffsetWidgetState(),
+        state: _TestAnimatedSlideWidgetState(),
       ),
     ));
 
@@ -190,24 +194,26 @@ void main() {
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
   });
-  
-  testWidgets('AnimatedOffset transition test', (WidgetTester tester) async {
+
+  testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         switchKey: switchKey,
-        state: _TestAnimatedOffsetWidgetState(),
+        state: _TestAnimatedSlideWidgetState(),
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
-      find.byType(TestAnimatedWidget)
-    ).rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester
+        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
+        .rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final SlideTransition offsetWidget = tester.widget<SlideTransition>(
-      find.ancestor(
-        of: find.byType(Placeholder),
-        matching: find.byType(SlideTransition),
-      ).first,
+      find
+          .ancestor(
+            of: find.byType(Placeholder),
+            matching: find.byType(SlideTransition),
+          )
+          .first,
     );
 
     expect(state.builds, equals(1));
@@ -215,17 +221,17 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(offsetWidget.position.value, equals(Offset(0,0)));
+    expect(offsetWidget.position.value, equals(Offset(0, 0)));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(offsetWidget.position.value, equals(Offset(0.5,0.5)));
+    expect(offsetWidget.position.value, equals(Offset(0.5, 0.5)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(0.75,0.75)));
+    expect(offsetWidget.position.value, equals(Offset(0.75, 0.75)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(1,1)));
+    expect(offsetWidget.position.value, equals(Offset(1, 1)));
     expect(state.builds, equals(2));
   });
 
@@ -257,15 +263,17 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
-      find.byType(TestAnimatedWidget)
-    ).rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester
+        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
+        .rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final ScaleTransition scaleWidget = tester.widget<ScaleTransition>(
-      find.ancestor(
-        of: find.byType(Placeholder),
-        matching: find.byType(ScaleTransition),
-      ).first,
+      find
+          .ancestor(
+            of: find.byType(Placeholder),
+            matching: find.byType(ScaleTransition),
+          )
+          .first,
     );
 
     expect(state.builds, equals(1));
@@ -287,7 +295,8 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedRotation onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedRotation onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -315,15 +324,17 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
-        find.byType(TestAnimatedWidget)
-    ).rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester
+        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
+        .rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final RotationTransition rotationWidget = tester.widget<RotationTransition>(
-      find.ancestor(
-        of: find.byType(Placeholder),
-        matching: find.byType(RotationTransition),
-      ).first,
+      find
+          .ancestor(
+            of: find.byType(Placeholder),
+            matching: find.byType(RotationTransition),
+          )
+          .first,
     );
 
     expect(state.builds, equals(1));
@@ -345,7 +356,8 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedOpacity onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedOpacity onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -373,15 +385,17 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
-        find.byType(TestAnimatedWidget)
-    ).rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester
+        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
+        .rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final FadeTransition opacityWidget = tester.widget<FadeTransition>(
-      find.ancestor(
-        of: find.byType(Placeholder),
-        matching: find.byType(FadeTransition),
-      ).first,
+      find
+          .ancestor(
+            of: find.byType(Placeholder),
+            matching: find.byType(FadeTransition),
+          )
+          .first,
     );
 
     expect(state.builds, equals(1));
@@ -403,8 +417,8 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-
-  testWidgets('SliverAnimatedOpacity onEnd callback test', (WidgetTester tester) async {
+  testWidgets('SliverAnimatedOpacity onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(TestAnimatedWidget(
       callback: mockOnEndFunction.handler,
       switchKey: switchKey,
@@ -423,7 +437,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('SliverAnimatedOpacity transition test', (WidgetTester tester) async {
+  testWidgets('SliverAnimatedOpacity transition test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         switchKey: switchKey,
@@ -431,15 +446,18 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
-        find.byType(TestAnimatedWidget)
-    ).rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester
+        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
+        .rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
-    final SliverFadeTransition opacityWidget = tester.widget<SliverFadeTransition>(
-      find.ancestor(
-        of: find.byType(Placeholder),
-        matching: find.byType(SliverFadeTransition),
-      ).first,
+    final SliverFadeTransition opacityWidget =
+        tester.widget<SliverFadeTransition>(
+      find
+          .ancestor(
+            of: find.byType(Placeholder),
+            matching: find.byType(SliverFadeTransition),
+          )
+          .first,
     );
 
     expect(state.builds, equals(1));
@@ -461,7 +479,8 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedDefaultTextStyle onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedDefaultTextStyle onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -482,7 +501,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPhysicalModel onEnd callback test', (WidgetTester tester) async {
+  testWidgets('AnimatedPhysicalModel onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -503,7 +523,8 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('TweenAnimationBuilder onEnd callback test', (WidgetTester tester) async {
+  testWidgets('TweenAnimationBuilder onEnd callback test',
+      (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -549,7 +570,8 @@ void main() {
       (WidgetTester tester) async {
     final GlobalKey<ImplicitlyAnimatedWidgetState<AnimatedOpacity>> key =
         GlobalKey<ImplicitlyAnimatedWidgetState<AnimatedOpacity>>();
-    final ValueNotifier<Curve> curve = ValueNotifier<Curve>(const Interval(0.0, 0.5));
+    final ValueNotifier<Curve> curve =
+        ValueNotifier<Curve>(const Interval(0.0, 0.5));
     await tester.pumpWidget(wrap(
       child: ValueListenableBuilder<Curve>(
         valueListenable: curve,
@@ -562,10 +584,10 @@ void main() {
       ),
     ));
 
-    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? firstState = key.currentState;
+    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? firstState =
+        key.currentState;
     final Animation<double>? firstAnimation = firstState?.animation;
-    if (firstAnimation == null)
-      fail('animation was null!');
+    if (firstAnimation == null) fail('animation was null!');
 
     final CurvedAnimation firstCurvedAnimation =
         firstAnimation as CurvedAnimation;
@@ -575,12 +597,13 @@ void main() {
     curve.value = const Interval(0.0, 0.6);
     await tester.pumpAndSettle();
 
-    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? secondState = key.currentState;
+    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? secondState =
+        key.currentState;
     final Animation<double>? secondAnimation = secondState?.animation;
-    if (secondAnimation == null)
-      fail('animation was null!');
+    if (secondAnimation == null) fail('animation was null!');
 
-    final CurvedAnimation secondCurvedAnimation = secondAnimation as CurvedAnimation;
+    final CurvedAnimation secondCurvedAnimation =
+        secondAnimation as CurvedAnimation;
 
     expect(firstState, equals(secondState));
     expect(firstAnimation, isNot(equals(secondAnimation)));
@@ -624,13 +647,17 @@ class TestAnimatedWidget extends StatefulWidget {
   final State<StatefulWidget> state;
 
   RebuildCountingState<StatefulWidget>? get rebuildState =>
-    state is RebuildCountingState<StatefulWidget> ? state as RebuildCountingState<StatefulWidget> : null;
+      state is RebuildCountingState<StatefulWidget>
+          ? state as RebuildCountingState<StatefulWidget>
+          : null;
 
   @override
-  State<StatefulWidget> createState() => state; // ignore: no_logic_in_create_state, this test predates the lint
+  State<StatefulWidget> createState() =>
+      state; // ignore: no_logic_in_create_state, this test predates the lint
 }
 
-abstract class _TestAnimatedWidgetState extends RebuildCountingState<TestAnimatedWidget> {
+abstract class _TestAnimatedWidgetState
+    extends RebuildCountingState<TestAnimatedWidget> {
   bool toggle = false;
   final Widget child = const Placeholder();
   final Duration duration = animationDuration;
@@ -675,8 +702,7 @@ class _TestAnimatedPaddingWidgetState extends _TestAnimatedWidgetState {
     return AnimatedPadding(
       duration: duration,
       onEnd: widget.callback,
-      padding:
-      toggle ? const EdgeInsets.all(8.0) : const EdgeInsets.all(16.0),
+      padding: toggle ? const EdgeInsets.all(8.0) : const EdgeInsets.all(16.0),
       child: child,
     );
   }
@@ -706,7 +732,8 @@ class _TestAnimatedPositionedWidgetState extends _TestAnimatedWidgetState {
   }
 }
 
-class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetState {
+class _TestAnimatedPositionedDirectionalWidgetState
+    extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
     return AnimatedPositionedDirectional(
@@ -718,13 +745,13 @@ class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetS
   }
 }
 
-class _TestAnimatedOffsetWidgetState extends _TestAnimatedWidgetState {
+class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
-    return AnimatedOffset(
+    return AnimatedSlide(
       duration: duration,
       onEnd: widget.callback,
-      offset: toggle ? Offset(1,1) : Offset(0,0),
+      offset: toggle ? Offset(1, 1) : Offset(0, 0),
       child: child,
     );
   }
@@ -802,15 +829,16 @@ class _TestSliverAnimatedOpacityWidgetState extends _TestAnimatedWidgetState {
   }
 }
 
-class _TestAnimatedDefaultTextStyleWidgetState extends _TestAnimatedWidgetState {
+class _TestAnimatedDefaultTextStyleWidgetState
+    extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
     return AnimatedDefaultTextStyle(
       duration: duration,
       onEnd: widget.callback,
       style: toggle
-        ? const TextStyle(fontStyle: FontStyle.italic)
-        : const TextStyle(fontStyle: FontStyle.normal),
+          ? const TextStyle(fontStyle: FontStyle.italic)
+          : const TextStyle(fontStyle: FontStyle.normal),
       child: child,
     );
   }
@@ -860,4 +888,4 @@ class _TestAnimatedThemeWidgetState extends _TestAnimatedWidgetState {
       child: child,
     );
   }
-} 
+}

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -13,8 +13,8 @@ class MockOnEndFunction {
   }
 }
 
-const Duration animationDuration = Duration(milliseconds: 1000);
-const Duration additionalDelay = Duration(milliseconds: 1);
+const Duration animationDuration = Duration(milliseconds:1000);
+const Duration additionalDelay = Duration(milliseconds:1);
 
 void main() {
   late MockOnEndFunction mockOnEndFunction;
@@ -66,8 +66,7 @@ void main() {
     expect(result, equals(Matrix4.translationValues(11.0, 21.0, 31.0)));
   });
 
-  testWidgets('AnimatedContainer onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedContainer onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -88,8 +87,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPadding onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedPadding onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -131,8 +129,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPositioned onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedPositioned onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -153,8 +150,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPositionedDirectional onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedPositionedDirectional onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -175,7 +171,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
+   testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -194,7 +190,7 @@ void main() {
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
   });
-
+  
   testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
@@ -203,17 +199,15 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester
-        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
-        .rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+      find.byType(TestAnimatedWidget)
+    ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final SlideTransition offsetWidget = tester.widget<SlideTransition>(
-      find
-          .ancestor(
-            of: find.byType(Placeholder),
-            matching: find.byType(SlideTransition),
-          )
-          .first,
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(SlideTransition),
+      ).first,
     );
 
     expect(state.builds, equals(1));
@@ -221,17 +215,17 @@ void main() {
     await tester.tap(switchFinder);
     expect(state.builds, equals(1));
     await tester.pump();
-    expect(offsetWidget.position.value, equals(Offset(0, 0)));
+    expect(offsetWidget.position.value, equals(Offset(0,0)));
     expect(state.builds, equals(2));
 
     await tester.pump(const Duration(milliseconds: 500));
-    expect(offsetWidget.position.value, equals(Offset(0.5, 0.5)));
+    expect(offsetWidget.position.value, equals(Offset(0.5,0.5)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(0.75, 0.75)));
+    expect(offsetWidget.position.value, equals(Offset(0.75,0.75)));
     expect(state.builds, equals(2));
     await tester.pump(const Duration(milliseconds: 250));
-    expect(offsetWidget.position.value, equals(Offset(1, 1)));
+    expect(offsetWidget.position.value, equals(Offset(1,1)));
     expect(state.builds, equals(2));
   });
 
@@ -263,17 +257,15 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester
-        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
-        .rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+      find.byType(TestAnimatedWidget)
+    ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final ScaleTransition scaleWidget = tester.widget<ScaleTransition>(
-      find
-          .ancestor(
-            of: find.byType(Placeholder),
-            matching: find.byType(ScaleTransition),
-          )
-          .first,
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(ScaleTransition),
+      ).first,
     );
 
     expect(state.builds, equals(1));
@@ -295,8 +287,7 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedRotation onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedRotation onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -324,17 +315,15 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester
-        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
-        .rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+        find.byType(TestAnimatedWidget)
+    ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final RotationTransition rotationWidget = tester.widget<RotationTransition>(
-      find
-          .ancestor(
-            of: find.byType(Placeholder),
-            matching: find.byType(RotationTransition),
-          )
-          .first,
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(RotationTransition),
+      ).first,
     );
 
     expect(state.builds, equals(1));
@@ -356,8 +345,7 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedOpacity onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedOpacity onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -385,17 +373,15 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester
-        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
-        .rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+        find.byType(TestAnimatedWidget)
+    ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
     final FadeTransition opacityWidget = tester.widget<FadeTransition>(
-      find
-          .ancestor(
-            of: find.byType(Placeholder),
-            matching: find.byType(FadeTransition),
-          )
-          .first,
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(FadeTransition),
+      ).first,
     );
 
     expect(state.builds, equals(1));
@@ -417,8 +403,8 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('SliverAnimatedOpacity onEnd callback test',
-      (WidgetTester tester) async {
+
+  testWidgets('SliverAnimatedOpacity onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(TestAnimatedWidget(
       callback: mockOnEndFunction.handler,
       switchKey: switchKey,
@@ -437,8 +423,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('SliverAnimatedOpacity transition test',
-      (WidgetTester tester) async {
+  testWidgets('SliverAnimatedOpacity transition test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         switchKey: switchKey,
@@ -446,18 +431,15 @@ void main() {
       ),
     ));
 
-    final RebuildCountingState<StatefulWidget> state = tester
-        .widget<TestAnimatedWidget>(find.byType(TestAnimatedWidget))
-        .rebuildState!;
+    final RebuildCountingState<StatefulWidget> state = tester.widget<TestAnimatedWidget>(
+        find.byType(TestAnimatedWidget)
+    ).rebuildState!;
     final Finder switchFinder = find.byKey(switchKey);
-    final SliverFadeTransition opacityWidget =
-        tester.widget<SliverFadeTransition>(
-      find
-          .ancestor(
-            of: find.byType(Placeholder),
-            matching: find.byType(SliverFadeTransition),
-          )
-          .first,
+    final SliverFadeTransition opacityWidget = tester.widget<SliverFadeTransition>(
+      find.ancestor(
+        of: find.byType(Placeholder),
+        matching: find.byType(SliverFadeTransition),
+      ).first,
     );
 
     expect(state.builds, equals(1));
@@ -479,8 +461,7 @@ void main() {
     expect(state.builds, equals(2));
   });
 
-  testWidgets('AnimatedDefaultTextStyle onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedDefaultTextStyle onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -501,8 +482,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('AnimatedPhysicalModel onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('AnimatedPhysicalModel onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -523,8 +503,7 @@ void main() {
     expect(mockOnEndFunction.called, 1);
   });
 
-  testWidgets('TweenAnimationBuilder onEnd callback test',
-      (WidgetTester tester) async {
+  testWidgets('TweenAnimationBuilder onEnd callback test', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       child: TestAnimatedWidget(
         callback: mockOnEndFunction.handler,
@@ -570,8 +549,7 @@ void main() {
       (WidgetTester tester) async {
     final GlobalKey<ImplicitlyAnimatedWidgetState<AnimatedOpacity>> key =
         GlobalKey<ImplicitlyAnimatedWidgetState<AnimatedOpacity>>();
-    final ValueNotifier<Curve> curve =
-        ValueNotifier<Curve>(const Interval(0.0, 0.5));
+    final ValueNotifier<Curve> curve = ValueNotifier<Curve>(const Interval(0.0, 0.5));
     await tester.pumpWidget(wrap(
       child: ValueListenableBuilder<Curve>(
         valueListenable: curve,
@@ -584,10 +562,10 @@ void main() {
       ),
     ));
 
-    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? firstState =
-        key.currentState;
+    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? firstState = key.currentState;
     final Animation<double>? firstAnimation = firstState?.animation;
-    if (firstAnimation == null) fail('animation was null!');
+    if (firstAnimation == null)
+      fail('animation was null!');
 
     final CurvedAnimation firstCurvedAnimation =
         firstAnimation as CurvedAnimation;
@@ -597,13 +575,12 @@ void main() {
     curve.value = const Interval(0.0, 0.6);
     await tester.pumpAndSettle();
 
-    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? secondState =
-        key.currentState;
+    final ImplicitlyAnimatedWidgetState<AnimatedOpacity>? secondState = key.currentState;
     final Animation<double>? secondAnimation = secondState?.animation;
-    if (secondAnimation == null) fail('animation was null!');
+    if (secondAnimation == null)
+      fail('animation was null!');
 
-    final CurvedAnimation secondCurvedAnimation =
-        secondAnimation as CurvedAnimation;
+    final CurvedAnimation secondCurvedAnimation = secondAnimation as CurvedAnimation;
 
     expect(firstState, equals(secondState));
     expect(firstAnimation, isNot(equals(secondAnimation)));
@@ -647,17 +624,13 @@ class TestAnimatedWidget extends StatefulWidget {
   final State<StatefulWidget> state;
 
   RebuildCountingState<StatefulWidget>? get rebuildState =>
-      state is RebuildCountingState<StatefulWidget>
-          ? state as RebuildCountingState<StatefulWidget>
-          : null;
+    state is RebuildCountingState<StatefulWidget> ? state as RebuildCountingState<StatefulWidget> : null;
 
   @override
-  State<StatefulWidget> createState() =>
-      state; // ignore: no_logic_in_create_state, this test predates the lint
+  State<StatefulWidget> createState() => state; // ignore: no_logic_in_create_state, this test predates the lint
 }
 
-abstract class _TestAnimatedWidgetState
-    extends RebuildCountingState<TestAnimatedWidget> {
+abstract class _TestAnimatedWidgetState extends RebuildCountingState<TestAnimatedWidget> {
   bool toggle = false;
   final Widget child = const Placeholder();
   final Duration duration = animationDuration;
@@ -702,7 +675,8 @@ class _TestAnimatedPaddingWidgetState extends _TestAnimatedWidgetState {
     return AnimatedPadding(
       duration: duration,
       onEnd: widget.callback,
-      padding: toggle ? const EdgeInsets.all(8.0) : const EdgeInsets.all(16.0),
+      padding:
+      toggle ? const EdgeInsets.all(8.0) : const EdgeInsets.all(16.0),
       child: child,
     );
   }
@@ -732,8 +706,7 @@ class _TestAnimatedPositionedWidgetState extends _TestAnimatedWidgetState {
   }
 }
 
-class _TestAnimatedPositionedDirectionalWidgetState
-    extends _TestAnimatedWidgetState {
+class _TestAnimatedPositionedDirectionalWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
     return AnimatedPositionedDirectional(
@@ -751,7 +724,7 @@ class _TestAnimatedSlideWidgetState extends _TestAnimatedWidgetState {
     return AnimatedSlide(
       duration: duration,
       onEnd: widget.callback,
-      offset: toggle ? Offset(1, 1) : Offset(0, 0),
+      offset: toggle ? Offset(1,1) : Offset(0,0),
       child: child,
     );
   }
@@ -829,16 +802,15 @@ class _TestSliverAnimatedOpacityWidgetState extends _TestAnimatedWidgetState {
   }
 }
 
-class _TestAnimatedDefaultTextStyleWidgetState
-    extends _TestAnimatedWidgetState {
+class _TestAnimatedDefaultTextStyleWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
     return AnimatedDefaultTextStyle(
       duration: duration,
       onEnd: widget.callback,
       style: toggle
-          ? const TextStyle(fontStyle: FontStyle.italic)
-          : const TextStyle(fontStyle: FontStyle.normal),
+        ? const TextStyle(fontStyle: FontStyle.italic)
+        : const TextStyle(fontStyle: FontStyle.normal),
       child: child,
     );
   }


### PR DESCRIPTION
While Flutter already provides easy-to-use implicitly animated widgets, like AnimatedOpacity or AnimatedPositioned (and [now](https://github.com/flutter/flutter/pull/83428) also AnimatedScale and AnimatedRotation), there's no such widget for item's offset animation — which would behave the same as `SlideTransition`, but wouldn't require AnimationController to be provided.

This PR adds `AnimatedOffset` widget to resolve this, which could be considered an implicitly animated version of `Transform.translate`.

Fixes: https://github.com/flutter/flutter/issues/86081

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
