### PR TITLE
Added 'exclude' parameter to 'testWidgets()'.

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -158,8 +158,8 @@ E? _lastWhereOrNull<E>(Iterable<E> list, bool Function(E) test) {
 void testWidgets(
   String description,
   WidgetTesterCallback callback, {
-  bool? skip,
-  bool? exclude,
+  bool skip = false,
+  bool exclude = false,
   test_package.Timeout? timeout,
   Duration? initialTimeout,
   bool semanticsEnabled = true,
@@ -207,7 +207,7 @@ void testWidgets(
           timeout: initialTimeout,
         );
       },
-      skip: exclude == true || skip == true,
+      skip: (exclude || skip) ? true : null,
       timeout: timeout ?? binding.defaultTestTimeout,
       tags: tags,
     );

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -115,6 +115,14 @@ E? _lastWhereOrNull<E>(Iterable<E> list, bool Function(E) test) {
 /// each value of the [TestVariant.values]. If [variant] is not set, the test
 /// will be run once using the base test environment.
 ///
+/// If either [exclude] or [skip] is `true`, then the test will be skipped. The
+/// difference is that [skip] is a temporary way to disable a problematic test
+/// while a fix is being developed. It should have a comment after it with a
+/// link to a tracking issue for the work on re-enabling the test.
+///
+/// [exclude] is used to indicate that the test is not designed to run under
+/// the condition given and should always be skipped when it is `true`.
+///
 /// If the [tags] are passed, they declare user-defined tags that are implemented by
 /// the `test` package.
 ///
@@ -132,11 +140,26 @@ E? _lastWhereOrNull<E>(Iterable<E> list, bool Function(E) test) {
 ///   expect(find.text('Success'), findsOneWidget);
 /// });
 /// ```
+///
+/// ### Excluded test
+/// ```dart
+/// testWidgets('Some test that will never make sense for the web', (WidgetTester tester) async {
+///   // test code
+/// }, exclude: isBrowser);
+/// ```
+///
+/// ### Skipped test
+/// ```dart
+/// testWidgets('Some flaky test', (WidgetTester tester) async {
+///   // test code
+/// }, skip: true); // https://github.com/flutter/flutter/issues/12345
+/// ```
 @isTest
 void testWidgets(
   String description,
   WidgetTesterCallback callback, {
   bool? skip,
+  bool? exclude,
   test_package.Timeout? timeout,
   Duration? initialTimeout,
   bool semanticsEnabled = true,
@@ -184,7 +207,7 @@ void testWidgets(
           timeout: initialTimeout,
         );
       },
-      skip: skip,
+      skip: exclude == true || skip == true,
       timeout: timeout ?? binding.defaultTestTimeout,
       tags: tags,
     );

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -738,6 +738,16 @@ void main() {
     });
   });
 
+  group('Skip and exclude work', () {
+    testWidgets('skipping a test skips it', (WidgetTester tester) async {
+      expect(true, false); // shouldn't get here
+    }, skip: true); // https://github.com/someissue
+
+    testWidgets('excluding a test skips it', (WidgetTester tester) async {
+      expect(true, false); // shouldn't get here
+    }, exclude: true);
+  });
+
   group('Pending timer', () {
     late TestExceptionReporter currentExceptionReporter;
     setUp(() {


### PR DESCRIPTION
Part of #86396. 

Adds a new `exclude` parameter to `testWidgets` that behaves the same as `skip` but is used to mark a test that should always be skipped under the condition as it isn't designed that way. `skip` is still used to mark tests that are just temporarily shut off to keep the tree open.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
