### PR TITLE
Make LiveTestWidgetsFlutterBinding work with setSurfaceSize and live tests

### DIFF
--- a/packages/flutter/test/animation/live_binding_test.dart
+++ b/packages/flutter/test/animation/live_binding_test.dart
@@ -25,9 +25,12 @@ void main() {
               border: Border.all(color: const Color.fromARGB(255, 0, 0, 0)),
             ),
             child: Center(
-              child: GestureDetector(
-                onTap: () {},
-                child: const Text('Test'),
+              child: Material(
+                child: InkWell(
+                  splashColor: Colors.blue,
+                  child: const SizedBox(width: 40, height: 40),
+                  onTap: () {},
+                ),
               ),
             ),
           ),
@@ -40,12 +43,12 @@ void main() {
     await tester.pumpFrames(target, const Duration(milliseconds: 50));
 
     final TestGesture gesture1 = await tester.createGesture();
-    await gesture1.down(tester.getCenter(find.byType(Text)) + const Offset(10, 10));
+    await gesture1.down(tester.getCenter(find.byType(InkWell)) + const Offset(10, 10));
 
     await tester.pumpFrames(target, const Duration(milliseconds: 100));
 
     final TestGesture gesture2 = await tester.createGesture();
-    await gesture2.down(tester.getTopLeft(find.byType(Text)) + const Offset(30, -10));
+    await gesture2.down(tester.getTopLeft(find.byType(InkWell)) + const Offset(30, -10));
     await gesture1.moveBy(const Offset(50, 50));
 
     await tester.pumpFrames(target, const Duration(milliseconds: 100));
@@ -56,6 +59,56 @@ void main() {
     await expectLater(
       animationSheet.collate(6),
       matchesGoldenFile('LiveBinding.press.animation.png'),
+    );
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/42767
+
+  testWidgets('Should show event indicator for pointer events with setSurfaceSize', (WidgetTester tester) async {
+    final AnimationSheetBuilder animationSheet = AnimationSheetBuilder(frameSize: const Size(200, 200), allLayers: true);
+    final Widget target = Container(
+      padding: const EdgeInsets.fromLTRB(20, 10, 25, 20),
+      child: animationSheet.record(
+        MaterialApp(
+          home: Container(
+            decoration: BoxDecoration(
+              color: const Color.fromARGB(255, 128, 128, 128),
+              border: Border.all(color: const Color.fromARGB(255, 0, 0, 0)),
+            ),
+            child: Center(
+              child: Material(
+                child: InkWell(
+                  splashColor: Colors.blue,
+                  child: const SizedBox(width: 40, height: 40),
+                  onTap: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.binding.setSurfaceSize(const Size(300, 300));
+    await tester.pumpWidget(target);
+
+    await tester.pumpFrames(target, const Duration(milliseconds: 50));
+
+    final TestGesture gesture1 = await tester.createGesture();
+    await gesture1.down(tester.getCenter(find.byType(InkWell)) + const Offset(10, 10));
+
+    await tester.pumpFrames(target, const Duration(milliseconds: 100));
+
+    final TestGesture gesture2 = await tester.createGesture();
+    await gesture2.down(tester.getTopLeft(find.byType(InkWell)) + const Offset(30, -10));
+    await gesture1.moveBy(const Offset(50, 50));
+
+    await tester.pumpFrames(target, const Duration(milliseconds: 100));
+    await gesture1.up();
+    await gesture2.up();
+    await tester.pumpFrames(target, const Duration(milliseconds: 50));
+
+    await expectLater(
+      animationSheet.collate(6),
+      matchesGoldenFile('LiveBinding.press.animation.2.png'),
     );
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/42767
 }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -119,6 +119,20 @@ mixin TestDefaultBinaryMessengerBinding on BindingBase, ServicesBinding {
 /// that actually needs to make a network call should provide its own
 /// `HttpClient` to the code making the call, so that it can appropriately mock
 /// or fake responses.
+///
+/// ### Coordinate spaces
+///
+/// [TestWidgetsFlutterBinding] might be run on devices of different screen
+/// sizes, while the testing widget is still told the same size to ensure
+/// consistent results. Consequently, code that deals with positions (such as
+/// pointer events or painting) must distinguish between two coordinate spaces:
+///
+///  * The _local coordinate space_ is the one used by the testing widget
+///    (typically an 800 by 600 window, but can be altered by [setSurfaceSize]).
+///  * The _global coordinate space_ is the one used by the device.
+///
+/// Positions can be transformed between coordinate spaces with [localToGlobal]
+/// and [globalToLocal].
 abstract class TestWidgetsFlutterBinding extends BindingBase
   with SchedulerBinding,
        ServicesBinding,
@@ -447,14 +461,16 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     });
   }
 
-  /// Convert the given point from the global coordinate system (as used by
-  /// pointer events from the device) to the coordinate system used by the
-  /// tests (an 800 by 600 window).
+  /// Convert the given point from the global coordinate space to the local
+  /// one.
+  ///
+  /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
   Offset globalToLocal(Offset point) => point;
 
-  /// Convert the given point from the coordinate system used by the tests (an
-  /// 800 by 600 window) to the global coordinate system (as used by pointer
-  /// events from the device).
+  /// Convert the given point from the local coordinate space to the global
+  /// one.
+  ///
+  /// For definitions for coordinate spaces, see [TestWidgetsFlutterBinding].
   Offset localToGlobal(Offset point) => point;
 
   /// The source of the current pointer event.
@@ -475,25 +491,21 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// [handlePointerEvent], then resets [pointerEventSource] to the previous
   /// value.
   ///
-  /// If `source` is [TestBindingEventSource.device], then the `event`
-  /// is based in the global coordinate system and the event is likely
-  /// triggered by the user physically interacting with the screen during a
-  /// live test on a real device (see [LiveTestWidgetsFlutterBinding]).
+  /// If `source` is [TestBindingEventSource.device], then the `event` is based
+  /// in the global coordinate space (for definitions for coordinate spaces,
+  /// see [TestWidgetsFlutterBinding]) and the event is likely triggered by the
+  /// user physically interacting with the screen during a live test on a real
+  /// device (see [LiveTestWidgetsFlutterBinding]).
   ///
-  /// If `source` is [TestBindingEventSource.test], then the `event`
-  /// is based in the local coordinate system and the event is likely
-  /// triggered by programatically simulated pointer event, such as:
+  /// If `source` is [TestBindingEventSource.test], then the `event` is based
+  /// in the local coordinate space and the event is likely triggered by
+  /// programatically simulated pointer event, such as:
   ///
   ///  * [WidgetController.tap] and alike methods, as well as directly using
   ///    [TestGesture]. They are usually used in
   ///    [AutomatedTestWidgetsFlutterBinding] but sometimes in live tests too.
   ///  * [WidgetController.timedDrag] and alike methods. They are usually used
   ///    in macrobenchmarks.
-  ///
-  /// See also:
-  ///
-  ///  * [localToGlobal] and [globalToLocal] for transforming between coordinate
-  ///    systems.
   void handlePointerEventForSource(
     PointerEvent event, {
     TestBindingEventSource source = TestBindingEventSource.device,
@@ -1550,6 +1562,9 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         break;
       case TestBindingEventSource.device:
         if (deviceEventDispatcher != null) {
+          // The pointer events received with this source has a global position
+          // (see [handlePointerEventForSource]). Transform it to the local
+          // coordinate space used by the testing widgets.
           final PointerEvent localEvent = event.copyWith(position: globalToLocal(event.position));
           withPointerEventSource(TestBindingEventSource.device,
             () => super.handlePointerEvent(localEvent)

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -499,7 +499,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   ///
   /// If `source` is [TestBindingEventSource.test], then the `event` is based
   /// in the local coordinate space and the event is likely triggered by
-  /// programatically simulated pointer event, such as:
+  /// programatically simulated pointer events, such as:
   ///
   ///  * [WidgetController.tap] and alike methods, as well as directly using
   ///    [TestGesture]. They are usually used in
@@ -1535,8 +1535,8 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   /// Dispatch an event to the targets found by a hit test on its position.
   ///
   /// If the [pointerEventSource] is [TestBindingEventSource.test], then
-  /// the event is forwarded to [GestureBinding.dispatchEvent] as normal,
-  /// and down events are also painted on the screen.
+  /// the event is forwarded to [GestureBinding.dispatchEvent] as usual;
+  /// additionally, down pointers are painted on the screen.
   ///
   /// If the [pointerEventSource] is [TestBindingEventSource.device], then
   /// the event, after being transformed to the local coordinate system, is

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -59,15 +59,19 @@ export 'package:test_api/test_api.dart' hide
 /// Signature for callback to [testWidgets] and [benchmarkWidgets].
 typedef WidgetTesterCallback = Future<void> Function(WidgetTester widgetTester);
 
-// [Iterable.lastWhere] but returns null if not found.
-T? _lastWhereOrNull<T>(Iterable<T> list, bool Function(T) condition) {
-  try {
-    return list.lastWhere(condition);
-  } catch(e) {
-    if (e is StateError) {
-      return null;
+// Return the last element that satisifes `test`, or return null if not found.
+E? _lastWhereOrNull<E>(Iterable<E> list, bool Function(E) test) {
+  late E result;
+  bool foundMatching = false;
+  for (final E element in list) {
+    if (test(element)) {
+      result = element;
+      foundMatching = true;
     }
   }
+  if (foundMatching)
+    return result;
+  return null;
 }
 
 /// Runs the [callback] inside the Flutter test environment.
@@ -812,10 +816,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         .whereType<RenderObject>()
         .first;
       final Element? innerTargetElement = _lastWhereOrNull(
-        collectAllElementsFrom(
-          binding.renderViewElement!,
-          skipOffstage: true,
-        ).cast<Element>(),
+        collectAllElementsFrom(binding.renderViewElement!, skipOffstage: true),
         (Element element) => element.renderObject == innerTarget,
       );
       if (innerTargetElement == null) {

--- a/packages/flutter_test/test/widget_tester_live_device_test.dart
+++ b/packages/flutter_test/test/widget_tester_live_device_test.dart
@@ -6,6 +6,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Only check the initial lines of the message, since the message walks the
+// entire widget tree back, and any changes to the widget tree break these
+// tests if we check the entire message.
+void _expectStartsWith(List<String?> actual, List<String?> matcher) {
+  expect(actual.sublist(0, matcher.length), equals(matcher));
+}
+
 void main() {
   final _MockLiveTestWidgetsFlutterBinding binding = _MockLiveTestWidgetsFlutterBinding();
 
@@ -14,8 +21,9 @@ void main() {
 
     int invocations = 0;
     await tester.pumpWidget(
-      MaterialApp(
-        home: Center(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
           child: GestureDetector(
             onTap: () {
               invocations++;
@@ -42,39 +50,82 @@ void main() {
     await tester.pump();
     expect(invocations, 0);
 
-    expect(printedMessages, equals('''
+    _expectStartsWith(printedMessages, '''
 Some possible finders for the widgets at Offset(400.0, 300.0):
   find.text('Test')
-  find.widgetWithText(RawGestureDetector, 'Test')
-  find.byType(GestureDetector)
-  find.byType(Center)
-  find.widgetWithText(IgnorePointer, 'Test')
-  find.byType(FadeTransition)
-  find.byType(FractionalTranslation)
-  find.byType(SlideTransition)
-  find.widgetWithText(FocusTrap, 'Test')
-  find.widgetWithText(PrimaryScrollController, 'Test')
-  find.widgetWithText(PageStorage, 'Test')
-'''.trim().split('\n')));
+'''.trim().split('\n'));
     printedMessages.clear();
 
     await binding.collectDebugPrints(printedMessages, () async {
       await tester.tapAt(const Offset(1, 1));
     });
     expect(printedMessages, equals('''
-Some possible finders for the widgets at Offset(1.0, 1.0):
-  find.byType(MouseRegion)
-  find.byType(ExcludeSemantics)
-  find.byType(BlockSemantics)
-  find.byType(ModalBarrier)
-  find.byType(Overlay)
+No widgets found at Offset(1.0, 1.0).
+'''.trim().split('\n')));
+  });
+
+  testWidgets('Should print message on pointer events with setSurfaceSize', (WidgetTester tester) async {
+    final List<String?> printedMessages = <String?>[];
+
+    int invocations = 0;
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child:GestureDetector(
+            onTap: () {
+              invocations++;
+            },
+            child: const Text('Test'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.binding.setSurfaceSize(const Size(2000, 1800));
+    await tester.pump();
+
+    final Offset widgetCenter = tester.getRect(find.byType(Text)).center;
+    expect(widgetCenter.dx, 1000);
+    expect(widgetCenter.dy, 900);
+
+    await binding.collectDebugPrints(printedMessages, () async {
+      await tester.tap(find.byType(Text));
+    });
+    await tester.pump();
+    expect(invocations, 0);
+
+    _expectStartsWith(printedMessages, '''
+Some possible finders for the widgets at Offset(1000.0, 900.0):
+  find.text('Test')
+'''.trim().split('\n'));
+    printedMessages.clear();
+
+    await binding.collectDebugPrints(printedMessages, () async {
+      await tester.tapAt(const Offset(1, 1));
+    });
+    expect(printedMessages, equals('''
+No widgets found at Offset(1.0, 1.0).
 '''.trim().split('\n')));
   });
 }
 
 class _MockLiveTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
   @override
-  TestBindingEventSource get pointerEventSource => TestBindingEventSource.device;
+  void handlePointerEventForSource(
+    PointerEvent event, {
+    TestBindingEventSource source = TestBindingEventSource.device,
+  }) {
+    // In this test we use `WidgetTester.tap` to simulate real device touches.
+    // `WidgetTester.tap` sends events in the local coordinate system, while
+    // real devices touches sends event in the global coordinate system.
+    // See the documentation of [handlePointerEventForSource] for details.
+    if (source == TestBindingEventSource.test) {
+      final PointerEvent globalEvent = event.copyWith(position: localToGlobal(event.position));
+      return super.handlePointerEventForSource(globalEvent, source: TestBindingEventSource.device);
+    }
+    return super.handlePointerEventForSource(event, source: source);
+  }
 
   List<String?>? _storeDebugPrints;
 


### PR DESCRIPTION
This PR fixes several bugs related to live tests, adds more tests, and completes the documentation of several methods related to pointer events. More specifically:

The several tests for `LiveTestWidgetsFlutterBinding` added by #83337 were discovered by https://github.com/flutter/flutter/pull/82712#issuecomment-871534510 to fail when `setSurfaceSize` is called. This PR fixed these problems and added a `setSurfaceSize` version for these tests.

This PR fixes few problems of live tests:

  * https://github.com/flutter/flutter/issues/82542 reported that simulated pointer events do not work on live tests (for example, some code lab tests are broken).
  * Tapping the screen on live tests should print the hit widgets, instead the events are currently forwarded to the app and painted.
  * The painted event positions currently do not match the positions where the user interact.

This PR changed the testing widget used in `animation/live_binding_test.dart`. The target widget is now an `InkWell` to clearly ensure that the `hitTest` occurs at the intended local position.

<img src="https://user-images.githubusercontent.com/1596656/125877276-84d9c26b-2b9a-41e5-9f9b-6b35ed853960.png" width="500">

Finally, this PR updated some documentations for some methods, most importantly, whether a pointer event should be in the global coordinate system or the local one.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
