### PR TITLE
Reset default UserTag at the time of the first flutter frame

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -859,6 +859,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
       firstFrameCallback = (List<FrameTiming> timings) {
         assert(sendFramesToEngine);
         if (!kReleaseMode) {
+          developer.UserTag.defaultTag.makeCurrent();
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});
         }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -859,6 +859,10 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
       firstFrameCallback = (List<FrameTiming> timings) {
         assert(sendFramesToEngine);
         if (!kReleaseMode) {
+          // Change the current user tag back to the default tag. At this point,
+          // the user tag should be set to "AppStartUp" (originally set in the
+          // engine), so we need to change it back to the default tag to mark
+          // the end of app start up for CPU profiles.
           developer.UserTag.defaultTag.makeCurrent();
           developer.Timeline.instantSync('Rasterized first useful frame');
           developer.postEvent('Flutter.FirstFrame', <String, dynamic>{});

--- a/packages/flutter/test/widgets/binding_first_frame_developer_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_developer_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter/test/widgets/binding_first_frame_developer_test.dart
+++ b/packages/flutter/test/widgets/binding_first_frame_developer_test.dart
@@ -1,0 +1,25 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:developer' as developer;
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('first frame callback sets the default UserTag', () {
+      final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+
+      expect(developer.getCurrentTag().label, equals('Default'));
+      developer.UserTag('test tag').makeCurrent();
+      expect(developer.getCurrentTag().label, equals('test tag'));
+
+      binding.drawFrame();
+      // Simulates the engine again.
+      binding.window.onReportTimings!(<FrameTiming>[]);
+
+      expect(developer.getCurrentTag().label, equals('Default'));
+  });
+}


### PR DESCRIPTION
This is the Flutter Framework side of https://github.com/flutter/flutter/issues/84884. An 'AppStartUp' user tag will be set in the engine at the beginning of startup (https://github.com/flutter/engine/blob/master/runtime/dart_vm.cc#L448 is the proposed location - see https://github.com/flutter/engine/pull/27553). This change resets the default user tag, which marks the end of the 'AppStartUp' tag. Tools will pull the CPU profile tagged with 'AppStartUp' to provide better app start up profiling support.

CC @xster @bkonyi @iskakaushik 