### PR TITLE
ImageInfo adds a new getter named sizeBytes to decouple ImageCache and ui.Image

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -411,7 +411,7 @@ class ImageCache {
     void listener(ImageInfo? info, bool syncCall) {
       int? sizeBytes;
       if (info != null) {
-        sizeBytes = info.image.height * info.image.width * 4;
+        sizeBytes = info.sizeBytes;
         info.dispose();
       }
       final _CachedImage image = _CachedImage(

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -98,6 +98,9 @@ class ImageInfo {
   /// the image.
   final ui.Image image;
 
+  /// The size of raw image pixels in bytes
+  int get sizeBytes => image.height * image.width * 4;
+
   /// The linear scale factor for drawing this image at its intended size.
   ///
   /// The scale factor applies to the width and the height.

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -98,7 +98,7 @@ class ImageInfo {
   /// the image.
   final ui.Image image;
 
-  /// The size of raw image pixels in bytes
+  /// The size of raw image pixels in bytes.
   int get sizeBytes => image.height * image.width * 4;
 
   /// The linear scale factor for drawing this image at its intended size.

--- a/packages/flutter/test/painting/image_info_test.dart
+++ b/packages/flutter/test/painting/image_info_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui show Image;
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> main() async {
+
+  final ui.Image smallImage = await createTestImage(width: 10, height: 20);
+  final ui.Image middleImage = await createTestImage(width: 20, height: 100);
+  final ui.Image bigImage = await createTestImage(width: 100, height: 200);
+
+  test('ImageInfo sizeBytes', () {
+    ImageInfo imageInfo = ImageInfo(image: smallImage);
+    expect(imageInfo.sizeBytes, equals(800));
+
+    imageInfo = ImageInfo(image: middleImage);
+    expect(imageInfo.sizeBytes, equals(8000));
+
+    imageInfo = ImageInfo(image: bigImage);
+    expect(imageInfo.sizeBytes, equals(80000));
+  });
+}

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -44,6 +44,9 @@ class TestImageInfo implements ImageInfo {
   }
 
   @override
+  int get sizeBytes => image.height * image.width * 4;
+
+  @override
   int get hashCode => hashValues(value, image, scale, debugLabel);
 
   @override


### PR DESCRIPTION
We used external texture to display the images in our flutter app. On the Android platform, we draw the Bitmap onto the SurfaceTexture, and on the iOS platform, we convert the UIImage to CVPixelBufferRef, and finally use the Texture Widget to display the image. 
We want to let the external texture can benefit from the ImageCache logic.We hope that ImageCache can no longer dependent on ui.Image, so that we can customize ImageInfo and ImageProvier to cache external texture images in ImageCache.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/86402

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
