### PR TITLE
Always return false for `hitTestChildren` when `RenderOpacity` is completely transparent

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -909,6 +909,11 @@ class RenderOpacity extends RenderProxyBox {
   }
 
   @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return _alpha != 0 && super.hitTestChildren(result, position: position);
+  }
+
+  @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
     if (child != null && (_alpha != 0 || alwaysIncludeSemantics))
       visitor(child!);
@@ -1052,6 +1057,11 @@ class RenderAnimatedOpacity extends RenderProxyBox with RenderProxyBoxMixin, Ren
        super(child) {
     this.opacity = opacity;
     this.alwaysIncludeSemantics = alwaysIncludeSemantics;
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return _alpha != 0 && super.hitTestChildren(result, position: position);
   }
 }
 

--- a/packages/flutter/lib/src/rendering/proxy_sliver.dart
+++ b/packages/flutter/lib/src/rendering/proxy_sliver.dart
@@ -189,6 +189,11 @@ class RenderSliverOpacity extends RenderProxySliver {
   }
 
   @override
+  bool hitTestChildren(SliverHitTestResult result, {required double mainAxisPosition, required double crossAxisPosition}) {
+    return _alpha != 0 && super.hitTestChildren(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
+  }
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('opacity', opacity));
@@ -391,5 +396,11 @@ class RenderSliverAnimatedOpacity extends RenderProxySliver with RenderAnimatedO
     this.opacity = opacity;
     this.alwaysIncludeSemantics = alwaysIncludeSemantics;
     child = sliver;
+  }
+
+  @override
+  bool hitTestChildren(SliverHitTestResult result, {required double mainAxisPosition, required double crossAxisPosition}) {
+    return Color.getAlphaFromOpacity(opacity.value) != 0
+        && super.hitTestChildren(result, mainAxisPosition: mainAxisPosition, crossAxisPosition: crossAxisPosition);
   }
 }

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -41,11 +41,13 @@ void main() {
 
     await tester.tap(find.text('Go'));
     await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(didDelete, isFalse);
 
     await tester.tap(find.text('Delete'));
     await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(didDelete, isTrue);
     expect(find.text('Delete'), findsNothing);
@@ -835,6 +837,7 @@ void main() {
 
     await tester.tap(find.text('Go'));
     await tester.pump();
+    await tester.pumpAndSettle();
 
     const Color normalButtonBackgroundColor = Color(0xCCF2F2F2);
     const Color pressedButtonBackgroundColor = Color(0xFFE1E1E1);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1552,6 +1552,7 @@ void main() {
     );
 
     await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Cut'), findsNothing);
@@ -4451,7 +4452,6 @@ void main() {
               child: Column(
                 children: <Widget>[
                   CupertinoTextField(
-                    key: const Key('field0'),
                     controller: controller,
                     style: const TextStyle(height: 4, color: ui.Color.fromARGB(100, 0, 0, 0)),
                     toolbarOptions: const ToolbarOptions(selectAll: true),
@@ -4467,13 +4467,12 @@ void main() {
       ),
     );
 
-    final Offset textfieldStart = tester.getTopLeft(find.byKey(const Key('field0')));
+    await tester.longPress(find.byType(EditableText));
+    await tester.pump();
+    await tester.pumpAndSettle();
 
-    await tester.longPressAt(textfieldStart + const Offset(50.0, 2.0));
-    await tester.pump(const Duration(milliseconds: 150));
-    // Tap the Select All button.
-    await tester.tapAt(textfieldStart + const Offset(20.0, 100.0));
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Select All'));
+    await tester.pump();
 
     await expectLater(
       find.byType(CupertinoApp),
@@ -4498,7 +4497,6 @@ void main() {
               child: Column(
                 children: <Widget>[
                   CupertinoTextField(
-                    key: const Key('field0'),
                     controller: controller,
                     style: const TextStyle(height: 4, color: ui.Color.fromARGB(100, 0, 0, 0)),
                     toolbarOptions: const ToolbarOptions(selectAll: true),
@@ -4514,15 +4512,14 @@ void main() {
       ),
     );
 
-    final Offset textfieldStart = tester.getTopLeft(find.byKey(const Key('field0')));
+    await tester.longPress(find.byType(EditableText));
+    await tester.pump();
+    await tester.pumpAndSettle();
 
-    await tester.longPressAt(textfieldStart + const Offset(50.0, 2.0));
-    await tester.pump(const Duration(milliseconds: 150));
-    // Tap the Select All button.
-    await tester.tapAt(textfieldStart + const Offset(20.0, 100.0));
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Select All'));
+    await tester.pump();
 
-    await expectLater(
+   await expectLater(
       find.byType(CupertinoApp),
       matchesGoldenFile('text_field_golden.TextSelectionStyle.2.png'),
     );

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -39,7 +39,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Alarm'));
+    await tester.tap(find.text('Alarm'), warnIfMissed: false);
 
     expect(mutatedIndex, 1);
   });
@@ -844,21 +844,21 @@ void main() {
     Iterable<RenderBox> actions = tester.renderObjectList(find.byType(InkResponse));
     final Offset originalOrigin = actions.elementAt(3).localToGlobal(Offset.zero);
 
-    await tester.tap(find.text('AC'));
+    await tester.tap(find.text('AC'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
     actions = tester.renderObjectList(find.byType(InkResponse));
     expect(actions.elementAt(3).localToGlobal(Offset.zero), equals(originalOrigin));
 
-    await tester.tap(find.text('Alarm'));
+    await tester.tap(find.text('Alarm'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
     actions = tester.renderObjectList(find.byType(InkResponse));
     expect(actions.elementAt(3).localToGlobal(Offset.zero), equals(originalOrigin));
 
-    await tester.tap(find.text('Time'));
+    await tester.tap(find.text('Time'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -899,7 +899,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Alarm'));
+    await tester.tap(find.text('Alarm'), warnIfMissed: false);
     await tester.pump(const Duration(seconds: 1));
     expect(Theme.of(tester.element(find.text('Alarm'))).brightness, equals(Brightness.dark));
   });
@@ -937,7 +937,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Alarm'));
+    await tester.tap(find.text('Alarm'), warnIfMissed: false);
     await tester.pump(const Duration(seconds: 1));
     expect(Theme.of(tester.element(find.text('Alarm'))).brightness, equals(Brightness.dark));
   });
@@ -1272,12 +1272,12 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(BottomNavigationBar));
     expect(box, isNot(paints..circle()));
 
-    await tester.tap(find.text('A'));
+    await tester.tap(find.text('A'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 20));
     expect(box, paints..circle(x: 200.0));
 
-    await tester.tap(find.text('B'));
+    await tester.tap(find.text('B'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 20));
     expect(box, paints..circle(x: 200.0)..translate(x: 400.0)..circle(x: 200.0));
@@ -1303,7 +1303,7 @@ void main() {
 
     expect(box, paints..translate()..save()..translate(x: 400.0)..circle(x: 200.0)..restore()..circle(x: 200.0));
 
-    await tester.tap(find.text('A'));
+    await tester.tap(find.text('A'), warnIfMissed: false);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 20));
     expect(
@@ -1571,7 +1571,7 @@ void main() {
 
     expect(_backgroundColor, Colors.red);
     expect(tester.widget<Material>(backgroundMaterial).color, Colors.red);
-    await tester.tap(find.text('green'));
+    await tester.tap(find.text('green'), warnIfMissed: false);
     await tester.pumpAndSettle();
     expect(_backgroundColor, Colors.green);
     expect(tester.widget<Material>(backgroundMaterial).color, Colors.green);
@@ -1616,7 +1616,7 @@ void main() {
     for (int pump = 1; pump < 9; pump++) {
       testWidgets('pump $pump', (WidgetTester tester) async {
         await tester.pumpWidget(runTest());
-        await tester.tap(find.text('Green'));
+        await tester.tap(find.text('Green'), warnIfMissed: false);
 
         for (int i = 0; i < pump; i++) {
           await tester.pump(const Duration(milliseconds: 30));

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -282,7 +282,7 @@ void main() {
     // by pressing the Alert's NO button.
     await tester.tap(find.byTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
-    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.pumpAndSettle(); // Call willPop which will show an Alert.
     await tester.tap(find.text('NO'));
     await tester.pump(); // Start the dismiss animation.
     await tester.pump(); // Resolve the willPop callback.
@@ -295,7 +295,7 @@ void main() {
     // didChangeDependencies() method doesn't add an extra willPop callback.
     await tester.tap(find.byTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
-    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.pumpAndSettle(); // Call willPop which will show an Alert.
     await tester.tap(find.text('NO'));
     await tester.pump(); // Start the dismiss animation.
     await tester.pump(); // Resolve the willPop callback.
@@ -306,7 +306,7 @@ void main() {
     // YES button.
     await tester.tap(find.byTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
-    await tester.pump(); // Call willPop which will show an Alert.
+    await tester.pumpAndSettle(); // Call willPop which will show an Alert.
     await tester.tap(find.text('YES'));
     await tester.pump(); // Start the dismiss animation.
     await tester.pump(); // Resolve the willPop callback.

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -291,6 +291,17 @@ void main() {
     ));
   });
 
+  test('The child is not hittestable if RenderOpacity is transparent', () {
+    // Regression test for https://github.com/flutter/flutter/issues/85108.
+    final RenderSizedBox child = RenderSizedBox(const Size(100.0, 100.0));
+    final RenderOpacity renderOpacity = RenderOpacity(opacity: 0.0, child: child);
+
+    layout(renderOpacity, phase: EnginePhase.composite);
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    renderOpacity.hitTest(hitTestResult, position: const Offset(1.0, 1.0));
+    expect(hitTestResult.path, isEmpty);
+  });
+
   test('RenderAnimatedOpacity does not composite if it is transparent', () async {
     final Animation<double> opacityAnimation = AnimationController(
       vsync: FakeTickerProvider(),
@@ -330,6 +341,26 @@ void main() {
       opacity: opacityAnimation,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
     ));
+  });
+
+  test('The child is not hittestable if RenderAnimatedOpacity is transparent', () {
+    // Regression test for https://github.com/flutter/flutter/issues/85108.
+    final RenderSizedBox child = RenderSizedBox(const Size(100.0, 100.0));
+
+    final Animation<double> opacityAnimation = AnimationController(
+      vsync: FakeTickerProvider(),
+    )..value = 0.0;
+
+    final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
+      alwaysIncludeSemantics: false,
+      opacity: opacityAnimation,
+      child: child, // size doesn't matter
+    );
+
+    layout(renderAnimatedOpacity, phase: EnginePhase.composite);
+    final BoxHitTestResult hitTestResult = BoxHitTestResult();
+    renderAnimatedOpacity.hitTest(hitTestResult, position: const Offset(1.0, 1.0));
+    expect(hitTestResult.path, isEmpty);
   });
 
   test('RenderShaderMask reuses its layer', () {

--- a/packages/flutter/test/rendering/proxy_sliver_test.dart
+++ b/packages/flutter/test/rendering/proxy_sliver_test.dart
@@ -77,6 +77,33 @@ void main() {
     expect(renderSliverOpacity.debugLayer, same(layer));
   });
 
+  test('The child is not hittestable if RenderSliverOpacity is transparent', () {
+    // Regression test for https://github.com/flutter/flutter/issues/85108.
+    final RenderSizedBox child = RenderSizedBox(const Size(100.0, 100.0));
+
+    final RenderSliverOpacity renderSliverOpacity = RenderSliverOpacity(
+      opacity: 0.0,
+      sliver: RenderSliverToBoxAdapter(child: child),
+    );
+
+    final RenderViewport root = RenderViewport(
+      axisDirection: AxisDirection.down,
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      cacheExtent: 250.0,
+      children: <RenderSliver>[renderSliverOpacity],
+    );
+
+    layout(root, phase: EnginePhase.composite);
+    final SliverHitTestResult hitTestResult = SliverHitTestResult();
+    renderSliverOpacity.hitTest(
+      hitTestResult,
+      mainAxisPosition: 10.0,
+      crossAxisPosition: 10.0,
+    );
+    expect(hitTestResult.path, isEmpty);
+  });
+
   test('RenderSliverAnimatedOpacity does not composite if it is transparent', () async {
     final Animation<double> opacityAnimation = AnimationController(
       vsync: FakeTickerProvider(),
@@ -158,5 +185,37 @@ void main() {
     pumpFrame(phase: EnginePhase.paint);
     expect(renderSliverAnimatedOpacity.debugNeedsPaint, false);
     expect(renderSliverAnimatedOpacity.debugLayer, same(layer));
+  });
+
+  test('The child is not hittestable if RenderSliverAnimatedOpacity is transparent', () {
+    // Regression test for https://github.com/flutter/flutter/issues/85108.
+    final RenderSizedBox child = RenderSizedBox(const Size(100.0, 100.0));
+
+    final Animation<double> opacityAnimation = AnimationController(
+      vsync: FakeTickerProvider(),
+    )..value = 0.0;
+
+    final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
+      alwaysIncludeSemantics: false,
+      opacity: opacityAnimation,
+      sliver: RenderSliverToBoxAdapter(child: child),
+    );
+
+    final RenderViewport root = RenderViewport(
+      axisDirection: AxisDirection.down,
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      cacheExtent: 250.0,
+      children: <RenderSliver>[renderSliverAnimatedOpacity],
+    );
+
+    layout(root, phase: EnginePhase.composite);
+    final SliverHitTestResult hitTestResult = SliverHitTestResult();
+    renderSliverAnimatedOpacity.hitTest(
+      hitTestResult,
+      mainAxisPosition: 10.0,
+      crossAxisPosition: 10.0,
+    );
+    expect(hitTestResult.path, isEmpty);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85108

Hit testing sometimes depends on information we generated during
the painting phase so it seems to make sense to make the contents not
hittestable if they're not visible.

For #85108 specifically the `TextPainter` class clears out its cache
when its `text` changes, even for cases where the text does not really
need a re-layout (e.g., color changes). Hit testing `TextSpan`s without
first calling layout in this case throws.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
