### PR TITLE
remove bringup field from "Linux docs_test"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1139,7 +1139,6 @@ targets:
 
   - name: Linux docs_test
     builder: Linux docs_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/84609
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
The [issue linked](https://github.com/flutter/flutter/issues/84609) has been marked closed (with a [re-run](https://github.com/flutter/flutter/pull/84728)), and this looks green as far back in the build dashboard as I looked.