### PR TITLE
Close the exit port used by the compute isolate utility function

### DIFF
--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -59,6 +59,7 @@ Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { St
   await result.future;
   Timeline.startSync('$debugLabel: end', flow: Flow.end(flow.id));
   resultPort.close();
+  exitPort.close();
   errorPort.close();
   isolate.kill();
   Timeline.finishSync();

--- a/packages/flutter/test/foundation/_compute_caller.dart
+++ b/packages/flutter/test/foundation/_compute_caller.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A test script that invokes compute() to start an isolate.
+
+import 'package:flutter/src/foundation/_isolates_io.dart';
+
+int getLength(String s) {
+  return s.length;
+}
+
+Future<void> main() async {
+  const String s = 'hello world';
+  final int result = await compute(getLength, s);
+  if (result != s.length) {
+    throw Exception('compute returned bad result');
+  }
+}

--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:platform/platform.dart';
 
 int test1(int value) {
   return value + 1;
@@ -28,5 +32,19 @@ void main() {
 
     expect(await compute(test1Async, 0), 1);
     expect(compute(test2Async, 0), throwsException);
+  }, skip: kIsWeb);
+
+  test('compute closes all ports', () async {
+    // Run a Dart script that calls compute().
+    // The Dart process will terminate only if the script exits cleanly with
+    // all isolate ports closed.
+    const FileSystem fs = LocalFileSystem();
+    const Platform platform = LocalPlatform();
+    final String flutterRoot = platform.environment['FLUTTER_ROOT']!;
+    final String dartPath = fs.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
+    final String packageRoot = fs.path.dirname(fs.path.fromUri(platform.script));
+    final String scriptPath = fs.path.join(packageRoot, 'test', 'foundation', '_compute_caller.dart');
+    final ProcessResult result = await Process.run(dartPath, <String>[scriptPath]);
+    expect(result.exitCode, 0);
   }, skip: kIsWeb);
 }


### PR DESCRIPTION
Receive ports are tracked in a static map within the Dart SDK until the
port is closed.  The map will hold references to handler closures,
which in turn may retain references to objects in the closure's context.

Fixes https://github.com/flutter/flutter/issues/86470
