### PR TITLE
Cancel DraggableScrollableSheet ballistic animation if a new activity begins

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -490,8 +490,8 @@ class _DraggableScrollableSheetScrollPosition
       debugLabel: objectRuntimeType(this, '_DraggableScrollableSheetPosition'),
       vsync: context.vsync,
     );
-    // Stop the controller if the cancel callback is called (see
-    // [beginActivity]).
+    // Stop the controller if the cancel callback is called.
+    // See: [beginActivity].
     _ballisticCancelCallback = ballisticController.stop;
     double lastDelta = 0;
     void _tick() {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -10,6 +10,7 @@ import 'framework.dart';
 import 'inherited_notifier.dart';
 import 'layout_builder.dart';
 import 'notification_listener.dart';
+import 'scroll_activity.dart';
 import 'scroll_context.dart';
 import 'scroll_controller.dart';
 import 'scroll_notification.dart';
@@ -431,8 +432,16 @@ class _DraggableScrollableSheetScrollPosition
         );
 
   VoidCallback? _dragCancelCallback;
+  VoidCallback? _ballisticCancelCallback;
   final _DraggableSheetExtent extent;
   bool get listShouldScroll => pixels > 0.0;
+
+  @override
+  void beginActivity(ScrollActivity? newActivity) {
+    // Cancel the running ballistic simulation, if there is one.
+    _ballisticCancelCallback?.call();
+    super.beginActivity(newActivity);
+  }
 
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
@@ -481,6 +490,9 @@ class _DraggableScrollableSheetScrollPosition
       debugLabel: objectRuntimeType(this, '_DraggableScrollableSheetPosition'),
       vsync: context.vsync,
     );
+    // Stop the controller if the cancel callback is called (see
+    // [beginActivity]).
+    _ballisticCancelCallback = ballisticController.stop;
     double lastDelta = 0;
     void _tick() {
       final double delta = ballisticController.value - lastDelta;
@@ -501,7 +513,10 @@ class _DraggableScrollableSheetScrollPosition
     ballisticController
       ..addListener(_tick)
       ..animateWith(simulation).whenCompleteOrCancel(
-        ballisticController.dispose,
+        () {
+          _ballisticCancelCallback = null;
+          ballisticController.dispose();
+        },
       );
   }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -490,7 +490,7 @@ class _DraggableScrollableSheetScrollPosition
       debugLabel: objectRuntimeType(this, '_DraggableScrollableSheetPosition'),
       vsync: context.vsync,
     );
-    // Stop the controller if the cancel callback is called.
+    // Stop the ballistic animation if a new activity starts.
     // See: [beginActivity].
     _ballisticCancelCallback = ballisticController.stop;
     double lastDelta = 0;

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -272,34 +272,28 @@ void main() {
         await tester.tap(find.text('TapHere'));
         expect(taps, 1);
         expect(find.text('Item 1'), findsOneWidget);
-        expect(find.text('Item 21'), findsOneWidget);
         expect(find.text('Item 31'), findsNothing);
         expect(find.text('Item 70'), findsNothing);
 
         await tester.fling(find.text('Item 1'), const Offset(0, -200), 2000);
-        // Don't pump and settle-we want to stop before the ballistic animation
-        // plays so that we can interrupt it.
+        // Don't pump and settle because we want to interrupt the ballistic scrolling animation.
         expect(find.text('TapHere'), findsOneWidget);
         await tester.tap(find.text('TapHere'), warnIfMissed: false);
         expect(taps, 2);
         expect(find.text('Item 1'), findsOneWidget);
-        expect(find.text('Item 21'), findsOneWidget);
         expect(find.text('Item 31'), findsOneWidget);
         expect(find.text('Item 70'), findsNothing);
 
-        // Interrupt the ballistic animation to cancel it. Use `dragFrom` here
-        // because, if the animation fails to interrupt, we won't know which
-        // item we can drag. This way, on interrupt failure, we'll get a more
-        // informative error later.
+        // Use `dragFrom` here because calling `drag` on a list item without
+        // first calling `pumpAndSettle` fails with a hit test error.
         await tester.dragFrom(const Offset(0, 200), const Offset(0, 200));
         await tester.pumpAndSettle();
 
-        // Verify ballistic animation has canceled and the sheet has returned
-        // to it's original position.
+        // Verify that the ballistic animation has canceled and the sheet has
+        // returned to it's original position.
         await tester.tap(find.text('TapHere'));
         expect(taps, 3);
         expect(find.text('Item 1'), findsOneWidget);
-        expect(find.text('Item 21'), findsOneWidget);
         expect(find.text('Item 31'), findsNothing);
         expect(find.text('Item 70'), findsNothing);
       }, variant: TargetPlatformVariant.all());

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -264,6 +264,46 @@ void main() {
         expect(find.text('Item 70'), findsNothing);
       }, variant: TargetPlatformVariant.all());
 
+      testWidgets('Ballistic animation on fling can be interrupted', (WidgetTester tester) async {
+        int taps = 0;
+        await tester.pumpWidget(_boilerplate(() => taps++));
+
+        expect(find.text('TapHere'), findsOneWidget);
+        await tester.tap(find.text('TapHere'));
+        expect(taps, 1);
+        expect(find.text('Item 1'), findsOneWidget);
+        expect(find.text('Item 21'), findsOneWidget);
+        expect(find.text('Item 31'), findsNothing);
+        expect(find.text('Item 70'), findsNothing);
+
+        await tester.fling(find.text('Item 1'), const Offset(0, -200), 2000);
+        // Don't pump and settle-we want to stop before the ballistic animation
+        // plays so that we can interrupt it.
+        expect(find.text('TapHere'), findsOneWidget);
+        await tester.tap(find.text('TapHere'), warnIfMissed: false);
+        expect(taps, 2);
+        expect(find.text('Item 1'), findsOneWidget);
+        expect(find.text('Item 21'), findsOneWidget);
+        expect(find.text('Item 31'), findsOneWidget);
+        expect(find.text('Item 70'), findsNothing);
+
+        // Interrupt the ballistic animation to cancel it. Use `dragFrom` here
+        // because, if the animation fails to interrupt, we won't know which
+        // item we can drag. This way, on interrupt failure, we'll get a more
+        // informative error later.
+        await tester.dragFrom(const Offset(0, 200), const Offset(0, 200));
+        await tester.pumpAndSettle();
+
+        // Verify ballistic animation has canceled and the sheet has returned
+        // to it's original position.
+        await tester.tap(find.text('TapHere'));
+        expect(taps, 3);
+        expect(find.text('Item 1'), findsOneWidget);
+        expect(find.text('Item 21'), findsOneWidget);
+        expect(find.text('Item 31'), findsNothing);
+        expect(find.text('Item 70'), findsNothing);
+      }, variant: TargetPlatformVariant.all());
+
       debugDefaultTargetPlatformOverride = null;
     });
 


### PR DESCRIPTION
Add a `_ballisticCancelCallback` to `_DraggableScrollableSheetScrollPosition` and use it to stop any playing ballistic animations if a new scroll activity is started.

Alternative implementation:
Start a `BallisticScrollActivity` instead of using an animation controller and `_tick`. This allows the scroll activity logic to manage interruptions for us (see `SingleContextScrollPosition.goBallistic`). Downsides:

- Will have to refactor to call `super.goBallistic(velocity)` from a listener on the activity
- Will have to manually interrupt the activity if it hits min or max extent

I think it's a value judgement as to which is cleaner so I went with simply updating the solution already present in the code. If reviewers see the alternative approach as significantly cleaner, I'm happy to refactor.

See https://github.com/flutter/flutter/issues/86573

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
