### PR TITLE
[flutter_tools] Refactor Android Studio Detection on Windows (support 4.x and 202x releases detection)

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -10,6 +10,7 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../ios/plist_parser.dart';
+import 'android_studio_validator.dart';
 
 // Android Studio layout:
 
@@ -372,52 +373,37 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         }
       }
     }
-
-    // 4.1 has a different location for AndroidStudio installs on Windows.
+    // Discover Android Studio > 4.1 
     if (globals.platform.isWindows && globals.platform.environment.containsKey('LOCALAPPDATA')) {
-      final File homeDot = globals.fs.file(globals.fs.path.join(
-        globals.platform.environment['LOCALAPPDATA']!,
-        'Google',
-        'AndroidStudio4.1',
-        '.home',
-      ));
-      if (homeDot.existsSync()) {
-        final String installPath = homeDot.readAsStringSync();
-        if (globals.fs.isDirectorySync(installPath)) {
-          final AndroidStudio studio = AndroidStudio(
-            installPath,
-            version: Version(4, 1, 0),
-            studioAppName: 'Android Studio 4.1',
-          );
-          if (studio != null && !_hasStudioAt(studio.directory, newerThan: studio.version)) {
-            studios.removeWhere((AndroidStudio other) => other.directory == studio.directory);
-            studios.add(studio);
-          }
-        }
+      final Directory cacheDir = globals.fs.directory(globals.fs.path.join(globals.platform.environment['LOCALAPPDATA']!, 'Google'));
+      if (!cacheDir.existsSync()) {
+        return studios;
       }
-    }
+      for (final Directory dir in cacheDir.listSync().whereType<Directory>()) {
+        final String name  = globals.fs.path.basename(dir.path); 
+        AndroidStudioValidator.idToTitle.forEach((String id, String title) {
+          if (name.startsWith(id)) {
+            final String version = name.substring(id.length);
+            String? installPath;
 
-    // 4.2 has a different location for AndroidStudio installs on Windows.
-    if (globals.platform.isWindows && globals.platform.environment.containsKey('LOCALAPPDATA')) {
-      final File homeDot = globals.fs.file(globals.fs.path.join(
-        globals.platform.environment['LOCALAPPDATA']!,
-        'Google',
-        'AndroidStudio4.2',
-        '.home',
-      ));
-      if (homeDot.existsSync()) {
-        final String installPath = homeDot.readAsStringSync();
-        if (globals.fs.isDirectorySync(installPath)) {
-          final AndroidStudio studio = AndroidStudio(
-            installPath,
-            version: Version(4, 2, 0),
-            studioAppName: 'Android Studio 4.2',
-          );
-          if (studio != null && !_hasStudioAt(studio.directory, newerThan: studio.version)) {
-            studios.removeWhere((AndroidStudio other) => other.directory == studio.directory);
-            studios.add(studio);
+            try {
+              installPath = globals.fs.file(globals.fs.path.join(dir.path, '.home')).readAsStringSync();
+            } on FileSystemException {
+              // ignored
+            }
+            if (installPath != null && globals.fs.isDirectorySync(installPath)) {
+              final AndroidStudio studio = AndroidStudio(
+                installPath,
+                version: Version.parse(version),
+                studioAppName: title,
+              );
+              if (studio != null && !_hasStudioAt(studio.directory, newerThan: studio.version)) {
+                studios.removeWhere((AndroidStudio other) => other.directory == studio.directory);
+                studios.add(studio);
+              }
+            }
           }
-        }
+        });
       }
     }
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -10,7 +10,7 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../ios/plist_parser.dart';
-import 'android_studio_validator.dart';
+import './android_studio_validator.dart';
 
 // Android Studio layout:
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -10,7 +10,7 @@ import '../base/version.dart';
 import '../convert.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../ios/plist_parser.dart';
-import './android_studio_validator.dart';
+import 'android_studio_validator.dart';
 
 // Android Studio layout:
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -373,6 +373,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         }
       }
     }
+    
     // Discover Android Studio > 4.1
     if (globals.platform.isWindows && globals.platform.environment.containsKey('LOCALAPPDATA')) {
       final Directory cacheDir = globals.fs.directory(globals.fs.path.join(globals.platform.environment['LOCALAPPDATA']!, 'Google'));

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -373,7 +373,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         }
       }
     }
-    
+
     // Discover Android Studio > 4.1
     if (globals.platform.isWindows && globals.platform.environment.containsKey('LOCALAPPDATA')) {
       final Directory cacheDir = globals.fs.directory(globals.fs.path.join(globals.platform.environment['LOCALAPPDATA']!, 'Google'));

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -373,14 +373,14 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         }
       }
     }
-    // Discover Android Studio > 4.1 
+    // Discover Android Studio > 4.1
     if (globals.platform.isWindows && globals.platform.environment.containsKey('LOCALAPPDATA')) {
       final Directory cacheDir = globals.fs.directory(globals.fs.path.join(globals.platform.environment['LOCALAPPDATA']!, 'Google'));
       if (!cacheDir.existsSync()) {
         return studios;
       }
       for (final Directory dir in cacheDir.listSync().whereType<Directory>()) {
-        final String name  = globals.fs.path.basename(dir.path); 
+        final String name  = globals.fs.path.basename(dir.path);
         AndroidStudioValidator.idToTitle.forEach((String id, String title) {
           if (name.startsWith(id)) {
             final String version = name.substring(id.length);

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -11,6 +11,11 @@ import '../doctor_validator.dart';
 import '../intellij/intellij.dart';
 import 'android_studio.dart';
 
+const String _androidStudioTitle = 'Android Studio';
+const String _androidStudioId = 'AndroidStudio';
+const String _androidStudioPreviewTitle = 'Android Studio Preview';
+const String _androidStudioPreviewStudioId = 'AndroidStudioPreview';
+
 class AndroidStudioValidator extends DoctorValidator {
   AndroidStudioValidator(this._studio, { required FileSystem fileSystem })
     : _fileSystem = fileSystem,
@@ -18,6 +23,11 @@ class AndroidStudioValidator extends DoctorValidator {
 
   final AndroidStudio _studio;
   final FileSystem _fileSystem;
+  
+  static const Map<String, String> idToTitle = <String, String>{
+    _androidStudioId: _androidStudioTitle,
+    _androidStudioPreviewStudioId: _androidStudioPreviewTitle,
+  };
 
   static List<DoctorValidator> allValidators(Config config, Platform platform, FileSystem fileSystem, UserMessages userMessages) {
     final List<AndroidStudio> studios = AndroidStudio.allInstalled();

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -14,7 +14,7 @@ import 'android_studio.dart';
 const String _androidStudioTitle = 'Android Studio';
 const String _androidStudioId = 'AndroidStudio';
 const String _androidStudioPreviewTitle = 'Android Studio Preview';
-const String _androidStudioPreviewStudioId = 'AndroidStudioPreview';
+const String _androidStudioPreviewId = 'AndroidStudioPreview';
 
 class AndroidStudioValidator extends DoctorValidator {
   AndroidStudioValidator(this._studio, { required FileSystem fileSystem })
@@ -26,7 +26,7 @@ class AndroidStudioValidator extends DoctorValidator {
 
   static const Map<String, String> idToTitle = <String, String>{
     _androidStudioId: _androidStudioTitle,
-    _androidStudioPreviewStudioId: _androidStudioPreviewTitle,
+    _androidStudioPreviewId: _androidStudioPreviewTitle,
   };
 
   static List<DoctorValidator> allValidators(Config config, Platform platform, FileSystem fileSystem, UserMessages userMessages) {

--- a/packages/flutter_tools/lib/src/android/android_studio_validator.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio_validator.dart
@@ -23,7 +23,7 @@ class AndroidStudioValidator extends DoctorValidator {
 
   final AndroidStudio _studio;
   final FileSystem _fileSystem;
-  
+
   static const Map<String, String> idToTitle = <String, String>{
     _androidStudioId: _androidStudioTitle,
     _androidStudioPreviewStudioId: _androidStudioPreviewTitle,

--- a/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_test.dart
@@ -402,7 +402,7 @@ void main() {
     final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
     expect(studio.version, Version(4, 1, 0));
-    expect(studio.studioAppName, 'Android Studio 4.1');
+    expect(studio.studioAppName, 'Android Studio');
   }, overrides: <Type, Generator>{
     Platform: () => windowsPlatform,
     FileSystem: () => windowsFileSystem,
@@ -420,7 +420,25 @@ void main() {
     final AndroidStudio studio = AndroidStudio.allInstalled().single;
 
     expect(studio.version, Version(4, 2, 0));
-    expect(studio.studioAppName, 'Android Studio 4.2');
+    expect(studio.studioAppName, 'Android Studio');
+  }, overrides: <Type, Generator>{
+    Platform: () => windowsPlatform,
+    FileSystem: () => windowsFileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('Can discover Android Studio 2020.3 location on Windows', () {
+    windowsFileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio2020.3\.home')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(r'C:\Program Files\AndroidStudio');
+    windowsFileSystem
+      .directory(r'C:\Program Files\AndroidStudio')
+      .createSync(recursive: true);
+
+    final AndroidStudio studio = AndroidStudio.allInstalled().single;
+
+    expect(studio.version, Version(2020, 3, 0));
+    expect(studio.studioAppName, 'Android Studio');
   }, overrides: <Type, Generator>{
     Platform: () => windowsPlatform,
     FileSystem: () => windowsFileSystem,
@@ -447,6 +465,24 @@ void main() {
 
   testUsingContext('Does not discover Android Studio 4.2 location on Windows if LOCALAPPDATA is null', () {
     windowsFileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio4.2\.home')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(r'C:\Program Files\AndroidStudio');
+    windowsFileSystem
+      .directory(r'C:\Program Files\AndroidStudio')
+      .createSync(recursive: true);
+
+    expect(AndroidStudio.allInstalled(), isEmpty);
+  }, overrides: <Type, Generator>{
+    Platform: () => FakePlatform(
+      operatingSystem: 'windows',
+      environment: <String, String>{}, // Does not include LOCALAPPDATA
+    ),
+    FileSystem: () => windowsFileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+  });
+
+  testUsingContext('Does not discover Android Studio 2020.3 location on Windows if LOCALAPPDATA is null', () {
+    windowsFileSystem.file(r'C:\Users\Dash\AppData\Local\Google\AndroidStudio2020.3\.home')
       ..createSync(recursive: true)
       ..writeAsStringSync(r'C:\Program Files\AndroidStudio');
     windowsFileSystem


### PR DESCRIPTION
This PR refactor Android Studio detection on Windows for Android Studio 4.1 and above. 

Instead of patching every new release for Android Studio, this PR adds similar detection like for Intellij in `flutter_tools`. 
As a result, we no longer need 4.1 and 4.2 detections separately (which I removed in this PR) 

These changes help detect older Android Studio versions such as 4.1, 4.2 (current version) and also support detecting new Android Studio Arctic Fox (with 202x versioning instead of 4.x)  on Windows and preview releases.  When Android Studio Arctic Fox becomes stable, there won't be a need to patch a detection for this release.

Related https://github.com/flutter/flutter/issues/85602

Here I have installed 4.1 (older), 4.2 (current), 2020.3 (Arctic fox) and 2021 (canary).
```console
[✓] Android Studio (version 4.1)
    • Android Studio at C:\Users\Taha\Code\android-studio-4.1
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 1.8.0_242-release-1644-b01)

[✓] Android Studio (version 4.2)
    • Android Studio at C:\Users\Taha\Code\android-studio
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.8+10-b944.6842174)

[✓] Android Studio (version 2020.3)
    • Android Studio at C:\Users\Taha\Code\android-studio-preview
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.10+0-b96-7249189)

[✓] Android Studio (version 2021.1)
    • Android Studio at C:\Users\Taha\Code\android-studio-canary
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.10+0-b96-7249189)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
