### PR TITLE
Add a "variant: " prefix to variant descriptions in test names

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -149,7 +149,13 @@ void testWidgets(
   final WidgetTester tester = WidgetTester._(binding);
   for (final dynamic value in variant.values) {
     final String variationDescription = variant.describeValue(value);
-    final String combinedDescription = variationDescription.isNotEmpty ? '$description ($variationDescription)' : description;
+    // IDEs may make assumptions about the format of this suffix in order to
+    // support running tests directly from the editor (where they may have
+    // access to only the test name, provided by the analysis server).
+    // See https://github.com/flutter/flutter/issues/86659.
+    final String combinedDescription = variationDescription.isNotEmpty
+        ? '$description (variant: $variationDescription)'
+        : description;
     test(
       combinedDescription,
       () {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -697,7 +697,10 @@ void main() {
       if (debugDefaultTargetPlatformOverride == null) {
         expect(tester.testDescription, equals('variant tests have descriptions with details'));
       } else {
-        expect(tester.testDescription, equals('variant tests have descriptions with details ($debugDefaultTargetPlatformOverride)'));
+        expect(
+          tester.testDescription,
+          equals('variant tests have descriptions with details (variant: $debugDefaultTargetPlatformOverride)'),
+        );
       }
     }, variant: TargetPlatformVariant(TargetPlatform.values.toSet()));
   });


### PR DESCRIPTION
This tweaks the suffix added to test names when using variants to be slightly more specific (` (variant: foo)` instead of just ` (foo)`:

<img width="859" alt="Screenshot 2021-07-20 at 09 54 00" src="https://user-images.githubusercontent.com/1078012/126292222-a490863f-1d38-4289-b018-7d4289c157d7.png">

This is to help editors that have access only to the test name that want to support running tests easily from the editor, but without leaving the regex passed to `flutter test --name` open-ended, which might match other tests than the one the user expected to run (if they have their own suffix in parens).

Right now, VS Code uses a regex like:

```
flutter test --name "^Counter increments smoke test$" test/widget_test.dart
```

But this fails for tests with variants. The goal is to change this regex to something like:

```
flutter test --name "^Counter increments smoke test( \(variant: .*\))?$" test/widget_test.dart
```

This will still avoid matching other tests with a suffix in parens, but allow the variants to run, fixing #86659.

IntelliJ doesn't currently use the same restrictive regex, but that leads to behaviour that could be considered a bug and is likely to be updated with https://github.com/flutter/flutter-intellij/issues/5650.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

@gspencergoog @jonahwilliams I'm assuming nobody outside of this repo is relying on the exact format of this suffix, but if you think that might not be correct, please let me know!