### PR TITLE
[flutter_releases] Fix dartdocs branch name on 2.2.x

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -265,7 +265,7 @@ String getBranchName({
   @visibleForTesting
   ProcessManager processManager = const LocalProcessManager(),
 }) {
-  final String? luciBranch = platform.environment['LUCI_BRANCH'];
+  final String luciBranch = platform.environment['LUCI_BRANCH'];
   if (luciBranch != null && luciBranch.trim().isNotEmpty) {
     return luciBranch.trim();
   }

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -7,7 +7,9 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
 import 'dartdoc_checker.dart';
@@ -253,8 +255,21 @@ ArgParser _createArgsParser() {
 
 final RegExp gitBranchRegexp = RegExp(r'^## (.*)');
 
-String getBranchName() {
-  final ProcessResult gitResult = Process.runSync('git', <String>['status', '-b', '--porcelain']);
+/// Get the name of the release branch.
+///
+/// On LUCI builds, the git HEAD is detached, so first check for the env
+/// variable "LUCI_BRANCH"; if it is not set, fall back to calling git.
+String getBranchName({
+  @visibleForTesting
+  Platform platform = const LocalPlatform(),
+  @visibleForTesting
+  ProcessManager processManager = const LocalProcessManager(),
+}) {
+  final String? luciBranch = platform.environment['LUCI_BRANCH'];
+  if (luciBranch != null && luciBranch.trim().isNotEmpty) {
+    return luciBranch.trim();
+  }
+  final ProcessResult gitResult = processManager.runSync(<String>['git', 'status', '-b', '--porcelain']);
   if (gitResult.exitCode != 0)
     throw 'git status exit with non-zero exit code: ${gitResult.exitCode}';
   final Match gitBranchMatch = gitBranchRegexp.firstMatch(

--- a/dev/tools/test/dartdoc_test.dart
+++ b/dev/tools/test/dartdoc_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:platform/platform.dart';
+import 'package:process/process.dart';
+import 'package:test/test.dart';
+
+import '../../../packages/flutter_tools/test/src/fake_process_manager.dart';
+import '../dartdoc.dart' show getBranchName;
+
+void main() {
+  const String branchName = 'stable';
+  test('getBranchName does not call git if env LUCI_BRANCH provided', () {
+    final Platform platform = FakePlatform(
+      environment: <String, String>{
+        'LUCI_BRANCH': branchName,
+      },
+    );
+
+    final ProcessManager processManager = FakeProcessManager.empty();
+
+    expect(
+      getBranchName(
+        platform: platform,
+        processManager: processManager,
+      ),
+      branchName,
+    );
+  });
+
+  test('getBranchName calls git if env LUCI_BRANCH not provided', () {
+    final Platform platform = FakePlatform(
+      environment: <String, String>{},
+    );
+
+    final ProcessManager processManager = FakeProcessManager.list(
+      <FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'status', '-b', '--porcelain'],
+          stdout: '## $branchName',
+        ),
+      ],
+    );
+
+    expect(
+      getBranchName(
+        platform: platform,
+        processManager: processManager,
+      ),
+      branchName,
+    );
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  test('getBranchName calls git if env LUCI_BRANCH is empty', () {
+    final Platform platform = FakePlatform(
+      environment: <String, String>{
+        'LUCI_BRANCH': '',
+      },
+    );
+
+    final ProcessManager processManager = FakeProcessManager.list(
+      <FakeCommand>[
+        const FakeCommand(
+          command: <String>['git', 'status', '-b', '--porcelain'],
+          stdout: '## $branchName',
+        ),
+      ],
+    );
+
+    expect(
+      getBranchName(
+        platform: platform,
+        processManager: processManager,
+      ),
+      branchName,
+    );
+    expect(processManager, hasNoRemainingExpectations);
+  });
+}

--- a/dev/tools/test/dartdoc_test.dart
+++ b/dev/tools/test/dartdoc_test.dart
@@ -18,7 +18,7 @@ void main() {
       },
     );
 
-    final ProcessManager processManager = FakeProcessManager.empty();
+    final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[]);
 
     expect(
       getBranchName(


### PR DESCRIPTION
cherrypick of teach dartdoc.dart about LUCI_BRANCH env var (#86592)

will fix https://github.com/flutter/flutter/issues/77178 and https://github.com/flutter/flutter/issues/86297 on stable.

NOTE: this will not be deployed until the next stable hotfix.