### PR TITLE
Clarify ReorderableListView drag handles on desktop and mobile

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -29,6 +29,12 @@ import 'theme.dart';
 /// The [onReorder] parameter is required and will be called when a child
 /// widget is dragged to a new position.
 ///
+/// A drag handle is stacked over the center of edge on
+/// [TargetPlatformVariant.desktop] platforms. On [TargetPlatformVariant.mobile]
+/// platforms, no handle is visible and a long press anywhere on the item starts
+/// a drag. To change this behavior use
+/// [ReorderableListView.buildDefaultDragHandles].
+///
 /// {@tool dartpad --template=stateful_widget_scaffold}
 ///
 /// ```dart

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -32,7 +32,7 @@ import 'theme.dart';
 /// A drag handle is stacked over the center of edge on
 /// [TargetPlatformVariant.desktop] platforms. On [TargetPlatformVariant.mobile]
 /// platforms, no handle is visible and a long press anywhere on the item starts
-/// a drag. To change this behavior use
+/// a drag. To change this behavior consider 
 /// [ReorderableListView.buildDefaultDragHandles].
 ///
 /// {@tool dartpad --template=stateful_widget_scaffold}


### PR DESCRIPTION
Prevents this https://github.com/flutter/flutter/issues/80553

More info here https://github.com/flutter/flutter/pull/80576

Comments only change. These changes were pre-approved on the pull 80576 but not pushed.