### PR TITLE
Manually close the tree for issue #86754

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart
@@ -3,8 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 
 Future<void> main() async {
   await task(createHotModeTest(deviceIdOverride: 'macos'));
+
+// TODO(zra): https://github.com/flutter/flutter/issues/86754
+  throw TaskResult.failure(
+      'Tree was manually closed for Android version of this test https://github.com/flutter/flutter/issues/86754');
 }


### PR DESCRIPTION
The internal roller is backed up.

See: https://github.com/flutter/flutter/issues/86754