### PR TITLE
Fix driver test to run locally.

### DIFF
--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -37,6 +37,7 @@ void main() {
     late FakeVM fakeVM;
     late FakeIsolate fakeIsolate;
     late VMServiceFlutterDriver driver;
+    late File logFile;
     int driverId = -1;
 
     setUp(() {
@@ -45,8 +46,14 @@ void main() {
       fakeClient = FakeVmService(fakeVM);
       fakeClient.responses['waitFor'] = makeFakeResponse(<String, dynamic>{'status':'ok'});
       driverId += 1;
+      logFile = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
     });
 
+    tearDown(() {
+      if (logFile.existsSync()) {
+        logFile.deleteSync();
+      }
+    });
 
     group('logCommunicationToFile', () {
       test('logCommunicationToFile = true', () async {
@@ -54,11 +61,10 @@ void main() {
 
         await driver.waitFor(find.byTooltip('foo'), timeout: _kTestTimeout);
 
-        final File file = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
-        final bool exists = file.existsSync();
-        expect(exists, true, reason: 'Not found ${file.path}');
+        final bool exists = logFile.existsSync();
+        expect(exists, true, reason: 'Not found ${logFile.path}');
 
-        final String commandLog = await file.readAsString();
+        final String commandLog = await logFile.readAsString();
         const String waitForCommandLog = '>>> {command: waitFor, timeout: $_kSerializedTestTimeout, finderType: ByTooltipMessage, text: foo}';
         const String responseLog = '<<< {isError: false, response: {status: ok}}';
 
@@ -71,9 +77,8 @@ void main() {
 
         await driver.waitFor(find.byTooltip('foo'), timeout: _kTestTimeout);
 
-        final File file = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
-        final bool exists = file.existsSync();
-        expect(exists, false, reason: 'because ${file.path} exists');
+        final bool exists = logFile.existsSync();
+        expect(exists, false, reason: 'because ${logFile.path} exists');
       });
     });
   });
@@ -691,6 +696,7 @@ void main() {
   group('WebFlutterDriver with logCommunicationToFile', () {
     late FakeFlutterWebConnection fakeConnection;
     late WebFlutterDriver driver;
+    late File logFile;
     int driverId = -1;
 
     setUp(() {
@@ -698,17 +704,23 @@ void main() {
       fakeConnection.supportsTimelineAction = true;
       fakeConnection.responses['waitFor'] = jsonEncode(makeFakeResponse(<String, dynamic>{'status': 'ok'}));
       driverId += 1;
+      logFile = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
+    });
+
+    tearDown(() {
+      if (logFile.existsSync()) {
+        logFile.deleteSync();
+      }
     });
 
     test('logCommunicationToFile = true', () async {
       driver = WebFlutterDriver.connectedTo(fakeConnection);
       await driver.waitFor(find.byTooltip('logCommunicationToFile test'), timeout: _kTestTimeout);
 
-      final File file = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
-      final bool exists = file.existsSync();
-      expect(exists, true, reason: 'Not found ${file.path}');
+      final bool exists = logFile.existsSync();
+      expect(exists, true, reason: 'Not found ${logFile.path}');
 
-      final String commandLog = await file.readAsString();
+      final String commandLog = await logFile.readAsString();
       const String waitForCommandLog = '>>> {command: waitFor, timeout: 1234, finderType: ByTooltipMessage, text: logCommunicationToFile test}';
       const String responseLog = '<<< {isError: false, response: {status: ok}, type: Response}';
 
@@ -719,9 +731,8 @@ void main() {
     test('logCommunicationToFile = false', () async {
       driver = WebFlutterDriver.connectedTo(fakeConnection, logCommunicationToFile: false);
       await driver.waitFor(find.byTooltip('logCommunicationToFile test'), timeout: _kTestTimeout);
-      final File file = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
-      final bool exists = file.existsSync();
-      expect(exists, false, reason: 'because ${file.path} exists');
+      final bool exists = logFile.existsSync();
+      expect(exists, false, reason: 'because ${logFile.path} exists');
     });
   });
 


### PR DESCRIPTION
## Description

This change fixes the driver tests "VMServiceFlutterDriver with logCommunicationToFile logCommunicationToFile logCommunicationToFile = false" and "WebFlutterDriver with logCommunicationToFile  logCommunicationToFile = false" so that they will no longer fail when run locally.

The issue was one of not cleaning up the log files after the test ran, so a later run with the same name would see it. Presumably on the servers the tests are run in a different environment where the names or locations of the output files end up being different.
