### PR TITLE
Increase Flutter framework minimum iOS version to 9.0

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -172,14 +172,16 @@ class _FlutterProject {
         // it's not a regression in the IPHONEOS_DEPLOYMENT_TARGET override logic.
         // The plugintest target should not have IPHONEOS_DEPLOYMENT_TARGET set.
         // See _reduceDarwinPluginMinimumVersion for details.
-        if (target == 'ios' && 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length != 6) {
-          throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET');
+        final int iosDeploymentTargetCount = 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
+        if (target == 'ios' && iosDeploymentTargetCount != 9) {
+          throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET, $iosDeploymentTargetCount found');
         }
 
         // Same for macOS, but 12.
         // The plugintest target should not have MACOSX_DEPLOYMENT_TARGET set.
-        if (target == 'macos' && 'MACOSX_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length != 12) {
-          throw TaskResult.failure('plugintest may contain MACOSX_DEPLOYMENT_TARGET');
+        final int macosDeploymentTargetCount = 'MACOSX_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
+        if (target == 'macos' && macosDeploymentTargetCount != 12) {
+          throw TaskResult.failure('plugintest may contain MACOSX_DEPLOYMENT_TARGET, $macosDeploymentTargetCount found');
         }
       }
     });

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -177,7 +177,7 @@ def flutter_install_ios_engine_pod(ios_application_path = nil)
         s.license          = { :type => 'MIT' }
         s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
         s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-        s.ios.deployment_target = '8.0'
+        s.ios.deployment_target = '9.0'
         # Framework linking is handled by Flutter tooling, not CocoaPods.
         # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
         s.vendored_frameworks = 'path/to/nothing'

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -286,7 +286,7 @@ LICENSE
   s.author                = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source                = { :http => '${_cache.storageBaseUrl}/flutter_infra_release/flutter/${_cache.engineRevision}/$artifactsMode/artifacts.zip' }
   s.documentation_url     = 'https://flutter.dev/docs'
-  s.platform              = :ios, '8.0'
+  s.platform              = :ios, '9.0'
   s.vendored_frameworks   = 'Flutter.xcframework'
 end
 ''';

--- a/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Flutter/engine/Flutter.podspec.tmpl
+++ b/packages/flutter_tools/templates/module/ios/host_app_ephemeral/Flutter/engine/Flutter.podspec.tmpl
@@ -15,6 +15,6 @@ This pod vends the iOS Flutter engine framework. It is compatible with applicati
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.documentation_url     = 'https://flutter.dev/docs'
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.vendored_frameworks = 'Flutter.xcframework'
 end


### PR DESCRIPTION
Default Flutter project has been 9.0 since https://github.com/flutter/flutter/pull/62902.  A project migration will be forced with https://github.com/flutter/flutter/pull/85174.  Mark the Flutter.xcframework minimum version as 9.0.

`plugin_test_ios` devicelab test wasn't passing due to the Flutter framework version.  Unfortunately it wasn't running (https://github.com/flutter/flutter/issues/86801) so that wasn't caught.  Make the test pass so it can be turned on.