### PR TITLE
[gen_l10n] correct variable name when the placeholder requiresFormatting

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -202,21 +202,16 @@ String _generatePluralMethod(Message message, String translationForMessage) {
     if (match != null && match.groupCount == 2) {
       String argValue = generateString(match.group(2)!);
       for (final Placeholder placeholder in message.placeholders) {
-        if (placeholder != countPlaceholder && placeholder.requiresFormatting) {
-          argValue = argValue.replaceAll(
-            '#${placeholder.name}#',
-            _needsCurlyBracketStringInterpolation(argValue, placeholder.name)
-              ? '\${${placeholder.name}String}'
-              : '\$${placeholder.name}String'
-          );
-        } else {
-          argValue = argValue.replaceAll(
-            '#${placeholder.name}#',
-            _needsCurlyBracketStringInterpolation(argValue, placeholder.name)
-              ? '\${${placeholder.name}}'
-              : '\$${placeholder.name}'
-          );
+        String variable = placeholder.name;
+        if (placeholder.requiresFormatting) {
+          variable += 'String';
         }
+        argValue = argValue.replaceAll(
+          '#${placeholder.name}#',
+          _needsCurlyBracketStringInterpolation(argValue, placeholder.name)
+            ? '\${$variable}'
+            : '\$$variable'
+        );
       }
       pluralLogicArgs.add('      ${pluralIds[pluralKey]}: $argValue');
     }
@@ -368,21 +363,16 @@ String _generateMethod(Message message, String translationForMessage) {
   String generateMessage() {
     String messageValue = generateString(translationForMessage);
     for (final Placeholder placeholder in message.placeholders) {
+      String variable = placeholder.name;
       if (placeholder.requiresFormatting) {
-        messageValue = messageValue.replaceAll(
-          '{${placeholder.name}}',
-          _needsCurlyBracketStringInterpolation(messageValue, placeholder.name)
-            ? '\${${placeholder.name}String}'
-            : '\$${placeholder.name}String'
-        );
-      } else {
-        messageValue = messageValue.replaceAll(
-          '{${placeholder.name}}',
-          _needsCurlyBracketStringInterpolation(messageValue, placeholder.name)
-            ? '\${${placeholder.name}}'
-            : '\$${placeholder.name}'
-        );
+        variable += 'String';
       }
+      messageValue = messageValue.replaceAll(
+        '{${placeholder.name}}',
+        _needsCurlyBracketStringInterpolation(messageValue, placeholder.name)
+          ? '\${$variable}'
+          : '\$$variable'
+      );
     }
 
     return messageValue;

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -2166,6 +2166,16 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
     "placeholders": {
       "count": {}
     }
+  },
+  "third": "{total,plural, =0{test {total}} other{ {total}}",
+  "@third": {
+    "description": "Third set of plural messages to test, for number.",
+    "placeholders": {
+      "total": {
+        "type": "int",
+        "format": "compactLong"
+      }
+    }
   }
 }
 ''';
@@ -2206,6 +2216,9 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
       expect(localizationsFile, contains(r'${count}m'));
       expect(localizationsFile, contains(r'test $count'));
       expect(localizationsFile, contains(r' $count'));
+      expect(localizationsFile, contains(r'String totalString = totalNumberFormat'));
+      expect(localizationsFile, contains(r'test $totalString'));
+      expect(localizationsFile, contains(r' $totalString'));
     });
 
     testWithoutContext(
@@ -2493,7 +2506,6 @@ String orderNumber(int number) {
     final String localizationsFile = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart'),
     ).readAsStringSync();
-    print(localizationsFile);
     expect(localizationsFile, containsIgnoringWhitespace(r'''
 AppLocalizations lookupAppLocalizations(Locale locale) {
 '''));


### PR DESCRIPTION
Fixes #75094

After #86167, the remaining part is the variable name.

The main change is modifying

    if (placeholder != countPlaceholder && placeholder.requiresFormatting) {

to

    if (placeholder.requiresFormatting) {

The other changes are unifying duplicate conditions (with the only difference in `variable`).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
