### PR TITLE
[gen_l10n] to handle arbitrary DateFormat patterns

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -111,17 +111,25 @@ String generateDateFormattingLogic(Message message) {
           'date formats.'
         );
       }
-      if (!placeholder.hasValidDateFormat) {
+      final bool? isCustomDateFormat = placeholder.isCustomDateFormat;
+      if (!placeholder.hasValidDateFormat
+          && (isCustomDateFormat == null || !isCustomDateFormat)) {
         throw L10nException(
           'Date format "$placeholderFormat" for placeholder '
           '${placeholder.name} does not have a corresponding DateFormat '
           "constructor\n. Check the intl library's DateFormat class "
-          'constructors for allowed date formats.'
+          'constructors for allowed date formats, or set "isCustomDateFormat" attribute '
+          'to "true".'
         );
       }
-      return dateFormatTemplate
+      if (placeholder.hasValidDateFormat) {
+        return dateFormatTemplate
+          .replaceAll('@(placeholder)', placeholder.name)
+          .replaceAll('@(format)', placeholderFormat);
+      }
+      return dateFormatCustomTemplate
         .replaceAll('@(placeholder)', placeholder.name)
-        .replaceAll('@(format)', placeholderFormat);
+        .replaceAll('@(format)', generateString(placeholderFormat));
     });
 
   return formatStatements.isEmpty ? '@(none)' : formatStatements.join('');

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -126,6 +126,11 @@ const String dateFormatTemplate = '''
     final String @(placeholder)String = @(placeholder)DateFormat.format(@(placeholder));
 ''';
 
+const String dateFormatCustomTemplate = '''
+    final intl.DateFormat @(placeholder)DateFormat = intl.DateFormat(@(format), localeName);
+    final String @(placeholder)String = @(placeholder)DateFormat.format(@(placeholder));
+''';
+
 const String getterTemplate = '''
   @override
   String get @(name) => @(message);''';

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -193,7 +193,8 @@ class Placeholder {
       example = _stringAttribute(resourceId, name, attributes, 'example'),
       type = _stringAttribute(resourceId, name, attributes, 'type') ?? 'Object',
       format = _stringAttribute(resourceId, name, attributes, 'format'),
-      optionalParameters = _optionalParameters(resourceId, name, attributes);
+      optionalParameters = _optionalParameters(resourceId, name, attributes),
+      isCustomDateFormat = _boolAttribute(resourceId, name, attributes, 'isCustomDateFormat');
 
   final String resourceId;
   final String name;
@@ -201,6 +202,7 @@ class Placeholder {
   final String? type;
   final String? format;
   final List<OptionalParameter> optionalParameters;
+  final bool? isCustomDateFormat;
 
   bool get requiresFormatting => <String>['DateTime', 'double', 'num'].contains(type) || (type == 'int' && format != null);
   bool get isNumber => <String>['double', 'int', 'num'].contains(type);
@@ -226,6 +228,25 @@ class Placeholder {
       );
     }
     return value;
+  }
+
+  static bool? _boolAttribute(
+      String resourceId,
+      String name,
+      Map<String, Object?> attributes,
+      String attributeName,
+      ) {
+    final Object? value = attributes[attributeName];
+    if (value == null) {
+      return null;
+    }
+    if (value != 'true' && value != 'false') {
+      throw L10nException(
+        'The "$attributeName" value of the "$name" placeholder in message $resourceId '
+            'must be a boolean value.',
+      );
+    }
+    return value == 'true';
   }
 
   static List<OptionalParameter> _optionalParameters(

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1429,6 +1429,80 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         );
       });
 
+      testWithoutContext('use standard date format whenever possible', () {
+        const String singleDateMessageArbFileString = '''
+{
+  "@@locale": "en",
+  "springBegins": "Spring begins on {springStartDate}",
+  "@springBegins": {
+      "description": "The first day of spring",
+      "placeholders": {
+          "springStartDate": {
+              "type": "DateTime",
+              "format": "yMd",
+              "isCustomDateFormat": "true"
+          }
+      }
+  }
+}''';
+        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+          ..createSync(recursive: true);
+        l10nDirectory.childFile(defaultTemplateArbFileName)
+            .writeAsStringSync(singleDateMessageArbFileString);
+
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+
+        final String localizationsFile = fs.file(
+          fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
+        ).readAsStringSync();
+        expect(localizationsFile, contains('DateFormat.yMd(localeName)'));
+      });
+
+      testWithoutContext('handle arbitrary formatted date', () {
+        const String singleDateMessageArbFileString = '''
+{
+  "@@locale": "en",
+  "springBegins": "Spring begins on {springStartDate}",
+  "@springBegins": {
+      "description": "The first day of spring",
+      "placeholders": {
+          "springStartDate": {
+              "type": "DateTime",
+              "format": "asdf o'clock",
+              "isCustomDateFormat": "true"
+          }
+      }
+  }
+}''';
+        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+          ..createSync(recursive: true);
+        l10nDirectory.childFile(defaultTemplateArbFileName)
+            .writeAsStringSync(singleDateMessageArbFileString);
+
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+
+        final String localizationsFile = fs.file(
+          fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
+        ).readAsStringSync();
+        expect(localizationsFile, contains(r"DateFormat('asdf o\'clock', localeName)"));
+      });
+
       testWithoutContext('throws an exception when no format attribute is passed in', () {
         const String singleDateMessageArbFileString = '''
 {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1356,13 +1356,13 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   "@@locale": "en",
   "springBegins": "Spring begins on {springStartDate}",
   "@springBegins": {
-      "description": "The first day of spring",
-      "placeholders": {
-          "springStartDate": {
-              "type": "DateTime",
-              "format": "yMd"
-          }
+    "description": "The first day of spring",
+    "placeholders": {
+      "springStartDate": {
+        "type": "DateTime",
+        "format": "yMd"
       }
+    }
   }
 }''';
         fs.currentDirectory.childDirectory('lib').childDirectory('l10n')..createSync(recursive: true)
@@ -1391,13 +1391,13 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   "@@locale": "en",
   "springBegins": "Spring begins on {springStartDate}",
   "@springBegins": {
-      "description": "The first day of spring",
-      "placeholders": {
-          "springStartDate": {
-              "type": "DateTime",
-              "format": "asdf"
-          }
+    "description": "The first day of spring",
+    "placeholders": {
+      "springStartDate": {
+        "type": "DateTime",
+        "format": "asdf"
       }
+    }
   }
 }''';
         final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
@@ -1435,14 +1435,14 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   "@@locale": "en",
   "springBegins": "Spring begins on {springStartDate}",
   "@springBegins": {
-      "description": "The first day of spring",
-      "placeholders": {
-          "springStartDate": {
-              "type": "DateTime",
-              "format": "yMd",
-              "isCustomDateFormat": "true"
-          }
+    "description": "The first day of spring",
+    "placeholders": {
+      "springStartDate": {
+        "type": "DateTime",
+        "format": "yMd",
+        "isCustomDateFormat": "true"
       }
+    }
   }
 }''';
         final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
@@ -1472,14 +1472,14 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
   "@@locale": "en",
   "springBegins": "Spring begins on {springStartDate}",
   "@springBegins": {
-      "description": "The first day of spring",
-      "placeholders": {
-          "springStartDate": {
-              "type": "DateTime",
-              "format": "asdf o'clock",
-              "isCustomDateFormat": "true"
-          }
+    "description": "The first day of spring",
+    "placeholders": {
+      "springStartDate": {
+        "type": "DateTime",
+        "format": "asdf o'clock",
+        "isCustomDateFormat": "true"
       }
+    }
   }
 }''';
         final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
@@ -1508,12 +1508,12 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
 {
   "springBegins": "Spring begins on {springStartDate}",
   "@springBegins": {
-      "description": "The first day of spring",
-      "placeholders": {
-          "springStartDate": {
-              "type": "DateTime"
-          }
+    "description": "The first day of spring",
+    "placeholders": {
+      "springStartDate": {
+        "type": "DateTime"
       }
+    }
   }
 }''';
         final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')


### PR DESCRIPTION
Fixes #77646

Use `DateFormat` constructor with any arbitrary pattern. However, I am not sure if it should throw an exception  in some particular case.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
