### PR TITLE
[flutter_conductor] fix cast error in codesign sub-command

### DIFF
--- a/dev/conductor/lib/codesign.dart
+++ b/dev/conductor/lib/codesign.dart
@@ -316,9 +316,15 @@ class CodesignCommand extends Command<void> {
           'Test failed because unexpected binaries found in the cache.');
     }
 
-    stdio.printStatus(
-        'Verified that binaries for commit ${argResults![kRevision] as String} are codesigned and have '
-        'expected entitlements.');
+    final String? desiredRevision = argResults![kRevision] as String?;
+    if (desiredRevision == null) {
+      stdio.printStatus(
+          'Verified that binaries are codesigned and have expected entitlements.');
+    } else {
+      stdio.printStatus(
+          'Verified that binaries for commit $desiredRevision are codesigned and have '
+          'expected entitlements.');
+    }
   }
 
   List<String>? _allBinaryPaths;

--- a/dev/conductor/test/codesign_test.dart
+++ b/dev/conductor/test/codesign_test.dart
@@ -81,6 +81,90 @@ void main() {
       );
     });
 
+    test('does not fail if --revision flag not provided', () async {
+      final List<FakeCommand> codesignCheckCommands = <FakeCommand>[];
+      for (final String bin in binariesWithEntitlements) {
+        codesignCheckCommands.add(
+          FakeCommand(
+            command: <String>['codesign', '-vvv', bin],
+          ),
+        );
+        codesignCheckCommands.add(
+          FakeCommand(
+            command: <String>['codesign', '--display', '--entitlements', ':-', bin],
+            stdout: expectedEntitlements.join('\n'),
+          ),
+        );
+      }
+      for (final String bin in binariesWithoutEntitlements) {
+        codesignCheckCommands.add(
+          FakeCommand(
+            command: <String>['codesign', '-vvv', bin],
+          ),
+        );
+      }
+      createRunner(commands: <FakeCommand>[
+        const FakeCommand(command: <String>[
+          'git',
+          'clone',
+          '--origin',
+          'upstream',
+          '--',
+          'file://$flutterRoot/',
+          '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
+        ]),
+        const FakeCommand(command: <String>[
+          'git',
+          'rev-parse',
+          'HEAD',
+        ], stdout: revision),
+        const FakeCommand(command: <String>[
+          'git',
+          'rev-parse',
+          'HEAD',
+        ], stdout: revision),
+        const FakeCommand(command: <String>[
+          'git',
+          'checkout',
+          revision,
+        ]),
+        const FakeCommand(command: <String>[
+          flutterBin,
+          'help',
+        ]),
+        const FakeCommand(command: <String>[
+          flutterBin,
+          'help',
+        ]),
+        const FakeCommand(command: <String>[
+          flutterBin,
+          'precache',
+          '--android',
+          '--ios',
+          '--macos',
+        ]),
+        FakeCommand(
+          command: const <String>[
+            'find',
+            '${checkoutsParentDirectory}flutter_conductor_checkouts/framework/bin/cache',
+            '-type',
+            'f',
+          ],
+          stdout: allBinaries.join('\n'),
+        ),
+        for (String bin in allBinaries)
+          FakeCommand(
+            command: <String>['file', '--mime-type', '-b', bin],
+            stdout: 'application/x-mach-binary',
+          ),
+        ...codesignCheckCommands,
+      ]);
+      await runner.run(<String>['codesign', '--$kVerify']);
+      expect(processManager.hasRemainingExpectations, false);
+      expect(stdio.stdout, contains('Verified that binaries are codesigned and have expected entitlements'));
+    });
+
+
     test('succeeds if every binary is codesigned and has correct entitlements', () async {
       final List<FakeCommand> codesignCheckCommands = <FakeCommand>[];
       for (final String bin in binariesWithEntitlements) {
@@ -156,6 +240,7 @@ void main() {
       ]);
       await runner.run(<String>['codesign', '--$kVerify', '--$kRevision', revision]);
       expect(processManager.hasRemainingExpectations, false);
+      expect(stdio.stdout, contains('Verified that binaries for commit $revision are codesigned and have expected entitlements'));
     });
 
     test('fails if a single binary is not codesigned', () async {


### PR DESCRIPTION
The `--revision` flag is NOT required, thus we should have never been casting the value of it to `String`, as it could be `null`.