### PR TITLE
Add entries in ci for `plugin_dependencies_test` and `gradle_java8_compile_test`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -155,6 +155,16 @@ targets:
       - dev/**
       - bin/**
 
+  - name: Linux gradle_java8_compile_test
+    builder: Linux gradle_java8_compile_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - bin/**
+
   - name: Linux gradle_plugin_bundle_test
     builder: Linux gradle_plugin_bundle_test
     properties:
@@ -210,6 +220,17 @@ targets:
 
   - name: Linux module_test
     builder: Linux module_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Linux plugin_dependencies_test
+    builder: Linux plugin_dependencies_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -675,6 +696,17 @@ targets:
       - dev/**
       - bin/**
 
+  - name: Mac plugin_dependencies_test
+    builder: Mac plugin_dependencies_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
   - name: Mac plugin_test
     builder: Mac plugin_test
     properties:
@@ -912,6 +944,17 @@ targets:
 
   - name: Windows module_host_with_custom_build_test
     builder: Windows module_host_with_custom_build_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Windows plugin_dependencies_test
+    builder: Windows plugin_dependencies_test
     properties:
       tags: >
         ["devicelab","hostonly"]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -157,6 +157,7 @@ targets:
 
   - name: Linux gradle_java8_compile_test
     builder: Linux gradle_java8_compile_test
+    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -231,6 +232,7 @@ targets:
 
   - name: Linux plugin_dependencies_test
     builder: Linux plugin_dependencies_test
+    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -698,6 +700,7 @@ targets:
 
   - name: Mac plugin_dependencies_test
     builder: Mac plugin_dependencies_test
+    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -955,6 +958,7 @@ targets:
 
   - name: Windows plugin_dependencies_test
     builder: Windows plugin_dependencies_test
+    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]


### PR DESCRIPTION
Follow up of https://flutter-review.googlesource.com/c/infra/+/15980.

Issue: https://github.com/flutter/flutter/issues/86802