### PR TITLE
Respect plugin excluded iOS architectures

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -167,14 +167,19 @@ class _FlutterProject {
         }
 
         final String podsProjectContent = podsProject.readAsStringSync();
-        // This may be a bit brittle, IPHONEOS_DEPLOYMENT_TARGET appears in the
-        // Pods Xcode project file 6 times. If this number changes, make sure
-        // it's not a regression in the IPHONEOS_DEPLOYMENT_TARGET override logic.
-        // The plugintest target should not have IPHONEOS_DEPLOYMENT_TARGET set.
-        // See _reduceDarwinPluginMinimumVersion for details.
-        final int iosDeploymentTargetCount = 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
-        if (target == 'ios' && iosDeploymentTargetCount != 9) {
-          throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET, $iosDeploymentTargetCount found');
+        if (target == 'ios') {
+          // This may be a bit brittle, IPHONEOS_DEPLOYMENT_TARGET appears in the
+          // Pods Xcode project file 6 times. If this number changes, make sure
+          // it's not a regression in the IPHONEOS_DEPLOYMENT_TARGET override logic.
+          // The plugintest target should not have IPHONEOS_DEPLOYMENT_TARGET set.
+          // See _reduceDarwinPluginMinimumVersion for details.
+          final int iosDeploymentTargetCount = 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
+          if (iosDeploymentTargetCount != 9) {
+            throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET, $iosDeploymentTargetCount found');
+          }
+          if (!podsProjectContent.contains(r'"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "$(inherited) i386";')) {
+            throw TaskResult.failure(r'EXCLUDED_ARCHS is not "$(inherited) i386"');
+          }
         }
 
         // Same for macOS, but 12.

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -74,7 +74,7 @@ def flutter_additional_ios_build_settings(target)
 
     # Override legacy Xcode 11 style VALID_ARCHS[sdk=iphonesimulator*]=x86_64 and prefer Xcode 12 EXCLUDED_ARCHS.
     build_configuration.build_settings['VALID_ARCHS[sdk=iphonesimulator*]'] = '$(ARCHS_STANDARD)'
-    build_configuration.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'i386'
+    build_configuration.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = '$(inherited) i386'
   end
 end
 

--- a/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
@@ -225,7 +225,7 @@ void main() {
           'FLUTTER_XCODE_ONLY_ACTIVE_ARCH': 'NO',
         },
       );
-      // This test case would fail if arm64 or i386 were not excluded.
+      // This test case would fail if arm64 or x86_64 simulators could not build.
       expect(buildSimulator.exitCode, 0);
 
       final File simulatorAppFrameworkBinary = fileSystem.file(fileSystem.path.join(
@@ -243,6 +243,7 @@ void main() {
         <String>['file', simulatorAppFrameworkBinary.path],
       );
       expect(archs.stdout, contains('Mach-O 64-bit dynamically linked shared library x86_64'));
+      expect(archs.stdout, contains('Mach-O 64-bit dynamically linked shared library arm64'));
     });
   }, skip: !platform.isMacOS, timeout: const Timeout(Duration(minutes: 5))
   );


### PR DESCRIPTION
Respect plugin Xcode build setting for `EXCLUDED_ARCHS` instead of overriding it.

Suggested in https://github.com/flutter/flutter/issues/85713#issuecomment-872457869