### PR TITLE
Report an error if the DraggableScrollableSheet fails to reset scaffold state

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2756,6 +2756,23 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             _dismissedBottomSheets.remove(bottomSheet);
           });
         }
+        if (_floatingActionButtonVisibilityValue != 1.0 || _showBodyScrim) {
+          FlutterError.reportError(FlutterErrorDetails(
+            exception: StateError(
+              'A DraggableScrollableSheet was used as a BottomSheet and '
+              'dismissed without resetting the body scrim or '
+              'FloatingActionButton visibility. This happens if the sheet has a '
+              'child that is hit testable outside of the scrollable, e.g. a '
+              'column with a nested ListView as a child.\n'
+              'Instead, consider using a CustomScrollView with a '
+              'SliverPersistentHeader.',
+            ),
+            library: 'Material',
+            context: ErrorDescription('while dismissing a bottom sheet'),
+          ));
+          showBodyScrim(false, 0.0);
+          _floatingActionButtonVisibilityValue = 1.0;
+        }
       },
       builder: builder,
       isPersistent: isPersistent,

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2756,7 +2756,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             _dismissedBottomSheets.remove(bottomSheet);
           });
         }
-        if (_floatingActionButtonVisibilityValue != 1.0 || _showBodyScrim) {
+        if ((widget.floatingActionButton != null && _floatingActionButtonVisibilityValue != 1.0) || _showBodyScrim) {
           FlutterError.reportError(FlutterErrorDetails(
             exception: StateError(
               'A DraggableScrollableSheet was used as a BottomSheet and '
@@ -2771,7 +2771,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             context: ErrorDescription('while dismissing a bottom sheet'),
           ));
           showBodyScrim(false, 0.0);
-          _floatingActionButtonVisibilityValue = 1.0;
+          if (widget.floatingActionButton != null) {
+            _floatingActionButtonVisibilityValue = 1.0;
+          }
         }
       },
       builder: builder,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/86908

This will now report an error with an explanation about how to fix things, and will still reset the scaffold state so that it is not left with a modal barrier/untappable FAB.

