### PR TITLE
Allow for customizing and theming of extended FAB content padding

### DIFF
--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -171,8 +171,7 @@ class FloatingActionButton extends StatelessWidget {
        _floatingActionButtonType = mini ? _FloatingActionButtonType.small : _FloatingActionButtonType.regular,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
-       extendedLeadingSpacing = null,
-       extendedTrailingSpacing = null,
+       extendedPadding = null,
        super(key: key);
 
   /// Creates a small circular floating action button.
@@ -219,8 +218,7 @@ class FloatingActionButton extends StatelessWidget {
        isExtended = false,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
-       extendedLeadingSpacing = null,
-       extendedTrailingSpacing = null,
+       extendedPadding = null,
        super(key: key);
 
   /// Creates a large circular floating action button.
@@ -267,8 +265,7 @@ class FloatingActionButton extends StatelessWidget {
        isExtended = false,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
-       extendedLeadingSpacing = null,
-       extendedTrailingSpacing = null,
+       extendedPadding = null,
        super(key: key);
 
   /// Creates a wider [StadiumBorder]-shaped floating action button with
@@ -300,8 +297,7 @@ class FloatingActionButton extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.extendedIconLabelSpacing,
-    this.extendedLeadingSpacing,
-    this.extendedTrailingSpacing,
+    this.extendedPadding,
     Widget? icon,
     required Widget label,
     this.enableFeedback,
@@ -526,18 +522,13 @@ class FloatingActionButton extends StatelessWidget {
   /// If that is also null, the default is 8.0.
   final double? extendedIconLabelSpacing;
 
-  /// The leading spacing for an extended [FloatingActionButton]'s content.
+  /// The padding for an extended [FloatingActionButton]'s content.
   ///
-  /// If null, [FloatingActionButtonThemeData.extendedLeadingSpacing] is used.
-  /// If that is also null, the default is 16.0 if an icon is provided, and 20.0
-  /// if not.
-  final double? extendedLeadingSpacing;
-
-  /// The trailing spacing for an extended [FloatingActionButton]'s content.
-  ///
-  /// If null, [FloatingActionButtonThemeData.extendedTrailingSpacing] is used.
-  /// If that is also null, the default is 20.0.
-  final double? extendedTrailingSpacing;
+  /// If null, [FloatingActionButtonThemeData.extendedPadding] is used. If that
+  /// is also null, the default is
+  /// `EdgeInsetsDirectional.only(start: 16.0, end: 20.0)` if an icon is
+  /// provided, and `EdgeInsetsDirectional.only(start: 20.0, end: 20.0)` if not.
+  final EdgeInsetsGeometry? extendedPadding;
 
   final _FloatingActionButtonType _floatingActionButtonType;
 
@@ -617,18 +608,20 @@ class FloatingActionButton extends StatelessWidget {
       case _FloatingActionButtonType.extended:
         sizeConstraints = floatingActionButtonTheme.extendedSizeConstraints ?? _kExtendedSizeConstraints;
         final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
-        final double leadingSpacing = extendedLeadingSpacing ?? floatingActionButtonTheme.extendedLeadingSpacing ?? (child != null && isExtended ? 16.0 : 20.0);
-        final double trailingSpacing = extendedTrailingSpacing ?? floatingActionButtonTheme.extendedTrailingSpacing ?? 20.0;
-        final Widget leading = SizedBox(width: leadingSpacing);
-        final Widget trailing = SizedBox(width: trailingSpacing);
+        final EdgeInsetsGeometry padding = extendedPadding
+            ?? floatingActionButtonTheme.extendedPadding
+            ?? (child != null && isExtended ? const EdgeInsetsDirectional.only(start: 16.0, end: 20.0) : const EdgeInsetsDirectional.only(start: 20.0, end: 20.0));
         resolvedChild = _ChildOverflowBox(
-          child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: child == null
-                  ? <Widget>[leading, _extendedLabel!, trailing]
-                  : isExtended
-                      ? <Widget>[leading, child!, SizedBox(width: iconLabelSpacing), _extendedLabel!, trailing]
-                      : <Widget>[leading, child!, trailing],
+          child: Padding(
+            padding: padding,
+            child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: child == null
+                    ? <Widget>[_extendedLabel!]
+                    : isExtended
+                        ? <Widget>[child!, SizedBox(width: iconLabelSpacing), _extendedLabel!]
+                        : <Widget>[child!,],
+            ),
           ),
         );
         break;

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -610,17 +610,20 @@ class FloatingActionButton extends StatelessWidget {
         final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
         final EdgeInsetsGeometry padding = extendedPadding
             ?? floatingActionButtonTheme.extendedPadding
-            ?? (child != null && isExtended ? const EdgeInsetsDirectional.only(start: 16.0, end: 20.0) : const EdgeInsetsDirectional.only(start: 20.0, end: 20.0));
+            ?? EdgeInsetsDirectional.only(start: child != null && isExtended ? 16.0 : 20.0, end: 20.0);
         resolvedChild = _ChildOverflowBox(
           child: Padding(
             padding: padding,
             child: Row(
                 mainAxisSize: MainAxisSize.min,
-                children: child == null
-                    ? <Widget>[_extendedLabel!]
-                    : isExtended
-                        ? <Widget>[child!, SizedBox(width: iconLabelSpacing), _extendedLabel!]
-                        : <Widget>[child!],
+                children: <Widget>[
+                  if (child != null)
+                    child!,
+                  if (child != null && isExtended)
+                    SizedBox(width: iconLabelSpacing),
+                  if (isExtended)
+                    _extendedLabel!,
+                ],
             ),
           ),
         );

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -620,7 +620,7 @@ class FloatingActionButton extends StatelessWidget {
                     ? <Widget>[_extendedLabel!]
                     : isExtended
                         ? <Widget>[child!, SizedBox(width: iconLabelSpacing), _extendedLabel!]
-                        : <Widget>[child!,],
+                        : <Widget>[child!],
             ),
           ),
         );

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -171,6 +171,8 @@ class FloatingActionButton extends StatelessWidget {
        _floatingActionButtonType = mini ? _FloatingActionButtonType.small : _FloatingActionButtonType.regular,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
+       extendedLeadingSpacing = null,
+       extendedTrailingSpacing = null,
        super(key: key);
 
   /// Creates a small circular floating action button.
@@ -217,6 +219,8 @@ class FloatingActionButton extends StatelessWidget {
        isExtended = false,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
+       extendedLeadingSpacing = null,
+       extendedTrailingSpacing = null,
        super(key: key);
 
   /// Creates a large circular floating action button.
@@ -263,6 +267,8 @@ class FloatingActionButton extends StatelessWidget {
        isExtended = false,
        _extendedLabel = null,
        extendedIconLabelSpacing = null,
+       extendedLeadingSpacing = null,
+       extendedTrailingSpacing = null,
        super(key: key);
 
   /// Creates a wider [StadiumBorder]-shaped floating action button with
@@ -294,6 +300,8 @@ class FloatingActionButton extends StatelessWidget {
     this.focusNode,
     this.autofocus = false,
     this.extendedIconLabelSpacing,
+    this.extendedLeadingSpacing,
+    this.extendedTrailingSpacing,
     Widget? icon,
     required Widget label,
     this.enableFeedback,
@@ -518,6 +526,19 @@ class FloatingActionButton extends StatelessWidget {
   /// If that is also null, the default is 8.0.
   final double? extendedIconLabelSpacing;
 
+  /// The leading spacing for an extended [FloatingActionButton]'s content.
+  ///
+  /// If null, [FloatingActionButtonThemeData.extendedLeadingSpacing] is used.
+  /// If that is also null, the default is 16.0 if an icon is provided, and 20.0
+  /// if not.
+  final double? extendedLeadingSpacing;
+
+  /// The trailing spacing for an extended [FloatingActionButton]'s content.
+  ///
+  /// If null, [FloatingActionButtonThemeData.extendedTrailingSpacing] is used.
+  /// If that is also null, the default is 20.0.
+  final double? extendedTrailingSpacing;
+
   final _FloatingActionButtonType _floatingActionButtonType;
 
   final Widget? _extendedLabel;
@@ -595,17 +616,20 @@ class FloatingActionButton extends StatelessWidget {
         break;
       case _FloatingActionButtonType.extended:
         sizeConstraints = floatingActionButtonTheme.extendedSizeConstraints ?? _kExtendedSizeConstraints;
-        final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
-        const Widget width20 = SizedBox(width: 20.0);
         const Widget width16 = SizedBox(width: 16.0);
+        final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
+        final double leadingSpacing = extendedLeadingSpacing ?? floatingActionButtonTheme.extendedLeadingSpacing ?? (child != null && isExtended ? 16.0 : 20.0);
+        final double trailingSpacing = extendedTrailingSpacing ?? floatingActionButtonTheme.extendedTrailingSpacing ?? 20.0;
+        final Widget leading = SizedBox(width: leadingSpacing);
+        final Widget trailing = SizedBox(width: trailingSpacing);
         resolvedChild = _ChildOverflowBox(
           child: Row(
               mainAxisSize: MainAxisSize.min,
               children: child == null
-                  ? <Widget>[width20, _extendedLabel!, width20]
+                  ? <Widget>[leading, _extendedLabel!, trailing]
                   : isExtended
-                      ? <Widget>[width16, child!, SizedBox(width: iconLabelSpacing), _extendedLabel!, width20]
-                      : <Widget>[width20, child!, width20],
+                      ? <Widget>[leading, child!, SizedBox(width: iconLabelSpacing), _extendedLabel!, trailing]
+                      : <Widget>[leading, child!, trailing],
           ),
         );
         break;

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -616,7 +616,6 @@ class FloatingActionButton extends StatelessWidget {
         break;
       case _FloatingActionButtonType.extended:
         sizeConstraints = floatingActionButtonTheme.extendedSizeConstraints ?? _kExtendedSizeConstraints;
-        const Widget width16 = SizedBox(width: 16.0);
         final double iconLabelSpacing = extendedIconLabelSpacing ?? floatingActionButtonTheme.extendedIconLabelSpacing ?? 8.0;
         final double leadingSpacing = extendedLeadingSpacing ?? floatingActionButtonTheme.extendedLeadingSpacing ?? (child != null && isExtended ? 16.0 : 20.0);
         final double trailingSpacing = extendedTrailingSpacing ?? floatingActionButtonTheme.extendedTrailingSpacing ?? 20.0;

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -48,8 +48,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     this.largeSizeConstraints,
     this.extendedSizeConstraints,
     this.extendedIconLabelSpacing,
-    this.extendedLeadingSpacing,
-    this.extendedTrailingSpacing,
+    this.extendedPadding,
   });
 
   /// Color to be used for the unselected, enabled [FloatingActionButton]'s
@@ -119,12 +118,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
   /// [FloatingActionButton].
   final double? extendedIconLabelSpacing;
 
-
-  /// The leading spacing for an extended [FloatingActionButton]'s content.
-  final double? extendedLeadingSpacing;
-
-  /// The trailing spacing for an extended [FloatingActionButton]'s content.
-  final double? extendedTrailingSpacing;
+  /// The padding for an extended [FloatingActionButton]'s content.
+  final EdgeInsetsGeometry? extendedPadding;
 
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
@@ -146,8 +141,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     BoxConstraints? largeSizeConstraints,
     BoxConstraints? extendedSizeConstraints,
     double? extendedIconLabelSpacing,
-    double? extendedLeadingSpacing,
-    double? extendedTrailingSpacing,
+    EdgeInsetsGeometry? extendedPadding,
   }) {
     return FloatingActionButtonThemeData(
       foregroundColor: foregroundColor ?? this.foregroundColor,
@@ -167,8 +161,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints: largeSizeConstraints ?? this.largeSizeConstraints,
       extendedSizeConstraints: extendedSizeConstraints ?? this.extendedSizeConstraints,
       extendedIconLabelSpacing: extendedIconLabelSpacing ?? this.extendedIconLabelSpacing,
-      extendedLeadingSpacing: extendedLeadingSpacing ?? this.extendedLeadingSpacing,
-      extendedTrailingSpacing: extendedTrailingSpacing ?? this.extendedTrailingSpacing,
+      extendedPadding: extendedPadding ?? this.extendedPadding,
     );
   }
 
@@ -199,8 +192,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints: BoxConstraints.lerp(a?.largeSizeConstraints, b?.largeSizeConstraints, t),
       extendedSizeConstraints: BoxConstraints.lerp(a?.extendedSizeConstraints, b?.extendedSizeConstraints, t),
       extendedIconLabelSpacing: lerpDouble(a?.extendedIconLabelSpacing, b?.extendedIconLabelSpacing, t),
-      extendedLeadingSpacing: lerpDouble(a?.extendedLeadingSpacing, b?.extendedLeadingSpacing, t),
-      extendedTrailingSpacing: lerpDouble(a?.extendedTrailingSpacing, b?.extendedTrailingSpacing, t),
+      extendedPadding: EdgeInsetsGeometry.lerp(a?.extendedPadding, b?.extendedPadding, t),
     );
   }
 
@@ -224,8 +216,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints,
       extendedSizeConstraints,
       extendedIconLabelSpacing,
-      extendedLeadingSpacing,
-      extendedTrailingSpacing,
+      extendedPadding,
     );
   }
 
@@ -253,8 +244,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
         && other.largeSizeConstraints == largeSizeConstraints
         && other.extendedSizeConstraints == extendedSizeConstraints
         && other.extendedIconLabelSpacing == extendedIconLabelSpacing
-        && other.extendedLeadingSpacing == extendedLeadingSpacing
-        && other.extendedTrailingSpacing == extendedTrailingSpacing;
+        && other.extendedPadding == extendedPadding;
   }
 
   @override
@@ -278,7 +268,6 @@ class FloatingActionButtonThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<BoxConstraints>('largeSizeConstraints', largeSizeConstraints, defaultValue: null));
     properties.add(DiagnosticsProperty<BoxConstraints>('extendedSizeConstraints', extendedSizeConstraints, defaultValue: null));
     properties.add(DoubleProperty('extendedIconLabelSpacing', extendedIconLabelSpacing, defaultValue: null));
-    properties.add(DoubleProperty('extendedLeadingSpacing', extendedLeadingSpacing, defaultValue: null));
-    properties.add(DoubleProperty('extendedTrailingSpacing', extendedTrailingSpacing, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('extendedPadding', extendedPadding, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -48,6 +48,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
     this.largeSizeConstraints,
     this.extendedSizeConstraints,
     this.extendedIconLabelSpacing,
+    this.extendedLeadingSpacing,
+    this.extendedTrailingSpacing,
   });
 
   /// Color to be used for the unselected, enabled [FloatingActionButton]'s
@@ -117,6 +119,13 @@ class FloatingActionButtonThemeData with Diagnosticable {
   /// [FloatingActionButton].
   final double? extendedIconLabelSpacing;
 
+
+  /// The leading spacing for an extended [FloatingActionButton]'s content.
+  final double? extendedLeadingSpacing;
+
+  /// The trailing spacing for an extended [FloatingActionButton]'s content.
+  final double? extendedTrailingSpacing;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   FloatingActionButtonThemeData copyWith({
@@ -137,6 +146,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
     BoxConstraints? largeSizeConstraints,
     BoxConstraints? extendedSizeConstraints,
     double? extendedIconLabelSpacing,
+    double? extendedLeadingSpacing,
+    double? extendedTrailingSpacing,
   }) {
     return FloatingActionButtonThemeData(
       foregroundColor: foregroundColor ?? this.foregroundColor,
@@ -156,6 +167,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints: largeSizeConstraints ?? this.largeSizeConstraints,
       extendedSizeConstraints: extendedSizeConstraints ?? this.extendedSizeConstraints,
       extendedIconLabelSpacing: extendedIconLabelSpacing ?? this.extendedIconLabelSpacing,
+      extendedLeadingSpacing: extendedLeadingSpacing ?? this.extendedLeadingSpacing,
+      extendedTrailingSpacing: extendedTrailingSpacing ?? this.extendedTrailingSpacing,
     );
   }
 
@@ -186,6 +199,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints: BoxConstraints.lerp(a?.largeSizeConstraints, b?.largeSizeConstraints, t),
       extendedSizeConstraints: BoxConstraints.lerp(a?.extendedSizeConstraints, b?.extendedSizeConstraints, t),
       extendedIconLabelSpacing: lerpDouble(a?.extendedIconLabelSpacing, b?.extendedIconLabelSpacing, t),
+      extendedLeadingSpacing: lerpDouble(a?.extendedLeadingSpacing, b?.extendedLeadingSpacing, t),
+      extendedTrailingSpacing: lerpDouble(a?.extendedTrailingSpacing, b?.extendedTrailingSpacing, t),
     );
   }
 
@@ -209,6 +224,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
       largeSizeConstraints,
       extendedSizeConstraints,
       extendedIconLabelSpacing,
+      extendedLeadingSpacing,
+      extendedTrailingSpacing,
     );
   }
 
@@ -235,7 +252,9 @@ class FloatingActionButtonThemeData with Diagnosticable {
         && other.smallSizeConstraints == smallSizeConstraints
         && other.largeSizeConstraints == largeSizeConstraints
         && other.extendedSizeConstraints == extendedSizeConstraints
-        && other.extendedIconLabelSpacing == extendedIconLabelSpacing;
+        && other.extendedIconLabelSpacing == extendedIconLabelSpacing
+        && other.extendedLeadingSpacing == extendedLeadingSpacing
+        && other.extendedTrailingSpacing == extendedTrailingSpacing;
   }
 
   @override
@@ -259,5 +278,7 @@ class FloatingActionButtonThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<BoxConstraints>('largeSizeConstraints', largeSizeConstraints, defaultValue: null));
     properties.add(DiagnosticsProperty<BoxConstraints>('extendedSizeConstraints', extendedSizeConstraints, defaultValue: null));
     properties.add(DoubleProperty('extendedIconLabelSpacing', extendedIconLabelSpacing, defaultValue: null));
+    properties.add(DoubleProperty('extendedLeadingSpacing', extendedLeadingSpacing, defaultValue: null));
+    properties.add(DoubleProperty('extendedTrailingSpacing', extendedTrailingSpacing, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -998,10 +998,12 @@ void main() {
     expect(tester.getSize(find.byKey(key)), const Size(96.0, 96.0));
   });
 
-  testWidgets('FloatingActionButton.extended can customize spacing between icon and label', (WidgetTester tester) async {
+  testWidgets('FloatingActionButton.extended can customize spacing', (WidgetTester tester) async {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
-    const double spacing = 33.0;
+    const double iconLabelSpacing = 33.0;
+    const double leadingSpacing = 13.0;
+    const double trailingSpacing = 23.0;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1009,14 +1011,18 @@ void main() {
           floatingActionButton: FloatingActionButton.extended(
             label: const Text('', key: labelKey),
             icon: const Icon(Icons.add, key: iconKey),
-            extendedIconLabelSpacing: spacing,
+            extendedIconLabelSpacing: iconLabelSpacing,
+            extendedLeadingSpacing: leadingSpacing,
+            extendedTrailingSpacing: trailingSpacing,
             onPressed: () {},
           ),
         ),
       ),
     );
 
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, spacing);
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
   });
 
   group('feedback', () {

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -1001,9 +1001,8 @@ void main() {
   testWidgets('FloatingActionButton.extended can customize spacing', (WidgetTester tester) async {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
-    const double iconLabelSpacing = 33.0;
-    const double leadingSpacing = 13.0;
-    const double trailingSpacing = 23.0;
+    const double spacing = 33.0;
+    const EdgeInsetsDirectional padding = EdgeInsetsDirectional.only(start: 5.0, end: 6.0);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1011,18 +1010,17 @@ void main() {
           floatingActionButton: FloatingActionButton.extended(
             label: const Text('', key: labelKey),
             icon: const Icon(Icons.add, key: iconKey),
-            extendedIconLabelSpacing: iconLabelSpacing,
-            extendedLeadingSpacing: leadingSpacing,
-            extendedTrailingSpacing: trailingSpacing,
+            extendedIconLabelSpacing: spacing,
+            extendedPadding: padding,
             onPressed: () {},
           ),
         ),
       ),
     );
 
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
-    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
-    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, spacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, padding.start);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, padding.end);
   });
 
   group('feedback', () {

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -180,13 +180,17 @@ void main() {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
     const BoxConstraints constraints = BoxConstraints.tightFor(height: 100.0);
-    const double spacing = 33.0;
+    const double iconLabelSpacing = 33.0;
+    const double leadingSpacing = 13.0;
+    const double trailingSpacing = 23.0;
 
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData().copyWith(
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
           extendedSizeConstraints: constraints,
-          extendedIconLabelSpacing: spacing,
+          extendedIconLabelSpacing: iconLabelSpacing,
+          extendedLeadingSpacing: leadingSpacing,
+          extendedTrailingSpacing: trailingSpacing,
         ),
       ),
       home: Scaffold(
@@ -199,18 +203,24 @@ void main() {
     ));
 
     expect(_getRawMaterialButton(tester).constraints, constraints);
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, spacing);
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
   });
 
   testWidgets('FloatingActionButton.extended spacing takes priority over FloatingActionButtonThemeData spacing', (WidgetTester tester) async {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
-    const double spacing = 33.0;
+    const double iconLabelSpacing = 33.0;
+    const double leadingSpacing = 13.0;
+    const double trailingSpacing = 23.0;
 
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData().copyWith(
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
           extendedIconLabelSpacing: 25.0,
+          extendedLeadingSpacing: 11.0,
+          extendedTrailingSpacing: 17.0,
         ),
       ),
       home: Scaffold(
@@ -218,12 +228,16 @@ void main() {
           onPressed: () { },
           label: const Text('Extended', key: labelKey),
           icon: const Icon(Icons.add, key: iconKey),
-          extendedIconLabelSpacing: spacing,
+          extendedIconLabelSpacing: iconLabelSpacing,
+          extendedLeadingSpacing: leadingSpacing,
+          extendedTrailingSpacing: trailingSpacing,
         ),
       ),
     ));
 
-    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, spacing);
+    expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
   });
 
   testWidgets('default FloatingActionButton debugFillProperties', (WidgetTester tester) async {
@@ -258,6 +272,8 @@ void main() {
       largeSizeConstraints: BoxConstraints.tightFor(width: 102.0, height: 102.0),
       extendedSizeConstraints: BoxConstraints(minHeight: 103.0, maxHeight: 103.0),
       extendedIconLabelSpacing: 12,
+      extendedLeadingSpacing: 13,
+      extendedTrailingSpacing: 14,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -282,7 +298,9 @@ void main() {
       'smallSizeConstraints: BoxConstraints(w=101.0, h=101.0)',
       'largeSizeConstraints: BoxConstraints(w=102.0, h=102.0)',
       'extendedSizeConstraints: BoxConstraints(0.0<=w<=Infinity, h=103.0)',
-      'extendedIconLabelSpacing: 12.0'
+      'extendedIconLabelSpacing: 12.0',
+      'extendedLeadingSpacing: 13.0',
+      'extendedTrailingSpacing: 14.0',
     ]);
   });
 }

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -181,16 +181,14 @@ void main() {
     const Key labelKey = Key('label');
     const BoxConstraints constraints = BoxConstraints.tightFor(height: 100.0);
     const double iconLabelSpacing = 33.0;
-    const double leadingSpacing = 13.0;
-    const double trailingSpacing = 23.0;
+    const EdgeInsetsDirectional padding = EdgeInsetsDirectional.only(start: 5.0, end: 6.0);
 
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData().copyWith(
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
           extendedSizeConstraints: constraints,
           extendedIconLabelSpacing: iconLabelSpacing,
-          extendedLeadingSpacing: leadingSpacing,
-          extendedTrailingSpacing: trailingSpacing,
+          extendedPadding: padding,
         ),
       ),
       home: Scaffold(
@@ -204,23 +202,21 @@ void main() {
 
     expect(_getRawMaterialButton(tester).constraints, constraints);
     expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
-    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
-    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, padding.start);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, padding.end);
   });
 
   testWidgets('FloatingActionButton.extended spacing takes priority over FloatingActionButtonThemeData spacing', (WidgetTester tester) async {
     const Key iconKey = Key('icon');
     const Key labelKey = Key('label');
     const double iconLabelSpacing = 33.0;
-    const double leadingSpacing = 13.0;
-    const double trailingSpacing = 23.0;
+    const EdgeInsetsDirectional padding = EdgeInsetsDirectional.only(start: 5.0, end: 6.0);
 
     await tester.pumpWidget(MaterialApp(
       theme: ThemeData().copyWith(
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
           extendedIconLabelSpacing: 25.0,
-          extendedLeadingSpacing: 11.0,
-          extendedTrailingSpacing: 17.0,
+          extendedPadding: EdgeInsetsDirectional.only(start: 7.0, end: 8.0),
         ),
       ),
       home: Scaffold(
@@ -229,15 +225,14 @@ void main() {
           label: const Text('Extended', key: labelKey),
           icon: const Icon(Icons.add, key: iconKey),
           extendedIconLabelSpacing: iconLabelSpacing,
-          extendedLeadingSpacing: leadingSpacing,
-          extendedTrailingSpacing: trailingSpacing,
+          extendedPadding: padding,
         ),
       ),
     ));
 
     expect(tester.getTopLeft(find.byKey(labelKey)).dx - tester.getTopRight(find.byKey(iconKey)).dx, iconLabelSpacing);
-    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, leadingSpacing);
-    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, trailingSpacing);
+    expect(tester.getTopLeft(find.byKey(iconKey)).dx - tester.getTopLeft(find.byType(FloatingActionButton)).dx, padding.start);
+    expect(tester.getTopRight(find.byType(FloatingActionButton)).dx - tester.getTopRight(find.byKey(labelKey)).dx, padding.end);
   });
 
   testWidgets('default FloatingActionButton debugFillProperties', (WidgetTester tester) async {
@@ -272,8 +267,7 @@ void main() {
       largeSizeConstraints: BoxConstraints.tightFor(width: 102.0, height: 102.0),
       extendedSizeConstraints: BoxConstraints(minHeight: 103.0, maxHeight: 103.0),
       extendedIconLabelSpacing: 12,
-      extendedLeadingSpacing: 13,
-      extendedTrailingSpacing: 14,
+      extendedPadding: EdgeInsetsDirectional.only(start: 7.0, end: 8.0),
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -299,8 +293,7 @@ void main() {
       'largeSizeConstraints: BoxConstraints(w=102.0, h=102.0)',
       'extendedSizeConstraints: BoxConstraints(0.0<=w<=Infinity, h=103.0)',
       'extendedIconLabelSpacing: 12.0',
-      'extendedLeadingSpacing: 13.0',
-      'extendedTrailingSpacing: 14.0',
+      'extendedPadding: EdgeInsetsDirectional(7.0, 0.0, 8.0, 0.0)',
     ]);
   });
 }


### PR DESCRIPTION
This change adds a parameter to the extended FAB constructor (and the FAB theme) to allow for the customization of the content's padding for the extended FAB.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
