### PR TITLE
Add a hook for scroll position to notify scrolling context when dimen…

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -525,7 +525,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       _gestureDetectorKey.currentState!.replaceSemanticsActions(actions);
   }
 
-
   // GESTURE RECOGNITION AND POINTER IGNORING
 
   final GlobalKey<RawGestureDetectorState> _gestureDetectorKey = GlobalKey<RawGestureDetectorState>();
@@ -719,6 +718,15 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     }
   }
 
+  bool _handleScrollMetricsNotification(ScrollMetricsNotification notification) {
+    if (notification.depth == 0) {
+      final RenderObject? scrollSemanticsRenderObject = _scrollSemanticsKey.currentContext?.findRenderObject();
+      if (scrollSemanticsRenderObject != null)
+        scrollSemanticsRenderObject.markNeedsSemanticsUpdate();
+    }
+    return false;
+  }
+
   // DESCRIPTION
 
   @override
@@ -757,12 +765,15 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     );
 
     if (!widget.excludeFromSemantics) {
-      result = _ScrollSemantics(
-        key: _scrollSemanticsKey,
-        position: position,
-        allowImplicitScrolling: _physics!.allowImplicitScrolling,
-        semanticChildCount: widget.semanticChildCount,
-        child: result,
+      result = NotificationListener<ScrollMetricsNotification>(
+        onNotification: _handleScrollMetricsNotification,
+        child: _ScrollSemantics(
+          key: _scrollSemanticsKey,
+          position: position,
+          allowImplicitScrolling: _physics!.allowImplicitScrolling,
+          semanticChildCount: widget.semanticChildCount,
+          child: result,
+        )
       );
     }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1264,7 +1264,6 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     } else {
       when = 'using the Scrollbar';
     }
-
     assert(
       scrollController != null,
       'A ScrollController is required when $when. '

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1264,6 +1264,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     } else {
       when = 'using the Scrollbar';
     }
+
     assert(
       scrollController != null,
       'A ScrollController is required when $when. '

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -787,7 +787,7 @@ void main() {
     ));
     expect(controller.page, 0);
     controller.jumpToPage(2);
-    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 1);
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
     expect(controller.page, 2);
     await tester.pumpWidget(
       PageStorage(

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -122,7 +122,7 @@ void main() {
     final TestGesture drag1 = await tester.startGesture(const Offset(10.0, 500.0));
     expect(await tester.pumpAndSettle(), 1); // Nothing to animate
     await drag1.moveTo(const Offset(10.0, 0.0));
-    expect(await tester.pumpAndSettle(), 1); // Nothing to animate
+    expect(await tester.pumpAndSettle(), 2); // Nothing to animate, only one semantics update
     await drag1.up();
     expect(await tester.pumpAndSettle(), 1); // Nothing to animate
     expect(position.pixels, moreOrLessEquals(500.0));
@@ -132,14 +132,14 @@ void main() {
     final TestGesture drag2 = await tester.startGesture(const Offset(10.0, 500.0));
     expect(await tester.pumpAndSettle(), 1); // Nothing to animate
     await drag2.moveTo(const Offset(10.0, 100.0));
-    expect(await tester.pumpAndSettle(), 1); // Nothing to animate
+    expect(await tester.pumpAndSettle(), 2); // Nothing to animate, only one semantics update
     expect(position.maxScrollExtent, 900.0);
     expect(position.pixels, lessThanOrEqualTo(900.0));
     expect(position.activity, isInstanceOf<DragScrollActivity>());
 
     final _ExpandingBoxState expandingBoxState = tester.state<_ExpandingBoxState>(find.byType(ExpandingBox));
     expandingBoxState.toggleSize();
-    expect(await tester.pumpAndSettle(), 1); // Nothing to animate
+    expect(await tester.pumpAndSettle(), 2); // Nothing to animate, only one semantics update
     expect(position.activity, isInstanceOf<DragScrollActivity>());
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
@@ -150,7 +150,7 @@ void main() {
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
     expect(position.pixels, 50.0);
-    expect(await tester.pumpAndSettle(), 1); // Nothing to animate
+    expect(await tester.pumpAndSettle(), 2); // Nothing to animate, only one semantics update
     expect(position.minScrollExtent, 0.0);
     expect(position.maxScrollExtent, 100.0);
     expect(position.pixels, 50.0);

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -23,7 +23,7 @@ void main() {
     await tester.pump();
     await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(31))));
     expect(controller.position.pixels, thirty + 200.0); // same distance past the end
-    expect(await tester.pumpAndSettle(), 7); // now it goes ballistic...
+    expect(await tester.pumpAndSettle(), 8); // now it goes ballistic...
     expect(controller.position.pixels, thirty + 100.0); // and ends up at the end
   });
 

--- a/packages/flutter/test/widgets/scrollable_restoration_test.dart
+++ b/packages/flutter/test/widgets/scrollable_restoration_test.dart
@@ -446,7 +446,6 @@ void main() {
     expect(find.text('Tile 12'), findsNothing);
 
     final TestRestorationData initialData = await tester.getRestorationData();
-
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
     await gesture.moveBy(const Offset(0, -525));
     await tester.pump();
@@ -457,12 +456,12 @@ void main() {
     expect(find.text('Tile 11'), findsOneWidget);
     expect(find.text('Tile 12'), findsOneWidget);
 
-    // Restoration data hasn't changed and no frame is scheduled.
+    // Restoration data hasn't changed.
     expect(await tester.getRestorationData(), initialData);
-    expect(tester.binding.hasScheduledFrame, isFalse);
 
     // Restoration data changes with up event.
     await gesture.up();
+    await tester.pump();
     expect(await tester.getRestorationData(), isNot(initialData));
   });
 }


### PR DESCRIPTION
The scrollable needs to know if the content dimensions in the scroll position has changed in order to update its semantics node correctly. This pr adds an API to ScrollingContext to listen to the change.

fixes https://github.com/flutter/flutter/issues/40419

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
