### PR TITLE
Added highlightColor param to TabBar

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -724,6 +724,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.unselectedLabelStyle,
     this.dragStartBehavior = DragStartBehavior.start,
     this.overlayColor,
+    this.highlightColor,
     this.mouseCursor,
     this.enableFeedback,
     this.onTap,
@@ -880,6 +881,11 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// for [InkResponse.focusColor], [InkResponse.hoverColor], [InkResponse.splashColor]
   /// will be used instead.
   final MaterialStateProperty<Color?>? overlayColor;
+
+  /// The highlight color of the ink response when pressed. If this property is
+  /// null then the highlight color of the theme, [ThemeData.highlightColor],
+  /// will be used.
+  final Color? highlightColor;
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
@@ -1273,6 +1279,7 @@ class _TabBarState extends State<TabBar> {
         onTap: () { _handleTap(index); },
         enableFeedback: widget.enableFeedback ?? true,
         overlayColor: widget.overlayColor,
+        highlightColor: widget.highlightColor,
         child: Padding(
           padding: EdgeInsets.only(bottom: widget.indicatorWeight),
           child: Stack(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -2777,6 +2777,35 @@ void main() {
     });
   });
 
+  testWidgets("Tab's ink well highlight color matches Tab highlightColor", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      boilerplate(
+        child: DefaultTabController(
+          length: 1,
+          child: TabBar(
+            tabs: const <Tab>[
+              Tab(text: 'A'),
+            ],
+            overlayColor: MaterialStateColor.resolveWith((Set<MaterialState> states) => Colors.transparent),
+            highlightColor: Colors.red,
+          ),
+        ),
+      ),
+    );
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.down(tester.getCenter(find.byType(Tab)));
+    await tester.pumpAndSettle();
+    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    final PaintPattern paintPattern = paints
+      // Transparent splash color
+      ..rect(rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0), color: Colors.transparent)
+      // Red highlight color
+      ..rect(rect: const Rect.fromLTRB(0.0, 276.0, 800.0, 324.0), color: const Color(0xfff44336));
+    expect(inkFeatures, paintPattern);
+  });
+
   group('Tab overlayColor affects ink response', () {
     testWidgets("Tab's ink well changes color on hover with Tab overlayColor", (WidgetTester tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
This PR adds a highlightColor parameter to the TabBar widget. This is to allow customization of the InkWell's highlight color.

Implements enhancement referenced in https://github.com/flutter/flutter/issues/86661

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
