### PR TITLE
Replace iOS physical/simulator bools with enum

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -50,7 +50,7 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.build;
 
   @override
-  bool get forSimulator => boolArg('simulator');
+  EnvironmentType get environmentType => boolArg('simulator') ? EnvironmentType.simulator : EnvironmentType.physical;
 
   @override
   bool get configOnly => boolArg('config-only');
@@ -91,7 +91,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.archive;
 
   @override
-  final bool forSimulator = false;
+  final EnvironmentType environmentType = EnvironmentType.physical;
 
   @override
   final bool configOnly = false;
@@ -208,7 +208,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   };
 
   XcodeBuildAction get xcodeBuildAction;
-  bool get forSimulator;
+  EnvironmentType get environmentType;
   bool get configOnly;
   bool get shouldCodesign;
 
@@ -229,19 +229,19 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    defaultBuildMode = forSimulator ? BuildMode.debug : BuildMode.release;
+    defaultBuildMode = environmentType == EnvironmentType.simulator ? BuildMode.debug : BuildMode.release;
     final BuildInfo buildInfo = await getBuildInfo();
 
     if (!supported) {
       throwToolExit('Building for iOS is only supported on macOS.');
     }
-    if (forSimulator && !buildInfo.supportsSimulator) {
+    if (environmentType == EnvironmentType.simulator && !buildInfo.supportsSimulator) {
       throwToolExit('${toTitleCase(buildInfo.friendlyModeName)} mode is not supported for simulators.');
     }
     if (configOnly && buildInfo.codeSizeDirectory != null) {
       throwToolExit('Cannot analyze code size without performing a full build.');
     }
-    if (!forSimulator && !shouldCodesign) {
+    if (environmentType == EnvironmentType.physical && !shouldCodesign) {
       globals.printStatus(
         'Warning: Building for device with codesigning disabled. You will '
         'have to manually codesign before deploying to device.',
@@ -254,7 +254,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       throwToolExit('Application not configured for iOS');
     }
 
-    final String logTarget = forSimulator ? 'simulator' : 'device';
+    final String logTarget = environmentType == EnvironmentType.simulator ? 'simulator' : 'device';
     final String typeName = globals.artifacts.getEngineType(TargetPlatform.ios, buildInfo.mode);
     if (xcodeBuildAction == XcodeBuildAction.build) {
       globals.printStatus('Building $app for $logTarget ($typeName)...');
@@ -265,7 +265,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       app: app,
       buildInfo: buildInfo,
       targetOverride: targetFile,
-      buildForDevice: !forSimulator,
+      environmentType: environmentType,
       codesign: shouldCodesign,
       configOnly: configOnly,
       buildAction: xcodeBuildAction,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -327,7 +327,7 @@ class IOSDevice extends Device {
           app: package as BuildableIOSApp,
           buildInfo: debuggingOptions.buildInfo,
           targetOverride: mainPath,
-          buildForDevice: true,
+          environmentType: EnvironmentType.physical,
           activeArch: cpuArchitecture,
           deviceID: id,
       );

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -96,7 +96,7 @@ Future<XcodeBuildResult> buildXcodeProject({
   BuildableIOSApp app,
   BuildInfo buildInfo,
   String targetOverride,
-  bool buildForDevice,
+  EnvironmentType environmentType = EnvironmentType.physical,
   DarwinArch activeArch,
   bool codesign = true,
   String deviceID,
@@ -181,10 +181,10 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   final Map<String, String> buildSettings = await app.project.buildSettingsForBuildInfo(
         buildInfo,
-        environmentType: buildForDevice ? EnvironmentType.physical : EnvironmentType.simulator,
+        environmentType: environmentType
       ) ?? <String, String>{};
 
-  if (codesign && buildForDevice) {
+  if (codesign && environmentType == EnvironmentType.physical) {
     autoSigningConfigs = await getCodeSigningIdentityDevelopmentTeam(
       buildSettings: buildSettings,
       processManager: globals.processManager,
@@ -251,18 +251,18 @@ Future<XcodeBuildResult> buildXcodeProject({
     // The -sdk argument has to be omitted if a watchOS companion app exists.
     // Otherwise the build will fail as WatchKit dependencies cannot be build using the iOS SDK.
     globals.printStatus('Watch companion app found. Adjusting build settings.');
-    if (!buildForDevice && (deviceID == null || deviceID == '')) {
+    if (environmentType == EnvironmentType.simulator && (deviceID == null || deviceID == '')) {
       globals.printError('No simulator device ID has been set.');
       globals.printError('A device ID is required to build an app with a watchOS companion app.');
       globals.printError('Please run "flutter devices" to get a list of available device IDs');
       globals.printError('and specify one using the -d, --device-id flag.');
       return XcodeBuildResult(success: false);
     }
-    if (!buildForDevice) {
+    if (environmentType == EnvironmentType.simulator) {
       buildCommands.addAll(<String>['-destination', 'id=$deviceID']);
     }
   } else {
-    if (buildForDevice) {
+    if (environmentType == EnvironmentType.physical) {
       buildCommands.addAll(<String>['-sdk', 'iphoneos']);
     } else {
       buildCommands.addAll(<String>['-sdk', 'iphonesimulator']);
@@ -378,7 +378,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       xcodeBuildExecution: XcodeBuildExecution(
         buildCommands: buildCommands,
         appDirectory: app.project.hostAppRoot.path,
-        buildForPhysicalDevice: buildForDevice,
+        environmentType: environmentType,
         buildSettings: buildSettings,
       ),
     );
@@ -390,7 +390,7 @@ Future<XcodeBuildResult> buildXcodeProject({
       // actual directory will end with 'iphonesimulator' for simulator builds.
       // The value of TARGET_BUILD_DIR is adjusted to accommodate for this effect.
       String targetBuildDir = buildSettings['TARGET_BUILD_DIR'];
-      if (hasWatchCompanion && !buildForDevice) {
+      if (hasWatchCompanion && environmentType == EnvironmentType.simulator) {
         globals.printTrace('Replacing iphoneos with iphonesimulator in TARGET_BUILD_DIR.');
         targetBuildDir = targetBuildDir.replaceFirst('iphoneos', 'iphonesimulator');
       }
@@ -437,7 +437,7 @@ Future<XcodeBuildResult> buildXcodeProject({
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: buildCommands,
           appDirectory: app.project.hostAppRoot.path,
-          buildForPhysicalDevice: buildForDevice,
+          environmentType: environmentType,
           buildSettings: buildSettings,
       ),
     );
@@ -508,7 +508,7 @@ return result.exitCode != 0 &&
 
 Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsage, Logger logger) async {
   if (result.xcodeBuildExecution != null &&
-      result.xcodeBuildExecution.buildForPhysicalDevice &&
+      result.xcodeBuildExecution.environmentType == EnvironmentType.physical &&
       result.stdout?.toUpperCase()?.contains('BITCODE') == true) {
     BuildEvent('xcode-bitcode-failure',
       type: 'ios',
@@ -533,7 +533,7 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
   }
 
   if (result.xcodeBuildExecution != null &&
-      result.xcodeBuildExecution.buildForPhysicalDevice &&
+      result.xcodeBuildExecution.environmentType == EnvironmentType.physical &&
       result.stdout?.contains('BCEROR') == true &&
       // May need updating if Xcode changes its outputs.
       result.stdout?.contains("Xcode couldn't find a provisioning profile matching") == true) {
@@ -544,14 +544,14 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
   // * DEVELOPMENT_TEAM (automatic signing)
   // * PROVISIONING_PROFILE (manual signing)
   if (result.xcodeBuildExecution != null &&
-      result.xcodeBuildExecution.buildForPhysicalDevice &&
+      result.xcodeBuildExecution.environmentType == EnvironmentType.physical &&
       !<String>['DEVELOPMENT_TEAM', 'PROVISIONING_PROFILE'].any(
         result.xcodeBuildExecution.buildSettings.containsKey)) {
     logger.printError(noDevelopmentTeamInstruction, emphasis: true);
     return;
   }
   if (result.xcodeBuildExecution != null &&
-      result.xcodeBuildExecution.buildForPhysicalDevice &&
+      result.xcodeBuildExecution.environmentType == EnvironmentType.physical &&
       result.xcodeBuildExecution.buildSettings['PRODUCT_BUNDLE_IDENTIFIER']?.contains('com.example') == true) {
     logger.printError('');
     logger.printError('It appears that your application still contains the default signing identifier.');
@@ -609,14 +609,14 @@ class XcodeBuildExecution {
   XcodeBuildExecution({
     @required this.buildCommands,
     @required this.appDirectory,
-    @required this.buildForPhysicalDevice,
+    @required this.environmentType,
     @required this.buildSettings,
   });
 
   /// The original list of Xcode build commands used to produce this build result.
   final List<String> buildCommands;
   final String appDirectory;
-  final bool buildForPhysicalDevice;
+  final EnvironmentType environmentType;
   /// The build settings corresponding to the [buildCommands] invocation.
   final Map<String, String> buildSettings;
 }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -529,7 +529,7 @@ class IOSSimulator extends Device {
       app: app,
       buildInfo: buildInfo,
       targetOverride: mainPath,
-      buildForDevice: false,
+      environmentType: EnvironmentType.simulator,
       deviceID: id,
     );
     if (!buildResult.success) {

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -149,7 +149,7 @@ void main() {
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: buildCommands,
           appDirectory: '/blah/blah',
-          buildForPhysicalDevice: true,
+          environmentType: EnvironmentType.physical,
           buildSettings: buildSettings,
         ),
       );
@@ -229,7 +229,7 @@ Error launching application on iPhone.''',
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
           appDirectory: '/blah/blah',
-          buildForPhysicalDevice: true,
+          environmentType: EnvironmentType.physical,
           buildSettings: buildSettings,
         ),
       );
@@ -310,7 +310,7 @@ Could not build the precompiled application for the device.''',
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
           appDirectory: '/blah/blah',
-          buildForPhysicalDevice: true,
+          environmentType: EnvironmentType.physical,
           buildSettings: buildSettings,
         ),
       );
@@ -347,7 +347,7 @@ Exited (sigterm)''',
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
           appDirectory: '/blah/blah',
-          buildForPhysicalDevice: true,
+          environmentType: EnvironmentType.physical,
           buildSettings: buildSettings,
         ),
       );
@@ -384,7 +384,7 @@ Exited (sigterm)''',
         xcodeBuildExecution: XcodeBuildExecution(
           buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
           appDirectory: '/blah/blah',
-          buildForPhysicalDevice: true,
+          environmentType: EnvironmentType.physical,
           buildSettings: buildSettings,
         ),
       );


### PR DESCRIPTION
The `buildForDevice` bool parameter keeps confusing me.  It's indicating whether the build should be for a simulator or physical device.  Instead of a bool, use the more descriptive existing `EnvironmentType` enum.  Adopt it in a few other places.