### PR TITLE
🔋 Enhance cupertino button fade in and fade out

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -148,8 +148,8 @@ class CupertinoButton extends StatefulWidget {
 
 class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProviderStateMixin {
   // Eyeballed values. Feel free to tweak.
-  static const Duration kFadeOutDuration = Duration(milliseconds: 10);
-  static const Duration kFadeInDuration = Duration(milliseconds: 100);
+  static const Duration kFadeOutDuration = Duration(milliseconds: 120);
+  static const Duration kFadeInDuration = Duration(milliseconds: 180);
   final Tween<double> _opacityTween = Tween<double>(begin: 1.0);
 
   late AnimationController _animationController;
@@ -213,8 +213,8 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
       return;
     final bool wasHeldDown = _buttonHeldDown;
     final TickerFuture ticker = _buttonHeldDown
-        ? _animationController.animateTo(1.0, duration: kFadeOutDuration)
-        : _animationController.animateTo(0.0, duration: kFadeInDuration);
+        ? _animationController.animateTo(1.0, duration: kFadeOutDuration, curve: Curves.easeInOutCubicEmphasized)
+        : _animationController.animateTo(0.0, duration: kFadeInDuration, curve: Curves.easeOutCubic);
     ticker.then<void>((void value) {
       if (mounted && wasHeldDown != _buttonHeldDown)
         _animate();

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -205,55 +205,27 @@ void main() {
     await tester.pump();
     FadeTransition transition = tester.firstWidget(find.byType(FadeTransition));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.464, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 50));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.403, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 100));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.400, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.400, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.483, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 50));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.650, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.795, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 50));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.894, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.955, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 50));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.988, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.999, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
+    await tester.pump(const Duration(milliseconds: 50));
     transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(1.0, epsilon: 0.001));
   });

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -207,19 +207,51 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.464, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.403, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.400, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.400, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
     expect(transition.opacity.value, moreOrLessEquals(0.4, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.437, epsilon: 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.483, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.55, epsilon: 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.650, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.737, epsilon: 0.001));
+    expect(transition.opacity.value, moreOrLessEquals(0.795, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.894, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.955, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.988, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 25));
+    transition = tester.firstWidget(find.byType(FadeTransition));
+    expect(transition.opacity.value, moreOrLessEquals(0.999, epsilon: 0.001));
 
     await tester.pump(const Duration(milliseconds: 25));
     transition = tester.firstWidget(find.byType(FadeTransition));


### PR DESCRIPTION
This part of the combing process of Cupertino widgets to make sure they match the swift ui implementation.

| Before | After |
| ------ | ------ |
| <video src="https://user-images.githubusercontent.com/41989385/127230200-27633427-64db-48da-b0b2-e1e400175671.mov" /> | <video src="https://user-images.githubusercontent.com/41989385/127230203-3ae3286c-2d8a-456e-b513-057867bcecfe.mov" /> |

helps in fixing #72545 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
