### PR TITLE
Add test ownership for firebase tests and docs tests

### DIFF
--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -189,6 +189,7 @@
 /dev/bots/analyze.dart @HansMuller @flutter/framework
 # Linux/Mac/Windows customer_testing
 /dev/customer_testing/run_tests.dart @HansMuller @flutter/framework
+# Linux docs
 # Linux docs_test
 # Linux docs_publish
 /dev/bots/docs.sh @HansMuller @flutter/framework

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -190,11 +190,17 @@
 # Linux/Mac/Windows customer_testing
 /dev/customer_testing/run_tests.dart @HansMuller @flutter/framework
 # Linux docs_test
+# Linux docs_publish
 /dev/bots/docs.sh @HansMuller @flutter/framework
 # Linux web_e2e_test
-/dev/integration_tests/web_e2e_tests  @ferhatb @flutter/web
+/dev/integration_tests/web_e2e_tests @ferhatb @flutter/web
 # Linux web_smoke_test
 /examples/hello_world/test_driver/smoke_web_engine.dart @ferhatb @flutter/web
+
+## Firebase tests
+/dev/integration_tests/abstract_method_smoke_test @blasten @flutter/android
+/dev/integration_tests/android_embedding_v2_smoke_test @blasten @flutter/android
+/dev/integration_tests/release_smoke_test @blasten @flutter/android
 
 ## Shards tests
 # TODO(keyonghan): add files/paths for below framework host only testss.


### PR DESCRIPTION
This PRs adds test ownership for the missing tests: firebase tests and docs tests.

This is part of https://github.com/flutter/flutter/issues/87144