### PR TITLE
Update the skipped test for dev.

### DIFF
--- a/dev/benchmarks/test_apps/stocks/test_driver/stock_view_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test_driver/stock_view_test.dart
@@ -39,6 +39,8 @@ void main() {
       final String symbol = await driver.getText(stockOption);
 
       expect(symbol, 'AAPL');
-    }, skip: 'Needs to be fixed on Fuchsia.', timeout: Timeout.none);
+    },
+    skip: 'Needs to be fixed on Fuchsia.', // https://github.com/flutter/flutter/issues/87069
+    timeout: Timeout.none);
   });
 }

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -282,7 +282,7 @@ void main() {
             contains('The binary $binPath was not codesigned!'),
           )),
         );
-      }, skip: !platform.isMacOS);
+      }, skip: !platform.isMacOS); // [intended] codesign is only available on macOS
     });
 
     group('ArchivePublisher for $platformName', () {

--- a/dev/bots/test/sdk_directory_has_space_test.dart
+++ b/dev/bots/test/sdk_directory_has_space_test.dart
@@ -17,5 +17,5 @@ void main() {
     expect(expectedName, contains(' '));
     final List<String> parts = path.split(Directory.current.absolute.path);
     expect(parts.reversed.take(3), <String?>['bots', 'dev', expectedName]);
-  }, skip: true); // https://github.com/flutter/flutter/issues/62919
+  }, skip: true); // https://github.com/flutter/flutter/issues/87285
 }

--- a/dev/integration_tests/flutter_gallery/test/accessibility_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/accessibility_test.dart
@@ -560,9 +560,7 @@ void main() {
         await tester.pumpWidget(MaterialApp(theme: theme, home: const DialogDemo()));
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         handle.dispose();
-      }, skip: theme == ThemeData.dark()); // Raised Button does not follow
-      // theme. https://github.com/flutter/flutter/issues/16488,
-      // https://github.com/flutter/flutter/issues/19623
+      });
 
       testWidgets('drawer_demo $themeName', (WidgetTester tester) async {
         tester.binding.addTime(const Duration(seconds: 3));
@@ -636,9 +634,7 @@ void main() {
         );
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         handle.dispose();
-      }, skip: theme == ThemeData.dark()); // Raised Button does not follow
-      // theme. https://github.com/flutter/flutter/issues/16488,
-      // https://github.com/flutter/flutter/issues/19623
+      });
 
       testWidgets('overscroll_demo', (WidgetTester tester) async {
         tester.binding.addTime(const Duration(seconds: 3));
@@ -664,9 +660,7 @@ void main() {
         );
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         handle.dispose();
-      }, skip: theme == ThemeData.dark()); // Raised Button does not follow
-      // theme. https://github.com/flutter/flutter/issues/16488,
-      // https://github.com/flutter/flutter/issues/19623
+      });
 
       testWidgets('progress_indicator_demo $themeName', (WidgetTester tester) async {
         tester.binding.addTime(const Duration(seconds: 3));
@@ -724,9 +718,7 @@ void main() {
         );
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         handle.dispose();
-      }, skip: theme == ThemeData.dark()); // Raised Button does not follow
-      // theme. https://github.com/flutter/flutter/issues/16488,
-      // https://github.com/flutter/flutter/issues/19623
+      });
 
       testWidgets('tabs_demo $themeName', (WidgetTester tester) async {
         tester.binding.addTime(const Duration(seconds: 3));

--- a/dev/tracing_tests/test/default_streams_test.dart
+++ b/dev/tracing_tests/test/default_streams_test.dart
@@ -37,5 +37,5 @@ void main() {
       'Embedder',
       'GC',
     ]));
-  }, skip: isBrowser); // uses dart:isolate and io
+  }, skip: isBrowser); // [intended] uses dart:isolate and io.
 }

--- a/dev/tracing_tests/test/image_cache_tracing_test.dart
+++ b/dev/tracing_tests/test/image_cache_tracing_test.dart
@@ -77,7 +77,7 @@ void main() {
         },
       ],
     );
-  }, skip: isBrowser); // uses dart:isolate and io
+  }, skip: isBrowser); // [intended] uses dart:isolate and io.
 }
 
 void _expectTimelineEvents(List<TimelineEvent> events, List<Map<String, dynamic>> expected) {

--- a/dev/tracing_tests/test/image_painting_event_test.dart
+++ b/dev/tracing_tests/test/image_painting_event_test.dart
@@ -74,7 +74,7 @@ void main() {
       jsonEncode(event.extensionData!.data),
       '{"test.png":{"source":"test.png","displaySize":{"width":200.0,"height":100.0},"imageSize":{"width":300.0,"height":300.0},"displaySizeInBytes":106666,"decodedSizeInBytes":480000}}',
     );
-  }, skip: isBrowser); // uses dart:isolate and io
+  }, skip: isBrowser); // [intended] uses dart:isolate and io.
 
   test('Image painting events - deduplicates across frames', () async {
     final Completer<Event> completer = Completer<Event>();
@@ -106,7 +106,7 @@ void main() {
       jsonEncode(event.extensionData!.data),
       '{"test.png":{"source":"test.png","displaySize":{"width":300.0,"height":300.0},"imageSize":{"width":300.0,"height":300.0},"displaySizeInBytes":480000,"decodedSizeInBytes":480000}}',
     );
-  }, skip: isBrowser); // uses dart:isolate and io
+  }, skip: isBrowser); // [intended] uses dart:isolate and io.
 }
 
 class TestCanvas implements Canvas {


### PR DESCRIPTION
Part of #86396.

Updated the skip tests under 'dev'. Turned some of them back on, updated others to use `testOn` instead of `skip` as they were intentional and not temporary skips.
