### PR TITLE
Added parameters boxHeightStyle, boxWidthStyle to RenderParagraph.getBoxesForSelection

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -792,11 +792,11 @@ class RenderParagraph extends RenderBox
   /// [ui.BoxHeightStyle.tight] and [ui.BoxWidthStyle.tight] respectively and
   /// must not be null.
   ///
-  /// A given selection might have more than one rect if the [RenderParagraph] 
+  /// A given selection might have more than one rect if the [RenderParagraph]
   /// contains multiple [InlineSpan]s or bidirectional text, because logically
   /// contiguous text might not be visually contiguous.
   ///
-  /// See [TextPainter.getBoxesForSelection], for which this is essentially a 
+  /// See [TextPainter.getBoxesForSelection], for which this is essentially a
   /// wrapper, for additional details.
   ///
   /// Valid only after [layout].

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -796,10 +796,12 @@ class RenderParagraph extends RenderBox
   /// contains multiple [InlineSpan]s or bidirectional text, because logically
   /// contiguous text might not be visually contiguous.
   ///
-  /// See [TextPainter.getBoxesForSelection], for which this is essentially a
-  /// wrapper, for additional details.
-  ///
   /// Valid only after [layout].
+  ///
+  /// See also:
+  ///
+  ///  * [TextPainter.getBoxesForSelection], the method in TextPainter to get
+  ///    the equivalent boxes.
   List<ui.TextBox> getBoxesForSelection(
     TextSelection selection, {
     ui.BoxHeightStyle boxHeightStyle = ui.BoxHeightStyle.tight,

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -4,7 +4,7 @@
 
 import 'dart:collection';
 import 'dart:math' as math;
-import 'dart:ui' as ui show Gradient, Shader, TextBox, PlaceholderAlignment, TextHeightBehavior;
+import 'dart:ui' as ui show Gradient, Shader, TextBox, PlaceholderAlignment, TextHeightBehavior, BoxHeightStyle, BoxWidthStyle;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -787,15 +787,33 @@ class RenderParagraph extends RenderBox
 
   /// Returns a list of rects that bound the given selection.
   ///
-  /// A given selection might have more than one rect if this text painter
-  /// contains bidirectional text because logically contiguous text might not be
-  /// visually contiguous.
+  /// The [boxHeightStyle] and [boxWidthStyle] arguments may be used to select
+  /// the shape of the [TextBox]es. These properties default to
+  /// [ui.BoxHeightStyle.tight] and [ui.BoxWidthStyle.tight] respectively and
+  /// must not be null.
+  ///
+  /// A given selection might have more than one rect if the [RenderParagraph] 
+  /// contains multiple [InlineSpan]s or bidirectional text, because logically
+  /// contiguous text might not be visually contiguous.
+  ///
+  /// See [TextPainter.getBoxesForSelection], for which this is essentially a 
+  /// wrapper, for additional details.
   ///
   /// Valid only after [layout].
-  List<ui.TextBox> getBoxesForSelection(TextSelection selection) {
+  List<ui.TextBox> getBoxesForSelection(
+    TextSelection selection, {
+    ui.BoxHeightStyle boxHeightStyle = ui.BoxHeightStyle.tight,
+    ui.BoxWidthStyle boxWidthStyle = ui.BoxWidthStyle.tight,
+  }) {
     assert(!debugNeedsLayout);
+    assert(boxHeightStyle != null);
+    assert(boxWidthStyle != null);
     _layoutTextWithConstraints(constraints);
-    return _textPainter.getBoxesForSelection(selection);
+    return _textPainter.getBoxesForSelection(
+      selection,
+      boxHeightStyle: boxHeightStyle,
+      boxWidthStyle: boxWidthStyle,
+    );
   }
 
   /// Returns the position within the text for the given pixel offset.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -167,7 +167,6 @@ void main() {
       const TextSelection(baseOffset: 0, extentOffset: 36),
     );
 
-    print(boxes);
     expect(boxes.length, equals(4));
 
     // The widths of the boxes should match the calculations above.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -171,7 +171,7 @@ void main() {
 
     // The widths of the boxes should match the calculations above.
     // The heights should all be 10, except for the box for 'smallsecond ',
-    // which should have height 8, and be alphabetic baseline-aligned with
+    // which should have height 5, and be alphabetic baseline-aligned with
     // 'First '. The Ahem font specifies alphabetic baselines at 0.2em above the
     // bottom extent, and 0.8em below the top, so the difference in top
     // alignment becomes (10px * 0.8 - 5px * 0.8) = 4px.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -153,7 +153,7 @@ void main() {
       ),
       textDirection: TextDirection.ltr,
     );
-    // Do layout with width chosen so that this splits as 
+    // Do layout with width chosen so that this splits as
     // First smallsecond |
     // third fourth |
     // fifth|
@@ -490,7 +490,7 @@ void main() {
     );
     // Fake the render boxes that correspond to the WidgetSpans. We use
     // RenderParagraph to reduce the dependencies this test has. The dimensions
-    // of these get used in place of the widths and heights specified in the 
+    // of these get used in place of the widths and heights specified in the
     // SizedBoxes above: each comes out as (w,h) = (14,14).
     final List<RenderBox> renderBoxes = <RenderBox>[
       RenderParagraph(const TextSpan(text: 'b'), textDirection: TextDirection.ltr),

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -178,13 +178,13 @@ void main() {
 
     // 'First ':
     expect(boxes[0], const TextBox.fromLTRBD(0.0, 0.0, 60.0, 10.0, TextDirection.ltr));
-    // 'smallsecond ' in size 8:
+    // 'smallsecond ' in size 5:
     expect(boxes[1], const TextBox.fromLTRBD(60.0, 4.0, 120.0, 9.0, TextDirection.ltr));
     // 'third fourth ':
     expect(boxes[2], const TextBox.fromLTRBD(0.0, 10.0, 130.0, 20.0, TextDirection.ltr));
     // 'fifth':
     expect(boxes[3], const TextBox.fromLTRBD(0.0, 20.0, 50.0, 30.0, TextDirection.ltr));
-  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61016
+  }, skip: !isLinux); // mac typography values can differ
 
   test('getBoxesForSelection test with boxHeightStyle and boxWidthStyle set to max', () {
     final RenderParagraph paragraph = RenderParagraph(


### PR DESCRIPTION
This adds the optional parameters `boxHeightStyle` and `boxWidthStyle` to the existing method `RenderParagraph.getBoxesForSelection`. This method is essentially a wrapper for the method `TextPainter.getBoxesForSelection`, accessed via the `RenderParagraph`'s private `_textPainter`. `TextPainter`'s version of the method sports these optional parameters, but they seem to have been overlooked when implementing `RenderParagraph`'s version; hence this patch.

This fixes #69080.

There didn't seem to be any existing tests for `TextPainter.getBoxesForSelection` that specified non-default values for `boxHeightStyle` and `boxWidthStyle`, so I put in two tests for this with this updated `RenderParagraph` version.

This is my first PR, so any advice is appreciated!

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
