### PR TITLE
Show Android SDK path in doctor on partial installation

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -183,6 +183,9 @@ class AndroidValidator extends DoctorValidator {
       }
       return ValidationResult(ValidationType.missing, messages);
     }
+
+    messages.add(ValidationMessage(_userMessages.androidSdkLocation(androidSdk.directory.path)));
+
     if (!androidSdk.cmdlineToolsAvailable) {
       messages.add(ValidationMessage.error(_userMessages.androidMissingCmdTools));
       return ValidationResult(ValidationType.missing, messages);
@@ -192,8 +195,6 @@ class AndroidValidator extends DoctorValidator {
       messages.add(ValidationMessage.hint(_userMessages.androidSdkLicenseOnly(kAndroidHome)));
       return ValidationResult(ValidationType.partial, messages);
     }
-
-    messages.add(ValidationMessage(_userMessages.androidSdkLocation(androidSdk.directory.path)));
 
     String? sdkVersionText;
     final AndroidSdkVersion? androidSdkLatestVersion = androidSdk.latestVersion;

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -342,7 +342,8 @@ Review licenses that have not been accepted (y/N)?
     sdk
       ..licensesAvailable = true
       ..platformToolsAvailable = false
-      ..cmdlineToolsAvailable = true;
+      ..cmdlineToolsAvailable = true
+      ..directory = fileSystem.directory('/foo/bar');
     final ValidationResult validationResult = await AndroidValidator(
       androidStudio: null,
       androidSdk: sdk,
@@ -354,10 +355,14 @@ Review licenses that have not been accepted (y/N)?
     ).validate();
 
     expect(validationResult.type, ValidationType.partial);
-    expect(
-      validationResult.messages.map((ValidationMessage message) => message.message),
-      contains(contains(UserMessages().androidSdkLicenseOnly(kAndroidHome))),
-    );
+
+    final ValidationMessage sdkMessage = validationResult.messages.first;
+    expect(sdkMessage.type, ValidationMessageType.information);
+    expect(sdkMessage.message, 'Android SDK at /foo/bar');
+
+    final ValidationMessage licenseMessage = validationResult.messages.last;
+    expect(licenseMessage.type, ValidationMessageType.hint);
+    expect(licenseMessage.message, UserMessages().androidSdkLicenseOnly(kAndroidHome));
   });
 
   testWithoutContext('detects minimum required SDK and buildtools', () async {
@@ -432,7 +437,8 @@ Review licenses that have not been accepted (y/N)?
     sdk
       ..licensesAvailable = true
       ..platformToolsAvailable = true
-      ..cmdlineToolsAvailable = false;
+      ..cmdlineToolsAvailable = false
+      ..directory = fileSystem.directory('/foo/bar');
 
     final AndroidValidator androidValidator = AndroidValidator(
       androidStudio: null,
@@ -448,10 +454,14 @@ Review licenses that have not been accepted (y/N)?
 
     final ValidationResult validationResult = await androidValidator.validate();
     expect(validationResult.type, ValidationType.missing);
-    expect(
-      validationResult.messages.last.message,
-      errorMessage,
-    );
+
+    final ValidationMessage sdkMessage = validationResult.messages.first;
+    expect(sdkMessage.type, ValidationMessageType.information);
+    expect(sdkMessage.message, 'Android SDK at /foo/bar');
+
+    final ValidationMessage cmdlineMessage = validationResult.messages.last;
+    expect(cmdlineMessage.type, ValidationMessageType.error);
+    expect(cmdlineMessage.message, errorMessage);
   });
 
   testWithoutContext('detects minimum required java version', () async {


### PR DESCRIPTION
Always show the Android SDK path in `flutter doctor -v`, even when cmdline tools or licenses are missing.

This would have helped me figure out my `path/to/sdkmanager`.

Before:
![Screen Shot 2021-07-28 at 3 12 53 PM](https://user-images.githubusercontent.com/682784/127403771-ca3014f3-2618-4c10-94ab-cd0acb89acca.png)

After:
![Screen Shot 2021-07-28 at 3 13 01 PM](https://user-images.githubusercontent.com/682784/127403767-2e0fddea-eecd-4a21-bf57-b33dd9007f91.png)