### PR TITLE
Exclude arm64 from iOS app archs if unsupported by plugins

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -204,7 +204,15 @@ List<String> _xcodeBuildSettingsLines({
     // ARM not yet supported https://github.com/flutter/flutter/issues/69221
     xcodeBuildSettings.add('EXCLUDED_ARCHS=arm64');
   } else {
-    xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=i386');
+    String excludedSimulatorArchs = 'i386';
+
+    // If any plugins or their dependencies do not support arm64 simulators
+    // (to run natively without Rosetta translation on an ARM Mac),
+    // the app will fail to build unless it also excludes arm64 simulators.
+    if (!project.ios.pluginsSupportArmSimulator) {
+      excludedSimulatorArchs += ' arm64';
+    }
+    xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=$excludedSimulatorArchs');
   }
 
   for (final MapEntry<String, String> config in buildInfo.toEnvironmentConfig().entries) {

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -4,6 +4,7 @@
 
 import '../artifacts.dart';
 import '../base/file_system.dart';
+import '../base/os.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../flutter_manifest.dart';
@@ -35,7 +36,7 @@ Future<void> updateGeneratedXcodeProperties({
   bool useMacOSConfig = false,
   String? buildDirOverride,
 }) async {
-  final List<String> xcodeBuildSettings = _xcodeBuildSettingsLines(
+  final List<String> xcodeBuildSettings = await _xcodeBuildSettingsLines(
     project: project,
     buildInfo: buildInfo,
     targetOverride: targetOverride,
@@ -136,13 +137,13 @@ String? parsedBuildNumber({
 }
 
 /// List of lines of build settings. Example: 'FLUTTER_BUILD_DIR=build'
-List<String> _xcodeBuildSettingsLines({
+Future<List<String>> _xcodeBuildSettingsLines({
   required FlutterProject project,
   required BuildInfo buildInfo,
   String? targetOverride,
   bool useMacOSConfig = false,
   String? buildDirOverride,
-}) {
+}) async {
   final List<String> xcodeBuildSettings = <String>[];
 
   final String flutterRoot = globals.fs.path.normalize(Cache.flutterRoot!);
@@ -209,7 +210,7 @@ List<String> _xcodeBuildSettingsLines({
     // If any plugins or their dependencies do not support arm64 simulators
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
-    if (!project.ios.pluginsSupportArmSimulator()) {
+    if (globals.os.hostPlatform == HostPlatform.darwin_arm && !(await project.ios.pluginsSupportArmSimulator())) {
       excludedSimulatorArchs += ' arm64';
     }
     xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=$excludedSimulatorArchs');

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -209,7 +209,7 @@ List<String> _xcodeBuildSettingsLines({
     // If any plugins or their dependencies do not support arm64 simulators
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
-    if (!project.ios.pluginsSupportArmSimulator) {
+    if (!project.ios.pluginsSupportArmSimulator()) {
       excludedSimulatorArchs += ' arm64';
     }
     xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=$excludedSimulatorArchs');

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -215,6 +215,58 @@ class XcodeProjectInterpreter {
     }
   }
 
+  /// Asynchronously retrieve xcode build settings for the generated Pods.xcodeproj plugins project.
+  ///
+  /// Returns the stdout of the Xcode command.
+  Future<String?> pluginsBuildSettingsOutput(
+      Directory podXcodeProject, {
+        Duration timeout = const Duration(minutes: 1),
+      }) async {
+    if (!podXcodeProject.existsSync()) {
+      // No plugins.
+      return null;
+    }
+    final Status status = _logger.startSpinner();
+    final List<String> showBuildSettingsCommand = <String>[
+      ...xcrunCommand(),
+      'xcodebuild',
+      '-alltargets',
+      '-sdk',
+      'iphonesimulator',
+      '-project',
+      podXcodeProject.path,
+      '-showBuildSettings',
+    ];
+    try {
+      // showBuildSettings is reported to occasionally timeout. Here, we give it
+      // a lot of wiggle room (locally on Flutter Gallery, this takes ~1s).
+      // When there is a timeout, we retry once.
+      final RunResult result = await _processUtils.run(
+        showBuildSettingsCommand,
+        throwOnError: true,
+        workingDirectory: podXcodeProject.path,
+        timeout: timeout,
+        timeoutRetries: 1,
+      );
+
+      // Return the stdout only. Do not parse with parseXcodeBuildSettings, `-alltargets` prints the build settings
+      // for all targets (one per plugin), so it would require a Map of Maps.
+      return result.stdout.trim();
+    } on Exception catch (error) {
+      if (error is ProcessException && error.toString().contains('timed out')) {
+        BuildEvent('xcode-show-build-settings-timeout',
+          type: 'ios',
+          command: showBuildSettingsCommand.join(' '),
+          flutterUsage: _usage,
+        ).send();
+      }
+      _logger.printTrace('Unexpected failure to get Pod Xcode project build settings: $error.');
+      return null;
+    } finally {
+      status.stop();
+    }
+  }
+
   Future<void> cleanWorkspace(String workspacePath, String scheme, { bool verbose = false }) async {
     await _processUtils.run(<String>[
       ...xcrunCommand(),

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -146,6 +146,25 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   /// Xcode workspace shared workspace settings file for the host app.
   File get xcodeWorkspaceSharedSettings => xcodeWorkspaceSharedData.childFile('WorkspaceSettings.xcsettings');
 
+  /// Do all plugins support arm64 simulators to run natively on an ARM Mac?
+  bool get pluginsSupportArmSimulator {
+    final File podProject = hostAppRoot
+        .childDirectory('Pods')
+        .childDirectory('Pods.xcodeproj')
+        .childFile('project.pbxproj');
+    if (!podProject.existsSync()) {
+      // No plugins.
+      return true;
+    }
+    final String podProjectContents = podProject.readAsStringSync();
+    // Quick and dirty way to see if any plugins or their dependencies exclude arm64 simulators
+    // as a valid architecture, usually because a binary is missing that slice.
+    // Example: "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
+    // NOT: "EXCLUDED_ARCHS[sdk=iphoneos*]" = "arm64 i386";
+    // NOT: "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386";
+    return !podProjectContents.contains(RegExp('EXCLUDED_ARCHS.*iphonesimulator.*arm64'));
+  }
+
   @override
   bool existsSync()  {
     return parent.isModule || _editableDirectory.existsSync();

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -147,7 +147,7 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   File get xcodeWorkspaceSharedSettings => xcodeWorkspaceSharedData.childFile('WorkspaceSettings.xcsettings');
 
   /// Do all plugins support arm64 simulators to run natively on an ARM Mac?
-  bool get pluginsSupportArmSimulator {
+  bool pluginsSupportArmSimulator() {
     final File podProject = hostAppRoot
         .childDirectory('Pods')
         .childDirectory('Pods.xcodeproj')

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -147,22 +147,27 @@ class IosProject extends FlutterProjectPlatform implements XcodeBasedProject {
   File get xcodeWorkspaceSharedSettings => xcodeWorkspaceSharedData.childFile('WorkspaceSettings.xcsettings');
 
   /// Do all plugins support arm64 simulators to run natively on an ARM Mac?
-  bool pluginsSupportArmSimulator() {
-    final File podProject = hostAppRoot
+  Future<bool> pluginsSupportArmSimulator() async {
+    final Directory podXcodeProject = hostAppRoot
         .childDirectory('Pods')
-        .childDirectory('Pods.xcodeproj')
-        .childFile('project.pbxproj');
-    if (!podProject.existsSync()) {
+        .childDirectory('Pods.xcodeproj');
+    if (!podXcodeProject.existsSync()) {
       // No plugins.
       return true;
     }
-    final String podProjectContents = podProject.readAsStringSync();
-    // Quick and dirty way to see if any plugins or their dependencies exclude arm64 simulators
+
+    final XcodeProjectInterpreter? xcodeProjectInterpreter = globals.xcodeProjectInterpreter;
+    if (xcodeProjectInterpreter == null) {
+      // Xcode isn't installed, don't try to check.
+      return false;
+    }
+    final String? buildSettings = await xcodeProjectInterpreter.pluginsBuildSettingsOutput(podXcodeProject);
+
+    // See if any plugins or their dependencies exclude arm64 simulators
     // as a valid architecture, usually because a binary is missing that slice.
-    // Example: "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
-    // NOT: "EXCLUDED_ARCHS[sdk=iphoneos*]" = "arm64 i386";
-    // NOT: "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386";
-    return !podProjectContents.contains(RegExp('EXCLUDED_ARCHS.*iphonesimulator.*arm64'));
+    // Example: EXCLUDED_ARCHS = arm64 i386
+    // NOT: EXCLUDED_ARCHS = i386
+    return buildSettings != null && !buildSettings.contains(RegExp('EXCLUDED_ARCHS.*arm64'));
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -40,12 +40,22 @@ void main() {
     ],
   );
 
-  const FakeCommand kARMCheckCommand = FakeCommand(
+  // x64 host.
+  const FakeCommand kx64CheckCommand = FakeCommand(
     command: <String>[
       'sysctl',
       'hw.optional.arm64',
     ],
     exitCode: 1,
+  );
+
+  // ARM host.
+  const FakeCommand kARMCheckCommand = FakeCommand(
+    command: <String>[
+      'sysctl',
+      'hw.optional.arm64',
+    ],
+    stdout: 'hw.optional.arm64: 1',
   );
 
   FakeProcessManager fakeProcessManager;
@@ -72,7 +82,7 @@ void main() {
   testWithoutContext('xcodebuild versionText returns null when xcodebuild is not fully installed', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: "xcode-select: error: tool 'xcodebuild' requires Xcode, "
@@ -89,7 +99,7 @@ void main() {
   testWithoutContext('xcodebuild versionText returns null when xcodebuild is not installed', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         exception: ProcessException(xcodebuild, <String>['-version']),
@@ -102,7 +112,7 @@ void main() {
   testWithoutContext('xcodebuild versionText returns formatted version text', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode 8.3.3\nBuild version 8E3004b',
@@ -116,7 +126,7 @@ void main() {
   testWithoutContext('xcodebuild versionText handles Xcode version string with unexpected format', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode Ultra5000\nBuild version 8E3004b',
@@ -130,7 +140,7 @@ void main() {
   testWithoutContext('xcodebuild version parts can be parsed', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode 11.4.1\nBuild version 11N111s',
@@ -144,7 +154,7 @@ void main() {
   testWithoutContext('xcodebuild minor and patch version default to 0', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode 11\nBuild version 11N111s',
@@ -158,7 +168,7 @@ void main() {
   testWithoutContext('xcodebuild version parts is null when version has unexpected format', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode Ultra5000\nBuild version 8E3004b',
@@ -194,7 +204,7 @@ void main() {
       'xcodebuild isInstalled is false when Xcode is not fully installed', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: "xcode-select: error: tool 'xcodebuild' requires Xcode, "
@@ -211,7 +221,7 @@ void main() {
   testWithoutContext('xcodebuild isInstalled is false when version has unexpected format', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode Ultra5000\nBuild version 8E3004b',
@@ -225,7 +235,7 @@ void main() {
   testWithoutContext('xcodebuild isInstalled is true when version has expected format', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-version'],
         stdout: 'Xcode 8.3.3\nBuild version 8E3004b',
@@ -239,13 +249,7 @@ void main() {
   testWithoutContext('xcrun runs natively on arm64', () {
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        stdout: 'hw.optional.arm64: 1',
-      ),
+      kARMCheckCommand,
     ]);
 
     expect(xcodeProjectInterpreter.xcrunCommand(), <String>[
@@ -297,7 +301,7 @@ void main() {
 
     fakeProcessManager.addCommands(<FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>[
           'xcrun',
@@ -331,7 +335,7 @@ void main() {
 
     fakeProcessManager.addCommands(<FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>[
           'xcrun',
@@ -360,7 +364,7 @@ void main() {
     };
     fakeProcessManager.addCommands(<FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>[
           'xcrun',
@@ -393,7 +397,7 @@ void main() {
 
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>[
           'xcrun',
@@ -418,7 +422,7 @@ void main() {
     const String workingDirectory = '/';
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-list'],
       ),
@@ -442,7 +446,7 @@ void main() {
 
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-list'],
         exitCode: 66,
@@ -468,7 +472,7 @@ void main() {
 
     fakeProcessManager.addCommands(const <FakeCommand>[
       kWhichSysctlCommand,
-      kARMCheckCommand,
+      kx64CheckCommand,
       FakeCommand(
         command: <String>['xcrun', 'xcodebuild', '-list'],
         exitCode: 74,
@@ -687,7 +691,7 @@ Information about project "Runner":
         xcodeProjectInterpreter = XcodeProjectInterpreter.test(processManager: fakeProcessManager);
       });
 
-      testUsingContext('does not arm64 simulator when supported by all plugins', () async {
+      testUsingContext('does not exclude arm64 simulator when supported by all plugins', () async {
         const BuildInfo buildInfo = BuildInfo.debug;
         final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
         final Directory podXcodeProject = project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
@@ -695,13 +699,7 @@ Information about project "Runner":
 
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
-          const FakeCommand(
-            command: <String>[
-              'sysctl',
-              'hw.optional.arm64',
-            ],
-            stdout: 'hw.optional.arm64: 1',
-          ),
+          kARMCheckCommand,
           FakeCommand(
             command: <String>[
               '/usr/bin/arch',
@@ -755,13 +753,7 @@ Build settings for action build and target plugin2:
 
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
-          const FakeCommand(
-            command: <String>[
-              'sysctl',
-              'hw.optional.arm64',
-            ],
-            stdout: 'hw.optional.arm64: 1',
-          ),
+          kARMCheckCommand,
           FakeCommand(
               command: <String>[
                 '/usr/bin/arch',
@@ -803,13 +795,7 @@ Build settings for action build and target plugin2:
 
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
-          const FakeCommand(
-            command: <String>[
-              'sysctl',
-              'hw.optional.arm64',
-            ],
-            stdout: 'hw.optional.arm64: 1',
-          ),
+          kARMCheckCommand,
           FakeCommand(
               command: <String>[
                 '/usr/bin/arch',

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -721,7 +721,7 @@ Build settings for action build and target plugin1:
     EXCLUDED_ARCHS = i386;
     INFOPLIST_FILE = Runner/Info.plist;
     UNRELATED_BUILD_SETTING = arm64;
-    
+
 Build settings for action build and target plugin2:
     ENABLE_BITCODE = NO;
     EXCLUDED_ARCHS = i386;
@@ -829,7 +829,7 @@ Build settings for action build and target plugin1:
     EXCLUDED_ARCHS = i386;
     INFOPLIST_FILE = Runner/Info.plist;
     UNRELATED_BUILD_SETTING = arm64;
-    
+
 Build settings for action build and target plugin2:
     ENABLE_BITCODE = NO;
     EXCLUDED_ARCHS = i386 arm64;

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -716,6 +716,8 @@ Information about project "Runner":
         ..writeAsStringSync('''
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "i386";
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = "arm64 i386";
+				EXCLUDED_ARCHS = "arm64 i386";
 				INFOPLIST_FILE = Runner/Info.plist;
 				UNRELATED_BUILD_SETTING = arm64;
           ''');

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -307,6 +307,14 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   }
 
   @override
+  Future<String> pluginsBuildSettingsOutput(
+      Directory podXcodeProject, {
+        Duration timeout = const Duration(minutes: 1),
+      }) async {
+    return null;
+  }
+
+  @override
   Future<void> cleanWorkspace(String workspacePath, String scheme, { bool verbose = false }) {
     return null;
   }


### PR DESCRIPTION
If any plugins declare they do not support arm64 simulators, also mark the entire iOS app as not supporting arm64 simulators to avoid compilation failures.  This will cause the app to run in x64 Rosetta translation mode.

Parse the output of
```
xcrun xcodebuild -alltargets -sdk iphonesimulator -project ios/Pods/Pods.xcodeproj -showBuildSettings
```

Plugins will be expected to add this to their podspec:

```ruby
  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
```
google_maps_flutter: https://github.com/flutter/flutter/issues/87242
google_sign_in: https://github.com/flutter/flutter/issues/87243

Fixes https://github.com/flutter/flutter/issues/85713