### PR TITLE
fix: fix BuildableMacOSApp pass no projectBundleId to super error

### DIFF
--- a/packages/flutter_tools/lib/src/macos/application_package.dart
+++ b/packages/flutter_tools/lib/src/macos/application_package.dart
@@ -24,7 +24,8 @@ abstract class MacOSApp extends ApplicationPackage {
 
   /// Creates a new [MacOSApp] from a macOS project directory.
   factory MacOSApp.fromMacOSProject(MacOSProject project) {
-    return BuildableMacOSApp(project);
+    // projectBundleId is unused for macOS apps. Use a placeholder bundle ID.
+    return BuildableMacOSApp(project, 'com.example.placeholder');
   }
 
   /// Creates a new [MacOSApp] from an existing app bundle.
@@ -139,7 +140,7 @@ class PrebuiltMacOSApp extends MacOSApp {
 }
 
 class BuildableMacOSApp extends MacOSApp {
-  BuildableMacOSApp(this.project);
+  BuildableMacOSApp(this.project, String projectBundleId): super(projectBundleId: projectBundleId);
 
   final MacOSProject project;
 

--- a/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/application_package_test.dart
@@ -12,8 +12,10 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/utils.dart';
+import 'package:flutter_tools/src/globals_null_migrated.dart' as globals;
 import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/macos/application_package.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -153,6 +155,14 @@ group('PrebuiltMacOSApp', () {
       expect(macosApp.bundleDir.path, endsWith('bundle.app'));
       expect(macosApp.id, 'fooBundleId');
       expect(macosApp.bundleName, endsWith('bundle.app'));
+    }, overrides: overrides);
+
+    testUsingContext('Success with project', () {
+      final MacOSApp macosApp = MacOSApp.fromMacOSProject(FlutterProject.fromDirectory(globals.fs.currentDirectory).macos);
+
+      expect(logger.errorText, isEmpty);
+      expect(macosApp.id, 'com.example.placeholder');
+      expect(macosApp.name, 'macOS');
     }, overrides: overrides);
   });
 }


### PR DESCRIPTION
*ApplicationPackage constructor assert id not null*
![](https://user-images.githubusercontent.com/10217632/127474768-191a4fef-fedc-4c45-b278-16033c43c1e2.png)

*MacOSApp extends ApplicationPackage and pass id to super*
![](https://user-images.githubusercontent.com/10217632/127475250-cf02b59a-086d-40ac-906d-9c84c5d1ccf2.png)

*BuildableMacOSApp extends MacOSApp but not pass id to super*
![](https://user-images.githubusercontent.com/10217632/127475405-b50959d6-0f04-4a43-831d-f0d20adacff0.png)

*When run flutter tools on debug mode to build macos application, it will get an error*

*This pr change BuildableMacOSApp to pass id to its super*
![](https://user-images.githubusercontent.com/10217632/127475693-2bfc38c0-b4dd-4945-9f3b-958640564ebe.png)

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/87265

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
