### PR TITLE
Fix race causing null dereference on getStack in web_tool_tests and CI flakes

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -250,17 +250,20 @@ abstract class FlutterTestDriver {
 
   // This method isn't racy. If the isolate is already paused,
   // it will immediately return.
-  Future<Isolate> waitForPause() async {
+  Future<Isolate> waitForPause() => waitForDebugEvent('Pause');
+  Future<Isolate> waitForResume() => waitForDebugEvent('Resume');
+
+  Future<Isolate> waitForDebugEvent(String kind) async {
     return _timeoutWithMessages<Isolate>(
       () async {
         final String flutterIsolate = await _getFlutterIsolateId();
         final Completer<Event> pauseEvent = Completer<Event>();
 
-        // Start listening for pause events.
+        // Start listening for events containing 'kind'.
         final StreamSubscription<Event> pauseSubscription = _vmService.onDebugEvent
           .where((Event event) {
             return event.isolate.id == flutterIsolate
-                && event.kind.startsWith('Pause');
+                && event.kind.startsWith(kind);
           })
           .listen((Event event) {
             if (!pauseEvent.isCompleted) {
@@ -268,14 +271,14 @@ abstract class FlutterTestDriver {
             }
           });
 
-        // But also check if the isolate was already paused (only after we've set
-        // up the subscription) to avoid races. If it was paused, we don't need to wait
+        // But also check if the isolate was already at the stae we need (only after we've
+        // set up the subscription) to avoid races. If it was paused, we don't need to wait
         // for the event.
         final Isolate isolate = await _vmService.getIsolate(flutterIsolate);
-        if (isolate.pauseEvent.kind.startsWith('Pause')) {
-          _debugPrint('Isolate was already paused (${isolate.pauseEvent.kind}).');
+        if (isolate.pauseEvent.kind.startsWith(kind)) {
+          _debugPrint('Isolate was already at "$kind" (${isolate.pauseEvent.kind}).');
         } else {
-          _debugPrint('Isolate is not already paused, waiting for event to arrive...');
+          _debugPrint('Waiting for "$kind" event to arrive...');
           await pauseEvent.future;
         }
 
@@ -284,7 +287,7 @@ abstract class FlutterTestDriver {
 
         return getFlutterIsolate();
       },
-      task: 'Waiting for isolate to pause',
+      task: 'Waiting for isolate to $kind',
     );
   }
 
@@ -312,6 +315,7 @@ abstract class FlutterTestDriver {
       () async => _vmService.resume(await _getFlutterIsolateId(), step: step),
       task: 'Resuming isolate (step=$step)',
     );
+    await waitForResume();
     return waitForNextPause ? waitForPause() : null;
   }
 

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -174,7 +174,7 @@ void main() {
 
 Future<void> failToEvaluateExpression(FlutterTestDriver flutter) async {
   await expectLater(
-    () => flutter.evaluateInFrame('"test"'),
+    flutter.evaluateInFrame('"test"'),
     throwsA(isA<RPCError>().having(
       (RPCError error) => error.message,
       'message',


### PR DESCRIPTION
One case of recent CI flakes in web_tool_tests was caused by a race condition between resuming
an isolate and waiting for the app to hit a next breakpoint. If resume gets delayed in the vm service,
the tests might get a stale "paused" state of the isolate and call `getStack` while running, which 
causes an exception in dwds, which is limited by chrome dev tools capabilities in that case and 
cannot get a stack while running.
    
Fix the race condition by waiting for `Resume` event before waiting for `Pause` in `TestDriver._resume`.
    
Following PR changes the null dereference to an RPCError in dwds if `getStack` while the app is running.
    
Related: https://github.com/dart-lang/webdev/pull/1370
    
Closes: https://github.com/dart-lang/webdev/issues/1369

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
