### PR TITLE
Deprecate ThemeData.fixTextFieldOutlineLabel

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,6 +15,39 @@
 version: 1
 transforms:
 
+  # Changes made in https://github.com/flutter/flutter/pull/87281
+  - title: "Remove 'fixTextFieldOutlineLabel'"
+    date: 2021-04-30
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ThemeData'
+    changes:
+      - kind: 'removeParameter'
+        name: 'fixTextFieldOutlineLabel'
+
+  # Changes made in https://github.com/flutter/flutter/pull/87281
+  - title: "Remove 'fixTextFieldOutlineLabel'"
+    date: 2021-04-30
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'raw'
+      inClass: 'ThemeData'
+    changes:
+      - kind: 'removeParameter'
+        name: 'fixTextFieldOutlineLabel'
+
+  # Changes made in https://github.com/flutter/flutter/pull/87281
+  - title: "Remove 'fixTextFieldOutlineLabel'"
+    date: 2021-04-30
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'ThemeData'
+    changes:
+      - kind: 'removeParameter'
+        name: 'fixTextFieldOutlineLabel'
+
   # Changes made in https://github.com/flutter/flutter/pull/81336
   - title: "Remove 'buttonColor'"
     date: 2021-04-30

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -336,6 +336,10 @@ class ThemeData with Diagnosticable {
     RadioThemeData? radioTheme,
     SwitchThemeData? switchTheme,
     ProgressIndicatorThemeData? progressIndicatorTheme,
+    @Deprecated(
+      'This "fix" is now enabled by default. '
+      'This feature was deprecated after v2.5.0-1.0.pre.',
+    )
     bool? fixTextFieldOutlineLabel,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
@@ -475,7 +479,7 @@ class ThemeData with Diagnosticable {
     switchTheme ??= const SwitchThemeData();
     progressIndicatorTheme ??= const ProgressIndicatorThemeData();
 
-    fixTextFieldOutlineLabel ??= false;
+    fixTextFieldOutlineLabel ??= true;
     useTextSelectionTheme ??= true;
 
     return ThemeData.raw(
@@ -687,6 +691,10 @@ class ThemeData with Diagnosticable {
     required this.radioTheme,
     required this.switchTheme,
     required this.progressIndicatorTheme,
+    @Deprecated(
+      'This "fix" is now enabled by default. '
+      'This feature was deprecated after v2.5.0-1.0.pre.',
+    )
     required this.fixTextFieldOutlineLabel,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
@@ -1326,16 +1334,18 @@ class ThemeData with Diagnosticable {
   /// A theme for customizing the appearance and layout of [ProgressIndicator] widgets.
   final ProgressIndicatorThemeData progressIndicatorTheme;
 
-  /// A temporary flag to allow apps to opt-in to a
+  /// An obsolete flag to allow apps to opt-out of a
   /// [small fix](https://github.com/flutter/flutter/issues/54028) for the Y
   /// coordinate of the floating label in a [TextField] [OutlineInputBorder].
   ///
   /// Setting this flag to true causes the floating label to be more precisely
   /// vertically centered relative to the border's outline.
   ///
-  /// The flag is currently false by default. It will be default true and
-  /// deprecated before the next beta release (1.18), and removed before the next
-  /// stable release (1.19).
+  /// The flag is true by default and its use is deprecated.
+  @Deprecated(
+    'This "fix" is now enabled by default. '
+    'This feature was deprecated after v2.5.0-1.0.pre.',
+  )
   final bool fixTextFieldOutlineLabel;
 
   /// A temporary flag that was used to opt-in to the new [TextSelectionTheme]

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1479,6 +1479,10 @@ class ThemeData with Diagnosticable {
     RadioThemeData? radioTheme,
     SwitchThemeData? switchTheme,
     ProgressIndicatorThemeData? progressIndicatorTheme,
+    @Deprecated(
+      'This "fix" is now enabled by default. '
+      'This feature was deprecated after v2.5.0-1.0.pre.',
+    )
     bool? fixTextFieldOutlineLabel,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -23,7 +23,6 @@ Widget buildInputDecorator({
   TextStyle? baseStyle,
   TextAlignVertical? textAlignVertical,
   VisualDensity? visualDensity,
-  bool fixTextFieldOutlineLabel = false,
   Widget child = const Text(
     'text',
     style: TextStyle(fontFamily: 'Ahem', fontSize: 16.0),
@@ -37,7 +36,6 @@ Widget buildInputDecorator({
             data: (theme ?? Theme.of(context)).copyWith(
               inputDecorationTheme: inputDecorationTheme,
               visualDensity: visualDensity,
-              fixTextFieldOutlineLabel: fixTextFieldOutlineLabel,
             ),
             child: Align(
               alignment: Alignment.topLeft,
@@ -3963,17 +3961,17 @@ void main() {
 
     await pumpDecorator(focused: false, empty: false);
     await tester.pumpAndSettle();
-    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -4)));
+    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
     expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: true, empty: true);
     await tester.pumpAndSettle();
-    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -4)));
+    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
     expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: true, empty: false);
     await tester.pumpAndSettle();
-    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -4)));
+    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
     expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: false, empty: true, enabled: false);
@@ -3983,7 +3981,7 @@ void main() {
 
     await pumpDecorator(focused: false, empty: false, enabled: false);
     await tester.pumpAndSettle();
-    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -4)));
+    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
     expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     // Focused and disabled happens with NavigationMode.directional.
@@ -3994,7 +3992,7 @@ void main() {
 
     await pumpDecorator(focused: true, empty: false, enabled: false);
     await tester.pumpAndSettle();
-    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -4)));
+    expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
     expect(getLabelRect(tester).size, equals(const Size(80, 16)));
   });
 
@@ -4589,10 +4587,6 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/54028
     await tester.pumpWidget(
       buildInputDecorator(
-        // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
-        // Ensures that the floating label is vertically centered relative to
-        // center of the top edge of the InputDecorator's outline border.
-        fixTextFieldOutlineLabel: true,
         isEmpty: true,
         decoration: const InputDecoration(
           labelText: 'label',

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -755,7 +755,6 @@ void main() {
       radioTheme: const RadioThemeData(),
       switchTheme: const SwitchThemeData(),
       progressIndicatorTheme: const ProgressIndicatorThemeData(),
-      fixTextFieldOutlineLabel: false,
       useTextSelectionTheme: false,
     );
 

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -387,4 +387,11 @@ void main() {
   listWheelViewport = ListWheelViewport(clipToSize: true);
   listWheelViewport = ListWheelViewport(clipToSize: false);
   listWheelViewport.clipToSize;
+
+  // Changes made in https://github.com/flutter/flutter/pull/87281
+  ThemeData themeData = ThemeData();
+  themeData = ThemeData(fixTextFieldOutlineLabel: true);
+  themeData = ThemeData.raw(fixTextFieldOutlineLabel: true);
+  themeData = themeData.copyWith(fixTextFieldOutlineLabel: true);
+  themeData.fixTextFieldOutlineLabel; // Removing field reference not supported.
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -359,4 +359,11 @@ void main() {
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
   listWheelViewport.clipBehavior;
+
+  // Changes made in https://github.com/flutter/flutter/pull/87281
+  ThemeData themeData = ThemeData();
+  themeData = ThemeData();
+  themeData = ThemeData.raw();
+  themeData = themeData.copyWith();
+  themeData.fixTextFieldOutlineLabel; // Removing field reference not supported.
 }


### PR DESCRIPTION
Deprecates what was supposed to have been a temporary flag: `ThemeData.fixTextFieldOutlineLabel`.  The flag's value is now true by default and now the InputDecorator's floating label is vertically centered instead of being slightly too low.

## Old - ThemeData.fixTextFieldOutlineLabel = false
<img width="96" alt="Screen Shot 2021-07-29 at 11 42 37 AM" src="https://user-images.githubusercontent.com/1377460/127548767-d20caa0f-df20-4897-9842-6e635b4fa30b.png">

## New - ThemeData.fixTextFieldOutlineLabel = true
<img width="88" alt="Screen Shot 2021-07-29 at 11 44 39 AM" src="https://user-images.githubusercontent.com/1377460/127548775-2f9b0b0b-c4ff-4a43-9129-f5d7e095de00.png">


Fixes https://github.com/flutter/flutter/issues/87224