### PR TITLE
Reattempt: Restores surface size and view configuration in the postTest of test binding

### DIFF
--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -7,8 +7,6 @@
 // initialize a binding, which rendering_tester will attempt to re-initialize
 // (or vice versa).
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -781,12 +779,6 @@ void main() {
     }
 
     testWidgets('Reverse List showOnScreen', (WidgetTester tester) async {
-      final ui.Size originalScreenSize = tester.binding.window.physicalSize;
-      final double originalDevicePixelRatio = tester.binding.window.devicePixelRatio;
-      addTearDown(() {
-        tester.binding.window.devicePixelRatioTestValue = originalDevicePixelRatio;
-        tester.binding.window.physicalSizeTestValue = originalScreenSize;
-      });
       const double screenHeight = 400.0;
       const double screenWidth = 400.0;
       const double itemHeight = screenHeight / 10.0;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -163,12 +163,21 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   }
   TestRestorationManager? _restorationManager;
 
+  // The configuration at the beginning of a widget test to be restored after
+  // the test.
+  //
+  // Normally this value should always be non-null during [postTest], except in
+  // rare cases [postTest] is called explicitly without [testWidgets] (so that
+  // [reset] is not called).
+  ViewConfiguration? _preTestViewConfiguration;
   /// Called by the test framework at the beginning of a widget test to
   /// prepare the binding for the next test.
   ///
   /// If [registerTestTextInput] returns true when this method is called,
   /// the [testTextInput] is configured to simulate the keyboard.
   void reset() {
+    assert(_surfaceSize == null);
+    _preTestViewConfiguration = renderView.configuration;
     _restorationManager = null;
     resetGestureBinding();
     testTextInput.reset();
@@ -942,6 +951,16 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         'active mouse gesture to remove the mouse pointer.');
     // ignore: invalid_use_of_visible_for_testing_member
     RendererBinding.instance!.initMouseTracker();
+    // Reset _surfaceSize and renderView.configuration.
+    //
+    // The _surfaceSize and renderView.configuration might be set within a
+    // test, but such changes should not be carried over. The
+    // renderView.configuration might also be set outside of a test, which
+    // *should* be kept between tests. Don't use [handleMetricsChanged] because
+    // it contains unwanted side effects.
+    _surfaceSize = null;
+    if (_preTestViewConfiguration != null && _preTestViewConfiguration != renderView.configuration)
+      renderView.configuration = _preTestViewConfiguration!;
   }
 }
 

--- a/packages/flutter_test/test/bindings_reset_configuration_test.dart
+++ b/packages/flutter_test/test/bindings_reset_configuration_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// This file contains tests for [testWidgets]. It is separated from bindings_test.dart
+// because it relies on a persistent side effect (altered view configuration).
+
+void main() {
+  final AutomatedTestWidgetsFlutterBinding binding = AutomatedTestWidgetsFlutterBinding();
+  group('testWidgets does not override pre-test viewConfiguration', () {
+    // Many tests are written in this way that a view configuration is set at
+    // the beginning of the file and is expected to take effect throughout the
+    // file.
+    binding.renderView.configuration = TestViewConfiguration(size: const Size(900, 900));
+
+    // Run the same test twice to ensure that the view configuration is as
+    // expected after a test.
+
+    for (int times = 1; times <= 2; times += 1) {
+      testWidgets('test $times', (WidgetTester tester) async {
+        expect(binding.renderView.configuration.size, const Size(900, 900));
+      });
+    }
+  });
+}

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -33,6 +33,26 @@ void main() {
     });
   });
 
+  group('testWidgets resets the surface size', () {
+    // A setSurfaceSize in one test should not bleed into another test.
+
+    // The next two tests must run in order.
+    int order = 0;
+
+    testWidgets('prepare: one test called setSurfaceSize', (WidgetTester tester) async {
+      assert(order == 0);
+      // This test case is only for preparation. It doesn't need `expect`.
+      binding.setSurfaceSize(const Size(100, 100));
+      order += 1;
+    });
+
+    testWidgets('other tests should still have the default surface size', (WidgetTester tester) async {
+      assert(order == 1);
+      expect(binding.renderView.configuration.size, const Size(800, 600));
+      order += 1;
+    });
+  });
+
   // The next three tests must run in order -- first using `test`, then `testWidgets`, then `test` again.
 
   int order = 0;


### PR DESCRIPTION
This is a reattempt to fix #87194. 

The previous attempt https://github.com/flutter/flutter/pull/87240 was reverted because many internal tests was written in a way that sets the view configuration at the beginning of a file and expect to use it throughout the file, which was broken by the previous method.

```dart
void main() {
  binding.renderView.configuration = TestViewConfiguration(size: const Size(900, 900));
  testWidget('test1', ...);
  testWidget('test2', ...);
}
```

This PR restores the surface size and the view configuration in the following strategy:
- The surface size is always reset to null at `postTest`, since the surface size can not be changed out of tests.
- The view configuration is recorded at `reset` (the pre-test hook), and is restored to that value at `postTest`.

I tested this change against some previously failing tests and they have been passing.

This PR also removes the temporary teardown cleanup in `viewport_test.dart`.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
