### PR TITLE
[ci.yaml] Prefix devicelab targets with the phone used

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2217,4 +2217,3 @@ targets:
       tags: >
         ["devicelab"]
     scheduler: luci
-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1256,7 +1256,7 @@ targets:
 
   - name: Linux_android flutter_gallery__transition_perf_e2e
     builder: Linux_android flutter_gallery__transition_perf_e2e
-    bringup: true
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
     presubmit: false
     properties:
       tags: >
@@ -1872,9 +1872,17 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux_android flutter_gallery__transition_perf_e2e
-    builder: Linux_android flutter_gallery__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
+    builder: Mac_ios flutter_gallery__transition_perf_e2e_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+    builder: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+    bringup: true
     presubmit: false
     properties:
       tags: >
@@ -2058,15 +2066,6 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
-    builder: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
-    bringup: true
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
   - name: Mac_ios new_gallery_ios__transition_perf
     builder: Mac_ios new_gallery_ios__transition_perf
     presubmit: false
@@ -2091,8 +2090,8 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux_android platform_channels_benchmarks
-    builder: Linux_android platform_channels_benchmarks
+  - name: Mac_ios platform_channels_benchmarks_ios
+    builder: Mac_ios platform_channels_benchmarks_ios
     presubmit: false
     properties:
       tags: >
@@ -2218,3 +2217,4 @@ targets:
       tags: >
         ["devicelab"]
     scheduler: luci
+

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2057,8 +2057,17 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Mac_ios native_ui_tests_ios32
-    builder: Mac_ios native_ui_tests_ios32
+  - name: Mac_ios32 native_ui_tests_ios32
+    builder: Mac_ios32 native_ui_tests_ios32
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+    builder: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
     bringup: true
     presubmit: false
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1053,136 +1053,136 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: Linux analyzer_benchmark
-    builder: Linux analyzer_benchmark
+  - name: Linux_android analyzer_benchmark
+    builder: Linux_android analyzer_benchmark
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux android_defines_test
-    builder: Linux android_defines_test
+  - name: Linux_android android_defines_test
+    builder: Linux_android android_defines_test
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux android_obfuscate_test
-    builder: Linux android_obfuscate_test
+  - name: Linux_android android_obfuscate_test
+    builder: Linux_android android_obfuscate_test
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux android_stack_size_test
-    builder: Linux android_stack_size_test
+  - name: Linux_android android_stack_size_test
+    builder: Linux_android android_stack_size_test
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux android_view_scroll_perf__timeline_summary
-    builder: Linux android_view_scroll_perf__timeline_summary
+  - name: Linux_android android_view_scroll_perf__timeline_summary
+    builder: Linux_android android_view_scroll_perf__timeline_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux animated_placeholder_perf__e2e_summary
-    builder: Linux animated_placeholder_perf__e2e_summary
+  - name: Linux_android animated_placeholder_perf__e2e_summary
+    builder: Linux_android animated_placeholder_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux backdrop_filter_perf__e2e_summary
-    builder: Linux backdrop_filter_perf__e2e_summary
+  - name: Linux_android backdrop_filter_perf__e2e_summary
+    builder: Linux_android backdrop_filter_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux basic_material_app_android__compile
-    builder: Linux basic_material_app_android__compile
+  - name: Linux_android basic_material_app_android__compile
+    builder: Linux_android basic_material_app_android__compile
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux color_filter_and_fade_perf__e2e_summary
-    builder: Linux color_filter_and_fade_perf__e2e_summary
+  - name: Linux_android color_filter_and_fade_perf__e2e_summary
+    builder: Linux_android color_filter_and_fade_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux complex_layout_android__compile
-    builder: Linux complex_layout_android__compile
+  - name: Linux_android complex_layout_android__compile
+    builder: Linux_android complex_layout_android__compile
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux complex_layout_android__scroll_smoothness
-    builder: Linux complex_layout_android__scroll_smoothness
+  - name: Linux_android complex_layout_android__scroll_smoothness
+    builder: Linux_android complex_layout_android__scroll_smoothness
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux complex_layout_scroll_perf__devtools_memory
-    builder: Linux complex_layout_scroll_perf__devtools_memory
+  - name: Linux_android complex_layout_scroll_perf__devtools_memory
+    builder: Linux_android complex_layout_scroll_perf__devtools_memory
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux complex_layout_semantics_perf
-    builder: Linux complex_layout_semantics_perf
+  - name: Linux_android complex_layout_semantics_perf
+    builder: Linux_android complex_layout_semantics_perf
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux cubic_bezier_perf__e2e_summary
-    builder: Linux cubic_bezier_perf__e2e_summary
+  - name: Linux_android cubic_bezier_perf__e2e_summary
+    builder: Linux_android cubic_bezier_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux cubic_bezier_perf_sksl_warmup__e2e_summary
-    builder: Linux cubic_bezier_perf_sksl_warmup__e2e_summary
+  - name: Linux_android cubic_bezier_perf_sksl_warmup__e2e_summary
+    builder: Linux_android cubic_bezier_perf_sksl_warmup__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux cull_opacity_perf__e2e_summary
-    builder: Linux cull_opacity_perf__e2e_summary
+  - name: Linux_android cull_opacity_perf__e2e_summary
+    builder: Linux_android cull_opacity_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux devtools_profile_start_test
-    builder: Linux devtools_profile_start_test
+  - name: Linux_android devtools_profile_start_test
+    builder: Linux_android devtools_profile_start_test
     bringup: true
     presubmit: false
     properties:
@@ -1206,234 +1206,234 @@ targets:
         ["framework","hostonly"]
     scheduler: luci
 
-  - name: Linux fast_scroll_heavy_gridview__memory
-    builder: Linux fast_scroll_heavy_gridview__memory
+  - name: Linux_android fast_scroll_heavy_gridview__memory
+    builder: Linux_android fast_scroll_heavy_gridview__memory
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_engine_group_performance
-    builder: Linux flutter_engine_group_performance
+  - name: Linux_android flutter_engine_group_performance
+    builder: Linux_android flutter_engine_group_performance
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__back_button_memory
-    builder: Linux flutter_gallery__back_button_memory
+  - name: Linux_android flutter_gallery__back_button_memory
+    builder: Linux_android flutter_gallery__back_button_memory
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__image_cache_memory
-    builder: Linux flutter_gallery__image_cache_memory
+  - name: Linux_android flutter_gallery__image_cache_memory
+    builder: Linux_android flutter_gallery__image_cache_memory
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__memory_nav
-    builder: Linux flutter_gallery__memory_nav
+  - name: Linux_android flutter_gallery__memory_nav
+    builder: Linux_android flutter_gallery__memory_nav
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__start_up
-    builder: Linux flutter_gallery__start_up
+  - name: Linux_android flutter_gallery__start_up
+    builder: Linux_android flutter_gallery__start_up
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__transition_perf_e2e
-    builder: Linux flutter_gallery__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+  - name: Linux_android flutter_gallery__transition_perf_e2e
+    builder: Linux_android flutter_gallery__transition_perf_e2e
+    bringup: true
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__transition_perf_hybrid
-    builder: Linux flutter_gallery__transition_perf_hybrid
+  - name: Linux_android flutter_gallery__transition_perf_hybrid
+    builder: Linux_android flutter_gallery__transition_perf_hybrid
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__transition_perf_with_semantics
-    builder: Linux flutter_gallery__transition_perf_with_semantics
+  - name: Linux_android flutter_gallery__transition_perf_with_semantics
+    builder: Linux_android flutter_gallery__transition_perf_with_semantics
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery__transition_perf
-    builder: Linux flutter_gallery__transition_perf
+  - name: Linux_android flutter_gallery__transition_perf
+    builder: Linux_android flutter_gallery__transition_perf
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery_android__compile
-    builder: Linux flutter_gallery_android__compile
+  - name: Linux_android flutter_gallery_android__compile
+    builder: Linux_android flutter_gallery_android__compile
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
-    builder: Linux flutter_gallery_sksl_warmup__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
+    builder: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
+    bringup: true
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery_sksl_warmup__transition_perf
-    builder: Linux flutter_gallery_sksl_warmup__transition_perf
+  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf
+    builder: Linux_android flutter_gallery_sksl_warmup__transition_perf
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery_v2_chrome_run_test
-    builder: Linux flutter_gallery_v2_chrome_run_test
+  - name: Linux_android flutter_gallery_v2_chrome_run_test
+    builder: Linux_android flutter_gallery_v2_chrome_run_test
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_gallery_v2_web_compile_test
-    builder: Linux flutter_gallery_v2_web_compile_test
+  - name: Linux_android flutter_gallery_v2_web_compile_test
+    builder: Linux_android flutter_gallery_v2_web_compile_test
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux flutter_test_performance
-    builder: Linux flutter_test_performance
+  - name: Linux_android flutter_test_performance
+    builder: Linux_android flutter_test_performance
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux frame_policy_delay_test_android
-    builder: Linux frame_policy_delay_test_android
+  - name: Linux_android frame_policy_delay_test_android
+    builder: Linux_android frame_policy_delay_test_android
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux hot_mode_dev_cycle_linux__benchmark
-    builder: Linux hot_mode_dev_cycle_linux__benchmark
+  - name: Linux_android hot_mode_dev_cycle_linux__benchmark
+    builder: Linux_android hot_mode_dev_cycle_linux__benchmark
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux image_list_jit_reported_duration
-    builder: Linux image_list_jit_reported_duration
+  - name: Linux_android image_list_jit_reported_duration
+    builder: Linux_android image_list_jit_reported_duration
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux image_list_reported_duration
-    builder: Linux image_list_reported_duration
+  - name: Linux_android image_list_reported_duration
+    builder: Linux_android image_list_reported_duration
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux large_image_changer_perf_android
-    builder: Linux large_image_changer_perf_android
+  - name: Linux_android large_image_changer_perf_android
+    builder: Linux_android large_image_changer_perf_android
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux animated_image_gc_perf
-    builder: Linux animated_image_gc_perf
+  - name: Linux_android animated_image_gc_perf
+    builder: Linux_android animated_image_gc_perf
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux linux_chrome_dev_mode
-    builder: Linux linux_chrome_dev_mode
+  - name: Linux_android linux_chrome_dev_mode
+    builder: Linux_android linux_chrome_dev_mode
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux multi_widget_construction_perf__e2e_summary
-    builder: Linux multi_widget_construction_perf__e2e_summary
+  - name: Linux_android multi_widget_construction_perf__e2e_summary
+    builder: Linux_android multi_widget_construction_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux new_gallery__crane_perf
-    builder: Linux new_gallery__crane_perf
+  - name: Linux_android new_gallery__crane_perf
+    builder: Linux_android new_gallery__crane_perf
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux picture_cache_perf__e2e_summary
-    builder: Linux picture_cache_perf__e2e_summary
+  - name: Linux_android picture_cache_perf__e2e_summary
+    builder: Linux_android picture_cache_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux platform_channels_benchmarks
-    builder: Linux platform_channels_benchmarks
+  - name: Linux_android platform_channels_benchmarks
+    builder: Linux_android platform_channels_benchmarks
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux platform_views_scroll_perf__timeline_summary
-    builder: Linux platform_views_scroll_perf__timeline_summary
+  - name: Linux_android platform_views_scroll_perf__timeline_summary
+    builder: Linux_android platform_views_scroll_perf__timeline_summary
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Linux routing_test
-    builder: Linux routing_test
+  - name: Linux_android routing_test
+    builder: Linux_android routing_test
     presubmit: false
     properties:
       tags: >
@@ -1448,8 +1448,8 @@ targets:
         ["devicelab","hostonly"]
     scheduler: luci
 
-  - name: Linux textfield_perf__e2e_summary
-    builder: Linux textfield_perf__e2e_summary
+  - name: Linux_android textfield_perf__e2e_summary
+    builder: Linux_android textfield_perf__e2e_summary
     presubmit: false
     properties:
       tags: >
@@ -1464,8 +1464,8 @@ targets:
         ["devicelab","hostonly"]
     scheduler: luci
 
-  - name: Linux web_size__compile_test
-    builder: Linux web_size__compile_test
+  - name: Linux_android web_size__compile_test
+    builder: Linux_android web_size__compile_test
     presubmit: false
     properties:
       tags: >
@@ -1872,16 +1872,16 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
-    builder: Mac_ios flutter_gallery__transition_perf_e2e_ios
+  - name: Linux_android flutter_gallery__transition_perf_e2e
+    builder: Linux_android flutter_gallery__transition_perf_e2e
     presubmit: false
     properties:
       tags: >
         ["devicelab"]
     scheduler: luci
 
-  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios32
-    builder: Mac_ios flutter_gallery__transition_perf_e2e_ios32
+  - name: Linux_android flutter_gallery__transition_perf_e2e
+    builder: Linux_android flutter_gallery__transition_perf_e2e
     bringup: true
     presubmit: false
     properties:
@@ -2090,8 +2090,8 @@ targets:
         ["devicelab"]
     scheduler: luci
 
-  - name: Mac_ios platform_channels_benchmarks_ios
-    builder: Mac_ios platform_channels_benchmarks_ios
+  - name: Linux_android platform_channels_benchmarks
+    builder: Linux_android platform_channels_benchmarks
     presubmit: false
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1297,7 +1297,7 @@ targets:
 
   - name: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
     builder: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
-    bringup: true
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
     presubmit: false
     properties:
       tags: >
@@ -1874,15 +1874,7 @@ targets:
 
   - name: Linux_android flutter_gallery__transition_perf_e2e
     builder: Linux_android flutter_gallery__transition_perf_e2e
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_e2e
-    builder: Linux_android flutter_gallery__transition_perf_e2e
-    bringup: true
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
     presubmit: false
     properties:
       tags: >


### PR DESCRIPTION
This ensures we can generate these builders correctly in the LUCI config (specifying, `linux_android`, `mac_ios32`). Most of the builders already do this, so it's making everything consistent.

https://github.com/flutter/flutter/issues/84998

https://flutter-review.googlesource.com/c/infra/+/16361 is the related LUCI config

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
