### PR TITLE
Use FLUTTER_VIEW_ID to find the Flutter view

### DIFF
--- a/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewGroup;
 
 import java.util.HashMap;
 
@@ -32,9 +31,7 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     private MethodChannel.Result permissionResult;
 
     private View getFlutterView() {
-        // TODO(egarciad): Set an unique ID in FlutterView, so it's easier to look it up.
-        ViewGroup root = (ViewGroup)findViewById(android.R.id.content);
-        return ((ViewGroup)root.getChildAt(0)).getChildAt(0);
+      return findViewById(FLUTTER_VIEW_ID);
     }
 
     @Override

--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/java/io/flutter/integration/androidviews/MainActivity.java
@@ -36,9 +36,7 @@ public class MainActivity extends FlutterActivity implements MethodChannel.Metho
     private MethodChannel.Result permissionResult;
 
     private View getFlutterView() {
-        // TODO(egarciad): Set an unique ID in FlutterView, so it's easier to look it up.
-        ViewGroup root = (ViewGroup)findViewById(android.R.id.content);
-        return ((ViewGroup)root.getChildAt(0)).getChildAt(0);
+      return findViewById(FLUTTER_VIEW_ID);
     }
 
     private String getViewName(View view) {


### PR DESCRIPTION
https://github.com/flutter/engine/pull/27645 was rolled back because of breakages to `embedded_android_views_integration_test` and `hybrid_android_views_integration_test`. This is because that PR tweaks the hierarchy of the `FlutterView` within the activity when a splash screen is not provided (there is no more intermediate `FlutterSplashView` that is the parent of `FlutterView`), making the `FlutterView` is no longer the grandchildren of the activity content. Hence in this PR, use `FLUTTER_VIEW_ID` which should be more resilent to similar future changes.

Related Issue: #85292

Tested:
- Locally running `embedded_android_views_integration_test` and `hybrid_android_views_integration_test`, with and without a local engine build of https://github.com/flutter/engine/pull/27645


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
