### PR TITLE
Mark 'Mac plugin_dependencies_test' unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1497,7 +1497,6 @@ targets:
 
   - name: Mac plugin_dependencies_test
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Not flaky
https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_prod_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac%20plugin_dependencies_test%22