### PR TITLE
Exclude arm64 from iOS app archs if unsupported by plugins on x64 Macs

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -4,7 +4,6 @@
 
 import '../artifacts.dart';
 import '../base/file_system.dart';
-import '../base/os.dart';
 import '../build_info.dart';
 import '../cache.dart';
 import '../flutter_manifest.dart';

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -210,7 +210,7 @@ Future<List<String>> _xcodeBuildSettingsLines({
     // If any plugins or their dependencies do not support arm64 simulators
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
-    if (globals.os.hostPlatform == HostPlatform.darwin_arm && !(await project.ios.pluginsSupportArmSimulator())) {
+    if (!(await project.ios.pluginsSupportArmSimulator())) {
       excludedSimulatorArchs += ' arm64';
     }
     xcodeBuildSettings.add('EXCLUDED_ARCHS[sdk=iphonesimulator*]=$excludedSimulatorArchs');

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -21,7 +20,6 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
-import '../../src/fakes.dart';
 
 const String xcodebuild = '/usr/bin/xcodebuild';
 

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -739,7 +739,6 @@ Build settings for action build and target plugin2:
       }, overrides: <Type, Generator>{
         Artifacts: () => localArtifacts,
         Platform: () => macOS,
-        OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
         FileSystem: () => fs,
         ProcessManager: () => fakeProcessManager,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
@@ -781,7 +780,6 @@ Build settings for action build and target plugin2:
       }, overrides: <Type, Generator>{
         Artifacts: () => localArtifacts,
         Platform: () => macOS,
-        OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
         FileSystem: () => fs,
         ProcessManager: () => fakeProcessManager,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
@@ -835,7 +833,6 @@ Build settings for action build and target plugin2:
       }, overrides: <Type, Generator>{
         Artifacts: () => localArtifacts,
         Platform: () => macOS,
-        OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
         FileSystem: () => fs,
         ProcessManager: () => fakeProcessManager,
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
@@ -846,7 +843,6 @@ Build settings for action build and target plugin2:
       testUsingContext(description, testMethod, overrides: <Type, Generator>{
         Artifacts: () => localArtifacts,
         Platform: () => macOS,
-        OperatingSystemUtils: () => FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
       });
@@ -875,7 +871,7 @@ Build settings for action build and target plugin2:
       expect(buildPhaseScriptContents.contains('EXCLUDED_ARCHS'), isFalse);
     });
 
-    testUsingOsxContext('excludes i386 simulator', () async {
+    testUsingOsxContext('does not exclude arm64 simulator when there are no plugins', () async {
       const BuildInfo buildInfo = BuildInfo.debug;
       final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(


### PR DESCRIPTION
Always exclude `arm64` iOS simulators when plugins don't support it, even when the host is running on an x64 Mac.  This supports the `ONLY_ACTIVE_ARCH=NO` case where all supported simulator architectures are built.

I still see the linker error on plugins CI on top of https://github.com/flutter/flutter/issues/85713 and https://github.com/flutter/plugins/pull/4208 (I was never able to reproduce this locally).

https://cirrus-ci.com/task/4907287669112832?logs=xcode_analyze#L1137-L1138

```
ld: in /var/folders/tn/f_9sf1xx5t14qm_6f83q3b840000gn/T/cirrus-ci-build/packages/google_sign_in/google_sign_in/example/ios/Pods/GoogleSignIn/Frameworks/GoogleSignIn.framework/GoogleSignIn(GIDEMMErrorHandler_3a47e13d8ca81b41e9cdb7ef5468004a.o), building for iOS Simulator, but linking in object file built for iOS, file '/var/folders/tn/f_9sf1xx5t14qm_6f83q3b840000gn/T/cirrus-ci-build/packages/google_sign_in/google_sign_in/example/ios/Pods/GoogleSignIn/Frameworks/GoogleSignIn.framework/GoogleSignIn' for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```