### PR TITLE
[ci.yaml] Add hot_mode_dev_cycle_win_target__benchmark and Linux gradle_plugin_light_apk_test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -184,7 +184,6 @@ targets:
       - bin/**
 
   - name: Linux gradle_plugin_light_apk_test
-    postsubmit: false
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -1812,6 +1811,14 @@ targets:
     runIf:
       - dev/**
       - bin/**
+
+  - name: Windows hot_mode_dev_cycle_win_target__benchmark
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
 
   - name: Windows module_custom_host_app_name_test
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -184,6 +184,7 @@ targets:
       - bin/**
 
   - name: Linux gradle_plugin_light_apk_test
+    postsubmit: false
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -1811,14 +1812,6 @@ targets:
     runIf:
       - dev/**
       - bin/**
-
-  - name: Windows hot_mode_dev_cycle_win_target__benchmark
-    bringup: true
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
 
   - name: Windows module_custom_host_app_name_test
     properties:

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -169,6 +169,7 @@
 /dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart @stuartmorgan @flutter/plugin
+/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_test.dart @zanderso @flutter/tool

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -169,7 +169,7 @@
 /dev/devicelab/bin/tasks/gradle_plugin_bundle_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/gradle_plugin_fat_apk_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/gradle_plugin_light_apk_test.dart @stuartmorgan @flutter/plugin
-/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark @cbracken @flutter/desktop
+/dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_test.dart @zanderso @flutter/tool


### PR DESCRIPTION
These are tests that are already running on LUCI, but haven't been connected here. These already appear to have TEST OWNERS assigned to them

https://github.com/flutter/flutter/issues/86802
https://github.com/flutter/flutter/issues/85803
Fixes https://github.com/flutter/flutter/issues/87373

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.