### PR TITLE
Do not run general and command subshard during web_tool_tests when subshard env is missing

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -140,7 +140,8 @@ Future<void> main(List<String> args) async {
       'framework_coverage': _runFrameworkCoverage,
       'framework_tests': _runFrameworkTests,
       'tool_tests': _runToolTests,
-      'web_tool_tests': _runToolTests,
+      // web_tool_tests is also used by HHH: https://dart.googlesource.com/recipes/+/refs/heads/master/recipes/dart/flutter_engine.py
+      'web_tool_tests': _runWebToolTests,
       'tool_integration_tests': _runIntegrationToolTests,
       // All the unit/widget tests run using `flutter test --platform=chrome`
       'web_tests': _runWebUnitTests,
@@ -355,7 +356,6 @@ Future<void> _runToolTests() async {
   await selectSubshard(<String, ShardRunner>{
     'general': _runGeneralToolTests,
     'commands': _runCommandsToolTests,
-    'web': _runWebToolTests,
   });
 }
 


### PR DESCRIPTION
Dart HHH was not passing in the expected `SUBSHARD` environment variables.  [This caused its `tool_tests` to run `web.shard` in addition to `general` and `commands`.](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8840285948223903360/+/u/flutter_test_tool_tests/stdout)  And for its `web_tool_tests`[ to run all the `tool_tests` shards again](https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8840268336106925888/+/u/flutter_test_web_tool_tests/stdout).  So all the tools tests were running for both HHH shards.

Instead, when subshard isn't specified, only run `general` and `commands` subshard for `tool_tests`, and only run the `web` subshard for `web_tool_tests`.  This shouldn't impact the flutter/flutter tests.

Fixes https://github.com/dart-lang/sdk/issues/46768.