### PR TITLE
Flutter_tools for web: report error messages with stacks on exit

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -314,17 +314,21 @@ class ResidentWebRunner extends ResidentRunner {
           enableDevTools: enableDevTools,
         );
       });
-    } on WebSocketException {
+    } on WebSocketException catch (error, stackTrace) {
       appFailedToStart();
+      _logger.printError('$error', stackTrace: stackTrace);
       throwToolExit(kExitMessage);
-    } on ChromeDebugException {
+    } on ChromeDebugException catch (error, stackTrace) {
       appFailedToStart();
+      _logger.printError('$error', stackTrace: stackTrace);
       throwToolExit(kExitMessage);
-    } on AppConnectionException {
+    } on AppConnectionException catch (error, stackTrace) {
       appFailedToStart();
+      _logger.printError('$error', stackTrace: stackTrace);
       throwToolExit(kExitMessage);
-    } on SocketException {
+    } on SocketException catch (error, stackTrace) {
       appFailedToStart();
+      _logger.printError('$error', stackTrace: stackTrace);
       throwToolExit(kExitMessage);
     } on Exception {
       appFailedToStart();

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -396,10 +396,11 @@ class ChromiumLauncher {
     if (!skipCheck) {
       try {
         await chrome.chromeConnection.getTabs();
-      } on Exception catch (e) {
+      } on Exception catch (error, stackTrace) {
+        _logger.printError('$error', stackTrace: stackTrace);
         await chrome.close();
         throwToolExit(
-            'Unable to connect to Chrome debug port: ${chrome.debugPort}\n $e');
+            'Unable to connect to Chrome debug port: ${chrome.debugPort}\n $error');
       }
     }
     currentCompleter.complete(chrome);

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -942,12 +942,14 @@ void main() {
   });
 
   testUsingContext('Successfully turns WebSocketException into ToolExit', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+    final BufferLogger logger = BufferLogger.test();
+    final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, logger: logger);
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     _setupMocks();
     webDevFS.exception = const WebSocketException();
 
     await expectLater(residentWebRunner.run, throwsToolExit());
+    expect(logger.errorText, contains('WebSocketException'));
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -556,7 +556,7 @@ void main() {
       contains('Unable to connect to Chrome debug port:'),
     );
     expect(logger.errorText, contains('SocketException'));
-  });
+  }, timeout: const Timeout.factor(2));
 }
 
 Future<Chromium> _testLaunchChrome(String userDataDir, FakeProcessManager processManager, ChromiumLauncher chromeLauncher) {

--- a/packages/flutter_tools/test/general.shard/web/chrome_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/chrome_test.dart
@@ -62,13 +62,12 @@ void main() {
   });
 
   testWithoutContext('can launch chrome and connect to the devtools', () async {
-    expect(
-      () async => _testLaunchChrome(
+    await expectReturnsNormallyLater(
+      _testLaunchChrome(
         '/.tmp_rand0/flutter_tools_chrome_device.rand0',
         processManager,
         chromeLauncher,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -79,13 +78,13 @@ void main() {
       chromeLauncher,
     );
 
-    expect(
-      () async => _testLaunchChrome(
+    await expectToolExitLater(
+      _testLaunchChrome(
         '/.tmp_rand0/flutter_tools_chrome_device.rand1',
         processManager,
         chromeLauncher,
       ),
-      throwsToolExit(message: 'Only one instance of chrome can be started'),
+      contains('Only one instance of chrome can be started'),
     );
   });
 
@@ -97,13 +96,12 @@ void main() {
     );
     await chrome.close();
 
-    expect(
-      () async => _testLaunchChrome(
+    await expectReturnsNormallyLater(
+      _testLaunchChrome(
         '/.tmp_rand0/flutter_tools_chrome_device.rand1',
         processManager,
         chromeLauncher,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -219,12 +217,11 @@ void main() {
       )
     ]);
 
-    expect(
-          () async => chromiumLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromiumLauncher.launch(
         'example_url',
         skipCheck: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -259,12 +256,11 @@ void main() {
       )
     ]);
 
-    expect(
-          () async => chromiumLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromiumLauncher.launch(
         'example_url',
         skipCheck: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -301,12 +297,11 @@ void main() {
       ),
     ]);
 
-    expect(
-      () async => chromiumLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromiumLauncher.launch(
         'example_url',
         skipCheck: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -322,13 +317,12 @@ void main() {
       stderr: kDevtoolsStderr,
     ));
 
-    expect(
-      () async => chromeLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromeLauncher.launch(
         'example_url',
         skipCheck: true,
         debugPort: 10000,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -348,13 +342,12 @@ void main() {
       stderr: kDevtoolsStderr,
     ));
 
-    expect(
-      () async => chromeLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromeLauncher.launch(
         'example_url',
         skipCheck: true,
         headless: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -451,13 +444,12 @@ void main() {
       stderr: kDevtoolsStderr,
     ));
 
-    expect(
-      () async => chromeLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromeLauncher.launch(
         'example_url',
         skipCheck: true,
         headless: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -488,13 +480,12 @@ void main() {
       stderr: kDevtoolsStderr,
     ));
 
-    expect(
-      () async => chromeLauncher.launch(
+    await expectReturnsNormallyLater(
+      chromeLauncher.launch(
         'example_url',
         skipCheck: true,
         headless: true,
-      ),
-      returnsNormally,
+      )
     );
   });
 
@@ -516,19 +507,19 @@ void main() {
       ));
     }
 
-    expect(
-      () async => chromeLauncher.launch(
+    await expectToolExitLater(
+      chromeLauncher.launch(
         'example_url',
         skipCheck: true,
         headless: true,
       ),
-      throwsToolExit(message: 'Failed to launch browser.'),
+      contains('Failed to launch browser.'),
     );
   });
 
   testWithoutContext('Logs an error and exits if connection check fails.', () async {
     final BufferLogger logger = BufferLogger.test();
-    chromeLauncher = ChromiumLauncher(
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
       platform: platform,
       processManager: processManager,
@@ -548,7 +539,7 @@ void main() {
     ));
 
     await expectToolExitLater(
-      chromeLauncher.launch(
+      chromiumLauncher.launch(
         'example_url',
         skipCheck: false,
         headless: false,

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -124,6 +124,15 @@ Future<void> expectToolExitLater(Future<dynamic> future, Matcher messageMatcher)
   }
 }
 
+Future<void> expectReturnsNormallyLater(Future<dynamic> future) async {
+  try {
+    await future;
+  // Catch all exceptions to give a better test failure message.
+  } catch (e, trace) { // ignore: avoid_catches_without_on_clauses
+    fail('Expected to run with no exceptions, got $e\n$trace');
+  }
+}
+
 Matcher containsIgnoringWhitespace(String toSearch) {
   return predicate(
     (String source) {


### PR DESCRIPTION
Print error messages and stacks in verbose mode before calling
`throwToolExit` on communication errors to chrome and dwds.

This will help us diagnose CI flakes:

Helps: https://github.com/flutter/flutter/issues/84012
Closes: https://github.com/flutter/flutter/issues/87149

Tests: this change only affects printing on exit, so it will be executed
by existing web_tool_tests when a corresponding exception happens.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
