### PR TITLE
Autocomplete: take initialValue into account when rebuilding

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -906,8 +906,14 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       widget.textEditingController,
     );
     _updateFocusNode(oldWidget.focusNode, widget.focusNode);
+
+    final bool initialValueChanged = oldWidget.initialValue != widget.initialValue;
     SchedulerBinding.instance!.addPostFrameCallback((Duration _) {
-      _updateOverlay();
+      if (widget.initialValue != null && initialValueChanged) {
+        _textEditingController.value = widget.initialValue!;
+      } else {
+        _updateOverlay();
+      }
     });
   }
 

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -647,6 +647,51 @@ void main() {
     );
   });
 
+  testWidgets('initialValue change rebuilds options', (WidgetTester tester) async {
+    TextEditingValue? initialValue;
+    Iterable<String>? lastOptions;
+
+    Widget builder() {
+      return MaterialApp(
+        home: Scaffold(
+          body: RawAutocomplete<String>(
+            initialValue: initialValue,
+            optionsBuilder: (TextEditingValue textEditingValue) {
+               return kOptions.where((String option) {
+                 return option.contains(textEditingValue.text.toLowerCase());
+               });
+            },
+            optionsViewBuilder: (BuildContext context, AutocompleteOnSelected<String> onSelected, Iterable<String> options) {
+              lastOptions = options;
+              return Container();
+            },
+            fieldViewBuilder: (BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
+              return TextField(
+                autofocus: true,
+                focusNode: focusNode,
+                controller: textEditingController,
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    initialValue = const TextEditingValue(text: 'go');
+    await tester.pumpWidget(builder());
+    tester.binding.scheduleFrame();
+    await tester.pump();
+    expect(lastOptions, <String>['dingo', 'flamingo', 'goose']);
+
+    initialValue = const TextEditingValue(text: 'goo');
+    await tester.pumpWidget(builder());
+    tester.binding.scheduleFrame();
+    await tester.pump();
+    expect(lastOptions, <String>['goose']);
+  });
+
   testWidgets('can navigate options with the keyboard', (WidgetTester tester) async {
     final GlobalKey fieldKey = GlobalKey();
     final GlobalKey optionsKey = GlobalKey();


### PR DESCRIPTION
Take `Autocomplete.initialValue` into account when the widget is rebuilt.

Fixes: #87473

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
