### PR TITLE
[ci.yaml] Remove builder, sort by name

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -8,16 +8,16 @@
 enabled_branches:
   - master
 
+platform_properties:
+
 targets:
   - name: Linux analyze
-    builder: Linux analyze
     properties:
       tags: >
         ["framework","hostonly"]
     scheduler: luci
 
   - name: Linux build_aar_module_test
-    builder: Linux build_aar_module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -27,29 +27,32 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: Linux customer_testing
-    builder: Linux customer_testing
-    properties:
-      tags: >
-        ["framework","hostonly"]
-    scheduler: luci
-
   - name: Linux build_tests_1_2
-    builder: Linux build_tests_1_2
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Linux build_tests_2_2
-    builder: Linux build_tests_2_2
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
+  - name: Linux customer_testing
+    properties:
+      tags: >
+        ["framework","hostonly"]
+    scheduler: luci
+
+  - name: Linux docs_publish
+    presubmit: false
+    properties:
+      tags: >
+        ["framework","hostonly"]
+    scheduler: luci
+
   - name: Linux docs_test
-    builder: Linux docs_test
     properties:
       tags: >
         ["framework","hostonly"]
@@ -62,8 +65,31 @@ targets:
       - packages/flutter_localizations/
       - bin/
 
+  - name: Linux firebase_abstract_method_smoke_test
+    properties:
+      tags: >
+        ["firebaselab"]
+    scheduler: luci
+
+  - name: Linux firebase_android_embedding_v2_smoke_test
+    properties:
+      tags: >
+        ["firebaselab"]
+    scheduler: luci
+
+  - name: Linux firebase_release_smoke_test
+    properties:
+      tags: >
+        ["firebaselab"]
+    scheduler: luci
+
+  - name: Linux flutter_plugins
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+
   - name: Linux framework_tests_libraries
-    builder: Linux framework_tests_libraries
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -81,7 +107,6 @@ targets:
       - bin/
 
   - name: Linux framework_tests_misc
-    builder: Linux framework_tests_misc
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -99,7 +124,6 @@ targets:
       - bin/
 
   - name: Linux framework_tests_widgets
-    builder: Linux framework_tests_widgets
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -116,36 +140,13 @@ targets:
       - packages/flutter_tools/lib/src/test/
       - bin/
 
-  - name: Linux firebase_abstract_method_smoke_test
-    builder: Linux firebase_abstract_method_smoke_test
-    properties:
-      tags: >
-        ["firebaselab"]
-    scheduler: luci
-
-  - name: Linux firebase_android_embedding_v2_smoke_test
-    builder: Linux firebase_android_embedding_v2_smoke_test
-    properties:
-      tags: >
-        ["firebaselab"]
-    scheduler: luci
-
-  - name: Linux firebase_release_smoke_test
-    builder: Linux firebase_release_smoke_test
-    properties:
-      tags: >
-        ["firebaselab"]
-    scheduler: luci
-
   - name: Linux fuchsia_precache
-    builder: Linux fuchsia_precache
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Linux gradle_desugar_classes_test
-    builder: Linux gradle_desugar_classes_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -155,7 +156,6 @@ targets:
       - bin/**
 
   - name: Linux gradle_java8_compile_test
-    builder: Linux gradle_java8_compile_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -165,7 +165,6 @@ targets:
       - bin/**
 
   - name: Linux gradle_plugin_bundle_test
-    builder: Linux gradle_plugin_bundle_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -175,7 +174,6 @@ targets:
       - bin/**
 
   - name: Linux gradle_plugin_fat_apk_test
-    builder: Linux gradle_plugin_fat_apk_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -185,7 +183,6 @@ targets:
       - bin/**
 
   - name: Linux gradle_plugin_light_apk_test
-    builder: Linux gradle_plugin_light_apk_test
     postsubmit: false
     properties:
       tags: >
@@ -195,8 +192,7 @@ targets:
       - dev/**
       - bin/**
 
-  - name: Linux module_host_with_custom_build_test
-    builder: Linux module_host_with_custom_build_test
+  - name: Linux module_custom_host_app_name_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -206,8 +202,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: Linux module_custom_host_app_name_test
-    builder: Linux module_custom_host_app_name_test
+  - name: Linux module_host_with_custom_build_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -218,7 +213,6 @@ targets:
       - bin/**
 
   - name: Linux module_test
-    builder: Linux module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -229,7 +223,6 @@ targets:
       - bin/**
 
   - name: Linux plugin_dependencies_test
-    builder: Linux plugin_dependencies_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -240,7 +233,6 @@ targets:
       - bin/**
 
   - name: Linux plugin_test
-    builder: Linux plugin_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -251,7 +243,6 @@ targets:
       - bin/**
 
   - name: Linux skp_generator
-    builder: Linux skp_generator
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -262,8 +253,14 @@ targets:
       - packages/flutter_tools/
       - bin/
 
+  - name: Linux technical_debt__cost
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+
   - name: Linux test_ownership
-    builder: Linux test_ownership
     bringup: true
     properties:
       tags: >
@@ -272,30 +269,7 @@ targets:
     runIf:
       - .ci.yaml
 
-  - name: Linux tool_tests_general
-    builder: Linux tool_tests_general
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/flutter_tools/
-      - bin/
-
-  - name: Linux tool_tests_commands
-    builder: Linux tool_tests_commands
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/flutter_tools/
-      - bin/
-
   - name: Linux tool_integration_tests_1_4
-    builder: Linux tool_integration_tests_1_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -306,7 +280,6 @@ targets:
       - bin/
 
   - name: Linux tool_integration_tests_2_4
-    builder: Linux tool_integration_tests_2_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -317,7 +290,6 @@ targets:
       - bin/
 
   - name: Linux tool_integration_tests_3_4
-    builder: Linux tool_integration_tests_3_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -328,7 +300,6 @@ targets:
       - bin/
 
   - name: Linux tool_integration_tests_4_4
-    builder: Linux tool_integration_tests_4_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -338,8 +309,7 @@ targets:
       - packages/flutter_tools/
       - bin/
 
-  - name: Linux web_tool_tests
-    builder: Linux web_tool_tests
+  - name: Linux tool_tests_commands
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -348,9 +318,25 @@ targets:
       - dev/
       - packages/flutter_tools/
       - bin/
+
+  - name: Linux tool_tests_general
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/flutter_tools/
+      - bin/
+
+  - name: Linux web_benchmarks_canvaskit
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
 
   - name: Linux web_benchmarks_html
-    builder: Linux web_benchmarks_html
     properties:
       tags: >
         ["devicelab"]
@@ -359,96 +345,7 @@ targets:
       - dev/**
       - bin/**
 
-  - name: Linux web_tests_0
-    builder: Linux web_tests_0
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_1
-    builder: Linux web_tests_1
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_2
-    builder: Linux web_tests_2
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_3
-    builder: Linux web_tests_3
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_4
-    builder: Linux web_tests_4
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_5
-    builder: Linux web_tests_5
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_6
-    builder: Linux web_tests_6
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
-  - name: Linux web_tests_7_last
-    builder: Linux web_tests_7_last
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/
-      - packages/
-      - bin/
-
   - name: Linux web_long_running_tests_1_5
-    builder: Linux web_long_running_tests_1_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -459,7 +356,6 @@ targets:
       - bin/
 
   - name: Linux web_long_running_tests_2_5
-    builder: Linux web_long_running_tests_2_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -470,7 +366,6 @@ targets:
       - bin/
 
   - name: Linux web_long_running_tests_3_5
-    builder: Linux web_long_running_tests_3_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -481,7 +376,6 @@ targets:
       - bin/
 
   - name: Linux web_long_running_tests_4_5
-    builder: Linux web_long_running_tests_4_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -492,7 +386,6 @@ targets:
       - bin/
 
   - name: Linux web_long_running_tests_5_5
-    builder: Linux web_long_running_tests_5_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -502,15 +395,436 @@ targets:
       - packages/
       - bin/
 
-  - name: Linux flutter_plugins
-    builder: Linux flutter_plugins
+  - name: Linux web_tests_0
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_1
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_2
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_3
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_4
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_5
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_6
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tests_7_last
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/
+      - bin/
+
+  - name: Linux web_tool_tests
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/
+      - packages/flutter_tools/
+      - bin/
+
+  - name: Linux_android analyzer_benchmark
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android android_defines_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android android_obfuscate_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android android_stack_size_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android android_view_scroll_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android animated_image_gc_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android animated_placeholder_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android backdrop_filter_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android basic_material_app_android__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android color_filter_and_fade_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android complex_layout_android__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android complex_layout_android__scroll_smoothness
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android complex_layout_scroll_perf__devtools_memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android complex_layout_semantics_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android cubic_bezier_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android cubic_bezier_perf_sksl_warmup__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android cull_opacity_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android devtools_profile_start_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android fast_scroll_heavy_gridview__memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_engine_group_performance
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__back_button_memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__image_cache_memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__memory_nav
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__transition_perf_e2e
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__transition_perf_hybrid
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery__transition_perf_with_semantics
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery_android__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery_v2_chrome_run_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_gallery_v2_web_compile_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android flutter_test_performance
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android frame_policy_delay_test_android
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android hot_mode_dev_cycle_linux__benchmark
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android image_list_jit_reported_duration
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android image_list_reported_duration
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android large_image_changer_perf_android
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android linux_chrome_dev_mode
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android multi_widget_construction_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android new_gallery__crane_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android picture_cache_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android platform_channels_benchmarks
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android platform_views_scroll_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android routing_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android textfield_perf__e2e_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Linux_android web_size__compile_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
 
   - name: Mac build_aar_module_test
-    builder: Mac build_aar_module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -521,7 +835,6 @@ targets:
       - bin/**
 
   - name: Mac build_ios_framework_module_test
-    builder: Mac build_ios_framework_module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -532,42 +845,46 @@ targets:
       - bin/**
 
   - name: Mac build_tests_1_4
-    builder: Mac build_tests_1_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Mac build_tests_2_4
-    builder: Mac build_tests_2_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Mac build_tests_3_4
-    builder: Mac build_tests_3_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Mac build_tests_4_4
-    builder: Mac build_tests_4_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Mac customer_testing
-    builder: Mac customer_testing
     properties:
       tags: >
         ["framework","hostonly"]
     scheduler: luci
 
+  - name: Mac dart_plugin_registry_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
   - name: Mac framework_tests_libraries
-    builder: Mac framework_tests_libraries
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -585,7 +902,6 @@ targets:
       - bin/**
 
   - name: Mac framework_tests_misc
-    builder: Mac framework_tests_misc
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -603,7 +919,6 @@ targets:
       - bin/**
 
   - name: Mac framework_tests_widgets
-    builder: Mac framework_tests_widgets
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -621,7 +936,6 @@ targets:
       - bin/**
 
   - name: Mac gradle_plugin_bundle_test
-    builder: Mac gradle_plugin_bundle_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -631,7 +945,6 @@ targets:
       - bin/**
 
   - name: Mac gradle_plugin_fat_apk_test
-    builder: Mac gradle_plugin_fat_apk_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -641,7 +954,6 @@ targets:
       - bin/**
 
   - name: Mac gradle_plugin_light_apk_test
-    builder: Mac gradle_plugin_light_apk_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -651,7 +963,6 @@ targets:
       - bin/**
 
   - name: Mac module_custom_host_app_name_test
-    builder: Mac module_custom_host_app_name_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -662,7 +973,6 @@ targets:
       - bin/**
 
   - name: Mac module_host_with_custom_build_test
-    builder: Mac module_host_with_custom_build_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -673,7 +983,6 @@ targets:
       - bin/**
 
   - name: Mac module_test
-    builder: Mac module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -684,7 +993,17 @@ targets:
       - bin/**
 
   - name: Mac module_test_ios
-    builder: Mac module_test_ios
+    bringup: true
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Mac plugin_dependencies_test
     bringup: true
     properties:
       tags: >
@@ -696,65 +1015,18 @@ targets:
       - bin/**
 
   - name: Mac plugin_lint_mac
-    builder: Mac plugin_lint_mac
     properties:
       tags: >
         ["devicelab","hostonly"]
     scheduler: luci
     runIf:
       - dev/**
-      - bin/**
-
-  - name: Mac plugin_dependencies_test
-    builder: Mac plugin_dependencies_test
-    bringup: true
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
       - bin/**
 
   - name: Mac plugin_test
-    builder: Mac plugin_test
     properties:
       tags: >
         ["devicelab","hostonly"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-
-  - name: Mac dart_plugin_registry_test
-    builder: Mac dart_plugin_registry_test
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-
-  - name: Mac tool_tests_general
-    builder: Mac tool_tests_general
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-
-  - name: Windows tool_tests_commands
-    builder: Windows tool_tests_commands
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -762,7 +1034,6 @@ targets:
       - bin/**
 
   - name: Mac tool_integration_tests_1_4
-    builder: Mac tool_integration_tests_1_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -773,7 +1044,6 @@ targets:
       - bin/**
 
   - name: Mac tool_integration_tests_2_4
-    builder: Mac tool_integration_tests_2_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -784,7 +1054,6 @@ targets:
       - bin/**
 
   - name: Mac tool_integration_tests_3_4
-    builder: Mac tool_integration_tests_3_4
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -795,7 +1064,23 @@ targets:
       - bin/**
 
   - name: Mac tool_integration_tests_4_4
-    builder: Mac tool_integration_tests_4_4
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Mac tool_tests_commands
+    presubmit: false
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+
+  - name: Mac tool_tests_general
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -806,7 +1091,6 @@ targets:
       - bin/**
 
   - name: Mac web_tool_tests
-    builder: Mac web_tool_tests
     postsubmit: false
     properties:
       tags: >
@@ -817,8 +1101,608 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
+  - name: Mac_android android_semantics_integration_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android backdrop_filter_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android channels_integration_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android color_filter_and_fade_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android complex_layout__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android complex_layout_scroll_perf__memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android complex_layout_scroll_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android cubic_bezier_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android cull_opacity_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android drive_perf_debug_warning
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android embedded_android_views_integration_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android external_ui_integration_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android fading_child_animation_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android fast_scroll_large_images__memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android flavors_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android flutter_view__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android fullscreen_textfield_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android hello_world__memory
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android hello_world_android__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android home_scroll_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android hot_mode_dev_cycle__benchmark
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android hybrid_android_views_integration_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android imagefiltered_transform_animation_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_test_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_ui_driver
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_ui_frame_number
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_ui_keyboard_resize
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_ui_screenshot
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android integration_ui_textfield
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android microbenchmarks
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android new_gallery__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android picture_cache_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android platform_channel_sample_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android platform_interaction_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android platform_view__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android run_release_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android service_extensions_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android smoke_catalina_start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android textfield_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_android tiles_scroll_perf__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
+    # This test was missed as a part of the migration to new infra tooling.
+    # Added as a part of https://github.com/flutter/flutter/issues/87345,
+    # this isn't flaky and "bringup: true" will be removed after a few runs.
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios basic_material_app_ios__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios channels_integration_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios complex_layout_ios__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios complex_layout_ios__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios cubic_bezier_perf_ios_sksl_warmup__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios external_ui_integration_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flavors_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_gallery_ios__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_gallery_ios__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_gallery_ios__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_gallery_ios_sksl_warmup__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios flutter_view_ios__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios hello_world_ios__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_test_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_ui_ios_driver
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_ui_ios_frame_number
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_ui_ios_keyboard_resize
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_ui_ios_screenshot
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios integration_ui_ios_textfield
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios ios_app_with_extensions_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios ios_content_validation_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios ios_defines_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios ios_platform_view_tests
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios large_image_changer_perf_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios macos_chrome_dev_mode
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios microbenchmarks_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios new_gallery_ios__transition_perf
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_channel_sample_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_channel_sample_test_swift
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_channels_benchmarks_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_interaction_test_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_view_ios__start_up
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios platform_views_scroll_perf_ios__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios simple_animation_perf_ios
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Mac_ios32 native_ui_tests_ios32
+    bringup: true
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
   - name: Windows build_aar_module_test
-    builder: Windows build_aar_module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -829,35 +1713,30 @@ targets:
       - bin/**
 
   - name: Windows build_tests_1_3
-    builder: Windows build_tests_1_3
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Windows build_tests_2_3
-    builder: Windows build_tests_2_3
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Windows build_tests_3_3
-    builder: Windows build_tests_3_3
     properties:
       tags: >
         ["framework","hostonly","shard"]
     scheduler: luci
 
   - name: Windows customer_testing
-    builder: Windows customer_testing
     properties:
       tags: >
         ["framework","hostonly"]
     scheduler: luci
 
   - name: Windows framework_tests_libraries
-    builder: Windows framework_tests_libraries
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -875,7 +1754,6 @@ targets:
       - bin/
 
   - name: Windows framework_tests_misc
-    builder: Windows framework_tests_misc
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -893,7 +1771,6 @@ targets:
       - bin/
 
   - name: Windows framework_tests_widgets
-    builder: Windows framework_tests_widgets
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -911,7 +1788,6 @@ targets:
       - bin/
 
   - name: Windows gradle_plugin_bundle_test
-    builder: Windows gradle_plugin_bundle_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -920,8 +1796,14 @@ targets:
       - dev/**
       - bin/**
 
+  - name: Windows gradle_plugin_fat_apk_test
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+
   - name: Windows gradle_plugin_light_apk_test
-    builder: Windows gradle_plugin_light_apk_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -931,18 +1813,6 @@ targets:
       - bin/**
 
   - name: Windows module_custom_host_app_name_test
-    builder: Windows module_custom_host_app_name_test
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-
-  - name: Windows module_test
-    builder: Windows module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -953,7 +1823,16 @@ targets:
       - bin/**
 
   - name: Windows module_host_with_custom_build_test
-    builder: Windows module_host_with_custom_build_test
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Windows module_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -964,7 +1843,6 @@ targets:
       - bin/**
 
   - name: Windows plugin_dependencies_test
-    builder: Windows plugin_dependencies_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -975,7 +1853,6 @@ targets:
       - bin/**
 
   - name: Windows plugin_test
-    builder: Windows plugin_test
     properties:
       tags: >
         ["devicelab","hostonly"]
@@ -985,19 +1862,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: Windows tool_tests_general
-    builder: Windows tool_tests_general
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-
   - name: Windows tool_integration_tests_1_5
-    builder: Windows tool_integration_tests_1_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1008,7 +1873,6 @@ targets:
       - bin/**
 
   - name: Windows tool_integration_tests_2_5
-    builder: Windows tool_integration_tests_2_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1019,7 +1883,6 @@ targets:
       - bin/**
 
   - name: Windows tool_integration_tests_3_5
-    builder: Windows tool_integration_tests_3_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1030,7 +1893,6 @@ targets:
       - bin/**
 
   - name: Windows tool_integration_tests_4_5
-    builder: Windows tool_integration_tests_4_5
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1041,7 +1903,26 @@ targets:
       - bin/**
 
   - name: Windows tool_integration_tests_5_5
-    builder: Windows tool_integration_tests_5_5
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Windows tool_tests_commands
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+
+  - name: Windows tool_tests_general
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1052,7 +1933,6 @@ targets:
       - bin/**
 
   - name: Windows web_tool_tests
-    builder: Windows web_tool_tests
     properties:
       tags: >
         ["framework","hostonly","shard"]
@@ -1062,1153 +1942,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
 
-  - name: Linux_android analyzer_benchmark
-    builder: Linux_android analyzer_benchmark
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android android_defines_test
-    builder: Linux_android android_defines_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android android_obfuscate_test
-    builder: Linux_android android_obfuscate_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android android_stack_size_test
-    builder: Linux_android android_stack_size_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android android_view_scroll_perf__timeline_summary
-    builder: Linux_android android_view_scroll_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android animated_placeholder_perf__e2e_summary
-    builder: Linux_android animated_placeholder_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android backdrop_filter_perf__e2e_summary
-    builder: Linux_android backdrop_filter_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android basic_material_app_android__compile
-    builder: Linux_android basic_material_app_android__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android color_filter_and_fade_perf__e2e_summary
-    builder: Linux_android color_filter_and_fade_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android complex_layout_android__compile
-    builder: Linux_android complex_layout_android__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android complex_layout_android__scroll_smoothness
-    builder: Linux_android complex_layout_android__scroll_smoothness
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android complex_layout_scroll_perf__devtools_memory
-    builder: Linux_android complex_layout_scroll_perf__devtools_memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android complex_layout_semantics_perf
-    builder: Linux_android complex_layout_semantics_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android cubic_bezier_perf__e2e_summary
-    builder: Linux_android cubic_bezier_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android cubic_bezier_perf_sksl_warmup__e2e_summary
-    builder: Linux_android cubic_bezier_perf_sksl_warmup__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android cull_opacity_perf__e2e_summary
-    builder: Linux_android cull_opacity_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android devtools_profile_start_test
-    builder: Linux_android devtools_profile_start_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux docs_publish
-    builder: Linux docs_publish
-    presubmit: false
-    properties:
-      tags: >
-        ["framework","hostonly"]
-    scheduler: luci
-
-  - name: Linux_android fast_scroll_heavy_gridview__memory
-    builder: Linux_android fast_scroll_heavy_gridview__memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_engine_group_performance
-    builder: Linux_android flutter_engine_group_performance
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__back_button_memory
-    builder: Linux_android flutter_gallery__back_button_memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__image_cache_memory
-    builder: Linux_android flutter_gallery__image_cache_memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__memory_nav
-    builder: Linux_android flutter_gallery__memory_nav
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__start_up
-    builder: Linux_android flutter_gallery__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_e2e
-    builder: Linux_android flutter_gallery__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_hybrid
-    builder: Linux_android flutter_gallery__transition_perf_hybrid
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_with_semantics
-    builder: Linux_android flutter_gallery__transition_perf_with_semantics
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf
-    builder: Linux_android flutter_gallery__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_android__compile
-    builder: Linux_android flutter_gallery_android__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
-    builder: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/83298
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf
-    builder: Linux_android flutter_gallery_sksl_warmup__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_v2_chrome_run_test
-    builder: Linux_android flutter_gallery_v2_chrome_run_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_v2_web_compile_test
-    builder: Linux_android flutter_gallery_v2_web_compile_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android flutter_test_performance
-    builder: Linux_android flutter_test_performance
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android frame_policy_delay_test_android
-    builder: Linux_android frame_policy_delay_test_android
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android hot_mode_dev_cycle_linux__benchmark
-    builder: Linux_android hot_mode_dev_cycle_linux__benchmark
-    bringup: true
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android image_list_jit_reported_duration
-    builder: Linux_android image_list_jit_reported_duration
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android image_list_reported_duration
-    builder: Linux_android image_list_reported_duration
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android large_image_changer_perf_android
-    builder: Linux_android large_image_changer_perf_android
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android animated_image_gc_perf
-    builder: Linux_android animated_image_gc_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android linux_chrome_dev_mode
-    builder: Linux_android linux_chrome_dev_mode
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android multi_widget_construction_perf__e2e_summary
-    builder: Linux_android multi_widget_construction_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android new_gallery__crane_perf
-    builder: Linux_android new_gallery__crane_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android picture_cache_perf__e2e_summary
-    builder: Linux_android picture_cache_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android platform_channels_benchmarks
-    builder: Linux_android platform_channels_benchmarks
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android platform_views_scroll_perf__timeline_summary
-    builder: Linux_android platform_views_scroll_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux_android routing_test
-    builder: Linux_android routing_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux technical_debt__cost
-    builder: Linux technical_debt__cost
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-
-  - name: Linux_android textfield_perf__e2e_summary
-    builder: Linux_android textfield_perf__e2e_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Linux web_benchmarks_canvaskit
-    builder: Linux web_benchmarks_canvaskit
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-
-  - name: Linux_android web_size__compile_test
-    builder: Linux_android web_size__compile_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android android_semantics_integration_test
-    builder: Mac_android android_semantics_integration_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android backdrop_filter_perf__timeline_summary
-    builder: Mac_android backdrop_filter_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android channels_integration_test
-    builder: Mac_android channels_integration_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android color_filter_and_fade_perf__timeline_summary
-    builder: Mac_android color_filter_and_fade_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android complex_layout__start_up
-    builder: Mac_android complex_layout__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android complex_layout_scroll_perf__memory
-    builder: Mac_android complex_layout_scroll_perf__memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android complex_layout_scroll_perf__timeline_summary
-    builder: Mac_android complex_layout_scroll_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android cubic_bezier_perf__timeline_summary
-    builder: Mac_android cubic_bezier_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
-    builder: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android cull_opacity_perf__timeline_summary
-    builder: Mac_android cull_opacity_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android drive_perf_debug_warning
-    builder: Mac_android drive_perf_debug_warning
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android embedded_android_views_integration_test
-    builder: Mac_android embedded_android_views_integration_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android external_ui_integration_test
-    builder: Mac_android external_ui_integration_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android fading_child_animation_perf__timeline_summary
-    builder: Mac_android fading_child_animation_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android fast_scroll_large_images__memory
-    builder: Mac_android fast_scroll_large_images__memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android flavors_test
-    builder: Mac_android flavors_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android flutter_view__start_up
-    builder: Mac_android flutter_view__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android fullscreen_textfield_perf__timeline_summary
-    builder: Mac_android fullscreen_textfield_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android hello_world__memory
-    builder: Mac_android hello_world__memory
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android hello_world_android__compile
-    builder: Mac_android hello_world_android__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android home_scroll_perf__timeline_summary
-    builder: Mac_android home_scroll_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android hot_mode_dev_cycle__benchmark
-    builder: Mac_android hot_mode_dev_cycle__benchmark
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android hybrid_android_views_integration_test
-    builder: Mac_android hybrid_android_views_integration_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android imagefiltered_transform_animation_perf__timeline_summary
-    builder: Mac_android imagefiltered_transform_animation_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_ui_driver
-    builder: Mac_android integration_ui_driver
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_ui_keyboard_resize
-    builder: Mac_android integration_ui_keyboard_resize
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_ui_frame_number
-    builder: Mac_android integration_ui_frame_number
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_ui_screenshot
-    builder: Mac_android integration_ui_screenshot
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_ui_textfield
-    builder: Mac_android integration_ui_textfield
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android integration_test_test
-    builder: Mac_android integration_test_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android microbenchmarks
-    builder: Mac_android microbenchmarks
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android new_gallery__transition_perf
-    builder: Mac_android new_gallery__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android picture_cache_perf__timeline_summary
-    builder: Mac_android picture_cache_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android platform_channel_sample_test
-    builder: Mac_android platform_channel_sample_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android platform_interaction_test
-    builder: Mac_android platform_interaction_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android platform_view__start_up
-    builder: Mac_android platform_view__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android run_release_test
-    builder: Mac_android run_release_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android service_extensions_test
-    builder: Mac_android service_extensions_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android smoke_catalina_start_up
-    builder: Mac_android smoke_catalina_start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android textfield_perf__timeline_summary
-    builder: Mac_android textfield_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_android tiles_scroll_perf__timeline_summary
-    builder: Mac_android tiles_scroll_perf__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac tool_tests_commands
-    builder: Mac tool_tests_commands
-    presubmit: false
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-
-  - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
-    builder: Mac_ios backdrop_filter_perf_ios__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
-    builder: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
-    presubmit: false
-    # This test was missed as a part of the migration to new infra tooling.
-    # Added as a part of https://github.com/flutter/flutter/issues/87345,
-    # this isn't flaky and "bringup: true" will be removed after a few runs.
-    bringup: true
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios basic_material_app_ios__compile
-    builder: Mac_ios basic_material_app_ios__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios channels_integration_test_ios
-    builder: Mac_ios channels_integration_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios complex_layout_ios__compile
-    builder: Mac_ios complex_layout_ios__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios complex_layout_ios__start_up
-    builder: Mac_ios complex_layout_ios__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
-    builder: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios external_ui_integration_test_ios
-    builder: Mac_ios external_ui_integration_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flavors_test_ios
-    builder: Mac_ios flavors_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_gallery__transition_perf_e2e_ios
-    builder: Mac_ios flutter_gallery__transition_perf_e2e_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
-    builder: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
-    bringup: true
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_gallery_ios__compile
-    builder: Mac_ios flutter_gallery_ios__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_gallery_ios__start_up
-    builder: Mac_ios flutter_gallery_ios__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_gallery_ios__transition_perf
-    builder: Mac_ios flutter_gallery_ios__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_gallery_ios_sksl_warmup__transition_perf
-    builder: Mac_ios flutter_gallery_ios_sksl_warmup__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios cubic_bezier_perf_ios_sksl_warmup__timeline_summary
-    builder: Mac_ios cubic_bezier_perf_ios_sksl_warmup__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios flutter_view_ios__start_up
-    builder: Mac_ios flutter_view_ios__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios hello_world_ios__compile
-    builder: Mac_ios hello_world_ios__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
-    builder: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_ui_ios_driver
-    builder: Mac_ios integration_ui_ios_driver
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_ui_ios_keyboard_resize
-    builder: Mac_ios integration_ui_ios_keyboard_resize
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_ui_ios_frame_number
-    builder: Mac_ios integration_ui_ios_frame_number
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_ui_ios_screenshot
-    builder: Mac_ios integration_ui_ios_screenshot
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_ui_ios_textfield
-    builder: Mac_ios integration_ui_ios_textfield
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios integration_test_test_ios
-    builder: Mac_ios integration_test_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios ios_app_with_extensions_test
-    builder: Mac_ios ios_app_with_extensions_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios ios_content_validation_test
-    builder: Mac_ios ios_content_validation_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios ios_defines_test
-    builder: Mac_ios ios_defines_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios ios_platform_view_tests
-    builder: Mac_ios ios_platform_view_tests
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios large_image_changer_perf_ios
-    builder: Mac_ios large_image_changer_perf_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios macos_chrome_dev_mode
-    builder: Mac_ios macos_chrome_dev_mode
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios microbenchmarks_ios
-    builder: Mac_ios microbenchmarks_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios32 native_ui_tests_ios32
-    builder: Mac_ios32 native_ui_tests_ios32
-    bringup: true
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios new_gallery_ios__transition_perf
-    builder: Mac_ios new_gallery_ios__transition_perf
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_channel_sample_test_ios
-    builder: Mac_ios platform_channel_sample_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_channel_sample_test_swift
-    builder: Mac_ios platform_channel_sample_test_swift
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_channels_benchmarks_ios
-    builder: Mac_ios platform_channels_benchmarks_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_interaction_test_ios
-    builder: Mac_ios platform_interaction_test_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_view_ios__start_up
-    builder: Mac_ios platform_view_ios__start_up
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios platform_views_scroll_perf_ios__timeline_summary
-    builder: Mac_ios platform_views_scroll_perf_ios__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
-    builder: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios simple_animation_perf_ios
-    builder: Mac_ios simple_animation_perf_ios
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark
-    builder: Mac_ios smoke_catalina_hot_mode_dev_cycle_ios__benchmark
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
-    builder: Mac_ios tiles_scroll_perf_ios__timeline_summary
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Windows gradle_plugin_fat_apk_test
-    builder: Windows gradle_plugin_fat_apk_test
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab","hostonly"]
-    scheduler: luci
-
-  - name: Windows_android complex_layout_win__compile
-    builder: Windows_android complex_layout_win__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
   - name: Windows_android basic_material_app_win__compile
-    builder: Windows_android basic_material_app_win__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Windows_android flutter_gallery_win__compile
-    builder: Windows_android flutter_gallery_win__compile
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Windows_android windows_chrome_dev_mode
-    builder: Windows_android windows_chrome_dev_mode
-    presubmit: false
-    properties:
-      tags: >
-        ["devicelab"]
-    scheduler: luci
-
-  - name: Windows_android flavors_test_win
-    builder: Windows_android flavors_test_win
     presubmit: false
     properties:
       tags: >
@@ -2216,7 +1950,27 @@ targets:
     scheduler: luci
 
   - name: Windows_android channels_integration_test_win
-    builder: Windows_android channels_integration_test_win
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Windows_android complex_layout_win__compile
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Windows_android flavors_test_win
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Windows_android flutter_gallery_win__compile
     presubmit: false
     properties:
       tags: >
@@ -2224,7 +1978,13 @@ targets:
     scheduler: luci
 
   - name: Windows_android hot_mode_dev_cycle_win__benchmark
-    builder: Windows_android hot_mode_dev_cycle_win__benchmark
+    presubmit: false
+    properties:
+      tags: >
+        ["devicelab"]
+    scheduler: luci
+
+  - name: Windows_android windows_chrome_dev_mode
     presubmit: false
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7,8 +7,9 @@
 #  * https://github.com/flutter/cocoon/blob/master/CI_YAML.md
 enabled_branches:
   - master
-
-platform_properties:
+  - dev
+  - beta
+  - stable
 
 targets:
   - name: Linux analyze


### PR DESCRIPTION
1. Remove the builder field
  - This is duplicate with name, and has been deprecated
2. Sort targets by name (makes it easier to diff the LUCI config PR)
3. Add release branches to enabled_branches

https://github.com/flutter/flutter/issues/84998

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

