### PR TITLE
Fix Cuptertino dialog test to check correct fade transition

### DIFF
--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1039,53 +1039,54 @@ void main() {
 
     // Enter animation.
     await tester.pump();
-    FadeTransition transition = tester.firstWidget(find.byType(FadeTransition));
+    final Finder fadeTransitionFinder = find.ancestor(of: find.byType(CupertinoAlertDialog), matching: find.byType(FadeTransition));
+    FadeTransition transition = tester.firstWidget(fadeTransitionFinder);
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.40, epsilon: 0.001));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.081, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.437, epsilon: 0.001));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.332, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.55, epsilon: 0.001));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.667, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
-    expect(transition.opacity.value, moreOrLessEquals(0.737, epsilon: 0.001));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.918, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.firstWidget(find.byType(FadeTransition));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
     expect(transition.opacity.value, moreOrLessEquals(1.0, epsilon: 0.001));
 
     await tester.tap(find.text('Delete'));
 
     // Exit animation, look at reverse FadeTransition.
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, moreOrLessEquals(0.500, epsilon: 0.001));
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(1.0, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.918, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
+    expect(transition.opacity.value, moreOrLessEquals(0.667, epsilon: 0.001));
+
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
     expect(transition.opacity.value, moreOrLessEquals(0.332, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, moreOrLessEquals(0.188, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
     expect(transition.opacity.value, moreOrLessEquals(0.081, epsilon: 0.001));
 
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
-    expect(transition.opacity.value, moreOrLessEquals(0.019, epsilon: 0.001));
-
-    await tester.pump(const Duration(milliseconds: 25));
-    transition = tester.widgetList(find.byType(FadeTransition)).elementAt(1) as FadeTransition;
+    await tester.pump(const Duration(milliseconds: 50));
+    transition = tester.firstWidget(fadeTransitionFinder);
     expect(transition.opacity.value, moreOrLessEquals(0.0, epsilon: 0.001));
   });
 


### PR DESCRIPTION
The Cupertino `FadeTransition animation for showCupertinoDialog()` test is supposed to check the animation speed of the dialog appearing and being dismissed.  However, it was actually checking the fade animation from buttons on the screen being tapped.

This caused test failures when the button (not dialog) fade animation was changed: https://github.com/flutter/flutter/pull/87139#issuecomment-887935979

Be more explicit about checking for the `CupertinoAlertDialog` transition.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.