### PR TITLE
Updated the skipped tests for cupertino package. (reland)

### DIFF
--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -917,7 +917,7 @@ void main() {
     // We must explicitly cause an "up" gesture to avoid a crash.
     // todo(mattcarroll) remove this call, https://github.com/flutter/flutter/issues/19540
     await gesture.up();
-  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/52960
+  });
 
   testWidgets('ScaleTransition animation for showCupertinoDialog()', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('!chrome')
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('!chrome')
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1621,7 +1621,7 @@ void main() {
     expect(find.text('field 1'), findsOneWidget);
     expect(find.text("j'aime la poutine"), findsOneWidget);
     expect(find.text('field 2'), findsNothing);
-  }, exclude: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets(
     'tap moves cursor to the edge of the word it tapped on',

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -289,7 +289,9 @@ void main() {
     expect(controller.text, ' blah2blah1');
     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 0));
     expect(find.byType(CupertinoButton), findsNothing);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }), skip: kIsWeb);
+  },
+  variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }),
+  skip: kIsWeb); // [intended] the web handles this on its own.
 
   testWidgets('Activates the text field when receives semantics focus on Mac', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
@@ -454,8 +456,7 @@ void main() {
       );
     },
     // TODO(mdebbar): Strut styles support.
-    // https://github.com/flutter/flutter/issues/32243
-    skip: isBrowser,
+    skip: isBrowser, // https://github.com/flutter/flutter/issues/32243
   );
 
   testWidgets(
@@ -485,8 +486,7 @@ void main() {
       );
     },
     // TODO(mdebbar): Strut styles support.
-    // https://github.com/flutter/flutter/issues/32243
-    skip: isBrowser,
+    skip: isBrowser, // https://github.com/flutter/flutter/issues/32243
   );
 
   testWidgets(
@@ -1489,7 +1489,7 @@ void main() {
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets('text field toolbar options correctly changes options', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
@@ -1532,7 +1532,7 @@ void main() {
       expect(find.text('Copy'), findsOneWidget);
       expect(find.text('Cut'), findsNothing);
       expect(find.text('Select All'), findsNothing);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets('Read only text field', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(text: 'readonly');
@@ -1569,7 +1569,7 @@ void main() {
     expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Cut'), findsNothing);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets('copy paste', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -1620,7 +1620,7 @@ void main() {
     expect(find.text('field 1'), findsOneWidget);
     expect(find.text("j'aime la poutine"), findsOneWidget);
     expect(find.text('field 2'), findsNothing);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, exclude: isContextMenuProvidedByPlatform);
 
   testWidgets(
     'tap moves cursor to the edge of the word it tapped on',
@@ -2204,7 +2204,7 @@ void main() {
     expect(find.text('Select All'), findsOneWidget);
     expect(find.text('Copy'), findsNothing);
     expect(find.text('Cut'), findsNothing);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets(
     'long press moves cursor to the exact long press position and shows toolbar',
@@ -3229,7 +3229,7 @@ void main() {
       textFieldTopLeft = tester.getTopLeft(find.byType(CupertinoTextField));
       expect(toolbarTopLeft.dy, lessThan(textFieldTopLeft.dy));
     },
-    skip: isContextMenuProvidedByPlatform,
+    skip: isContextMenuProvidedByPlatform, // [intended] only applies to platforms where we supply the context menu.
   );
 
   testWidgets('text field respects keyboardAppearance from theme', (WidgetTester tester) async {
@@ -3826,7 +3826,7 @@ void main() {
       expect(find.byType(CupertinoTextSelectionToolbar), findsOneWidget);
       expect(tester.takeException(), null);
     });
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   group('textAlignVertical position', () {
     group('simple case', () {

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -290,8 +290,9 @@ void main() {
     expect(controller.selection, const TextSelection(baseOffset: 0, extentOffset: 0));
     expect(find.byType(CupertinoButton), findsNothing);
   },
-  variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }),
-  skip: kIsWeb); // [intended] the web handles this on its own.
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }),
+    skip: kIsWeb, // [intended] the web handles this on its own.
+  );
 
   testWidgets('Activates the text field when receives semantics focus on Mac', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);

--- a/packages/flutter/test/cupertino/text_form_field_row_test.dart
+++ b/packages/flutter/test/cupertino/text_form_field_row_test.dart
@@ -262,7 +262,7 @@ void main() {
 
     await tester.pump(const Duration(milliseconds: 200));
     expect(renderEditable, paintsExactlyCountTimes(#drawRect, 0));
-  }, skip: isBrowser); // We do not use Flutter-rendered context menu on the Web
+  }, skip: isBrowser); // [intended] We do not use Flutter-rendered context menu on the Web.
 
   testWidgets('onTap is called upon tap', (WidgetTester tester) async {
     int tapCount = 0;

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -251,7 +251,7 @@ void main() {
     expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Cut'), findsOneWidget);
   },
-    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    exclude: isBrowser, // We do not use Flutter-rendered context menu on the Web
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
@@ -305,7 +305,7 @@ void main() {
       expect(find.text('◀'), findsNothing);
       expect(find.text('▶'), findsNothing);
     },
-      skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+      skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
@@ -376,7 +376,7 @@ void main() {
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);
     },
-      skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+      skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
@@ -478,7 +478,7 @@ void main() {
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);
     },
-      skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+      skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
 
@@ -596,7 +596,7 @@ void main() {
       expect(find.text('▶'), findsOneWidget);
       expect(appearsEnabled(tester, '▶'), true);
     },
-      skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+      skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
     );
   });
@@ -677,7 +677,7 @@ void main() {
     expect(handles.first.size.height, 60.5);
     expect(handles.last.size.height, 35.5);
   },
-    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
@@ -761,7 +761,7 @@ void main() {
     expect(handles.first.size.height, 110.5);
     expect(handles.last.size.height, 110.5);
   },
-    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
@@ -842,7 +842,7 @@ void main() {
     expect(handles.first.size.height, 60.5);
     expect(handles.last.size.height, 45.5);
   },
-    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
@@ -928,7 +928,7 @@ void main() {
     expect(handles.first.size.height, 50.5);
     expect(handles.last.size.height, 50.5); // This is 60.5 with the previous frame.
   },
-    skip: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 }

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -251,7 +251,7 @@ void main() {
     expect(find.text('Copy'), findsOneWidget);
     expect(find.text('Cut'), findsOneWidget);
   },
-    exclude: isBrowser, // We do not use Flutter-rendered context menu on the Web
+    skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -180,7 +180,7 @@ void main() {
     expect(find.byType(TestBox), findsNWidgets(7));
     expect(_findOverflowNextButton(), findsOneWidget);
     expect(_findOverflowBackButton(), findsNothing);
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 
   testWidgets('positions itself at anchorAbove if it fits', (WidgetTester tester) async {
     late StateSetter setState;
@@ -229,7 +229,7 @@ void main() {
     await tester.pump();
     toolbarY = tester.getTopLeft(_findToolbar()).dy;
     expect(toolbarY, equals(anchorAboveY - height - _kToolbarContentDistance));
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 
   testWidgets('can create and use a custom toolbar', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
@@ -262,5 +262,5 @@ void main() {
     expect(find.text('Copy'), findsNothing);
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Select all'), findsNothing);
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 }


### PR DESCRIPTION
_Attempting a reland of #87289._

Part of #86396.

Updated the skip tests in the 'cupertino' package. Turned some tests back on and marked others with `exclude` instead of `skip` as they will never work on the web.

