### PR TITLE
Mark high flaky tests as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -799,6 +799,7 @@ targets:
 
   - name: Linux_android android_stack_size_test
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -989,6 +990,7 @@ targets:
 
   - name: Linux_android flutter_gallery__memory_nav
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -1009,6 +1011,7 @@ targets:
 
   - name: Linux_android flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -1029,6 +1032,7 @@ targets:
 
   - name: Linux_android flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -1059,6 +1063,7 @@ targets:
 
   - name: Linux_android flutter_gallery_sksl_warmup__transition_perf
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
This is a manual step for conflicting PRs filed the `fluttergithubbot`.
All these tests have exceeded flaky SLO 2%.

Related issues:
https://github.com/flutter/flutter/issues/87494
https://github.com/flutter/flutter/issues/87492
https://github.com/flutter/flutter/issues/87490
https://github.com/flutter/flutter/issues/87485
https://github.com/flutter/flutter/issues/87479

/cc @chinmaygarde 