### PR TITLE
Wait for module UI test buttons to be hittable before tapping them

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -5,29 +5,26 @@
 @import XCTest;
 
 @interface FlutterUITests : XCTestCase
+@property (strong) XCUIApplication *app;
 @end
 
 @implementation FlutterUITests
 
 - (void)setUp {
+    [super setUp];
     self.continueAfterFailure = NO;
+
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app launch];
+    self.app = app;
 }
 
 - (void)testFullScreenColdPop {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
-
-    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-    XCUIElement *coldButton = app.buttons[@"Full Screen (Cold)"];
-    [self expectationForPredicate:hittable evaluatedWithObject:coldButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [coldButton tap];
-
+    XCUIApplication *app = self.app;
+    [self waitForAndTapElement:app.buttons[@"Full Screen (Cold)"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
-    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
-    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [incrementButton tap];
+
+    [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -36,22 +33,12 @@
 }
 
 - (void)testFullScreenWarm {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
+    XCUIApplication *app = self.app;
 
-    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-    XCUIElement *warmButton = app.buttons[@"Full Screen (Warm)"];
-    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [warmButton tap];
-
+    [self waitForAndTapElement:app.buttons[@"Full Screen (Warm)"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
 
-    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
-    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [incrementButton tap];
-
+    [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -60,22 +47,12 @@
 }
 
 - (void)testFlutterViewWarm {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
+    XCUIApplication *app = self.app;
 
-    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-    XCUIElement *warmButton = app.buttons[@"Flutter View (Warm)"];
-    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [warmButton tap];
-
+    [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
 
-    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
-    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [incrementButton tap];
-
+    [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -84,23 +61,14 @@
 }
 
 - (void)testHybridViewWarm {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
+    XCUIApplication *app = self.app;
 
-    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-    XCUIElement *warmButton = app.buttons[@"Hybrid View (Warm)"];
-    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [warmButton tap];
+    [self waitForAndTapElement:app.buttons[@"Hybrid View (Warm)"]];
 
     XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
-    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
-    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [incrementButton tap];
-
+    [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
     XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
@@ -114,14 +82,9 @@
 }
 
 - (void)testDualCold {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
+    XCUIApplication *app = self.app;
 
-    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-    XCUIElement *button = app.buttons[@"Dual Flutter View (Cold)"];
-    [self expectationForPredicate:hittable evaluatedWithObject:button handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [button tap];
+    [self waitForAndTapElement:app.buttons[@"Dual Flutter View (Cold)"]];
 
     // There are two marquees.
     XCUIElementQuery *marqueeQuery = [app.staticTexts matchingIdentifier:@"This is Marquee"];
@@ -131,6 +94,13 @@
     // Back navigation.
     [app.navigationBars[@"Dual Flutter Views"].buttons[@"Flutter iOS Demos Home"] tap];
     XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+}
+
+- (void)waitForAndTapElement:(XCUIElement *)element {
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
+    [self expectationForPredicate:hittable evaluatedWithObject:element handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [element tap];
 }
 
 @end

--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -17,12 +17,17 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     XCUIElement *coldButton = app.buttons[@"Full Screen (Cold)"];
-    XCTAssertTrue([coldButton waitForExistenceWithTimeout:60.0]);
+    [self expectationForPredicate:hittable evaluatedWithObject:coldButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [coldButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
-    [app.otherElements[@"Increment via Flutter"] tap];
+    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
+    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [incrementButton tap];
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -34,12 +39,19 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     XCUIElement *warmButton = app.buttons[@"Full Screen (Warm)"];
-    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
-    [app.otherElements[@"Increment via Flutter"] tap];
+
+    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
+    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [incrementButton tap];
+
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -51,12 +63,19 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     XCUIElement *warmButton = app.buttons[@"Flutter View (Warm)"];
-    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
-    [app.otherElements[@"Increment via Flutter"] tap];
+
+    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
+    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [incrementButton tap];
+
     XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
 
     // Back navigation.
@@ -68,14 +87,20 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     XCUIElement *warmButton = app.buttons[@"Hybrid View (Warm)"];
-    XCTAssertTrue([warmButton waitForExistenceWithTimeout:60.0]);
+    [self expectationForPredicate:hittable evaluatedWithObject:warmButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [warmButton tap];
 
     XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
-    [app.otherElements[@"Increment via Flutter"] tap];
+    XCUIElement *incrementButton = app.otherElements[@"Increment via Flutter"];
+    [self expectationForPredicate:hittable evaluatedWithObject:incrementButton handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [incrementButton tap];
+
     XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
@@ -92,7 +117,11 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     [app launch];
 
-    [app.buttons[@"Dual Flutter View (Cold)"] tap];
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
+    XCUIElement *button = app.buttons[@"Dual Flutter View (Cold)"];
+    [self expectationForPredicate:hittable evaluatedWithObject:button handler:nil];
+    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [button tap];
 
     // There are two marquees.
     XCUIElementQuery *marqueeQuery = [app.staticTexts matchingIdentifier:@"This is Marquee"];


### PR DESCRIPTION
Another attempt at deflaking the `module_test_ios` tests.  Wait for the buttons to both exist and be "hittable" before tapping.  I wasn't able to reproduce these flakes locally.

See also #85650

Speculatively fixes https://github.com/flutter/flutter/issues/87478

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.