### PR TITLE
Future builder enhancements

### DIFF
--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -750,9 +750,9 @@ class FutureBuilder<T> extends StatefulWidget {
   final WidgetBuilder? onError;
 
   /// The listener that is called when the passed in [Future] state changes.
-  /// 
+  ///
   /// Consider using this for side effects in response to [Future] state changes.
-  final AsyncSnapshotListener<T>? listen;  
+  final AsyncSnapshotListener<T>? listen;
 
   /// Whether the latest error received by the asynchronous computation should
   /// be rethrown or swallowed. This property is useful for debugging purposes.
@@ -800,7 +800,7 @@ class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
     if (_snapshot.hasError && widget.onError != null) {
       return widget.onError!(context);
     }
-    
+
     if (_snapshot.connectionState == ConnectionState.waiting && widget.onPending != null) {
       return widget.onPending!(context);
     }


### PR DESCRIPTION
This PR adds three parameters to the FutureBuilder.

`listen`: Adds the ability to trigger side effects outside of the build cycle whenever the future state changes
`onPending`: Widget builder that is called when the future is pending
`onError`: Widget builder that is called when the future throws

Refer to issue https://github.com/flutter/flutter/issues/87399.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.