### PR TITLE
Prevent Scrollbar axis flipping when there is an oriented scroll controller

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1525,7 +1525,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     );
   }
 
-  bool _debugCheckNotificationAxis(Axis notificationAxisDirection) {
+  bool _debugCheckNotificationAxis(Axis notificationAxis) {
     final ScrollController? scrollController = widget.controller ??
         PrimaryScrollController.of(context);
     if (scrollController == null) {
@@ -1539,9 +1539,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     // axis of the scroll position and scrollbar should always match.
     if ((scrollController != null && scrollController.hasClients) || enableGestures) {
       assert(
-        scrollController.position.axis == notificationAxisDirection,
-        "The AxisDirection of the Scrollbar's ScrollController does not match the "
-        'AxisDirection of the received ScrollNotification. '
+        scrollController.position.axis == notificationAxis,
+        "The Axis of the Scrollbar's ScrollController does not match the "
+        'Axis of the received ScrollNotification. '
       );
     }
     return true;

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1543,9 +1543,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     }
     // Ensure we are not flipping axes if the scrollbar is not passive.
     // It is valid for a scrollbar to change axes based on a notification if it
-    // is passive, but if it has a scroll controller and supports gestures, the
+    // is passive, but if it has a scroll controller, the
     // axis of the scroll position and scrollbar should always match.
-    if ((scrollController != null && scrollController.hasClients) || enableGestures) {
+    if (scrollController != null && scrollController.hasClients) {
       assert(
         scrollController.position.axis == notificationAxis,
         "The Axis of the Scrollbar's ScrollController does not match the "

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1647,7 +1647,6 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: RawScrollbar(
-            isAlwaysShown: true,
             controller: verticalScrollController,
             // This scrollbar will receive a notification from both nested
             // scroll views of opposite axes.
@@ -1669,18 +1668,16 @@ void main() {
     }
 
     await tester.pumpWidget(buildFrame());
+    await tester.pumpAndSettle();
 
-    final AssertionError error = tester.takeException() as AssertionError;
-    expect(error.message, contains('Axis'));
-
-    // expect(
-    //   () async => tester.pumpWidget(buildFrame()),
-    //   throwsA(isAssertionError.having(
-    //     (AssertionError e) => e.message,
-    //     'message',
-    //     contains("The AxisDirection of the Scrollbar's ScrollController does not "
-    //       'match the AxisDirection of the received ScrollNotification. '),
-    //   )),
-    // );
+    expect(
+      () => horizontalScrollController.jumpTo(10.0),
+      throwsA(isAssertionError.having(
+        (AssertionError e) => e.message,
+        'message',
+        contains("The Axis of the Scrollbar's ScrollController does not "
+          'match the Axis of the received ScrollNotification. '),
+      )),
+    );
   });
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1638,7 +1638,8 @@ void main() {
     expect(find.byType(RawScrollbar), isNot(paints..rect())); // Not shown.
   });
 
-  testWidgets('The scrollbar checks for matching axes', (WidgetTester tester) async {
+  testWidgets('Scrollbar will not flip axes based on notification is there is a scroll controller', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/87697
     final ScrollController verticalScrollController = ScrollController();
     final ScrollController horizontalScrollController = ScrollController();
     Widget buildFrame() {
@@ -1647,15 +1648,17 @@ void main() {
         child: MediaQuery(
           data: const MediaQueryData(),
           child: RawScrollbar(
+            isAlwaysShown: true,
             controller: verticalScrollController,
-            // This scrollbar will receive a notification from both nested
-            // scroll views of opposite axes.
+            // This scrollbar will receive scroll notifications from both nested
+            // scroll views of opposite axes, but should stay on the vertical
+            // axis that its scroll controller is associated with.
             notificationPredicate: (ScrollNotification notification) => notification.depth <= 1,
             child: SingleChildScrollView(
               controller: verticalScrollController,
               child: SingleChildScrollView(
-                controller: horizontalScrollController,
                 scrollDirection: Axis.horizontal,
+                controller: horizontalScrollController,
                 child: const SizedBox(
                   width: 1000.0,
                   height: 1000.0,
@@ -1669,15 +1672,30 @@ void main() {
 
     await tester.pumpWidget(buildFrame());
     await tester.pumpAndSettle();
-
+    expect(verticalScrollController.offset, 0.0);
+    expect(horizontalScrollController.offset, 0.0);
     expect(
-      () => horizontalScrollController.jumpTo(10.0),
-      throwsA(isAssertionError.having(
-        (AssertionError e) => e.message,
-        'message',
-        contains("The Axis of the Scrollbar's ScrollController does not "
-          'match the Axis of the received ScrollNotification. '),
-      )),
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 360.0),
+          color: const Color(0x66BCBCBC),
+        ),
+    );
+
+    // Move the horizontal scroll view. The vertical scrollbar should not flip.
+    horizontalScrollController.jumpTo(10.0);
+    expect(verticalScrollController.offset, 0.0);
+    expect(horizontalScrollController.offset, 10.0);
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 360.0),
+          color: const Color(0x66BCBCBC),
+        ),
     );
   });
 }

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1648,7 +1648,7 @@ void main() {
     expect(find.byType(RawScrollbar), isNot(paints..rect())); // Not shown.
   });
 
-  testWidgets('The bar can show or hide when the window size change', (WidgetTester tester) async {
+  testWidgets('The scrollbar checks for matching axes', (WidgetTester tester) async {
     final ScrollController verticalScrollController = ScrollController();
     final ScrollController horizontalScrollController = ScrollController();
     Widget buildFrame() {
@@ -1679,17 +1679,18 @@ void main() {
     }
 
     await tester.pumpWidget(buildFrame());
-    await tester.pumpAndSettle();
-    expect(verticalScrollController.offset, 0.0);
-    expect(horizontalScrollController.offset, 0.0);
-    horizontalScrollController.jumpTo(10.0);
-    final AssertionError exception = tester.takeException() as AssertionError;
-    expect(
-      exception.message,
-      contains(
-        "The AxisDirection of the Scrollbar's ScrollController does not "
-        'match the AxisDirection of the received ScrollNotification. '
-      )
-    );
+
+    final AssertionError error = tester.takeException() as AssertionError;
+    expect(error.message, contains('Axis'));
+
+    // expect(
+    //   () async => tester.pumpWidget(buildFrame()),
+    //   throwsA(isAssertionError.having(
+    //     (AssertionError e) => e.message,
+    //     'message',
+    //     contains("The AxisDirection of the Scrollbar's ScrollController does not "
+    //       'match the AxisDirection of the received ScrollNotification. '),
+    //   )),
+    // );
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/87697

When there is an oriented scroll controller attached to a scrollbar, the scrollbar should not flip axes based on the scroll notification it receives.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
