### PR TITLE
[WIP] Remove ellipsis overflow clipping from RenderParagraph

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -655,7 +655,7 @@ class RenderParagraph extends RenderBox
           break;
         case TextOverflow.clip:
         case TextOverflow.ellipsis:
-          _needsClipping = true;
+          _needsClipping = false;
           _overflowShader = null;
           break;
         case TextOverflow.fade:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/86782

Removes clipping when ellipsis overflow occurs. We clip when using ellipsis overflow, however, this is actually redundant since our layout engines do not draw overflowed ellipsised text. By removing this, we prevent the edge case of vertical clipping in this particular case.