### PR TITLE
Categorize flutter tool commands

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -106,6 +106,9 @@ class AnalyzeCommand extends FlutterCommand {
   String get description => "Analyze the project's Dart code.";
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   bool get shouldRunPub {
     // If they're not analyzing the current project.
     if (!boolArg('current-package')) {

--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -106,7 +106,7 @@ class AnalyzeCommand extends FlutterCommand {
   String get description => "Analyze the project's Dart code.";
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   bool get shouldRunPub {

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -140,6 +140,9 @@ class AssembleCommand extends FlutterCommand {
   String get name => 'assemble';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   Future<CustomDimensions> get usageValues async {
     final FlutterProject flutterProject = FlutterProject.current();
     if (flutterProject == null) {

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -140,7 +140,7 @@ class AssembleCommand extends FlutterCommand {
   String get name => 'assemble';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<CustomDimensions> get usageValues async {

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -145,7 +145,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
 `$ flutter attach --debug-port 12345`''';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   int get debugPort {
     if (argResults['debug-port'] == null) {

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -144,6 +144,9 @@ If the app or module is already running and the specific observatory port is
 known, it can be explicitly provided to attach via the command-line, e.g.
 `$ flutter attach --debug-port 12345`''';
 
+  @override
+  final String category = FlutterCommandCategories.tools;
+
   int get debugPort {
     if (argResults['debug-port'] == null) {
       return null;

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -58,6 +58,9 @@ class BuildCommand extends FlutterCommand {
   final String description = 'Build an executable app or install bundle.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   Future<FlutterCommandResult> runCommand() async => null;
 }
 

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -58,7 +58,7 @@ class BuildCommand extends FlutterCommand {
   final String description = 'Build an executable app or install bundle.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<FlutterCommandResult> runCommand() async => null;

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -28,6 +28,9 @@ class ChannelCommand extends FlutterCommand {
   final String description = 'List or switch Flutter channels.';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   String get invocation => '${runner.executableName} $name [<channel-name>]';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -28,7 +28,7 @@ class ChannelCommand extends FlutterCommand {
   final String description = 'List or switch Flutter channels.';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   String get invocation => '${runner.executableName} $name [<channel-name>]';

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -28,7 +28,7 @@ class ChannelCommand extends FlutterCommand {
   final String description = 'List or switch Flutter channels.';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   String get invocation => '${runner.executableName} $name [<channel-name>]';

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -30,6 +30,9 @@ class CleanCommand extends FlutterCommand {
   final String description = 'Delete the build/ and .dart_tool/ directories.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};
 
   @override

--- a/packages/flutter_tools/lib/src/commands/clean.dart
+++ b/packages/flutter_tools/lib/src/commands/clean.dart
@@ -30,7 +30,7 @@ class CleanCommand extends FlutterCommand {
   final String description = 'Delete the build/ and .dart_tool/ directories.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -55,6 +55,9 @@ class ConfigCommand extends FlutterCommand {
     "Flutter tools over time. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/";
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   final List<String> aliases = <String>['configure'];
 
   @override

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -55,7 +55,7 @@ class ConfigCommand extends FlutterCommand {
     "Flutter tools over time. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/";
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   final List<String> aliases = <String>['configure'];

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -55,7 +55,7 @@ class ConfigCommand extends FlutterCommand {
     "Flutter tools over time. See Google's privacy policy: https://www.google.com/intl/en/policies/privacy/";
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   final List<String> aliases = <String>['configure'];

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -79,6 +79,9 @@ class CreateCommand extends CreateBase {
     'If run on a project that already exists, this will repair the project, recreating any files that are missing.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   String get invocation => '${runner.executableName} $name <output directory>';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -79,7 +79,7 @@ class CreateCommand extends CreateBase {
     'If run on a project that already exists, this will repair the project, recreating any files that are missing.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   String get invocation => '${runner.executableName} $name <output directory>';

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -159,6 +159,9 @@ Requires the custom devices feature to be enabled. You can enable it using "flut
   String get name => 'custom-devices';
 
   @override
+  String get category => FlutterCommandCategories.tools;
+
+  @override
   Future<FlutterCommandResult> runCommand() async => null;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -159,7 +159,7 @@ Requires the custom devices feature to be enabled. You can enable it using "flut
   String get name => 'custom-devices';
 
   @override
-  String get category => FlutterCommandCategories.tools;
+  String get category => FlutterCommandCategory.tools;
 
   @override
   Future<FlutterCommandResult> runCommand() async => null;

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -51,7 +51,7 @@ class DaemonCommand extends FlutterCommand {
 
   @override
   final String category = FlutterCommandCategories.tools;
-  
+
   @override
   final bool hidden;
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -50,7 +50,7 @@ class DaemonCommand extends FlutterCommand {
   final String description = 'Run a persistent, JSON-RPC based server to communicate with devices.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   final bool hidden;

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -50,6 +50,9 @@ class DaemonCommand extends FlutterCommand {
   final String description = 'Run a persistent, JSON-RPC based server to communicate with devices.';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+  
+  @override
   final bool hidden;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -34,6 +34,9 @@ class DevicesCommand extends FlutterCommand {
   final String description = 'List all connected devices.';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+
+  @override
   Duration get deviceDiscoveryTimeout {
     if (argResults['timeout'] != null) {
       final int timeoutSeconds = int.tryParse(stringArg('timeout'));

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -34,7 +34,7 @@ class DevicesCommand extends FlutterCommand {
   final String description = 'List all connected devices.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   Duration get deviceDiscoveryTimeout {

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -32,6 +32,9 @@ class DoctorCommand extends FlutterCommand {
   final String description = 'Show information about the installed tooling.';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     globals.flutterVersion.fetchTagsAndUpdate();
     if (argResults.wasParsed('check-for-remote-artifacts')) {

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -32,7 +32,7 @@ class DoctorCommand extends FlutterCommand {
   final String description = 'Show information about the installed tooling.';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -32,7 +32,7 @@ class DoctorCommand extends FlutterCommand {
   final String description = 'Show information about the installed tooling.';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -77,6 +77,9 @@ class DowngradeCommand extends FlutterCommand {
   String get name => 'downgrade';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     // Commands do not necessarily have access to the correct zone injected
     // values when being created. Fields must be lazily instantiated in runCommand,

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -77,7 +77,7 @@ class DowngradeCommand extends FlutterCommand {
   String get name => 'downgrade';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -77,7 +77,7 @@ class DowngradeCommand extends FlutterCommand {
   String get name => 'downgrade';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -22,7 +22,7 @@ import '../device.dart';
 import '../drive/drive_service.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../resident_runner.dart';
-import '../runner/flutter_command.dart' show FlutterCommandResult, FlutterOptions;
+import '../runner/flutter_command.dart' show FlutterCommandCategories, FlutterCommandResult, FlutterOptions;
 import '../web/web_device.dart';
 import 'run.dart';
 
@@ -171,6 +171,9 @@ class DriveCommand extends RunCommandBase {
 
   @override
   final String description = 'Run integration tests for the project on an attached device or emulator.';
+
+  @override
+  String get category => FlutterCommandCategories.project;
 
   @override
   final List<String> aliases = <String>['driver'];

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -22,7 +22,7 @@ import '../device.dart';
 import '../drive/drive_service.dart';
 import '../globals_null_migrated.dart' as globals;
 import '../resident_runner.dart';
-import '../runner/flutter_command.dart' show FlutterCommandCategories, FlutterCommandResult, FlutterOptions;
+import '../runner/flutter_command.dart' show FlutterCommandCategory, FlutterCommandResult, FlutterOptions;
 import '../web/web_device.dart';
 import 'run.dart';
 
@@ -173,7 +173,7 @@ class DriveCommand extends RunCommandBase {
   final String description = 'Run integration tests for the project on an attached device or emulator.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   final List<String> aliases = <String>['driver'];

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -32,6 +32,9 @@ class EmulatorsCommand extends FlutterCommand {
   final String description = 'List, launch and create emulators.';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+
+  @override
   final List<String> aliases = <String>['emulator'];
 
   @override

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -32,7 +32,7 @@ class EmulatorsCommand extends FlutterCommand {
   final String description = 'List, launch and create emulators.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   final List<String> aliases = <String>['emulator'];

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -30,7 +30,7 @@ class FormatCommand extends FlutterCommand {
   final String description = 'Format one or more Dart files.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   String get invocation => '${runner.executableName} $name <one or more paths>';

--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -30,6 +30,9 @@ class FormatCommand extends FlutterCommand {
   final String description = 'Format one or more Dart files.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   String get invocation => '${runner.executableName} $name <one or more paths>';
 
   @override

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -195,6 +195,9 @@ class GenerateLocalizationsCommand extends FlutterCommand {
   String get name => 'gen-l10n';
 
   @override
+  String get category => FlutterCommandCategories.project;
+  
+  @override
   Future<FlutterCommandResult> runCommand() async {
     if (_fileSystem.file('l10n.yaml').existsSync()) {
       final LocalizationOptions options = parseLocalizationsOptions(

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -196,7 +196,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
 
   @override
   String get category => FlutterCommandCategories.project;
-  
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     if (_fileSystem.file('l10n.yaml').existsSync()) {

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -195,7 +195,7 @@ class GenerateLocalizationsCommand extends FlutterCommand {
   String get name => 'gen-l10n';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -30,6 +30,9 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   @override
   final String description = 'Install a Flutter app on an attached device.';
 
+  @override
+  final String category = FlutterCommandCategories.tools;
+
   Device device;
 
   bool get uninstallOnly => boolArg('uninstall-only');

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -31,7 +31,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
   final String description = 'Install a Flutter app on an attached device.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   Device device;
 

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -29,6 +29,9 @@ class LogsCommand extends FlutterCommand {
   final String description = 'Show log output for running Flutter apps.';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+
+  @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};
 
   Device device;

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -29,7 +29,7 @@ class LogsCommand extends FlutterCommand {
   final String description = 'Show log output for running Flutter apps.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -51,6 +51,9 @@ class PackagesCommand extends FlutterCommand {
   final String description = 'Commands for managing Flutter packages.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   Future<FlutterCommandResult> runCommand() async => null;
 }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -51,7 +51,7 @@ class PackagesCommand extends FlutterCommand {
   final String description = 'Commands for managing Flutter packages.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<FlutterCommandResult> runCommand() async => null;

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -78,6 +78,9 @@ class PrecacheCommand extends FlutterCommand {
     'for all currently enabled platforms';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   bool get shouldUpdateCache => false;
 
   /// Some flags are umbrella names that expand to include multiple artifacts.

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -78,7 +78,7 @@ class PrecacheCommand extends FlutterCommand {
     'for all currently enabled platforms';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -78,7 +78,7 @@ class PrecacheCommand extends FlutterCommand {
     'for all currently enabled platforms';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -343,6 +343,9 @@ class RunCommand extends RunCommandBase {
   @override
   final String description = 'Run your Flutter app on an attached device.';
 
+  @override
+  String get category => FlutterCommandCategories.project;
+
   List<Device> devices;
   bool webMode = false;
 

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -344,7 +344,7 @@ class RunCommand extends RunCommandBase {
   final String description = 'Run your Flutter app on an attached device.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   List<Device> devices;
   bool webMode = false;

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -62,6 +62,9 @@ class ScreenshotCommand extends FlutterCommand {
   String get description => 'Take a screenshot from a connected device.';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+
+  @override
   final List<String> aliases = <String>['pic'];
 
   Device device;

--- a/packages/flutter_tools/lib/src/commands/screenshot.dart
+++ b/packages/flutter_tools/lib/src/commands/screenshot.dart
@@ -62,7 +62,7 @@ class ScreenshotCommand extends FlutterCommand {
   String get description => 'Take a screenshot from a connected device.';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   final List<String> aliases = <String>['pic'];

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -32,6 +32,9 @@ class ShellCompletionCommand extends FlutterCommand {
       'complete flutter commands and options.';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   final List<String> aliases = <String>['zsh-completion'];
 
   @override

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -32,7 +32,7 @@ class ShellCompletionCommand extends FlutterCommand {
       'complete flutter commands and options.';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   final List<String> aliases = <String>['zsh-completion'];

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -32,7 +32,7 @@ class ShellCompletionCommand extends FlutterCommand {
       'complete flutter commands and options.';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   final List<String> aliases = <String>['zsh-completion'];

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -60,6 +60,9 @@ class SymbolizeCommand extends FlutterCommand {
   String get name => 'symbolize';
 
   @override
+  final String category = FlutterCommandCategories.tools;
+
+  @override
   bool get shouldUpdateCache => false;
 
   @override

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -60,7 +60,7 @@ class SymbolizeCommand extends FlutterCommand {
   String get name => 'symbolize';
 
   @override
-  final String category = FlutterCommandCategories.tools;
+  final String category = FlutterCommandCategory.tools;
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -250,6 +250,9 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
   String get description => 'Run Flutter unit tests for the current project.';
 
   @override
+  String get category => FlutterCommandCategories.project;
+
+  @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) {
     _testFiles = argResults.rest.map<String>(globals.fs.path.absolute).toList();
     if (_testFiles.isEmpty) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -250,7 +250,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
   String get description => 'Run Flutter unit tests for the current project.';
 
   @override
-  String get category => FlutterCommandCategories.project;
+  String get category => FlutterCommandCategory.project;
 
   @override
   Future<FlutterCommandResult> verifyThenRunCommand(String commandPath) {

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -64,7 +64,7 @@ class UpgradeCommand extends FlutterCommand {
   final String description = 'Upgrade your copy of Flutter.';
 
   @override
-  final String category = FlutterCommandCategory.installation;
+  final String category = FlutterCommandCategory.sdk;
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -64,7 +64,7 @@ class UpgradeCommand extends FlutterCommand {
   final String description = 'Upgrade your copy of Flutter.';
 
   @override
-  final String category = FlutterCommandCategories.installation;
+  final String category = FlutterCommandCategory.installation;
 
   @override
   bool get shouldUpdateCache => false;

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -64,6 +64,9 @@ class UpgradeCommand extends FlutterCommand {
   final String description = 'Upgrade your copy of Flutter.';
 
   @override
+  final String category = FlutterCommandCategories.installation;
+
+  @override
   bool get shouldUpdateCache => false;
 
   @override

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -122,6 +122,13 @@ class FlutterOptions {
   static const String kInitializeFromDill = 'initialize-from-dill';
 }
 
+/// flutter command categories for usage.
+class FlutterCommandCategories {
+  static const String project = 'Project';
+  static const String tools = 'Tools & devices';
+  static const String installation = 'Flutter installation';
+}
+
 abstract class FlutterCommand extends Command<void> {
   /// The currently executing command (or sub-command).
   ///

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -124,9 +124,9 @@ class FlutterOptions {
 
 /// flutter command categories for usage.
 class FlutterCommandCategory {
-  static const String installation = 'Flutter installation';
+  static const String sdk = 'Flutter SDK';
   static const String project = 'Project';
-  static const String tools = 'Tools & devices';
+  static const String tools = 'Tools & Devices';
 }
 
 abstract class FlutterCommand extends Command<void> {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -124,9 +124,9 @@ class FlutterOptions {
 
 /// flutter command categories for usage.
 class FlutterCommandCategories {
+  static const String installation = 'Flutter installation';
   static const String project = 'Project';
   static const String tools = 'Tools & devices';
-  static const String installation = 'Flutter installation';
 }
 
 abstract class FlutterCommand extends Command<void> {

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -123,7 +123,7 @@ class FlutterOptions {
 }
 
 /// flutter command categories for usage.
-class FlutterCommandCategories {
+class FlutterCommandCategory {
   static const String installation = 'Flutter installation';
   static const String project = 'Project';
   static const String tools = 'Tools & devices';

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -43,7 +43,7 @@ void verifyCommand(Command<Object> runner) {
         FlutterCommandCategory.project,
         FlutterCommandCategory.tools,
       ),
-      reason: 'command ${runner.name} has a category matching FlutterCommandCategory'
+      reason: "top-level command ${runner.name} doesn't have a valid category",
     );
   }
   

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -7,6 +7,9 @@
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/executable.dart' as executable;
+import 'package:flutter_tools/src/commands/build.dart';
+import 'package:flutter_tools/src/commands/custom_devices.dart';
+import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 
 import '../src/common.dart';
@@ -34,6 +37,18 @@ void verifyCommandRunner(CommandRunner<Object> runner) {
 void verifyCommand(Command<Object> runner) {
   expect(runner.argParser, isNotNull, reason: 'command ${runner.name} has no argParser');
   verifyOptions(runner.name, runner.argParser.options.values);
+  if (runner.hidden == false && runner.parent == null) {
+    expect(
+      runner.category,
+      anyOf(
+        FlutterCommandCategory.installation,
+        FlutterCommandCategory.project,
+        FlutterCommandCategory.tools,
+      ),
+      reason: 'command ${runner.name} has a category matching FlutterCommandCategory'
+    );
+  }
+  
   runner.subcommands.values.forEach(verifyCommand);
 }
 

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -7,8 +7,6 @@
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/executable.dart' as executable;
-import 'package:flutter_tools/src/commands/build.dart';
-import 'package:flutter_tools/src/commands/custom_devices.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -46,7 +46,7 @@ void verifyCommand(Command<Object> runner) {
       reason: "top-level command ${runner.name} doesn't have a valid category",
     );
   }
-  
+
   runner.subcommands.values.forEach(verifyCommand);
 }
 

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -39,7 +39,7 @@ void verifyCommand(Command<Object> runner) {
     expect(
       runner.category,
       anyOf(
-        FlutterCommandCategory.installation,
+        FlutterCommandCategory.sdk,
         FlutterCommandCategory.project,
         FlutterCommandCategory.tools,
       ),


### PR DESCRIPTION
Now that `args` [supports command categorisation](https://github.com/dart-lang/args/pull/202), assign a category to all  flutter tool commands. The three categories are:
* Flutter SDK
* Project
* Tools & Devices


<img width="664" alt="Screen Shot 2021-10-05 at 15 16 44" src="https://user-images.githubusercontent.com/6655696/136088438-9175b13c-06ec-4e74-8951-127a844a707b.png">

Ready when https://pub.dev/packages/args 2.3.0 is available and packages are updated.

Closes flutter/flutter#83706
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
