### PR TITLE
Migrate python invocations to python3

### DIFF
--- a/dev/bots/README.md
+++ b/dev/bots/README.md
@@ -47,7 +47,7 @@ To run `prepare_package.dart` locally:
 
 - Make sure the `depot_tools` is in your `PATH`. If you're on Windows, you also need
   an environment variable called `DEPOT_TOOLS` with the path to `depot_tools` as value.
-- Run `gsutil.py config` (or `python %DEPOT_TOOLS%\gsutil.py` on Windows) to
+- Run `gsutil.py config` (or `python3 %DEPOT_TOOLS%\gsutil.py` on Windows) to
   authenticate with your auth token.
 - Create a local temp directory. `cd` into it.
 - Run `dart [path to your normal Flutter repo]/dev/bots/prepare_package.dart

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -669,7 +669,7 @@ class ArchivePublisher {
     }
     if (platform.isWindows) {
       return _processRunner.runProcess(
-        <String>['python', path.join(platform.environment['DEPOT_TOOLS']!, 'gsutil.py'), '--', ...args],
+        <String>['python3', path.join(platform.environment['DEPOT_TOOLS']!, 'gsutil.py'), '--', ...args],
         workingDirectory: workingDirectory,
         failOk: failOk,
       );

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -289,7 +289,7 @@ void main() {
       late FakeProcessManager processManager;
       late Directory tempDir;
       final String gsutilCall = platform.isWindows
-          ? 'python ${path.join("D:", "depot_tools", "gsutil.py")}'
+          ? 'python3 ${path.join("D:", "depot_tools", "gsutil.py")}'
           : 'gsutil.py';
       final String releasesName = 'releases_$platformName.json';
       final String archiveName = platform.isLinux ? 'archive.tar.xz' : 'archive.zip';


### PR DESCRIPTION
Python 2 has been end-of-life'd since January 2020, all Python scripts
on which Flutter depends have been migrated to Python 3. This changes
documentation and remaining invocations to explicitly invoke python3.

Issue: https://github.com/flutter/flutter/issues/83043

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
