### PR TITLE
[ci.yaml] Fix firebase recipe, xcode version, and web_benchmarks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -303,7 +303,7 @@ targets:
       - bin/
 
   - name: Linux firebase_abstract_method_smoke_test
-    recipe: firebaselab
+    recipe: firebaselab/firebaselab
     timeout: 60
     properties:
       dependencies: >-
@@ -316,7 +316,7 @@ targets:
     scheduler: luci
 
   - name: Linux firebase_android_embedding_v2_smoke_test
-    recipe: firebaselab
+    recipe: firebaselab/firebaselab
     timeout: 60
     properties:
       dependencies: >-
@@ -329,7 +329,7 @@ targets:
     scheduler: luci
 
   - name: Linux firebase_release_smoke_test
-    recipe: firebaselab
+    recipe: firebaselab/firebaselab
     timeout: 60
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -70,7 +70,7 @@ platform_properties:
       os: Mac-10.15
       device_type: none
       mac_model: Macmini8,1
-      xcode: 12a7209
+      xcode: 12c33
   mac_android:
     properties:
       caches: >-
@@ -112,7 +112,7 @@ platform_properties:
         ]
       os: Mac-10.15
       device_os: iOS-14.4.2
-      xcode: 12a7209
+      xcode: 12c33
   mac_ios32:
     properties:
       caches: >-
@@ -134,7 +134,7 @@ platform_properties:
         ]
       os: Mac-10.15
       device_os: iOS-9.3.6
-      xcode: 12a7209
+      xcode: 12c33
   windows:
     properties:
       caches: >-
@@ -861,6 +861,7 @@ targets:
         ]
       tags: >
         ["devicelab"]
+      task_name: web_benchmarks_html
     scheduler: luci
     runIf:
       - dev/**


### PR DESCRIPTION
1. Fixes firebase lab recipe
2. Sets xcode to 12c33 (what was in starlark)
3. Fix web_benchmarks_html missing task_name (this target was missing from ci.yaml)

In addition, the main issue was missing to update the devicelab_osx_sdk in starlark

https://github.com/flutter/flutter/issues/85803

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
