### PR TITLE
More gracefully handle license loading failures

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -571,6 +571,17 @@ class _PackagesViewState extends State<_PackagesView> {
           builder: (BuildContext context, BoxConstraints constraints) {
             switch (snapshot.connectionState) {
               case ConnectionState.done:
+                if (snapshot.hasError) {
+                  assert(() {
+                    FlutterError.reportError(FlutterErrorDetails(
+                      exception: snapshot.error!,
+                      stack: snapshot.stackTrace,
+                      context: ErrorDescription('while decoding the license file'),
+                    ));
+                    return true;
+                  }());
+                  return Center(child: Text(snapshot.error.toString()));
+                }
                 _initDefaultDetailPage(snapshot.data!, context);
                 return ValueListenableBuilder<int?>(
                   valueListenable: widget.selectedId,


### PR DESCRIPTION
This prevents an exception from being thrown (and ErrorWidget shown) when something goes wrong loading the licenses.

I tried to add a test:

```dart
// Copyright 2014 The Flutter Authors. All rights reserved.                                                                                       
// Use of this source code is governed by a BSD-style license that can be                                                                         
// found in the LICENSE file.                                                                                                                     

import 'package:flutter/foundation.dart';
import 'package:flutter/material.dart';
import 'package:flutter_test/flutter_test.dart';

void main() {
  testWidgets('AboutListTile control test', (WidgetTester tester) async {
    LicenseRegistry.addLicense(() => Stream<LicenseEntry>.error(Exception('Injected failure')));
    await tester.pumpWidget(const MaterialApp(home: Material(child: AboutListTile())));
    await tester.tap(find.byType(ListTile));
    await tester.pump();
    await tester.pump(const Duration(seconds: 2));
    await tester.tap(find.text('VIEW LICENSES'));
    await tester.pump();
    await tester.pump(const Duration(seconds: 2));
    await tester.pumpAndSettle();
    expect(find.text('Injected failure'), findsOneWidget);
  });
}
```

...but it hung (pumpAndSettle spins forever, until a timeout) and I couldn't figure out why before my timebox ran out. It seems to only happen in `flutter test` mode (when running the test in `flutter run`, it passes), and it only seems to happen when the addLicense stream has an error stream (the FutureBuilder never gets the onError call).