### PR TITLE
Fix compile error in SliverAppBar sample code

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1434,7 +1434,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///       child: Padding(
 ///         padding: const EdgeInsets.all(8),
 ///         child: OverflowBar(
-///           alignment: MainAxisAlignment.spaceEvenly,
+///           overflowAlignment: OverflowBarAlignment.center,
 ///           children: <Widget>[
 ///             Row(
 ///               mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Description
SliverAppBar Flutter API's interactive app section currently can't compile the sample code. 
Changing alignment attribute to overflowAlignment would fix the issue.

- Related issue: [#86297](https://github.com/flutter/flutter/issues/86297)
- No Test for documentation correction

## Related Issues

- https://github.com/flutter/flutter/issues/86297