### PR TITLE
Changing ElevatedButton.child to be non-nullable

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -96,7 +96,7 @@ class ElevatedButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool autofocus = false,
     Clip clipBehavior = Clip.none,
-    required Widget? child,
+    required Widget child,
   }) : super(
     key: key,
     onPressed: onPressed,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7157,7 +7157,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///         height: 100.0,
 ///         child: ElevatedButton(
 ///           onPressed: () {},
-///           child: null,
+///           child: Container(),
 ///         ),
 ///       ),
 ///       SizedBox(
@@ -7170,7 +7170,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///               primary: Colors.blue.shade200,
 ///             ),
 ///             onPressed: () {},
-///             child: null,
+///             child: Container(),
 ///           ),
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7157,7 +7157,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///         height: 100.0,
 ///         child: ElevatedButton(
 ///           onPressed: () {},
-///           child: Container(),
+///           child: Text('Lower'),
 ///         ),
 ///       ),
 ///       SizedBox(
@@ -7170,7 +7170,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///               primary: Colors.blue.shade200,
 ///             ),
 ///             onPressed: () {},
-///             child: Container(),
+///             child: Text('Upper'),
 ///           ),
 ///         ),
 ///       ),

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -7157,7 +7157,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///         height: 100.0,
 ///         child: ElevatedButton(
 ///           onPressed: () {},
-///           child: Text('Lower'),
+///           child: const Text('Lower'),
 ///         ),
 ///       ),
 ///       SizedBox(
@@ -7170,7 +7170,7 @@ class IgnorePointer extends SingleChildRenderObjectWidget {
 ///               primary: Colors.blue.shade200,
 ///             ),
 ///             onPressed: () {},
-///             child: Text('Upper'),
+///             child: const Text('Upper'),
 ///           ),
 ///         ),
 ///       ),

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -244,7 +244,7 @@ void main() {
                 onPressed: () {
                   pressed = true;
                 },
-                child: null,
+                child: Container(),
               ),
               const Material(
                 type: MaterialType.transparency,

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -244,7 +244,7 @@ void main() {
                 onPressed: () {
                   pressed = true;
                 },
-                child: Container(),
+                child: const Text('Button'),
               ),
               const Material(
                 type: MaterialType.transparency,

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -287,7 +287,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       final GlobalKey topButtonKey = GlobalKey();
 
       Widget selectButtonBuilder(BuildContext context, VoidCallback onPressed) {
-        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: null));
+        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: Container()));
       }
       // State type is private, hence using dynamic.
       dynamic getInspectorState() => inspectorKey.currentState;
@@ -390,7 +390,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       final GlobalKey inspectorKey = GlobalKey();
 
       Widget selectButtonBuilder(BuildContext context, VoidCallback onPressed) {
-        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: null));
+        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: Container()));
       }
       // State type is private, hence using dynamic.
       dynamic getInspectorState() => inspectorKey.currentState;
@@ -590,7 +590,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       InspectorSelectButtonBuilder selectButtonBuilder(Key key) {
         return (BuildContext context, VoidCallback onPressed) {
-          return Material(child: ElevatedButton(onPressed: onPressed, key: key, child: null));
+          return Material(child: ElevatedButton(onPressed: onPressed, key: key, child: Container()));
         };
       }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -287,7 +287,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       final GlobalKey topButtonKey = GlobalKey();
 
       Widget selectButtonBuilder(BuildContext context, VoidCallback onPressed) {
-        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: Container()));
+        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: const Text('Button')));
       }
       // State type is private, hence using dynamic.
       dynamic getInspectorState() => inspectorKey.currentState;
@@ -390,7 +390,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       final GlobalKey inspectorKey = GlobalKey();
 
       Widget selectButtonBuilder(BuildContext context, VoidCallback onPressed) {
-        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: Container()));
+        return Material(child: ElevatedButton(onPressed: onPressed, key: selectButtonKey, child: const Text('Button')));
       }
       // State type is private, hence using dynamic.
       dynamic getInspectorState() => inspectorKey.currentState;
@@ -590,7 +590,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       InspectorSelectButtonBuilder selectButtonBuilder(Key key) {
         return (BuildContext context, VoidCallback onPressed) {
-          return Material(child: ElevatedButton(onPressed: onPressed, key: key, child: Container()));
+          return Material(child: ElevatedButton(onPressed: onPressed, key: key, child: const Text('Button')));
         };
       }
 


### PR DESCRIPTION
Fixing inconsistency introduced during the null safety migration (#67166). Arguments for ElevatedButton.child being nullable / non-nullable are as below.

| Nullable | Non-nullable |
| :---: | :---: |
| Makes it easy to test and try out widgets | Bugs can be caught when users forgets to fill out the child |
| ElevatedButton, among the 3, alone can sustain without a child, as it has other useful anatomy | Will maintain consistency, as similar widgets have non-nullable child(ren) |
| Works well in specific use cases | Follows the material design pattern |

fixes #87849 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
