### PR TITLE
[ci.yaml] Add clang to tool integration tests, gems fix

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -64,7 +64,6 @@ platform_properties:
         ]
       dependencies: >-
         [
-          {"dependency": "gems"},
           {"dependency": "xcode"}
         ]
       os: Mac-10.15
@@ -707,6 +706,7 @@ targets:
         [
           {"dependency": "android_sdk"},
           {"dependency": "chrome_and_driver"},
+          {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -730,6 +730,7 @@ targets:
         [
           {"dependency": "android_sdk"},
           {"dependency": "chrome_and_driver"},
+          {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -752,6 +753,7 @@ targets:
         [
           {"dependency": "android_sdk"},
           {"dependency": "chrome_and_driver"},
+          {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -774,6 +776,7 @@ targets:
         [
           {"dependency": "android_sdk"},
           {"dependency": "chrome_and_driver"},
+          {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -1406,6 +1409,7 @@ targets:
     properties:
       tags: >
         ["devicelab"]
+      task_name: flutter_gallery__transition_perf_e2e
     scheduler: luci
 
   - name: Linux_android flutter_gallery__transition_perf_hybrid
@@ -1641,6 +1645,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
+          {"dependency": "gems"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"}
         ]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -62,6 +62,8 @@ platform_properties:
           {"name":"pub_cache","path":".pub-cache"},
           {"name":"xcode_binary","path":"xcode_binary"}
         ]
+      dependencies: >-
+        []
       os: Mac-10.15
       device_type: none
       mac_model: Macmini8,1
@@ -734,6 +736,7 @@ targets:
       subshard: "2_4"
       tags: >
         ["framework","hostonly","shard"]
+      test_timeout_secs: "2700"
     scheduler: luci
     runIf:
       - dev/
@@ -757,6 +760,7 @@ targets:
       subshard: "3_4"
       tags: >
         ["framework","hostonly","shard"]
+      test_timeout_secs: "2700"
     scheduler: luci
     runIf:
       - dev/
@@ -780,6 +784,7 @@ targets:
       subshard: "4_4"
       tags: >
         ["framework","hostonly","shard"]
+      test_timeout_secs: "2700"
     scheduler: luci
     runIf:
       - dev/

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -62,10 +62,6 @@ platform_properties:
           {"name":"pub_cache","path":".pub-cache"},
           {"name":"xcode_binary","path":"xcode_binary"}
         ]
-      dependencies: >-
-        [
-          {"dependency": "xcode"}
-        ]
       os: Mac-10.15
       device_type: none
       mac_model: Macmini8,1


### PR DESCRIPTION
1. Add clang to Linux tool integration tests (missing in starlark)
2. Remove gems as mac platform dependency
3. Fix task name in recently added target

https://github.com/flutter/flutter/issues/84998

Manual roll at https://flutter-review.googlesource.com/c/infra/+/16700

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
