### PR TITLE
[docs] spelling correction for showModalBottomSheet docs in bottom sheet file

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -593,7 +593,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 ///
 /// A closely related widget is a persistent bottom sheet, which shows
 /// information that supplements the primary content of the app without
-/// preventing the use from interacting with the app. Persistent bottom sheets
+/// preventing the user from interacting with the app. Persistent bottom sheets
 /// can be created and displayed with the [showBottomSheet] function or the
 /// [ScaffoldState.showBottomSheet] method.
 ///


### PR DESCRIPTION
This PR corrects the wrongly spelt word "user" which was initially "use".

The word "user" was erroneously written as "use"