### PR TITLE
Add conditional dir change message

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -326,10 +326,11 @@ class CreateCommand extends CreateBase {
       final List<String> requestedPlatforms = _getUserRequestedPlatforms();
 
       // Let them know a summary of the state of their tooling.
+      
+      final String dirChangeCmd = relativeAppPath == '.' ? '' : '\n  \$ cd $relativeAppPath';
       globals.printStatus('''
 In order to run your $application, type:
-
-  \$ cd $relativeAppPath
+  $dirChangeCmd
   \$ flutter run
 
 Your $application code is in $relativeAppMain.

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -326,7 +326,6 @@ class CreateCommand extends CreateBase {
       final List<String> requestedPlatforms = _getUserRequestedPlatforms();
 
       // Let them know a summary of the state of their tooling.
-      
       final String dirChangeCmd = relativeAppPath == '.' ? '' : '\n  \$ cd $relativeAppPath';
       globals.printStatus('''
 In order to run your $application, type:


### PR DESCRIPTION
**This PR adds a conditional printing of the  `cd` command based on the relative path.**
Isn't it a bad idea to do `cd .`? This PR fixes this instruction given by flutter at the end of running `flutter create`.

Before -
```
In order to run your application, type:
  
  $ cd .
  $ flutter run

Your application code is in ./lib/main.dart.
```

After - 

If there is no need to change dir.
```
In order to run your application, type:
  
  $ flutter run

Your application code is in ./lib/main.dart.
```

And if there is,
```
In order to run your application, type:
  
  $ cd ./foo/bar
  $ flutter run

Your application code is in ./lib/main.dart.
```

Thanks :)