### PR TITLE
Added a check to the analyzer script to detect skipped tests.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -283,13 +283,12 @@ Future<void> _verifyNoMissingLicenseForExtension(String workingDirectory, String
   }
 }
 
-final RegExp _skipTestCommentPattern = RegExp(r'skip:.*?//(.*)');
+final RegExp _skipTestCommentPattern = RegExp(r'\bskip:.*?//(.*)');
 const Pattern _skipTestIntentionalPattern = '[intended]';
 final Pattern _skipTestTrackingBugPattern = RegExp(r'https+?://github.com/.*/issues/[0-9]+');
 
 Future<void> verifySkipTestComments(String workingDirectory) async {
   final List<String> errors = <String>[];
-  assert("// foo\n}, skip: isBrowser); // this is some text\n'".contains(_skipTestCommentPattern));
   final List<File> testFiles = await _allFiles(workingDirectory, 'dart', minimumMatches: 1500)
       .where((File f) => f.path.endsWith('_test.dart')).toList();
 

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -289,10 +289,10 @@ final Pattern _skipTestTrackingBugPattern = RegExp(r'https+?://github.com/.*/iss
 
 Future<void> verifySkipTestComments(String workingDirectory) async {
   final List<String> errors = <String>[];
-  final List<File> testFiles = await _allFiles(workingDirectory, 'dart', minimumMatches: 1500)
-      .where((File f) => f.path.endsWith('_test.dart')).toList();
+  final Stream<File> testFiles = _allFiles(workingDirectory, 'dart', minimumMatches: 1500)
+    .where((File f) => f.path.endsWith('_test.dart'));
 
-  for (final File file in testFiles) {
+  await for (final File file in testFiles) {
     final List<String> lines = file.readAsLinesSync();
     for (int index = 0; index < lines.length; index++) {
       final Match? match = _skipTestCommentPattern.firstMatch(lines[index]);

--- a/dev/devicelab/bin/tasks/technical_debt__cost.dart
+++ b/dev/devicelab/bin/tasks/technical_debt__cost.dart
@@ -58,7 +58,7 @@ Future<double> findCostsForFile(File file) async {
       total += deprecationCost;
     if (line.contains(legacyDeprecationPattern))
       total += legacyDeprecationCost;
-    if (isTest && line.contains('skip:'))
+    if (isTest && line.contains('skip:') && !line.contains('[intended]'))
       total += skipCost;
     if (isDart && isOptingOutOfNullSafety(line))
       total += fileNullSafetyMigrationCost;


### PR DESCRIPTION
Part of the [Skip test audit](https://github.com/flutter/flutter/issues/86396).

Adds a check to the analyzer that enforces a justification comment after a `skip` parameter in tests, as described in [Tree hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene#skipped-tests).

If a skipped test doesn't include a comment on the same line justifying why it is skipped, it will be considered an error. The comment should contain either a link to a tracking github issue, or include `[intended]` with a description of why the test is not designed for the skip condition.

The failure output will look something like:

```
% dart --enable-asserts dev/bots/analyze.dart
▌12:23:36▐ STARTING ANALYSIS
▌12:23:36▐ runtimeType in toString...
▌12:23:36▐ debug mode instead of checked mode...
▌12:23:37▐ Unexpected binaries...
▌12:23:37▐ RUNNING: cd .; git ls-files -z
▌12:23:37▐ ELAPSED TIME: 0.025s for git ls-files -z in .
▌12:23:37▐ Trailing spaces...
▌12:23:38▐ Deprecations...
▌12:23:39▐ Skip test comments...
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/integration.shard/variable_expansion_windows_test.dart:20}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/integration.shard/overall_experience_test.dart:418}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/general.shard/cache_test.dart:97}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/general.shard/cache_test.dart:106}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/web.shard/vm_service_web_test.dart:65}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart:72}: skip test without a justification comment.
/Users/darrenaustin/dev/flutter/packages/flutter_tools/test/general.shard/android/gradle_test.dart:706}: skip test without a justification comment.

See: https://github.com/flutter/flutter/wiki/Tree-hygiene#skipped-tests
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

Also updated the technical debt calculation to ignore `[intended]` skipped tests as they will never be reenabled and shouldn't count towards out debt.
