### PR TITLE
Fix incorrect logging.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -120,7 +120,7 @@ class Multiple extends Transition {
 
   @override
   String toString() {
-    if (_originalPatterns.length == patterns.length) {
+    if (patterns.isEmpty) {
       return '${_originalPatterns.map(describe).join(', ')} (all matched)';
     }
     return '${_originalPatterns.map(describe).join(', ')} (matched ${_originalPatterns.length - patterns.length} so far)';


### PR DESCRIPTION
I had this test wrong, so it was saying "all matched" when nothing was matched rather than when all was matched.
