### PR TITLE
Support flutter create --platform singular flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -151,6 +151,7 @@ abstract class CreateBase extends FlutterCommand {
   void addPlatformsOptions({String customHelp}) {
     argParser.addMultiOption('platforms',
       help: customHelp ?? _kDefaultPlatformArgumentHelp,
+      aliases: <String>[ 'platform' ],
       defaultsTo: <String>[
         ..._kAvailablePlatforms,
         if (featureFlags.isWindowsUwpEnabled)

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -517,7 +517,7 @@ void main() {
   testUsingContext('plugin project supports web', () async {
     await _createAndAnalyzeProject(
       projectDir,
-      <String>['--template=plugin', '--platforms=web'],
+      <String>['--template=plugin', '--platform=web'],
       <String>[
         'lib/flutter_project.dart',
         'lib/flutter_project_web.dart',
@@ -606,7 +606,7 @@ void main() {
         '--org', 'com.bar.foo',
         '-i', 'objc',
         '-a', 'java',
-        '--platforms', 'android',
+        '--platform', 'android',
       ], <String>[
         'android/src/main/java/com/bar/foo/flutter_project/FlutterProjectPlugin.java',
         'example/android/app/src/main/java/com/bar/foo/flutter_project_example/MainActivity.java',
@@ -733,7 +733,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms', 'android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform', 'android', projectDir.path]);
 
     void expectExists(String relPath) {
       expect(globals.fs.isFileSync('${projectDir.path}/$relPath'), true);
@@ -752,7 +752,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--platforms', 'android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--platform', 'android', projectDir.path]);
 
     final String androidManifest = await globals.fs.file(
       '${projectDir.path}/android/app/src/main/AndroidManifest.xml'
@@ -859,7 +859,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=winuwp',
+      '--platform=winuwp',
       projectDir.path,
     ]);
 
@@ -885,7 +885,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=linux',
+      '--platform=linux',
       projectDir.path,
     ]);
 
@@ -908,7 +908,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=linux', projectDir.path]);
 
     expect(
         projectDir.childDirectory('linux').childFile('CMakeLists.txt'), exists);
@@ -946,7 +946,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=macos',
+      '--platform=macos',
       projectDir.path,
     ]);
 
@@ -970,7 +970,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=macos', projectDir.path]);
 
     expect(projectDir.childDirectory('macos').childFile('flutter_project.podspec'),
         exists);
@@ -1005,7 +1005,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=windows',
+      '--platform=windows',
       projectDir.path,
     ]);
 
@@ -1045,7 +1045,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', projectDir.path]);
 
     expect(projectDir.childDirectory('windows').childFile('CMakeLists.txt'),
         exists);
@@ -1091,7 +1091,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=web',
+      '--platform=web',
       projectDir.path,
     ]);
 
@@ -1118,7 +1118,7 @@ void main() {
     await runner.run(<String>[
       'create',
       '--no-pub',
-      '--platforms=web',
+      '--platform=web',
       projectDir.path,
     ]);
 
@@ -1899,7 +1899,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
 
     expect(projectDir.childDirectory('ios'), exists);
     expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
@@ -1919,7 +1919,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     expect(projectDir.childDirectory('android'), exists);
     expect(
@@ -1941,7 +1941,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=web', projectDir.path]);
     expect(
         projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
         exists);
@@ -1963,7 +1963,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=web', projectDir.path]);
     expect(
         projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
         isNot(exists));
@@ -1983,7 +1983,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
 
     expect(projectDir.childDirectory('ios'), exists);
     expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
@@ -1997,7 +1997,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     expect(projectDir.childDirectory('android'), exists);
     expect(
@@ -2012,7 +2012,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=linux', projectDir.path]);
 
     expect(projectDir.childDirectory('linux'), exists);
     expect(
@@ -2027,7 +2027,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=macos', projectDir.path]);
 
     expect(projectDir.childDirectory('macos'), exists);
     expect(
@@ -2042,7 +2042,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', projectDir.path]);
 
     expect(projectDir.childDirectory('windows'), exists);
     expect(
@@ -2057,7 +2057,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=web', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=web', projectDir.path]);
 
     expect(
         projectDir.childDirectory('lib').childFile('flutter_project_web.dart'),
@@ -2071,7 +2071,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
     expect(projectDir.childDirectory('ios'), exists);
     expect(projectDir.childDirectory('example').childDirectory('ios'), exists);
     validatePubspecForPlugin(projectDir: projectDir.absolute.path, expectedPlatforms: const <String>[
@@ -2079,7 +2079,7 @@ void main() {
     ], pluginClass: 'FlutterProjectPlugin',
     unexpectedPlatforms: <String>['some_platform']);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=macos', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=macos', projectDir.path]);
     expect(projectDir.childDirectory('macos'), exists);
     expect(
         projectDir.childDirectory('example').childDirectory('macos'), exists);
@@ -2116,7 +2116,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await expectLater(
-      runner.run(<String>['create', '--no-pub', '--template=module', '--platforms=ios', projectDir.path])
+      runner.run(<String>['create', '--no-pub', '--template=module', '--platform=ios', projectDir.path])
       , throwsToolExit(message: 'The "--platforms" argument is not supported', exitCode:2));
   });
 
@@ -2126,7 +2126,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
     await expectLater(
-      runner.run(<String>['create', '--no-pub', '--template=package', '--platforms=ios', projectDir.path])
+      runner.run(<String>['create', '--no-pub', '--template=package', '--platform=ios', projectDir.path])
       , throwsToolExit(message: 'The "--platforms" argument is not supported', exitCode: 2));
   });
 
@@ -2135,7 +2135,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
     expect(projectDir.childDirectory('android'), exists);
     expect(
         projectDir.childDirectory('example').childDirectory('android'), exists);
@@ -2158,7 +2158,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
     expect(projectDir.childDirectory('android'), exists);
     expect(
         projectDir.childDirectory('example').childDirectory('android'), exists);
@@ -2169,7 +2169,7 @@ void main() {
     expect(projectDir.childDirectory('example').childDirectory('android'),
         isNot(exists));
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', projectDir.path]);
 
     expect(projectDir.childDirectory('android'), exists);
     expect(
@@ -2186,7 +2186,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(projectDir.childDirectory('android'), isNot(exists));
@@ -2198,7 +2198,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(projectDir.childDirectory('windows'), isNot(exists));
@@ -2212,7 +2212,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(projectDir.childDirectory('linux'), isNot(exists));
@@ -2226,7 +2226,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(projectDir.childDirectory('lib').childFile('flutter_project_web.dart'), isNot(exists));
@@ -2239,7 +2239,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
 
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(projectDir.childDirectory('macos'), isNot(exists));
@@ -2257,9 +2257,9 @@ void main() {
     final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
     final String relativeExamplePath = globals.fs.path.normalize(globals.fs.path.join(relativePluginPath, 'example/lib/main.dart'));
 
-    await runner.run(<String>['create', '--no-pub', '--org=com.example', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--org=com.example', '--template=plugin', '--platform=android', projectDir.path]);
     expect(logger.statusText, contains('Your example app code is in $relativeExamplePath.\n'));
-    await runner.run(<String>['create', '--no-pub', '--org=com.example', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--org=com.example', '--template=plugin', '--platform=ios', projectDir.path]);
     expect(logger.statusText, contains('Your example app code is in $relativeExamplePath.\n'));
     await runner.run(<String>['create', '--no-pub', projectDir.path]);
     expect(logger.statusText, contains('Your example app code is in $relativeExamplePath.\n'));
@@ -2272,7 +2272,7 @@ void main() {
 
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
     final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
     expect(logger.statusText, isNot(contains('You need to update $relativePluginPath/pubspec.yaml to support android.\n')));
@@ -2287,9 +2287,9 @@ void main() {
     final CommandRunner<void> runner = createTestCommandRunner(command);
     final String projectDirPath = globals.fs.path.normalize(projectDir.absolute.path);
     final String relativePluginPath = globals.fs.path.normalize(globals.fs.path.relative(projectDirPath));
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
     expect(logger.statusText, isNot(contains('You need to update $relativePluginPath/pubspec.yaml to support ios.\n')));
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=android', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=android', projectDir.path]);
     expect(logger.statusText, contains('You need to update $relativePluginPath/pubspec.yaml to support android.\n'));
   }, overrides: <Type, Generator> {
     Logger: () => logger,
@@ -2332,7 +2332,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', '--skip-name-checks', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=linux', '--skip-name-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('linux');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';
@@ -2363,7 +2363,7 @@ void main() {
 
     const String projectName = 'foo_BarBaz';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', '--skip-name-checks', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', '--skip-name-checks', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('windows');
 
     const String classFilenameBase = 'foo_bar_baz_plugin';
@@ -2395,7 +2395,7 @@ void main() {
 
     const String projectName = 'foo_bar_plugin';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=linux', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=linux', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('linux');
 
     // If the project already ends in _plugin, it shouldn't be added again.
@@ -2431,7 +2431,7 @@ void main() {
 
     const String projectName = 'foo_bar_plugin';
     final Directory projectDir = tempDir.childDirectory(projectName);
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', projectDir.path]);
     final Directory platformDir = projectDir.childDirectory('windows');
 
     // If the project already ends in _plugin, it shouldn't be added again.
@@ -2481,7 +2481,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=ios', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=ios', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.errorText, isNot(contains(_kNoPlatformsMessage)));
 
@@ -2541,7 +2541,7 @@ void main() {
     final CreateCommand command = CreateCommand();
     final CommandRunner<void> runner = createTestCommandRunner(command);
 
-    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platforms=windows', projectDir.path]);
+    await runner.run(<String>['create', '--no-pub', '--template=plugin', '--platform=windows', projectDir.path]);
     await runner.run(<String>['create', '--no-pub', '--template=plugin', projectDir.path]);
     expect(logger.statusText, isNot(contains(_kDisabledPlatformRequestedMessage)));
 


### PR DESCRIPTION
Alias `--platforms=` for singular usage `--platform=macos` `--platform=web` etc.

Fixes https://github.com/flutter/flutter/issues/88075