### PR TITLE
Add platform tags to devicelab tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1169,7 +1169,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: analyzer_benchmark
     scheduler: luci
 
@@ -1179,7 +1179,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: android_defines_test
     scheduler: luci
 
@@ -1189,7 +1189,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: android_obfuscate_test
     scheduler: luci
 
@@ -1199,7 +1199,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: android_stack_size_test
     scheduler: luci
 
@@ -1209,7 +1209,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: android_view_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -1219,7 +1219,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: animated_image_gc_perf
     scheduler: luci
 
@@ -1229,7 +1229,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: animated_placeholder_perf__e2e_summary
     scheduler: luci
 
@@ -1239,7 +1239,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: backdrop_filter_perf__e2e_summary
     scheduler: luci
 
@@ -1249,7 +1249,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: basic_material_app_android__compile
     scheduler: luci
 
@@ -1259,7 +1259,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: color_filter_and_fade_perf__e2e_summary
     scheduler: luci
 
@@ -1269,7 +1269,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: complex_layout_android__compile
     scheduler: luci
 
@@ -1279,7 +1279,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: complex_layout_android__scroll_smoothness
     scheduler: luci
 
@@ -1289,7 +1289,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: complex_layout_scroll_perf__devtools_memory
     scheduler: luci
 
@@ -1299,7 +1299,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: complex_layout_semantics_perf
     scheduler: luci
 
@@ -1309,7 +1309,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: cubic_bezier_perf__e2e_summary
     scheduler: luci
 
@@ -1319,7 +1319,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: cubic_bezier_perf_sksl_warmup__e2e_summary
     scheduler: luci
 
@@ -1329,7 +1329,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: cull_opacity_perf__e2e_summary
     scheduler: luci
 
@@ -1339,7 +1339,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: devtools_profile_start_test
     scheduler: luci
 
@@ -1349,7 +1349,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: fast_scroll_heavy_gridview__memory
     scheduler: luci
 
@@ -1359,7 +1359,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_engine_group_performance
     scheduler: luci
 
@@ -1369,7 +1369,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__back_button_memory
     scheduler: luci
 
@@ -1379,7 +1379,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__image_cache_memory
     scheduler: luci
 
@@ -1389,7 +1389,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__memory_nav
     scheduler: luci
 
@@ -1399,7 +1399,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__start_up
     scheduler: luci
 
@@ -1409,7 +1409,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__transition_perf
     scheduler: luci
 
@@ -1420,7 +1420,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__transition_perf_e2e
     scheduler: luci
 
@@ -1430,7 +1430,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__transition_perf_hybrid
     scheduler: luci
 
@@ -1440,7 +1440,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery__transition_perf_with_semantics
     scheduler: luci
 
@@ -1450,7 +1450,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery_android__compile
     scheduler: luci
 
@@ -1460,7 +1460,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery_sksl_warmup__transition_perf
     scheduler: luci
 
@@ -1471,7 +1471,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery_sksl_warmup__transition_perf_e2e
     scheduler: luci
 
@@ -1481,7 +1481,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery_v2_chrome_run_test
     scheduler: luci
 
@@ -1491,7 +1491,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_gallery_v2_web_compile_test
     scheduler: luci
 
@@ -1501,7 +1501,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: flutter_test_performance
     scheduler: luci
 
@@ -1511,7 +1511,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: frame_policy_delay_test_android
     scheduler: luci
 
@@ -1521,7 +1521,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: hot_mode_dev_cycle_linux__benchmark
     scheduler: luci
 
@@ -1531,7 +1531,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: image_list_jit_reported_duration
     scheduler: luci
 
@@ -1541,7 +1541,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: image_list_reported_duration
     scheduler: luci
 
@@ -1551,7 +1551,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: large_image_changer_perf_android
     scheduler: luci
 
@@ -1561,7 +1561,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: linux_chrome_dev_mode
     scheduler: luci
 
@@ -1571,7 +1571,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: multi_widget_construction_perf__e2e_summary
     scheduler: luci
 
@@ -1581,7 +1581,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: new_gallery__crane_perf
     scheduler: luci
 
@@ -1591,7 +1591,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: picture_cache_perf__e2e_summary
     scheduler: luci
 
@@ -1601,7 +1601,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: platform_channels_benchmarks
     scheduler: luci
 
@@ -1611,7 +1611,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: platform_views_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -1621,7 +1621,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: routing_test
     scheduler: luci
 
@@ -1631,7 +1631,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: textfield_perf__e2e_summary
     scheduler: luci
 
@@ -1641,7 +1641,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","linux"]
       task_name: web_size__compile_test
     scheduler: luci
 
@@ -2296,7 +2296,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: android_semantics_integration_test
     scheduler: luci
 
@@ -2306,7 +2306,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: backdrop_filter_perf__timeline_summary
     scheduler: luci
 
@@ -2316,7 +2316,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: channels_integration_test
     scheduler: luci
 
@@ -2326,7 +2326,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: color_filter_and_fade_perf__timeline_summary
     scheduler: luci
 
@@ -2336,7 +2336,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: complex_layout__start_up
     scheduler: luci
 
@@ -2346,7 +2346,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: complex_layout_scroll_perf__memory
     scheduler: luci
 
@@ -2356,7 +2356,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: complex_layout_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -2366,7 +2366,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: cubic_bezier_perf__timeline_summary
     scheduler: luci
 
@@ -2376,7 +2376,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: cubic_bezier_perf_sksl_warmup__timeline_summary
     scheduler: luci
 
@@ -2386,7 +2386,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: cull_opacity_perf__timeline_summary
     scheduler: luci
 
@@ -2396,7 +2396,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: drive_perf_debug_warning
     scheduler: luci
 
@@ -2406,7 +2406,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: embedded_android_views_integration_test
     scheduler: luci
 
@@ -2416,7 +2416,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: external_ui_integration_test
     scheduler: luci
 
@@ -2426,7 +2426,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: fading_child_animation_perf__timeline_summary
     scheduler: luci
 
@@ -2436,7 +2436,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: fast_scroll_large_images__memory
     scheduler: luci
 
@@ -2446,7 +2446,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: flavors_test
     scheduler: luci
 
@@ -2456,7 +2456,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: flutter_view__start_up
     scheduler: luci
 
@@ -2466,7 +2466,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: fullscreen_textfield_perf__timeline_summary
     scheduler: luci
 
@@ -2476,7 +2476,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: hello_world__memory
     scheduler: luci
 
@@ -2486,7 +2486,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: hello_world_android__compile
     scheduler: luci
 
@@ -2496,7 +2496,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: home_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -2506,7 +2506,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: hot_mode_dev_cycle__benchmark
     scheduler: luci
 
@@ -2516,7 +2516,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: hybrid_android_views_integration_test
     scheduler: luci
 
@@ -2526,7 +2526,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: imagefiltered_transform_animation_perf__timeline_summary
     scheduler: luci
 
@@ -2536,7 +2536,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_test_test
     scheduler: luci
 
@@ -2546,7 +2546,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_ui_driver
     scheduler: luci
 
@@ -2556,7 +2556,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_ui_frame_number
     scheduler: luci
 
@@ -2566,7 +2566,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_ui_keyboard_resize
     scheduler: luci
 
@@ -2576,7 +2576,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_ui_screenshot
     scheduler: luci
 
@@ -2586,7 +2586,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: integration_ui_textfield
     scheduler: luci
 
@@ -2596,7 +2596,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: microbenchmarks
     scheduler: luci
 
@@ -2606,7 +2606,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: new_gallery__transition_perf
     scheduler: luci
 
@@ -2616,7 +2616,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: picture_cache_perf__timeline_summary
     scheduler: luci
 
@@ -2626,7 +2626,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: platform_channel_sample_test
     scheduler: luci
 
@@ -2636,7 +2636,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: platform_interaction_test
     scheduler: luci
 
@@ -2646,7 +2646,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: platform_view__start_up
     scheduler: luci
 
@@ -2656,7 +2656,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: run_release_test
     scheduler: luci
 
@@ -2666,7 +2666,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: service_extensions_test
     scheduler: luci
 
@@ -2676,7 +2676,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: smoke_catalina_start_up
     scheduler: luci
 
@@ -2686,7 +2686,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: textfield_perf__timeline_summary
     scheduler: luci
 
@@ -2696,7 +2696,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","mac"]
       task_name: tiles_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -2707,7 +2707,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
     scheduler: luci
 
@@ -2717,7 +2717,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: backdrop_filter_perf_ios__timeline_summary
     scheduler: luci
 
@@ -2727,7 +2727,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: basic_material_app_ios__compile
     scheduler: luci
 
@@ -2737,7 +2737,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: channels_integration_test_ios
     scheduler: luci
 
@@ -2747,7 +2747,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: complex_layout_ios__compile
     scheduler: luci
 
@@ -2757,7 +2757,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: complex_layout_ios__start_up
     scheduler: luci
 
@@ -2767,7 +2767,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: complex_layout_scroll_perf_ios__timeline_summary
     scheduler: luci
 
@@ -2777,7 +2777,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: cubic_bezier_perf_ios_sksl_warmup__timeline_summary
     scheduler: luci
 
@@ -2787,7 +2787,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: external_ui_integration_test_ios
     scheduler: luci
 
@@ -2797,7 +2797,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flavors_test_ios
     scheduler: luci
 
@@ -2807,7 +2807,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
     scheduler: luci
 
@@ -2817,7 +2817,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_gallery_ios__compile
     scheduler: luci
 
@@ -2827,7 +2827,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_gallery_ios__start_up
     scheduler: luci
 
@@ -2837,7 +2837,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_gallery_ios__transition_perf
     scheduler: luci
 
@@ -2847,7 +2847,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_gallery_ios_sksl_warmup__transition_perf
     scheduler: luci
 
@@ -2857,7 +2857,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: flutter_view_ios__start_up
     scheduler: luci
 
@@ -2867,7 +2867,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: hello_world_ios__compile
     scheduler: luci
 
@@ -2877,7 +2877,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     scheduler: luci
 
@@ -2887,7 +2887,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_test_test_ios
     scheduler: luci
 
@@ -2897,7 +2897,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_ui_ios_driver
     scheduler: luci
 
@@ -2907,7 +2907,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_ui_ios_frame_number
     scheduler: luci
 
@@ -2917,7 +2917,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_ui_ios_keyboard_resize
     scheduler: luci
 
@@ -2927,7 +2927,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_ui_ios_screenshot
     scheduler: luci
 
@@ -2937,7 +2937,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: integration_ui_ios_textfield
     scheduler: luci
 
@@ -2947,7 +2947,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: ios_app_with_extensions_test
     scheduler: luci
 
@@ -2957,7 +2957,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: ios_content_validation_test
     scheduler: luci
 
@@ -2967,7 +2967,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: ios_defines_test
     scheduler: luci
 
@@ -2977,7 +2977,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: ios_platform_view_tests
     scheduler: luci
 
@@ -2987,7 +2987,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: large_image_changer_perf_ios
     scheduler: luci
 
@@ -2997,7 +2997,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: macos_chrome_dev_mode
     scheduler: luci
 
@@ -3007,7 +3007,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: microbenchmarks_ios
     scheduler: luci
 
@@ -3017,7 +3017,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: new_gallery_ios__transition_perf
     scheduler: luci
 
@@ -3027,7 +3027,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_channel_sample_test_ios
     scheduler: luci
 
@@ -3037,7 +3037,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_channel_sample_test_swift
     scheduler: luci
 
@@ -3047,7 +3047,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_channels_benchmarks_ios
     scheduler: luci
 
@@ -3057,7 +3057,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_interaction_test_ios
     scheduler: luci
 
@@ -3067,7 +3067,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_view_ios__start_up
     scheduler: luci
 
@@ -3077,7 +3077,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: platform_views_scroll_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3087,7 +3087,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: post_backdrop_filter_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3097,7 +3097,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: simple_animation_perf_ios
     scheduler: luci
 
@@ -3107,7 +3107,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: smoke_catalina_hot_mode_dev_cycle_ios__benchmark
     scheduler: luci
 
@@ -3117,7 +3117,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios","mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3128,7 +3128,7 @@ targets:
     timeout: 90
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios32","mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios32
     scheduler: luci
 
@@ -3139,7 +3139,7 @@ targets:
     timeout: 90
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","ios32","mac"]
       task_name: native_ui_tests_ios32
     scheduler: luci
 
@@ -3682,7 +3682,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: basic_material_app_win__compile
     scheduler: luci
 
@@ -3692,7 +3692,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: channels_integration_test_win
     scheduler: luci
 
@@ -3702,7 +3702,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: complex_layout_win__compile
     scheduler: luci
 
@@ -3712,7 +3712,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: flavors_test_win
     scheduler: luci
 
@@ -3722,7 +3722,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: flutter_gallery_win__compile
     scheduler: luci
 
@@ -3732,7 +3732,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: hot_mode_dev_cycle_win__benchmark
     scheduler: luci
 
@@ -3742,6 +3742,6 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab"]
+        ["devicelab","android","windows"]
       task_name: windows_chrome_dev_mode
     scheduler: luci


### PR DESCRIPTION
This is to better support labeling tests: adding platform tags. This way we can query by flexible label/tags, not limited by the builder_name.

These tags will be promoted to the properties of the build, which will be further populated to the swarming bigquery table. 

https://github.com/flutter/flutter/issues/83916