### PR TITLE
Bump snippets to 0.2.3, fix redundant global activate in docs.sh

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -19,7 +19,7 @@ import 'package:path/path.dart' as path;
 import 'package:watcher/watcher.dart';
 
 // If you update this version, also update it in dev/bots/docs.sh
-const String _snippetsActivateVersion = '0.2.2';
+const String _snippetsActivateVersion = '0.2.3';
 
 final String _flutterRoot = path.dirname(path.dirname(path.dirname(path.fromUri(Platform.script))));
 final String _defaultFlutterPackage = path.join(_flutterRoot, 'packages', 'flutter', 'lib');

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -26,13 +26,7 @@ function generate_docs() {
     # assets-for-api-docs repo:
     # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
     # >>> If you update this version, also update it in dev/bots/analyze_sample_code.dart <<<
-    "$PUB" global activate snippets 0.2.2
-
-    # Install and activate the snippets tool, which resides in the
-    # assets-for-api-docs repo:
-    # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
-    # >>> If you update this version, also update it in dev/bots/analyze_sample_code.dart <<<
-    "$PUB" global activate snippets 0.2.1
+    "$PUB" global activate snippets 0.2.3
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.


### PR DESCRIPTION
## Description

This bumps the snippets package activation to 0.2.3, in order to pick up bug fixes and changes to publishing snippets.

Also, fixes a merge error in `docs.sh` where it was activating the package twice.