### PR TITLE
Revert "Update MaterialScrollBehavior.buildScrollbar for horizontal axes"

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -693,13 +693,8 @@ class MaterialApp extends StatefulWidget {
 /// [GlowingOverscrollIndicator] to [Scrollable] descendants when executing on
 /// [TargetPlatform.android] and [TargetPlatform.fuchsia].
 ///
-/// The [buildScrollbar] function is called by the [Scrollable] to wrap with a
-/// [Scrollbar] when appropriate. On all platforms, when the Scrollable [Axis] is
-/// [Axis.horizontal], an always visible Scrollbar will be applied. This is
-/// because horizontal [ScrollView]s have lower discoverability as scrollable
-/// content. When the Axis is [Axis.vertical] a Scrollbar is applied on
-/// desktop platforms. In this vertical case, [Scrollbar.isAlwaysShown] is not
-/// set and will defer to the inherited [ScrollbarTheme].
+/// When using the desktop platform, if the [Scrollable] widget scrolls in the
+/// [Axis.vertical], a [Scrollbar] is applied.
 ///
 /// See also:
 ///
@@ -721,11 +716,7 @@ class MaterialScrollBehavior extends ScrollBehavior {
     // the base class as well.
     switch (axisDirectionToAxis(details.direction)) {
       case Axis.horizontal:
-        return Scrollbar(
-          isAlwaysShown: true,
-          controller: details.controller,
-          child: child,
-        );
+        return child;
       case Axis.vertical:
         switch (getPlatform(context)) {
           case TargetPlatform.linux:

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1308,16 +1308,13 @@ class _TabBarState extends State<TabBar> {
 
     if (widget.isScrollable) {
       _scrollController ??= _TabBarScrollController(this);
-      tabBar = ScrollConfiguration(
-        behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
-        child: SingleChildScrollView(
-          dragStartBehavior: widget.dragStartBehavior,
-          scrollDirection: Axis.horizontal,
-          controller: _scrollController,
-          padding: widget.padding,
-          physics: widget.physics,
-          child: tabBar,
-        ),
+      tabBar = SingleChildScrollView(
+        dragStartBehavior: widget.dragStartBehavior,
+        scrollDirection: Axis.horizontal,
+        controller: _scrollController,
+        padding: widget.padding,
+        physics: widget.physics,
+        child: tabBar,
       );
     } else if (widget.padding != null) {
       tabBar = Padding(

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1557,20 +1557,4 @@ void main() {
         ),
     );
   });
-
-  testWidgets('MaterialScrollBehavior applies always shown Scrollbar to horizontal scrollables', (WidgetTester tester) async {
-    final ScrollController controller = ScrollController();
-    await tester.pumpWidget(MaterialApp(
-      home: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        controller: controller,
-        child: const SizedBox(
-          width: 4000.0,
-          height: 4000.0,
-        ),
-      ),
-    ));
-    await tester.pumpAndSettle();
-    expect(find.byType(Scrollbar), paints..rect());
-  });
 }


### PR DESCRIPTION
Reverts flutter/flutter#87740

This is causing google3 scuba failures. The horizontal scrollbar is added to horizontally scrolling carousels of Material cards that presumably should never have a scrollbar.

Before re-applying, we need to opt those out of this change or find a smarter way to decide whether the horizontal scrollbar is shown.

/cc @Piinks @angjieli 