### PR TITLE
Bump to Gradle 7 and use Open JDK 11

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1266,41 +1266,61 @@ targets:
   - name: Linux_android complex_layout_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab"]
       task_name: complex_layout_android__compile
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_android__scroll_smoothness
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab"]
       task_name: complex_layout_android__scroll_smoothness
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_scroll_perf__devtools_memory
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab"]
       task_name: complex_layout_scroll_perf__devtools_memory
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_semantics_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab"]
       task_name: complex_layout_semantics_perf
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
     scheduler: luci
 
   - name: Linux_android cubic_bezier_perf__e2e_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1276,6 +1276,10 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_android__scroll_smoothness
@@ -1290,6 +1294,10 @@ targets:
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
         ]
     scheduler: luci
 
@@ -1306,6 +1314,10 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_semantics_perf
@@ -1320,6 +1332,10 @@ targets:
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
         ]
     scheduler: luci
 

--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Migrate a single test to Gradle 7 and use Open JDK 11.

Issue: https://github.com/flutter/flutter/issues/87649
Related PR: https://github.com/flutter/flutter/pull/87761