### PR TITLE
Add favicon link to web template

### DIFF
--- a/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
@@ -26,6 +26,9 @@
   <meta name="apple-mobile-web-app-title" content="{{projectName}}">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" href="favicon.png"/>
+
   <title>{{projectName}}</title>
   <link rel="manifest" href="manifest.json">
 </head>


### PR DESCRIPTION
The discussion is here: https://github.com/flutter/flutter/issues/87828

It was accidentally removed in a previous commit.