### PR TITLE
Rename IOSDeviceInterface to IOSDeviceConnectionInterface

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -138,12 +138,6 @@ class IOSDevices extends PollingDeviceDiscovery {
   List<String> get wellKnownIds => const <String>[];
 }
 
-enum IOSDeviceInterface {
-  none,
-  usb,
-  network,
-}
-
 class IOSDevice extends Device {
   IOSDevice(String id, {
     @required FileSystem fileSystem,
@@ -191,13 +185,13 @@ class IOSDevice extends Device {
   }
 
   @override
-  bool get supportsHotReload => interfaceType == IOSDeviceInterface.usb;
+  bool get supportsHotReload => interfaceType == IOSDeviceConnectionInterface.usb;
 
   @override
-  bool get supportsHotRestart => interfaceType == IOSDeviceInterface.usb;
+  bool get supportsHotRestart => interfaceType == IOSDeviceConnectionInterface.usb;
 
   @override
-  bool get supportsFlutterExit => interfaceType == IOSDeviceInterface.usb;
+  bool get supportsFlutterExit => interfaceType == IOSDeviceConnectionInterface.usb;
 
   @override
   final String name;
@@ -207,7 +201,7 @@ class IOSDevice extends Device {
 
   final DarwinArch cpuArchitecture;
 
-  final IOSDeviceInterface interfaceType;
+  final IOSDeviceConnectionInterface interfaceType;
 
   Map<IOSApp, DeviceLogReader> _logReaders;
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -19,7 +19,7 @@ import '../base/process.dart';
 import '../cache.dart';
 import '../convert.dart';
 import 'code_signing.dart';
-import 'devices.dart';
+import 'iproxy.dart';
 
 // Error message patterns from ios-deploy output
 const String noProvisioningProfileErrorOne = 'Error 0xe8008015';
@@ -91,7 +91,7 @@ class IOSDeploy {
     @required String bundlePath,
     @required Directory appDeltaDirectory,
     @required List<String>launchArguments,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) async {
     appDeltaDirectory?.createSync(recursive: true);
     final List<String> launchCommand = <String>[
@@ -104,7 +104,7 @@ class IOSDeploy {
         '--app_deltas',
         appDeltaDirectory.path,
       ],
-      if (interfaceType != IOSDeviceInterface.network)
+      if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',
@@ -129,7 +129,7 @@ class IOSDeploy {
     @required String bundlePath,
     @required Directory appDeltaDirectory,
     @required List<String> launchArguments,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) {
     appDeltaDirectory?.createSync(recursive: true);
     // Interactive debug session to support sending the lldb detach command.
@@ -148,7 +148,7 @@ class IOSDeploy {
         appDeltaDirectory.path,
       ],
       '--debug',
-      if (interfaceType != IOSDeviceInterface.network)
+      if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',
@@ -171,7 +171,7 @@ class IOSDeploy {
     @required String bundlePath,
     @required Directory appDeltaDirectory,
     @required List<String> launchArguments,
-    @required IOSDeviceInterface interfaceType,
+    @required IOSDeviceConnectionInterface interfaceType,
   }) async {
     appDeltaDirectory?.createSync(recursive: true);
     final List<String> launchCommand = <String>[
@@ -184,7 +184,7 @@ class IOSDeploy {
         '--app_deltas',
         appDeltaDirectory.path,
       ],
-      if (interfaceType != IOSDeviceInterface.network)
+      if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
       '--justlaunch',
       if (launchArguments.isNotEmpty) ...<String>[

--- a/packages/flutter_tools/lib/src/ios/iproxy.dart
+++ b/packages/flutter_tools/lib/src/ios/iproxy.dart
@@ -8,6 +8,12 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 
+enum IOSDeviceConnectionInterface {
+  none,
+  usb,
+  network,
+}
+
 /// Wraps iproxy command line tool port forwarding.
 ///
 /// See https://github.com/libimobiledevice/libusbmuxd.
@@ -19,6 +25,7 @@ class IProxy {
     required MapEntry<String, String> dyLdLibEntry,
   }) : _dyLdLibEntry = dyLdLibEntry,
         _processUtils = ProcessUtils(processManager: processManager, logger: logger),
+        _logger = logger,
         _iproxyPath = iproxyPath;
 
   /// Create a [IProxy] for testing.
@@ -41,6 +48,7 @@ class IProxy {
 
   final String _iproxyPath;
   final ProcessUtils _processUtils;
+  final Logger _logger;
   final MapEntry<String, String> _dyLdLibEntry;
 
   Future<Process> forward(int devicePort, int hostPort, String deviceId) {
@@ -51,6 +59,8 @@ class IProxy {
         '$hostPort:$devicePort',
         '--udid',
         deviceId,
+        if (_logger.isVerbose)
+          '--debug',
       ],
       environment: Map<String, String>.fromEntries(
         <MapEntry<String, String>>[_dyLdLibEntry],

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -25,7 +25,7 @@ import '../project.dart';
 import '../reporting/reporting.dart';
 import 'application_package.dart';
 import 'code_signing.dart';
-import 'devices.dart';
+import 'iproxy.dart';
 import 'migrations/deployment_target_migration.dart';
 import 'migrations/project_base_configuration_migration.dart';
 import 'migrations/project_build_location_migration.dart';
@@ -73,7 +73,7 @@ class IMobileDevice {
   Future<void> takeScreenshot(
     File outputFile,
     String deviceID,
-    IOSDeviceInterface interfaceType,
+    IOSDeviceConnectionInterface interfaceType,
   ) {
     return _processUtils.run(
       <String>[
@@ -81,7 +81,7 @@ class IMobileDevice {
         outputFile.path,
         '--udid',
         deviceID,
-        if (interfaceType == IOSDeviceInterface.network)
+        if (interfaceType == IOSDeviceConnectionInterface.network)
           '--network',
       ],
       throwOnError: true,

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -293,11 +293,11 @@ class XCDevice {
           }
         }
 
-        final IOSDeviceInterface interface = _interfaceType(device);
+        final IOSDeviceConnectionInterface interface = _interfaceType(device);
 
         // Only support USB devices, skip "network" interface (Xcode > Window > Devices and Simulators > Connect via network).
         // TODO(jmagman): Remove this check once wirelessly detected devices can be observed and attached, https://github.com/flutter/flutter/issues/15072.
-        if (interface != IOSDeviceInterface.usb) {
+        if (interface != IOSDeviceConnectionInterface.usb) {
           continue;
         }
 
@@ -353,18 +353,18 @@ class XCDevice {
     return null;
   }
 
-  static IOSDeviceInterface _interfaceType(Map<String, dynamic> deviceProperties) {
+  static IOSDeviceConnectionInterface _interfaceType(Map<String, dynamic> deviceProperties) {
     // Interface can be "usb", "network", or "none" for simulators
     // and unknown future interfaces.
     if (deviceProperties.containsKey('interface')) {
       if ((deviceProperties['interface'] as String).toLowerCase() == 'network') {
-        return IOSDeviceInterface.network;
+        return IOSDeviceConnectionInterface.network;
       } else {
-        return IOSDeviceInterface.usb;
+        return IOSDeviceConnectionInterface.usb;
       }
     }
 
-    return IOSDeviceInterface.none;
+    return IOSDeviceConnectionInterface.none;
   }
 
   static String _sdkVersion(Map<String, dynamic> deviceProperties) {

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -76,7 +76,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       );
     });
 
@@ -92,7 +92,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '1.0.0',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       ).majorSdkVersion, 1);
       expect(IOSDevice(
         'device-123',
@@ -105,7 +105,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '13.1.1',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       ).majorSdkVersion, 13);
       expect(IOSDevice(
         'device-123',
@@ -118,7 +118,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '10',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       ).majorSdkVersion, 10);
       expect(IOSDevice(
         'device-123',
@@ -131,7 +131,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: '0',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       ).majorSdkVersion, 0);
       expect(IOSDevice(
         'device-123',
@@ -144,7 +144,7 @@ void main() {
         name: 'iPhone 1',
         cpuArchitecture: DarwinArch.arm64,
         sdkVersion: 'bogus',
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       ).majorSdkVersion, 0);
     });
 
@@ -160,7 +160,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3 17C54',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       );
 
       expect(await device.sdkNameAndVersion,'iOS 13.3 17C54');
@@ -178,7 +178,7 @@ void main() {
         name: 'iPhone 1',
         sdkVersion: '13.3',
         cpuArchitecture: DarwinArch.arm64,
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       );
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);
@@ -202,7 +202,7 @@ void main() {
               name: 'iPhone 1',
               sdkVersion: '13.3',
               cpuArchitecture: DarwinArch.arm64,
-              interfaceType: IOSDeviceInterface.usb,
+              interfaceType: IOSDeviceConnectionInterface.usb,
             );
           },
           throwsAssertionError,
@@ -290,7 +290,7 @@ void main() {
           name: 'iPhone 1',
           sdkVersion: '13.3',
           cpuArchitecture: DarwinArch.arm64,
-          interfaceType: IOSDeviceInterface.usb,
+          interfaceType: IOSDeviceConnectionInterface.usb,
         );
         logReader1 = createLogReader(device, appPackage1, process1);
         logReader2 = createLogReader(device, appPackage2, process2);
@@ -351,7 +351,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       );
 
       device2 = IOSDevice(
@@ -365,7 +365,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         fileSystem: MemoryFileSystem.test(),
-        interfaceType: IOSDeviceInterface.usb,
+        interfaceType: IOSDeviceConnectionInterface.usb,
       );
     });
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -14,8 +14,8 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/ios/devices.dart';
 import 'package:flutter_tools/src/ios/ios_deploy.dart';
+import 'package:flutter_tools/src/ios/iproxy.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -74,7 +74,7 @@ void main () {
         bundlePath: '/',
         appDeltaDirectory: appDeltaDirectory,
         launchArguments: <String>['--enable-dart-profiling'],
-        interfaceType: IOSDeviceInterface.network,
+        interfaceType: IOSDeviceConnectionInterface.network,
       );
 
       expect(await iosDeployDebugger.launchAndAttach(), isTrue);

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -61,7 +61,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceInterface.usb,
+      interfaceType: IOSDeviceConnectionInterface.usb,
       artifacts: artifacts,
     );
     final bool wasInstalled = await device.installApp(iosApp);
@@ -90,7 +90,7 @@ void main() {
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
       fileSystem: fileSystem,
-      interfaceType: IOSDeviceInterface.network,
+      interfaceType: IOSDeviceConnectionInterface.network,
       artifacts: artifacts,
     );
     final bool wasInstalled = await device.installApp(iosApp);
@@ -275,7 +275,7 @@ IOSDevice setUpIOSDevice({
   @required ProcessManager processManager,
   FileSystem fileSystem,
   Logger logger,
-  IOSDeviceInterface interfaceType,
+  IOSDeviceConnectionInterface interfaceType,
   Artifacts artifacts,
 }) {
   logger ??= BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -87,6 +87,6 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
     sdkVersion: '13.3',
     cpuArchitecture: DarwinArch.arm64,
     iProxy: IProxy.test(logger: BufferLogger.test(), processManager: FakeProcessManager.any()),
-    interfaceType: IOSDeviceInterface.usb,
+    interfaceType: IOSDeviceConnectionInterface.usb,
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -265,7 +265,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     cpuArchitecture: DarwinArch.arm64,
-    interfaceType: IOSDeviceInterface.usb,
+    interfaceType: IOSDeviceConnectionInterface.usb,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -379,7 +379,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     cpuArchitecture: DarwinArch.arm64,
-    interfaceType: IOSDeviceInterface.usb,
+    interfaceType: IOSDeviceConnectionInterface.usb,
   );
 }
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/ios/devices.dart';
+import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
@@ -77,7 +77,7 @@ void main() {
         expect(() async => iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceInterface.usb,
+          IOSDeviceConnectionInterface.usb,
         ), throwsA(anything));
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       });
@@ -100,7 +100,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceInterface.usb,
+          IOSDeviceConnectionInterface.usb,
         );
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       });
@@ -123,7 +123,7 @@ void main() {
         await iMobileDevice.takeScreenshot(
           outputFile,
           '1234',
-          IOSDeviceInterface.network,
+          IOSDeviceConnectionInterface.network,
         );
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       });


### PR DESCRIPTION
I renamed this enum in https://github.com/flutter/flutter/pull/60408 but abandoned it because the feature didn't work, but I'd still like the name change.

Also move the enum to null-safe `iproxy.dart`.  This will unblock a few of these libraries from being migrated to null safety.