### PR TITLE
[flutter_tools] Fix hang in DesktopLogReader

### DIFF
--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -289,17 +289,13 @@ void main() {
     final FakeDesktopDevice device = setUpDesktopDevice(
       processManager: processManager,
     );
-    final Completer<void> testCompleter = Completer<void>();
-    final List<String> logOutput = <String>[];
-    device.getLogReader().logLines.listen((String line) {
-      logOutput.add(line);
-    }, onDone: () {
-      expect(logOutput, contains('Oops'));
-      testCompleter.complete();
-    });
     unawaited(Future<void>(() {
       exitCompleter.complete();
     }));
+
+    // Start looking for 'Oops' in the stream before starting the app.
+    expect(device.getLogReader().logLines, emits('Oops'));
+
     final FakeApplicationPackage package = FakeApplicationPackage();
     await device.startApp(
       package,
@@ -309,7 +305,6 @@ void main() {
         dartEntrypointArgs: <String>['arg1', 'arg2'],
       ),
     );
-    await testCompleter.future;
   });
 }
 


### PR DESCRIPTION
When `asFuture()` is called on the stream subscriptions for process stdout and stderr after the exitCode future has completed, it can be too late for the returned Futures to ever be completed causing the tool to hang as in:

https://luci-milo.appspot.com/ui/p/flutter/builders/prod/Mac_ios_staging%20hot_mode_dev_cycle_macos_target__benchmark/1016/overview

This PR calls `asFuture` before the completion of the exitCode future has a chance to be noticed such that the returned Futures will be completed as expected.

I've modified the related test to be simpler. I had made it more complex in my last PR due to not understanding this problem.