### PR TITLE
Revert "Bump to Gradle 7 and use Open JDK 11"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1266,77 +1266,41 @@ targets:
   - name: Linux_android complex_layout_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","linux"]
       task_name: complex_layout_android__compile
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_android__scroll_smoothness
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","linux"]
       task_name: complex_layout_android__scroll_smoothness
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_scroll_perf__devtools_memory
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","linux"]
       task_name: complex_layout_scroll_perf__devtools_memory
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
     scheduler: luci
 
   - name: Linux_android complex_layout_semantics_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","linux"]
       task_name: complex_layout_semantics_perf
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
     scheduler: luci
 
   - name: Linux_android cubic_bezier_perf__e2e_summary

--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/benchmarks/complex_layout/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Reverts flutter/flutter#88133

Suspected to have broken the tree: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20tiles_scroll_perf__timeline_summary/2222/overview