### PR TITLE
Autocomplete: support asynchronous options

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -751,16 +751,22 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
 
   // Called when _textEditingController changes.
   void _onChangedField() {
-    final Iterable<T> options = widget.optionsBuilder(
-      _textEditingController.value,
-    );
-    _options = options;
+    _updateOptions();
     _updateHighlight(_highlightedOptionIndex.value);
     if (_selection != null
         && _textEditingController.text != widget.displayStringForOption(_selection!)) {
       _selection = null;
     }
     _updateOverlay();
+  }
+
+  // Called when the field's text changes, or when the widget configuration
+  // changes while the overlay is visible.
+  void _updateOptions() {
+    final Iterable<T> options = widget.optionsBuilder(
+      _textEditingController.value,
+    );
+    _options = options;
   }
 
   // Called when the field's FocusNode changes.
@@ -907,6 +913,9 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     );
     _updateFocusNode(oldWidget.focusNode, widget.focusNode);
     SchedulerBinding.instance!.addPostFrameCallback((Duration _) {
+       if (_shouldShowOptions) {
+         _updateOptions();
+       }
       _updateOverlay();
     });
   }

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -647,6 +647,52 @@ void main() {
     );
   });
 
+  testWidgets('rebuilds the options while they are visible', (WidgetTester tester) async {
+    final GlobalKey fieldKey = GlobalKey();
+    final GlobalKey optionsKey = GlobalKey();
+    final List<String> availableOptions = List<String>.of(kOptions);
+    Iterable<String>? lastOptions;
+    Widget builder() {
+      return MaterialApp(
+        home: Scaffold(
+          body: RawAutocomplete<String>(
+            optionsBuilder: (TextEditingValue textEditingValue) {
+              lastOptions = List<String>.of(availableOptions).where((String option) {
+                return option.contains(textEditingValue.text.toLowerCase());
+              });
+              return lastOptions!;
+            },
+            optionsViewBuilder: (BuildContext context, AutocompleteOnSelected<String> onSelected, Iterable<String> options) {
+              return Container(key: optionsKey);
+            },
+            fieldViewBuilder: (BuildContext context, TextEditingController textEditingController, FocusNode focusNode, VoidCallback onFieldSubmitted) {
+              return TextField(
+                key: fieldKey,
+                autofocus: true,
+                focusNode: focusNode,
+                controller: textEditingController,
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+
+    // Enter text to show the options.
+    await tester.enterText(find.byKey(fieldKey), 'go');
+    await tester.pumpAndSettle();
+    expect(find.byKey(optionsKey), findsOneWidget);
+    expect(lastOptions, <String>['dingo', 'flamingo', 'goose']);
+
+    // Rebuild the options while they are visible.
+    availableOptions.add('gorilla');
+    await tester.pumpWidget(builder());
+    expect(find.byKey(optionsKey), findsOneWidget);
+    expect(lastOptions, <String>['dingo', 'flamingo', 'goose', 'gorilla']);
+  });
+
   testWidgets('can navigate options with the keyboard', (WidgetTester tester) async {
     final GlobalKey fieldKey = GlobalKey();
     final GlobalKey optionsKey = GlobalKey();


### PR DESCRIPTION
This change adds support for asynchronous options for use cases where new options are not immediately available as the user types.

Fixes: #87521

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

