### PR TITLE
Allow small overflow in RenderParagraph

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -497,9 +497,11 @@ class RenderParagraph extends RenderBox
     final bool widthMatters = softWrap || overflow == TextOverflow.ellipsis;
     _textPainter.layout(
       minWidth: minWidth,
-      maxWidth: widthMatters ?
-        maxWidth :
-        double.infinity,
+      maxWidth: widthMatters
+        // Add tolerance to allow small overflow for cases when constraints
+        // are slightly smaller than it is needed to layout the text without overflow
+        ? maxWidth + precisionErrorTolerance
+        : double.infinity,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -139,7 +139,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   /// The animation controller that the route uses to drive the transitions.
   ///
   /// The animation itself is exposed by the [animation] property.
-  @protected
+  @visibleForTesting
   AnimationController? get controller => _controller;
   AnimationController? _controller;
 

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -1320,6 +1320,63 @@ void main() {
     },
   );
 
+  testWidgets('CupertinoNavigationBar is not flickering', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/71389
+    late BuildContext secondPageContext;
+
+    Widget createPage(BuildContext context, String title) {
+      return Center(
+        child: SizedBox(
+          width: 392.72727272727275,
+          child: CupertinoPageScaffold(
+            navigationBar: CupertinoNavigationBar(
+              middle: Text(
+                title,
+                overflow: TextOverflow.clip,
+              ),
+            ),
+            child: Center(
+              child: CupertinoButton(
+                child: const Text('Go'),
+                onPressed: () {
+                  Navigator.pushNamed(context, '/second');
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        title: 'Flutter Demo',
+        home: Builder(
+          builder: (BuildContext context) => createPage(context, 'First Page'),
+        ),
+        routes: <String, WidgetBuilder>{
+          '/second': (BuildContext context) {
+            secondPageContext = context;
+            return createPage(context, 'Second Page');
+          },
+        },
+      ),
+    );
+
+    await tester.tap(find.text('Go'));
+
+    await tester.pump();
+
+    final AnimationController controller = ModalRoute.of(secondPageContext)!.controller!;
+    controller.value = 0.16247749999999997;
+
+    await tester.pump();
+
+    // Not working...
+
+    // expect(find.text('First Page').first, isNot(paints..clipRect()));
+  });
+
   testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/71389
     await tester.pumpWidget(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/42988

| With fix | Without |
| - | - |
| ![Screenshot_1629048488](https://user-images.githubusercontent.com/39104740/129487149-f3f87287-16dc-4c7b-812b-b60e07c05c0c.png) | ![Screenshot_1629048654](https://user-images.githubusercontent.com/39104740/129487152-f2030287-994f-4a2a-921e-873dd113b0e6.png) |

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].


