### PR TITLE
Animation controller test

### DIFF
--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -57,6 +57,7 @@ void main() {
     expect(didDismiss, isTrue);
 
     controller.stop();
+    controller.dispose();
   });
 
   test('Receives status callbacks for forward and reverse', () {
@@ -118,6 +119,7 @@ void main() {
     expect(valueLog, equals(<AnimationStatus>[]));
 
     controller.stop();
+    controller.dispose();
   });
 
   test('Forward and reverse from values', () {
@@ -144,6 +146,7 @@ void main() {
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.dismissed, AnimationStatus.forward ]));
     expect(valueLog, equals(<double>[ 0.0 ]));
     expect(controller.value, equals(0.0));
+    controller.dispose();
   });
 
   test('Forward and reverse with different durations', () {
@@ -207,6 +210,7 @@ void main() {
     tick(const Duration(milliseconds: 310));
     expect(controller.value, moreOrLessEquals(0.0));
     controller.stop();
+    controller.dispose();
   });
 
   test('Forward only from value', () {
@@ -226,6 +230,7 @@ void main() {
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward ]));
     expect(valueLog, equals(<double>[ 0.2 ]));
     expect(controller.value, equals(0.2));
+    controller.dispose();
   });
 
   test('Can fling to upper and lower bounds', () {
@@ -256,6 +261,7 @@ void main() {
     tick(const Duration(seconds: 6));
     expect(largeRangeController.value, -30.0);
     largeRangeController.stop();
+    controller.dispose();
   });
 
   test('Custom springDescription can be applied', () {
@@ -279,6 +285,7 @@ void main() {
     tick(const Duration(milliseconds: 50));
 
     expect(customSpringController.value < controller.value, true);
+    controller.dispose();
   });
 
   test('lastElapsedDuration control test', () {
@@ -292,6 +299,7 @@ void main() {
     tick(const Duration(milliseconds: 40));
     expect(controller.lastElapsedDuration, equals(const Duration(milliseconds: 20)));
     controller.stop();
+    controller.dispose();
   });
 
   test('toString control test', () {
@@ -311,6 +319,7 @@ void main() {
     tick(const Duration(milliseconds: 50));
     expect(controller, hasOneLineDescription);
     controller.stop();
+    controller.dispose();
   });
 
   test('velocity test - linear', () {
@@ -354,6 +363,7 @@ void main() {
     expect(controller.velocity, 0.0);
 
     controller.stop();
+    controller.dispose();
   });
 
   test('Disposed AnimationController toString works', () {
@@ -407,6 +417,7 @@ void main() {
     );
     expect(() { controller.repeat(); }, throwsFlutterError);
     expect(() { controller.repeat(period: null); }, throwsFlutterError);
+    controller.dispose();
   });
 
   test('Do not animate if already at target', () {
@@ -421,6 +432,7 @@ void main() {
     controller.animateTo(0.5, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
     expect(controller.value, equals(0.5));
+    controller.dispose();
   });
 
   test('Do not animate to upperBound if already at upperBound', () {
@@ -437,6 +449,7 @@ void main() {
     controller.animateTo(1.0, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
     expect(controller.value, equals(1.0));
+    controller.dispose();
   });
 
   test('Do not animate to lowerBound if already at lowerBound', () {
@@ -453,6 +466,7 @@ void main() {
     controller.animateTo(0.0, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.completed ]));
     expect(controller.value, equals(0.0));
+    controller.dispose();
   });
 
   test('Do not animate if already at target mid-flight (forward)', () {
@@ -475,6 +489,7 @@ void main() {
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     expect(controller.value, currentValue);
+    controller.dispose();
   });
 
   test('Do not animate if already at target mid-flight (reverse)', () {
@@ -497,6 +512,7 @@ void main() {
     controller.animateTo(currentValue, duration: const Duration(milliseconds: 100));
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.reverse, AnimationStatus.completed ]));
     expect(controller.value, currentValue);
+    controller.dispose();
   });
 
   test('animateTo can deal with duration == Duration.zero', () {
@@ -510,6 +526,7 @@ void main() {
     controller.animateTo(1.0, duration: Duration.zero);
     expect(SchedulerBinding.instance!.transientCallbackCount, equals(0), reason: 'Expected no animation.');
     expect(controller.value, 1.0);
+    controller.dispose();
   });
 
   test('resetting animation works at all phases', () {
@@ -563,6 +580,7 @@ void main() {
     expect(controller.value, 0.0);
     expect(controller.status, AnimationStatus.dismissed);
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed, AnimationStatus.dismissed ]));
+    controller.dispose();
   });
 
   test('setting value directly sets correct status', () {
@@ -591,6 +609,7 @@ void main() {
     controller.value = 0.0;
     expect(controller.value, 0.0);
     expect(controller.status, AnimationStatus.dismissed);
+    controller.dispose();
   });
 
   test('animateTo sets correct status', () {
@@ -637,6 +656,7 @@ void main() {
     expect(controller.value, 0.0);
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
+    controller.dispose();
   });
 
   test('after a reverse call animateTo sets correct status', () {
@@ -665,6 +685,7 @@ void main() {
     expect(controller.value, 0.5);
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
+    controller.dispose();
   });
 
   test('after a forward call animateTo sets correct status', () {
@@ -693,6 +714,7 @@ void main() {
     expect(controller.value, 0.5);
     expect(statusLog, equals(<AnimationStatus>[ AnimationStatus.forward, AnimationStatus.completed ]));
     statusLog.clear();
+    controller.dispose();
   });
 
   test(
@@ -743,6 +765,7 @@ void main() {
       tick(Duration.zero);
       tick(const Duration(milliseconds: 150));
       expect(controller.value, 0.0);
+      controller.dispose();
     },
   );
 
@@ -785,6 +808,7 @@ void main() {
       tick(Duration.zero);
       tick(const Duration(milliseconds: 125));
       expect(controller.value, 1.0);
+      controller.dispose();
     },
   );
 
@@ -795,6 +819,7 @@ void main() {
 
       final AnimationController repeating = AnimationController.unbounded(vsync: const TestVSync());
       expect(repeating.animationBehavior, AnimationBehavior.preserve);
+      controller.dispose();
     });
 
     test('AnimationBehavior.preserve runs at normal speed when animatingTo', () {
@@ -820,6 +845,7 @@ void main() {
       expect(controller.value, 1.0);
       expect(controller.status, AnimationStatus.completed);
       debugSemanticsDisableAnimations = false;
+      controller.dispose();
     });
 
     test('AnimationBehavior.normal runs at 20x speed when animatingTo', () {
@@ -845,6 +871,7 @@ void main() {
       expect(controller.value, 1.0);
       expect(controller.status, AnimationStatus.completed);
       debugSemanticsDisableAnimations = null;
+      controller.dispose();
     });
 
     test('AnimationBehavior.normal runs "faster" than AnimationBehavior.preserve', () {
@@ -864,6 +891,7 @@ void main() {
       // We don't assert a specific faction that normal animation.
       expect(controller.value < fastController.value, true);
       debugSemanticsDisableAnimations = null;
+      controller.dispose();
     });
   });
 
@@ -895,6 +923,7 @@ void main() {
     tick(Duration.zero);
     tick(const Duration(seconds: 2));
     expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    controller.dispose();
   });
 
   test('Simulations run forward even after a reverse run', () {
@@ -915,6 +944,7 @@ void main() {
     tick(Duration.zero);
     tick(const Duration(seconds: 2));
     expect(statuses, <AnimationStatus>[AnimationStatus.forward]);
+    controller.dispose();
   });
 
   test('Repeating animation with reverse: true report as forward and reverse', () {
@@ -933,6 +963,7 @@ void main() {
     statuses.clear();
     tick(const Duration(seconds: 1));
     expect(statuses, <AnimationStatus>[AnimationStatus.reverse]);
+    controller.dispose();
   });
 
   test('AnimateBack can runs successfully with just "reverseDuration" property set', () {

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -256,6 +256,7 @@ void main() {
     expect(largeRangeController.value, -30.0);
     largeRangeController.stop();
     controller.dispose();
+    largeRangeController.dispose();
   });
 
   test('Custom springDescription can be applied', () {
@@ -280,6 +281,7 @@ void main() {
 
     expect(customSpringController.value < controller.value, true);
     controller.dispose();
+    customSpringController.dispose();
   });
 
   test('lastElapsedDuration control test', () {
@@ -814,6 +816,7 @@ void main() {
       final AnimationController repeating = AnimationController.unbounded(vsync: const TestVSync());
       expect(repeating.animationBehavior, AnimationBehavior.preserve);
       controller.dispose();
+      repeating.dispose();
     });
 
     test('AnimationBehavior.preserve runs at normal speed when animatingTo', () {
@@ -886,6 +889,7 @@ void main() {
       expect(controller.value < fastController.value, true);
       debugSemanticsDisableAnimations = null;
       controller.dispose();
+      fastController.dispose();
     });
   });
 


### PR DESCRIPTION
Fixes test/animation/animation_controller_test.dart in #85160

**Problem:**
The test 'animateTo can deal with duration == Duration.Zero' was failing with the following error:

>   Expected: <0>
>     Actual: <5>
>   Expected no animation. 
>   package:test_api                                     expect
>   package:flutter_test/src/widget_tester.dart 484:3    expect
>   test/animation/animation_controller_test.dart 511:5  main.<fn>

Following line finds 5 transientCallbacks scheduled, while expecting zero, if shuffled with seed 123:

`expect(SchedulerBinding.instance!.transientCallbackCount, equals(0), reason: 'Expected no animation.');`

This is caused by some other test leaving transientCallbacks scheduled. 

The tests I have identified leaving transientCallbacks behind is:
	1. 'calling repeat with reverse set to true makes the animation alternate 'between lowerBound and upperBound values on each repeat' (1 callback)
	2. calling repeat with specified min and max values makes the animation alternate between min and max values on each repeat (1 callback)
	3. 2 AnimationBehavior > AnimationBehavior.normal runs "faster" than AnimationBehavior.preserve (2 callbacks)
	4. 1 Simulations run forward (1 callback)
	5. 1 Simulations run forward even after a reverse run (1 callback)
	6. 1 Repeating animation with reverse: true report as forward and reverse (1 callback)

**Fix:**
By disposing the AnimationController after each test, the transientCallbacks get cleaned up.
I chose to dispose all controllers in every test, to make sure there is no risk of leaks.

**Alternate fixes:**

- I tried disposing the controller variable for all tests in tearDown instead of inside each test, but that broke some other tests due to controllers being disposed twice.
- One could consider to only dispose the controllers confirmed to break the test 'animateTocan deal with…'. 

I am happy for any feedback about the best solution. 




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

