### PR TITLE
Move the documentation for `compute` to the `ComputeImpl` typedef

### DIFF
--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -46,5 +46,5 @@ typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q
 
 /// A function that spawns an isolate and runs a callback on that isolate.
 ///
-/// See [ComputeImpl].
+/// See [ComputeImpl] for usage details.
 const ComputeImpl compute = _isolates.compute;

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -18,10 +18,9 @@ import '_isolates_io.dart'
 typedef ComputeCallback<Q, R> = FutureOr<R> Function(Q message);
 
 /// The signature of [compute].
-typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q message, { String? debugLabel });
-
-/// Spawn an isolate, run `callback` on that isolate, passing it `message`, and
-/// (eventually) return the value returned by `callback`.
+///
+/// [compute] spawns an isolate, runs `callback` on that isolate, passes it
+/// `message`, and (eventually) returns the value returned by `callback`.
 ///
 /// This is useful for operations that take longer than a few milliseconds, and
 /// which would therefore risk skipping frames. For tasks that will only take a
@@ -44,4 +43,7 @@ typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q
 ///
 /// The `debugLabel` argument can be specified to provide a name to add to the
 /// [Timeline]. This is useful when profiling an application.
+typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q message, { String? debugLabel });
+
+/// See [ComputeImpl].
 const ComputeImpl compute = _isolates.compute;

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -46,5 +46,7 @@ typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q
 
 /// A function that spawns an isolate and runs a callback on that isolate.
 ///
-/// See [ComputeImpl] for usage details.
+/// See also:
+///
+///   * [ComputeImpl], for function parameters and usage details.
 const ComputeImpl compute = _isolates.compute;

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -17,10 +17,9 @@ import '_isolates_io.dart'
 /// {@macro flutter.foundation.compute.limitations}
 typedef ComputeCallback<Q, R> = FutureOr<R> Function(Q message);
 
-/// The signature of [compute].
-///
-/// [compute] spawns an isolate, runs `callback` on that isolate, passes it
-/// `message`, and (eventually) returns the value returned by `callback`.
+/// The signature of [compute], which spawns an isolate, runs `callback` on
+/// that isolate, passes it `message`, and (eventually) returns the value
+/// returned by `callback`.
 ///
 /// This is useful for operations that take longer than a few milliseconds, and
 /// which would therefore risk skipping frames. For tasks that will only take a
@@ -45,5 +44,7 @@ typedef ComputeCallback<Q, R> = FutureOr<R> Function(Q message);
 /// [Timeline]. This is useful when profiling an application.
 typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q message, { String? debugLabel });
 
+/// A function that spawns an isolate and runs a callback on that isolate.
+///
 /// See [ComputeImpl].
 const ComputeImpl compute = _isolates.compute;

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -27,7 +27,7 @@ typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
 /// Prints a message to the console, which you can access using the "flutter"
 /// tool's "logs" command ("flutter logs").
 ///
-/// See [DebugPrintCallback].
+/// See [DebugPrintCallback] for usage details.
 DebugPrintCallback debugPrint = debugPrintThrottled;
 
 /// Alternative implementation of [debugPrint] that does not throttle.

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -6,13 +6,9 @@ import 'dart:async';
 import 'dart:collection';
 
 /// Signature for [debugPrint] implementations.
-typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
-
-/// Prints a message to the console, which you can access using the "flutter"
-/// tool's "logs" command ("flutter logs").
 ///
-/// If a wrapWidth is provided, each line of the message is word-wrapped to that
-/// width. (Lines may be separated by newline characters, as in '\n'.)
+/// If a [wrapWidth] is provided, each line of the [message] is word-wrapped to
+/// that width. (Lines may be separated by newline characters, as in '\n'.)
 ///
 /// By default, this function very crudely attempts to throttle the rate at
 /// which messages are sent to avoid data loss on Android. This means that
@@ -26,6 +22,12 @@ typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
 ///
 /// The default value is [debugPrintThrottled]. For a version that acts
 /// identically but does not throttle, use [debugPrintSynchronously].
+typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
+
+/// Prints a message to the console, which you can access using the "flutter"
+/// tool's "logs" command ("flutter logs").
+///
+/// See [DebugPrintCallback].
 DebugPrintCallback debugPrint = debugPrintThrottled;
 
 /// Alternative implementation of [debugPrint] that does not throttle.

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -27,7 +27,9 @@ typedef DebugPrintCallback = void Function(String? message, { int? wrapWidth });
 /// Prints a message to the console, which you can access using the "flutter"
 /// tool's "logs" command ("flutter logs").
 ///
-/// See [DebugPrintCallback] for usage details.
+/// See also:
+///
+///   * [DebugPrintCallback], for function parameters and usage details.
 DebugPrintCallback debugPrint = debugPrintThrottled;
 
 /// Alternative implementation of [debugPrint] that does not throttle.


### PR DESCRIPTION
When `compute` was refactored, the generated dartdoc documentation
became awkward because it referred to various parameter names now
hidden behind a `typedef`.

In this case, the `ComputeImpl` `typedef` is used in only one place,
so we could just inline its definition.  However, since it's a public
`typedef`, that would technically be a breaking change, so I've opted
to move `compute`'s dartdoc comment to `ComputeImpl` instead.

Fixes https://github.com/flutter/flutter/issues/88258.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
