### PR TITLE
Removed no-shuffle tag and fixed leak in debug_test.dart

### DIFF
--- a/packages/flutter/test/gestures/debug_test.dart
+++ b/packages/flutter/test/gestures/debug_test.dart
@@ -154,6 +154,7 @@ void main() {
     tap.addPointer(event);
     tap.didExceedDeadline();
     expect(tap.toString(), equalsIgnoringHashCodes('TapGestureRecognizer#00000(state: possible, button: 1, sent tap down)'));
+    GestureBinding.instance!.gestureArena.close(1);
     tap.dispose();
   });
 }

--- a/packages/flutter/test/gestures/debug_test.dart
+++ b/packages/flutter/test/gestures/debug_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -160,5 +154,6 @@ void main() {
     tap.addPointer(event);
     tap.didExceedDeadline();
     expect(tap.toString(), equalsIgnoringHashCodes('TapGestureRecognizer#00000(state: possible, button: 1, sent tap down)'));
+    tap.dispose();
   });
 }


### PR DESCRIPTION
Fixes test/gestures/debug_test.dart of #85160

## Problem
The `TapGestureRecognizer` in the test named 'TapGestureRecognizer _sentTapDown toString' was not disposed, which was breaking a couple of other tests.
This worked fine when not shuffling the tests as the test was executed last. 

## Fix
Dispose the `TapGestureRecognizer`



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

