### PR TITLE
Fix race conditions in test_driver for tool tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
@@ -4,8 +4,6 @@
 
 // @dart = 2.8
 
-import 'dart:io';
-
 import 'package:file/file.dart';
 
 import '../src/common.dart';

--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
@@ -52,5 +52,5 @@ void main() {
     }
 
     await _flutter.stop();
-  }, skip: Platform.isWindows); // Skipping for https://github.com/flutter/flutter/issues/87481
+  });
 }

--- a/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debugger_stepping_test.dart
@@ -32,8 +32,7 @@ void main() {
 
     await _flutter.run(withDebugger: true, startPaused: true);
     await _flutter.addBreakpoint(_project.breakpointUri, _project.breakpointLine);
-    await _flutter.resume();
-    await _flutter.waitForPause(); // Now we should be on the breakpoint.
+    await _flutter.resume(waitForNextPause: true); // Now we should be on the breakpoint.
 
     expect((await _flutter.getSourceLocation()).line, equals(_project.breakpointLine));
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -267,37 +267,30 @@ abstract class FlutterTestDriver {
     return waitForDebugEvent(kind, isolateId, event);
   }
 
-  /// Subscribes to debug events containing [kind] and returns a future that
-  /// completes when the [kind] event is received.
+  /// Subscribes to debug events containing [kind].
+  ///
+  /// Returns a future that completes when the [kind] event is received.
   ///
   /// Note that this method should be called before the command that triggers
   /// the event to subscribe to the event in time, for example:
   ///
   /// ```
   ///  var event = subscribeToDebugEvent('Pause', id); // Subscribe to 'pause' events.
-  ///  ...                                             // Code that pauses the app,
+  ///  ...                                             // Code that pauses the app.
   ///  await waitForDebugEvent('Pause', id, event);    // Isolate is paused now.
   /// ```
-  Future<Event> subscribeToDebugEvent(String kind, String isolateId) async {
-    final Completer<Event> pauseEvent = Completer<Event>();
+  Future<Event> subscribeToDebugEvent(String kind, String isolateId) {
     _debugPrint('Start listening for $kind events');
 
-    final StreamSubscription<Event> pauseSubscription = _vmService.onDebugEvent
-        .where((Event event) {
-          return event.isolate.id == isolateId
-              && event.kind.startsWith(kind);
-        })
-        .listen((Event event) {
-          if (!pauseEvent.isCompleted) {
-            pauseEvent.complete(event);
-          }
-        });
-
-    return pauseEvent.future.whenComplete(() => pauseSubscription.cancel());
+    return _vmService.onDebugEvent
+      .where((Event event) {
+        return event.isolate.id == isolateId
+            && event.kind.startsWith(kind);
+      }).first;
   }
 
-  /// Wait for the [event] if needed. 
-  /// 
+  /// Wait for the [event] if needed.
+  ///
   /// Return immediately if the isolate is already in the desired state.
   Future<Isolate> waitForDebugEvent(String kind, String isolateId, Future<Event> event) {
     return _timeoutWithMessages<Isolate>(

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -235,8 +235,10 @@ abstract class FlutterTestDriver {
   /// an hour before setting the breakpoint. Would the code still eventually hit
   /// the breakpoint and stop?
   Future<void> breakAt(Uri uri, int line) async {
+    final String isolateId = await _getFlutterIsolateId();
+    final Future<Event> event = subscribeToPauseEvent(isolateId);
     await addBreakpoint(uri, line);
-    await waitForPause();
+    await waitForPauseEvent(isolateId, event);
   }
 
   Future<void> addBreakpoint(Uri uri, int line) async {
@@ -248,44 +250,71 @@ abstract class FlutterTestDriver {
     );
   }
 
-  // This method isn't racy. If the isolate is already paused,
-  // it will immediately return.
-  Future<Isolate> waitForPause() => waitForDebugEvent('Pause');
-  Future<Isolate> waitForResume() => waitForDebugEvent('Resume');
+  Future<Event> subscribeToPauseEvent(String isolateId) => subscribeToDebugEvent('Pause', isolateId);
+  Future<Event> subscribeToResumeEvent(String isolateId) => subscribeToDebugEvent('Resume', isolateId);
 
-  Future<Isolate> waitForDebugEvent(String kind) async {
+  Future<Isolate> waitForPauseEvent(String isolateId, Future<Event> event) =>
+      waitForDebugEvent('Pause', isolateId, event);
+  Future<Isolate> waitForResumeEvent(String isolateId, Future<Event> event) =>
+      waitForDebugEvent('Resume', isolateId, event);
+
+  Future<Isolate> waitForPause() async => subscribeAndWaitForDebugEvent('Pause', await _getFlutterIsolateId());
+  Future<Isolate> waitForResume() async => subscribeAndWaitForDebugEvent('Resume', await _getFlutterIsolateId());
+
+
+  Future<Isolate> subscribeAndWaitForDebugEvent(String kind, String isolateId) {
+    final Future<Event> event = subscribeToDebugEvent(kind, isolateId);
+    return waitForDebugEvent(kind, isolateId, event);
+  }
+
+  /// Subscribes to debug events containing [kind] and returns a future that
+  /// completes when the [kind] event is received.
+  ///
+  /// Note that this method should be called before the command that triggers
+  /// the event to subscribe to the event in time, for example:
+  ///
+  /// ```
+  ///  var event = subscribeToDebugEvent('Pause', id); // Subscribe to 'pause' events.
+  ///  ...                                             // Code that pauses the app,
+  ///  await waitForDebugEvent('Pause', id, event);    // Isolate is paused now.
+  /// ```
+  Future<Event> subscribeToDebugEvent(String kind, String isolateId) async {
+    final Completer<Event> pauseEvent = Completer<Event>();
+    _debugPrint('Start listening for $kind events');
+
+    final StreamSubscription<Event> pauseSubscription = _vmService.onDebugEvent
+        .where((Event event) {
+          return event.isolate.id == isolateId
+              && event.kind.startsWith(kind);
+        })
+        .listen((Event event) {
+          if (!pauseEvent.isCompleted) {
+            pauseEvent.complete(event);
+          }
+        });
+
+    return pauseEvent.future.whenComplete(() => pauseSubscription.cancel());
+  }
+
+  /// Wait for the [event] if needed. 
+  /// 
+  /// Return immediately if the isolate is already in the desired state.
+  Future<Isolate> waitForDebugEvent(String kind, String isolateId, Future<Event> event) {
     return _timeoutWithMessages<Isolate>(
       () async {
-        final String flutterIsolate = await _getFlutterIsolateId();
-        final Completer<Event> pauseEvent = Completer<Event>();
-
-        // Start listening for events containing 'kind'.
-        final StreamSubscription<Event> pauseSubscription = _vmService.onDebugEvent
-          .where((Event event) {
-            return event.isolate.id == flutterIsolate
-                && event.kind.startsWith(kind);
-          })
-          .listen((Event event) {
-            if (!pauseEvent.isCompleted) {
-              pauseEvent.complete(event);
-            }
-          });
-
-        // But also check if the isolate was already at the stae we need (only after we've
-        // set up the subscription) to avoid races. If it was paused, we don't need to wait
-        // for the event.
-        final Isolate isolate = await _vmService.getIsolate(flutterIsolate);
+        // But also check if the isolate was already at the state we need (only after we've
+        // set up the subscription) to avoid races. If it already in the desired state, we
+        // don't need to wait for the event.
+        final Isolate isolate = await _vmService.getIsolate(isolateId);
         if (isolate.pauseEvent.kind.startsWith(kind)) {
           _debugPrint('Isolate was already at "$kind" (${isolate.pauseEvent.kind}).');
+          event.ignore();
         } else {
           _debugPrint('Waiting for "$kind" event to arrive...');
-          await pauseEvent.future;
+          await event;
         }
 
-        // Cancel the subscription on either of the above.
-        await pauseSubscription.cancel();
-
-        return getFlutterIsolate();
+        return _vmService.getIsolate(isolateId);
       },
       task: 'Waiting for isolate to $kind',
     );
@@ -311,12 +340,17 @@ abstract class FlutterTestDriver {
 
   Future<Isolate> _resume(String step, bool waitForNextPause) async {
     assert(waitForNextPause != null);
+    final String isolateId = await _getFlutterIsolateId();
+
+    final Future<Event> resume = subscribeToResumeEvent(isolateId);
+    final Future<Event> pause = subscribeToPauseEvent(isolateId);
+
     await _timeoutWithMessages<dynamic>(
-      () async => _vmService.resume(await _getFlutterIsolateId(), step: step),
+      () async => _vmService.resume(isolateId, step: step),
       task: 'Resuming isolate (step=$step)',
     );
-    await waitForResume();
-    return waitForNextPause ? waitForPause() : null;
+    await waitForResumeEvent(isolateId, resume);
+    return waitForNextPause? waitForPauseEvent(isolateId, pause): null;
   }
 
   Future<ObjRef> evaluateInFrame(String expression) async {

--- a/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
@@ -29,9 +29,7 @@ void main() {
       withDebugger: true, startPaused: true, chrome: true,
       additionalCommandArgs: <String>['--verbose', '--web-renderer=html']);
     await flutter.addBreakpoint(_project.breakpointUri, _project.breakpointLine);
-    await flutter.resume();
-    await flutter.waitForPause(); // Now we should be on the breakpoint.
-
+    await flutter.resume(waitForNextPause: true); // Now we should be on the breakpoint.
     expect((await flutter.getSourceLocation()).line, equals(_project.breakpointLine));
 
     // Issue 5 steps, ensuring that we end up on the annotated lines each time.

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -127,8 +127,7 @@ void main() {
         project.breakpointAppUri,
         project.breakpointLine,
       );
-      await flutter.resume();
-      return flutter.waitForPause();
+      return flutter.resume(waitForNextPause: true);
     }
 
     Future<void> startPaused({bool expressionEvaluation}) {

--- a/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
@@ -62,7 +62,7 @@ void main() {
         validateFlutterVersion(client1),
         validateFlutterVersion(client2)]
       );
-    }, skip: true); // DDS failure: https://github.com/dart-lang/sdk/issues/45569
+    }, skip: true); // DDS failure: https://github.com/dart-lang/sdk/issues/46696
   });
 
   group('Clients of flutter run on web with DDS disabled', () {


### PR DESCRIPTION
Subscribe to events before sending commands to VM that trigger
the event in question, to prevent a race where the event arrives
before subscription.

Previous fix for another race condition exposed the current issue:
Related: https://github.com/flutter/flutter/pull/87278
Related: https://github.com/dart-lang/webdev/issues/1369

Closes:https://github.com/flutter/flutter/issues/87481

Tests: the fix is only in tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
