### PR TITLE
Add java:11 dependency to remaining tasks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2368,21 +2368,39 @@ targets:
   - name: Mac_android complex_layout__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","mac"]
       task_name: complex_layout__start_up
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Mac_android complex_layout_scroll_perf__memory
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","mac"]
       task_name: complex_layout_scroll_perf__memory
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Mac_android complex_layout_scroll_perf__timeline_summary
@@ -2729,10 +2747,19 @@ targets:
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
+    bringup: true
     properties:
       tags: >
         ["devicelab","android","mac"]
       task_name: tiles_scroll_perf__timeline_summary
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
@@ -3737,11 +3764,20 @@ targets:
   - name: Windows_android complex_layout_win__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
+    bringup: true
     timeout: 60
     properties:
       tags: >
         ["devicelab","android","windows"]
       task_name: complex_layout_win__compile
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Windows_android flavors_test_win


### PR DESCRIPTION
These were missing in https://github.com/flutter/flutter/pull/88319