### PR TITLE
Adding isRefreshing bool attribute to RefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -122,6 +122,7 @@ class RefreshIndicator extends StatefulWidget {
     this.semanticsValue,
     this.strokeWidth = 2.0,
     this.triggerMode = RefreshIndicatorTriggerMode.onEdge,
+    this.isRefreshing
   }) : assert(child != null),
        assert(onRefresh != null),
        assert(notificationPredicate != null),
@@ -210,6 +211,10 @@ class RefreshIndicator extends StatefulWidget {
   ///
   /// Defaults to [RefreshIndicatorTriggerMode.onEdge].
   final RefreshIndicatorTriggerMode triggerMode;
+
+  /// Defines if the refresh indicator should be running.
+  /// Not running by default.
+  final bool? isRefreshing;
 
   @override
   RefreshIndicatorState createState() => RefreshIndicatorState();
@@ -467,6 +472,34 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       });
   }
 
+  // Method to verify the isRefreshing attribute and show/hide indicator
+  bool _checkIsRefreshing(bool? isRefreshing) {
+    if (isRefreshing != null) {
+      if (isRefreshing) {
+        _showProgressIndicator();
+      } else {
+        //Hides indicator only if running
+        if (mounted && _mode == _RefreshIndicatorMode.refresh) {
+          _dismiss(_RefreshIndicatorMode.done);
+        }
+      }
+      return isRefreshing;
+    }
+    return false;
+  }
+
+  // Method to show the progress indicator
+  void _showProgressIndicator() {
+    if (_mode == null || _isIndicatorAtTop == null || _dragOffset == null) {
+      _isIndicatorAtTop = true;
+      _dragOffset = 0.0;
+      _scaleController.value = 0.0;
+      _positionController.animateTo(1.0 / _kDragSizeFactorLimit,
+          duration: _kIndicatorSnapDuration);
+      _mode = _RefreshIndicatorMode.refresh;
+    }
+  }
+
   /// Show the refresh indicator and run the refresh callback as if it had
   /// been started interactively. If this method is called while the refresh
   /// callback is running, it quietly does nothing.
@@ -515,7 +548,9 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     }());
 
     final bool showIndeterminateIndicator =
-      _mode == _RefreshIndicatorMode.refresh || _mode == _RefreshIndicatorMode.done;
+        _checkIsRefreshing(widget.isRefreshing)     ||
+            _mode == _RefreshIndicatorMode.refresh  ||
+            _mode == _RefreshIndicatorMode.done;
 
     return Stack(
       children: <Widget>[

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -868,4 +868,61 @@ void main() {
     await tester.pump();
     expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, red.withOpacity(1.0));
   });
+
+  testWidgets('RefreshIndicator.isRefreshing set to true',
+          (WidgetTester tester) async {
+        const bool isRefreshing = true;
+
+        refreshCalled = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: RefreshIndicator(
+              isRefreshing: isRefreshing,
+              onRefresh: refresh,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const <Widget>[
+                  SizedBox(
+                    height: 200.0,
+                    child: Text('X'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(refreshCalled, false);
+        expect(find.byType(RefreshProgressIndicator), findsOneWidget);
+      });
+
+  testWidgets('RefreshIndicator.isRefreshing set to false',
+          (WidgetTester tester) async {
+        const bool isRefreshing = false;
+
+        refreshCalled = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: RefreshIndicator(
+              isRefreshing: isRefreshing,
+              onRefresh: refresh,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const <Widget>[
+                  SizedBox(
+                    height: 200.0,
+                    child: Text('X'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        expect(refreshCalled, false);
+        expect(find.byType(RefreshProgressIndicator), findsNothing);
+      });
+
 }


### PR DESCRIPTION
Implements the feature requested by the issue below. 
It was added a parameter `isRefreshing` to show/hide the RefreshProgressIndicator for the RefreshIndicator widget.

Examples:
//Starts the loading for the component
```
RefreshIndicator(
              isRefreshing: true
...

```

//Hides the loading for the component
```
RefreshIndicator(
              isRefreshing: false
...

```
*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/40235

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
