### PR TITLE
Fixed leak and removed no-shuffle tag in test/gestures/tap_test.dart

### DIFF
--- a/packages/flutter/test/gestures/tap_test.dart
+++ b/packages/flutter/test/gestures/tap_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -838,11 +832,11 @@ void main() {
     });
 
     tearDown(() {
-      recognized.clear();
       primary.dispose();
       primary2.dispose();
       secondary.dispose();
       tertiary.dispose();
+      recognized.clear();
     });
 
     testGesture('A primary tap recognizer does not form competition with a secondary tap recognizer', (GestureTester tester) {


### PR DESCRIPTION
Fixes test/gestures/tap_test.dart in #85160.

## Problem
When running test with randomize seed 1000 following error occurred:

> Recognizers listening on different buttons do not form competition: A primary tap recognizer does not form competition with a tertiary tap recognizer [E]
>   Expected: ['primaryDown']
>     Actual: ['primaryCancel', 'primary2Cancel', 'primaryDown']
>      Which: at location [0] is 'primaryCancel' instead of 'primaryDown'

This happens because in the tearDown() of the group, the list `recognized` was cleared before disposing tap gestures. When disposing a tap down, a tap cancel was fired and registered in the `recognized` list. And so the list was not cleared when entering next test.

## Fix
Clear `recognized` after disposing tap gestures in tearDown().


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

