### PR TITLE
Make MultiChildRenderObjectWidget and its descendants const

### DIFF
--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -55,8 +55,8 @@ class PlatformViewLayout extends StatelessWidget {
             child: Material(
               elevation: (index % 5 + 1).toDouble(),
               color: Colors.white,
-              child: Stack(
-                children: const <Widget> [
+              child: const Stack(
+                children: <Widget> [
                   DummyPlatformView(),
                   RotationContainer(),
                 ],

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -59,8 +59,8 @@ class PlatformViewLayout extends StatelessWidget {
             child: Material(
               elevation: (index % 5 + 1).toDouble(),
               color: Colors.white,
-              child: Stack(
-                children: const <Widget> [
+              child: const Stack(
+                children: <Widget> [
                   DummyPlatformView(),
                   RotationContainer(),
                 ],

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
@@ -77,9 +77,9 @@ class _PopupControlsPageState extends State<PopupControlsPage> {
                       return AlertDialog(
                         key: const ValueKey<String>(alertKeyValue),
                         title: const Text('Title text', key: ValueKey<String>('$alertKeyValue.Title')),
-                        content: SingleChildScrollView(
+                        content: const SingleChildScrollView(
                           child: ListBody(
-                            children: const <Widget>[
+                            children: <Widget>[
                               Text('Body text line 1.', key: ValueKey<String>('$alertKeyValue.Body1')),
                               Text('Body text line 2.', key: ValueKey<String>('$alertKeyValue.Body2')),
                             ],

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1871,7 +1871,7 @@ class CupertinoDialogAction extends StatelessWidget {
 //
 // See [_RenderCupertinoDialogActions] for specific layout policy details.
 class _CupertinoDialogActionsRenderWidget extends MultiChildRenderObjectWidget {
-  _CupertinoDialogActionsRenderWidget({
+  const _CupertinoDialogActionsRenderWidget({
     Key? key,
     required List<Widget> actionButtons,
     double dividerThickness = 0.0,

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -427,7 +427,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
 }
 
 class _SegmentedControlRenderWidget<T> extends MultiChildRenderObjectWidget {
-  _SegmentedControlRenderWidget({
+  const _SegmentedControlRenderWidget({
     Key? key,
     List<Widget> children = const <Widget>[],
     required this.selectedIndex,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -701,7 +701,7 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
 }
 
 class _SegmentedControlRenderWidget<T> extends MultiChildRenderObjectWidget {
-  _SegmentedControlRenderWidget({
+  const _SegmentedControlRenderWidget({
     Key? key,
     List<Widget> children = const <Widget>[],
     required this.highlightedIndex,

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -234,7 +234,7 @@ class ButtonBar extends StatelessWidget {
 class _ButtonBarRow extends Flex {
   /// Creates a button bar that attempts to display in a row, but displays in
   /// a column if there is insufficient horizontal space.
-  _ButtonBarRow({
+  const _ButtonBarRow({
     required List<Widget> children,
     Axis direction = Axis.horizontal,
     MainAxisSize mainAxisSize = MainAxisSize.max,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -194,9 +194,9 @@ class Dialog extends StatelessWidget {
 ///     builder: (BuildContext context) {
 ///       return AlertDialog(
 ///         title: const Text('AlertDialog Title'),
-///         content: SingleChildScrollView(
+///         content: const SingleChildScrollView(
 ///           child: ListBody(
-///             children: const <Widget>[
+///             children: <Widget>[
 ///               Text('This is a demo alert dialog.'),
 ///               Text('Would you like to approve of this message?'),
 ///             ],

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -645,7 +645,7 @@ class _MergeableMaterialSliceKey extends GlobalKey {
 }
 
 class _MergeableMaterialListBody extends ListBody {
-  _MergeableMaterialListBody({
+  const _MergeableMaterialListBody({
     required List<Widget> children,
     Axis mainAxis = Axis.vertical,
     required this.items,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -283,7 +283,7 @@ class _TabLabelBarRenderer extends RenderFlex {
 // upon layout. The tab widths are only used at paint time (see _IndicatorPainter)
 // or in response to input.
 class _TabLabelBar extends Flex {
-  _TabLabelBar({
+  const _TabLabelBar({
     Key? key,
     List<Widget> children = const <Widget>[],
     required this.onPerformLayout,

--- a/packages/flutter/lib/src/material/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar.dart
@@ -357,7 +357,7 @@ class _TextSelectionToolbarTrailingEdgeAlignRenderBox extends RenderProxyBox {
 // Renders the menu items in the correct positions in the menu and its overflow
 // submenu based on calculating which item would first overflow.
 class _TextSelectionToolbarItemsLayout extends MultiChildRenderObjectWidget {
-  _TextSelectionToolbarItemsLayout({
+  const _TextSelectionToolbarItemsLayout({
     Key? key,
     required this.isAbove,
     required this.overflowOpen,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2192,7 +2192,7 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
   /// Creates a custom multi-child layout.
   ///
   /// The [delegate] argument must not be null.
-  CustomMultiChildLayout({
+  const CustomMultiChildLayout({
     Key? key,
     required this.delegate,
     List<Widget> children = const <Widget>[],
@@ -3682,7 +3682,7 @@ class ListBody extends MultiChildRenderObjectWidget {
   /// given axis.
   ///
   /// By default, the [mainAxis] is [Axis.vertical].
-  ListBody({
+  const ListBody({
     Key? key,
     this.mainAxis = Axis.vertical,
     this.reverse = false,
@@ -3842,7 +3842,7 @@ class Stack extends MultiChildRenderObjectWidget {
   ///
   /// By default, the non-positioned children of the stack are aligned by their
   /// top left corners.
-  Stack({
+  const Stack({
     Key? key,
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
@@ -3975,7 +3975,7 @@ class IndexedStack extends Stack {
   /// Creates a [Stack] widget that paints a single child.
   ///
   /// The [index] argument must not be null.
-  IndexedStack({
+  const IndexedStack({
     Key? key,
     AlignmentGeometry alignment = AlignmentDirectional.topStart,
     TextDirection? textDirection,
@@ -4473,7 +4473,7 @@ class Flex extends MultiChildRenderObjectWidget {
   /// to be necessary to decide which direction to lay the children in or to
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
-  Flex({
+  const Flex({
     Key? key,
     required this.direction,
     this.mainAxisAlignment = MainAxisAlignment.start,
@@ -4850,7 +4850,7 @@ class Row extends Flex {
   /// unless the row has no children or only one child) or to disambiguate
   /// `start` or `end` values for the [mainAxisAlignment], the [textDirection]
   /// must not be null.
-  Row({
+  const Row({
     Key? key,
     MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
     MainAxisSize mainAxisSize = MainAxisSize.max,
@@ -5050,7 +5050,7 @@ class Column extends Flex {
   /// any. If there is no ambient directionality, and a text direction is going
   /// to be necessary to disambiguate `start` or `end` values for the
   /// [crossAxisAlignment], the [textDirection] must not be null.
-  Column({
+  const Column({
     Key? key,
     MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
     MainAxisSize mainAxisSize = MainAxisSize.max,
@@ -5327,7 +5327,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// to be necessary to decide which direction to lay the children in or to
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
-  Wrap({
+  const Wrap({
     Key? key,
     this.direction = Axis.horizontal,
     this.alignment = WrapAlignment.start,
@@ -5703,7 +5703,7 @@ class Flow extends MultiChildRenderObjectWidget {
   /// a repaint boundary.
   ///
   /// The [delegate] argument must not be null.
-  Flow.unwrapped({
+  const Flow.unwrapped({
     Key? key,
     required this.delegate,
     List<Widget> children = const <Widget>[],

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1773,22 +1773,9 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///
   /// The [children] argument must not be null and must not contain any null
   /// objects.
-  MultiChildRenderObjectWidget({ Key? key, this.children = const <Widget>[] })
+  const MultiChildRenderObjectWidget({ Key? key, this.children = const <Widget>[] })
     : assert(children != null),
-      super(key: key) {
-    assert(() {
-      for (int index = 0; index < children.length; index++) {
-        // TODO(a14n): remove this check to have a lot more const widget
-        if (children[index] == null) {
-          throw FlutterError(
-              "$runtimeType's children must not contain any null values, "
-                  'but a null value was found at index $index',
-          );
-        }
-      }
-      return true;
-    }()); // https://github.com/dart-lang/sdk/issues/29276
-  }
+      super(key: key);
 
   /// The widgets below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -100,7 +100,7 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   /// [overflowDirection], and [clipBehavior] parameters must not be
   /// null. The [children] argument must not be null and must not contain
   /// any null objects.
-  OverflowBar({
+  const OverflowBar({
     Key? key,
     this.spacing = 0.0,
     this.alignment,

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -526,7 +526,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
 ///
 /// The first [skipCount] children are considered "offstage".
 class _Theatre extends MultiChildRenderObjectWidget {
-  _Theatre({
+  const _Theatre({
     Key? key,
     this.skipCount = 0,
     this.clipBehavior = Clip.hardEdge,

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -284,7 +284,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   /// rebuild this widget when the [offset] changes.
   ///
   /// The [offset] argument must not be null.
-  ShrinkWrappingViewport({
+  const ShrinkWrappingViewport({
     Key? key,
     this.axisDirection = AxisDirection.down,
     this.crossAxisDirection,

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -228,7 +228,7 @@ void main() {
                   ),
                   child: page1Center,
                 )
-                : Stack();
+                : const Stack();
           },
         ),
       ),
@@ -271,7 +271,7 @@ void main() {
                       ],
                     ),
                   )
-                  : Stack();
+                  : const Stack();
             },
           ),
         ),

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -341,9 +341,9 @@ void main() {
 
     testWidgets('ButtonBar has a min height of 52 when using ButtonBarLayoutBehavior.constrained', (WidgetTester tester) async {
       await tester.pumpWidget(
-        SingleChildScrollView(
+        const SingleChildScrollView(
           child: ListBody(
-            children: const <Widget>[
+            children: <Widget>[
               Directionality(
                 textDirection: TextDirection.ltr,
                 child: ButtonBar(
@@ -364,9 +364,9 @@ void main() {
 
     testWidgets('ButtonBar has padding applied when using ButtonBarLayoutBehavior.padded', (WidgetTester tester) async {
       await tester.pumpWidget(
-        SingleChildScrollView(
+        const SingleChildScrollView(
           child: ListBody(
-            children: const <Widget>[
+            children: <Widget>[
               Directionality(
                 textDirection: TextDirection.ltr,
                 child: ButtonBar(

--- a/packages/flutter/test/material/icons_test.dart
+++ b/packages/flutter/test/material/icons_test.dart
@@ -59,11 +59,11 @@ void main() {
   testWidgets('A sample of icons look as expected', (WidgetTester tester) async {
     await _loadIconFont();
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: IconTheme(
-        data: const IconThemeData(size: 200),
+        data: IconThemeData(size: 200),
         child: Wrap(
-          children: const <Icon>[
+          children: <Icon>[
             Icon(Icons.ten_k),
             Icon(Icons.ac_unit),
             Icon(Icons.local_taxi),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4964,14 +4964,14 @@ void main() {
     };
     try {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Center(
             child: Directionality(
               textDirection: TextDirection.ltr,
               child: InputDecorator(
-                decoration: const InputDecoration(),
+                decoration: InputDecoration(),
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     SizedBox(height: 0),
                     Positioned(
                       bottom: 5,

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -229,23 +229,23 @@ void main() {
           addRepaintBoundaries: false,
           addSemanticIndexes: false,
           cacheExtent: 0.0,
-          children: <Widget>[
+          children: const <Widget>[
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 ]),
               ),
             ),
-            const AutomaticKeepAlive(
+            AutomaticKeepAlive(
               child: SizedBox(
                 key: GlobalObjectKey<_LeafState>(2),
                 height: 400.0,
               ),
             ),
-            const AutomaticKeepAlive(
+            AutomaticKeepAlive(
               child: SizedBox(
                 key: GlobalObjectKey<_LeafState>(3),
                 height: 400.0,
@@ -313,11 +313,11 @@ void main() {
           addRepaintBoundaries: false,
           addSemanticIndexes: false,
           cacheExtent: 0.0,
-          children: <Widget>[
+          children: const <Widget>[
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 ]),
@@ -326,7 +326,7 @@ void main() {
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
                 ]),
@@ -335,7 +335,7 @@ void main() {
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),
                 ]),
@@ -369,11 +369,11 @@ void main() {
         addRepaintBoundaries: false,
         addSemanticIndexes: false,
         cacheExtent: 0.0,
-        children: <Widget>[
+        children: const <Widget>[
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
               ]),
             ),
@@ -381,7 +381,7 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
               ]),
@@ -390,7 +390,7 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
@@ -433,11 +433,11 @@ void main() {
         addRepaintBoundaries: false,
         addSemanticIndexes: false,
         cacheExtent: 0.0,
-        children: <Widget>[
+        children: const <Widget>[
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
               ]),
@@ -446,13 +446,13 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[]),
+              child: Stack(children: <Widget>[]),
             ),
           ),
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -12,7 +12,7 @@ void main() {
   testWidgets('GlobalKey children of one node', (WidgetTester tester) async {
     // This is actually a test of the regular duplicate key logic, which
     // happens before the duplicate GlobalKey logic.
-    await tester.pumpWidget(Stack(children: const <Widget>[
+    await tester.pumpWidget(const Stack(children: <Widget>[
       DummyWidget(key: GlobalObjectKey(0)),
       DummyWidget(key: GlobalObjectKey(0)),
     ]));
@@ -24,9 +24,9 @@ void main() {
   });
 
   testWidgets('GlobalKey children of two nodes - A', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         DummyWidget(child: DummyWidget(key: GlobalObjectKey(0))),
         DummyWidget(
           child: DummyWidget(key: GlobalObjectKey(0),
@@ -44,9 +44,9 @@ void main() {
   });
 
   testWidgets('GlobalKey children of two different nodes - B', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         DummyWidget(child: DummyWidget(key: GlobalObjectKey(0))),
         DummyWidget(key: Key('x'), child: DummyWidget(key:  GlobalObjectKey(0))),
       ],

--- a/packages/flutter/test/widgets/list_body_test.dart
+++ b/packages/flutter/test/widgets/list_body_test.dart
@@ -31,7 +31,7 @@ void main() {
   testWidgets('ListBody down', (WidgetTester tester) async {
     await tester.pumpWidget(Flex(
       direction: Axis.vertical,
-      children: <Widget>[ ListBody(children: children) ],
+      children: const <Widget>[ ListBody(children: children) ],
     ));
 
     expectRects(
@@ -48,7 +48,7 @@ void main() {
   testWidgets('ListBody up', (WidgetTester tester) async {
     await tester.pumpWidget(Flex(
       direction: Axis.vertical,
-      children: <Widget>[ ListBody(reverse: true, children: children) ],
+      children: const <Widget>[ ListBody(reverse: true, children: children) ],
     ));
 
     expectRects(
@@ -66,7 +66,7 @@ void main() {
     await tester.pumpWidget(Flex(
       textDirection: TextDirection.ltr,
       direction: Axis.horizontal,
-      children: <Widget>[
+      children: const <Widget>[
         Directionality(
           textDirection: TextDirection.ltr,
           child: ListBody(mainAxis: Axis.horizontal, children: children),
@@ -89,7 +89,7 @@ void main() {
     await tester.pumpWidget(Flex(
       textDirection: TextDirection.ltr,
       direction: Axis.horizontal,
-      children: <Widget>[
+      children: const <Widget>[
         Directionality(
           textDirection: TextDirection.rtl,
           child: ListBody(mainAxis: Axis.horizontal, children: children),
@@ -114,7 +114,7 @@ void main() {
     FlutterError.onError = (FlutterErrorDetails error) => errors.add(error);
     try {
       await tester.pumpWidget(
-        SizedBox(
+        const SizedBox(
           width: 100,
           height: 100,
           child: Directionality(
@@ -159,7 +159,7 @@ void main() {
                   Flex(
                     textDirection: TextDirection.ltr,
                     direction: Axis.vertical,
-                    children: <Widget>[
+                    children: const <Widget>[
                       Directionality(
                         textDirection: TextDirection.ltr,
                         child: ListBody(

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -411,9 +411,9 @@ void main() {
   });
 
   testWidgets('ModalBarrier uses default mouse cursor', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         MouseRegion(cursor: SystemMouseCursors.click),
         ModalBarrier(dismissible: false),
       ],

--- a/packages/flutter/test/widgets/multichild_test.dart
+++ b/packages/flutter/test/widgets/multichild_test.dart
@@ -32,7 +32,7 @@ void checkTree(WidgetTester tester, List<BoxDecoration> expectedDecorations) {
 }
 
 class MockMultiChildRenderObjectWidget extends MultiChildRenderObjectWidget {
-  MockMultiChildRenderObjectWidget({ Key? key, required List<Widget> children }) : super(key: key, children: children);
+  const MockMultiChildRenderObjectWidget({ Key? key, required List<Widget> children }) : super(key: key, children: children);
 
   @override
   RenderObject createRenderObject(BuildContext context) {
@@ -45,9 +45,9 @@ void main() {
   testWidgets('MultiChildRenderObjectElement control test', (WidgetTester tester) async {
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -58,9 +58,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationC),
         ],
@@ -70,9 +70,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -83,9 +83,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
           DecoratedBox(key: Key('a'), decoration: kBoxDecorationA),
@@ -96,9 +96,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC, kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('a'), decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationC),
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
@@ -109,9 +109,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationC),
         ],
       ),
@@ -120,7 +120,7 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <BoxDecoration>[]);
@@ -130,9 +130,9 @@ void main() {
   testWidgets('MultiChildRenderObjectElement with stateless widgets', (WidgetTester tester) async {
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -143,9 +143,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DummyWidget(
             child: DecoratedBox(decoration: kBoxDecorationB),
@@ -158,9 +158,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DummyWidget(
             child: DummyWidget(
@@ -175,9 +175,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             child: DummyWidget(
               child: DecoratedBox(decoration: kBoxDecorationB),
@@ -194,9 +194,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             child: DecoratedBox(decoration: kBoxDecorationB),
           ),
@@ -211,9 +211,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             key: Key('b'),
             child: DecoratedBox(decoration: kBoxDecorationB),
@@ -229,9 +229,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             key: Key('a'),
             child: DecoratedBox(decoration: kBoxDecorationA),
@@ -247,7 +247,7 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <BoxDecoration>[]);
@@ -255,9 +255,9 @@ void main() {
 
   testWidgets('MultiChildRenderObjectElement with stateful widgets', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
         ],
@@ -267,9 +267,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             left: DecoratedBox(decoration: kBoxDecorationA),
             right: DecoratedBox(decoration: kBoxDecorationB),
@@ -287,9 +287,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             left: DecoratedBox(decoration: kBoxDecorationA),
             right: DecoratedBox(decoration: kBoxDecorationB),
@@ -306,9 +306,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             key: Key('flip'),
             left: DecoratedBox(decoration: kBoxDecorationA),
@@ -319,9 +319,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('c'), decoration: kBoxDecorationC),
           FlipWidget(
             key: Key('flip'),
@@ -340,9 +340,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationC, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             key: Key('flip'),
             left: DecoratedBox(decoration: kBoxDecorationA),

--- a/packages/flutter/test/widgets/overflow_bar_test.dart
+++ b/packages/flutter/test/widgets/overflow_bar_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('OverflowBar documented defaults', (WidgetTester tester) async {
-    final OverflowBar bar = OverflowBar();
+    const OverflowBar bar = OverflowBar();
     expect(bar.spacing, 0);
     expect(bar.alignment, null);
     expect(bar.overflowSpacing, 0);
@@ -26,7 +26,7 @@ void main() {
         child: Center(
           child: ConstrainedBox(
             constraints: BoxConstraints.tight(size),
-            child: OverflowBar(),
+            child: const OverflowBar(),
           ),
         ),
       ),
@@ -35,7 +35,7 @@ void main() {
     expect(tester.getSize(find.byType(OverflowBar)), size);
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: OverflowBar(),
@@ -182,11 +182,11 @@ void main() {
           child: Container(
             width: width,
             alignment: Alignment.topLeft,
-            child: IntrinsicWidth(
+            child: const IntrinsicWidth(
               child: OverflowBar(
                 spacing: 4,
                 overflowSpacing: 8,
-                children: const <Widget>[
+                children: <Widget>[
                   SizedBox(width: 48, height: 50),
                   SizedBox(width: 64, height: 25),
                   SizedBox(width: 32, height: 75),
@@ -213,11 +213,11 @@ void main() {
           child: Container(
             width: maxWidth,
             alignment: Alignment.topLeft,
-            child: IntrinsicHeight(
+            child: const IntrinsicHeight(
               child: OverflowBar(
                 spacing: 4,
                 overflowSpacing: 8,
-                children: const <Widget>[
+                children: <Widget>[
                   SizedBox(width: 48, height: 50),
                   SizedBox(width: 64, height: 25),
                   SizedBox(width: 32, height: 75),

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -51,9 +51,9 @@ final TestParentData kNonPositioned = TestParentData();
 void main() {
   testWidgets('ParentDataWidget control test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           Positioned(
             top: 10.0,
@@ -72,9 +72,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 5.0,
             right: 7.0,
@@ -101,9 +101,9 @@ void main() {
     const DecoratedBox kDecoratedBoxC = DecoratedBox(decoration: kBoxDecorationC);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 5.0,
             right: 7.0,
@@ -126,9 +126,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 6.0,
             right: 8.0,
@@ -197,9 +197,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             child: FlipWidget(left: kDecoratedBoxA, right: kDecoratedBoxB),
@@ -220,9 +220,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             top: 7.0,
             child: FlipWidget(left: kDecoratedBoxA, right: kDecoratedBoxB),
@@ -243,7 +243,7 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <TestParentData>[]);
@@ -251,11 +251,11 @@ void main() {
 
   testWidgets('ParentDataWidget conflicting data', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             Positioned(
               top: 5.0,
               bottom: 8.0,
@@ -287,7 +287,7 @@ void main() {
       ),
     );
 
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
 
     checkTree(tester, <TestParentData>[]);
 
@@ -325,7 +325,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <TestParentData>[]);

--- a/packages/flutter/test/widgets/placeholder_test.dart
+++ b/packages/flutter/test/widgets/placeholder_test.dart
@@ -13,11 +13,11 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 600.0));
     await tester.pumpWidget(const Center(child: Placeholder()));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 600.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(top: 0.0, bottom: 0.0, child: Placeholder())]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(top: 0.0, bottom: 0.0, child: Placeholder())]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(400.0, 600.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(left: 0.0, right: 0.0, child: Placeholder())]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(left: 0.0, right: 0.0, child: Placeholder())]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 400.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(top: 0.0, child: Placeholder(fallbackWidth: 200.0, fallbackHeight: 300.0))]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(top: 0.0, child: Placeholder(fallbackWidth: 200.0, fallbackHeight: 300.0))]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(200.0, 300.0));
   });
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -20,7 +20,7 @@ class TestPaintingContext implements PaintingContext {
 void main() {
   testWidgets('Can construct an empty Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(),
       ),
@@ -29,7 +29,7 @@ void main() {
 
   testWidgets('Can construct an empty Centered Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(child: Stack()),
       ),
@@ -40,9 +40,9 @@ void main() {
     const Key key = Key('container');
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.topLeft,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             left: 10.0,
             child: SizedBox(
@@ -68,9 +68,9 @@ void main() {
     expect(parentData.height, isNull);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.topLeft,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             child: SizedBox(
@@ -98,9 +98,9 @@ void main() {
     const SizedBox sizedBox = SizedBox(key: key, width: 10.0, height: 10.0);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[ Positioned(left: 10.0, child: sizedBox) ],
+        children: <Widget>[ Positioned(left: 10.0, child: sizedBox) ],
       ),
     );
     Element containerElement = tester.element(find.byKey(key));
@@ -115,9 +115,9 @@ void main() {
     expect(parentData.height, isNull);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[ sizedBox ],
+        children: <Widget>[ sizedBox ],
       ),
     );
     containerElement = tester.element(find.byKey(key));
@@ -136,12 +136,12 @@ void main() {
     const Key child1Key = Key('child1');
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             alignment: Alignment.center,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -159,12 +159,12 @@ void main() {
     expect(child1RenderObjectParentData.offset, equals(const Offset(5.0, 5.0)));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             alignment: AlignmentDirectional.bottomEnd,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -182,12 +182,12 @@ void main() {
     const Key child1Key = Key('child1');
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Center(
           child: Stack(
             alignment: Alignment.center,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -205,12 +205,12 @@ void main() {
     expect(child1RenderObjectParentData.offset, equals(const Offset(5.0, 5.0)));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Center(
           child: Stack(
             alignment: AlignmentDirectional.bottomEnd,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -225,7 +225,7 @@ void main() {
 
   testWidgets('Can construct an empty IndexedStack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: IndexedStack(),
       ),
@@ -234,7 +234,7 @@ void main() {
 
   testWidgets('Can construct an empty Centered IndexedStack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(child: IndexedStack()),
       ),
@@ -316,9 +316,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             left: 10.0,
             width: 11.0,
@@ -348,9 +348,9 @@ void main() {
     expect(renderBox.size.height, equals(12.0));
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             width: 11.0,
@@ -377,11 +377,11 @@ void main() {
   });
 
   testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
     final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, clipBehavior: Clip.hardEdge));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
   });
 
@@ -417,12 +417,12 @@ void main() {
 
   testWidgets('Stack clip test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             clipBehavior: Clip.hardEdge,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(
                 width: 100.0,
                 height: 100.0,
@@ -447,12 +447,12 @@ void main() {
     expect(context.invocations.first.memberName, equals(#pushClipRect));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             clipBehavior: Clip.none,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(
                 width: 100.0,
                 height: 100.0,
@@ -623,18 +623,18 @@ void main() {
 
   testWidgets('Can change the text direction of a Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.center,
       ),
     );
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: AlignmentDirectional.topStart,
         textDirection: TextDirection.rtl,
       ),
     );
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.center,
       ),
     );
@@ -642,11 +642,11 @@ void main() {
 
   testWidgets('Alignment with partially-positioned children', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Stack(
           alignment: Alignment.center,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -671,11 +671,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.center,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -700,11 +700,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.bottomRight,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -729,11 +729,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.topLeft,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -760,7 +760,7 @@ void main() {
 
   testWidgets('Stack error messages', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(),
+      const Stack(),
     );
     expect(
       tester.takeException().toString(),

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1226,21 +1226,21 @@ void main() {
             height: 100,
             child: IntrinsicWidth(
               child: RichText(
-                text: TextSpan(
-                  style: const TextStyle(fontSize: 16, height: 1),
+                text: const TextSpan(
+                  style: TextStyle(fontSize: 16, height: 1),
                   children: <InlineSpan>[
-                    const TextSpan(text: 'S '),
+                    TextSpan(text: 'S '),
                     WidgetSpan(
                       alignment: PlaceholderAlignment.top,
                       child: Wrap(
                         direction: Axis.vertical,
-                        children: const <Widget>[
+                        children: <Widget>[
                           SizedBox(width: 200, height: 100),
                           SizedBox(width: 200, height: 30),
                         ],
                       ),
                     ),
-                    const TextSpan(text: ' E'),
+                    TextSpan(text: ' E'),
                   ],
                 ),
               ),

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -249,10 +249,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('WidgetInspector smoke test', (WidgetTester tester) async {
       // This is a smoke test to verify that adding the inspector doesn't crash.
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -262,12 +262,12 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       );
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: WidgetInspector(
             selectButtonBuilder: null,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a', textDirection: TextDirection.ltr),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -367,8 +367,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             selectButtonBuilder: null,
             child: Transform(
               transform: Matrix4.identity()..scale(0.0),
-              child: Stack(
-                children: const <Widget>[
+              child: const Stack(
+                children: <Widget>[
                   Text('a', textDirection: TextDirection.ltr),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -733,10 +733,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService maybeSetSelection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -780,10 +780,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService defunct selection regression test', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
             ],
           ),
@@ -837,10 +837,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -908,10 +908,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -935,10 +935,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService creationLocation', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -983,10 +983,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('test transformDebugCreator will re-order if after stack trace', (WidgetTester tester) async {
       final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1046,10 +1046,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('test transformDebugCreator will not re-order if before stack trace', (WidgetTester tester) async {
       final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1112,10 +1112,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1146,10 +1146,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1178,10 +1178,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1206,10 +1206,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService setPubRootDirectories', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1316,10 +1316,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('ext.flutter.inspector.setSelection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1365,10 +1365,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1434,10 +1434,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1462,10 +1462,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1498,10 +1498,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1585,10 +1585,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1669,10 +1669,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1722,10 +1722,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('ext.flutter.inspector creationLocation', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1765,10 +1765,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('ext.flutter.inspector.setPubRootDirectories', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1846,10 +1846,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       // Ensure that passing the isolate id as an argument won't break
       // setPubRootDirectories command.
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -18,10 +18,10 @@ void verify(WidgetTester tester, List<Offset> answerKey) {
 void main() {
   testWidgets('Basic Wrap test (LTR)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -37,10 +37,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.center,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -56,10 +56,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.end,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -75,11 +75,11 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.start,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -95,11 +95,11 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.center,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -115,11 +115,11 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.end,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -138,10 +138,10 @@ void main() {
 
   testWidgets('Basic Wrap test (RTL)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -157,10 +157,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.center,
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -176,10 +176,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.end,
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -195,12 +195,12 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.start,
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -216,12 +216,12 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.center,
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -237,12 +237,12 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.start,
         crossAxisAlignment: WrapCrossAlignment.end,
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -260,16 +260,16 @@ void main() {
   });
 
   testWidgets('Empty wrap', (WidgetTester tester) async {
-    await tester.pumpWidget(Center(child: Wrap(alignment: WrapAlignment.center)));
+    await tester.pumpWidget(const Center(child: Wrap(alignment: WrapAlignment.center)));
     expect(tester.renderObject<RenderBox>(find.byType(Wrap)).size, equals(Size.zero));
   });
 
   testWidgets('Wrap alignment (LTR)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.center,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -282,11 +282,11 @@ void main() {
       const Offset(405.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceBetween,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -299,11 +299,11 @@ void main() {
       const Offset(500.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceAround,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -316,11 +316,11 @@ void main() {
       const Offset(460.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceEvenly,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -335,11 +335,11 @@ void main() {
   });
 
   testWidgets('Wrap alignment (RTL)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.center,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -352,11 +352,11 @@ void main() {
       const Offset(95.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceBetween,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -369,11 +369,11 @@ void main() {
       Offset.zero,
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceAround,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -386,11 +386,11 @@ void main() {
       const Offset(30.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceEvenly,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -405,11 +405,11 @@ void main() {
   });
 
   testWidgets('Wrap runAlignment (DOWN)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.center,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -426,11 +426,11 @@ void main() {
       const Offset(0.0, 310.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceBetween,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -447,11 +447,11 @@ void main() {
       const Offset(0.0, 540.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceAround,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -468,11 +468,11 @@ void main() {
       const Offset(0.0, 455.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceEvenly,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -492,12 +492,12 @@ void main() {
   });
 
   testWidgets('Wrap runAlignment (UP)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.center,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -514,12 +514,12 @@ void main() {
       const Offset(0.0, 230.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceBetween,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -536,12 +536,12 @@ void main() {
       Offset.zero,
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceAround,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -558,12 +558,12 @@ void main() {
       const Offset(0.0, 75.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceEvenly,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -584,13 +584,13 @@ void main() {
 
   testWidgets('Shrink-wrapping Wrap test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           alignment: WrapAlignment.end,
           crossAxisAlignment: WrapCrossAlignment.end,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 10.0),
             SizedBox(width: 200.0, height: 20.0),
             SizedBox(width: 300.0, height: 30.0),
@@ -608,13 +608,13 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           alignment: WrapAlignment.end,
           crossAxisAlignment: WrapCrossAlignment.end,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 400.0, height: 40.0),
             SizedBox(width: 300.0, height: 30.0),
             SizedBox(width: 200.0, height: 20.0),
@@ -634,14 +634,14 @@ void main() {
 
   testWidgets('Wrap spacing test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           runSpacing: 10.0,
           alignment: WrapAlignment.start,
           crossAxisAlignment: WrapCrossAlignment.start,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 500.0, height: 10.0),
             SizedBox(width: 500.0, height: 20.0),
             SizedBox(width: 500.0, height: 30.0),
@@ -661,7 +661,7 @@ void main() {
 
   testWidgets('Vertical Wrap test with spacing', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           direction: Axis.vertical,
@@ -670,7 +670,7 @@ void main() {
           alignment: WrapAlignment.start,
           crossAxisAlignment: WrapCrossAlignment.start,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 10.0, height: 250.0),
             SizedBox(width: 20.0, height: 250.0),
             SizedBox(width: 30.0, height: 250.0),
@@ -692,14 +692,14 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           direction: Axis.horizontal,
           spacing: 12.0,
           runSpacing: 8.0,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 10.0, height: 250.0),
             SizedBox(width: 20.0, height: 250.0),
             SizedBox(width: 30.0, height: 250.0),
@@ -722,19 +722,19 @@ void main() {
   });
 
   testWidgets('Visual overflow generates a clip', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 500.0),
       ],
     ));
 
     expect(tester.renderObject<RenderBox>(find.byType(Wrap)), isNot(paints..clipRect()));
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       textDirection: TextDirection.ltr,
       clipBehavior: Clip.hardEdge,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 500.0),
         SizedBox(width: 500.0, height: 500.0),
       ],
@@ -780,18 +780,18 @@ void main() {
   });
 
   testWidgets('RenderWrap toStringShallow control test', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(alignment: WrapAlignment.center));
+    await tester.pumpWidget(const Wrap(alignment: WrapAlignment.center));
 
     final RenderBox wrap = tester.renderObject(find.byType(Wrap));
     expect(wrap.toStringShallow(), hasOneLineDescription);
   });
 
   testWidgets('RenderWrap toString control test', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       direction: Axis.vertical,
       runSpacing: 7.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 400.0),
         SizedBox(width: 500.0, height: 400.0),
         SizedBox(width: 500.0, height: 400.0),
@@ -806,18 +806,18 @@ void main() {
 
   testWidgets('Wrap baseline control test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Center(
+      const Center(
         child: Baseline(
           baseline: 180.0,
           baselineType: TextBaseline.alphabetic,
           child: DefaultTextStyle(
-            style: const TextStyle(
+            style: TextStyle(
               fontFamily: 'Ahem',
               fontSize: 100.0,
             ),
             child: Wrap(
               textDirection: TextDirection.ltr,
-              children: const <Widget>[
+              children: <Widget>[
                 Text('X', textDirection: TextDirection.ltr),
               ],
             ),
@@ -833,12 +833,12 @@ void main() {
   });
 
   testWidgets('Spacing with slight overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       direction: Axis.horizontal,
       textDirection: TextDirection.ltr,
       spacing: 10.0,
       runSpacing: 10.0,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 200.0, height: 10.0),
         SizedBox(width: 200.0, height: 10.0),
         SizedBox(width: 200.0, height: 10.0),
@@ -858,13 +858,13 @@ void main() {
   testWidgets('Object exactly matches container width', (WidgetTester tester) async {
     await tester.pumpWidget(
       Column(
-        children: <Widget>[
+        children: const <Widget>[
           Wrap(
             direction: Axis.horizontal,
             textDirection: TextDirection.ltr,
             spacing: 10.0,
             runSpacing: 10.0,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(width: 800.0, height: 10.0),
             ],
           ),
@@ -877,13 +877,13 @@ void main() {
 
     await tester.pumpWidget(
       Column(
-        children: <Widget>[
+        children: const <Widget>[
           Wrap(
             direction: Axis.horizontal,
             textDirection: TextDirection.ltr,
             spacing: 10.0,
             runSpacing: 10.0,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(width: 800.0, height: 10.0),
               SizedBox(width: 800.0, height: 10.0),
             ],
@@ -900,11 +900,11 @@ void main() {
   });
 
   testWidgets('Wrap can set and update clipBehavior', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Wrap(textDirection: TextDirection.ltr));
     final RenderWrap renderObject = tester.allRenderObjects.whereType<RenderWrap>().first;
     expect(renderObject.clipBehavior, equals(Clip.none));
 
-    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.antiAlias));
+    await tester.pumpWidget(const Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.antiAlias));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 


### PR DESCRIPTION
Relates to https://github.com/dart-lang/sdk/issues/29276

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
