### PR TITLE
Add fixes for AppBar deprecations

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,6 +15,468 @@
 version: 1
 transforms:
 
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'backgroundColor'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      getter: color
+      inClass: 'AppBarTheme'
+    changes:
+      - kind: 'rename'
+        newName: 'backgroundColor'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Remove 'backwardsCompatibility'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'AppBarTheme'
+    changes:
+    - kind: 'removeParameter'
+      name: 'backwardsCompatibility'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Remove 'backwardsCompatibility'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBarTheme'
+    changes:
+    - kind: 'removeParameter'
+      name: 'backwardsCompatibility'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Remove 'backwardsCompatibility'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'SliverAppBar'
+    changes:
+    - kind: 'removeParameter'
+      name: 'backwardsCompatibility'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Remove 'backwardsCompatibility'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBar'
+    changes:
+    - kind: 'removeParameter'
+      name: 'backwardsCompatibility'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle' & 'titleTextStyle'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'AppBarTheme'
+    changes:
+    - kind: 'addParameter'
+      index: 12
+      name: 'toolbarTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.bodyText2'
+        requiredIf: "textTheme != ''"
+    - kind: 'addParameter'
+      index: 13
+      name: 'titleTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.headline6'
+        requiredIf: "textTheme != ''"
+    - kind: 'removeParameter'
+      name: 'textTheme'
+    variables:
+      textTheme:
+        kind: 'fragment'
+        value: 'arguments[textTheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle' & 'titleTextStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBarTheme'
+    changes:
+    - kind: 'addParameter'
+      index: 13
+      name: 'toolbarTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.bodyText2'
+        requiredIf: "textTheme != ''"
+    - kind: 'addParameter'
+      index: 14
+      name: 'titleTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.headline6'
+        requiredIf: "textTheme != ''"
+    - kind: 'removeParameter'
+      name: 'textTheme'
+    variables:
+      textTheme:
+        kind: 'fragment'
+        value: 'arguments[textTheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'AppBarTheme'
+    changes:
+      - kind: 'rename'
+        newName: 'toolbarTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'titleTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'AppBarTheme'
+    changes:
+      - kind: 'rename'
+        newName: 'titleTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle' & 'titleTextStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'SliverAppBar'
+    changes:
+    - kind: 'addParameter'
+      index: 32
+      name: 'toolbarTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.bodyText2'
+        requiredIf: "textTheme != ''"
+    - kind: 'addParameter'
+      index: 33
+      name: 'titleTextStyle'
+      style: optional_named
+      argumentValue:
+        expression: '{% textTheme %}.headline6'
+        requiredIf: "textTheme != ''"
+    - kind: 'removeParameter'
+      name: 'textTheme'
+    variables:
+      textTheme:
+        kind: 'fragment'
+        value: 'arguments[textTheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'SliverAppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'toolbarTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'titleTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'SliverAppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'titleTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle' & 'titleTextStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBar'
+    changes:
+      - kind: 'addParameter'
+        index: 24
+        name: 'toolbarTextStyle'
+        style: optional_named
+        argumentValue:
+          expression: '{% textTheme %}.bodyText2'
+          requiredIf: "textTheme != ''"
+      - kind: 'addParameter'
+        index: 25
+        name: 'titleTextStyle'
+        style: optional_named
+        argumentValue:
+          expression: '{% textTheme %}.headline6'
+          requiredIf: "textTheme != ''"
+      - kind: 'removeParameter'
+        name: 'textTheme'
+    variables:
+      textTheme:
+        kind: 'fragment'
+        value: 'arguments[textTheme]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'toolbarTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'AppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'toolbarTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'titleTextStyle'"
+    date: 2021-07-12
+    # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
+    bulkApply: false
+    element:
+      uris: [ 'material.dart' ]
+      field: 'textTheme'
+      inClass: 'AppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'titleTextStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'AppBarTheme'
+    oneOf:
+    - if: "brightness == 'Brightness.dark'"
+      changes:
+        - kind: 'addParameter'
+          index: 14
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.light'
+            requiredIf: "brightness == 'Brightness.dark'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    - if: "brightness == 'Brightness.light'"
+      changes:
+        - kind: 'addParameter'
+          index: 14
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.dark'
+            requiredIf: "brightness == 'Brightness.light'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    variables:
+      brightness:
+        kind: 'fragment'
+        value: 'arguments[brightness]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBarTheme'
+    oneOf:
+    - if: "brightness == 'Brightness.dark'"
+      changes:
+        - kind: 'addParameter'
+          index: 14
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.light'
+            requiredIf: "brightness == 'Brightness.dark'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    - if: "brightness == 'Brightness.light'"
+      changes:
+        - kind: 'addParameter'
+          index: 14
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.dark'
+            requiredIf: "brightness == 'Brightness.light'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    variables:
+      brightness:
+        kind: 'fragment'
+        value: 'arguments[brightness]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      field: 'brightness'
+      inClass: 'AppBarTheme'
+    changes:
+      - kind: 'rename'
+        newName: 'systemOverlayStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'SliverAppBar'
+    oneOf:
+    - if: "brightness == 'Brightness.dark'"
+      changes:
+        - kind: 'addParameter'
+          index: 34
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.light'
+            requiredIf: "brightness == 'Brightness.dark'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    - if: "brightness == 'Brightness.light'"
+      changes:
+        - kind: 'addParameter'
+          index: 34
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.dark'
+            requiredIf: "brightness == 'Brightness.light'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    variables:
+      brightness:
+        kind: 'fragment'
+        value: 'arguments[brightness]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      field: 'brightness'
+      inClass: 'SliverAppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'systemOverlayStyle'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2020-07-12
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'AppBar'
+    oneOf:
+    - if: "brightness == 'Brightness.dark'"
+      changes:
+        - kind: 'addParameter'
+          index: 27
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.light'
+            requiredIf: "brightness == 'Brightness.dark'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    - if: "brightness == 'Brightness.light'"
+      changes:
+        - kind: 'addParameter'
+          index: 27
+          name: 'systemOverlayStyle'
+          style: optional_named
+          argumentValue:
+            expression: '{% SystemUiOverlayStyle %}.dark'
+            requiredIf: "brightness == 'Brightness.light'"
+            variables:
+              SystemUiOverlayStyle:
+                kind: 'import'
+                uris: [ 'services.dart' ]
+                name: 'SystemUiOverlayStyle'
+        - kind: 'removeParameter'
+          name: 'brightness'
+    variables:
+      brightness:
+        kind: 'fragment'
+        value: 'arguments[brightness]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/86198
+  - title: "Migrate to 'systemOverlayStyle'"
+    date: 2021-07-12
+    element:
+      uris: [ 'material.dart' ]
+      field: 'brightness'
+      inClass: 'AppBar'
+    changes:
+      - kind: 'rename'
+        newName: 'systemOverlayStyle'
+
   # Changes made in https://github.com/flutter/flutter/pull/87839
   - title: "Migrate to 'disallowIndicator'"
     date: 2021-08-06

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1572,6 +1572,10 @@ class SliverAppBar extends StatefulWidget {
     this.shape,
     this.toolbarHeight = kToolbarHeight,
     this.leadingWidth,
+    @Deprecated(
+      'This property is obsolete and is false by default. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     this.backwardsCompatibility,
     this.toolbarTextStyle,
     this.titleTextStyle,
@@ -1832,6 +1836,10 @@ class SliverAppBar extends StatefulWidget {
   /// {@macro flutter.material.appbar.backwardsCompatibility}
   ///
   /// This property is used to configure an [AppBar].
+  @Deprecated(
+    'This property is obsolete and is false by default. '
+    'This feature was deprecated after v2.4.0-0.0.pre.',
+  )
   final bool? backwardsCompatibility;
 
   /// {@macro flutter.material.appbar.toolbarTextStyle}

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -228,6 +228,10 @@ class AppBarTheme with Diagnosticable {
   /// new values.
   AppBarTheme copyWith({
     IconThemeData? actionsIconTheme,
+    @Deprecated(
+      'This property is no longer used, please use systemOverlayStyle instead. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     Brightness? brightness,
     Color? color,
     Color? backgroundColor,
@@ -236,6 +240,10 @@ class AppBarTheme with Diagnosticable {
     Color? shadowColor,
     ShapeBorder? shape,
     IconThemeData? iconTheme,
+    @Deprecated(
+      'This property is no longer used, please use toolbarTextStyle and titleTextStyle instead. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     TextTheme? textTheme,
     bool? centerTitle,
     double? titleSpacing,
@@ -243,6 +251,10 @@ class AppBarTheme with Diagnosticable {
     TextStyle? toolbarTextStyle,
     TextStyle? titleTextStyle,
     SystemUiOverlayStyle? systemOverlayStyle,
+    @Deprecated(
+      'This property is obsolete and is false by default. '
+      'This feature was deprecated after v2.4.0-0.0.pre.',
+    )
     bool? backwardsCompatibility,
   }) {
     assert(

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -398,4 +398,57 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
   notification.disallowGlow();
+
+  // Changes made in https://github.com/flutter/flutter/pull/86198
+  AppBar appBar = AppBar();
+  appBar = AppBar(brightness: Brightness.light);
+  appBar = AppBar(brightness: Brightness.dark);
+  appBar.brightness;
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar(brightness: Brightness.light);
+  sliverAppBar = SliverAppBar(brightness: Brightness.dark);
+  sliverAppBar.brightness;
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme(brightness: Brightness.light);
+  appBarTheme = AppBarTheme(brightness: Brightness.dark);
+  appBarTheme = appBarTheme.copyWith(brightness: Brightness.light);
+  appBarTheme = appBarTheme.copyWith(brightness: Brightness.dark);
+  appBarTheme.brightness;
+
+  TextTheme myTextTheme = TextTheme();
+  AppBar appBar = AppBar();
+  appBar = AppBar(textTheme: myTextTheme);
+  appBar = AppBar(textTheme: myTextTheme);
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar(textTheme: myTextTheme);
+  sliverAppBar = SliverAppBar(textTheme: myTextTheme);
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme(textTheme: myTextTheme);
+  appBarTheme = AppBarTheme(textTheme: myTextTheme);
+  appBarTheme = appBarTheme.copyWith(textTheme: myTextTheme);
+  appBarTheme = appBarTheme.copyWith(textTheme: myTextTheme);
+
+  AppBar appBar = AppBar();
+  appBar = AppBar(backwardsCompatibility: true);
+  appBar = AppBar(backwardsCompatibility: false));
+  appBar.backwardsCompatibility; // Removing field reference not supported.
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar(backwardsCompatibility: true);
+  sliverAppBar = SliverAppBar(backwardsCompatibility: false);
+  sliverAppBar.backwardsCompatibility; // Removing field reference not supported.
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme(backwardsCompatibility: true);
+  appBarTheme = AppBarTheme(backwardsCompatibility: false);
+  appBarTheme = appBarTheme.copyWith(backwardsCompatibility: true);
+  appBarTheme = appBarTheme.copyWith(backwardsCompatibility: false);
+  appBarTheme.backwardsCompatibility; // Removing field reference not supported.
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme.color;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() {
   // Generic reference variables.
@@ -370,4 +371,57 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
   notification.disallowIndicator();
+
+  // Changes made in https://github.com/flutter/flutter/pull/86198
+  AppBar appBar = AppBar();
+  appBar = AppBar(systemOverlayStyle: SystemUiOverlayStyle.dark);
+  appBar = AppBar(systemOverlayStyle: SystemUiOverlayStyle.light);
+  appBar.systemOverlayStyle;
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar(systemOverlayStyle: SystemUiOverlayStyle.dark);
+  sliverAppBar = SliverAppBar(systemOverlayStyle: SystemUiOverlayStyle.light);
+  sliverAppBar.systemOverlayStyle;
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.dark);
+  appBarTheme = AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light);
+  appBarTheme = appBarTheme.copyWith(systemOverlayStyle: SystemUiOverlayStyle.dark);
+  appBarTheme = appBarTheme.copyWith(systemOverlayStyle: SystemUiOverlayStyle.light);
+  appBarTheme.systemOverlayStyle;
+
+  TextTheme myTextTheme = TextTheme();
+  AppBar appBar = AppBar();
+  appBar = AppBar(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+  appBar = AppBar(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+  sliverAppBar = SliverAppBar(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+  appBarTheme = AppBarTheme(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+  appBarTheme = appBarTheme.copyWith(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+  appBarTheme = appBarTheme.copyWith(toolbarTextStyle: myTextTheme.bodyText2, titleTextStyle: myTextTheme.headline6);
+
+  AppBar appBar = AppBar();
+  appBar = AppBar();
+  appBar = AppBar());
+  appBar.backwardsCompatibility; // Removing field reference not supported.
+
+  SliverAppBar sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar();
+  sliverAppBar = SliverAppBar();
+  sliverAppBar.backwardsCompatibility; // Removing field reference not supported.
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme();
+  appBarTheme = AppBarTheme();
+  appBarTheme = appBarTheme.copyWith();
+  appBarTheme = appBarTheme.copyWith();
+  appBarTheme.backwardsCompatibility; // Removing field reference not supported.
+
+  AppBarTheme appBarTheme = AppBarTheme();
+  appBarTheme.backgroundColor;
 }


### PR DESCRIPTION
Original PR (https://github.com/flutter/flutter/pull/86382) was stuck on what appears to be a flaky customer test

**From Original PR**

---

This adds fixes for the deprecations added in https://github.com/flutter/flutter/pull/86198

Fixes #74908

It also adds a few missing deprecation notices to the affected api.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
