### PR TITLE
Adding Tooltip.custom constructor to create a tooltip with custom widget.  

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -94,17 +94,19 @@ import 'tooltip_theme.dart';
 /// ```dart
 /// Widget build(BuildContext context) {
 ///     return Tooltip.custom(
-///       tooltip: TextSpan(
-///         text: " Custom",
-///         style: TextStyle(color: Colors.red),
-///         children: [
-///           TextSpan(
-///             text: "Test Tooltip",
-///             style: TextStyle(color: Colors.white70),
-///           ),
-///         ],
+///       tooltip: RichText(
+///         text: const TextSpan(
+///           text: " Custom",
+///           style: TextStyle(color: Colors.red),
+///           children: [
+///             TextSpan(
+///               text: "Test Tooltip",
+///               style: TextStyle(color: Colors.white70),
+///             ),
+///           ],
+///         ),
 ///       ),
-///       child: Text('Hover over the text to show a custom tooltip.'),
+///       child: const Text('Hover over the text to show a custom tooltip.'),
 ///    );
 /// }
 /// ```

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -85,12 +85,13 @@ import 'tooltip_theme.dart';
 ///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
 ///
-/// This example show a basic [Tooltip.custom] which has a [Container]
-/// containing [Text] as child.
-/// [tooltip] contains your widget to be shown by the tooltip when
-/// the child that Tooltip wraps is hovered over on web or desktop. On mobile,
-/// the tooltip is shown when the widget is long pressed. Also, [decoration],
-/// [height] and other options can be specified like above example.
+/// This example show a basic [Tooltip.custom] example which has a [RichText]
+/// containing a [TextSpan] as child where it shows red text and another
+/// [TextSpan] in the children which shows white text. [tooltip] contains your
+/// widget to be shown by the tooltip when the child that Tooltip wraps is
+/// hovered over on web or desktop. On mobile, the tooltip is shown when the
+/// widget is long pressed. Also, [decoration], [height] and other options can
+/// be specified like above example.
 /// ```dart
 /// Widget build(BuildContext context) {
 ///     return Tooltip.custom(
@@ -154,8 +155,8 @@ class Tooltip extends StatefulWidget {
   /// Creates a tooltip using a widget provided to the [tooltip].
   ///
   /// **NOTE :** Using [Tooltip] and [Tooltip.custom], like examples given
-  /// below, will result in same results unless the [textStyle] or
-  /// [TooltipTheme] is not customised for the first example.Therefore, it is
+  /// below, will show the same results unless the custom [textStyle] or
+  /// [TooltipTheme] is not procvided for the [Tooltip]. Therefore, it is
   /// recommended to use the [Tooltip] instead of [Tooltip.custom] in general
   /// scenarios where just simple text tooltips needed like following examples.
   /// ```dart

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -82,10 +82,10 @@ import 'tooltip_theme.dart';
 /// }
 /// ```
 /// {@end-tool}
-/// 
+///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
 ///
-/// This example show a basic [Tooltip.custom] which has a [Container] 
+/// This example show a basic [Tooltip.custom] which has a [Container]
 /// containing [Text] as child.
 /// [tooltip] contains your widget to be shown by the tooltip when
 /// the child that Tooltip wraps is hovered over on web or desktop. On mobile,
@@ -150,26 +150,26 @@ class Tooltip extends StatefulWidget {
        super(key: key);
 
   /// Creates a tooltip using a widget provided to the [tooltip].
-  /// 
-  /// **NOTE :** Using [Tooltip] and [Tooltip.custom], like examples given 
-  /// below, will result in same results unless the [textStyle] or 
-  /// [TooltipTheme] is not customised for the first example.Therefore, it is 
-  /// recommended to use the [Tooltip] instead of [Tooltip.custom] in general 
+  ///
+  /// **NOTE :** Using [Tooltip] and [Tooltip.custom], like examples given
+  /// below, will result in same results unless the [textStyle] or
+  /// [TooltipTheme] is not customised for the first example.Therefore, it is
+  /// recommended to use the [Tooltip] instead of [Tooltip.custom] in general
   /// scenarios where just simple text tooltips needed like following examples.
   /// ```dart
   /// Tooltip(
   ///   message:"my tooltip",
-  /// ) 
-  /// 
+  /// )
+  ///
   /// Tooltip.custom(
   ///   tooltip: Text("my tooltip"),
   /// )
-  /// ``` 
+  /// ```
   ///
-  /// **NOTE :** 
+  /// **NOTE :**
   /// By default, tooltips should adhere to the
   /// [Material specification](https://material.io/design/components/tooltips.html#spec).
-  /// But, in the case of [Tooltip.custom], this will ignore the [TooltipTheme.of] as widget 
+  /// But, in the case of [Tooltip.custom], this will ignore the [TooltipTheme.of] as widget
   /// provided in the [tooltip] will use themes like as it would be using in the
   /// normal application.
   ///
@@ -206,19 +206,19 @@ class Tooltip extends StatefulWidget {
   /// tooltip will be shown in the tooltip and message property will be used
   /// for semantics if [excludeFromSemantics] is true.
   ///
-  /// In some cases, like information button tooltip, [Tooltip.custom] 
-  /// can be used which accepts widget. In case of [Tooltip.custom], 
-  /// [TooltipTheme.of] will be ignored.  
+  /// In some cases, like information button tooltip, [Tooltip.custom]
+  /// can be used which accepts widget. In case of [Tooltip.custom],
+  /// [TooltipTheme.of] will be ignored.
   final String? message;
 
-  /// The widget to display in the tooltip. This can be any widget like 
+  /// The widget to display in the tooltip. This can be any widget like
   /// the [child].
-  /// 
-  /// General use case will be a information button tooltips where custom 
+  ///
+  /// General use case will be a information button tooltips where custom
   /// tooltip content can be defined using [tooltip] widget.
-  /// 
+  ///
   /// For example,
-  /// 
+  ///
   /// ```dart
   /// Tooltip.custom(
   ///   child: Text("Custom tooltip"),
@@ -293,7 +293,7 @@ class Tooltip extends StatefulWidget {
   /// Tooltip(
   ///   tooltip: Container(
   ///     child: Text("tooltip")
-  ///   ), 
+  ///   ),
   ///   semanticsLabel: 'semantics for tooltip'
   /// )
   /// ```

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -102,17 +102,17 @@ typedef TooltipWidgetBuilder = Widget Function(
 ///       message: "Custom "
 ///       tooltipBuilder: (BuildContext context, String message) {
 ///         return RichText(
-///           text: const TextSpan(
+///           text: TextSpan(
 ///             text: message,
-///             style: TextStyle(color: Colors.red),
-///             children: [
+///             style: const TextStyle(color: Colors.red),
+///             children: const [
 ///               TextSpan(
 ///                 text: "Test Tooltip",
 ///                 style: TextStyle(color: Colors.white70),
 ///               ),
 ///             ],
 ///           ),
-///         ),
+///         );
 ///       },
 ///       child: const Text('Hover over the text to show a custom tooltip.'),
 ///    );

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -15,8 +15,7 @@ import 'theme.dart';
 import 'tooltip_theme.dart';
 
 /// The signature of the [TooltipWidgetBuilder] builder function.
-typedef TooltipWidgetBuilder = Widget Function(
-    BuildContext context, String message);
+typedef TooltipWidgetBuilder = Widget Function(BuildContext context, String message);
 
 /// A material design tooltip.
 ///
@@ -152,8 +151,8 @@ class Tooltip extends StatefulWidget {
     this.child,
     this.triggerMode,
     this.enableFeedback,
-  })  : assert(message != null, 'A non-null String must be provided in message to a Tooltip widget.'),
-        super(key: key);
+  }) : assert(message != null),
+       super(key: key);
 
   /// The text to display in the tooltip. [message] is used to show a text
   /// tooltips which is general use cases.
@@ -304,12 +303,12 @@ class Tooltip extends StatefulWidget {
     properties.add(DoubleProperty('height', height, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
-    properties.add( DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
+    properties.add(DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
     properties.add(FlagProperty('position', value: preferBelow, ifTrue: 'below', ifFalse: 'above', showName: true, defaultValue: null));
     properties.add(FlagProperty('semantics', value: excludeFromSemantics, ifTrue: 'excluded', showName: true, defaultValue: null));
     properties.add(DiagnosticsProperty<Duration>('wait duration', waitDuration, defaultValue: null));
     properties.add(DiagnosticsProperty<Duration>('show duration', showDuration, defaultValue: null));
-    properties.add(DiagnosticsProperty<TooltipTriggerMode>( 'triggerMode', triggerMode, defaultValue: null));
+    properties.add(DiagnosticsProperty<TooltipTriggerMode>('triggerMode', triggerMode, defaultValue: null));
     properties.add(FlagProperty('enableFeedback', value: enableFeedback, ifTrue: 'true', showName: true, defaultValue: null));
   }
 }
@@ -356,7 +355,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       reverseDuration: _fadeOutDuration,
       vsync: this,
     )
-     ..addStatusListener(_handleStatusChanged);
+      ..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
     RendererBinding.instance!.mouseTracker.addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
@@ -420,7 +419,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     }
   }
 
-  void _hideTooltip({bool immediately = false}) {
+  void _hideTooltip({ bool immediately = false }) {
     _showTimer?.cancel();
     _showTimer = null;
     if (immediately) {
@@ -435,7 +434,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     _pressActivated = false;
   }
 
-  void _showTooltip({bool immediately = false}) {
+  void _showTooltip({ bool immediately = false }) {
     _hideTimer?.cancel();
     _hideTimer = null;
     if (immediately) {
@@ -636,9 +635,9 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
     required this.target,
     required this.verticalOffset,
     required this.preferBelow,
-  })  : assert(target != null),
-        assert(verticalOffset != null),
-        assert(preferBelow != null);
+  }) : assert(target != null),
+       assert(verticalOffset != null),
+       assert(preferBelow != null);
 
   /// The offset of the target the tooltip is positioned near in the global
   /// coordinate system.
@@ -707,7 +706,7 @@ class _TooltipOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget result = IgnorePointer(
-        child: FadeTransition(
+      child: FadeTransition(
         opacity: animation,
         child: ConstrainedBox(
           constraints: BoxConstraints(minHeight: height),

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -176,9 +176,9 @@ class Tooltip extends StatefulWidget {
   /// if tooltipBuilder is provided, default text tooltip will be ignored and
   /// the returned widget will be displayed as a tooltip. [message] will be only
   /// used for semantics if excludeSemantics is not true.
-  /// 
+  ///
   /// ** NOTE **
-  /// When tooltipBuilder is used, returned widget will not use the [TooltipTheme.of]. 
+  /// When tooltipBuilder is used, returned widget will not use the [TooltipTheme.of].
   final TooltipWidgetBuilder? tooltipBuilder;
 
   /// The height of the tooltip's [child].

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -14,6 +14,10 @@ import 'feedback.dart';
 import 'theme.dart';
 import 'tooltip_theme.dart';
 
+/// The signature of the [TooltipWidgetBuilder] builder function.
+typedef TooltipWidgetBuilder = Widget Function(
+    BuildContext context, String message);
+
 /// A material design tooltip.
 ///
 /// Tooltips provide text labels which help explain the function of a button or
@@ -85,28 +89,31 @@ import 'tooltip_theme.dart';
 ///
 /// {@tool dartpad --template=stateless_widget_scaffold_center}
 ///
-/// This example show a basic [Tooltip.custom] example which has a [RichText]
-/// containing a [TextSpan] as child where it shows red text and another
-/// [TextSpan] in the children which shows white text. [tooltip] contains your
-/// widget to be shown by the tooltip when the child that Tooltip wraps is
-/// hovered over on web or desktop. On mobile, the tooltip is shown when the
-/// widget is long pressed. Also, [decoration], [height] and other options can
-/// be specified like above example.
+/// This example show a basic [Tooltip] example which has a [RichText] containing
+/// a [TextSpan] as child where it applys red color to the text and another [TextSpan]
+/// in the children which applys the whitecolor to the text. [tooltipBuilder]
+/// returns your widget to be shown as a tooltip when the child that Tooltip
+/// wraps is hovered over on web or desktop. On mobile, the tooltip is shown when
+/// the widget is long pressed. Also, [decoration], [height] and other options
+/// can be specified like above example.
 /// ```dart
 /// Widget build(BuildContext context) {
-///     return Tooltip.custom(
-///       tooltip: RichText(
-///         text: const TextSpan(
-///           text: " Custom",
-///           style: TextStyle(color: Colors.red),
-///           children: [
-///             TextSpan(
-///               text: "Test Tooltip",
-///               style: TextStyle(color: Colors.white70),
-///             ),
-///           ],
+///     return Tooltip(
+///       message: "Custom "
+///       tooltipBuilder: (BuildContext context, String message) {
+///         return RichText(
+///           text: const TextSpan(
+///             text: message,
+///             style: TextStyle(color: Colors.red),
+///             children: [
+///               TextSpan(
+///                 text: "Test Tooltip",
+///                 style: TextStyle(color: Colors.white70),
+///               ),
+///             ],
+///           ),
 ///         ),
-///       ),
+///       },
 ///       child: const Text('Hover over the text to show a custom tooltip.'),
 ///    );
 /// }
@@ -130,7 +137,8 @@ class Tooltip extends StatefulWidget {
   /// override the default values _and_ the values in [TooltipTheme.of].
   const Tooltip({
     Key? key,
-    required String this.message,
+    required this.message,
+    this.tooltipBuilder,
     this.height,
     this.padding,
     this.margin,
@@ -144,63 +152,11 @@ class Tooltip extends StatefulWidget {
     this.child,
     this.triggerMode,
     this.enableFeedback,
-  }) : assert(
-         message != null,
-         'A non-null String must be provided in message to a Tooltip widget.',
-       ),
-       tooltip = null,
-       semanticsLabel = null,
-       super(key: key);
-
-  /// Creates a tooltip using a widget provided to the [tooltip].
-  ///
-  /// **NOTE :** Using [Tooltip] and [Tooltip.custom], like examples given
-  /// below, will show the same results unless the custom [textStyle] or
-  /// [TooltipTheme] is not procvided for the [Tooltip]. Therefore, it is
-  /// recommended to use the [Tooltip] instead of [Tooltip.custom] in general
-  /// scenarios where just simple text tooltips needed like following examples.
-  /// ```dart
-  /// Tooltip(
-  ///   message:"my tooltip",
-  /// )
-  ///
-  /// Tooltip.custom(
-  ///   tooltip: Text("my tooltip"),
-  /// )
-  /// ```
-  ///
-  /// **NOTE :**
-  /// By default, tooltips should adhere to the
-  /// [Material specification](https://material.io/design/components/tooltips.html#spec).
-  /// But, in the case of [Tooltip.custom], this will ignore the [TooltipTheme.of] as widget
-  /// provided in the [tooltip] will use themes like as it would be using in the
-  /// normal application.
-  ///
-  /// All parameters that are defined in the constructor will
-  /// override the default values _and_ the values in [TooltipTheme.of].
-  const Tooltip.custom({
-    Key? key,
-    required Widget this.tooltip,
-    this.height,
-    this.padding,
-    this.margin,
-    this.verticalOffset,
-    this.preferBelow,
-    this.semanticsLabel,
-    this.decoration,
-    this.waitDuration,
-    this.showDuration,
-    this.child,
-    this.triggerMode,
-    this.enableFeedback,
-  }) : assert(
-         tooltip != null,
-         'A non-null Widget must be provided in tooltip to a Tooltip.custom widget.',
-       ),
-       message = null,
-       textStyle = null,
-       excludeFromSemantics = true,
-       super(key: key);
+  })  : assert(
+          message != null,
+          'A non-null String must be provided in message to a Tooltip widget.',
+        ),
+        super(key: key);
 
   /// The text to display in the tooltip. [message] is used to show a text
   /// tooltips which is general use cases.
@@ -212,32 +168,18 @@ class Tooltip extends StatefulWidget {
   /// In some cases, like information button tooltip, [Tooltip.custom]
   /// can be used which accepts widget. In case of [Tooltip.custom],
   /// [TooltipTheme.of] will be ignored.
-  final String? message;
+  final String message;
 
-  /// The widget to display in the tooltip. This can be any widget like
-  /// the [child].
+  /// [tooltipBuilder] which returns the widget. It provides [BuildContext] & [message]
+  /// which is the input value of the [message] of [Tooltip] widget.
   ///
-  /// General use case will be a information button tooltips where custom
-  /// tooltip content can be defined using [tooltip] widget.
-  ///
-  /// For example,
-  ///
-  /// ```dart
-  /// Tooltip.custom(
-  ///   child: Text("Custom tooltip"),
-  ///   tooltip: TextSpan(
-  ///              text: "Custom ",
-  ///              style: TextStyle(color: Colors.red),
-  ///              children: [
-  ///                TextSpan(
-  ///                  text: "Tooltip",
-  ///                  style: TextStyle(color: Colors.green),
-  ///                ),
-  ///             ],
-  ///          ),
-  ///       ),
-  /// ```
-  final Widget? tooltip;
+  /// if tooltipBuilder is provided, default text tooltip will be ignored and
+  /// the returned widget will be displayed as a tooltip. [message] will be only
+  /// used for semantics if excludeSemantics is not true.
+  /// 
+  /// ** NOTE **
+  /// When tooltipBuilder is used, returned widget will not use the [TooltipTheme.of]. 
+  final TooltipWidgetBuilder? tooltipBuilder;
 
   /// The height of the tooltip's [child].
   ///
@@ -285,22 +227,6 @@ class Tooltip extends StatefulWidget {
   /// [Tooltip.message]. Set this property to true if the app is going to
   /// provide its own custom semantics label.
   final bool? excludeFromSemantics;
-
-  /// A semantics label for the [Tooltip.custom].
-  ///
-  /// If present, the semantics of [Tooltip.custom] widget will be defined using
-  /// [semanticsLabel].
-  ///
-  /// Example,
-  /// ```dart
-  /// Tooltip(
-  ///   tooltip: Container(
-  ///     child: Text("tooltip")
-  ///   ),
-  ///   semanticsLabel: 'semantics for tooltip'
-  /// )
-  /// ```
-  final String? semanticsLabel;
 
   /// The widget below this widget in the tree.
   ///
@@ -366,7 +292,8 @@ class Tooltip extends StatefulWidget {
   static bool dismissAllToolTips() {
     if (_openedToolTips.isNotEmpty) {
       // Avoid concurrent modification.
-      final List<_TooltipState> openedToolTips = List<_TooltipState>.from(_openedToolTips);
+      final List<_TooltipState> openedToolTips =
+          List<_TooltipState>.from(_openedToolTips);
       for (final _TooltipState state in openedToolTips) {
         state._hideTooltip(immediately: true);
       }
@@ -383,18 +310,35 @@ class Tooltip extends StatefulWidget {
     super.debugFillProperties(properties);
     properties.add(StringProperty('message', message, showName: false));
     properties.add(DoubleProperty('height', height, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
-    properties.add(DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
-    properties.add(FlagProperty('position', value: preferBelow, ifTrue: 'below', ifFalse: 'above', showName: true, defaultValue: null));
-    properties.add(FlagProperty('semantics', value: excludeFromSemantics, ifTrue: 'excluded', showName: true, defaultValue: null));
-    properties.add(DiagnosticsProperty<Duration>('wait duration', waitDuration, defaultValue: null));
-    properties.add(DiagnosticsProperty<Duration>('show duration', showDuration, defaultValue: null));
-    properties.add(DiagnosticsProperty<TooltipTriggerMode>('triggerMode', triggerMode, defaultValue: null));
-    properties.add(FlagProperty('enableFeedback', value: enableFeedback, ifTrue: 'true', showName: true, defaultValue: null));
-    if (semanticsLabel != null) {
-      properties.add(StringProperty('semanticsLabel', semanticsLabel));
-    }
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin,
+        defaultValue: null));
+    properties.add(
+        DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
+    properties.add(FlagProperty('position',
+        value: preferBelow,
+        ifTrue: 'below',
+        ifFalse: 'above',
+        showName: true,
+        defaultValue: null));
+    properties.add(FlagProperty('semantics',
+        value: excludeFromSemantics,
+        ifTrue: 'excluded',
+        showName: true,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<Duration>('wait duration', waitDuration,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<Duration>('show duration', showDuration,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<TooltipTriggerMode>(
+        'triggerMode', triggerMode,
+        defaultValue: null));
+    properties.add(FlagProperty('enableFeedback',
+        value: enableFeedback,
+        ifTrue: 'true',
+        showName: true,
+        defaultValue: null));
   }
 }
 
@@ -408,7 +352,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   static const Duration _defaultHoverShowDuration = Duration(milliseconds: 100);
   static const Duration _defaultWaitDuration = Duration.zero;
   static const bool _defaultExcludeFromSemantics = false;
-  static const TooltipTriggerMode _defaultTriggerMode = TooltipTriggerMode.longPress;
+  static const TooltipTriggerMode _defaultTriggerMode =
+      TooltipTriggerMode.longPress;
   static const bool _defaultEnableFeedback = true;
 
   late double height;
@@ -439,10 +384,10 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       duration: _fadeInDuration,
       reverseDuration: _fadeOutDuration,
       vsync: this,
-    )
-      ..addStatusListener(_handleStatusChanged);
+    )..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
-    RendererBinding.instance!.mouseTracker.addListener(_handleMouseTrackerChange);
+    RendererBinding.instance!.mouseTracker
+        .addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
     GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
@@ -490,7 +435,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     if (!mounted) {
       return;
     }
-    final bool mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    final bool mouseIsConnected =
+        RendererBinding.instance!.mouseTracker.mouseIsConnected;
     if (mouseIsConnected != _mouseIsConnected) {
       setState(() {
         _mouseIsConnected = mouseIsConnected;
@@ -504,7 +450,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     }
   }
 
-  void _hideTooltip({ bool immediately = false }) {
+  void _hideTooltip({bool immediately = false}) {
     _showTimer?.cancel();
     _showTimer = null;
     if (immediately) {
@@ -519,7 +465,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     _pressActivated = false;
   }
 
-  void _showTooltip({ bool immediately = false }) {
+  void _showTooltip({bool immediately = false}) {
     _hideTimer?.cancel();
     _hideTimer = null;
     if (immediately) {
@@ -560,18 +506,31 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       ancestor: overlayState.context.findRenderObject(),
     );
 
+    // if the builder is not provided, assigning a buider which returns default
+    // Text widget with the message.
+    final TooltipWidgetBuilder builder = widget.tooltipBuilder ??
+        (BuildContext context, String message) =>
+            Text(message, style: textStyle);
+
+    /// Widget which will be displayed in the tooltip
+    final Widget tooltip = builder(context, widget.message);
+
     // We create this widget outside of the overlay entry's builder to prevent
     // updated values from happening to leak into the overlay when the overlay
     // rebuilds.
     final Widget overlay = Directionality(
       textDirection: Directionality.of(context),
       child: _TooltipOverlay(
-        tooltip: widget.tooltip ?? Text(widget.message!, style: textStyle),
+        tooltip: tooltip,
         height: height,
         padding: padding,
         margin: margin,
-        onEnter: _mouseIsConnected ? (PointerEnterEvent event) => _showTooltip() : null,
-        onExit: _mouseIsConnected ? (PointerExitEvent event) => _hideTooltip() : null,
+        onEnter: _mouseIsConnected
+            ? (PointerEnterEvent event) => _showTooltip()
+            : null,
+        onExit: _mouseIsConnected
+            ? (PointerExitEvent event) => _hideTooltip()
+            : null,
         decoration: decoration,
         animation: CurvedAnimation(
           parent: _controller,
@@ -584,9 +543,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     );
     _entry = OverlayEntry(builder: (BuildContext context) => overlay);
     overlayState.insert(_entry!);
-    if(widget.semanticsLabel != null || widget.message != null){
-      SemanticsService.tooltip(widget.semanticsLabel ?? widget.message!);
-    }
+    SemanticsService.tooltip(widget.message);
     Tooltip._openedToolTips.add(this);
   }
 
@@ -622,8 +579,10 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   void dispose() {
-    GestureBinding.instance!.pointerRouter.removeGlobalRoute(_handlePointerEvent);
-    RendererBinding.instance!.mouseTracker.removeListener(_handleMouseTrackerChange);
+    GestureBinding.instance!.pointerRouter
+        .removeGlobalRoute(_handlePointerEvent);
+    RendererBinding.instance!.mouseTracker
+        .removeListener(_handleMouseTrackerChange);
     _removeEntry();
     _controller.dispose();
     super.dispose();
@@ -670,25 +629,40 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     height = widget.height ?? tooltipTheme.height ?? _getDefaultTooltipHeight();
     padding = widget.padding ?? tooltipTheme.padding ?? _getDefaultPadding();
     margin = widget.margin ?? tooltipTheme.margin ?? _defaultMargin;
-    verticalOffset = widget.verticalOffset ?? tooltipTheme.verticalOffset ?? _defaultVerticalOffset;
-    preferBelow = widget.preferBelow ?? tooltipTheme.preferBelow ?? _defaultPreferBelow;
-    excludeFromSemantics = widget.excludeFromSemantics ?? tooltipTheme.excludeFromSemantics ?? _defaultExcludeFromSemantics;
-    decoration = widget.decoration ?? tooltipTheme.decoration ?? defaultDecoration;
+    verticalOffset = widget.verticalOffset ??
+        tooltipTheme.verticalOffset ??
+        _defaultVerticalOffset;
+    preferBelow =
+        widget.preferBelow ?? tooltipTheme.preferBelow ?? _defaultPreferBelow;
+    excludeFromSemantics = widget.excludeFromSemantics ??
+        tooltipTheme.excludeFromSemantics ??
+        _defaultExcludeFromSemantics;
+    decoration =
+        widget.decoration ?? tooltipTheme.decoration ?? defaultDecoration;
     textStyle = widget.textStyle ?? tooltipTheme.textStyle ?? defaultTextStyle;
-    waitDuration = widget.waitDuration ?? tooltipTheme.waitDuration ?? _defaultWaitDuration;
-    showDuration = widget.showDuration ?? tooltipTheme.showDuration ?? _defaultShowDuration;
-    hoverShowDuration = widget.showDuration ?? tooltipTheme.showDuration ?? _defaultHoverShowDuration;
-    triggerMode = widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
-    enableFeedback = widget.enableFeedback ?? tooltipTheme.enableFeedback ?? _defaultEnableFeedback;
+    waitDuration = widget.waitDuration ??
+        tooltipTheme.waitDuration ??
+        _defaultWaitDuration;
+    showDuration = widget.showDuration ??
+        tooltipTheme.showDuration ??
+        _defaultShowDuration;
+    hoverShowDuration = widget.showDuration ??
+        tooltipTheme.showDuration ??
+        _defaultHoverShowDuration;
+    triggerMode =
+        widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
+    enableFeedback = widget.enableFeedback ??
+        tooltipTheme.enableFeedback ??
+        _defaultEnableFeedback;
 
     Widget result = GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onLongPress: (triggerMode == TooltipTriggerMode.longPress) ?
-        _handlePress : null,
+      onLongPress:
+          (triggerMode == TooltipTriggerMode.longPress) ? _handlePress : null,
       onTap: (triggerMode == TooltipTriggerMode.tap) ? _handlePress : null,
       excludeFromSemantics: true,
       child: Semantics(
-        label: widget.semanticsLabel ?? (excludeFromSemantics ? null : widget.message),
+        label: excludeFromSemantics ? null : widget.message,
         child: widget.child,
       ),
     );
@@ -716,9 +690,9 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
     required this.target,
     required this.verticalOffset,
     required this.preferBelow,
-  }) : assert(target != null),
-       assert(verticalOffset != null),
-       assert(preferBelow != null);
+  })  : assert(target != null),
+        assert(verticalOffset != null),
+        assert(preferBelow != null);
 
   /// The offset of the target the tooltip is positioned near in the global
   /// coordinate system.
@@ -735,7 +709,8 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
   final bool preferBelow;
 
   @override
-  BoxConstraints getConstraintsForChild(BoxConstraints constraints) => constraints.loosen();
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
+      constraints.loosen();
 
   @override
   Offset getPositionForChild(Size size, Size childSize) {
@@ -750,9 +725,9 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_TooltipPositionDelegate oldDelegate) {
-    return target != oldDelegate.target
-        || verticalOffset != oldDelegate.verticalOffset
-        || preferBelow != oldDelegate.preferBelow;
+    return target != oldDelegate.target ||
+        verticalOffset != oldDelegate.verticalOffset ||
+        preferBelow != oldDelegate.preferBelow;
   }
 }
 
@@ -787,26 +762,25 @@ class _TooltipOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget result = IgnorePointer(
-      child: FadeTransition(
-        opacity: animation,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(minHeight: height),
-          child: DefaultTextStyle(
-            style: Theme.of(context).textTheme.bodyText2!,
-            child: Container(
-              decoration: decoration,
-              padding: padding,
-              margin: margin,
-              child: Center(
-                widthFactor: 1.0,
-                heightFactor: 1.0,
-                child: tooltip,
-              ),
+        child: FadeTransition(
+      opacity: animation,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: height),
+        child: DefaultTextStyle(
+          style: Theme.of(context).textTheme.bodyText2!,
+          child: Container(
+            decoration: decoration,
+            padding: padding,
+            margin: margin,
+            child: Center(
+              widthFactor: 1.0,
+              heightFactor: 1.0,
+              child: tooltip,
             ),
           ),
         ),
-      )
-    );
+      ),
+    ));
     if (onEnter != null || onExit != null) {
       result = MouseRegion(
         onEnter: onEnter,

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -99,7 +99,7 @@ typedef TooltipWidgetBuilder = Widget Function(
 /// ```dart
 /// Widget build(BuildContext context) {
 ///     return Tooltip(
-///       message: "Custom "
+///       message: "Custom ",
 ///       tooltipBuilder: (BuildContext context, String message) {
 ///         return RichText(
 ///           text: TextSpan(

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -152,22 +152,15 @@ class Tooltip extends StatefulWidget {
     this.child,
     this.triggerMode,
     this.enableFeedback,
-  })  : assert(
-          message != null,
-          'A non-null String must be provided in message to a Tooltip widget.',
-        ),
+  })  : assert(message != null, 'A non-null String must be provided in message to a Tooltip widget.'),
         super(key: key);
 
   /// The text to display in the tooltip. [message] is used to show a text
   /// tooltips which is general use cases.
   ///
-  /// When [tooltip] and [message] both are provided, widget provided in the
-  /// tooltip will be shown in the tooltip and message property will be used
+  /// When [tooltipBuilder] and [message] both are provided, widget returned by
+  /// [tooltipBuilder] will be shown in the tooltip and message property will be used
   /// for semantics if [excludeFromSemantics] is true.
-  ///
-  /// In some cases, like information button tooltip, [Tooltip.custom]
-  /// can be used which accepts widget. In case of [Tooltip.custom],
-  /// [TooltipTheme.of] will be ignored.
   final String message;
 
   /// [tooltipBuilder] which returns the widget. It provides [BuildContext] & [message]
@@ -292,8 +285,7 @@ class Tooltip extends StatefulWidget {
   static bool dismissAllToolTips() {
     if (_openedToolTips.isNotEmpty) {
       // Avoid concurrent modification.
-      final List<_TooltipState> openedToolTips =
-          List<_TooltipState>.from(_openedToolTips);
+      final List<_TooltipState> openedToolTips = List<_TooltipState>.from(_openedToolTips);
       for (final _TooltipState state in openedToolTips) {
         state._hideTooltip(immediately: true);
       }
@@ -310,35 +302,15 @@ class Tooltip extends StatefulWidget {
     super.debugFillProperties(properties);
     properties.add(StringProperty('message', message, showName: false));
     properties.add(DoubleProperty('height', height, defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin,
-        defaultValue: null));
-    properties.add(
-        DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
-    properties.add(FlagProperty('position',
-        value: preferBelow,
-        ifTrue: 'below',
-        ifFalse: 'above',
-        showName: true,
-        defaultValue: null));
-    properties.add(FlagProperty('semantics',
-        value: excludeFromSemantics,
-        ifTrue: 'excluded',
-        showName: true,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty<Duration>('wait duration', waitDuration,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty<Duration>('show duration', showDuration,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty<TooltipTriggerMode>(
-        'triggerMode', triggerMode,
-        defaultValue: null));
-    properties.add(FlagProperty('enableFeedback',
-        value: enableFeedback,
-        ifTrue: 'true',
-        showName: true,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('margin', margin, defaultValue: null));
+    properties.add( DoubleProperty('vertical offset', verticalOffset, defaultValue: null));
+    properties.add(FlagProperty('position', value: preferBelow, ifTrue: 'below', ifFalse: 'above', showName: true, defaultValue: null));
+    properties.add(FlagProperty('semantics', value: excludeFromSemantics, ifTrue: 'excluded', showName: true, defaultValue: null));
+    properties.add(DiagnosticsProperty<Duration>('wait duration', waitDuration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Duration>('show duration', showDuration, defaultValue: null));
+    properties.add(DiagnosticsProperty<TooltipTriggerMode>( 'triggerMode', triggerMode, defaultValue: null));
+    properties.add(FlagProperty('enableFeedback', value: enableFeedback, ifTrue: 'true', showName: true, defaultValue: null));
   }
 }
 
@@ -352,8 +324,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   static const Duration _defaultHoverShowDuration = Duration(milliseconds: 100);
   static const Duration _defaultWaitDuration = Duration.zero;
   static const bool _defaultExcludeFromSemantics = false;
-  static const TooltipTriggerMode _defaultTriggerMode =
-      TooltipTriggerMode.longPress;
+  static const TooltipTriggerMode _defaultTriggerMode = TooltipTriggerMode.longPress;
   static const bool _defaultEnableFeedback = true;
 
   late double height;
@@ -384,10 +355,10 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       duration: _fadeInDuration,
       reverseDuration: _fadeOutDuration,
       vsync: this,
-    )..addStatusListener(_handleStatusChanged);
+    )
+     ..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
-    RendererBinding.instance!.mouseTracker
-        .addListener(_handleMouseTrackerChange);
+    RendererBinding.instance!.mouseTracker.addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
     GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
@@ -435,8 +406,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     if (!mounted) {
       return;
     }
-    final bool mouseIsConnected =
-        RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    final bool mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
     if (mouseIsConnected != _mouseIsConnected) {
       setState(() {
         _mouseIsConnected = mouseIsConnected;
@@ -508,9 +478,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
     // if the builder is not provided, assigning a buider which returns default
     // Text widget with the message.
-    final TooltipWidgetBuilder builder = widget.tooltipBuilder ??
-        (BuildContext context, String message) =>
-            Text(message, style: textStyle);
+    final TooltipWidgetBuilder builder = widget.tooltipBuilder ?? (BuildContext context, String message) => Text(message, style: textStyle);
 
     /// Widget which will be displayed in the tooltip
     final Widget tooltip = builder(context, widget.message);
@@ -525,12 +493,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         height: height,
         padding: padding,
         margin: margin,
-        onEnter: _mouseIsConnected
-            ? (PointerEnterEvent event) => _showTooltip()
-            : null,
-        onExit: _mouseIsConnected
-            ? (PointerExitEvent event) => _hideTooltip()
-            : null,
+        onEnter: _mouseIsConnected ? (PointerEnterEvent event) => _showTooltip() : null,
+        onExit: _mouseIsConnected ? (PointerExitEvent event) => _hideTooltip() : null,
         decoration: decoration,
         animation: CurvedAnimation(
           parent: _controller,
@@ -579,10 +543,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   @override
   void dispose() {
-    GestureBinding.instance!.pointerRouter
-        .removeGlobalRoute(_handlePointerEvent);
-    RendererBinding.instance!.mouseTracker
-        .removeListener(_handleMouseTrackerChange);
+    GestureBinding.instance!.pointerRouter.removeGlobalRoute(_handlePointerEvent);
+    RendererBinding.instance!.mouseTracker.removeListener(_handleMouseTrackerChange);
     _removeEntry();
     _controller.dispose();
     super.dispose();
@@ -629,36 +591,20 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     height = widget.height ?? tooltipTheme.height ?? _getDefaultTooltipHeight();
     padding = widget.padding ?? tooltipTheme.padding ?? _getDefaultPadding();
     margin = widget.margin ?? tooltipTheme.margin ?? _defaultMargin;
-    verticalOffset = widget.verticalOffset ??
-        tooltipTheme.verticalOffset ??
-        _defaultVerticalOffset;
-    preferBelow =
-        widget.preferBelow ?? tooltipTheme.preferBelow ?? _defaultPreferBelow;
-    excludeFromSemantics = widget.excludeFromSemantics ??
-        tooltipTheme.excludeFromSemantics ??
-        _defaultExcludeFromSemantics;
-    decoration =
-        widget.decoration ?? tooltipTheme.decoration ?? defaultDecoration;
+    verticalOffset = widget.verticalOffset ?? tooltipTheme.verticalOffset ?? _defaultVerticalOffset;
+    preferBelow = widget.preferBelow ?? tooltipTheme.preferBelow ?? _defaultPreferBelow;
+    excludeFromSemantics = widget.excludeFromSemantics ?? tooltipTheme.excludeFromSemantics ?? _defaultExcludeFromSemantics;
+    decoration = widget.decoration ?? tooltipTheme.decoration ?? defaultDecoration;
     textStyle = widget.textStyle ?? tooltipTheme.textStyle ?? defaultTextStyle;
-    waitDuration = widget.waitDuration ??
-        tooltipTheme.waitDuration ??
-        _defaultWaitDuration;
-    showDuration = widget.showDuration ??
-        tooltipTheme.showDuration ??
-        _defaultShowDuration;
-    hoverShowDuration = widget.showDuration ??
-        tooltipTheme.showDuration ??
-        _defaultHoverShowDuration;
-    triggerMode =
-        widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
-    enableFeedback = widget.enableFeedback ??
-        tooltipTheme.enableFeedback ??
-        _defaultEnableFeedback;
+    waitDuration = widget.waitDuration ?? tooltipTheme.waitDuration ?? _defaultWaitDuration;
+    showDuration = widget.showDuration ?? tooltipTheme.showDuration ?? _defaultShowDuration;
+    hoverShowDuration = widget.showDuration ?? tooltipTheme.showDuration ?? _defaultHoverShowDuration;
+    triggerMode = widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
+    enableFeedback = widget.enableFeedback ?? tooltipTheme.enableFeedback ?? _defaultEnableFeedback;
 
     Widget result = GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onLongPress:
-          (triggerMode == TooltipTriggerMode.longPress) ? _handlePress : null,
+      onLongPress: (triggerMode == TooltipTriggerMode.longPress) ? _handlePress : null,
       onTap: (triggerMode == TooltipTriggerMode.tap) ? _handlePress : null,
       excludeFromSemantics: true,
       child: Semantics(
@@ -709,8 +655,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
   final bool preferBelow;
 
   @override
-  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
-      constraints.loosen();
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) => constraints.loosen();
 
   @override
   Offset getPositionForChild(Size size, Size childSize) {
@@ -725,9 +670,9 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_TooltipPositionDelegate oldDelegate) {
-    return target != oldDelegate.target ||
-        verticalOffset != oldDelegate.verticalOffset ||
-        preferBelow != oldDelegate.preferBelow;
+    return target != oldDelegate.target
+        || verticalOffset != oldDelegate.verticalOffset
+        || preferBelow != oldDelegate.preferBelow;
   }
 }
 
@@ -763,24 +708,25 @@ class _TooltipOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget result = IgnorePointer(
         child: FadeTransition(
-      opacity: animation,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(minHeight: height),
-        child: DefaultTextStyle(
-          style: Theme.of(context).textTheme.bodyText2!,
-          child: Container(
-            decoration: decoration,
-            padding: padding,
-            margin: margin,
-            child: Center(
-              widthFactor: 1.0,
-              heightFactor: 1.0,
-              child: tooltip,
+        opacity: animation,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: height),
+          child: DefaultTextStyle(
+            style: Theme.of(context).textTheme.bodyText2!,
+            child: Container(
+              decoration: decoration,
+              padding: padding,
+              margin: margin,
+              child: Center(
+                widthFactor: 1.0,
+                heightFactor: 1.0,
+                child: tooltip,
+              ),
             ),
           ),
         ),
       ),
-    ));
+    );
     if (onEnter != null || onExit != null) {
       result = MouseRegion(
         onEnter: onEnter,

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -2261,7 +2261,7 @@ void main() {
       await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       final RenderParagraph tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
- 
+
       // Why 14.0 and not 10.0? because it is default size for the Text Widget,
       // Tooltip.custom does not apply default tooltip style to its decendant
       // Text Widget

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -40,6 +40,13 @@ Finder _findTooltipContainer(String tooltipText) {
   );
 }
 
+Finder _findCustomTooltipParent(String tooltipText,Type type) {
+  return find.ancestor(
+    of: find.text(tooltipText),
+    matching: find.byType(type),
+  );
+}
+
 void main() {
   testWidgets('Does tooltip end up in the right place - center', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
@@ -1497,16 +1504,1588 @@ void main() {
     await testGestureLongPress(tester, tooltip);
     expect(find.text(tooltipText), findsNothing);
   });
+
+  group('Tooltip.custom adds provided widgets with its attributes as tooltip',() {
+    testWidgets('Does tooltip adds SizedBox', (WidgetTester tester) async {
+      final GlobalKey key= GlobalKey();
+
+      const SizedBox sizedBoxTooltip= SizedBox(
+        height: 80.0,
+        width: 100.0,
+        child: Text(tooltipText),
+      );
+      await setCustomTooltip(tester, key, sizedBoxTooltip);
+
+      final RenderBox tipBox = tester.renderObject(
+        _findCustomTooltipParent(tooltipText, SizedBox),
+      );
+
+      expect(tipBox.size.height, 80.0);
+      expect(tipBox.size.width, 100.0);
+
+    });
+
+    testWidgets('Does tooltip adds Container', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      final GlobalKey containerKey = GlobalKey();
+      final Container containerTooltip = Container(
+        key: containerKey,
+        height: 50.0,
+        width: 80.0,
+        color: Colors.red,
+        child: const Text(tooltipText),
+      );
+      await setCustomTooltip(tester, key, containerTooltip);
+
+      final RenderBox tipContainer = tester.renderObject(
+        find.ancestor(
+          of: find.text(tooltipText),
+          matching: find.byKey(containerKey),
+        )
+      );
+      
+      expect(tipContainer.size.height, 50.0);
+      expect(tipContainer.size.width, 80.0);
+      expect(tipContainer, paints..rect(
+        rect: const Rect.fromLTWH(0.0,0.0,80.0,50.0),
+        color: const Color(0xfff44336),
+      ));
+    });
+  });
+
+  group('Tooltip.custom tests', () {
+   
+    testWidgets('Does tooltip end up in the right place - center', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 300.0,
+                        top: 0.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 20.0,
+                          padding: const EdgeInsets.all(5.0),
+                          verticalOffset: 20.0,
+                          preferBelow: false,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *      o            * y=0
+       *      |            * }- 20.0 vertical offset, of which 10.0 is in the screen edge margin
+       *   +----+          * \- (5.0 padding in height)
+       *   |    |          * |- 20 height
+       *   +----+          * /- (5.0 padding in height)
+       *                   *
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset tipInGlobal = tip.localToGlobal(tip.size.topCenter(Offset.zero));
+      // The exact position of the left side depends on the font the test framework
+      // happens to pick, so we don't test that.
+      expect(tipInGlobal.dx, 300.0);
+      expect(tipInGlobal.dy, 20.0);
+    });
+
+    testWidgets('Does tooltip end up in the right place - center with padding outside overlay', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Overlay(
+              initialEntries: <OverlayEntry>[
+                OverlayEntry(
+                  builder: (BuildContext context) {
+                    return Stack(
+                      children: <Widget>[
+                        Positioned(
+                          left: 300.0,
+                          top: 0.0,
+                          child: Tooltip.custom(
+                            key: key,
+                            tooltip: ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: const Text(tooltipText),
+                            ),
+                            height: 20.0,
+                            padding: const EdgeInsets.all(5.0),
+                            verticalOffset: 20.0,
+                            preferBelow: false,
+                            child: const SizedBox(
+                              width: 0.0,
+                              height: 0.0,
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /************************ 800x600 screen
+       *   ________________   * }- 20.0 padding outside overlay
+       *  |    o           |  * y=0
+       *  |    |           |  * }- 20.0 vertical offset, of which 10.0 is in the screen edge margin
+       *  | +----+         |  * \- (5.0 padding in height)
+       *  | |    |         |  * |- 20 height
+       *  | +----+         |  * /- (5.0 padding in height)
+       *  |________________|  *
+       *                      * } - 20.0 padding outside overlay
+       ************************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset tipInGlobal = tip.localToGlobal(tip.size.topCenter(Offset.zero));
+      // The exact position of the left side depends on the font the test framework
+      // happens to pick, so we don't test that.
+      expect(tipInGlobal.dx, 320.0);
+      expect(tipInGlobal.dy, 40.0);
+    });
+
+    testWidgets('Does tooltip end up in the right place - top left', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 0.0,
+                        top: 0.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 20.0,
+                          padding: const EdgeInsets.all(5.0),
+                          verticalOffset: 20.0,
+                          preferBelow: false,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *o                  * y=0
+      *|                  * }- 20.0 vertical offset, of which 10.0 is in the screen edge margin
+      *+----+             * \- (5.0 padding in height)
+      *|    |             * |- 20 height
+      *+----+             * /- (5.0 padding in height)
+      *                   *
+      *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(24.0)); // 14.0 height + 5.0 padding * 2 (top, bottom)
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)), equals(const Offset(10.0, 20.0)));
+    });
+
+    testWidgets('Does tooltip end up in the right place - center prefer above fits', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 400.0,
+                        top: 300.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 100.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 100.0,
+                          preferBelow: false,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *        ___        * }- 10.0 margin
+       *       |___|       * }-100.0 height
+       *         |         * }-100.0 vertical offset
+       *         o         * y=300.0
+       *                   *
+       *                   *
+       *                   *
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(100.0));
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(100.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(200.0));
+    });
+
+    testWidgets('Does tooltip end up in the right place - center prefer above does not fit', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 400.0,
+                        top: 299.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 190.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 100.0,
+                          preferBelow: false,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      // we try to put it here but it doesn't fit:
+      /********************* 800x600 screen
+       *        ___        * }- 10.0 margin
+       *       |___|       * }-190.0 height (starts at y=9.0)
+       *         |         * }-100.0 vertical offset
+       *         o         * y=299.0
+       *                   *
+       *                   *
+       *                   *
+       *********************/
+
+      // so we put it here:
+      /********************* 800x600 screen
+       *                   *
+       *                   *
+       *         o         * y=299.0
+       *        _|_        * }-100.0 vertical offset
+       *       |___|       * }-190.0 height
+       *                   * }- 10.0 margin
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(190.0));
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(399.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(589.0));
+    });
+
+    testWidgets('Does tooltip end up in the right place - center prefer below fits', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 400.0,
+                        top: 300.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 190.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 100.0,
+                          preferBelow: true,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *                   *
+       *                   *
+       *         o         * y=300.0
+       *        _|_        * }-100.0 vertical offset
+       *       |___|       * }-190.0 height
+       *                   * }- 10.0 margin
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(190.0));
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(400.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(590.0));
+    });
+
+    testWidgets('Does tooltip end up in the right place - way off to the right',
+        (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 1600.0,
+                        top: 300.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 10.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 10.0,
+                          preferBelow: true,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *                   *
+       *                   *
+       *                   * y=300.0;   target -->   o
+       *              ___| * }-10.0 vertical offset
+       *             |___| * }-10.0 height
+       *                   *
+       *                   * }-10.0 margin
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(14.0));
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(310.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dx, equals(790.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(324.0));
+    });
+
+    testWidgets('Does tooltip end up in the right place - near the edge', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 780.0,
+                        top: 300.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text(tooltipText),
+                          ),
+                          height: 10.0,
+                          padding: EdgeInsets.zero,
+                          verticalOffset: 10.0,
+                          preferBelow: true,
+                          child: const SizedBox(
+                            width: 0.0,
+                            height: 0.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      /********************* 800x600 screen
+       *                   *
+       *                   *
+       *                o  * y=300.0
+       *              __|  * }-10.0 vertical offset
+       *             |___| * }-10.0 height
+       *                   *
+       *                   * }-10.0 margin
+       *********************/
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(14.0));
+      expect(tip.localToGlobal(tip.size.topLeft(Offset.zero)).dy, equals(310.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dx, equals(790.0));
+      expect(tip.localToGlobal(tip.size.bottomRight(Offset.zero)).dy, equals(324.0));
+    });
+
+    testWidgets('Custom tooltip margin', (WidgetTester tester) async {
+      const double _customMarginValue = 10.0;
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Tooltip.custom(
+                    key: key,
+                    tooltip: ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 0),
+                      child: const Text(tooltipText),
+                    ),
+                    padding: EdgeInsets.zero,
+                    margin: const EdgeInsets.all(_customMarginValue),
+                    child: const SizedBox(
+                      width: 0.0,
+                      height: 0.0,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      final Offset topLeftTipInGlobal = tester.getTopLeft(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset topLeftTooltipContentInGlobal = tester.getTopLeft(find.text(tooltipText));
+      expect(topLeftTooltipContentInGlobal.dx, topLeftTipInGlobal.dx + _customMarginValue);
+      expect(topLeftTooltipContentInGlobal.dy, topLeftTipInGlobal.dy + _customMarginValue);
+
+      final Offset topRightTipInGlobal = tester.getTopRight(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset topRightTooltipContentInGlobal = tester.getTopRight(find.text(tooltipText));
+      expect(topRightTooltipContentInGlobal.dx, topRightTipInGlobal.dx - _customMarginValue);
+      expect(topRightTooltipContentInGlobal.dy, topRightTipInGlobal.dy + _customMarginValue);
+
+      final Offset bottomLeftTipInGlobal = tester.getBottomLeft(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset bottomLeftTooltipContentInGlobal = tester.getBottomLeft(find.text(tooltipText));
+      expect(bottomLeftTooltipContentInGlobal.dx, bottomLeftTipInGlobal.dx + _customMarginValue);
+      expect(bottomLeftTooltipContentInGlobal.dy, bottomLeftTipInGlobal.dy - _customMarginValue);
+
+      final Offset bottomRightTipInGlobal = tester.getBottomRight(
+        _findTooltipContainer(tooltipText),
+      );
+      final Offset bottomRightTooltipContentInGlobal = tester.getBottomRight(find.text(tooltipText));
+      expect(bottomRightTooltipContentInGlobal.dx, bottomRightTipInGlobal.dx - _customMarginValue);
+      expect(bottomRightTooltipContentInGlobal.dy, bottomRightTipInGlobal.dy - _customMarginValue);
+    });
+
+    testWidgets('Default tooltip message textStyle should be null', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(MaterialApp(
+        home: Tooltip.custom(
+          key: key,
+          tooltip: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 0),
+            child: const Text(tooltipText),
+          ),
+          child: Container(
+            width: 100.0,
+            height: 100.0,
+            color: Colors.green[500],
+          ),
+        ),
+      ));
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      // As custom tooltip will not apply default text style we can expect null
+      // textStyle
+      final TextStyle? textStyle = tester.widget<Text>(find.text(tooltipText)).style;
+      expect(textStyle, null);
+    });
+
+    testWidgets('Tooltip overlay respects ambient Directionality', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/40702.
+      Widget buildApp(String text, TextDirection textDirection) {
+        return MaterialApp(
+          home: Directionality(
+            textDirection: textDirection,
+            child: Center(
+              child: Tooltip.custom(
+                tooltip: ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: const Text(tooltipText),
+                ),
+                child: Container(
+                  width: 100.0,
+                  height: 100.0,
+                  color: Colors.green[500],
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildApp(tooltipText, TextDirection.rtl));
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsOneWidget);
+      RenderParagraph tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
+      expect(tooltipRenderParagraph.textDirection, TextDirection.rtl);
+
+      await tester.pumpWidget(buildApp(tooltipText, TextDirection.ltr));
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsOneWidget);
+      tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
+      expect(tooltipRenderParagraph.textDirection, TextDirection.ltr);
+    });
+
+    testWidgets('Tooltip overlay wrapped with a non-fallback DefaultTextStyle widget', (WidgetTester tester) async {
+      // A Material widget is needed as an ancestor of the Text widget.
+      // It is invalid to have text in a Material application that
+      // does not have a Material ancestor.
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(MaterialApp(
+        home: Tooltip.custom(
+          key: key,
+          tooltip: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 0),
+            child: const Text(tooltipText),
+          ),
+          child: Container(
+            width: 100.0,
+            height: 100.0,
+            color: Colors.green[500],
+          ),
+        ),
+      ));
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      final TextStyle textStyle = tester.widget<DefaultTextStyle>(
+        find.ancestor(
+          of: find.text(tooltipText),
+          matching: find.byType(DefaultTextStyle),
+        ).first,
+      ).style;
+
+      // The default fallback text style results in a text with a
+      // double underline of Color(0xffffff00).
+      expect(textStyle.decoration, isNot(TextDecoration.underline));
+      expect(textStyle.decorationColor, isNot(const Color(0xffffff00)));
+      expect(textStyle.decorationStyle, isNot(TextDecorationStyle.double));
+    });
+
+    testWidgets('Does tooltip end up with the right default size, shape, and color', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Tooltip.custom(
+                    key: key,
+                    tooltip: ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 0),
+                      child: const Text(tooltipText),
+                    ),
+                    child: const SizedBox(
+                      width: 0.0,
+                      height: 0.0,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(32.0));
+      expect(tip.size.width, equals(74.0));
+      expect(tip, paints..rrect(
+        rrect: RRect.fromRectAndRadius(tip.paintBounds, const Radius.circular(4.0)),
+        color: const Color(0xe6616161),
+      ));
+    });
+
+    testWidgets('Tooltip default size, shape, and color test for Desktop', (WidgetTester tester) async {
+      // Regressing test for https://github.com/flutter/flutter/issues/68601
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Tooltip.custom(
+            key: key,
+            tooltip: const Text(tooltipText),
+            child: const SizedBox(
+              width: 0.0,
+              height: 0.0,
+            ),
+          ),
+        ),
+      );
+      // ignore: avoid_dynamic_calls
+      (key.currentState as dynamic).ensureTooltipVisible();
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      final RenderParagraph tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
+      
+      // Why 14.0 and not 10.0? because it is default size for the Text Widget,
+      // Tooltip.custom does not apply default tooltip style to its decendant
+      // Text Widget
+      expect(tooltipRenderParagraph.textSize.height, equals(14.0)); 
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(24.0));
+      expect(tip.size.width, equals(58.0));
+      expect(tip, paints..rrect(
+        rrect: RRect.fromRectAndRadius(tip.paintBounds, const Radius.circular(4.0)),
+        color: const Color(0xe6616161),
+      ));
+    },
+        variant: const TargetPlatformVariant(<TargetPlatform>{
+          TargetPlatform.macOS,
+          TargetPlatform.linux,
+          TargetPlatform.windows
+        }));
+
+    testWidgets('Can tooltip decoration be customized', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      const Decoration customDecoration = ShapeDecoration(
+        shape: StadiumBorder(),
+        color: Color(0x80800000),
+      );
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Tooltip.custom(
+                    key: key,
+                    decoration: customDecoration,
+                    tooltip: ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 0),
+                      child: const Text(tooltipText),
+                    ),
+                    child: const SizedBox(
+                      width: 0.0,
+                      height: 0.0,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+      _ensureTooltipVisible(key);
+      await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      final RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(32.0));
+      expect(tip.size.width, equals(74.0));
+      expect(tip, paints..path(
+        color: const Color(0x80800000),
+      ));
+    });
+
+    testWidgets('Tooltip stays after long press', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text(tooltipText),
+              ),
+              child: Container(
+                width: 100.0,
+                height: 100.0,
+                color: Colors.green[500],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.byType(Tooltip);
+      TestGesture gesture = await tester.startGesture(tester.getCenter(tooltip));
+
+      // long press reveals tooltip
+      await tester.pump(kLongPressTimeout);
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(find.text(tooltipText), findsOneWidget);
+      await gesture.up();
+
+      // tap (down, up) gesture hides tooltip, since its not
+      // a long press
+      await tester.tap(tooltip);
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(find.text(tooltipText), findsNothing);
+
+      // long press once more
+      gesture = await tester.startGesture(tester.getCenter(tooltip));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text(tooltipText), findsNothing);
+
+      await tester.pump(kLongPressTimeout);
+      await tester.pump(const Duration(milliseconds: 10));
+      expect(find.text(tooltipText), findsOneWidget);
+
+      // keep holding the long press, should still show tooltip
+      await tester.pump(kLongPressTimeout);
+      expect(find.text(tooltipText), findsOneWidget);
+      await gesture.up();
+    });
+
+    testWidgets('Tooltip shows/hides when hovered', (WidgetTester tester) async {
+      const Duration waitDuration = Duration.zero;
+      TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(() async {
+        if (gesture != null) return gesture.removePointer();
+      });
+      await gesture.addPointer();
+      await gesture.moveTo(const Offset(1.0, 1.0));
+      await tester.pump();
+      await gesture.moveTo(Offset.zero);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text(tooltipText),
+              ),
+              waitDuration: waitDuration,
+              child: const SizedBox(
+                width: 100.0,
+                height: 100.0,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.byType(Tooltip);
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(tooltip));
+      await tester.pump();
+      // Wait for it to appear.
+      await tester.pump(waitDuration);
+      expect(find.text(tooltipText), findsOneWidget);
+
+      // Wait a looong time to make sure that it doesn't go away if the mouse is
+      // still over the widget.
+      await tester.pump(const Duration(days: 1));
+      await tester.pumpAndSettle();
+      expect(find.text(tooltipText), findsOneWidget);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+
+      // Wait for it to disappear.
+      await tester.pumpAndSettle();
+      await gesture.removePointer();
+      gesture = null;
+      expect(find.text(tooltipText), findsNothing);
+    });
+
+    testWidgets('Tooltip text is also hoverable', (WidgetTester tester) async {
+      const Duration waitDuration = Duration.zero;
+      TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(() async {
+        if (gesture != null) return gesture.removePointer();
+      });
+      await gesture.addPointer();
+      await gesture.moveTo(const Offset(1.0, 1.0));
+      await tester.pump();
+      await gesture.moveTo(Offset.zero);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text(tooltipText),
+              ),
+              waitDuration: waitDuration,
+              child: const Text('I am tool tip'),
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.byType(Tooltip);
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(tooltip));
+      await tester.pump();
+      // Wait for it to appear.
+      await tester.pump(waitDuration);
+      expect(find.text(tooltipText), findsOneWidget);
+
+      // Wait a looong time to make sure that it doesn't go away if the mouse is
+      // still over the widget.
+      await tester.pump(const Duration(days: 1));
+      await tester.pumpAndSettle();
+      expect(find.text(tooltipText), findsOneWidget);
+
+      // Hover to the tool tip text and verify the tooltip doesn't go away.
+      await gesture.moveTo(tester.getTopLeft(find.text(tooltipText)));
+      await tester.pump(const Duration(days: 1));
+      await tester.pumpAndSettle();
+      expect(find.text(tooltipText), findsOneWidget);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+
+      // Wait for it to disappear.
+      await tester.pumpAndSettle();
+      await gesture.removePointer();
+      gesture = null;
+      expect(find.text(tooltipText), findsNothing);
+    });
+
+    testWidgets('Tooltip can be dismissed by escape key', (WidgetTester tester) async {
+      const Duration waitDuration = Duration.zero;
+      TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(() async {
+        if (gesture != null) return gesture.removePointer();
+      });
+      await gesture.addPointer();
+      await gesture.moveTo(const Offset(1.0, 1.0));
+      await tester.pump();
+      await gesture.moveTo(Offset.zero);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text(tooltipText),
+              ),
+              waitDuration: waitDuration,
+              child: const Text('I am tool tip'),
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.byType(Tooltip);
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(tooltip));
+      await tester.pump();
+      // Wait for it to appear.
+      await tester.pump(waitDuration);
+      expect(find.text(tooltipText), findsOneWidget);
+
+      // Try to dismiss the tooltip with the shortcut key
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+      expect(find.text(tooltipText), findsNothing);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pumpAndSettle();
+      await gesture.removePointer();
+      gesture = null;
+    });
+
+    testWidgets('Multiple Tooltips are dismissed by escape key', (WidgetTester tester) async {
+      const Duration waitDuration = Duration.zero;
+      TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(() async {
+        if (gesture != null) return gesture.removePointer();
+      });
+      await gesture.addPointer();
+      await gesture.moveTo(const Offset(1.0, 1.0));
+      await tester.pump();
+      await gesture.moveTo(Offset.zero);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Column(
+              children: <Widget>[
+                Tooltip.custom(
+                  tooltip: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 0),
+                    child: const Text('message1'),
+                  ),
+                  waitDuration: waitDuration,
+                  showDuration: const Duration(days: 1),
+                  child: const Text('tooltip1'),
+                ),
+                const Spacer(flex: 2),
+                Tooltip.custom(
+                  tooltip: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 0),
+                    child: const Text('message2'),
+                  ),
+                  waitDuration: waitDuration,
+                  showDuration: const Duration(days: 1),
+                  child: const Text('tooltip2'),
+                ),
+                const Spacer(flex: 2),
+                const Tooltip(
+                  message: 'message3',
+                  waitDuration: waitDuration,
+                  showDuration: Duration(days: 1),
+                  child: Text('tooltip3'),
+                )
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.text('tooltip1');
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(tooltip));
+      await tester.pump();
+      await tester.pump(waitDuration);
+      expect(find.text('message1'), findsOneWidget);
+
+      final Finder secondTooltip = find.text('tooltip2');
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(secondTooltip));
+      await tester.pump();
+      await tester.pump(waitDuration);
+
+
+      final Finder thirdTooltip = find.text('tooltip3');
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(thirdTooltip));
+      await tester.pump();
+      await tester.pump(waitDuration);
+      // Make sure both messages are on the screen.
+      expect(find.text('message1'), findsOneWidget);
+      expect(find.text('message2'), findsOneWidget);
+      expect(find.text('message3'), findsOneWidget);
+
+      // Try to dismiss the tooltip with the shortcut key
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+      expect(find.text('message1'), findsNothing);
+      expect(find.text('message2'), findsNothing);
+      expect(find.text('message3'), findsNothing);
+
+      await gesture.moveTo(Offset.zero);
+      await tester.pumpAndSettle();
+      await gesture.removePointer();
+      gesture = null;
+    });
+
+    testWidgets('Tooltip does not attempt to show after unmount', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/54096.
+      const Duration waitDuration = Duration(seconds: 1);
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(() async {
+        if (gesture != null) return gesture.removePointer();
+      });
+      await gesture.addPointer();
+      await gesture.moveTo(const Offset(1.0, 1.0));
+      await tester.pump();
+      await gesture.moveTo(Offset.zero);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text('message2'),
+              ),
+              waitDuration: waitDuration,
+              child: const SizedBox(
+                width: 100.0,
+                height: 100.0,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Finder tooltip = find.byType(Tooltip);
+      await gesture.moveTo(Offset.zero);
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(tooltip));
+      await tester.pump();
+
+      // Pump another random widget to unmount the Tooltip widget.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: SizedBox(),
+          ),
+        ),
+      );
+
+      // If the issue regresses, an exception will be thrown while we are waiting.
+      await tester.pump(waitDuration);
+    });
+
+    testWidgets('Does tooltip add semantics', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Overlay(
+            initialEntries: <OverlayEntry>[
+              OverlayEntry(
+                builder: (BuildContext context) {
+                  return Stack(
+                    children: <Widget>[
+                      Positioned(
+                        left: 780.0,
+                        top: 300.0,
+                        child: Tooltip.custom(
+                          key: key,
+                          tooltip: ConstrainedBox(
+                            constraints: const BoxConstraints(minHeight: 0),
+                            child: const Text('message'),
+                          ),
+                          semanticsLabel: 'message',
+                          child: const SizedBox(width: 10.0, height: 10.0),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final TestSemantics expected = TestSemantics.root(
+        children: <TestSemantics>[
+          TestSemantics.rootChild(
+            id: 1,
+            label: 'message',
+            textDirection: TextDirection.ltr,
+          ),
+        ],
+      );
+
+      expect(semantics, hasSemantics(expected, ignoreTransform: true, ignoreRect: true));
+
+      // This triggers a rebuild of the semantics because the tree changes.
+      _ensureTooltipVisible(key);
+
+      await tester.pump(const Duration( seconds: 2)); // faded in, show timer started (and at 0.0)
+
+      expect(semantics, hasSemantics(expected, ignoreTransform: true, ignoreRect: true));
+
+      semantics.dispose();
+    });
+
+    testWidgets('Tooltip overlay does not update', (WidgetTester tester) async {
+      Widget buildApp(String text) {
+        return MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: Text(text),
+              ),
+              child: Container(
+                width: 100.0,
+                height: 100.0,
+                color: Colors.green[500],
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildApp(tooltipText));
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsOneWidget);
+      await tester.pumpWidget(buildApp('NEW'));
+      expect(find.text(tooltipText), findsOneWidget);
+      await tester.tapAt(const Offset(5.0, 5.0));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.text(tooltipText), findsNothing);
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsNothing);
+    });
+
+    testWidgets('Tooltip text scales with textScaleFactor', (WidgetTester tester) async {
+      Widget buildApp(String text, {required double textScaleFactor}) {
+        return MediaQuery(
+          data: MediaQueryData(textScaleFactor: textScaleFactor),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Navigator(
+              onGenerateRoute: (RouteSettings settings) {
+                return MaterialPageRoute<void>(
+                  builder: (BuildContext context) {
+                    return Center(
+                      child: Tooltip.custom(
+                        tooltip: ConstrainedBox(
+                          constraints: const BoxConstraints(minHeight: 0),
+                          child: Text(text),
+                        ),
+                        child: Container(
+                          width: 100.0,
+                          height: 100.0,
+                          color: Colors.green[500],
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildApp(tooltipText, textScaleFactor: 1.0));
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsOneWidget);
+      expect(tester.getSize(find.text(tooltipText)), equals(const Size(42.0, 14.0)));
+      RenderBox tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(32.0));
+
+      await tester.pumpWidget(buildApp(tooltipText, textScaleFactor: 4.0));
+      await tester.longPress(find.byType(Tooltip));
+      expect(find.text(tooltipText), findsOneWidget);
+      expect(tester.getSize(find.text(tooltipText)), equals(const Size(168.0, 56.0)));
+      tip = tester.renderObject(
+        _findTooltipContainer(tooltipText),
+      );
+      expect(tip.size.height, equals(56.0));
+    });
+
+    testWidgets('Haptic feedback', (WidgetTester tester) async {
+      final FeedbackTester feedback = FeedbackTester();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 0),
+                child: const Text('Foo'),
+              ),
+              child: Container(
+                width: 100.0,
+                height: 100.0,
+                color: Colors.green[500],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(Tooltip));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+      expect(feedback.hapticCount, 1);
+
+      feedback.dispose();
+    });
+
+    testWidgets('Semantics included', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: Text('Foo'),
+              semanticsLabel: 'Foo',
+              child: Text('Bar'),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+          semantics,
+          hasSemantics(
+              TestSemantics.root(
+                children: <TestSemantics>[
+                  TestSemantics.rootChild(
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                label: 'Foo\nBar',
+                                textDirection: TextDirection.ltr,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              ignoreRect: true,
+              ignoreId: true,
+              ignoreTransform: true));
+
+      semantics.dispose();
+    });
+
+    testWidgets('Semantics excluded', (WidgetTester tester) async {
+      final SemanticsTester semantics = SemanticsTester(tester);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: Text('Foo'),
+              child: Text('Bar'),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+          semantics,
+          hasSemantics(
+              TestSemantics.root(
+                children: <TestSemantics>[
+                  TestSemantics.rootChild(
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                label: 'Bar',
+                                textDirection: TextDirection.ltr,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              ignoreRect: true,
+              ignoreId: true,
+              ignoreTransform: true));
+
+      semantics.dispose();
+    });
+
+    testWidgets('has semantic events', (WidgetTester tester) async {
+      final List<dynamic> semanticEvents = <dynamic>[];
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+          SystemChannels.accessibility, (dynamic message) async {
+        semanticEvents.add(message);
+      });
+      final SemanticsTester semantics = SemanticsTester(tester);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: Tooltip.custom(
+              tooltip: const Text('Foo'),
+              semanticsLabel: 'Foo',
+              child: Container(
+                width: 100.0,
+                height: 100.0,
+                color: Colors.green[500],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(Tooltip));
+      final RenderObject object = tester.firstRenderObject(find.byType(Tooltip));
+
+      expect(
+          semanticEvents,
+          unorderedEquals(<dynamic>[
+            <String, dynamic>{
+              'type': 'longPress',
+              'nodeId': findDebugSemantics(object).id,
+              'data': <String, dynamic>{},
+            },
+            <String, dynamic>{
+              'type': 'tooltip',
+              'data': <String, dynamic>{
+                'message': 'Foo',
+              },
+            },
+          ]));
+      semantics.dispose();
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, null);
+    });
+
+    testWidgets('Tooltip implements debugFillProperties', (WidgetTester tester) async {
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+
+      // Not checking controller, inputFormatters, focusNode
+      const Tooltip.custom(
+        key: ValueKey<String>('foo'),
+        tooltip: Text('message'),
+        decoration: BoxDecoration(),
+        waitDuration: Duration(seconds: 1),
+        showDuration: Duration(seconds: 2),
+        padding: EdgeInsets.zero,
+        margin: EdgeInsets.all(5.0),
+        height: 100.0,
+        semanticsLabel: 'message',
+        preferBelow: false,
+        verticalOffset: 50.0,
+        triggerMode: TooltipTriggerMode.manual,
+        enableFeedback: true,
+      ).debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description, <String>[
+        'null',
+        'height: 100.0',
+        'padding: EdgeInsets.zero',
+        'margin: EdgeInsets.all(5.0)',
+        'vertical offset: 50.0',
+        'position: above',
+        'semantics: excluded',
+        'wait duration: 0:00:01.000000',
+        'show duration: 0:00:02.000000',
+        'triggerMode: TooltipTriggerMode.manual',
+        'enableFeedback: true',
+        'semanticsLabel: "message"', 
+      ]);
+    });
+
+    testWidgets('Tooltip triggers on tap when trigger mode is tap', (WidgetTester tester) async {
+      await setWidgetForTooltipMode(tester, TooltipTriggerMode.tap, isCustomTooltip: true);
+
+      final Finder tooltip = find.byType(Tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureTap(tester, tooltip);
+      expect(find.text(tooltipText), findsOneWidget);
+    });
+
+    testWidgets('Tooltip triggers on long press when mode is long press', (WidgetTester tester) async {
+      await setWidgetForTooltipMode(tester, TooltipTriggerMode.longPress, isCustomTooltip: true);
+
+      final Finder tooltip = find.byType(Tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureTap(tester, tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureLongPress(tester, tooltip);
+      expect(find.text(tooltipText), findsOneWidget);
+    });
+
+    testWidgets('Tooltip does not trigger on tap when trigger mode is longPress', (WidgetTester tester) async {
+      await setWidgetForTooltipMode(tester, TooltipTriggerMode.longPress, isCustomTooltip: true);
+
+      final Finder tooltip = find.byType(Tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureTap(tester, tooltip);
+      expect(find.text(tooltipText), findsNothing);
+    });
+
+    testWidgets('Tooltip does not trigger when trigger mode is manual', (WidgetTester tester) async {
+      await setWidgetForTooltipMode(tester, TooltipTriggerMode.manual, isCustomTooltip: true);
+
+      final Finder tooltip = find.byType(Tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureTap(tester, tooltip);
+      expect(find.text(tooltipText), findsNothing);
+
+      await testGestureLongPress(tester, tooltip);
+      expect(find.text(tooltipText), findsNothing);
+    });
+
+  });
 }
 
-Future<void> setWidgetForTooltipMode(WidgetTester tester, TooltipTriggerMode triggerMode) async {
-  await tester.pumpWidget(
-    MaterialApp(
-      home: Tooltip(
+Future<void> setWidgetForTooltipMode(WidgetTester tester, TooltipTriggerMode triggerMode,{bool isCustomTooltip = false}) async {
+  final Tooltip tooltip;
+
+  if(!isCustomTooltip){
+    tooltip =  Tooltip(
         message: tooltipText,
         triggerMode: triggerMode,
         child: const SizedBox(width: 100.0, height: 100.0),
-      ),
+      );
+  } else{
+    tooltip =  Tooltip.custom(
+        tooltip: const Text(tooltipText),
+        triggerMode: triggerMode,
+        child: const SizedBox(width: 100.0, height: 100.0),
+      );
+  }
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: tooltip,
     ),
   );
 }
@@ -1528,4 +3107,17 @@ SemanticsNode findDebugSemantics(RenderObject object) {
   if (object.debugSemantics != null)
     return object.debugSemantics!;
   return findDebugSemantics(object.parent! as RenderObject);
+}
+
+Future<void> setCustomTooltip(WidgetTester tester, GlobalKey key, Widget widget) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Tooltip.custom(
+        key: key,
+        tooltip: widget
+      ),
+    ),  
+  );
+  _ensureTooltipVisible(key);
+  await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 }

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1543,7 +1543,6 @@ void main() {
           matching: find.byKey(containerKey),
         )
       );
-      
       expect(tipContainer.size.height, 50.0);
       expect(tipContainer.size.width, 80.0);
       expect(tipContainer, paints..rect(
@@ -1554,7 +1553,6 @@ void main() {
   });
 
   group('Tooltip.custom tests', () {
-   
     testWidgets('Does tooltip end up in the right place - center', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(
@@ -2263,11 +2261,11 @@ void main() {
       await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
       final RenderParagraph tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
-      
+ 
       // Why 14.0 and not 10.0? because it is default size for the Text Widget,
       // Tooltip.custom does not apply default tooltip style to its decendant
       // Text Widget
-      expect(tooltipRenderParagraph.textSize.height, equals(14.0)); 
+      expect(tooltipRenderParagraph.textSize.height, equals(14.0));
 
       final RenderBox tip = tester.renderObject(
         _findTooltipContainer(tooltipText),
@@ -3013,7 +3011,7 @@ void main() {
         'show duration: 0:00:02.000000',
         'triggerMode: TooltipTriggerMode.manual',
         'enableFeedback: true',
-        'semanticsLabel: "message"', 
+        'semanticsLabel: "message"',
       ]);
     });
 
@@ -3116,7 +3114,7 @@ Future<void> setCustomTooltip(WidgetTester tester, GlobalKey key, Widget widget)
         key: key,
         tooltip: widget
       ),
-    ),  
+    ),
   );
   _ensureTooltipVisible(key);
   await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -2381,7 +2381,8 @@ void main() {
       const Duration waitDuration = Duration.zero;
       TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(() async {
-        if (gesture != null) return gesture.removePointer();
+        if (gesture != null)
+          return gesture.removePointer();
       });
       await gesture.addPointer();
       await gesture.moveTo(const Offset(1.0, 1.0));
@@ -2435,7 +2436,8 @@ void main() {
       const Duration waitDuration = Duration.zero;
       TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(() async {
-        if (gesture != null) return gesture.removePointer();
+        if (gesture != null)
+          return gesture.removePointer();
       });
       await gesture.addPointer();
       await gesture.moveTo(const Offset(1.0, 1.0));
@@ -2492,7 +2494,8 @@ void main() {
       const Duration waitDuration = Duration.zero;
       TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(() async {
-        if (gesture != null) return gesture.removePointer();
+        if (gesture != null)
+          return gesture.removePointer();
       });
       await gesture.addPointer();
       await gesture.moveTo(const Offset(1.0, 1.0));
@@ -2538,7 +2541,8 @@ void main() {
       const Duration waitDuration = Duration.zero;
       TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(() async {
-        if (gesture != null) return gesture.removePointer();
+        if (gesture != null)
+          return gesture.removePointer();
       });
       await gesture.addPointer();
       await gesture.moveTo(const Offset(1.0, 1.0));
@@ -2627,7 +2631,8 @@ void main() {
       const Duration waitDuration = Duration(seconds: 1);
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       addTearDown(() async {
-        if (gesture != null) return gesture.removePointer();
+        if (gesture != null)
+          return gesture.removePointer();
       });
       await gesture.addPointer();
       await gesture.moveTo(const Offset(1.0, 1.0));

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1514,7 +1514,7 @@ void main() {
         width: 100.0,
         child: Text(tooltipText),
       );
-      await setCustomTooltip(tester, key, sizedBoxTooltip);
+      await setCustomTooltip(tester, key, 'message', sizedBoxTooltip);
 
       final RenderBox tipBox = tester.renderObject(
         _findCustomTooltipParent(tooltipText, SizedBox),
@@ -1535,7 +1535,7 @@ void main() {
         color: Colors.red,
         child: const Text(tooltipText),
       );
-      await setCustomTooltip(tester, key, containerTooltip);
+      await setCustomTooltip(tester, key, 'message', containerTooltip);
 
       final RenderBox tipContainer = tester.renderObject(
         find.ancestor(
@@ -1552,7 +1552,7 @@ void main() {
     });
   });
 
-  group('Tooltip.custom tests', () {
+  group('Widget tooltip tests:', () {
     testWidgets('Does tooltip end up in the right place - center', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(
@@ -1567,12 +1567,15 @@ void main() {
                       Positioned(
                         left: 300.0,
                         top: 0.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 20.0,
                           padding: const EdgeInsets.all(5.0),
                           verticalOffset: 20.0,
@@ -1629,12 +1632,15 @@ void main() {
                         Positioned(
                           left: 300.0,
                           top: 0.0,
-                          child: Tooltip.custom(
+                          child: Tooltip(
                             key: key,
-                            tooltip: ConstrainedBox(
-                              constraints: const BoxConstraints(minHeight: 0),
-                              child: const Text(tooltipText),
-                            ),
+                            message:tooltipText,
+                            tooltipBuilder: (BuildContext context, String message) {
+                              return ConstrainedBox(
+                                constraints: const BoxConstraints(minHeight: 0),
+                                child: Text(message),
+                              );
+                            },
                             height: 20.0,
                             padding: const EdgeInsets.all(5.0),
                             verticalOffset: 20.0,
@@ -1692,12 +1698,15 @@ void main() {
                       Positioned(
                         left: 0.0,
                         top: 0.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 20.0,
                           padding: const EdgeInsets.all(5.0),
                           verticalOffset: 20.0,
@@ -1749,12 +1758,15 @@ void main() {
                       Positioned(
                         left: 400.0,
                         top: 300.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 100.0,
                           padding: EdgeInsets.zero,
                           verticalOffset: 100.0,
@@ -1808,12 +1820,15 @@ void main() {
                       Positioned(
                         left: 400.0,
                         top: 299.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 190.0,
                           padding: EdgeInsets.zero,
                           verticalOffset: 100.0,
@@ -1878,12 +1893,15 @@ void main() {
                       Positioned(
                         left: 400.0,
                         top: 300.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 190.0,
                           padding: EdgeInsets.zero,
                           verticalOffset: 100.0,
@@ -1937,12 +1955,15 @@ void main() {
                       Positioned(
                         left: 1600.0,
                         top: 300.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 10.0,
                           padding: EdgeInsets.zero,
                           verticalOffset: 10.0,
@@ -1997,12 +2018,15 @@ void main() {
                       Positioned(
                         left: 780.0,
                         top: 300.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text(tooltipText),
-                          ),
+                          message: tooltipText,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           height: 10.0,
                           padding: EdgeInsets.zero,
                           verticalOffset: 10.0,
@@ -2053,12 +2077,15 @@ void main() {
             initialEntries: <OverlayEntry>[
               OverlayEntry(
                 builder: (BuildContext context) {
-                  return Tooltip.custom(
+                  return Tooltip(
                     key: key,
-                    tooltip: ConstrainedBox(
-                      constraints: const BoxConstraints(minHeight: 0),
-                      child: const Text(tooltipText),
-                    ),
+                    message: tooltipText,
+                    tooltipBuilder: (BuildContext context, String message) {
+                      return ConstrainedBox(
+                        constraints: const BoxConstraints(minHeight: 0),
+                        child: Text(message),
+                      );
+                    },
                     padding: EdgeInsets.zero,
                     margin: const EdgeInsets.all(_customMarginValue),
                     child: const SizedBox(
@@ -2107,12 +2134,15 @@ void main() {
     testWidgets('Default tooltip message textStyle should be null', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(MaterialApp(
-        home: Tooltip.custom(
+        home: Tooltip(
           key: key,
-          tooltip: ConstrainedBox(
-            constraints: const BoxConstraints(minHeight: 0),
-            child: const Text(tooltipText),
-          ),
+          message: tooltipText,
+          tooltipBuilder: (BuildContext context, String message) {
+            return ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 0),
+              child: Text(message),
+            );
+          },
           child: Container(
             width: 100.0,
             height: 100.0,
@@ -2136,11 +2166,14 @@ void main() {
           home: Directionality(
             textDirection: textDirection,
             child: Center(
-              child: Tooltip.custom(
-                tooltip: ConstrainedBox(
-                  constraints: const BoxConstraints(minHeight: 0),
-                  child: const Text(tooltipText),
-                ),
+              child: Tooltip(
+                message: tooltipText,
+                tooltipBuilder: (BuildContext context, String message) {
+                  return ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 0),
+                    child: Text(message),
+                  );
+                },
                 child: Container(
                   width: 100.0,
                   height: 100.0,
@@ -2171,12 +2204,15 @@ void main() {
       // does not have a Material ancestor.
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(MaterialApp(
-        home: Tooltip.custom(
+        home: Tooltip(
           key: key,
-          tooltip: ConstrainedBox(
-            constraints: const BoxConstraints(minHeight: 0),
-            child: const Text(tooltipText),
-          ),
+          message: tooltipText,
+          tooltipBuilder: (BuildContext context, String message) {
+            return ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 0),
+              child: Text(message),
+            );
+          },
           child: Container(
             width: 100.0,
             height: 100.0,
@@ -2210,12 +2246,15 @@ void main() {
             initialEntries: <OverlayEntry>[
               OverlayEntry(
                 builder: (BuildContext context) {
-                  return Tooltip.custom(
+                  return Tooltip(
                     key: key,
-                    tooltip: ConstrainedBox(
-                      constraints: const BoxConstraints(minHeight: 0),
-                      child: const Text(tooltipText),
-                    ),
+                    message: tooltipText,
+                    tooltipBuilder: (BuildContext context, String message) {
+                      return ConstrainedBox(
+                        constraints: const BoxConstraints(minHeight: 0),
+                        child: Text(message),
+                      );
+                    },
                     child: const SizedBox(
                       width: 0.0,
                       height: 0.0,
@@ -2246,9 +2285,12 @@ void main() {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(
         MaterialApp(
-          home: Tooltip.custom(
+          home: Tooltip(
             key: key,
-            tooltip: const Text(tooltipText),
+            message: tooltipText,
+            tooltipBuilder: (BuildContext context, String message) {
+              return Text(message);
+            },
             child: const SizedBox(
               width: 0.0,
               height: 0.0,
@@ -2296,13 +2338,16 @@ void main() {
             initialEntries: <OverlayEntry>[
               OverlayEntry(
                 builder: (BuildContext context) {
-                  return Tooltip.custom(
+                  return Tooltip(
                     key: key,
                     decoration: customDecoration,
-                    tooltip: ConstrainedBox(
-                      constraints: const BoxConstraints(minHeight: 0),
-                      child: const Text(tooltipText),
-                    ),
+                    message: tooltipText,
+                    tooltipBuilder: (BuildContext context, String message) {
+                      return ConstrainedBox(
+                        constraints: const BoxConstraints(minHeight: 0),
+                        child: Text(message),
+                      );
+                    },
                     child: const SizedBox(
                       width: 0.0,
                       height: 0.0,
@@ -2331,11 +2376,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text(tooltipText),
-              ),
+            child: Tooltip(
+              message: tooltipText,
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               child: Container(
                 width: 100.0,
                 height: 100.0,
@@ -2392,11 +2440,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text(tooltipText),
-              ),
+            child: Tooltip(
+              message: tooltipText,
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               waitDuration: waitDuration,
               child: const SizedBox(
                 width: 100.0,
@@ -2447,11 +2498,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text(tooltipText),
-              ),
+            child: Tooltip(
+              message: tooltipText,
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               waitDuration: waitDuration,
               child: const Text('I am tool tip'),
             ),
@@ -2505,11 +2559,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text(tooltipText),
-              ),
+            child: Tooltip(
+              message: tooltipText,
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               waitDuration: waitDuration,
               child: const Text('I am tool tip'),
             ),
@@ -2554,21 +2611,27 @@ void main() {
           home: Center(
             child: Column(
               children: <Widget>[
-                Tooltip.custom(
-                  tooltip: ConstrainedBox(
-                    constraints: const BoxConstraints(minHeight: 0),
-                    child: const Text('message1'),
-                  ),
+                Tooltip(
+                  message: 'message1',
+                  tooltipBuilder: (BuildContext context, String message) {
+                    return ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 0),
+                      child: Text(message),
+                    );
+                  },
                   waitDuration: waitDuration,
                   showDuration: const Duration(days: 1),
                   child: const Text('tooltip1'),
                 ),
                 const Spacer(flex: 2),
-                Tooltip.custom(
-                  tooltip: ConstrainedBox(
-                    constraints: const BoxConstraints(minHeight: 0),
-                    child: const Text('message2'),
-                  ),
+                Tooltip(
+                  message: 'message2',
+                  tooltipBuilder: (BuildContext context, String message) {
+                    return ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 0),
+                      child: Text(message),
+                    );
+                  },
                   waitDuration: waitDuration,
                   showDuration: const Duration(days: 1),
                   child: const Text('tooltip2'),
@@ -2600,7 +2663,9 @@ void main() {
       await gesture.moveTo(tester.getCenter(secondTooltip));
       await tester.pump();
       await tester.pump(waitDuration);
-
+      // Make sure both messages are on the screen.
+      expect(find.text('message1'), findsOneWidget);
+      expect(find.text('message2'), findsOneWidget);
 
       final Finder thirdTooltip = find.text('tooltip3');
       await gesture.moveTo(Offset.zero);
@@ -2608,7 +2673,7 @@ void main() {
       await gesture.moveTo(tester.getCenter(thirdTooltip));
       await tester.pump();
       await tester.pump(waitDuration);
-      // Make sure both messages are on the screen.
+      // Make sure three messages are on the screen.
       expect(find.text('message1'), findsOneWidget);
       expect(find.text('message2'), findsOneWidget);
       expect(find.text('message3'), findsOneWidget);
@@ -2642,11 +2707,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text('message2'),
-              ),
+            child: Tooltip(
+              message: 'message2',
+              tooltipBuilder: (BuildContext context, String message) {
+                  return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               waitDuration: waitDuration,
               child: const SizedBox(
                 width: 100.0,
@@ -2692,13 +2760,15 @@ void main() {
                       Positioned(
                         left: 780.0,
                         top: 300.0,
-                        child: Tooltip.custom(
+                        child: Tooltip(
                           key: key,
-                          tooltip: ConstrainedBox(
-                            constraints: const BoxConstraints(minHeight: 0),
-                            child: const Text('message'),
-                          ),
-                          semanticsLabel: 'message',
+                          message: 'message',
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                            );
+                          },
                           child: const SizedBox(width: 10.0, height: 10.0),
                         ),
                       ),
@@ -2737,11 +2807,14 @@ void main() {
       Widget buildApp(String text) {
         return MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: Text(text),
-              ),
+            child: Tooltip(
+              message: text,
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               child: Container(
                 width: 100.0,
                 height: 100.0,
@@ -2776,11 +2849,14 @@ void main() {
                 return MaterialPageRoute<void>(
                   builder: (BuildContext context) {
                     return Center(
-                      child: Tooltip.custom(
-                        tooltip: ConstrainedBox(
-                          constraints: const BoxConstraints(minHeight: 0),
-                          child: Text(text),
-                        ),
+                      child: Tooltip(
+                        message: text,
+                          tooltipBuilder: (BuildContext context, String message) {
+                            return ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 0),
+                              child: Text(message),
+                          );
+                        },
                         child: Container(
                           width: 100.0,
                           height: 100.0,
@@ -2820,11 +2896,14 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 0),
-                child: const Text('Foo'),
-              ),
+            child: Tooltip(
+              message: 'Foo',
+              tooltipBuilder: (BuildContext context, String message) {
+                return ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 0),
+                  child: Text(message),
+                );
+              },
               child: Container(
                 width: 100.0,
                 height: 100.0,
@@ -2846,12 +2925,14 @@ void main() {
       final SemanticsTester semantics = SemanticsTester(tester);
 
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: Text('Foo'),
-              semanticsLabel: 'Foo',
-              child: Text('Bar'),
+            child: Tooltip(
+              message: 'Foo',
+              tooltipBuilder: (BuildContext context, String message) {
+                return Text(message);
+              },
+              child: const Text('Bar'),
             ),
           ),
         ),
@@ -2892,11 +2973,15 @@ void main() {
       final SemanticsTester semantics = SemanticsTester(tester);
 
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: Text('Foo'),
-              child: Text('Bar'),
+            child: Tooltip(
+              message: 'Foo',
+              tooltipBuilder: (BuildContext context, String message) {
+                return Text(message);
+              },
+              excludeFromSemantics: true,
+              child: const Text('Bar'),
             ),
           ),
         ),
@@ -2944,9 +3029,11 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Center(
-            child: Tooltip.custom(
-              tooltip: const Text('Foo'),
-              semanticsLabel: 'Foo',
+            child: Tooltip(
+              message: 'Foo',
+              tooltipBuilder: (BuildContext context, String message) {
+                return Text(message);
+              },
               child: Container(
                 width: 100.0,
                 height: 100.0,
@@ -2983,16 +3070,18 @@ void main() {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
 
       // Not checking controller, inputFormatters, focusNode
-      const Tooltip.custom(
-        key: ValueKey<String>('foo'),
-        tooltip: Text('message'),
-        decoration: BoxDecoration(),
-        waitDuration: Duration(seconds: 1),
-        showDuration: Duration(seconds: 2),
+      Tooltip(
+        key: const ValueKey<String>('foo'),
+        message: 'message',
+        tooltipBuilder: (BuildContext context, String message) {
+          return Text(message);
+        },
+        decoration: const BoxDecoration(),
+        waitDuration: const Duration(seconds: 1),
+        showDuration: const Duration(seconds: 2),
         padding: EdgeInsets.zero,
-        margin: EdgeInsets.all(5.0),
+        margin: const EdgeInsets.all(5.0),
         height: 100.0,
-        semanticsLabel: 'message',
         preferBelow: false,
         verticalOffset: 50.0,
         triggerMode: TooltipTriggerMode.manual,
@@ -3005,18 +3094,16 @@ void main() {
           .toList();
 
       expect(description, <String>[
-        'null',
+        '"message"',
         'height: 100.0',
         'padding: EdgeInsets.zero',
         'margin: EdgeInsets.all(5.0)',
         'vertical offset: 50.0',
         'position: above',
-        'semantics: excluded',
         'wait duration: 0:00:01.000000',
         'show duration: 0:00:02.000000',
         'triggerMode: TooltipTriggerMode.manual',
         'enableFeedback: true',
-        'semanticsLabel: "message"',
       ]);
     });
 
@@ -3074,16 +3161,19 @@ Future<void> setWidgetForTooltipMode(WidgetTester tester, TooltipTriggerMode tri
 
   if(!isCustomTooltip){
     tooltip =  Tooltip(
-        message: tooltipText,
-        triggerMode: triggerMode,
-        child: const SizedBox(width: 100.0, height: 100.0),
-      );
+      message: tooltipText,
+      triggerMode: triggerMode,
+      child: const SizedBox(width: 100.0, height: 100.0),
+    );
   } else{
-    tooltip =  Tooltip.custom(
-        tooltip: const Text(tooltipText),
-        triggerMode: triggerMode,
-        child: const SizedBox(width: 100.0, height: 100.0),
-      );
+    tooltip =  Tooltip(
+      message: tooltipText,
+      tooltipBuilder: (BuildContext context, String message) {
+          return Text(message);
+      },
+      triggerMode: triggerMode,
+      child: const SizedBox(width: 100.0, height: 100.0),
+    );
   }
 
   await tester.pumpWidget(
@@ -3112,12 +3202,15 @@ SemanticsNode findDebugSemantics(RenderObject object) {
   return findDebugSemantics(object.parent! as RenderObject);
 }
 
-Future<void> setCustomTooltip(WidgetTester tester, GlobalKey key, Widget widget) async {
+Future<void> setCustomTooltip(WidgetTester tester, GlobalKey key, String message, Widget widget) async {
   await tester.pumpWidget(
     MaterialApp(
-      home: Tooltip.custom(
+      home: Tooltip(
         key: key,
-        tooltip: widget
+        message: message,
+        tooltipBuilder: (BuildContext context, String message) {
+          return widget;
+        },
       ),
     ),
   );

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -847,10 +847,12 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
         final Widget widget = element.widget;
         if (widget is Tooltip) {
-          final Iterable<Element> matches = find.byTooltip(widget.message).evaluate();
-          if (matches.length == 1) {
-            printToConsole("  find.byTooltip('${widget.message}')");
-            continue;
+          if(widget.message != null){
+            final Iterable<Element> matches = find.byTooltip(widget.message!).evaluate();
+            if (matches.length == 1) {
+              printToConsole("  find.byTooltip('${widget.message}')");
+              continue;
+            }
           }
         }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -847,12 +847,10 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
         final Widget widget = element.widget;
         if (widget is Tooltip) {
-          if(widget.message != null){
-            final Iterable<Element> matches = find.byTooltip(widget.message!).evaluate();
-            if (matches.length == 1) {
-              printToConsole("  find.byTooltip('${widget.message}')");
-              continue;
-            }
+          final Iterable<Element> matches = find.byTooltip(widget.message).evaluate();
+          if (matches.length == 1) {
+            printToConsole("  find.byTooltip('${widget.message}')");
+            continue;
           }
         }
 


### PR DESCRIPTION
*Added a Tooltip.custom() constructor to accept custom widget as a parameter to create a custom tooltip like for the info button in the image. It will continue to accept the message parameter for the Tooltip widget and It will not break the current code.*

![image](https://user-images.githubusercontent.com/45857340/124516784-8036f500-ddb0-11eb-859b-8b8f0af5f895.png)

[Targetting proposal](https://github.com/flutter/flutter/issues/85923)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat