### PR TITLE
Migrate dds.dart to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 
 import 'package:dds/dds.dart' as dds;
@@ -15,36 +13,33 @@ import 'logger.dart';
 
 @visibleForTesting
 Future<dds.DartDevelopmentService> Function(
-  Uri,
-  {bool enableAuthCodes,
+  Uri remoteVmServiceUri, {
+  bool enableAuthCodes,
   bool ipv6,
-  Uri serviceUri,
+  Uri? serviceUri,
 }) ddsLauncherCallback = dds.DartDevelopmentService.startDartDevelopmentService;
 
 /// Helper class to launch a [dds.DartDevelopmentService]. Allows for us to
 /// mock out this functionality for testing purposes.
 class DartDevelopmentService {
-  dds.DartDevelopmentService _ddsInstance;
+  dds.DartDevelopmentService? _ddsInstance;
 
-  Uri get uri => _ddsInstance?.uri ?? _existingDdsUri;
-  Uri _existingDdsUri;
+  Uri? get uri => _ddsInstance?.uri ?? _existingDdsUri;
+  Uri? _existingDdsUri;
 
   Future<void> get done => _completer.future;
   final Completer<void> _completer = Completer<void>();
 
   Future<void> startDartDevelopmentService(
-    Uri observatoryUri,
-    int hostPort,
-    bool ipv6,
-    bool disableServiceAuthCodes, {
-    @required Logger logger,
+    Uri observatoryUri, {
+    required Logger logger,
+    int? hostPort,
+    bool? ipv6,
+    bool? disableServiceAuthCodes,
   }) async {
     final Uri ddsUri = Uri(
       scheme: 'http',
-      host: (ipv6 ?
-        io.InternetAddress.loopbackIPv6 :
-        io.InternetAddress.loopbackIPv4
-      ).host,
+      host: (ipv6 == true ? io.InternetAddress.loopbackIPv6 : io.InternetAddress.loopbackIPv4).host,
       port: hostPort ?? 0,
     );
     logger.printTrace(
@@ -55,15 +50,15 @@ class DartDevelopmentService {
       _ddsInstance = await ddsLauncherCallback(
           observatoryUri,
           serviceUri: ddsUri,
-          enableAuthCodes: !disableServiceAuthCodes,
-          ipv6: ipv6,
+          enableAuthCodes: disableServiceAuthCodes == true,
+          ipv6: ipv6 == true,
         );
-      unawaited(_ddsInstance.done.whenComplete(() {
+      unawaited(_ddsInstance?.done.whenComplete(() {
         if (!_completer.isCompleted) {
           _completer.complete();
         }
       }));
-      logger.printTrace('DDS is listening at ${_ddsInstance.uri}.');
+      logger.printTrace('DDS is listening at ${_ddsInstance?.uri}.');
     } on dds.DartDevelopmentServiceException catch (e) {
       logger.printTrace('Warning: Failed to start DDS: ${e.message}');
       if (e.errorCode == dds.DartDevelopmentServiceException.existingDdsInstanceError) {

--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -50,7 +50,7 @@ class DartDevelopmentService {
       _ddsInstance = await ddsLauncherCallback(
           observatoryUri,
           serviceUri: ddsUri,
-          enableAuthCodes: disableServiceAuthCodes == true,
+          enableAuthCodes: disableServiceAuthCodes != true,
           ipv6: ipv6 == true,
         );
       unawaited(_ddsInstance?.done.whenComplete(() {

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -225,9 +225,9 @@ class FlutterDriverService extends DriverService {
       try {
         await device.dds.startDartDevelopmentService(
           uri,
-          debuggingOptions.ddsPort,
-          ipv6,
-          debuggingOptions.disableServiceAuthCodes,
+          hostPort: debuggingOptions.ddsPort,
+          ipv6: ipv6,
+          disableServiceAuthCodes: debuggingOptions.disableServiceAuthCodes,
           logger: _logger,
         );
         _vmServiceUri = device.dds.uri.toString();

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -65,9 +65,9 @@ Future<void> _kDefaultDartDevelopmentServiceStarter(
 ) async {
   await device.dds.startDartDevelopmentService(
     observatoryUri,
-    0,
-    true,
-    disableServiceAuthCodes,
+    hostPort: 0,
+    ipv6: true,
+    disableServiceAuthCodes: disableServiceAuthCodes,
     logger: globals.logger,
   );
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -263,9 +263,9 @@ class FlutterDevice {
         try {
           await device.dds.startDartDevelopmentService(
             observatoryUri,
-            ddsPort,
-            ipv6,
-            disableServiceAuthCodes,
+            hostPort: ddsPort,
+            ipv6: ipv6,
+            disableServiceAuthCodes: disableServiceAuthCodes,
             logger: globals.logger,
           );
         } on dds.DartDevelopmentServiceException catch (e, st) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -767,11 +767,11 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
 
   @override
   Future<void> startDartDevelopmentService(
-    Uri observatoryUri,
+    Uri observatoryUri, {
+    @required Logger logger,
     int hostPort,
     bool ipv6,
-    bool disableServiceAuthCodes, {
-    @required Logger logger,
+    bool disableServiceAuthCodes,
   }) async {}
 
   @override

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -605,11 +605,11 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
 
   @override
   Future<void> startDartDevelopmentService(
-    Uri observatoryUri,
+    Uri observatoryUri, {
+    @required Logger logger,
     int hostPort,
     bool ipv6,
-    bool disableServiceAuthCodes, {
-    @required Logger logger,
+    bool disableServiceAuthCodes,
   }) async {
     started = true;
   }

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -1008,7 +1008,13 @@ class FakeFuchsiaSdk extends Fake implements FuchsiaSdk {
 
 class FakeDartDevelopmentService extends Fake implements DartDevelopmentService {
   @override
-  Future<void> startDartDevelopmentService(Uri observatoryUri, int hostPort, bool ipv6, bool disableServiceAuthCodes, {Logger logger}) async { }
+  Future<void> startDartDevelopmentService(
+    Uri observatoryUri, {
+    @required Logger logger,
+    int hostPort,
+    bool ipv6,
+    bool disableServiceAuthCodes,
+  }) async {}
 
   @override
   Uri get uri => Uri.parse('example');

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1808,7 +1808,7 @@ void main() {
       ..dds = DartDevelopmentService();
     ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) {
       expect(uri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isFalse);
+      expect(enableAuthCodes, isTrue);
       expect(ipv6, isFalse);
       expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
       throw FakeDartDevelopmentServiceException(message:
@@ -1855,7 +1855,7 @@ void main() {
     final Completer<void>done = Completer<void>();
     ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) async {
       expect(uri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isTrue);
+      expect(enableAuthCodes, isFalse);
       expect(ipv6, isTrue);
       expect(serviceUri, Uri(scheme: 'http', host: '::1', port: 0));
       done.complete();
@@ -1886,7 +1886,7 @@ void main() {
       ..dds = DartDevelopmentService();
     ddsLauncherCallback = (Uri uri, {bool enableAuthCodes, bool ipv6, Uri serviceUri}) {
       expect(uri, Uri(scheme: 'foo', host: 'bar'));
-      expect(enableAuthCodes, isFalse);
+      expect(enableAuthCodes, isTrue);
       expect(ipv6, isFalse);
       expect(serviceUri, Uri(scheme: 'http', host: '127.0.0.1', port: 0));
       throw FakeDartDevelopmentServiceException(message: 'No URI');


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/88015 was reverted due to https://github.com/dart-lang/sdk/issues/46934.

Re-migrate dds.dart.  Add a unit test to check the host port is 0 when unspecified.

Part of #71511