### PR TITLE
Fix BoxDecoration crash with BorderRadiusDirectional

### DIFF
--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -485,7 +485,7 @@ class _BoxDecorationPainter extends BoxPainter {
       canvas,
       rect,
       shape: _decoration.shape,
-      borderRadius: _decoration.borderRadius as BorderRadius?,
+      borderRadius: _decoration.borderRadius?.resolve(textDirection),
       textDirection: configuration.textDirection,
     );
   }

--- a/packages/flutter/test/widgets/box_decoration_test.dart
+++ b/packages/flutter/test/widgets/box_decoration_test.dart
@@ -391,7 +391,7 @@ Future<void> main() async {
       itemsTapped = <int>[];
       return Align(
         alignment: Alignment.topLeft,
-        child:GestureDetector(
+        child: GestureDetector(
           behavior: HitTestBehavior.deferToChild,
           child: Container(
             key: key,
@@ -424,16 +424,16 @@ Future<void> main() async {
     const Offset fartherBorderRadiusPoint = Offset(borderDiagonalOffset,borderDiagonalOffset);
 
     await tester.tapAt(topLeft);
-    expect(itemsTapped, isEmpty,reason: 'top left tapped');
+    expect(itemsTapped, isEmpty, reason: 'top left tapped');
 
     await tester.tapAt(borderTopTangent);
-    expect(itemsTapped, isEmpty,reason: 'border top tapped');
+    expect(itemsTapped, isEmpty, reason: 'border top tapped');
 
     await tester.tapAt(borderLeftTangent);
-    expect(itemsTapped, isEmpty,reason: 'border left tapped');
+    expect(itemsTapped, isEmpty, reason: 'border left tapped');
 
     await tester.tapAt(fartherBorderRadiusPoint);
-    expect(itemsTapped, isEmpty,reason: 'border center tapped');
+    expect(itemsTapped, isEmpty, reason: 'border center tapped');
 
     await tester.tap(find.byKey(key));
     expect(itemsTapped, <int>[1]);
@@ -451,7 +451,7 @@ Future<void> main() async {
       itemsTapped = <int>[];
       return Align(
         alignment: Alignment.topLeft,
-        child:GestureDetector(
+        child: GestureDetector(
           behavior: HitTestBehavior.deferToChild,
           child: Container(
             key: key,
@@ -476,13 +476,13 @@ Future<void> main() async {
     const Offset fartherBorderRadiusPoint = Offset(borderDiagonalOffset+1,borderDiagonalOffset+1);
 
     await tester.tapAt(borderTopTangent);
-    expect(itemsTapped, <int>[1],reason: 'border Top not tapped');
+    expect(itemsTapped, <int>[1], reason: 'border Top not tapped');
 
     await tester.tapAt(borderLeftTangent);
-    expect(itemsTapped, <int>[1,1],reason: 'border Left not tapped');
+    expect(itemsTapped, <int>[1,1], reason: 'border Left not tapped');
 
     await tester.tapAt(fartherBorderRadiusPoint);
-    expect(itemsTapped, <int>[1,1,1],reason: 'border center not tapped');
+    expect(itemsTapped, <int>[1,1,1], reason: 'border center not tapped');
 
     await tester.tap(find.byKey(key));
     expect(itemsTapped, <int>[1,1,1,1]);
@@ -499,7 +499,7 @@ Future<void> main() async {
       itemsTapped = <int>[];
       return Align(
         alignment: Alignment.topLeft,
-        child:GestureDetector(
+        child: GestureDetector(
           behavior: HitTestBehavior.deferToChild,
           child: Container(
             key: key,
@@ -532,27 +532,45 @@ Future<void> main() async {
     const Offset topLeftInside = Offset(radius, radius);
 
     await tester.tapAt(topRightInside);
-    expect(itemsTapped, <int>[1,1],reason: 'top right not tapped');
+    expect(itemsTapped, <int>[1,1], reason: 'top right not tapped');
 
     await tester.tapAt(topRightOutside);
-    expect(itemsTapped, <int>[1,1],reason: 'top right tapped');
+    expect(itemsTapped, <int>[1,1], reason: 'top right tapped');
 
     await tester.tapAt(bottomRightInside);
-    expect(itemsTapped, <int>[1,1,1],reason: 'bottom right not tapped');
+    expect(itemsTapped, <int>[1,1,1], reason: 'bottom right not tapped');
 
     await tester.tapAt(bottomRightOutside);
-    expect(itemsTapped, <int>[1,1,1],reason: 'bottom right tapped');
+    expect(itemsTapped, <int>[1,1,1], reason: 'bottom right tapped');
 
     await tester.tapAt(bottomLeftInside);
-    expect(itemsTapped, <int>[1,1,1,1],reason: 'bottom left not tapped');
+    expect(itemsTapped, <int>[1,1,1,1], reason: 'bottom left not tapped');
 
     await tester.tapAt(bottomLeftOutside);
-    expect(itemsTapped, <int>[1,1,1,1],reason: 'bottom left tapped');
+    expect(itemsTapped, <int>[1,1,1,1], reason: 'bottom left tapped');
 
     await tester.tapAt(topLeftInside);
-    expect(itemsTapped, <int>[1,1,1,1,1],reason: 'top left not tapped');
+    expect(itemsTapped, <int>[1,1,1,1,1], reason: 'top left not tapped');
 
     await tester.tapAt(topLeftOutside);
-    expect(itemsTapped, <int>[1,1,1,1,1],reason: 'top left tapped');
+    expect(itemsTapped, <int>[1,1,1,1,1], reason: 'top left tapped');
+  });
+
+  testWidgets("BoxDecoration doesn't crash with BorderRadiusDirectional", (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/88039
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border.all(),
+            borderRadius: const BorderRadiusDirectional.all(
+              Radius.circular(1.0),
+            ),
+          ),
+        ),
+      ),
+    );
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/88039

Instead of casting the geomerty needed to be resolved with textDirection

Also made some formatting changes in tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

