### PR TITLE
Run plugin_lint_mac task when either flutter_tools or integration_test packages change

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2092,6 +2092,8 @@ targets:
     scheduler: luci
     runIf:
       - dev/**
+      - packages/flutter_tools/**
+      - packages/integration_test/**
       - bin/**
 
   - name: Mac plugin_test


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/88013 caused the warning:
```
packages/integration_test/ios/Classes/FLTIntegrationTestCase.m:34:46: note: enclose 'localizedCapitalizedString' in an @available check to silence this warning
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8838626342733142481/+/u/run_plugin_lint_mac/test_stdout

However, the `plugin_lint_mac` shard was not run on presubmit on that PR, so it wasn't caught until post-submission.  Run `plugin_lint_mac` if anything in that package, or the tool, changes.