### PR TITLE
Add brief delays in android_views test to better accommodate lagging emulators

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -22,11 +22,13 @@ Future<void> main() async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
     await driver.tap(motionEventsListTile);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
     final SerializableFinder backButton = find.byValueKey('back');
     await driver.tap(backButton);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
   }, timeout: Timeout.none);
 
   group('WindowManager', ()
@@ -35,11 +37,13 @@ Future<void> main() async {
       final SerializableFinder wmListTile =
       find.byValueKey('WmIntegrationsListTile');
       await driver.tap(wmListTile);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     tearDownAll(() async {
       await driver.waitFor(find.pageBack());
       await driver.tap(find.pageBack());
+      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     test('AlertDialog from platform view context', () async {
@@ -47,6 +51,7 @@ Future<void> main() async {
           'ShowAlertDialog');
       await driver.waitFor(showAlertDialog);
       await driver.tap(showAlertDialog);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String status = await driver.getText(find.byValueKey('Status'));
       expect(status, 'Success');
     }, timeout: Timeout.none);
@@ -55,8 +60,10 @@ Future<void> main() async {
       final SerializableFinder addWindow = find.byValueKey('AddWindow');
       await driver.waitFor(addWindow);
       await driver.tap(addWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final SerializableFinder tapWindow = find.byValueKey('TapWindow');
       await driver.tap(tapWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String windowClickCount = await driver.getText(
         find.byValueKey('WindowClickCount'),
       );


### PR DESCRIPTION
Emulators running on LUCI can sometimes be slower than expected, causing tests to hang. Adds brief delays to help alleviate flakiness caused by this.
