### PR TITLE
Fixed leak and removed no-shuffle tag in scheduler_test.dart

### DIFF
--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:async';
 import 'dart:ui' show window;
 
@@ -140,6 +134,10 @@ void main() {
     for (final VoidCallback timer in timerQueueTasks) {
       timer();
     }
+
+    // As events are locked, make scheduleTask execute after the test or it
+    // will execute during following tests and risk failure.
+    addTearDown(() => scheduler.handleEventLoopCallback());
   });
 
   test('Flutter.Frame event fired', () async {


### PR DESCRIPTION
This PR fixed the problem that has prevented scheduler_test.dart being shuffled. Part of #85160.

One test schedules a task, but events are locked so the scheduled task does not execute and this messes up other tests.
This PR adds a teardown that executes the scheduled task after the test, when events are unlocked.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.


