### PR TITLE
Fixed leak and removed no-shuffle tag in ticker_test.dart

### DIFF
--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Future<void> controlAppLifeCycleState(AppLifecycleState state) async {
+  Future<void> setAppLifeCycleState(AppLifecycleState state) async {
     final ByteData? message =
         const StringCodec().encodeMessage(state.toString());
     await ServicesBinding.instance!.defaultBinaryMessenger
@@ -101,7 +101,7 @@ void main() {
     late Ticker ticker;
 
     void testFunction() {
-      ticker = Ticker((Duration _) {});
+      ticker = Ticker((Duration _) { });
     }
 
     testFunction();
@@ -110,8 +110,7 @@ void main() {
     expect(ticker.toString(debugIncludeStack: true), contains('testFunction'));
   });
 
-  testWidgets('Ticker can be sped up with time dilation',
-      (WidgetTester tester) async {
+  testWidgets('Ticker can be sped up with time dilation', (WidgetTester tester) async {
     timeDilation = 0.5; // Move twice as fast.
     late Duration lastDuration;
     void handleTick(Duration duration) {
@@ -127,8 +126,7 @@ void main() {
     ticker.dispose();
   });
 
-  testWidgets('Ticker can be slowed down with time dilation',
-      (WidgetTester tester) async {
+  testWidgets('Ticker can be slowed down with time dilation', (WidgetTester tester) async {
     timeDilation = 2.0; // Move half as fast.
     late Duration lastDuration;
     void handleTick(Duration duration) {
@@ -144,8 +142,7 @@ void main() {
     ticker.dispose();
   });
 
-  testWidgets('Ticker stops ticking when application is paused',
-      (WidgetTester tester) async {
+  testWidgets('Ticker stops ticking when application is paused', (WidgetTester tester) async {
     int tickCount = 0;
     void handleTick(Duration duration) {
       tickCount += 1;
@@ -158,19 +155,18 @@ void main() {
     expect(ticker.isActive, isTrue);
     expect(tickCount, equals(0));
 
-    controlAppLifeCycleState(AppLifecycleState.paused);
+    setAppLifeCycleState(AppLifecycleState.paused);
 
     expect(ticker.isTicking, isFalse);
     expect(ticker.isActive, isTrue);
 
     ticker.stop();
 
-    controlAppLifeCycleState(AppLifecycleState.resumed);
+    setAppLifeCycleState(AppLifecycleState.resumed);
   });
 
-  testWidgets('Ticker can be created before application unpauses',
-      (WidgetTester tester) async {
-    controlAppLifeCycleState(AppLifecycleState.paused);
+  testWidgets('Ticker can be created before application unpauses', (WidgetTester tester) async {
+    setAppLifeCycleState(AppLifecycleState.paused);
 
     int tickCount = 0;
     void handleTick(Duration duration) {
@@ -188,7 +184,7 @@ void main() {
     expect(tickCount, equals(0));
     expect(ticker.isTicking, isFalse);
 
-    controlAppLifeCycleState(AppLifecycleState.resumed);
+    setAppLifeCycleState(AppLifecycleState.resumed);
 
     await tester.pump(const Duration(milliseconds: 10));
 


### PR DESCRIPTION
This PR fixed the problem that has prevented ticker_test.dart being shuffled. Part of #85160.

One test paused the app life cycle state which broke other tests when shuffled. 
This PR resumes the app life cycle state before the test finishes. Some duplicated lines of code is refactored into method `setAppLifeCycleState()` as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
