### PR TITLE
Fixed leak and removed no-shuffle tag in platform_channel_test.dart

### DIFF
--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=456"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -232,6 +232,7 @@ void main() {
             .having((PlatformException e) => e.message, 'message', equals('sayHello failed')),
         ),
       );
+      channel.setMethodCallHandler(null);
     });
 
     test('can handle method call with other error result', () async {
@@ -251,6 +252,7 @@ void main() {
             .having((PlatformException e) => e.message, 'message', equals('Invalid argument(s): bad')),
         ),
       );
+      channel.setMethodCallHandler(null);
     });
 
     test('can check the mock handler', () async {


### PR DESCRIPTION
This PR fixed the problem that prevented platform_channel_test.dart being shuffled. Part of #85160.

A couple of tests sets up callbacks through `setMethodCallHandler()` that gets unresolved and breaks other tests.
This PR clears those callbacks by passing null to `setMethodCallHandler`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

