### PR TITLE
Avoid reporting frame/raster times for large image changer

### DIFF
--- a/dev/devicelab/bin/tasks/large_image_changer_perf_ios.dart
+++ b/dev/devicelab/bin/tasks/large_image_changer_perf_ios.dart
@@ -15,5 +15,16 @@ Future<void> main() async {
     'large_image_changer',
     measureCpuGpu: true,
     measureMemory: true,
+    // This benchmark doesn't care about frame times, frame times will be heavily
+    // impacted by IO time for loading the image initially.
+    benchmarkScoreKeys: <String>[
+      'average_cpu_usage',
+      'average_gpu_usage',
+      'average_memory_usage',
+      '90th_percentile_memory_usage',
+      '99th_percentile_memory_usage',
+      'new_gen_gc_count',
+      'old_gen_gc_count',
+    ],
   ).run);
 }


### PR DESCRIPTION
Preparing for reland of https://github.com/flutter/flutter/pull/87238

This benchmark does not report frame times on Android, and its frame times are heavily impacted by image IO. AFAICT, the "regression" caused by removing shader warmup is because there is no activity on the raster thread at the beginning of the benchmark now, which heavily skews the worst/99th/90th raster times upward. However, removing shader warmup does significantly improve memory usage, which is what this benchmark was actually written for.

After this patch, the benchmark will no longer report the frame/raster times to Skia perf.