### PR TITLE
Fixed leak and removed no-shuffle tag in widgets/app_overrides_test.dart

### DIFF
--- a/packages/flutter/test/widgets/app_overrides_test.dart
+++ b/packages/flutter/test/widgets/app_overrides_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -62,9 +56,11 @@ void main() {
     expect(find.byType(Navigator), findsOneWidget);
     expect(find.byType(PerformanceOverlay), findsOneWidget);
     expect(find.byType(CheckedModeBanner), findsOneWidget);
+    WidgetsApp.showPerformanceOverlayOverride = false;
   });
 
   testWidgets('showPerformanceOverlayOverride false', (WidgetTester tester) async {
+    WidgetsApp.showPerformanceOverlayOverride = true;
     expect(WidgetsApp.showPerformanceOverlayOverride, true);
     WidgetsApp.showPerformanceOverlayOverride = false;
     await pumpApp(tester);
@@ -83,9 +79,11 @@ void main() {
     expect(find.byType(Navigator), findsOneWidget);
     expect(find.byType(PerformanceOverlay), findsNothing);
     expect(find.byType(CheckedModeBanner), findsNothing);
+    WidgetsApp.debugAllowBannerOverride = true; // restore to default value
   });
 
   testWidgets('debugAllowBannerOverride true', (WidgetTester tester) async {
+    WidgetsApp.debugAllowBannerOverride = false;
     expect(WidgetsApp.showPerformanceOverlayOverride, false);
     expect(WidgetsApp.debugAllowBannerOverride, false);
     WidgetsApp.debugAllowBannerOverride = true;


### PR DESCRIPTION
This PR fixed the problem that has prevented app_overrides_test.dart being shuffled. Part of #85160.

This test is testing `WidgetsApp.showPerformanceOverlayOverride` and `WidgetsApp.debugAllowBannerOverride`.

## The problem
There was a strong dependecy to the default ordering of the tests. The value of `showPerformanceOverlayOverride` or `debugAllowBannerOverride` was expected to be the value that was set in previous test. 

## The fix

- Make the values be set to default values after each test:
`WidgetsApp.showPerformanceOverlayOverride=false`
`WidgetsApp.debugAllowBannerOverride=true`
- Set the expected value at the start of the test, if the default value is not expected.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

