### PR TITLE
Prepare the flutter.material.RawMaterialButton.mouseCursor doc template for themeable mouse cursors

### DIFF
--- a/packages/flutter/lib/src/material/button.dart
+++ b/packages/flutter/lib/src/material/button.dart
@@ -127,9 +127,9 @@ class RawMaterialButton extends StatefulWidget {
   ///  * [MaterialState.hovered].
   ///  * [MaterialState.focused].
   ///  * [MaterialState.disabled].
+  /// {@endtemplate}
   ///
   /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
-  /// {@endtemplate}
   final MouseCursor? mouseCursor;
 
   /// Defines the default text style, with [Material.textStyle], for the

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -384,6 +384,8 @@ class FloatingActionButton extends StatelessWidget {
   final VoidCallback? onPressed;
 
   /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  ///
+  /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
   final MouseCursor? mouseCursor;
 
   /// The z-coordinate at which to place this button relative to its parent.

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -131,6 +131,8 @@ class MaterialButton extends StatelessWidget {
   final ValueChanged<bool>? onHighlightChanged;
 
   /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  ///
+  /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
   final MouseCursor? mouseCursor;
 
   /// Defines the button's base colors, and the defaults for the button's minimum

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -229,6 +229,8 @@ class ToggleButtons extends StatelessWidget {
   final void Function(int index)? onPressed;
 
   /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  ///
+  /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
   final MouseCursor? mouseCursor;
 
   /// The [TextStyle] to apply to any text in these toggle buttons.
@@ -821,6 +823,8 @@ class _ToggleButton extends StatelessWidget {
   final VoidCallback? onPressed;
 
   /// {@macro flutter.material.RawMaterialButton.mouseCursor}
+  ///
+  /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
   final MouseCursor? mouseCursor;
 
   /// The width and color of the button's leading side border.


### PR DESCRIPTION
Prepare the docs for themeable mouse cursors by moving

> If this property is null, [MaterialStateMouseCursor.clickable] will be used.

outside the template, because when adding themeable mouse cursors, the description changes to something like:

> If null, then the value of [FloatingActionButtonThemeData.mouseCursor] is used. If that is also null, then [MaterialStateMouseCursor.clickable] is used.

Coincidentally, this also fixes IconButton.mouseCursor docs that ended up having duplicate defaults in #63885.

## Related issues

Motivated by themeable mouse cursors: #88371
Fixes IconButton.mouseCursor docs: #63885

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
