### PR TITLE
Fixed leak and remove no-shuffle tag on binding_test.dart

### DIFF
--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=382757700"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -238,6 +232,7 @@ void main() {
       '   argument.\n',
     );
   });
+  
   testWidgets('defaultStackFilter elides framework Element mounting stacks', (WidgetTester tester) async {
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
     late FlutterErrorDetails errorDetails;

--- a/packages/flutter/test/widgets/binding_test.dart
+++ b/packages/flutter/test/widgets/binding_test.dart
@@ -56,6 +56,13 @@ void main() {
     WidgetsFlutterBinding.ensureInitialized();
   });
 
+  Future<void> setAppLifeCycleState(AppLifecycleState state) async {
+    final ByteData? message =
+        const StringCodec().encodeMessage(state.toString());
+    await ServicesBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage('flutter/lifecycle', message, (_) {});
+  }
+
   testWidgets('didHaveMemoryPressure callback', (WidgetTester tester) async {
     final MemoryPressureObserver observer = MemoryPressureObserver();
     WidgetsBinding.instance!.addObserver(observer);
@@ -66,25 +73,22 @@ void main() {
   });
 
   testWidgets('handleLifecycleStateChanged callback', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance!.defaultBinaryMessenger;
     final AppLifecycleStateObserver observer = AppLifecycleStateObserver();
     WidgetsBinding.instance!.addObserver(observer);
 
-    ByteData message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.paused);
     expect(observer.lifecycleState, AppLifecycleState.paused);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.resumed);
     expect(observer.lifecycleState, AppLifecycleState.resumed);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.inactive);
     expect(observer.lifecycleState, AppLifecycleState.inactive);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.detached')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.detached);
     expect(observer.lifecycleState, AppLifecycleState.detached);
+
+    setAppLifeCycleState(AppLifecycleState.resumed);
   });
 
   testWidgets('didPushRoute callback', (WidgetTester tester) async {
@@ -111,7 +115,8 @@ void main() {
     final ByteData message = const JSONMethodCodec().encodeMethodCall(
       const MethodCall('pushRouteInformation', testRouteInformation),
     );
-    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/navigation', message, (_) { });
+    await ServicesBinding.instance!.defaultBinaryMessenger
+        .handlePlatformMessage('flutter/navigation', message, (_) {});
     expect(observer.pushedRoute, 'testRouteName');
     WidgetsBinding.instance!.removeObserver(observer);
   });
@@ -133,7 +138,6 @@ void main() {
     WidgetsBinding.instance!.removeObserver(observer);
   });
 
-
   testWidgets('didPushRouteInformation callback with null state', (WidgetTester tester) async {
     final PushRouteInformationObserver observer = PushRouteInformationObserver();
     WidgetsBinding.instance!.addObserver(observer);
@@ -152,36 +156,28 @@ void main() {
   });
 
   testWidgets('Application lifecycle affects frame scheduling', (WidgetTester tester) async {
-    final BinaryMessenger defaultBinaryMessenger = ServicesBinding.instance!.defaultBinaryMessenger;
-    ByteData message;
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.paused);
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.resumed);
     expect(tester.binding.hasScheduledFrame, isTrue);
     await tester.pump();
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.inactive);
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.detached')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.detached);
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.inactive')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.inactive);
     expect(tester.binding.hasScheduledFrame, isTrue);
     await tester.pump();
     expect(tester.binding.hasScheduledFrame, isFalse);
 
-    message = const StringCodec().encodeMessage('AppLifecycleState.paused')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.paused);
     expect(tester.binding.hasScheduledFrame, isFalse);
 
     tester.binding.scheduleFrame();
@@ -193,7 +189,9 @@ void main() {
     expect(tester.binding.hasScheduledFrame, isFalse);
 
     int frameCount = 0;
-    tester.binding.addPostFrameCallback((Duration duration) { frameCount += 1; });
+    tester.binding.addPostFrameCallback((Duration duration) {
+      frameCount += 1;
+    });
     expect(tester.binding.hasScheduledFrame, isFalse);
     await tester.pump(const Duration(milliseconds: 1));
     expect(tester.binding.hasScheduledFrame, isFalse);
@@ -204,8 +202,7 @@ void main() {
     expect(frameCount, 1);
 
     // Get the tester back to a resumed state for subsequent tests.
-    message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
-    await defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
+    setAppLifeCycleState(AppLifecycleState.resumed);
     expect(tester.binding.hasScheduledFrame, isTrue);
     await tester.pump();
   });
@@ -241,7 +238,6 @@ void main() {
       '   argument.\n',
     );
   });
-
   testWidgets('defaultStackFilter elides framework Element mounting stacks', (WidgetTester tester) async {
     final FlutterExceptionHandler? oldHandler = FlutterError.onError;
     late FlutterErrorDetails errorDetails;


### PR DESCRIPTION
This PR fixed the problem that prevented binding_test.dart being shuffled. Part of #85160.

## The Problem
App life cycle state was left in the state _detached_, which messed up other tests when shuffled.

## The Fix
This PR adds a line that resumes the app life cycle state (line 85).
Duplicated code is refactored into method `setAppLifeCycleState`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

