### PR TITLE
Skip flaky 'Child windows can handle touches' test in `android_views` integration test

### DIFF
--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -61,6 +61,6 @@ Future<void> main() async {
         find.byValueKey('WindowClickCount'),
       );
       expect(windowClickCount, 'Click count: 1');
-    }, timeout: Timeout.none, skip: true);
+    }, timeout: Timeout.none, skip: true); // TODO(garyq): Skipped, see https://github.com/flutter/flutter/issues/88479
   });
 }

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -22,13 +22,11 @@ Future<void> main() async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
     await driver.tap(motionEventsListTile);
-    await Future<void>.delayed(const Duration(milliseconds: 100));
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
     final SerializableFinder backButton = find.byValueKey('back');
     await driver.tap(backButton);
-    await Future<void>.delayed(const Duration(milliseconds: 100));
   }, timeout: Timeout.none);
 
   group('WindowManager', ()
@@ -37,13 +35,11 @@ Future<void> main() async {
       final SerializableFinder wmListTile =
       find.byValueKey('WmIntegrationsListTile');
       await driver.tap(wmListTile);
-      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     tearDownAll(() async {
       await driver.waitFor(find.pageBack());
       await driver.tap(find.pageBack());
-      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     test('AlertDialog from platform view context', () async {
@@ -51,7 +47,6 @@ Future<void> main() async {
           'ShowAlertDialog');
       await driver.waitFor(showAlertDialog);
       await driver.tap(showAlertDialog);
-      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String status = await driver.getText(find.byValueKey('Status'));
       expect(status, 'Success');
     }, timeout: Timeout.none);
@@ -60,10 +55,8 @@ Future<void> main() async {
       final SerializableFinder addWindow = find.byValueKey('AddWindow');
       await driver.waitFor(addWindow);
       await driver.tap(addWindow);
-      await Future<void>.delayed(const Duration(milliseconds: 100));
       final SerializableFinder tapWindow = find.byValueKey('TapWindow');
       await driver.tap(tapWindow);
-      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String windowClickCount = await driver.getText(
         find.byValueKey('WindowClickCount'),
       );

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -61,6 +61,6 @@ Future<void> main() async {
         find.byValueKey('WindowClickCount'),
       );
       expect(windowClickCount, 'Click count: 1');
-    }, timeout: Timeout.none);
+    }, timeout: Timeout.none, skip: true);
   });
 }

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -22,11 +22,13 @@ Future<void> main() async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
     await driver.tap(motionEventsListTile);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
     await driver.waitFor(find.byValueKey('PlatformView'));
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
     final SerializableFinder backButton = find.byValueKey('back');
     await driver.tap(backButton);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
   }, timeout: Timeout.none);
 
   group('WindowManager', ()
@@ -35,11 +37,13 @@ Future<void> main() async {
       final SerializableFinder wmListTile =
       find.byValueKey('WmIntegrationsListTile');
       await driver.tap(wmListTile);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     tearDownAll(() async {
       await driver.waitFor(find.pageBack());
       await driver.tap(find.pageBack());
+      await Future<void>.delayed(const Duration(milliseconds: 100));
     });
 
     test('AlertDialog from platform view context', () async {
@@ -47,6 +51,7 @@ Future<void> main() async {
           'ShowAlertDialog');
       await driver.waitFor(showAlertDialog);
       await driver.tap(showAlertDialog);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String status = await driver.getText(find.byValueKey('Status'));
       expect(status, 'Success');
     }, timeout: Timeout.none);
@@ -55,8 +60,10 @@ Future<void> main() async {
       final SerializableFinder addWindow = find.byValueKey('AddWindow');
       await driver.waitFor(addWindow);
       await driver.tap(addWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final SerializableFinder tapWindow = find.byValueKey('TapWindow');
       await driver.tap(tapWindow);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       final String windowClickCount = await driver.getText(
         find.byValueKey('WindowClickCount'),
       );


### PR DESCRIPTION
Skip 'Child windows can handle touches' test as this test frequently flakes when run on an emulator on LUCI.

See: https://github.com/flutter/flutter/issues/88479

Example flakes: https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/8d7f2ebd86a42a6c678c21f5cdd316dfe44e1c995d9faf5c229101a277177a27/+/build.proto?server=chromium-swarm.appspot.com
https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/474fe1f1f2d50f7679e821205cb4601086c42aca84f0f2b53231a335e785bcb6/+/build.proto?server=chromium-swarm.appspot.com
https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/6c3e75ca2b5014173f3126d6095708323142cc6241136a26cbd3e6d559869c0d/+/build.proto?server=chromium-swarm.appspot.com

Healthy run with the test skipped:
https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/0521c4edccef81288bfb98e2793b87a6257f321cd742b6e2faa9064075754934/+/build.proto?server=chromium-swarm.appspot.com