### PR TITLE
Revert "Reland "Android Q transition by default (#82670)""

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -63,14 +63,13 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 /// A mixin that provides platform-adaptive transitions for a [PageRoute].
 ///
 /// {@template flutter.material.materialRouteTransitionMixin}
-/// For Android, the entrance transition for the page zooms in while the
-/// exiting page zooms and fades out. The exit transition is similar, but in
-/// reverse.
+/// For Android, the entrance transition for the page slides the route upwards
+/// and fades it in. The exit transition is the same, but in reverse.
 ///
-/// For iOS, the page slides in from the right and exits in reverse. The page
-/// also shifts to the left in parallax when another page enters to cover it.
-/// (These directions are flipped in environments with a right-to-left reading
-/// direction.)
+/// The transition is adaptive to the platform and on iOS, the route slides in
+/// from the right and exits in reverse. The route also shifts to the left in
+/// parallax when another page enters to cover it. (These directions are flipped
+/// in environments with a right-to-left reading direction.)
 /// {@endtemplate}
 ///
 /// See also:

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -9,8 +9,7 @@ import 'colors.dart';
 import 'theme.dart';
 
 // Slides the page upwards and fades it in, starting from 1/4 screen
-// below the top. The transition is intended to match the default for
-// Android O.
+// below the top.
 class _FadeUpwardsPageTransition extends StatelessWidget {
   _FadeUpwardsPageTransition({
     Key? key,
@@ -147,7 +146,7 @@ class _OpenUpwardsPageTransition extends StatelessWidget {
 }
 
 // Zooms and fades a new page in, zooming out the previous page. This transition
-// is designed to match the Android Q activity transition.
+// is designed to match the Android 10 activity transition.
 class _ZoomPageTransition extends StatelessWidget {
   /// Creates a [_ZoomPageTransition].
   ///
@@ -292,16 +291,16 @@ class _ZoomEnterTransition extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     double opacity = 0;
-    // The transition's scrim opacity only increases on the forward transition.
-    // In the reverse transition, the opacity should always be 0.0.
+    // The transition's scrim opacity only increases on the forward transition. In the reverse
+    // transition, the opacity should always be 0.0.
     //
-    // Therefore, we need to only apply the scrim opacity animation when
-    // the transition is running forwards.
+    // Therefore, we need to only apply the scrim opacity animation when the transition
+    // is running forwards.
     //
-    // The reason that we check that the animation's status is not `completed`
-    // instead of checking that it is `forward` is that this allows
-    // the interrupted reversal of the forward transition to smoothly fade
-    // the scrim away. This prevents a disjointed removal of the scrim.
+    // The reason that we check that the animation's status is not `completed` instead
+    // of checking that it is `forward` is that this allows the interrupted reversal of the
+    // forward transition to smoothly fade the scrim away. This prevents a disjointed
+    // removal of the scrim.
     if (!reverse && animation.status != AnimationStatus.completed) {
       opacity = _scrimOpacityTween.evaluate(animation)!;
     }
@@ -318,14 +317,17 @@ class _ZoomEnterTransition extends StatelessWidget {
     return AnimatedBuilder(
       animation: animation,
       builder: (BuildContext context, Widget? child) {
-        return ColoredBox(
+        return Container(
           color: Colors.black.withOpacity(opacity),
           child: child,
         );
       },
       child: FadeTransition(
         opacity: fadeTransition,
-        child: ScaleTransition(scale: scaleTransition, child: child),
+        child: ScaleTransition(
+          scale: scaleTransition,
+          child: child,
+        ),
       ),
     );
   }
@@ -372,7 +374,10 @@ class _ZoomExitTransition extends StatelessWidget {
 
     return FadeTransition(
       opacity: fadeTransition,
-      child: ScaleTransition(scale: scaleTransition, child: child),
+      child: ScaleTransition(
+        scale: scaleTransition,
+        child: child,
+      ),
     );
   }
 }
@@ -386,12 +391,11 @@ class _ZoomExitTransition extends StatelessWidget {
 ///
 /// See also:
 ///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
+///  * [ZoomPageTransitionsBuilder], which defines a page transition similar
+///    to the one provided in Android 10.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 abstract class PageTransitionsBuilder {
@@ -415,19 +419,18 @@ abstract class PageTransitionsBuilder {
   );
 }
 
-/// Used by [PageTransitionsTheme] to define a vertically fading
-/// [MaterialPageRoute] page transition animation that looks like
-/// the default page transition used on Android O.
+/// Used by [PageTransitionsTheme] to define a default [MaterialPageRoute] page
+/// transition animation.
 ///
-/// The animation fades the new page in while translating it upwards,
+/// The default animation fades the new page in while translating it upwards,
 /// starting from about 25% below the top of the screen.
 ///
 /// See also:
 ///
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
+///  * [ZoomPageTransitionsBuilder], which defines a page transition similar
+///    to the one provided in Android 10.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class FadeUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
@@ -452,10 +455,9 @@ class FadeUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 /// See also:
 ///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
+///  * [ZoomPageTransitionsBuilder], which defines a page transition similar
+///    to the one provided in Android 10.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
@@ -481,19 +483,18 @@ class OpenUpwardsPageTransitionsBuilder extends PageTransitionsBuilder {
 
 /// Used by [PageTransitionsTheme] to define a zooming [MaterialPageRoute] page
 /// transition animation that looks like the default page transition used on
-/// Android Q.
+/// Android 10.
 ///
 /// See also:
 ///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android P.
+///    similar to the one provided by Android P.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 class ZoomPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Constructs a page transition animation that matches the transition used on
-  /// Android Q.
+  /// Android 10.
   const ZoomPageTransitionsBuilder();
 
   @override
@@ -517,12 +518,11 @@ class ZoomPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 /// See also:
 ///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
+///  * [ZoomPageTransitionsBuilder], which defines a page transition similar
+///    to the one provided in Android 10.
 class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Constructs a page transition animation that matches the iOS transition.
   const CupertinoPageTransitionsBuilder();
@@ -554,12 +554,9 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 ///
 ///  * [ThemeData.pageTransitionsTheme], which defines the default page
 ///    transitions for the overall theme.
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a default page transition.
 ///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
 ///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided by Android Q.
 ///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
 ///    transition that matches native iOS page transitions.
 @immutable
@@ -577,9 +574,9 @@ class PageTransitionsTheme with Diagnosticable {
 
   static const Map<TargetPlatform, PageTransitionsBuilder> _defaultBuilders = <TargetPlatform, PageTransitionsBuilder>{
     // Only have default transitions for mobile platforms
-    TargetPlatform.android: ZoomPageTransitionsBuilder(),
+    TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
     TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-    TargetPlatform.fuchsia: ZoomPageTransitionsBuilder(),
+    TargetPlatform.fuchsia: FadeUpwardsPageTransitionsBuilder(),
   };
 
   static const Map<TargetPlatform, PageTransitionsBuilder> _defaultWebBuilders = <TargetPlatform, PageTransitionsBuilder>{
@@ -590,7 +587,8 @@ class PageTransitionsTheme with Diagnosticable {
   Map<TargetPlatform, PageTransitionsBuilder> get builders => _builders;
   final Map<TargetPlatform, PageTransitionsBuilder> _builders;
 
-  /// Delegates to the builder for the current [ThemeData.platform].
+  /// Delegates to the builder for the current [ThemeData.platform]
+  /// or [FadeUpwardsPageTransitionsBuilder].
   ///
   /// [MaterialPageRoute.buildTransitions] delegates to this method.
   Widget buildTransitions<T>(

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -459,7 +459,7 @@ void main() {
       home: Material(child: buildTable(sortAscending: true)),
     ));
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    Transform transformOfArrow = tester.firstWidget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.identity()),
@@ -471,7 +471,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    transformOfArrow = tester.firstWidget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.rotationZ(math.pi)),

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -98,12 +98,7 @@ void main() {
     );
 
     final RenderBox clipRect = tester.renderObject(find.byType(ClipRect).first);
-    final Transform transform = tester.firstWidget(
-      find.descendant(
-        of: find.byType(FlexibleSpaceBar),
-        matching: find.byType(Transform),
-      ),
-    );
+    final Transform transform = tester.firstWidget(find.byType(Transform));
 
     // The current (200) is half way between the min (100) and max (300) and the
     // lerp values used to calculate the scale are 1 and 1.5, so we check for 1.25.

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -12,24 +12,6 @@ import '../rendering/mock_canvas.dart';
 
 void main() {
   testWidgets('test page transition', (WidgetTester tester) async {
-    Iterable<T> _findWidgets<T extends Widget>(Finder of) {
-      return tester.widgetList<T>(
-        find.ancestor(of: of, matching: find.byType(T)),
-      );
-    }
-
-    FadeTransition _findForwardFadeTransition(Finder of) {
-      return _findWidgets<FadeTransition>(of).where(
-        (FadeTransition t) => t.opacity.status == AnimationStatus.forward,
-      ).first;
-    }
-
-    ScaleTransition _findForwardScaleTransition(Finder of) {
-      return _findWidgets<ScaleTransition>(of).where(
-        (ScaleTransition t) => t.scale.status == AnimationStatus.forward,
-      ).first;
-    }
-
     await tester.pumpWidget(
       MaterialApp(
         home: const Material(child: Text('Page 1')),
@@ -41,23 +23,27 @@ void main() {
       ),
     );
 
+    final Offset widget1TopLeft = tester.getTopLeft(find.text('Page 1'));
+
     tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
-
-    ScaleTransition widget1Scale = _findForwardScaleTransition(find.text('Page 1'));
-    ScaleTransition widget2Scale = _findForwardScaleTransition(find.text('Page 2'));
-    FadeTransition widget2Opacity = _findForwardFadeTransition(find.text('Page 2'));
-
-    // Page 1 is enlarging, starts from 1.0.
-    expect(widget1Scale.scale.value, greaterThan(1.0));
-    // Page 2 is enlarging from the value less than 1.0.
-    expect(widget2Scale.scale.value, lessThan(1.0));
-    // Page 2 is becoming none transparent.
-    expect(widget2Opacity.opacity.value, lessThan(1.0));
-
-    await tester.pump(const Duration(milliseconds: 250));
     await tester.pump(const Duration(milliseconds: 1));
+
+    FadeTransition widget2Opacity =
+        tester.element(find.text('Page 2')).findAncestorWidgetOfExactType<FadeTransition>()!;
+    Offset widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+    final Size widget2Size = tester.getSize(find.text('Page 2'));
+
+    // Android transition is vertical only.
+    expect(widget1TopLeft.dx == widget2TopLeft.dx, true);
+    // Page 1 is above page 2 mid-transition.
+    expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
+    // Animation begins 3/4 of the way up the page.
+    expect(widget2TopLeft.dy < widget2Size.height / 4.0, true);
+    // Animation starts with page 2 being near transparent.
+    expect(widget2Opacity.opacity.value < 0.01, true);
+
+    await tester.pump(const Duration(milliseconds: 300));
 
     // Page 2 covers page 1.
     expect(find.text('Page 1'), findsNothing);
@@ -65,21 +51,18 @@ void main() {
 
     tester.state<NavigatorState>(find.byType(Navigator)).pop();
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
-
-    widget1Scale = _findForwardScaleTransition(find.text('Page 1'));
-    widget2Scale = _findForwardScaleTransition(find.text('Page 2'));
-    widget2Opacity = _findForwardFadeTransition(find.text('Page 2'));
-
-    // Page 1 is narrowing down, but still larger than 1.0.
-    expect(widget1Scale.scale.value, greaterThan(1.0));
-    // Page 2 is smaller than 1.0.
-    expect(widget2Scale.scale.value, lessThan(1.0));
-    // Page 2 is becoming transparent.
-    expect(widget2Opacity.opacity.value, lessThan(1.0));
-
-    await tester.pump(const Duration(milliseconds: 200));
     await tester.pump(const Duration(milliseconds: 1));
+
+    widget2Opacity =
+        tester.element(find.text('Page 2')).findAncestorWidgetOfExactType<FadeTransition>()!;
+    widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
+
+    // Page 2 starts to move down.
+    expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
+    // Page 2 starts to lose opacity.
+    expect(widget2Opacity.opacity.value < 1.0, true);
+
+    await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Page 1'), isOnstage);
     expect(find.text('Page 2'), findsNothing);
@@ -171,70 +154,6 @@ void main() {
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     skip: kIsWeb, // [intended] no default transitions on the web.
   );
-
-  testWidgets('test page transition with FadeUpwardsPageTransitionBuilder', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(
-          pageTransitionsTheme: const PageTransitionsTheme(
-            builders: <TargetPlatform, PageTransitionsBuilder>{
-              TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-            },
-          ),
-        ),
-        home: const Material(child: Text('Page 1')),
-        routes: <String, WidgetBuilder>{
-          '/next': (BuildContext context) {
-            return const Material(child: Text('Page 2'));
-          },
-        },
-      ),
-    );
-
-    final Offset widget1TopLeft = tester.getTopLeft(find.text('Page 1'));
-
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 1));
-
-    FadeTransition widget2Opacity =
-    tester.element(find.text('Page 2')).findAncestorWidgetOfExactType<FadeTransition>()!;
-    Offset widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
-    final Size widget2Size = tester.getSize(find.text('Page 2'));
-
-    // Android transition is vertical only.
-    expect(widget1TopLeft.dx == widget2TopLeft.dx, true);
-    // Page 1 is above page 2 mid-transition.
-    expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
-    // Animation begins 3/4 of the way up the page.
-    expect(widget2TopLeft.dy < widget2Size.height / 4.0, true);
-    // Animation starts with page 2 being near transparent.
-    expect(widget2Opacity.opacity.value < 0.01, true);
-
-    await tester.pump(const Duration(milliseconds: 300));
-
-    // Page 2 covers page 1.
-    expect(find.text('Page 1'), findsNothing);
-    expect(find.text('Page 2'), isOnstage);
-
-    tester.state<NavigatorState>(find.byType(Navigator)).pop();
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 1));
-
-    widget2Opacity =
-    tester.element(find.text('Page 2')).findAncestorWidgetOfExactType<FadeTransition>()!;
-    widget2TopLeft = tester.getTopLeft(find.text('Page 2'));
-
-    // Page 2 starts to move down.
-    expect(widget1TopLeft.dy < widget2TopLeft.dy, true);
-    // Page 2 starts to lose opacity.
-    expect(widget2Opacity.opacity.value < 1.0, true);
-
-    await tester.pump(const Duration(milliseconds: 300));
-
-    expect(find.text('Page 1'), isOnstage);
-    expect(find.text('Page 2'), findsNothing);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('test fullscreen dialog transition', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -66,7 +66,7 @@ void main() {
     skip: kIsWeb, // [intended] no default transitions on the web.
   );
 
-  testWidgets('Default PageTransitionsTheme builds a _ZoomPageTransition for android', (WidgetTester tester) async {
+  testWidgets('Default PageTransitionsTheme builds a _FadeUpwardsPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: TextButton(
@@ -83,20 +83,20 @@ void main() {
       ),
     );
 
-    Finder findZoomPageTransition() {
+    Finder findFadeUpwardsPageTransition() {
       return find.descendant(
         of: find.byType(MaterialApp),
-        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ZoomPageTransition'),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_FadeUpwardsPageTransition'),
       );
     }
 
     expect(Theme.of(tester.element(find.text('push'))).platform, debugDefaultTargetPlatformOverride);
-    expect(findZoomPageTransition(), findsOneWidget);
+    expect(findFadeUpwardsPageTransition(), findsOneWidget);
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
-    expect(findZoomPageTransition(), findsOneWidget);
+    expect(findFadeUpwardsPageTransition(), findsOneWidget);
   },
     variant: TargetPlatformVariant.only(TargetPlatform.android),
     skip: kIsWeb, // [intended] no default transitions on the web.
@@ -145,7 +145,7 @@ void main() {
     skip: kIsWeb, // [intended] no default transitions on the web.
   );
 
-  testWidgets('PageTransitionsTheme override builds a _FadeUpwardsTransition', (WidgetTester tester) async {
+  testWidgets('PageTransitionsTheme override builds a _ZoomPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: TextButton(
@@ -161,7 +161,7 @@ void main() {
         theme: ThemeData(
           pageTransitionsTheme: const PageTransitionsTheme(
             builders: <TargetPlatform, PageTransitionsBuilder>{
-              TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(), // creates a _FadeUpwardsTransition
+              TargetPlatform.android: ZoomPageTransitionsBuilder(), // creates a _ZoomPageTransition
             },
           ),
         ),
@@ -169,20 +169,20 @@ void main() {
       ),
     );
 
-    Finder findFadeUpwardsPageTransition() {
+    Finder findZoomPageTransition() {
       return find.descendant(
         of: find.byType(MaterialApp),
-        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_FadeUpwardsPageTransition'),
+        matching: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_ZoomPageTransition'),
       );
     }
 
     expect(Theme.of(tester.element(find.text('push'))).platform, debugDefaultTargetPlatformOverride);
-    expect(findFadeUpwardsPageTransition(), findsOneWidget);
+    expect(findZoomPageTransition(), findsOneWidget);
 
     await tester.tap(find.text('push'));
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
-    expect(findFadeUpwardsPageTransition(), findsOneWidget);
+    expect(findZoomPageTransition(), findsOneWidget);
   },
     variant: TargetPlatformVariant.only(TargetPlatform.android),
     skip: kIsWeb, // [intended] no default transitions on the web.

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -70,12 +70,6 @@ Future<void> pumpTestWidget(
 }
 
 void main() {
-  // Find the exact transform which is the descendant of [UserAccountsDrawerHeader].
-  final Finder findTransform = find.descendant(
-    of: find.byType(UserAccountsDrawerHeader),
-    matching: find.byType(Transform),
-  );
-
   testWidgets('UserAccountsDrawerHeader test', (WidgetTester tester) async {
     await pumpTestWidget(tester);
 
@@ -133,7 +127,7 @@ void main() {
 
   testWidgets('UserAccountsDrawerHeader icon rotation test', (WidgetTester tester) async {
     await pumpTestWidget(tester);
-    Transform transformWidget = tester.firstWidget(findTransform);
+    Transform transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon is right side up.
     expect(transformWidget.transform.getRotation()[0], 1.0);
@@ -146,7 +140,7 @@ void main() {
 
     await tester.pumpAndSettle();
     await tester.pump();
-    transformWidget = tester.firstWidget(findTransform);
+    transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon has rotated 180 degrees.
     expect(transformWidget.transform.getRotation()[0], -1.0);
@@ -159,7 +153,7 @@ void main() {
 
     await tester.pumpAndSettle();
     await tester.pump();
-    transformWidget = tester.firstWidget(findTransform);
+    transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon has rotated 180 degrees back to the original position.
     expect(transformWidget.transform.getRotation()[0], 1.0);
@@ -184,7 +178,7 @@ void main() {
       ),
     ));
 
-    Transform transformWidget = tester.firstWidget(findTransform);
+    Transform transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon is right side up.
     expect(transformWidget.transform.getRotation()[0], 1.0);
@@ -195,7 +189,7 @@ void main() {
     expect(tester.hasRunningAnimations, isFalse);
 
     expect(await tester.pumpAndSettle(), 1);
-    transformWidget = tester.firstWidget(findTransform);
+    transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon has not rotated.
     expect(transformWidget.transform.getRotation()[0], 1.0);
@@ -204,7 +198,7 @@ void main() {
 
   testWidgets('UserAccountsDrawerHeader icon rotation test speeeeeedy', (WidgetTester tester) async {
     await pumpTestWidget(tester);
-    Transform transformWidget = tester.firstWidget(findTransform);
+    Transform transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon is right side up.
     expect(transformWidget.transform.getRotation()[0], 1.0);
@@ -236,7 +230,7 @@ void main() {
 
     await tester.pumpAndSettle();
     await tester.pump();
-    transformWidget = tester.firstWidget(findTransform);
+    transformWidget = tester.firstWidget(find.byType(Transform));
 
     // Icon has rotated 180 degrees back to the original position.
     expect(transformWidget.transform.getRotation()[0], 1.0);

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -728,14 +728,7 @@ Future<void> main() async {
 
   testWidgets('Hero pop transition interrupted by a push', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        routes: routes,
-        theme: ThemeData(pageTransitionsTheme: const PageTransitionsTheme(
-          builders: <TargetPlatform, PageTransitionsBuilder>{
-            TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-          },
-        )),
-      ),
+      MaterialApp(routes: routes),
     );
 
     // Pushes MaterialPageRoute '/two'.

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -533,7 +533,7 @@ void main() {
         matches(RegExp(r'^The specific RenderFlex in question is: RenderFlex#..... OVERFLOWING:$')),
         startsWith('  creator: Row ← Test ← '),
         contains(' ← '),
-        endsWith('    ⋯'),
+        endsWith(' ← ⋯'),
         '  parentData: <none> (can use size)',
         '  constraints: BoxConstraints(w=800.0, h=600.0)',
         '  size: Size(800.0, 600.0)',


### PR DESCRIPTION
Reverts flutter/flutter#88409

Caused a performance regression, see #88480.

Unfortunately #88409 also caused some unexpected golden image failures on internal tests, i.e. not just failures that were obviously due to the route change animation (see internal Google issue b/197155815)

Fixes #88480
