### PR TITLE
Explicitly declare `android:exported` in examples' manifest

### DIFF
--- a/examples/flutter_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter_view/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@ found in the LICENSE file. -->
 
     <application android:label="flutter_view" android:icon="@mipmap/ic_launcher">
         <activity android:name=".MainActivity"
+                  android:exported="true"
                   android:launchMode="singleTop"
                   android:theme="@style/Theme.AppCompat"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/examples/hello_world/android/app/src/main/AndroidManifest.xml
+++ b/examples/hello_world/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@ found in the LICENSE file. -->
 
     <application android:label="hello_world" android:icon="@mipmap/ic_launcher">
         <activity android:name="io.flutter.embedding.android.FlutterActivity"
+                  android:exported="true"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
                   android:hardwareAccelerated="true"

--- a/examples/image_list/android/app/src/main/AndroidManifest.xml
+++ b/examples/image_list/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@ found in the LICENSE file. -->
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name="io.flutter.embedding.android.FlutterActivity"
+            android:exported="true"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/examples/layers/android/app/src/main/AndroidManifest.xml
+++ b/examples/layers/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@ found in the LICENSE file. -->
 
     <application android:label="Flutter Layers" android:icon="@mipmap/ic_launcher">
         <activity android:name="io.flutter.embedding.android.FlutterActivity"
+                  android:exported="true"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
                   android:hardwareAccelerated="true"

--- a/examples/platform_channel/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_channel/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@ found in the LICENSE file. -->
 
     <application android:label="@string/app_name">
         <activity android:name=".MainActivity"
+                  android:exported="true"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/examples/platform_view/android/app/src/main/AndroidManifest.xml
+++ b/examples/platform_view/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@ found in the LICENSE file. -->
         android:label="platform_view">
         <activity
             android:name="io.flutter.examples.platform_view.MainActivity"
+            android:exported="true"
             android:theme="@android:style/Theme.Black.NoTitleBar"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
This is a prerequisite for bumping the target SDK.

https://developer.android.com/about/versions/12/behavior-changes-12#exported

*List which issues are fixed by this PR. You must list at least one issue.* I don't think there is an issue filed for this yet. This only takes effect if we set target SDK >= 31.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
