### PR TITLE
Do not crash when dragging ReorderableListView  with two fingers simultaneously

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -522,6 +522,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
   int? _insertIndex;
   Offset? _finalDropPosition;
   MultiDragGestureRecognizer? _recognizer;
+  int? _recognizerPointer;
   bool _autoScrolling = false;
   // To implement the gap for the dragged item, we replace the dragged item
   // with a zero sized box, and then translate all of the later items down
@@ -579,12 +580,18 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     setState(() {
       if (_dragInfo != null) {
         cancelReorder();
+      } else if (_recognizer != null && _recognizerPointer != event.pointer) {
+        _recognizer!.dispose();
+        _recognizer = null;
+        _recognizerPointer = null;
       }
+
       if (_items.containsKey(index)) {
         _dragIndex = index;
         _recognizer = recognizer
           ..onStart = _dragStart
           ..addPointer(event);
+        _recognizerPointer = event.pointer;
       } else {
         // TODO(darrenaustin): Can we handle this better, maybe scroll to the item?
         throw Exception('Attempting to start a drag on a non-visible item');


### PR DESCRIPTION
Fixes #88191

When the two pointers start dragging simultaneously, it will happen that two MultiDragGestureRecognizer wins simultaneously and lead to an assertion(assert(_dragInfo == null);).
Fix solution: If a recognizer is created by another pointer, it will be destroyed before adding the new recognizer.