### PR TITLE
Use `dart pub` instead of `pub` to invoke pub from tools

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -234,9 +234,7 @@ class _DefaultPub implements Pub {
     final bool verbose = _logger.isVerbose;
     final List<String> args = <String>[
       if (verbose)
-        '--verbose'
-      else
-        '--verbosity=warning',
+        '--verbose',
       ...<String>[
         command,
         '--no-precompile',
@@ -419,7 +417,7 @@ class _DefaultPub implements Pub {
       'cache',
       'dart-sdk',
       'bin',
-      'pub',
+      'dart',
     ]);
     if (!_processManager.canRun(sdkPath)) {
       throwToolExit(
@@ -428,7 +426,7 @@ class _DefaultPub implements Pub {
         'permissions for the current user.'
       );
     }
-    return <String>[sdkPath, ...arguments];
+    return <String>[sdkPath, 'pub', ...arguments];
   }
 
   // Returns the environment value that should be used when running pub.

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -426,7 +426,7 @@ class _DefaultPub implements Pub {
         'permissions for the current user.'
       );
     }
-    return <String>[sdkPath, 'pub', ...arguments];
+    return <String>[sdkPath, '--no-analytics', 'pub', ...arguments];
   }
 
   // Returns the environment value that should be used when running pub.

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1729,7 +1729,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', '--offline', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
       expect(loggingProcessManager.commands.first, contains('--offline'));
     },
     overrides: <Type, Generator>{
@@ -1754,7 +1754,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
       expect(loggingProcessManager.commands.first, isNot(contains('--offline')));
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -451,7 +451,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', 'pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -476,7 +476,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', 'pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -503,7 +503,7 @@ void main() {
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
+          '/bin/cache/dart-sdk/bin/dart', 'pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );
@@ -529,7 +529,7 @@ void main() {
       Cache.flutterRoot = '';
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/pub', 'upgrade', '-h'],
+          '/bin/cache/dart-sdk/bin/dart', 'pub', 'upgrade', '-h'],
           stdin:  IOSink(StreamController<List<int>>().sink),
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -451,7 +451,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', 'pub', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -476,7 +476,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', 'pub', '--trace', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -503,7 +503,7 @@ void main() {
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/dart', 'pub', 'run', '--foo', 'bar'],
+          '/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );
@@ -529,7 +529,7 @@ void main() {
       Cache.flutterRoot = '';
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/dart', 'pub', 'upgrade', '-h'],
+          '/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'upgrade', '-h'],
           stdin:  IOSink(StreamController<List<int>>().sink),
         ),
       );

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -26,7 +26,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.empty();
     final BufferLogger logger = BufferLogger.test();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/pub');
+    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/dart');
 
     fileSystem.file('pubspec.yaml').createSync();
 

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -51,8 +51,8 @@ void main() {
     testWithoutContext('does not skip pub get the parameter is false', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ])
@@ -99,8 +99,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ])
@@ -147,8 +147,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ])
@@ -262,8 +262,8 @@ void main() {
     'but the current framework version is not the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ])
@@ -301,8 +301,8 @@ void main() {
     'but the current framework version does not exist yet', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ])
@@ -339,8 +339,8 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ], onRun: () {
@@ -377,8 +377,8 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ]),
@@ -413,8 +413,8 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the package config is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ])
@@ -452,8 +452,8 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the pubspec.lock is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ])
@@ -495,8 +495,8 @@ void main() {
 
     const FakeCommand pubGetCommand = FakeCommand(
       command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
+        'bin/cache/dart-sdk/bin/dart',
+        'pub',
         'get',
         '--no-precompile',
       ],
@@ -591,8 +591,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -636,8 +636,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -677,8 +677,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -799,8 +799,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -840,8 +840,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -882,8 +882,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -894,16 +894,16 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
       ),
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],
@@ -914,8 +914,8 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          'pub',
           'get',
           '--no-precompile',
         ],

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -52,6 +52,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -100,6 +101,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -148,6 +150,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -263,6 +266,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -302,6 +306,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -340,6 +345,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -378,6 +384,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -414,6 +421,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -453,6 +461,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -496,6 +505,7 @@ void main() {
     const FakeCommand pubGetCommand = FakeCommand(
       command: <String>[
         'bin/cache/dart-sdk/bin/dart',
+        '--no-analytics',
         'pub',
         'get',
         '--no-precompile',
@@ -592,6 +602,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -637,6 +648,7 @@ void main() {
       FakeCommand(
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -678,6 +690,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -800,6 +813,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -841,6 +855,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -883,6 +898,7 @@ void main() {
       FakeCommand(
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -895,6 +911,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -903,6 +920,7 @@ void main() {
       FakeCommand(
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',
@@ -915,6 +933,7 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
           'pub',
           'get',
           '--no-precompile',


### PR DESCRIPTION
The top-level `pub` command is being deprecated https://github.com/dart-lang/pub/issues/2736. Start using `dart pub` instead.

Fixes: https://github.com/flutter/flutter/issues/88507

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
