### PR TITLE
[WIP] Win32 template: Add dark theme support

### DIFF
--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/flutter_window.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/flutter_window.cpp
@@ -55,6 +55,9 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
       break;
+    case WM_DWMCOLORIZATIONCOLORCHANGED:
+      flutter_controller_->engine()->ReloadPlatformBrightness();
+      break;
   }
 
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);


### PR DESCRIPTION
This PR changes `windows` template to receive theme (dark/light) update and to apply brightness to flutter by using the function added in flutter/engine#28131.
Please merge after installation bundle contains flutter/engine#28131.

After this PR is merged, please make announcement to win32 user that they need to apply this patch to existing applications to use the feature of this PR.

Engine PR: flutter/engine#28131

No changes in `flutter/test`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.