### PR TITLE
Update text_painter.dart

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -161,7 +161,7 @@ class TextPainter {
   TextPainter({
     InlineSpan? text,
     TextAlign textAlign = TextAlign.start,
-    TextDirection? textDirection,
+    TextDirection textDirection = TextDirection.ltr,
     double textScaleFactor = 1.0,
     int? maxLines,
     String? ellipsis,

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -161,7 +161,7 @@ class TextPainter {
   TextPainter({
     InlineSpan? text,
     TextAlign textAlign = TextAlign.start,
-    TextDirection textDirection = TextDirection.ltr,
+    TextDirection? textDirection,
     double textScaleFactor = 1.0,
     int? maxLines,
     String? ellipsis,
@@ -171,6 +171,7 @@ class TextPainter {
     ui.TextHeightBehavior? textHeightBehavior,
   }) : assert(text == null || text.debugAssertIsValid()),
        assert(textAlign != null),
+       assert(textDirection != null),
        assert(textScaleFactor != null),
        assert(maxLines == null || maxLines > 0),
        assert(textWidthBasis != null),


### PR DESCRIPTION
This PR adds default value to the `textDirection` of `TextPainter` class. `textDirection` was nullable value, and was null by default but if we don't give `TextDirection` then no text was painted in the canvas. This creates confusion among users. So there were two options, one was to make it required or give it a default value. In this PR I gave the default value of `TextDirection.ltr` to the `textDirection` of `TextPainter` class.

## Pre-launch Checklist

- [x  ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x ] I signed the [CLA].
- [ x ] I listed at least one issue that this PR fixes in the description above.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
