### PR TITLE
PopupMenuButton has inconsistent theme in GridTile(#74977)

### DIFF
--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -67,13 +67,13 @@ class GridTileBar extends StatelessWidget {
       end: trailing != null ? 8.0 : 16.0,
     );
 
-    final ThemeData darkTheme = ThemeData.dark();
+    final ThemeData theme = Theme.of(context);
     return Container(
       padding: padding,
       decoration: decoration,
       height: (title != null && subtitle != null) ? 68.0 : 48.0,
       child: Theme(
-        data: darkTheme,
+        data: theme,
         child: IconTheme.merge(
           data: const IconThemeData(color: Colors.white),
           child: Row(
@@ -88,13 +88,13 @@ class GridTileBar extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       DefaultTextStyle(
-                        style: darkTheme.textTheme.subtitle1!,
+                        style: theme.textTheme.subtitle1!,
                         softWrap: false,
                         overflow: TextOverflow.ellipsis,
                         child: title!,
                       ),
                       DefaultTextStyle(
-                        style: darkTheme.textTheme.caption!,
+                        style: theme.textTheme.caption!,
                         softWrap: false,
                         overflow: TextOverflow.ellipsis,
                         child: subtitle!,
@@ -105,7 +105,7 @@ class GridTileBar extends StatelessWidget {
               else if (title != null || subtitle != null)
                 Expanded(
                   child: DefaultTextStyle(
-                    style: darkTheme.textTheme.subtitle1!,
+                    style: theme.textTheme.subtitle1!,
                     softWrap: false,
                     overflow: TextOverflow.ellipsis,
                     child: title ?? subtitle!,

--- a/packages/flutter/test/material/grid_title_test.dart
+++ b/packages/flutter/test/material/grid_title_test.dart
@@ -49,4 +49,87 @@ void main() {
 
     expect(find.text('Simple'), findsOneWidget);
   });
+
+  testWidgets('GridTile consistent theme', (WidgetTester tester) async {
+    final GridTile gridTile = GridTile(
+      footer: GridTileBar(
+        backgroundColor: Colors.blue,
+        trailing: PopupMenuButton<String>(
+          itemBuilder: (BuildContext context) {
+            return [
+              const PopupMenuItem<String>(
+                value: 'Flutter',
+                child: Text('Working a lot harder'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'Dart',
+                child: Text('Being a lot smarter'),
+              ),
+              const PopupMenuItem<String>(
+                value: 'iOS',
+                child: Text('Being a self-starter'),
+              ),
+            ];
+          },
+          icon: const Icon(
+            Icons.more_vert,
+            size: 28,
+          ),
+        ),
+      ),
+      child: const FlutterLogo(
+        style: FlutterLogoStyle.horizontal,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: gridTile,
+        ),
+      ),
+    );
+
+    Theme theme = tester.firstWidget(find.byType(Theme));
+    expect(theme.data, ThemeData.light());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light(),
+        home: Scaffold(
+          body: gridTile,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    theme = tester.firstWidget(find.byType(Theme));
+    expect(theme.data, ThemeData.light());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: gridTile,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    theme = tester.firstWidget(find.byType(Theme));
+    expect(theme.data, ThemeData.dark());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        themeMode: ThemeMode.light,
+        home: Scaffold(
+          body: gridTile,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    theme = tester.firstWidget(find.byType(Theme));
+    expect(theme.data, ThemeData.light());
+  });
 }

--- a/packages/flutter/test/material/grid_title_test.dart
+++ b/packages/flutter/test/material/grid_title_test.dart
@@ -56,7 +56,7 @@ void main() {
         backgroundColor: Colors.blue,
         trailing: PopupMenuButton<String>(
           itemBuilder: (BuildContext context) {
-            return [
+            return <PopupMenuItem<String>>[
               const PopupMenuItem<String>(
                 value: 'Flutter',
                 child: Text('Working a lot harder'),


### PR DESCRIPTION
PopupMenuButton was showing different type of themes in appbar and in GridTile.

Resolved consistent PopupMenuButton theme in GridTile and AppBar.

fixes #74977