### PR TITLE
[flutter_conductor] Push correct revision to mirror remote from conductor

### DIFF
--- a/dev/conductor/lib/next.dart
+++ b/dev/conductor/lib/next.dart
@@ -105,8 +105,6 @@ void runNext({
         upstreamRemote: upstream,
         previousCheckoutLocation: state.engine.checkoutPath,
       );
-      final String headRevision = engine.reverseParse('HEAD');
-
       // check if the candidate branch is enabled in .ci.yaml
       if (!engine.ciYaml.enabledBranches.contains(state.engine.candidateBranch)) {
         engine.ciYaml.enableBranch(state.engine.candidateBranch);
@@ -157,7 +155,7 @@ void runNext({
       }
 
       engine.pushRef(
-        fromRef: headRevision,
+        fromRef: 'HEAD',
         // Explicitly create new branch
         toRef: 'refs/heads/${state.engine.workingBranch}',
         remote: state.engine.mirror.name,
@@ -288,10 +286,8 @@ void runNext({
         }
       }
 
-      final String headRevision = framework.reverseParse('HEAD');
-
       framework.pushRef(
-        fromRef: headRevision,
+        fromRef: 'HEAD',
         // Explicitly create new branch
         toRef: 'refs/heads/${state.framework.workingBranch}',
         remote: state.framework.mirror.name,

--- a/dev/conductor/lib/next.dart
+++ b/dev/conductor/lib/next.dart
@@ -221,7 +221,6 @@ void runNext({
         upstreamRemote: upstream,
         previousCheckoutLocation: state.framework.checkoutPath,
       );
-      final String headRevision = framework.reverseParse('HEAD');
 
       // Check if the current candidate branch is enabled
       if (!framework.ciYaml.enabledBranches.contains(state.framework.candidateBranch)) {
@@ -288,6 +287,8 @@ void runNext({
           return;
         }
       }
+
+      final String headRevision = framework.reverseParse('HEAD');
 
       framework.pushRef(
         fromRef: headRevision,

--- a/dev/conductor/test/next_test.dart
+++ b/dev/conductor/test/next_test.dart
@@ -84,10 +84,6 @@ void main() {
           const FakeCommand(
             command: <String>['git', 'checkout', workingBranch],
           ),
-          const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision1,
-          ),
         ]);
         final FakePlatform platform = FakePlatform(
           environment: <String, String>{
@@ -149,10 +145,6 @@ void main() {
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(command: <String>['git', 'fetch', 'upstream']),
           const FakeCommand(command: <String>['git', 'checkout', workingBranch]),
-          const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision1,
-          ),
           const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
             stdout: 'MM blah',
@@ -234,10 +226,6 @@ void main() {
             },
           ),
           const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision1,
-          ),
-          const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
             stdout: 'MM .ci.yaml',
           ),
@@ -247,7 +235,7 @@ void main() {
             command: <String>['git', 'rev-parse', 'HEAD'],
             stdout: revision2,
           ),
-          const FakeCommand(command: <String>['git', 'push', 'mirror', '$revision1:refs/heads/$workingBranch']),
+          const FakeCommand(command: <String>['git', 'push', 'mirror', 'HEAD:refs/heads/$workingBranch']),
         ]);
         final FakePlatform platform = FakePlatform(
           environment: <String, String>{
@@ -730,11 +718,7 @@ void main() {
             stdout: revision4,
           ),
           const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision2,
-          ),
-          const FakeCommand(
-            command: <String>['git', 'push', 'mirror', '$revision2:refs/heads/$workingBranch'],
+            command: <String>['git', 'push', 'mirror', 'HEAD:refs/heads/$workingBranch'],
           ),
         ]);
         writeStateToFile(
@@ -775,7 +759,7 @@ void main() {
         );
         expect(
           stdio.stdout,
-          contains('Executed command: `git push mirror $revision2:refs/heads/$workingBranch`'),
+          contains('Executed command: `git push mirror HEAD:refs/heads/$workingBranch`'),
         );
         expect(stdio.error, isEmpty);
       });

--- a/dev/conductor/test/next_test.dart
+++ b/dev/conductor/test/next_test.dart
@@ -534,10 +534,6 @@ void main() {
             },
           ),
           const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision2,
-          ),
-          const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
             stdout: 'MM /path/to/.ci.yaml',
           ),
@@ -628,10 +624,6 @@ void main() {
           const FakeCommand(command: <String>['git', 'fetch', 'upstream']),
           const FakeCommand(command: <String>['git', 'checkout', workingBranch]),
           const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision2,
-          ),
-          const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
             stdout: 'MM path/to/.ci.yaml',
           ),
@@ -710,10 +702,6 @@ void main() {
             },
           ),
           const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision2,
-          ),
-          const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
             stdout: 'MM path/to/.ci.yaml',
           ),
@@ -740,6 +728,10 @@ void main() {
           const FakeCommand(
             command: <String>['git', 'rev-parse', 'HEAD'],
             stdout: revision4,
+          ),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'HEAD'],
+            stdout: revision2,
           ),
           const FakeCommand(
             command: <String>['git', 'push', 'mirror', '$revision2:refs/heads/$workingBranch'],


### PR DESCRIPTION
## Issue

fixes https://github.com/flutter/flutter/issues/88606

> When pushing the local working branch of the Flutter framework to the conductor user's mirror remote, it pushes the wrong commit hash, because it captures this hash before applying the engine roll commit.

## Solution

Rather than querying the HEAD commit and explicitly pushing that revision to the remote, simple use `HEAD` in the `git push` command.