### PR TITLE
Fix DPR in test view configuration

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1732,7 +1732,7 @@ class TestViewConfiguration extends ViewConfiguration {
   TestViewConfiguration._(Size size, ui.FlutterView window)
     : _paintMatrix = _getMatrix(size, window.devicePixelRatio, window),
       _hitTestMatrix = _getMatrix(size, 1.0, window),
-      super(size: size);
+      super(size: size, devicePixelRatio: window.devicePixelRatio);
 
   static Matrix4 _getMatrix(Size size, double devicePixelRatio, ui.FlutterView window) {
     final double inverseRatio = devicePixelRatio / window.devicePixelRatio;

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -24,6 +24,11 @@ void main() {
       // The code below will throw without the default.
       TestViewConfiguration(size: const Size(1280.0, 800.0));
     });
+
+    test('sets the DPR to match the window', () {
+      final TestViewConfiguration configuration = TestViewConfiguration(size: const Size(1280.0, 800.0));
+      expect(configuration.devicePixelRatio, binding.window.devicePixelRatio);
+    });
   });
 
   group(AutomatedTestWidgetsFlutterBinding, () {

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -282,8 +282,8 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     );
   }
 
-  /// This is a convenience method that calls [traceTimeline] and sends the
-  /// result back to the host for the [flutter_driver] style tests.
+  /// This is a convenience wrap of [traceTimeline] and send the result back to
+  /// the host for the [flutter_driver] style tests.
   ///
   /// This records the timeline during `action` and adds the result to
   /// [reportData] with `reportKey`. The [reportData] contains extra information
@@ -293,30 +293,7 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   /// to `build/integration_response_data.json` with the key `timeline`.
   ///
   /// For tests with multiple calls of this method, `reportKey` needs to be a
-  /// unique key, otherwise the later result will override earlier one. Tests
-  /// that call this multiple times must also provide a custom
-  /// [ResponseDataCallback] to decide where and how to write the output
-  /// timelines. For example,
-  ///
-  /// ```dart
-  /// import 'package:integration_test/integration_test_driver.dart';
-  ///
-  /// Future<void> main() {
-  ///   return integrationDriver(
-  ///     responseDataCallback: (data) async {
-  ///       if (data != null) {
-  ///         for (var entry in data.entries) {
-  ///           print('Writing ${entry.key} to the disk.');
-  ///           await writeResponseData(
-  ///             entry.value as Map<String, dynamic>,
-  ///             testOutputFilename: entry.key,
-  ///           );
-  ///         }
-  ///       }
-  ///     },
-  ///   );
-  /// }
-  /// ```
+  /// unique key, otherwise the later result will override earlier one.
   ///
   /// The `streams` and `retainPriorEvents` parameters are passed as-is to
   /// [traceTimeline].
@@ -418,14 +395,6 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   /// See [TestWidgetsFlutterBinding.defaultTestTimeout] for more details.
   set defaultTestTimeout(Timeout timeout) => _defaultTestTimeout = timeout;
   Timeout? _defaultTestTimeout;
-
-  @override
-  void attachRootWidget(Widget rootWidget) {
-    // This is a workaround where screenshots of root widgets have incorrect
-    // bounds.
-    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
-    super.attachRootWidget(RepaintBoundary(child: rootWidget));
-  }
 
   @override
   void reportExceptionNoticed(FlutterErrorDetails exception) {

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -282,8 +282,8 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
     );
   }
 
-  /// This is a convenience wrap of [traceTimeline] and send the result back to
-  /// the host for the [flutter_driver] style tests.
+  /// This is a convenience method that calls [traceTimeline] and sends the
+  /// result back to the host for the [flutter_driver] style tests.
   ///
   /// This records the timeline during `action` and adds the result to
   /// [reportData] with `reportKey`. The [reportData] contains extra information
@@ -293,7 +293,30 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   /// to `build/integration_response_data.json` with the key `timeline`.
   ///
   /// For tests with multiple calls of this method, `reportKey` needs to be a
-  /// unique key, otherwise the later result will override earlier one.
+  /// unique key, otherwise the later result will override earlier one. Tests
+  /// that call this multiple times must also provide a custom
+  /// [ResponseDataCallback] to decide where and how to write the output
+  /// timelines. For example,
+  ///
+  /// ```dart
+  /// import 'package:integration_test/integration_test_driver.dart';
+  ///
+  /// Future<void> main() {
+  ///   return integrationDriver(
+  ///     responseDataCallback: (data) async {
+  ///       if (data != null) {
+  ///         for (var entry in data.entries) {
+  ///           print('Writing ${entry.key} to the disk.');
+  ///           await writeResponseData(
+  ///             entry.value as Map<String, dynamic>,
+  ///             testOutputFilename: entry.key,
+  ///           );
+  ///         }
+  ///       }
+  ///     },
+  ///   );
+  /// }
+  /// ```
   ///
   /// The `streams` and `retainPriorEvents` parameters are passed as-is to
   /// [traceTimeline].

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -126,11 +126,10 @@ Future<void> main() async {
       });
     });
 
-    // TODO(jiahaog): Remove when https://github.com/flutter/flutter/issues/66006 is fixed.
-    testWidgets('root widgets are wrapped with a RepaintBoundary', (WidgetTester tester) async {
+    testWidgets('root view reports correct dimensions', (WidgetTester tester) async {
       await tester.pumpWidget(const Placeholder());
 
-      expect(find.byType(RepaintBoundary), findsOneWidget);
+      expect(tester.binding.renderView.paintBounds, const Rect.fromLTWH(0, 0, 2400, 1800));
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/66006

The problem is that the view configuration was always getting a DPR of 1.0, which did not match the actual DPR of the window - so the `paintBounds` for `RenderView` returned an unadjusted size which made the screenshot truncated.