### PR TITLE
Mark module_test_ios unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2060,7 +2060,6 @@ targets:
 
   - name: Mac module_test_ios
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       caches: >-


### PR DESCRIPTION
Test is not flaky in last 50 runs.  It being on would have caught https://github.com/flutter/flutter/issues/88547.