### PR TITLE
Add android_views integration tests to ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1676,13 +1676,12 @@ targets:
       task_name: web_size__compile_test
     scheduler: luci
 
-  - name: Linux Android Views
+  - name: Linux android views
     recipe: flutter/android_views
     properties:
       dependencies: >-
         [
-          # {"dependency": "android_sdk"},
-          # {"dependency": "android_avd"},
+          {"dependency": "android_sdk"},
         ]
     timeout: 60
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1678,6 +1678,7 @@ targets:
 
   - name: Linux android views
     recipe: flutter/android_views
+    bringup: true
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1682,6 +1682,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
+          {"dependency": "android_avd", "version": "31"},
         ]
     timeout: 60
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1683,7 +1683,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "android_avd", "version": "31"},
+          {"dependency": "android_avd", "version": "31"}
         ]
     timeout: 60
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1678,7 +1678,6 @@ targets:
 
   - name: Linux android views
     recipe: flutter/android_views
-    bringup: true
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1676,6 +1676,17 @@ targets:
       task_name: web_size__compile_test
     scheduler: luci
 
+  - name: Linux Android Views
+    recipe: flutter/android_views
+    properties:
+      dependencies: >-
+        [
+          # {"dependency": "android_sdk"},
+          # {"dependency": "android_avd"},
+        ]
+    timeout: 60
+    scheduler: luci
+
   - name: Mac build_aar_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
Adds a builder to run the android recipe introduced in https://flutter-review.googlesource.com/c/recipes/+/16580