### PR TITLE
Minor PointerExitEvent class docs update :)

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1325,7 +1325,7 @@ mixin _CopyPointerExitEvent on PointerEvent {
 }
 
 /// The pointer has moved with respect to the device while the pointer is or is
-/// not in contact with the device, and entered a target object.
+/// not in contact with the device, and exited a target object.
 ///
 /// See also:
 ///


### PR DESCRIPTION
I updated PointerExitEvent class docs.
I just changed `entered` to `exited`