### PR TITLE
Fix Dismissible confirmDismiss errors

### DIFF
--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -841,7 +841,6 @@ void main() {
   });
 
   testWidgets('Dismissible cannot be dragged with pending confirmDismiss', (WidgetTester tester) async {
-
     final Completer<bool?> completer = Completer<bool?>();
     await tester.pumpWidget(
       buildTest(

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -781,9 +781,6 @@ void main() {
   testWidgets('Pending confirmDismiss does not cause errors', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/54990
 
-    scrollDirection = Axis.vertical;
-    dismissDirection = DismissDirection.horizontal;
-
     late Completer<bool?> completer;
     Widget buildFrame() {
       completer = Completer<bool?>();
@@ -844,8 +841,6 @@ void main() {
   });
 
   testWidgets('Dismissible cannot be dragged with pending confirmDismiss', (WidgetTester tester) async {
-    scrollDirection = Axis.vertical;
-    dismissDirection = DismissDirection.horizontal;
 
     final Completer<bool?> completer = Completer<bool?>();
     await tester.pumpWidget(
@@ -873,9 +868,6 @@ void main() {
   testWidgets('Drag to end and release - items does not get stuck if confirmDismiss returns false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/87556
 
-    scrollDirection = Axis.vertical;
-    dismissDirection = DismissDirection.horizontal;
-
     final Completer<bool?> completer = Completer<bool?>();
     await tester.pumpWidget(
       buildTest(
@@ -893,9 +885,6 @@ void main() {
   });
 
   testWidgets('Dismissible with null resizeDuration calls onDismissed immediately', (WidgetTester tester) async {
-    scrollDirection = Axis.vertical;
-    dismissDirection = DismissDirection.horizontal;
-
     bool resized = false;
     bool dismissed = false;
 
@@ -905,7 +894,7 @@ void main() {
         child: Dismissible(
           dragStartBehavior: DragStartBehavior.down,
           key: UniqueKey(),
-          direction: dismissDirection,
+          direction: DismissDirection.horizontal,
           resizeDuration: null,
           onDismissed: (DismissDirection direction) {
             dismissed = true;
@@ -914,8 +903,8 @@ void main() {
             resized = true;
           },
           child: const SizedBox(
-            width: itemExtent,
-            height: itemExtent,
+            width: 100.0,
+            height: 100.0,
             child: Text('0'),
           ),
         ),

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -899,44 +899,28 @@ void main() {
     bool resized = false;
     bool dismissed = false;
 
-    await tester.pumpWidget(Directionality(
-      textDirection: TextDirection.ltr,
-      child: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          Widget buildDismissibleItem(int item) {
-            return Dismissible(
-              dragStartBehavior: DragStartBehavior.down,
-              key: ValueKey<int>(item),
-              direction: dismissDirection,
-              resizeDuration: null,
-              onDismissed: (DismissDirection direction) {
-                dismissed = true;
-              },
-              onResize: () {
-                resized = true;
-              },
-              child: SizedBox(
-                width: itemExtent,
-                height: itemExtent,
-                child: Text(item.toString()),
-              ),
-            );
-          }
-
-          return Container(
-            padding: const EdgeInsets.all(10.0),
-            child: ListView(
-              dragStartBehavior: DragStartBehavior.down,
-              scrollDirection: scrollDirection,
-              itemExtent: itemExtent,
-              children: <int>[0, 1, 2, 3, 4, 5, 6, 7, 8]
-                .where((int i) => !dismissedItems.contains(i))
-                .map<Widget>(buildDismissibleItem).toList(),
-            ),
-          );
-        },
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Dismissible(
+          dragStartBehavior: DragStartBehavior.down,
+          key: UniqueKey(),
+          direction: dismissDirection,
+          resizeDuration: null,
+          onDismissed: (DismissDirection direction) {
+            dismissed = true;
+          },
+          onResize: () {
+            resized = true;
+          },
+          child: const SizedBox(
+            width: itemExtent,
+            height: itemExtent,
+            child: Text('0'),
+          ),
+        ),
       ),
-    ));
+    );
 
     await dismissElement(tester, find.text('0'), gestureDirection: AxisDirection.right);
     await tester.pump();
@@ -944,7 +928,7 @@ void main() {
     expect(resized, false);
   });
 
-  testWidgets('setState that does not remove the Dismissible from tree should throws Error', (WidgetTester tester) async {
+  testWidgets('setState that does not remove the Dismissible from tree should throw Error', (WidgetTester tester) async {
     const Axis scrollDirection = Axis.vertical;
     const DismissDirection dismissDirection = DismissDirection.horizontal;
 

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -794,7 +794,7 @@ void main() {
       );
     }
 
-    // false for _handleDragEnd - when dragged to the end and released 
+    // false for _handleDragEnd - when dragged to the end and released
 
     await tester.pumpWidget(buildFrame());
 
@@ -806,7 +806,7 @@ void main() {
     completer.complete(false);
     await tester.pump();
 
-    // true for _handleDragEnd - when dragged to the end and released 
+    // true for _handleDragEnd - when dragged to the end and released
 
     await tester.pumpWidget(buildFrame());
 
@@ -892,7 +892,7 @@ void main() {
     expect(tester.getTopLeft(find.text('0')), position);
   });
 
-  testWidgets('null resizeDuration calls onDismissed immediately', (WidgetTester tester) async {
+  testWidgets('Dismissible with null resizeDuration calls onDismissed immediately', (WidgetTester tester) async {
     scrollDirection = Axis.vertical;
     dismissDirection = DismissDirection.horizontal;
 

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,6 +21,7 @@ Widget buildTest({
   TextDirection textDirection = TextDirection.ltr,
   Future<bool?> Function(BuildContext context, DismissDirection direction)? confirmDismiss,
   ScrollController? controller,
+  ScrollPhysics? scrollPhysics,
   Widget? background,
 }) {
   return Directionality(
@@ -59,6 +62,7 @@ Widget buildTest({
         return Container(
           padding: const EdgeInsets.all(10.0),
           child: ListView(
+            physics: scrollPhysics,
             controller: controller,
             dragStartBehavior: DragStartBehavior.down,
             scrollDirection: scrollDirection,
@@ -83,23 +87,23 @@ Future<void> dismissElement(WidgetTester tester, Finder finder, { required AxisD
       // getTopRight() returns a point that's just beyond itemWidget's right
       // edge and outside the Dismissible event listener's bounds.
       downLocation = tester.getTopRight(finder) + const Offset(-0.1, 0.0);
-      upLocation = tester.getTopLeft(finder);
+      upLocation = tester.getTopLeft(finder) + const Offset(-0.1, 0.0);
       break;
     case AxisDirection.right:
       // we do the same thing here to keep the test symmetric
       downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
-      upLocation = tester.getTopRight(finder);
+      upLocation = tester.getTopRight(finder) + const Offset(0.1, 0.0);
       break;
     case AxisDirection.up:
       // getBottomLeft() returns a point that's just below itemWidget's bottom
       // edge and outside the Dismissible event listener's bounds.
       downLocation = tester.getBottomLeft(finder) + const Offset(0.0, -0.1);
-      upLocation = tester.getTopLeft(finder);
+      upLocation = tester.getTopLeft(finder) + const Offset(0.0, -0.1);
       break;
     case AxisDirection.down:
       // again with doing the same here for symmetry
       downLocation = tester.getTopLeft(finder) + const Offset(0.1, 0.0);
-      upLocation = tester.getBottomLeft(finder);
+      upLocation = tester.getBottomLeft(finder) + const Offset(0.1, 0.0);
       break;
   }
 
@@ -146,12 +150,7 @@ Future<void> dismissItem(
   expect(itemFinder, findsOneWidget);
 
   await mechanism(tester, itemFinder, gestureDirection: gestureDirection);
-
-  await tester.pump(); // start the slide
-  await tester.pump(const Duration(seconds: 1)); // finish the slide and start shrinking...
-  await tester.pump(); // first frame of shrinking animation
-  await tester.pump(const Duration(seconds: 1)); // finish the shrinking and call the callback...
-  await tester.pump(); // rebuild after the callback removes the entry
+  await tester.pumpAndSettle();
 }
 
 Future<void> checkFlingItemBeforeMovementEnd(
@@ -779,6 +778,172 @@ void main() {
     expect(confirmDismissDirection, DismissDirection.endToStart);
   });
 
+  testWidgets('Pending confirmDismiss does not cause errors', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/54990
+
+    scrollDirection = Axis.vertical;
+    dismissDirection = DismissDirection.horizontal;
+
+    late Completer<bool?> completer;
+    Widget buildFrame() {
+      completer = Completer<bool?>();
+      return buildTest(
+        confirmDismiss: (BuildContext context, DismissDirection dismissDirection) {
+          return completer.future;
+        },
+      );
+    }
+
+    // false for _handleDragEnd - when dragged to the end and released 
+
+    await tester.pumpWidget(buildFrame());
+
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right);
+    expect(find.text('0'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+
+    await tester.pumpWidget(const SizedBox());
+    completer.complete(false);
+    await tester.pump();
+
+    // true for _handleDragEnd - when dragged to the end and released 
+
+    await tester.pumpWidget(buildFrame());
+
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right);
+    expect(find.text('0'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+
+    await tester.pumpWidget(const SizedBox());
+    completer.complete(true);
+    await tester.pump();
+
+    // false for _handleDismissStatusChanged - when fling reaches the end
+
+    await tester.pumpWidget(buildFrame());
+
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right, mechanism: flingElement);
+    expect(find.text('0'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+
+    await tester.pumpWidget(const SizedBox());
+    completer.complete(false);
+    await tester.pump();
+
+    // true for _handleDismissStatusChanged - when fling reaches the end
+
+    await tester.pumpWidget(buildFrame());
+
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right, mechanism: flingElement);
+    expect(find.text('0'), findsOneWidget);
+    expect(dismissedItems, isEmpty);
+
+    await tester.pumpWidget(const SizedBox());
+    completer.complete(true);
+    await tester.pump();
+  });
+
+  testWidgets('Dismissible cannot be dragged with pending confirmDismiss', (WidgetTester tester) async {
+    scrollDirection = Axis.vertical;
+    dismissDirection = DismissDirection.horizontal;
+
+    final Completer<bool?> completer = Completer<bool?>();
+    await tester.pumpWidget(
+      buildTest(
+        confirmDismiss: (BuildContext context, DismissDirection dismissDirection) {
+          return completer.future;
+        },
+      ),
+    );
+
+    // Trigger confirmDismiss call.
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right);
+    final Offset position = tester.getTopLeft(find.text('0'));
+
+    // Try to move and verify it has not moved.
+    Offset dragAt = tester.getTopLeft(find.text('0'));
+    dragAt = Offset(100.0, dragAt.dy);
+    final TestGesture gesture = await tester.startGesture(dragAt);
+    await gesture.moveTo(dragAt + const Offset(100.0, 0.0));
+    await gesture.up();
+    await tester.pump();
+    expect(tester.getTopLeft(find.text('0')), position);
+  });
+
+  testWidgets('Drag to end and release - items does not get stuck if confirmDismiss returns false', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/87556
+
+    scrollDirection = Axis.vertical;
+    dismissDirection = DismissDirection.horizontal;
+
+    final Completer<bool?> completer = Completer<bool?>();
+    await tester.pumpWidget(
+      buildTest(
+        confirmDismiss: (BuildContext context, DismissDirection dismissDirection) {
+          return completer.future;
+        },
+      ),
+    );
+
+    final Offset position = tester.getTopLeft(find.text('0'));
+    await dismissItem(tester, 0, gestureDirection: AxisDirection.right);
+    completer.complete(false);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('0')), position);
+  });
+
+  testWidgets('null resizeDuration calls onDismissed immediately', (WidgetTester tester) async {
+    scrollDirection = Axis.vertical;
+    dismissDirection = DismissDirection.horizontal;
+
+    bool resized = false;
+    bool dismissed = false;
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          Widget buildDismissibleItem(int item) {
+            return Dismissible(
+              dragStartBehavior: DragStartBehavior.down,
+              key: ValueKey<int>(item),
+              direction: dismissDirection,
+              resizeDuration: null,
+              onDismissed: (DismissDirection direction) {
+                dismissed = true;
+              },
+              onResize: () {
+                resized = true;
+              },
+              child: SizedBox(
+                width: itemExtent,
+                height: itemExtent,
+                child: Text(item.toString()),
+              ),
+            );
+          }
+
+          return Container(
+            padding: const EdgeInsets.all(10.0),
+            child: ListView(
+              dragStartBehavior: DragStartBehavior.down,
+              scrollDirection: scrollDirection,
+              itemExtent: itemExtent,
+              children: <int>[0, 1, 2, 3, 4, 5, 6, 7, 8]
+                .where((int i) => !dismissedItems.contains(i))
+                .map<Widget>(buildDismissibleItem).toList(),
+            ),
+          );
+        },
+      ),
+    ));
+
+    await dismissElement(tester, find.text('0'), gestureDirection: AxisDirection.right);
+    await tester.pump();
+    expect(dismissed, true);
+    expect(resized, false);
+  });
+
   testWidgets('setState that does not remove the Dismissible from tree should throws Error', (WidgetTester tester) async {
     const Axis scrollDirection = Axis.vertical;
     const DismissDirection dismissDirection = DismissDirection.horizontal;
@@ -912,7 +1077,10 @@ void main() {
   });
 
   testWidgets('DismissDirection.none does not trigger dismiss', (WidgetTester tester) async {
-    await tester.pumpWidget(buildTest(dismissDirection: DismissDirection.none));
+    await tester.pumpWidget(buildTest(
+      dismissDirection: DismissDirection.none,
+      scrollPhysics: const NeverScrollableScrollPhysics(),
+    ));
     expect(dismissedItems, isEmpty);
 
     await dismissItem(tester, 0, gestureDirection: AxisDirection.left);
@@ -941,7 +1109,7 @@ void main() {
     await dismissItem(tester, 0, gestureDirection: AxisDirection.down);
     expect(controller.offset, 0.0);
     await dismissItem(tester, 0, gestureDirection: AxisDirection.up);
-    expect(controller.offset, 99.9);
+    expect(controller.offset, 100.0);
     controller.dispose();
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/54990
Fixes https://github.com/flutter/flutter/issues/87556
Fixes https://github.com/flutter/flutter/issues/88671

Some comments:

1. https://github.com/flutter/flutter/issues/54990 was caused by that some state callbacks ran on disposed state because they were waiting for `confirmDismiss` to end
2. https://github.com/flutter/flutter/issues/87556 had somewhat a similar reason, after the `confirmDismiss` resolved, the `false` result was ignored on this line. Instead, `_moveController!.reverse()` should be called

https://github.com/flutter/flutter/blob/2526cb07cb1f689f857af841570e21f980f44564/packages/flutter/lib/src/widgets/dismissible.dart#L462-L465

3. To prevent unexpected behaviors, disallowed widget dragging when `confirmDismiss` future is pending

4. In the tests the `dismissElement` made the Dismissible to not fully move, because of small offset. To make tests for this PR I fixed it and discovered a few things to tune in the test coverage:
   * `DismissDirection.none does not trigger dismiss` test - needed to make list unscrollable, otherwise the item would be destroyed, because it went out of `cacheExtent`
   * `DismissDirection.none does not prevent scrolling` test - needed just to change a value

5. https://github.com/flutter/flutter/issues/88671 was discovered from the `dismissElement` change, because [the test](https://github.com/flutter/flutter/blob/2ad8e7093f46f44f7bda4ae0c41043bc0688d927/packages/flutter/test/widgets/dismissible_test.dart#L532) that was checking the threshold now failed, so this issue doesn't need any new test

6. Added a new test `Dismissible with null resizeDuration calls onDismissed immediately` - just to increase the test coverage

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
