### PR TITLE
Blurstyle for boxshadow v2

### DIFF
--- a/packages/flutter/lib/src/painting/box_shadow.dart
+++ b/packages/flutter/lib/src/painting/box_shadow.dart
@@ -36,10 +36,16 @@ class BoxShadow extends ui.Shadow {
     Offset offset = Offset.zero,
     double blurRadius = 0.0,
     this.spreadRadius = 0.0,
+    this.blurStyle = BlurStyle.normal,
   }) : super(color: color, offset: offset, blurRadius: blurRadius);
 
   /// The amount the box should be inflated prior to applying the blur.
   final double spreadRadius;
+
+  /// The [BlurStyle] to use for this shadow.
+  ///
+  /// Defaults to [BlurStyle.normal].
+  final BlurStyle blurStyle;
 
   /// Create the [Paint] object that corresponds to this shadow description.
   ///
@@ -51,7 +57,7 @@ class BoxShadow extends ui.Shadow {
   Paint toPaint() {
     final Paint result = Paint()
       ..color = color
-      ..maskFilter = MaskFilter.blur(BlurStyle.normal, blurSigma);
+      ..maskFilter = MaskFilter.blur(blurStyle, blurSigma);
     assert(() {
       if (debugDisableShadows)
         result.maskFilter = null;
@@ -68,6 +74,7 @@ class BoxShadow extends ui.Shadow {
       offset: offset * factor,
       blurRadius: blurRadius * factor,
       spreadRadius: spreadRadius * factor,
+      blurStyle: blurStyle,
     );
   }
 
@@ -91,6 +98,7 @@ class BoxShadow extends ui.Shadow {
       offset: Offset.lerp(a.offset, b.offset, t)!,
       blurRadius: ui.lerpDouble(a.blurRadius, b.blurRadius, t)!,
       spreadRadius: ui.lerpDouble(a.spreadRadius, b.spreadRadius, t)!,
+      blurStyle: a.blurStyle == BlurStyle.normal ? b.blurStyle : a.blurStyle,
     );
   }
 
@@ -123,12 +131,13 @@ class BoxShadow extends ui.Shadow {
         && other.color == color
         && other.offset == offset
         && other.blurRadius == blurRadius
-        && other.spreadRadius == spreadRadius;
+        && other.spreadRadius == spreadRadius
+        && other.blurStyle == blurStyle;
   }
 
   @override
-  int get hashCode => hashValues(color, offset, blurRadius, spreadRadius);
+  int get hashCode => hashValues(color, offset, blurRadius, spreadRadius, blurStyle);
 
   @override
-  String toString() => 'BoxShadow($color, $offset, ${debugFormatDouble(blurRadius)}, ${debugFormatDouble(spreadRadius)})';
+  String toString() => 'BoxShadow($color, $offset, ${debugFormatDouble(blurRadius)}, ${debugFormatDouble(spreadRadius)}), $blurStyle';
 }

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -265,4 +265,128 @@ void main() {
       matchesGoldenFile('boxShadow.boxStyle.normal.0.0.png'),
     );
   });
+
+  testWidgets('BoxShadow BoxStyle.normal.wide_radius', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.amber,
+            width: 128,
+            height: 128,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 16.0, offset: Offset(4, 4), blurStyle: BlurStyle.normal, color: Colors.green, spreadRadius: 2)],
+                ),
+                width: 64,
+                height: 64,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.normal.wide_radius.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.outer.wide_radius', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.amber,
+            width: 128,
+            height: 128,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 16.0, offset: Offset(4, 4), blurStyle: BlurStyle.outer, color: Colors.red, spreadRadius: 2)],
+                ),
+                width: 64,
+                height: 64,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.outer.wide_radius.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.solid.wide_radius', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.grey,
+            width: 128,
+            height: 128,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 16.0, offset: Offset(4, 4), blurStyle: BlurStyle.solid, color: Colors.purple, spreadRadius: 2)],
+                ),
+                width: 64,
+                height: 64,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.solid.wide_radius.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.inner.wide_radius', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.green,
+            width: 128,
+            height: 128,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 16.0, offset: Offset(4, 4), blurStyle: BlurStyle.inner, color: Colors.amber, spreadRadius: 2)],
+                ),
+                width: 64,
+                height: 64,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.inner.wide_radius.0.0.png'),
+    );
+  });
 }

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -107,7 +109,160 @@ void main() {
     expect(shadowList, equals(<BoxShadow>[shadow4, shadow1.scale(0.5)]));
   });
 
+  test('BoxShadow BlurStyle test', () {
+    const BoxShadow shadow1 = BoxShadow(blurRadius: 4.0);
+    const BoxShadow shadow2 = BoxShadow(blurRadius: 4.0, blurStyle: BlurStyle.outer);
+    final BoxShadow shadow3 = BoxShadow.lerp(shadow1, null, 0.25)!;
+    final BoxShadow shadow4 = BoxShadow.lerp(null, shadow1, 0.25)!;
+    final BoxShadow shadow5 = BoxShadow.lerp(shadow1, shadow2, 0.25)!;
+    final BoxShadow shadow6 = BoxShadow.lerp(const BoxShadow(blurStyle: BlurStyle.solid), shadow2, 0.25)!;
+
+    expect(shadow1.blurStyle, equals(BlurStyle.normal));
+    expect(shadow2.blurStyle, equals(BlurStyle.outer));
+    expect(shadow3.blurStyle, equals(BlurStyle.normal));
+    expect(shadow4.blurStyle, equals(BlurStyle.normal));
+    expect(shadow5.blurStyle, equals(BlurStyle.outer));
+    expect(shadow6.blurStyle, equals(BlurStyle.solid));
+
+    List<BoxShadow> shadowList = BoxShadow.lerpList(<BoxShadow>[shadow2, shadow1], <BoxShadow>[shadow3], 0.5)!;
+    expect(shadowList[0].blurStyle, equals(BlurStyle.outer));
+    expect(shadowList[1].blurStyle, equals(BlurStyle.normal));
+
+    shadowList = BoxShadow.lerpList(<BoxShadow>[shadow6], <BoxShadow>[shadow3, shadow1], 0.5)!;
+    expect(shadowList[0].blurStyle, equals(BlurStyle.solid));
+    expect(shadowList[1].blurStyle, equals(BlurStyle.normal));
+
+    shadowList = BoxShadow.lerpList(<BoxShadow>[shadow3], <BoxShadow>[shadow6, shadow1], 0.5)!;
+    expect(shadowList[0].blurStyle, equals(BlurStyle.solid));
+    expect(shadowList[1].blurStyle, equals(BlurStyle.normal));
+
+    shadowList = BoxShadow.lerpList(<BoxShadow>[shadow3], <BoxShadow>[shadow2, shadow1], 0.5)!;
+    expect(shadowList[0].blurStyle, equals(BlurStyle.outer));
+    expect(shadowList[1].blurStyle, equals(BlurStyle.normal));
+  });
+
   test('BoxShadow toString test', () {
-    expect(const BoxShadow(blurRadius: 4.0).toString(), equals('BoxShadow(Color(0xff000000), Offset(0.0, 0.0), 4.0, 0.0)'));
+    expect(const BoxShadow(blurRadius: 4.0).toString(), equals('BoxShadow(Color(0xff000000), Offset(0.0, 0.0), 4.0, 0.0), BlurStyle.normal'));
+    expect(const BoxShadow(blurRadius: 4.0, blurStyle: BlurStyle.solid).toString(), equals('BoxShadow(Color(0xff000000), Offset(0.0, 0.0), 4.0, 0.0), BlurStyle.solid'));
+  });
+
+  testWidgets('BoxShadow BoxStyle.solid', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.white,
+            width: 50,
+            height: 50,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 3.0, blurStyle: BlurStyle.solid)],
+                ),
+                width: 10,
+                height: 10,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.solid.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.outer', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.white,
+            width: 50,
+            height: 50,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 8.0, blurStyle: BlurStyle.outer)],
+                ),
+                width: 20,
+                height: 20,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.outer.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.inner', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.white,
+            width: 50,
+            height: 50,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 4.0, blurStyle: BlurStyle.inner)],
+                ),
+                width: 20,
+                height: 20,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.inner.0.0.png'),
+    );
+  });
+
+  testWidgets('BoxShadow BoxStyle.normal', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          key: key,
+          child: Container(
+            color: Colors.white,
+            width: 50,
+            height: 50,
+            child: Center(
+              child: Container(
+                decoration: const BoxDecoration(
+                  boxShadow: <BoxShadow>[BoxShadow(blurRadius: 4.0, blurStyle: BlurStyle.normal)],
+                ),
+                width: 20,
+                height: 20,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byKey(key),
+      matchesGoldenFile('boxShadow.boxStyle.normal.0.0.png'),
+    );
   });
 }

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -8,6 +8,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  tearDown(() {
+    debugDisableShadows = true;
+  });
+
   test('BorderSide control test', () {
     const BorderSide side1 = BorderSide();
     final BorderSide side2 = side1.copyWith(
@@ -148,6 +152,7 @@ void main() {
 
   testWidgets('BoxShadow BoxStyle.solid', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -174,10 +179,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.solid.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.outer', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -204,10 +211,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.outer.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.inner', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -234,10 +243,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.inner.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.normal', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -264,10 +275,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.normal.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.normal.wide_radius', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -295,10 +308,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.normal.wide_radius.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.outer.wide_radius', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -326,10 +341,12 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.outer.wide_radius.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.solid.wide_radius', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -352,15 +369,16 @@ void main() {
         ),
       ),
     );
-
     await expectLater(
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.solid.wide_radius.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 
   testWidgets('BoxShadow BoxStyle.inner.wide_radius', (WidgetTester tester) async {
     final Key key = UniqueKey();
+    debugDisableShadows = false;
     await tester.pumpWidget(
       Center(
         child: RepaintBoundary(
@@ -383,10 +401,10 @@ void main() {
         ),
       ),
     );
-
     await expectLater(
       find.byKey(key),
       matchesGoldenFile('boxShadow.boxStyle.inner.wide_radius.0.0.png'),
     );
+    debugDisableShadows = true;
   });
 }


### PR DESCRIPTION
`BoxShadow` does not support all the `BlurStyle`s

Adds support for shadow types as mentioned in issue #52999

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
