### PR TITLE
Update dartdoc to 2.0.0.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 1.0.2
+    "$PUB" global activate dartdoc 2.0.0
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
This updates dartdoc to the latest version for Flutter.

The TL;DR for Flutter is that this fixes some crash bugs that Flutter hasn't run into yet, but probably will as new language features get more use.

Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v2.0.0