### PR TITLE
Use default value for `ResultData` when uploading metrics from test runner

### DIFF
--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -45,11 +45,13 @@ Future<FlutterDestination> connectFlutterDestination() async {
 ///     ]
 ///   }
 List<MetricPoint> parse(Map<String, dynamic> resultsJson) {
-  final List<String> scoreKeys = (resultsJson['BenchmarkScoreKeys'] as List<dynamic>).cast<String>();
-  final Map<String, dynamic> resultData = resultsJson['ResultData'] as Map<String, dynamic>;
+  final List<String> scoreKeys =
+      (resultsJson['BenchmarkScoreKeys'] as List<dynamic>?)?.cast<String>() ?? const <String>[];
+  final Map<String, dynamic> resultData =
+      resultsJson['ResultData'] as Map<String, dynamic>? ?? const <String, dynamic>{};
   final String gitBranch = (resultsJson['CommitBranch'] as String).trim();
   final String gitSha = (resultsJson['CommitSha'] as String).trim();
-  final String builderName = resultsJson['BuilderName'] as String;
+  final String builderName = (resultsJson['BuilderName'] as String).trim();
   final List<MetricPoint> metricPoints = <MetricPoint>[];
   for (final String scoreKey in scoreKeys) {
     metricPoints.add(

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -18,15 +18,25 @@ void main() {
           'average_frame_build_time_millis': 0.4550425531914895,
           '90th_percentile_frame_build_time_millis': 0.473
         },
-        'BenchmarkScoreKeys': <String>[
-          'average_frame_build_time_millis',
-          '90th_percentile_frame_build_time_millis'
-        ]
+        'BenchmarkScoreKeys': <String>['average_frame_build_time_millis', '90th_percentile_frame_build_time_millis']
       };
       final List<MetricPoint> metricPoints = parse(results);
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
       expect(metricPoints[1].value, equals(0.473));
+    });
+
+    test('succeeds - null ResultData', () {
+      final Map<String, dynamic> results = <String, dynamic>{
+        'CommitBranch': 'master',
+        'CommitSha': 'abc',
+        'BuilderName': 'test',
+        'ResultData': null,
+        'BenchmarkScoreKeys': null
+      };
+      final List<MetricPoint> metricPoints = parse(results);
+
+      expect(metricPoints.length, 0);
     });
   });
 }

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -16,9 +16,12 @@ void main() {
         'BuilderName': 'test',
         'ResultData': <String, dynamic>{
           'average_frame_build_time_millis': 0.4550425531914895,
-          '90th_percentile_frame_build_time_millis': 0.473
+          '90th_percentile_frame_build_time_millis': 0.473,
         },
-        'BenchmarkScoreKeys': <String>['average_frame_build_time_millis', '90th_percentile_frame_build_time_millis']
+        'BenchmarkScoreKeys': <String>[
+          'average_frame_build_time_millis',
+          '90th_percentile_frame_build_time_millis',
+        ],
       };
       final List<MetricPoint> metricPoints = parse(results);
 
@@ -32,7 +35,7 @@ void main() {
         'CommitSha': 'abc',
         'BuilderName': 'test',
         'ResultData': null,
-        'BenchmarkScoreKeys': null
+        'BenchmarkScoreKeys': null,
       };
       final List<MetricPoint> metricPoints = parse(results);
 


### PR DESCRIPTION
This is to fix: https://github.com/flutter/flutter/issues/88484#issuecomment-904199382, when `ResultData` is null. The updating would be a no-op for this case.