### PR TITLE
Remove dependency in Linux Android Views

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1683,7 +1683,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "android_avd", "version": "31"}
         ]
     timeout: 60
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1682,7 +1682,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk"},
+          {"dependency": "android_sdk"}
         ]
     timeout: 60
     scheduler: luci


### PR DESCRIPTION
The `android_avd` dependency does not yet exist and is WIP in https://flutter-review.googlesource.com/c/recipes/+/17280

This removes it so that the current version can pass. We should add this back once the above CL lands.