### PR TITLE
Revert "Use `dart pub` instead of `pub` to invoke pub from tools"

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -234,7 +234,9 @@ class _DefaultPub implements Pub {
     final bool verbose = _logger.isVerbose;
     final List<String> args = <String>[
       if (verbose)
-        '--verbose',
+        '--verbose'
+      else
+        '--verbosity=warning',
       ...<String>[
         command,
         '--no-precompile',
@@ -417,7 +419,7 @@ class _DefaultPub implements Pub {
       'cache',
       'dart-sdk',
       'bin',
-      'dart',
+      'pub',
     ]);
     if (!_processManager.canRun(sdkPath)) {
       throwToolExit(
@@ -426,7 +428,7 @@ class _DefaultPub implements Pub {
         'permissions for the current user.'
       );
     }
-    return <String>[sdkPath, '--no-analytics', 'pub', ...arguments];
+    return <String>[sdkPath, ...arguments];
   }
 
   // Returns the environment value that should be used when running pub.

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1729,7 +1729,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', '--offline', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
       expect(loggingProcessManager.commands.first, contains('--offline'));
     },
     overrides: <Type, Generator>{
@@ -1754,7 +1754,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
       expect(loggingProcessManager.commands.first, isNot(contains('--offline')));
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -451,7 +451,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -476,7 +476,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', '--trace', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -503,7 +503,7 @@ void main() {
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'run', '--foo', 'bar'],
+          '/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );
@@ -529,7 +529,7 @@ void main() {
       Cache.flutterRoot = '';
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/dart', '--no-analytics', 'pub', 'upgrade', '-h'],
+          '/bin/cache/dart-sdk/bin/pub', 'upgrade', '-h'],
           stdin:  IOSink(StreamController<List<int>>().sink),
         ),
       );

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -26,7 +26,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.empty();
     final BufferLogger logger = BufferLogger.test();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/dart');
+    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/pub');
 
     fileSystem.file('pubspec.yaml').createSync();
 
@@ -51,9 +51,8 @@ void main() {
     testWithoutContext('does not skip pub get the parameter is false', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -100,9 +99,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -149,9 +147,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -265,9 +262,8 @@ void main() {
     'but the current framework version is not the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ])
@@ -305,9 +301,8 @@ void main() {
     'but the current framework version does not exist yet', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ])
@@ -344,9 +339,8 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ], onRun: () {
@@ -383,9 +377,8 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ]),
@@ -420,9 +413,8 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the package config is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ])
@@ -460,9 +452,8 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the pubspec.lock is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ])
@@ -504,9 +495,8 @@ void main() {
 
     const FakeCommand pubGetCommand = FakeCommand(
       command: <String>[
-        'bin/cache/dart-sdk/bin/dart',
-        '--no-analytics',
-        'pub',
+        'bin/cache/dart-sdk/bin/pub',
+        '--verbosity=warning',
         'get',
         '--no-precompile',
       ],
@@ -601,9 +591,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -647,9 +636,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -689,9 +677,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -812,9 +799,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -854,9 +840,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -897,9 +882,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -910,18 +894,16 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
       ),
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -932,9 +914,8 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          'bin/cache/dart-sdk/bin/pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],


### PR DESCRIPTION
Reverts flutter/flutter#88509

Seems to be causing a problem on Windows_android windows_chrome_dev_mode

https://ci.chromium.org/ui/p/flutter/builders/prod/Windows_android%20windows_chrome_dev_mode/1347/overview