### PR TITLE
Add pageDelay to fullscreen_textfield_perf_test

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
@@ -11,6 +11,7 @@ void main() {
   macroPerfTest(
     'fullscreen_textfield_perf',
     kFullscreenTextRouteName,
+    pageDelay: const Duration(milliseconds: 50),
     driverOps: (FlutterDriver driver) async {
       final SerializableFinder textfield = find.byValueKey('fullscreen-textfield');
       driver.tap(textfield);


### PR DESCRIPTION
The e2e version of this benchmark includes the pageDelay, explaining that it is necessary to account for communication delays that aren't present in the e2e version. Since the e2e version is working, and the non-e2e one isn't, this PR adds the delay to the non-e2e version on the theory that it is needed in both versions for correctness.

Related https://github.com/flutter/flutter/issues/88795