### PR TITLE
Document AssetBundle loadString Decoding Behavior

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -64,10 +64,10 @@ abstract class AssetBundle {
   /// caller is going to be doing its own caching. (It might not be cached if
   /// it's set to true either, depending on the asset bundle implementation.)
   ///
-  /// The function expects the stored string to be UTF-8-encoded.
-  /// [Utf8Codec] will be used for decoding the string and the decoding process
-  /// is delegated to an isolate for strings larger than 50 KB to avoid jank on
-  /// the main thread.
+  /// The function expects the stored string to be UTF-8-encoded as
+  /// [Utf8Codec] will be used for decoding the string. If the string is
+  /// larger than 50 KB, the decoding process is delegated to an
+  /// isolate to avoid jank on the main thread.
   Future<String> loadString(String key, { bool cache = true }) async {
     final ByteData data = await load(key);
     if (data == null)

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -62,8 +62,12 @@ abstract class AssetBundle {
   /// If the `cache` argument is set to false, then the data will not be
   /// cached, and reading the data may bypass the cache. This is useful if the
   /// caller is going to be doing its own caching. (It might not be cached if
-  /// it's set to true either, that depends on the asset bundle
-  /// implementation.)
+  /// it's set to true either, depending on the asset bundle implementation.)
+  ///
+  /// The function expects the stored string to be UTF-8-encoded.
+  /// [Utf8Codec] will be used for decoding the string and the decoding process
+  /// is delegated to an isolate for strings larger than 50 KB to avoid jank on
+  /// the main thread.
   Future<String> loadString(String key, { bool cache = true }) async {
     final ByteData data = await load(key);
     if (data == null)


### PR DESCRIPTION
Documents how `AssetBundle.loadString` behaves in terms of decoding the loaded strings.

Fixes #6723 and also documents the isolate behavior since I figured this would be useful. We can also remove that section if it is too much of an implementation detail.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
