### PR TITLE
Addresses the proposal to add a PageView.separated widget

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -713,7 +713,6 @@ class PageView extends StatefulWidget {
   /// PageView.separated(
   ///   itemCount: 25,
   ///   scrollDirection: Axis.vertical,
-  ///   controller: _pageController,
   ///   separatorBuilder: (BuildContext context, int index) => Container(
   ///     color: Colors.red,
   ///     alignment: Alignment.center,

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -689,19 +689,44 @@ class PageView extends StatefulWidget {
   /// Creates a scrollable list that works page by page using widgets separated
   /// by list item "separators".
   ///
-  /// This constructor is appropriate for list views with a large number of
+  /// This constructor is appropriate for page views with a large number of
   /// item and separator children because the builders are only called for
   /// the children that are actually visible.
   ///
-  /// Providing a non-null [itemCount] lets the [PageView] compute the maximum
-  /// scroll extent.
+  /// Separators only appear between list items: separator 0 appears after item
+  /// 0 and the last separator appears before the last item.
   ///
-  /// [itemBuilder] will be called only with indices greater than or equal to
-  /// zero and less than [itemCount].
+  /// The `separatorBuilder` callback will be called with indices greater than
+  /// zero and less than `itemCount - 1`.
   ///
-  /// [PageView.builder] by default does not support child reordering. If
-  /// you are planning to change child order at a later time, consider using
-  /// [PageView] or [PageView.custom].
+  /// The `itemBuilder` and `separatorBuilder` callbacks should always return a
+  /// non-null widget, and actually create widget instances when called. Avoid
+  /// using a builder that returns a previously-constructed widget; if the page
+  /// view's children are created in advance, or all at once when the [PageView]
+  /// itself is created, it is more efficient to use the [PageView] constructor.
+  ///
+  /// {@tool snippet}
+  ///
+  /// This example shows how to create [PageView] whose pages
+  /// are separated by a red [Container]s.
+  /// ```dart
+  /// PageView.separated(
+  ///   itemCount: 25,
+  ///   scrollDirection: Axis.vertical,
+  ///   controller: _pageController,
+  ///   separatorBuilder: (BuildContext context, int index) => Container(
+  ///     color: Colors.red,
+  ///     alignment: Alignment.center,
+  ///     child: Text('separator $index'),
+  ///   ),
+  ///   itemBuilder: (BuildContext context, int index) {
+  ///     return Center(
+  ///       child: Text('item $index'),
+  ///   );
+  ///  },
+  /// )
+  /// ```
+  /// {@end-tool}
   ///
   /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
   PageView.separated({

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -686,6 +686,62 @@ class PageView extends StatefulWidget {
        childrenDelegate = SliverChildBuilderDelegate(itemBuilder, childCount: itemCount),
        super(key: key);
 
+  /// Creates a scrollable list that works page by page using widgets separated
+  /// by list item "separators".
+  ///
+  /// This constructor is appropriate for list views with a large number of
+  /// item and separator children because the builders are only called for
+  /// the children that are actually visible.
+  ///
+  /// Providing a non-null [itemCount] lets the [PageView] compute the maximum
+  /// scroll extent.
+  ///
+  /// [itemBuilder] will be called only with indices greater than or equal to
+  /// zero and less than [itemCount].
+  ///
+  /// [PageView.builder] by default does not support child reordering. If
+  /// you are planning to change child order at a later time, consider using
+  /// [PageView] or [PageView.custom].
+  ///
+  /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
+  PageView.separated({
+    Key? key,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    PageController? controller,
+    this.physics,
+    this.pageSnapping = true,
+    this.onPageChanged,
+    required IndexedWidgetBuilder itemBuilder,
+    required IndexedWidgetBuilder separatorBuilder,
+    required int itemCount,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.allowImplicitScrolling = false,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+    this.scrollBehavior,
+    this.padEnds = true
+  }) : assert(allowImplicitScrolling != null),
+       assert(clipBehavior != null),
+       controller = controller ?? _defaultPageController,
+       childrenDelegate = SliverChildBuilderDelegate((BuildContext context, int index) {
+           final int itemIndex = index ~/ 2;
+           final Widget widget;
+           if (index.isEven) {
+             widget = itemBuilder(context, itemIndex);
+           } else {
+             widget = separatorBuilder(context, itemIndex);
+             assert(() {
+               if (widget == null) {
+                 throw FlutterError('separatorBuilder cannot return null.');
+               }
+               return true;
+             }());
+           }
+           return widget;
+         },childCount: _computeActualChildCount(itemCount)),
+       super(key: key);     
+
   /// Creates a scrollable list that works page by page with a custom child
   /// model.
   ///
@@ -895,6 +951,11 @@ class PageView extends StatefulWidget {
 
   @override
   State<PageView> createState() => _PageViewState();
+
+  // Helper method to compute the actual child count for the separated constructor.
+  static int _computeActualChildCount(int itemCount) {
+    return math.max(0, itemCount * 2 - 1);
+  }
 }
 
 class _PageViewState extends State<PageView> {

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -765,7 +765,7 @@ class PageView extends StatefulWidget {
            }
            return widget;
          },childCount: _computeActualChildCount(itemCount)),
-       super(key: key);     
+       super(key: key);
 
   /// Creates a scrollable list that works page by page with a custom child
   /// model.

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1016,4 +1016,85 @@ void main() {
 
     expect(tester.widget<SliverFillViewport>(viewportFinder()).padEnds, false);
   });
+
+  testWidgets('PageView.separated must return a separator widget', (WidgetTester tester) async {
+    final PageController controller = PageController(initialPage: 0);
+
+    Widget build(PageController controller) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageView.separated(
+          controller: controller,
+          itemCount: kStates.length,
+          separatorBuilder: (BuildContext context, int index) => Container(
+            color: Colors.red,
+            alignment: Alignment.center,
+            child:
+                Text('separator $index', style: TextStyle(color: Colors.white)),
+          ),
+          itemBuilder: (BuildContext context, int index) {
+            return Container(
+              height: 200.0,
+              color: index.isEven
+                  ? const Color(0xFF0000FF)
+                  : const Color(0xFF00FF00),
+              child: Text(kStates[index]),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(controller));
+    expect(find.text(kStates[0]), findsOneWidget);
+    controller.nextPage(
+      curve: Curves.easeInOut,
+      duration: const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+    /// expect a separator widget
+    expect(find.text('separator 0'), findsOneWidget);  
+  });
+
+
+    /// This test verifies the the separator widget is not built at the extreme ends of pageview
+    /// i.e at first and last page.
+    testWidgets('PageView.separated separator widget must not be at index 0 and at index n-1', (WidgetTester tester) async {
+    final PageController controller = PageController(initialPage: 0);
+
+    Widget build(PageController controller) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageView.separated(
+          controller: controller,
+          itemCount: kStates.length,
+          separatorBuilder: (BuildContext context, int index) => Container(
+            color: Colors.red,
+            alignment: Alignment.center,
+            child:
+                Text('separator $index', style: TextStyle(color: Colors.white)),
+          ),
+          itemBuilder: (BuildContext context, int index) {
+            return Container(
+              height: 200.0,
+              color: index.isEven
+                  ? const Color(0xFF0000FF)
+                  : const Color(0xFF00FF00),
+              child: Text(kStates[index]),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(controller));
+    expect(find.text('separator 0'), findsNothing);
+    ///animates to the last page  
+    controller.animateToPage((kStates.length-1)*2,
+      curve: Curves.easeInOut,
+      duration: const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+    /// should not expect a separator widget at the last page
+    expect(find.text('separator ${kStates.length-2}'), findsNothing);
+    expect(find.text(kStates[kStates.length-1]), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1097,4 +1097,48 @@ void main() {
     expect(find.text('separator ${kStates.length-2}'), findsNothing);
     expect(find.text(kStates[kStates.length-1]), findsOneWidget);
   });
+
+  testWidgets('Animate to a random page and verify separator widget is built', (WidgetTester tester) async {
+    final PageController controller = PageController(initialPage: 0);
+
+    Widget build(PageController controller) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: PageView.separated(
+          controller: controller,
+          itemCount: kStates.length,
+          separatorBuilder: (BuildContext context, int index) => Container(
+            color: Colors.red,
+            alignment: Alignment.center,
+            child:
+                Text('separator $index', style: TextStyle(color: Colors.white)),
+          ),
+          itemBuilder: (BuildContext context, int index) {
+            return Container(
+              height: 200.0,
+              color: index.isEven
+                  ? const Color(0xFF0000FF)
+                  : const Color(0xFF00FF00),
+              child: Text(kStates[index]),
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(controller));
+    ///animates to page at (index:50)  
+    controller.animateToPage((kStates.length),
+      curve: Curves.easeInOut,
+      duration: const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+    /// should not expect a separator widget at the last page
+    expect(find.text(kStates[kStates.length~/2]), findsOneWidget);
+    controller.previousPage(
+      curve: Curves.easeInOut,
+      duration: const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+    int separatorIndex = (kStates.length~/2)-1;
+    expect(find.text('separator $separatorIndex'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1030,7 +1030,7 @@ void main() {
             color: Colors.red,
             alignment: Alignment.center,
             child:
-                Text('separator $index', style: TextStyle(color: Colors.white)),
+                Text('separator $index', style: const TextStyle(color: Colors.white)),
           ),
           itemBuilder: (BuildContext context, int index) {
             return Container(
@@ -1071,7 +1071,7 @@ void main() {
             color: Colors.red,
             alignment: Alignment.center,
             child:
-                Text('separator $index', style: TextStyle(color: Colors.white)),
+                Text('separator $index', style: const TextStyle(color: Colors.white)),
           ),
           itemBuilder: (BuildContext context, int index) {
             return Container(
@@ -1111,7 +1111,7 @@ void main() {
             color: Colors.red,
             alignment: Alignment.center,
             child:
-                Text('separator $index', style: TextStyle(color: Colors.white)),
+                Text('separator $index', style:const TextStyle(color: Colors.white)),
           ),
           itemBuilder: (BuildContext context, int index) {
             return Container(
@@ -1128,7 +1128,7 @@ void main() {
 
     await tester.pumpWidget(build(controller));
     ///animates to page at (index:50)
-    controller.animateToPage((kStates.length),
+    controller.animateToPage(kStates.length,
       curve: Curves.easeInOut,
       duration: const Duration(milliseconds: 500));
     await tester.pumpAndSettle();
@@ -1138,7 +1138,7 @@ void main() {
       curve: Curves.easeInOut,
       duration: const Duration(milliseconds: 500));
     await tester.pumpAndSettle();
-    int separatorIndex = (kStates.length~/2)-1;
+    final int separatorIndex = (kStates.length~/2)-1;
     expect(find.text('separator $separatorIndex'), findsOneWidget);
   });
 }

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1052,7 +1052,7 @@ void main() {
       duration: const Duration(milliseconds: 500));
     await tester.pumpAndSettle();
     /// expect a separator widget
-    expect(find.text('separator 0'), findsOneWidget);  
+    expect(find.text('separator 0'), findsOneWidget);
   });
 
 
@@ -1088,7 +1088,7 @@ void main() {
 
     await tester.pumpWidget(build(controller));
     expect(find.text('separator 0'), findsNothing);
-    ///animates to the last page  
+    ///animates to the last page
     controller.animateToPage((kStates.length-1)*2,
       curve: Curves.easeInOut,
       duration: const Duration(milliseconds: 500));
@@ -1127,7 +1127,7 @@ void main() {
     }
 
     await tester.pumpWidget(build(controller));
-    ///animates to page at (index:50)  
+    ///animates to page at (index:50)
     controller.animateToPage((kStates.length),
       curve: Curves.easeInOut,
       duration: const Duration(milliseconds: 500));


### PR DESCRIPTION
This PR addresses the proposal #79018 to add a Pageview.separated widget which is analogous to [Listview.separated](https://api.flutter.dev/flutter/widgets/ListView/ListView.separated.html).
Let me know your feedback, I am open to incorporate the requested changes.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
