### PR TITLE
Fixed leak and removed no-shuffle tag in widgets/debug_test.dart

### DIFF
--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -273,5 +267,6 @@ void main() {
         '   The value of a widget debug variable was changed by the test.\n',
       );
     }
+    debugHighlightDeprecatedWidgets = false;
   });
 }


### PR DESCRIPTION
This PR fixed the problem that prevented debug_test.dart being shuffled. Part of #85160.

## The Problem
The `debugHighlightDeprecatedWidgets` variable was not reverted to `false` at the end of a test and so it stayed `true` breaking other tests.

## The Fix
Set `debugHighlightDeprecatedWidgets` to `false` at end of the test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
