### PR TITLE
Fixed leak and removed no-shuffle tag in platform_view_test.dart

### DIFF
--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -3,11 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=4281596210"
-@Tags(<String>['no-shuffle'])
 
 import 'dart:async';
 import 'dart:typed_data';
@@ -1191,6 +1186,10 @@ void main() {
 
     testWidgets('clip is handled correctly during resizing', (WidgetTester tester) async {
       // Regressing test for https://github.com/flutter/flutter/issues/67343
+
+      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+      viewsController.registerViewType('webview');
+
       Widget buildView(double width, double height, Clip clipBehavior) {
         return Center(
           child: SizedBox(


### PR DESCRIPTION
This PR fixed the problem that prevented platform_view_test.dart being shuffled. Part of #85160.

## The Problem
One test depended on view type _'webview'_ to be registered in the `FakeAndroidPlatformViewsController`. If some other test registered another view type (ie _maps_) before running this test, this test would break.

## The Fix
Register view type _'webview'_ at the start of the test to ensure the correct view type during the test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

