### PR TITLE
Updated some skip test comments that were missed in the audit.

### DIFF
--- a/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
+++ b/dev/integration_tests/flutter_gallery/test_driver/transitions_perf_test.dart
@@ -180,7 +180,10 @@ void main([List<String> args = const <String>[]]) {
       // Assert that we can use semantics related finders in profile mode.
       final int id = await driver.getSemanticsId(find.bySemanticsLabel('Material'));
       expect(id, greaterThan(-1));
-    }, skip: !withSemantics, timeout: Timeout.none);
+    },
+        skip: !withSemantics, // [intended] test only makes sense when semantics are turned on.
+        timeout: Timeout.none,
+    );
 
     test('all demos', () async {
       // Collect timeline data for just a limited set of demos to avoid OOMs.

--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     expect(await compute(test1Async, 0), 1);
     expect(compute(test2Async, 0), throwsException);
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // [intended] isn't supported on the web.
 
   test('compute closes all ports', () async {
     // Run a Dart script that calls compute().

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -5203,7 +5203,10 @@ void main() {
 
     const String expected = ' housa bige jumped over a mouse';
     expect(find.text(expected), findsOneWidget);
-  }, skip: areKeyEventsHandledByPlatform, variant: KeySimulatorTransitModeVariant.all());
+  },
+      skip: areKeyEventsHandledByPlatform, // [intended] only applies to platforms where we handle key events.
+      variant: KeySimulatorTransitModeVariant.all()
+  );
 
   testWidgets('Select all test', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -367,8 +367,7 @@ void main() {
 
     // TODO(yjbanov): ahem.ttf doesn't have Chinese glyphs, making this test
     //                sensitive to browser/OS when running in web mode:
-    //                https://github.com/flutter/flutter/issues/83129
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/83129
 
   test('text is painted above selection', () {
     final TextSelectionDelegate delegate = FakeEditableTextState();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5261,7 +5261,7 @@ void main() {
     );
     expect(controller.text, equals(testText), reason: 'on $platform');
   },
-    skip: kIsWeb,
+    skip: kIsWeb, // [intended] on web these keys are handled by the browser.
     variant: TargetPlatformVariant.all(),
   );
 
@@ -5404,7 +5404,7 @@ void main() {
     );
     expect(controller.text, equals(testText), reason: 'on $platform');
   },
-    skip: kIsWeb,
+    skip: kIsWeb, // [intended] on web these keys are handled by the browser.
     variant: TargetPlatformVariant.all(),
   );
 


### PR DESCRIPTION
These skipped tests were missed in the audit of #86396. This updates the skip tests with a comment that they are either intended, or with an issue tracking the work to reenable them.
