### PR TITLE
Enhance the skip test parsing the analyzer script.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -283,7 +283,7 @@ Future<void> _verifyNoMissingLicenseForExtension(String workingDirectory, String
   }
 }
 
-final RegExp _skipTestCommentPattern = RegExp(r'\bskip:.*?//(.*)');
+final RegExp _skipTestCommentPattern = RegExp(r'\bskip:(.*?//(.*))?');
 const Pattern _skipTestIntentionalPattern = '[intended]';
 final Pattern _skipTestTrackingBugPattern = RegExp(r'https+?://github.com/.*/issues/[0-9]+');
 
@@ -296,12 +296,14 @@ Future<void> verifySkipTestComments(String workingDirectory) async {
     final List<String> lines = file.readAsLinesSync();
     for (int index = 0; index < lines.length; index++) {
       final Match? match = _skipTestCommentPattern.firstMatch(lines[index]);
-      final String? skipComment = match?.group(1);
-      if (skipComment != null
-          && !skipComment.contains(_skipTestIntentionalPattern)
-          && !skipComment.contains(_skipTestTrackingBugPattern)) {
-        final int sourceLine = index + 1;
-        errors.add('${file.path}:$sourceLine}: skip test without a justification comment.');
+      if (match != null) {
+        final String? skipComment = match.group(2);
+        if (skipComment == null ||
+            (!skipComment.contains(_skipTestIntentionalPattern) &&
+             !skipComment.contains(_skipTestTrackingBugPattern))) {
+          final int sourceLine = index + 1;
+          errors.add('${file.path}:$sourceLine: skip test without a justification comment.');
+        }
       }
     }
   }


### PR DESCRIPTION
The skip test check in the current analyzer script uses a regexp to search for "skip:" parameters in *_test.dart files. However, as @gspencergoog pointed out in the review of #88003, that would also catch instances of a skip parameter used in code outside of the test functions.

This PR uses the Dart AST parser (thanks for the sample @gspencergoog!) to make sure we only test 'skip' parameters in the test functions ('test', 'testWidgets', 'group', 'except'). It also fixes a bug where skips with no comment at all weren't flagged.
