### PR TITLE
Fixed leak and removed no-shuffle tag in scroll_aware_image_provider_test.dart

### DIFF
--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=123"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:ui' as ui show Image;
 
 import 'package:flutter/widgets.dart';
@@ -374,7 +368,7 @@ void main() {
     expect(imageCache!.currentSize, 0);
 
     // Occupy the only slot in the cache with another image.
-    final TestImageProvider testImageProvider2 = TestImageProvider(testImage);
+    final TestImageProvider testImageProvider2 = TestImageProvider(testImage.clone());
     testImageProvider2.complete();
     await precacheImage(testImageProvider2, context.context!);
     expect(imageCache!.containsKey(testImageProvider), false);


### PR DESCRIPTION
This PR fixed the problem that prevented scroll_aware_image_provider_test.dart being shuffled. Part of #85160.

## The Problem
In `setUpAll()` a test image is created called `testImage` which is used as a boilerplate for running tests upon. 
This `testImage` was cloned in every test that modifies it, except in one test. This test modified the actual `testImage` so the following tests got an image with wrong properties.

## The Fix
Clone the ´testImage´ =). 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.