### PR TITLE
Account for additional warning text from the tool

### DIFF
--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -508,7 +508,9 @@ void main() {
         logging: false,
       );
       expect(result.exitCode, 0);
-      expect(result.stdout, <Object>[
+      // TODO(sigurdm): Remove the filter when
+      // https://github.com/flutter/flutter/pull/88792 is relanded.
+      expect(result.stdout.where((String line) => !line.startsWith('"The top level `pub.bat` command is deprecated.')), <Object>[
         startsWith('Performing hot reload...'),
         '',
         '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════',


### PR DESCRIPTION
The change to update the tool to use `dart pub` was reverted, and needs further investigation from @sigurdm.

In the meantime `pub` has started generating warning output directing users to migrate.

This PR updates the overall_experience_test to compensate for the additional output.