### PR TITLE
Add download script for deferred components assets

### DIFF
--- a/dev/integration_tests/deferred_components_test/.gitignore
+++ b/dev/integration_tests/deferred_components_test/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+/customassets/
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/dev/integration_tests/deferred_components_test/README.md
+++ b/dev/integration_tests/deferred_components_test/README.md
@@ -6,7 +6,7 @@ This integration test app requires manually downloading additional assets to bui
 
 `./download_assets.sh`
 
-before running any of the test.
+before running any of the tests.
 
 ## Tests
 

--- a/dev/integration_tests/deferred_components_test/README.md
+++ b/dev/integration_tests/deferred_components_test/README.md
@@ -1,5 +1,13 @@
 # Deferred components integration test app
 
+## Setup
+
+This integration test app requires manually downloading additional assets to build. Run
+
+`./download_assets.sh`
+
+before running any of the test.
+
 ## Tests
 
 This app contains two sets of tests:

--- a/dev/integration_tests/deferred_components_test/download_assets.sh
+++ b/dev/integration_tests/deferred_components_test/download_assets.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+mkdir customassets
+curl https://raw.githubusercontent.com/flutter/goldens/0fbd6c5d30ec714ffefd63b47910aee7debd2e7e/dev/integration_tests/assets_for_deferred_components_test/flutter_logo.png --output customassets/flutter_logo.png
+curl https://raw.githubusercontent.com/flutter/goldens/0fbd6c5d30ec714ffefd63b47910aee7debd2e7e/dev/integration_tests/assets_for_deferred_components_test/key.properties --output android/key.properties
+curl https://raw.githubusercontent.com/flutter/goldens/0fbd6c5d30ec714ffefd63b47910aee7debd2e7e/dev/integration_tests/assets_for_deferred_components_test/testing-keystore.jks --output android/testing-keystore.jks


### PR DESCRIPTION
Due to the restriction against checking in non-UTF-8 files, we need to download these assets and binary files to use this as part of a LUCI integration test.
