### PR TITLE
Use bucket to check staging test instead of builder name

### DIFF
--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -23,7 +23,7 @@ class UploadResultsCommand extends Command<void> {
     argParser.addOption('luci-builder', help: '[Flutter infrastructure] Name of the LUCI builder being run on.');
     argParser.addOption('test-status', help: 'Test status: Succeeded|Failed');
     argParser.addOption('commit-time', help: 'Commit time in UNIX timestamp');
-    argParser.addOption('build-bucket', help: '[Flutter infrastructure] Luci builder bucket the test is running in.');
+    argParser.addOption('builder-bucket', help: '[Flutter infrastructure] Luci builder bucket the test is running in.');
   }
 
   @override

--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -23,7 +23,7 @@ class UploadResultsCommand extends Command<void> {
     argParser.addOption('luci-builder', help: '[Flutter infrastructure] Name of the LUCI builder being run on.');
     argParser.addOption('test-status', help: 'Test status: Succeeded|Failed');
     argParser.addOption('commit-time', help: 'Commit time in UNIX timestamp');
-    argParser.addOption('build-bucket', help: 'Luci build bucket the test is running in.');
+    argParser.addOption('build-bucket', help: '[Flutter infrastructure] Luci builder bucket the test is running in.');
   }
 
   @override
@@ -41,7 +41,7 @@ class UploadResultsCommand extends Command<void> {
     final String? builderName = argResults!['luci-builder'] as String?;
     final String? testStatus = argResults!['test-status'] as String?;
     final String? commitTime = argResults!['commit-time'] as String?;
-    final String? buildBucket = argResults!['build-bucket'] as String?;
+    final String? builderBucket = argResults!['builder-bucket'] as String?;
 
     // Upload metrics to skia perf from test runner when `resultsPath` is specified.
     if (resultsPath != null) {
@@ -56,7 +56,7 @@ class UploadResultsCommand extends Command<void> {
       gitBranch: gitBranch,
       builderName: builderName,
       testStatus: testStatus,
-      buildBucket: buildBucket,
+      builderBucket: builderBucket,
     );
   }
 }

--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -23,6 +23,7 @@ class UploadResultsCommand extends Command<void> {
     argParser.addOption('luci-builder', help: '[Flutter infrastructure] Name of the LUCI builder being run on.');
     argParser.addOption('test-status', help: 'Test status: Succeeded|Failed');
     argParser.addOption('commit-time', help: 'Commit time in UNIX timestamp');
+    argParser.addOption('build-bucket', help: 'Luci build bucket the test is running in.');
   }
 
   @override
@@ -40,6 +41,7 @@ class UploadResultsCommand extends Command<void> {
     final String? builderName = argResults!['luci-builder'] as String?;
     final String? testStatus = argResults!['test-status'] as String?;
     final String? commitTime = argResults!['commit-time'] as String?;
+    final String? buildBucket = argResults!['build-bucket'] as String?;
 
     // Upload metrics to skia perf from test runner when `resultsPath` is specified.
     if (resultsPath != null) {
@@ -54,6 +56,7 @@ class UploadResultsCommand extends Command<void> {
       gitBranch: gitBranch,
       builderName: builderName,
       testStatus: testStatus,
+      buildBucket: buildBucket,
     );
   }
 }

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -90,7 +90,7 @@ class Cocoon {
     String? gitBranch,
     String? builderName,
     String? testStatus,
-    String? buildBucket,
+    String? builderBucket,
   }) async {
     Map<String, dynamic> resultsJson = <String, dynamic>{};
     if (resultsPath != null) {
@@ -103,7 +103,7 @@ class Cocoon {
       resultsJson['NewStatus'] = testStatus;
     }
     resultsJson['TestFlaky'] = isTestFlaky ?? false;
-    if (_shouldUpdateCocoon(resultsJson, buildBucket)) {
+    if (_shouldUpdateCocoon(resultsJson, builderBucket: builderBucket)) {
       await retry(
         () async => _sendUpdateTaskRequest(resultsJson).timeout(Duration(seconds: requestTimeoutLimit)),
         retryIf: (Exception e) => e is SocketException || e is TimeoutException || e is ClientException,
@@ -113,10 +113,9 @@ class Cocoon {
   }
 
   /// Only post-submit tests on `master` are allowed to update in cocoon.
-  bool _shouldUpdateCocoon(Map<String, dynamic> resultJson, String? buildBucket) {
+  bool _shouldUpdateCocoon(Map<String, dynamic> resultJson, {String? builderBucket = 'prod'}) {
     const List<String> supportedBranches = <String>['master'];
-    return supportedBranches.contains(resultJson['CommitBranch']) &&
-        buildBucket != 'staging';
+    return supportedBranches.contains(resultJson['CommitBranch']) && builderBucket != 'staging';
   }
 
   /// Write the given parameters into an update task request and store the JSON in [resultsPath].

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -90,6 +90,7 @@ class Cocoon {
     String? gitBranch,
     String? builderName,
     String? testStatus,
+    String? buildBucket,
   }) async {
     Map<String, dynamic> resultsJson = <String, dynamic>{};
     if (resultsPath != null) {
@@ -102,7 +103,7 @@ class Cocoon {
       resultsJson['NewStatus'] = testStatus;
     }
     resultsJson['TestFlaky'] = isTestFlaky ?? false;
-    if (_shouldUpdateCocoon(resultsJson)) {
+    if (_shouldUpdateCocoon(resultsJson, buildBucket)) {
       await retry(
         () async => _sendUpdateTaskRequest(resultsJson).timeout(Duration(seconds: requestTimeoutLimit)),
         retryIf: (Exception e) => e is SocketException || e is TimeoutException || e is ClientException,
@@ -112,10 +113,10 @@ class Cocoon {
   }
 
   /// Only post-submit tests on `master` are allowed to update in cocoon.
-  bool _shouldUpdateCocoon(Map<String, dynamic> resultJson) {
+  bool _shouldUpdateCocoon(Map<String, dynamic> resultJson, String? buildBucket) {
     const List<String> supportedBranches = <String>['master'];
     return supportedBranches.contains(resultJson['CommitBranch']) &&
-        !resultJson['BuilderName'].toString().toLowerCase().contains('staging');
+        buildBucket != 'staging';
   }
 
   /// Write the given parameters into an update task request and store the JSON in [resultsPath].

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -360,7 +360,7 @@ void main() {
       fs.file(resultsPath).writeAsStringSync(updateTaskJson);
 
       // This will fail if it decided to upload results
-      await cocoon.sendTaskStatus(resultsPath: resultsPath, buildBucket: 'staging');
+      await cocoon.sendTaskStatus(resultsPath: resultsPath, builderBucket: 'staging');
     });
   });
 

--- a/dev/devicelab/test/cocoon_test.dart
+++ b/dev/devicelab/test/cocoon_test.dart
@@ -353,14 +353,14 @@ void main() {
       const String updateTaskJson = '{'
           '"CommitBranch":"master",'
           '"CommitSha":"$commitSha",'
-          '"BuilderName":"Linux_staging_test",'
+          '"BuilderName":"builderAbc",'
           '"NewStatus":"Succeeded",'
           '"ResultData":{"i":0.0,"j":0.0,"not_a_metric":"something"},'
           '"BenchmarkScoreKeys":["i","j"]}';
       fs.file(resultsPath).writeAsStringSync(updateTaskJson);
 
       // This will fail if it decided to upload results
-      await cocoon.sendTaskStatus(resultsPath: resultsPath);
+      await cocoon.sendTaskStatus(resultsPath: resultsPath, buildBucket: 'staging');
     });
   });
 


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/88835. Instead of using builder name to check whether a test is from staging pool, we use `bucket` to provide more flexibility.

More context about naming builders without `staging` keyword: https://flutter-review.googlesource.com/c/recipes/+/17001