### PR TITLE
Configurable adb for deferred components release test script

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -14,7 +14,7 @@ rm -f build/app/outputs/bundle/release/run_logcat.log
 flutter build appbundle
 
 java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --device-spec=avd_device_config.json
-java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks --device-spec=avd_device_config.json
+java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
 $2 shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -14,7 +14,7 @@ rm -f build/app/outputs/bundle/release/run_logcat.log
 flutter build appbundle
 
 java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --device-spec=avd_device_config.json
-java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
+java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks --device-spec=avd_device_config.json
 
 $2 shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -13,7 +13,7 @@ rm -f build/app/outputs/bundle/release/run_logcat.log
 
 flutter build appbundle
 
-java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --device-spec=avd_device_config.json
+java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
 java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
 $2 shell "

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -14,25 +14,28 @@
 # The modified bundletool which waives the density requirement is at:
 # https://chrome-infra-packages.appspot.com/p/flutter/android/bundletool/+/vFt1jA0cUeZLmUCVR5NG2JVB-SgJ18GH_pVYKMOlfUIC
 
-# Store the time to prevent capturing logs from previous runs.
-script_start_time=$($2 shell 'date +"%m-%d %H:%M:%S.0"')
+bundletool_jar_path=$1
+adb_path=$2
 
-$2 uninstall "io.flutter.integration.deferred_components_test"
+# Store the time to prevent capturing logs from previous runs.
+script_start_time=$($adb_path shell 'date +"%m-%d %H:%M:%S.0"')
+
+$adb_path uninstall "io.flutter.integration.deferred_components_test"
 
 rm -f build/app/outputs/bundle/release/app-release.apks
 rm -f build/app/outputs/bundle/release/run_logcat.log
 
 flutter build appbundle
 
-java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
-java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
+java -jar $bundletool_jar_path build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
+java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
-$2 shell "
+$adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
 sleep 12
 exit
 "
-$2 logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
+$adb_path logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
 echo ""
 if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferred code"; then
   echo "All tests passed."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -3,6 +3,17 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# Usage:
+#
+#   ./run_release_test.sh <bundletool.jar path> <adb path>
+#
+# In CI, this script currently depends on a modified version of bundletool because
+# ddmlib which bundletool depends on does not yet support detecting QEMU emulator device
+# density system properties. See https://android.googlesource.com/platform/tools/base/+/refs/heads/master/ddmlib/src/main/java/com/android/ddmlib/IDevice.java#46
+#
+# The modified bundletool which waives the density requirement is at:
+# https://chrome-infra-packages.appspot.com/p/flutter/android/bundletool/+/vFt1jA0cUeZLmUCVR5NG2JVB-SgJ18GH_pVYKMOlfUIC
+
 # Store the time to prevent capturing logs from previous runs.
 script_start_time=$($2 shell 'date +"%m-%d %H:%M:%S.0"')
 

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -4,9 +4,9 @@
 # found in the LICENSE file.
 
 # Store the time to prevent capturing logs from previous runs.
-script_start_time=$(adb shell 'date +"%m-%d %H:%M:%S.0"')
+script_start_time=$($2 shell 'date +"%m-%d %H:%M:%S.0"')
 
-adb uninstall "io.flutter.integration.deferred_components_test"
+$2 uninstall "io.flutter.integration.deferred_components_test"
 
 rm -f build/app/outputs/bundle/release/app-release.apks
 rm -f build/app/outputs/bundle/release/run_logcat.log
@@ -16,12 +16,12 @@ flutter build appbundle
 java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
 java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
-adb shell "
+$2 shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
 sleep 12
 exit
 "
-adb logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
+$2 logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
 echo ""
 if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferred code"; then
   echo "All tests passed."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -13,7 +13,7 @@ rm -f build/app/outputs/bundle/release/run_logcat.log
 
 flutter build appbundle
 
-java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
+java -jar $1 build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --device-spec=avd_device_config.json
 java -jar $1 install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
 $2 shell "


### PR DESCRIPTION
Allow the executables of the test script to be fully configurable for providing different versions of bundletool and adb in recipes. Needed for https://flutter-review.googlesource.com/c/recipes/+/17280