### PR TITLE
Intuitive Error when showSnackBar is called During Build

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -258,6 +258,34 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// ** See code in examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.0.dart **
   /// {@end-tool}
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBar(SnackBar snackBar) {
+    assert(() {
+      if ((context as StatefulElement).owner!.debugBuilding) {
+        final List<DiagnosticsNode> information = <DiagnosticsNode>[
+          ErrorSummary('Snack bars cannot be shown during build.'),
+          ErrorDescription(
+            'The showSnackBar() method was called during build, which is '
+            'prohibited as showing snack bars requires updating state. Updating '
+            'state is not possible during build as it requires marking the '
+            'ScaffoldMessenger as needing to build while the framework is '
+            'already in the process of building widgets.',
+          ),
+          ErrorHint(
+            'Instead of calling showSnackBar() during build, call it directly '
+            'in your on tap (and related) callbacks. If you need to immediately '
+            'show a snack bar, make the call in initState() or '
+            'didChangeDependencies() instead. Otherwise, you can also schedule a '
+            'post-frame callback using SchedulerBinding.addPostFrameCallback to '
+            'show the snack bar after the current frame.',
+          ),
+          context.describeOwnershipChain(
+            'The ownership chain for the particular ScaffoldMessenger is',
+          ),
+        ];
+        throw FlutterError.fromParts(information);
+      }
+      return true;
+    }());
+
     _snackBarController ??= SnackBar.createAnimationController(vsync: this)
       ..addStatusListener(_handleSnackBarStatusChanged);
     if (_snackBars.isEmpty) {
@@ -2040,6 +2068,34 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     'This feature was deprecated after v1.23.0-14.0.pre.',
   )
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBar(SnackBar snackbar) {
+    assert(() {
+      if ((context as StatefulElement).owner!.debugBuilding) {
+        final List<DiagnosticsNode> information = <DiagnosticsNode>[
+          ErrorSummary('Snack bars cannot be shown during build.'),
+          ErrorDescription(
+            'The showSnackBar() method was called during build, which is '
+            'prohibited as showing snack bars requires updating state. Updating '
+            'state is not possible during build as it requires marking the '
+            'ScaffoldMessenger as needing to build while the framework is '
+            'already in the process of building widgets.',
+          ),
+          ErrorHint(
+            'Instead of calling showSnackBar() during build, call it directly '
+            'in your on tap (and related) callbacks. If you need to immediately '
+            'show a snack bar, make the call in initState() or '
+            'didChangeDependencies() instead. Otherwise, you can also schedule a '
+            'post-frame callback using SchedulerBinding.addPostFrameCallback to '
+            'show the snack bar after the current frame.',
+          ),
+          context.describeOwnershipChain(
+            'The ownership chain for the particular ScaffoldMessenger is',
+          ),
+        ];
+        throw FlutterError.fromParts(information);
+      }
+      return true;
+    }());
+
     _snackBarController ??= SnackBar.createAnimationController(vsync: this)
       ..addStatusListener(_handleSnackBarStatusChange);
     if (_snackBars.isEmpty) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1097,7 +1097,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
           ErrorHint(
             'Instead of performing asynchronous work inside a call to setState(), first '
             'execute the work (without updating the widget state), and then synchronously '
-           'update the state inside a call to setState().',
+            'update the state inside a call to setState().',
           ),
         ]);
       }
@@ -4247,7 +4247,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
             ErrorSummary('setState() or markNeedsBuild() called during build.'),
             ErrorDescription(
               'This ${widget.runtimeType} widget cannot be marked as needing to build because the framework '
-              'is already in the process of building widgets.  A widget can be marked as '
+              'is already in the process of building widgets. A widget can be marked as '
               'needing to be built during the build phase only if one of its ancestors '
               'is currently building. This exception is allowed because the framework '
               'builds parent widgets before children, which means a dirty descendant '

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1097,7 +1097,7 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
           ErrorHint(
             'Instead of performing asynchronous work inside a call to setState(), first '
             'execute the work (without updating the widget state), and then synchronously '
-            'update the state inside a call to setState().',
+           'update the state inside a call to setState().',
           ),
         ]);
       }
@@ -4247,7 +4247,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
             ErrorSummary('setState() or markNeedsBuild() called during build.'),
             ErrorDescription(
               'This ${widget.runtimeType} widget cannot be marked as needing to build because the framework '
-              'is already in the process of building widgets. A widget can be marked as '
+              'is already in the process of building widgets.  A widget can be marked as '
               'needing to be built during the build phase only if one of its ancestors '
               'is currently building. This exception is allowed because the framework '
               'builds parent widgets before children, which means a dirty descendant '

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2517,6 +2517,60 @@ void main() {
       'was set by default.',
     );
   });
+
+  testWidgets(
+      'ScaffoldMessenger showSnackBar throws intuitive error message if called during build',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+              content: SizedBox(),
+              duration: Duration(seconds: 2),
+            ));
+            return const SizedBox();
+          },
+        ),
+      ),
+    ));
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+
+    final ErrorSummary summary = (exception as FlutterError)
+            .diagnostics
+            .firstWhere((DiagnosticsNode element) => element is ErrorSummary)
+        as ErrorSummary;
+    expect(summary.toString(), 'Snack bars cannot be shown during build.');
+  });
+
+  testWidgets(
+      'Scaffold showSnackBar throws intuitive error message if called during build',
+          (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) {
+            Scaffold.of(context).showSnackBar(const SnackBar(
+              content: SizedBox(),
+              duration: Duration(seconds: 2),
+            ));
+            return const SizedBox();
+          },
+        ),
+      ),
+    ));
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+
+    final ErrorSummary summary = (exception as FlutterError)
+        .diagnostics
+        .firstWhere((DiagnosticsNode element) => element is ErrorSummary)
+    as ErrorSummary;
+    expect(summary.toString(), 'Snack bars cannot be shown during build.');
+  });
 }
 
 /// Start test for "SnackBar dismiss test".


### PR DESCRIPTION
Adds an intuitive error message for when `showSnackBar` is called during build. This PR adds the error for both `ScaffoldMessenger` and the legacy API for consistency.

Fixes #66789

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
