### PR TITLE
Fixed leak and removed no-shuffle tag in dismissible_test.dart

### DIFF
--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -230,9 +230,9 @@ void main() {
   });
 
   tearDown(() {
-    // To make sure dismissDirection does not have unpredicted values when 
+    // To make sure dismissDirection does not have unpredicted values when
     // tests are being shuffled, restore it to default value after each test.
-    dismissDirection = defaultDismissDirection; 
+    dismissDirection = defaultDismissDirection;
   });
 
   testWidgets('Horizontal drag triggers dismiss scrollDirection=vertical', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -2,19 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=456"
-@Tags(<String>['no-shuffle'])
-
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const double itemExtent = 100.0;
 Axis scrollDirection = Axis.vertical;
-DismissDirection dismissDirection = DismissDirection.horizontal;
+DismissDirection defaultDismissDirection = DismissDirection.horizontal;
+DismissDirection dismissDirection = defaultDismissDirection;
 late DismissDirection reportedDismissDirection;
 List<int> dismissedItems = <int>[];
 Widget? background;
@@ -232,6 +227,12 @@ void main() {
   setUp(() {
     dismissedItems = <int>[];
     background = null;
+  });
+
+  tearDown(() {
+    // To make sure dismissDirection does not have unpredicted values when 
+    // tests are being shuffled, restore it to default value after each test.
+    dismissDirection = defaultDismissDirection; 
   });
 
   testWidgets('Horizontal drag triggers dismiss scrollDirection=vertical', (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixed the problem that prevented dismissible_test.dart being shuffled. Part of #85160.

## The Problem
Some tests in the bottom of this file set the `dismissDirection` to `DismissDirection.none`, which broke some other tests when shuffled.

## The Fix
To prevent `dismissDirection` to have unpredicted values when tests are being shuffled, this PR restores it to the default value of `DismissDirection.horizontal` after every test has run.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

