### PR TITLE
Fix Stack references in Overlay docs

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -214,10 +214,10 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
   }
 }
 
-/// A [Stack] of entries that can be managed independently.
+/// A stack of entries that can be managed independently.
 ///
 /// Overlays let independent child widgets "float" visual elements on top of
-/// other widgets by inserting them into the overlay's [Stack]. The overlay lets
+/// other widgets by inserting them into the overlay's stack. The overlay lets
 /// each of these widgets manage their participation in the overlay using
 /// [OverlayEntry] objects.
 ///
@@ -225,12 +225,19 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
 /// overlay created by the [Navigator] in a [WidgetsApp] or a [MaterialApp]. The
 /// navigator uses its overlay to manage the visual appearance of its routes.
 ///
+/// The [Overlay] widget uses a custom stack implementation, which however is
+/// very similar to the [Stack] widget. The main use case of [Overlay] is
+/// related to navigation and being able to insert widgets on top of the pages
+/// in an app. If you are purely looking to display a stack of widgets, consider
+/// using [Stack] instead.
+///
 /// See also:
 ///
-///  * [OverlayEntry].
-///  * [OverlayState].
-///  * [WidgetsApp].
-///  * [MaterialApp].
+///  * [OverlayEntry], the class that is used for describing the overlay entries.
+///  * [OverlayState], which is used to insert the entries into the overlay.
+///  * [WidgetsApp], which inserts an [Overlay] widget indirectly via its [Navigator].
+///  * [MaterialApp], which inserts an [Overlay] widget indirectly via its [Navigator].
+///  * [Stack], which allows you to directly display a stack of widgets.
 class Overlay extends StatefulWidget {
   /// Creates an overlay.
   ///

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -225,11 +225,10 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
 /// overlay created by the [Navigator] in a [WidgetsApp] or a [MaterialApp]. The
 /// navigator uses its overlay to manage the visual appearance of its routes.
 ///
-/// The [Overlay] widget uses a custom stack implementation, which however is
-/// very similar to the [Stack] widget. The main use case of [Overlay] is
-/// related to navigation and being able to insert widgets on top of the pages
-/// in an app. If you are purely looking to display a stack of widgets, consider
-/// using [Stack] instead.
+/// The [Overlay] widget uses a custom stack implementation, which is very
+/// similar to the [Stack] widget. The main use case of [Overlay] is related to
+/// navigation and being able to insert widgets on top of the pages in an app.
+/// To simply display a stack of widgets, consider using [Stack] instead.
 ///
 /// See also:
 ///
@@ -237,7 +236,7 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
 ///  * [OverlayState], which is used to insert the entries into the overlay.
 ///  * [WidgetsApp], which inserts an [Overlay] widget indirectly via its [Navigator].
 ///  * [MaterialApp], which inserts an [Overlay] widget indirectly via its [Navigator].
-///  * [Stack], which allows you to directly display a stack of widgets.
+///  * [Stack], which allows directly displaying a stack of widgets.
 class Overlay extends StatefulWidget {
   /// Creates an overlay.
   ///


### PR DESCRIPTION
The `Overlay` docs here were horribly outdated. They are written as though `Overlay` was simply a `Stack` (as in its `build` method would simply return a `Stack`).  
This has, however, not been the case anymore for the past 5 years. In fact, a custom `_Theatre` render object (similar to `Stack`) replaced the `Stack` usage back in August of 2016 (5 years ago). See https://github.com/flutter/flutter/pull/5624/files#diff-6ea34306ad31c88d41a39d24aaad65a2ef227ebbee8919697b3411ff2ef0f897L271.

Furthermore, I made sure to address #65890 by explaining the actual relation to the `Stack` widget right now.

Fixes #65890.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
