### PR TITLE
Stop calling top level pub

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,10 +115,10 @@ task:
         MEMORY: 10G
         SHOULD_UPDATE_PACKAGES: "FALSE"
       script:
-        - (cd packages/flutter_tools; dart pub get)
-        - (cd packages/flutter_tools/test/data/asset_test/main; dart pub get)
-        - (cd packages/flutter_tools/test/data/asset_test/font; dart pub get)
-        - (cd dev/bots; dart pub get)
+        - (cd packages/flutter_tools; dart __deprecated_pub get)
+        - (cd packages/flutter_tools/test/data/asset_test/main; dart __deprecated_pub get)
+        - (cd packages/flutter_tools/test/data/asset_test/font; dart __deprecated_pub get)
+        - (cd dev/bots; dart __deprecated_pub get)
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: tool_tests-commands-linux
@@ -131,8 +131,8 @@ task:
         MEMORY: 10G
         SHOULD_UPDATE_PACKAGES: "FALSE"
       script:
-        - (cd packages/flutter_tools; dart pub get)
-        - (cd dev/bots; dart pub get)
+        - (cd packages/flutter_tools; dart __deprecated_pub get)
+        - (cd dev/bots; dart __deprecated_pub get)
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: docs-linux # linux-only
@@ -168,7 +168,7 @@ task:
         - flutter config --enable-web
         - git clone https://github.com/flutter/web_installers.git
         - cd web_installers/packages/web_drivers/
-        - dart pub get
+        - dart __deprecated_pub get
         - dart lib/web_driver_installer.dart chromedriver --install-only
         - chromedriver/chromedriver --port=4444 &
         - sleep 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,10 +115,10 @@ task:
         MEMORY: 10G
         SHOULD_UPDATE_PACKAGES: "FALSE"
       script:
-        - (cd packages/flutter_tools; pub get)
-        - (cd packages/flutter_tools/test/data/asset_test/main; pub get)
-        - (cd packages/flutter_tools/test/data/asset_test/font; pub get)
-        - (cd dev/bots; pub get)
+        - (cd packages/flutter_tools; dart pub get)
+        - (cd packages/flutter_tools/test/data/asset_test/main; dart pub get)
+        - (cd packages/flutter_tools/test/data/asset_test/font; dart pub get)
+        - (cd dev/bots; dart pub get)
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: tool_tests-commands-linux
@@ -131,8 +131,8 @@ task:
         MEMORY: 10G
         SHOULD_UPDATE_PACKAGES: "FALSE"
       script:
-        - (cd packages/flutter_tools; pub get)
-        - (cd dev/bots; pub get)
+        - (cd packages/flutter_tools; dart pub get)
+        - (cd dev/bots; dart pub get)
         - dart --enable-asserts ./dev/bots/test.dart
 
     - name: docs-linux # linux-only
@@ -168,7 +168,7 @@ task:
         - flutter config --enable-web
         - git clone https://github.com/flutter/web_installers.git
         - cd web_installers/packages/web_drivers/
-        - pub get
+        - dart pub get
         - dart lib/web_driver_installer.dart chromedriver --install-only
         - chromedriver/chromedriver --port=4444 &
         - sleep 1

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -24,7 +24,6 @@ SET engine_version_path=%FLUTTER_ROOT%\bin\internal\engine.version
 SET pub_cache_path=%FLUTTER_ROOT%\.pub-cache
 
 SET dart=%dart_sdk_path%\bin\dart.exe
-SET pub=%dart_sdk_path%\bin\pub.bat
 
 REM Detect which PowerShell executable is available on the Host
 REM PowerShell version <= 5: PowerShell.exe
@@ -139,16 +138,16 @@ GOTO :after_subroutine
       SET /A remaining_tries=%total_tries%-1
       :retry_pub_upgrade
         ECHO Running pub upgrade... 1>&2
-        CALL "%pub%" upgrade "%VERBOSITY%" --no-precompile
+        "%dart%" pub upgrade "%VERBOSITY%" --no-precompile
         IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
-        ECHO Error (%ERRORLEVEL%): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left) 1>&2
+        ECHO Error (%ERRORLEVEL%): Unable to 'dart pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left) 1>&2
         timeout /t 5 /nobreak 2>NUL
         SET /A remaining_tries-=1
         IF "%remaining_tries%" EQU "0" GOTO upgrade_retries_exhausted
         GOTO :retry_pub_upgrade
       :upgrade_retries_exhausted
         SET exit_code=%ERRORLEVEL%
-        ECHO Error: 'pub upgrade' still failing after %total_tries% tries. 1>&2
+        ECHO Error: 'dart pub upgrade' still failing after %total_tries% tries. 1>&2
         GOTO final_exit
       :upgrade_succeeded
     ENDLOCAL

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -138,16 +138,16 @@ GOTO :after_subroutine
       SET /A remaining_tries=%total_tries%-1
       :retry_pub_upgrade
         ECHO Running pub upgrade... 1>&2
-        "%dart%" pub upgrade "%VERBOSITY%" --no-precompile
+        "%dart%" __deprecated_pub upgrade "%VERBOSITY%" --no-precompile
         IF "%ERRORLEVEL%" EQU "0" goto :upgrade_succeeded
-        ECHO Error (%ERRORLEVEL%): Unable to 'dart pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left) 1>&2
+        ECHO Error (%ERRORLEVEL%): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (%remaining_tries% tries left) 1>&2
         timeout /t 5 /nobreak 2>NUL
         SET /A remaining_tries-=1
         IF "%remaining_tries%" EQU "0" GOTO upgrade_retries_exhausted
         GOTO :retry_pub_upgrade
       :upgrade_retries_exhausted
         SET exit_code=%ERRORLEVEL%
-        ECHO Error: 'dart pub upgrade' still failing after %total_tries% tries. 1>&2
+        ECHO Error: 'pub upgrade' still failing after %total_tries% tries. 1>&2
         GOTO final_exit
       :upgrade_succeeded
     ENDLOCAL

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -21,14 +21,14 @@ function retry_upgrade {
   local total_tries="10"
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
-    (cd "$FLUTTER_TOOLS_DIR" && "$DART" pub upgrade "$VERBOSITY" --no-precompile) && break
-    >&2 echo "Error: Unable to 'dart pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    (cd "$FLUTTER_TOOLS_DIR" && "$DART" __deprecated_pub upgrade "$VERBOSITY" --no-precompile) && break
+    >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    >&2 echo "Command 'dart pub upgrade' still failed after $total_tries tries, giving up."
+    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
     return 1
   fi
   return 0

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -21,14 +21,14 @@ function retry_upgrade {
   local total_tries="10"
   local remaining_tries=$((total_tries - 1))
   while [[ "$remaining_tries" -gt 0 ]]; do
-    (cd "$FLUTTER_TOOLS_DIR" && "$PUB" upgrade "$VERBOSITY" --no-precompile) && break
-    >&2 echo "Error: Unable to 'pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
+    (cd "$FLUTTER_TOOLS_DIR" && "$DART" pub upgrade "$VERBOSITY" --no-precompile) && break
+    >&2 echo "Error: Unable to 'dart pub upgrade' flutter tool. Retrying in five seconds... ($remaining_tries tries left)"
     remaining_tries=$((remaining_tries - 1))
     sleep 5
   done
 
   if [[ "$remaining_tries" == 0 ]]; then
-    >&2 echo "Command 'pub upgrade' still failed after $total_tries tries, giving up."
+    >&2 echo "Command 'dart pub upgrade' still failed after $total_tries tries, giving up."
     return 1
   fi
   return 0
@@ -180,14 +180,12 @@ function shared::execute() {
   DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
 
   DART="$DART_SDK_PATH/bin/dart"
-  PUB="$DART_SDK_PATH/bin/pub"
 
   # If running over git-bash, overrides the default UNIX executables with win32
   # executables
   case "$(uname -s)" in
     MINGW*)
       DART="$DART.exe"
-      PUB="$PUB.bat"
       ;;
   esac
 

--- a/dev/customer_testing/ci.bat
+++ b/dev/customer_testing/ci.bat
@@ -8,9 +8,9 @@ REM This should match the ci.sh file in this directory.
 REM This is called from the LUCI recipes:
 REM https://flutter.googlesource.com/recipes/+/refs/heads/master/recipe_modules/adhoc_validation/resources/customer_testing.bat
 
-dart pub get
+dart __deprecated_pub get
 CD ..\tools
-dart pub get
+dart __deprecated_pub get
 CD ..\customer_testing
 
 CMD /S /C "IF EXIST "..\..\bin\cache\pkg\tests\" RMDIR /S /Q ..\..\bin\cache\pkg\tests"

--- a/dev/customer_testing/ci.bat
+++ b/dev/customer_testing/ci.bat
@@ -8,9 +8,9 @@ REM This should match the ci.sh file in this directory.
 REM This is called from the LUCI recipes:
 REM https://flutter.googlesource.com/recipes/+/refs/heads/master/recipe_modules/adhoc_validation/resources/customer_testing.bat
 
-pub get
+dart pub get
 CD ..\tools
-pub get
+dart pub get
 CD ..\customer_testing
 
 CMD /S /C "IF EXIST "..\..\bin\cache\pkg\tests\" RMDIR /S /Q ..\..\bin\cache\pkg\tests"

--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -15,8 +15,8 @@ set -ex
 # largely not needed to run the flutter/tests tests.
 #
 # However, we do need to update this directory and the tools directory.
-dart pub get
-(cd ../tools; dart pub get) # used for find_commit.dart below
+dart __deprecated_pub get
+(cd ../tools; dart __deprecated_pub get) # used for find_commit.dart below
 
 # Next we need to update the flutter/tests checkout.
 #

--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -15,8 +15,8 @@ set -ex
 # largely not needed to run the flutter/tests tests.
 #
 # However, we do need to update this directory and the tools directory.
-pub get
-(cd ../tools; pub get) # used for find_commit.dart below
+dart pub get
+(cd ../tools; dart pub get) # used for find_commit.dart below
 
 # Next we need to update the flutter/tests checkout.
 #

--- a/examples/api/windows/flutter/generated_plugin_registrant.h
+++ b/examples/api/windows/flutter/generated_plugin_registrant.h
@@ -1,7 +1,3 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 //
 //  Generated file. Do not edit.
 //

--- a/examples/api/windows/flutter/generated_plugin_registrant.h
+++ b/examples/api/windows/flutter/generated_plugin_registrant.h
@@ -1,6 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 //
 //  Generated file. Do not edit.
 //

--- a/examples/api/windows/flutter/generated_plugin_registrant.h
+++ b/examples/api/windows/flutter/generated_plugin_registrant.h
@@ -1,3 +1,6 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 //
 //  Generated file. Do not edit.
 //

--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -109,7 +109,7 @@ Future<void> main(List<String> args) async {
       DevtoolsLauncher: () => DevtoolsServerLauncher(
         processManager: globals.processManager,
         fileSystem: globals.fs,
-        pubExecutable: globals.artifacts.getHostArtifact(HostArtifact.pubExecutable).path,
+        dartExecutable: globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
         logger: globals.logger,
         platform: globals.platform,
         persistentToolState: globals.persistentToolState,

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -101,9 +101,6 @@ enum HostArtifact {
   iproxy,
   /// The root of the sky_engine package.
   skyEnginePath,
-
-  /// The pub or pub.bat executable
-  pubExecutable,
 }
 
 // TODO(knopp): Remove once darwin artifacts are universal and moved out of darwin-x64
@@ -263,11 +260,6 @@ String _hostArtifactToFileName(HostArtifact artifact, bool windows) {
     case HostArtifact.webPrecompiledCanvaskitSoundSdkSourcemaps:
     case HostArtifact.webPrecompiledCanvaskitAndHtmlSoundSdkSourcemaps:
       return 'dart_sdk.js.map';
-    case HostArtifact.pubExecutable:
-      if (windows) {
-        return 'pub.bat';
-      }
-      return 'pub';
   }
 }
 
@@ -405,9 +397,6 @@ class CachedArtifacts implements Artifacts {
         final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
         final String path = _fileSystem.path.join(dartPackageDirectory.path,  _hostArtifactToFileName(artifact, _platform.isWindows));
         return _fileSystem.directory(path);
-      case HostArtifact.pubExecutable:
-        final String path = _fileSystem.path.join(_dartSdkPath(_fileSystem), 'bin',  _hostArtifactToFileName(artifact, _platform.isWindows));
-        return _fileSystem.file(path);
       case HostArtifact.dart2jsSnapshot:
       case HostArtifact.dartdevcSnapshot:
       case HostArtifact.kernelWorkerSnapshot:
@@ -791,9 +780,6 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
         final Directory dartPackageDirectory = _cache.getCacheDir('pkg');
         final String path = _fileSystem.path.join(dartPackageDirectory.path,  _hostArtifactToFileName(artifact, _platform.isWindows));
         return _fileSystem.directory(path);
-      case HostArtifact.pubExecutable:
-        final String path = _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin',  _hostArtifactToFileName(artifact, _platform.isWindows));
-        return _fileSystem.file(path);
       case HostArtifact.iosDeploy:
         final String artifactFileName = _hostArtifactToFileName(artifact, _platform.isWindows);
         return _cache.getArtifactDirectory('ios-deploy').childFile(artifactFileName);

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -216,7 +216,7 @@ Future<T> runInContext<T>(
       DevtoolsLauncher: () => DevtoolsServerLauncher(
         processManager: globals.processManager,
         fileSystem: globals.fs,
-        pubExecutable: globals.artifacts.getHostArtifact(HostArtifact.pubExecutable).path,
+        dartExecutable: globals.artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
         logger: globals.logger,
         platform: globals.platform,
         persistentToolState: globals.persistentToolState,

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -419,7 +419,7 @@ class _DefaultPub implements Pub {
       'cache',
       'dart-sdk',
       'bin',
-      'pub',
+      'dart',
     ]);
     if (!_processManager.canRun(sdkPath)) {
       throwToolExit(
@@ -428,7 +428,7 @@ class _DefaultPub implements Pub {
         'permissions for the current user.'
       );
     }
-    return <String>[sdkPath, ...arguments];
+    return <String>[sdkPath, '__deprecated_pub', ...arguments];
   }
 
   // Returns the environment value that should be used when running pub.

--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -154,7 +154,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
   /// Check if the DevTools package is already active by running "pub global list".
   Future<bool> _checkForActiveDevTools() async {
     final io.ProcessResult _pubGlobalListProcess = await _processManager.run(
-      <String>[ _dartExecutable, 'global', 'list' ],
+      <String>[ _dartExecutable, 'pub', 'global', 'list' ],
     );
     return _pubGlobalListProcess.stdout.toString().contains(_devToolsInstalledPattern);
   }
@@ -181,6 +181,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
       final io.ProcessResult _devToolsActivateProcess = await _processManager
           .run(<String>[
         _dartExecutable,
+        'pub',
         'global',
         'activate',
         'devtools',

--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -25,13 +25,13 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
     @required Platform platform,
     @required ProcessManager processManager,
     @required FileSystem fileSystem,
-    @required String pubExecutable,
+    @required String dartExecutable,
     @required Logger logger,
     @required PersistentToolState persistentToolState,
     @visibleForTesting io.HttpClient httpClient,
   })  : _processManager = processManager,
         _fileSystem = fileSystem,
-        _pubExecutable = pubExecutable,
+        _dartExecutable = dartExecutable,
         _logger = logger,
         _platform = platform,
         _persistentToolState = persistentToolState,
@@ -39,7 +39,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
 
   final ProcessManager _processManager;
   final FileSystem _fileSystem;
-  final String _pubExecutable;
+  final String _dartExecutable;
   final Logger _logger;
   final Platform _platform;
   final PersistentToolState _persistentToolState;
@@ -118,7 +118,8 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
       }
 
       _devToolsProcess = await _processManager.start(<String>[
-        _pubExecutable,
+        _dartExecutable,
+        'pub',
         'global',
         'run',
         'devtools',
@@ -153,7 +154,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
   /// Check if the DevTools package is already active by running "pub global list".
   Future<bool> _checkForActiveDevTools() async {
     final io.ProcessResult _pubGlobalListProcess = await _processManager.run(
-      <String>[ _pubExecutable, 'global', 'list' ],
+      <String>[ _dartExecutable, 'global', 'list' ],
     );
     return _pubGlobalListProcess.stdout.toString().contains(_devToolsInstalledPattern);
   }
@@ -179,7 +180,7 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
     try {
       final io.ProcessResult _devToolsActivateProcess = await _processManager
           .run(<String>[
-        _pubExecutable,
+        _dartExecutable,
         'global',
         'activate',
         'devtools',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1729,7 +1729,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', '--offline', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
       expect(loggingProcessManager.commands.first, contains('--offline'));
     },
     overrides: <Type, Generator>{
@@ -1754,7 +1754,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
 
       await runner.run(<String>['create', '--pub', projectDir.path]);
-      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]pub')));
+      expect(loggingProcessManager.commands.first, contains(matches(r'dart-sdk[\\/]bin[\\/]dart')));
       expect(loggingProcessManager.commands.first, isNot(contains('--offline')));
     },
     overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -529,7 +529,7 @@ void main() {
       Cache.flutterRoot = '';
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/dart', '_deprecated_pub', 'upgrade', '-h'],
+          '/bin/cache/dart-sdk/bin/dart', '__deprecated_pub', 'upgrade', '-h'],
           stdin:  IOSink(StreamController<List<int>>().sink),
         ),
       );

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -451,7 +451,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '__deprecated_pub', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -476,7 +476,7 @@ void main() {
       Cache.flutterRoot = '';
       globals.fs.file('pubspec.yaml').createSync();
       processManager.addCommand(
-        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/pub', '--trace', 'run', 'test']),
+        const FakeCommand(command: <String>['/bin/cache/dart-sdk/bin/dart', '__deprecated_pub', '--trace', 'run', 'test']),
       );
       await createTestCommandRunner(PackagesCommand()).run(<String>['packages', 'test']);
 
@@ -503,7 +503,7 @@ void main() {
       final IOSink stdin = IOSink(StreamController<List<int>>().sink);
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/pub', 'run', '--foo', 'bar'],
+          '/bin/cache/dart-sdk/bin/dart', '__deprecated_pub', 'run', '--foo', 'bar'],
           stdin: stdin,
         ),
       );
@@ -529,7 +529,7 @@ void main() {
       Cache.flutterRoot = '';
       processManager.addCommand(
         FakeCommand(command: const <String>[
-          '/bin/cache/dart-sdk/bin/pub', 'upgrade', '-h'],
+          '/bin/cache/dart-sdk/bin/dart', '_deprecated_pub', 'upgrade', '-h'],
           stdin:  IOSink(StreamController<List<int>>().sink),
         ),
       );

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -26,7 +26,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.empty();
     final BufferLogger logger = BufferLogger.test();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
-    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/pub');
+    processManager.excludedExecutables.add('bin/cache/dart-sdk/bin/dart');
 
     fileSystem.file('pubspec.yaml').createSync();
 
@@ -51,8 +51,8 @@ void main() {
     testWithoutContext('does not skip pub get the parameter is false', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ])
@@ -99,8 +99,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ])
@@ -147,8 +147,8 @@ void main() {
     testWithoutContext('does not skip pub get if package_config.json has "generator": "pub"', () async {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ])
@@ -262,10 +262,10 @@ void main() {
     'but the current framework version is not the same as the last version', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ])
     ]);
     final BufferLogger logger = BufferLogger.test();
@@ -301,10 +301,10 @@ void main() {
     'but the current framework version does not exist yet', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+           'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ])
     ]);
     final BufferLogger logger = BufferLogger.test();
@@ -339,10 +339,10 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(command: const <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ], onRun: () {
         fileSystem.file('.dart_tool/package_config.json').createSync(recursive: true);
       })
@@ -377,10 +377,10 @@ void main() {
     final MemoryFileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ]),
     ]);
     final BufferLogger logger = BufferLogger.test();
@@ -413,10 +413,10 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the package config is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ])
     ]);
     final BufferLogger logger = BufferLogger.test();
@@ -452,10 +452,10 @@ void main() {
   testWithoutContext('checkUpToDate does not skip pub get if the pubspec.lock is older that the pubspec', () async {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ])
     ]);
     final BufferLogger logger = BufferLogger.test();
@@ -495,10 +495,10 @@ void main() {
 
     const FakeCommand pubGetCommand = FakeCommand(
       command: <String>[
-        'bin/cache/dart-sdk/bin/pub',
-        '--verbosity=warning',
-        'get',
-        '--no-precompile',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
+          'get',
+          '--no-precompile',
       ],
       exitCode: 69,
       environment: <String, String>{'FLUTTER_ROOT': '', 'PUB_ENVIRONMENT': 'flutter_cli:flutter_tests'},
@@ -591,8 +591,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -636,8 +636,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -677,8 +677,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -799,8 +799,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -840,8 +840,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -882,8 +882,8 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -894,16 +894,17 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '--no-analytics',
+          'pub',
           'get',
           '--no-precompile',
         ],
       ),
       FakeCommand(
         command: const <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],
@@ -914,8 +915,8 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
-          'bin/cache/dart-sdk/bin/pub',
-          '--verbosity=warning',
+          'bin/cache/dart-sdk/bin/dart',
+          '__deprecated_pub',
           'get',
           '--no-precompile',
         ],

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -53,6 +53,7 @@ void main() {
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -101,6 +102,7 @@ void main() {
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -149,6 +151,7 @@ void main() {
         const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ])
@@ -264,6 +267,7 @@ void main() {
       const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ])
@@ -303,6 +307,7 @@ void main() {
       const FakeCommand(command: <String>[
            'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ])
@@ -341,6 +346,7 @@ void main() {
       FakeCommand(command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ], onRun: () {
@@ -379,6 +385,7 @@ void main() {
       const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ]),
@@ -415,6 +422,7 @@ void main() {
       const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ])
@@ -454,6 +462,7 @@ void main() {
       const FakeCommand(command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ])
@@ -497,6 +506,7 @@ void main() {
       command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
       ],
@@ -593,6 +603,7 @@ void main() {
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -638,6 +649,7 @@ void main() {
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -679,6 +691,7 @@ void main() {
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -801,6 +814,7 @@ void main() {
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -842,6 +856,7 @@ void main() {
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -884,6 +899,7 @@ void main() {
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -895,8 +911,8 @@ void main() {
       const FakeCommand(
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
-          '--no-analytics',
-          'pub',
+          '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -905,6 +921,7 @@ void main() {
         command: const <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],
@@ -917,6 +934,7 @@ void main() {
         command: <String>[
           'bin/cache/dart-sdk/bin/dart',
           '__deprecated_pub',
+          '--verbosity=warning',
           'get',
           '--no-precompile',
         ],

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -61,6 +61,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -92,6 +93,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -100,6 +102,7 @@ void main() {
         ),
         FakeCommand(
           command: const <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -136,6 +139,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -162,6 +166,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -188,6 +193,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -196,6 +202,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'activate',
@@ -206,6 +213,7 @@ void main() {
         ),
         FakeCommand(
           command: const <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -235,6 +243,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -243,6 +252,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'activate',
@@ -253,6 +263,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -261,6 +272,7 @@ void main() {
         ),
         FakeCommand(
           command: const <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -290,6 +302,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -298,6 +311,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'activate',
@@ -308,6 +322,7 @@ void main() {
         ),
         FakeCommand(
           command: const <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -342,6 +357,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -350,6 +366,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -369,6 +386,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       const FakeCommand(
         command: <String>[
+          'dart',
           'pub',
           'global',
           'list',
@@ -377,6 +395,7 @@ void main() {
       ),
       const FakeCommand(
         command: <String>[
+          'dart',
           'pub',
           'global',
           'run',
@@ -415,6 +434,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -423,6 +443,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'activate',
@@ -434,6 +455,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -462,6 +484,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -470,6 +493,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'activate',
@@ -480,6 +504,7 @@ void main() {
         ),
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'run',
@@ -514,6 +539,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',
@@ -547,6 +573,7 @@ void main() {
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
+            'dart',
             'pub',
             'global',
             'list',

--- a/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
+++ b/packages/flutter_tools/test/general.shard/devtools_launcher_test.dart
@@ -46,7 +46,7 @@ void main() {
 
    testWithoutContext('DevtoolsLauncher does not launch devtools if unable to reach pub.dev and there is no activated package', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -77,7 +77,7 @@ void main() {
   testWithoutContext('DevtoolsLauncher launches devtools if unable to reach pub.dev but there is an activated package', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -119,7 +119,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher pings PUB_HOSTED_URL instead of pub.dev for online check', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: FakePlatform(environment: <String, String>{
@@ -151,7 +151,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher handles an invalid PUB_HOSTED_URL', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: FakePlatform(environment: <String, String>{
@@ -179,7 +179,7 @@ void main() {
   testWithoutContext('DevtoolsLauncher launches DevTools through pub and saves the URI', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -226,7 +226,7 @@ void main() {
   testWithoutContext('DevtoolsLauncher launches DevTools in browser', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -281,7 +281,7 @@ void main() {
   testWithoutContext('DevtoolsLauncher does not launch a new DevTools instance if one is already active', () async {
     final Completer<void> completer = Completer<void>();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -333,7 +333,7 @@ void main() {
   testWithoutContext('DevtoolsLauncher does not activate DevTools if it was recently activated', () async {
     persistentToolState.lastDevToolsActivation = DateTime.now();
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -389,7 +389,7 @@ void main() {
       ),
     ]);
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -406,7 +406,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher prints error if exception is thrown during activate', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -453,7 +453,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher prints error if exception is thrown during launch', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -499,7 +499,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher prints trace if connecting to pub.dev throws', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,
@@ -530,7 +530,7 @@ void main() {
 
   testWithoutContext('DevtoolsLauncher prints trace if connecting to pub.dev returns non-OK status code', () async {
     final DevtoolsLauncher launcher = DevtoolsServerLauncher(
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       fileSystem: fakefs,
       logger: logger,
       platform: platform,

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -111,7 +111,7 @@ void main() {
     final DevtoolsServerLauncher launcher = DevtoolsServerLauncher(
       processManager: FakeProcessManager.empty(),
       fileSystem: fakefs,
-      pubExecutable: 'pub',
+      dartExecutable: 'dart',
       logger: BufferLogger.test(),
       platform: FakePlatform(),
       persistentToolState: null,

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -508,9 +508,7 @@ void main() {
         logging: false,
       );
       expect(result.exitCode, 0);
-      // TODO(sigurdm): Remove the filter when
-      // https://github.com/flutter/flutter/pull/88792 is relanded.
-      expect(result.stdout.where((String line) => !line.startsWith('"The top level `pub.bat` command is deprecated.')), <Object>[
+      expect(result.stdout, <Object>[
         startsWith('Performing hot reload...'),
         '',
         '══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════',


### PR DESCRIPTION
This avoid the deprecation notice from the top level `pub` tool.

Fixes: https://github.com/flutter/flutter/issues/88507

Ideally we would shell out to `dart pub` but we want to take that step later.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
