### PR TITLE
Add flutter desktop build dependencies to test_misc shards

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -389,7 +389,10 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "goldctl"}
+          {"dependency": "goldctl"},
+          {"dependency": "clang"},
+          {"dependency": "cmake"},
+          {"dependency": "ninja"}
         ]
       shard: framework_tests
       subshard: misc
@@ -1882,7 +1885,8 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "goldctl"}
+          {"dependency": "goldctl"},
+          {"dependency": "xcode"}
         ]
       shard: framework_tests
       subshard: misc
@@ -3367,7 +3371,8 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "goldctl"}
+          {"dependency": "goldctl"},
+          {"dependency": "vs_build"}
         ]
       shard: framework_tests
       subshard: misc


### PR DESCRIPTION
## Description

This adds the dependencies necessary to build a desktop app to the test_misc shards so that example integration tests can be run.