### PR TITLE
Fix (Vertical)Divider samples & docs

### DIFF
--- a/examples/api/lib/material/divider/divider.0.dart
+++ b/examples/api/lib/material/divider/divider.0.dart
@@ -65,10 +65,11 @@ class MyStatelessWidget extends StatelessWidget {
             ),
           ),
           const Divider(
+            color: Colors.black,
             height: 20,
             thickness: 5,
             indent: 20,
-            endIndent: 20,
+            endIndent: 0,
           ),
           // Subheader example from Material spec.
           // https://material.io/components/dividers#types

--- a/examples/api/lib/material/divider/divider.0.dart
+++ b/examples/api/lib/material/divider/divider.0.dart
@@ -65,11 +65,11 @@ class MyStatelessWidget extends StatelessWidget {
             ),
           ),
           const Divider(
-            color: Colors.black,
             height: 20,
             thickness: 5,
             indent: 20,
             endIndent: 0,
+            color: Colors.black,
           ),
           // Subheader example from Material spec.
           // https://material.io/components/dividers#types

--- a/examples/api/lib/material/divider/vertical_divider.0.dart
+++ b/examples/api/lib/material/divider/vertical_divider.0.dart
@@ -64,11 +64,11 @@ class MyStatelessWidget extends StatelessWidget {
             ),
           ),
           const VerticalDivider(
-            color: Colors.grey,
             width: 20,
             thickness: 1,
             indent: 20,
             endIndent: 0,
+            color: Colors.grey,
           ),
           Expanded(
             child: Container(

--- a/examples/api/lib/material/divider/vertical_divider.0.dart
+++ b/examples/api/lib/material/divider/vertical_divider.0.dart
@@ -12,7 +12,7 @@
 //***************************************************************************
 //* ▼▼▼▼▼▼▼▼ description ▼▼▼▼▼▼▼▼ (do not modify or remove section marker)
 
-// This sample shows how to display a [VerticalDivider] between an purple and orange box
+// This sample shows how to display a [VerticalDivider] between a purple and orange box
 // inside a [Row]. The [VerticalDivider] is 20 logical pixels in width and contains a
 // horizontally centered black line that is 1 logical pixels thick. The grey
 // line is indented by 20 logical pixels.

--- a/examples/api/lib/material/divider/vertical_divider.0.dart
+++ b/examples/api/lib/material/divider/vertical_divider.0.dart
@@ -65,10 +65,10 @@ class MyStatelessWidget extends StatelessWidget {
           ),
           const VerticalDivider(
             color: Colors.grey,
+            width: 20,
             thickness: 1,
             indent: 20,
             endIndent: 0,
-            width: 20,
           ),
           Expanded(
             child: Container(

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -649,6 +649,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 ///
 /// ** See code in examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart **
 /// {@end-tool}
+///
 /// See also:
 ///
 ///  * [BottomSheet], which becomes the parent of the widget returned by the

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -37,6 +37,7 @@ import 'theme.dart';
 ///
 ///  * [PopupMenuDivider], which is the equivalent but for popup menus.
 ///  * [ListTile.divideTiles], another approach to dividing widgets in a list.
+///  * [VerticalDivider], which is the vertical analog of this widget.
 ///  * <https://material.io/design/components/dividers.html>
 class Divider extends StatelessWidget {
   /// Creates a material design divider.
@@ -186,7 +187,7 @@ class Divider extends StatelessWidget {
 /// padding is automatically computed from the width.
 ///
 /// {@tool dartpad --template=stateless_widget_scaffold}
-/// This sample shows how to display a [VerticalDivider] between an purple and orange box
+/// This sample shows how to display a [VerticalDivider] between a purple and orange box
 /// inside a [Row]. The [VerticalDivider] is 20 logical pixels in width and contains a
 /// horizontally centered black line that is 1 logical pixels thick. The grey
 /// line is indented by 20 logical pixels.
@@ -196,6 +197,7 @@ class Divider extends StatelessWidget {
 /// See also:
 ///
 ///  * [ListView.separated], which can be used to generate vertical dividers.
+///  * [Divider], which is the horizontal analog of this widget.
 ///  * <https://material.io/design/components/dividers.html>
 class VerticalDivider extends StatelessWidget {
   /// Creates a material design vertical divider.

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -33,6 +33,7 @@ import 'theme.dart';
 ///
 /// ** See code in examples/api/lib/material/divider/divider.0.dart **
 /// {@end-tool}
+///
 /// See also:
 ///
 ///  * [PopupMenuDivider], which is the equivalent but for popup menus.
@@ -194,6 +195,7 @@ class Divider extends StatelessWidget {
 ///
 /// ** See code in examples/api/lib/material/divider/vertical_divider.0.dart **
 /// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ListView.separated], which can be used to generate vertical dividers.

--- a/packages/flutter/lib/src/widgets/color_filter.dart
+++ b/packages/flutter/lib/src/widgets/color_filter.dart
@@ -24,7 +24,7 @@ import 'framework.dart';
 /// ** See code in examples/api/lib/widgets/color_filter/color_filtered.0.dart **
 ///{@end-tool}
 ///
-/// See Also:
+/// See also:
 ///
 ///  * [BlendMode], describes how to blend a source image with the destination image.
 ///  * [ColorFilter], which describes a function that modify a color to a different color.


### PR DESCRIPTION
Fixes the `Divider` sample to match the actual sample description. Also adjusts the `VerticalDivider` sample to match the order of arguments to the one used in `Divider` → they are both aligned now.  
The vertical divider sample description and code were already matching, so I did not adjust that.

Furthermore, adds links between to the two widgets in the "See also:" section.

Fixes #87848

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
