### PR TITLE
Add gems to framework_tests_misc Mac dependencies to get cocoapods

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1886,7 +1886,8 @@ targets:
       dependencies: >-
         [
           {"dependency": "goldctl"},
-          {"dependency": "xcode"}
+          {"dependency": "xcode"},
+          {"dependency": "gems"}
         ]
       shard: framework_tests
       subshard: misc


### PR DESCRIPTION
## Description

Adds gems to framework_tests_misc Mac dependencies to get cocoapods, since that is bundled in with the gems in the dependencies.
