### PR TITLE
Eliminate uses of pub executable in docs publishing and sample analysis.

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -5,13 +5,13 @@ dartdoc:
   # The dev/bots/docs.sh script does this automatically.
   tools:
     snippet:
-      command: ["bin/cache/dart-sdk/bin/pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=snippet"]
+      command: ["bin/cache/dart-sdk/bin/dart", "pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=snippet"]
       description: "Creates sample code documentation output from embedded documentation samples."
     sample:
-      command: ["bin/cache/dart-sdk/bin/pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=sample"]
+      command: ["bin/cache/dart-sdk/bin/dart", "pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=sample"]
       description: "Creates full application sample code documentation output from embedded documentation samples."
     dartpad:
-      command: ["bin/cache/dart-sdk/bin/pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=dartpad"]
+      command: ["bin/cache/dart-sdk/bin/dart", "pub", "global", "run", "snippets", "--output-directory=doc/snippets", "--type=dartpad"]
       description: "Creates full application sample code documentation output from embedded documentation samples and displays it in an embedded DartPad."
   errors:
     # Default errors of dartdoc:

--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -26,13 +26,6 @@ final String _defaultFlutterPackage = path.join(_flutterRoot, 'packages', 'flutt
 final String _defaultDartUiLocation = path.join(_flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui');
 final String _flutter = path.join(_flutterRoot, 'bin', Platform.isWindows ? 'flutter.bat' : 'flutter');
 
-/// Finds the location of the pub executable, with the assumption that it is
-/// in the same location as the Dart executable used to run this script.
-String get _pubExecutable {
-  final File dartExecutable = File(Platform.resolvedExecutable);
-  return path.join(path.dirname(dartExecutable.absolute.path), Platform.isWindows ? 'pub.exe' : 'pub');
-}
-
 Future<void> main(List<String> arguments) async {
   final ArgParser argParser = ArgParser();
   argParser.addOption(
@@ -129,8 +122,9 @@ Future<void> main(List<String> arguments) async {
   if (parsedArguments['global-activate-snippets']! as bool) {
     try {
       Process.runSync(
-        _pubExecutable,
+        Platform.resolvedExecutable,
         <String>[
+          'pub',
           'global',
           'activate',
           'snippets',
@@ -449,8 +443,9 @@ class SampleChecker {
       _flutterVersion = versionResult.stdout as String? ?? '';
     }
     return Process.run(
-      _pubExecutable,
+      Platform.resolvedExecutable,
       <String>[
+        'pub',
         'global',
         'run',
         'snippets',

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,18 +20,18 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$PUB" global activate dartdoc 2.0.0
+    "$DART" pub global activate dartdoc 2.0.0
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:
     # https://github.com/flutter/assets-for-api-docs/tree/master/packages/snippets
     # >>> If you update this version, also update it in dev/bots/analyze_sample_code.dart <<<
-    "$PUB" global activate snippets 0.2.3
+    "$DART" pub global activate snippets 0.2.3
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.
     (cd "$FLUTTER_ROOT/dev/tools" && "$FLUTTER" pub get)
-    (cd "$FLUTTER_ROOT/dev/tools" && "$PUB" get)
+    (cd "$FLUTTER_ROOT/dev/tools" && "$DART" pub get)
     (cd "$FLUTTER_ROOT" && "$DART" --disable-dart-dev --enable-asserts "$FLUTTER_ROOT/dev/tools/dartdoc.dart")
     (cd "$FLUTTER_ROOT" && "$DART" --disable-dart-dev --enable-asserts "$FLUTTER_ROOT/dev/tools/java_and_objc_doc.dart")
 }
@@ -128,7 +128,6 @@ FLUTTER_BIN="$FLUTTER_ROOT/bin"
 DART_BIN="$FLUTTER_ROOT/bin/cache/dart-sdk/bin"
 FLUTTER="$FLUTTER_BIN/flutter"
 DART="$DART_BIN/dart"
-PUB="$DART_BIN/pub"
 export PATH="$FLUTTER_BIN:$DART_BIN:$PATH"
 
 # Make sure dart is installed by invoking Flutter to download it.


### PR DESCRIPTION
## Description

This change eliminates the use of the pub executable and instead uses `dart pub` for sample analysis and document generation.

## Tests

 - No tests were harmed in the creating of this PR.