### PR TITLE
[WillPopScope] handle new route if moved from one navigator to another

### DIFF
--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -85,7 +85,6 @@ class _WillPopScopeState extends State<WillPopScope> {
   @override
   void didUpdateWidget(WillPopScope oldWidget) {
     super.didUpdateWidget(oldWidget);
-    assert(_route == ModalRoute.of(context));
     if (widget.onWillPop != oldWidget.onWillPop && _route != null) {
       if (oldWidget.onWillPop != null)
         _route!.removeScopedWillPopCallback(oldWidget.onWillPop!);

--- a/packages/flutter/test/material/will_pop_test.dart
+++ b/packages/flutter/test/material/will_pop_test.dart
@@ -65,13 +65,35 @@ class SampleForm extends StatelessWidget {
 }
 
 // Expose the protected hasScopedWillPopCallback getter
-class TestPageRoute<T> extends MaterialPageRoute<T> {
-  TestPageRoute({ required WidgetBuilder builder })
-    : super(builder: builder, maintainState: true);
+class _TestPageRoute<T> extends MaterialPageRoute<T> {
+  _TestPageRoute({
+    RouteSettings? settings,
+    required WidgetBuilder builder,
+  }) : super(builder: builder, maintainState: true, settings: settings);
 
   bool get hasCallback => super.hasScopedWillPopCallback;
 }
 
+class _TestPage extends Page<dynamic> {
+  _TestPage({
+    required this.builder,
+    required LocalKey key,
+  })  : _key = GlobalKey(),
+        super(key: key);
+
+  final WidgetBuilder builder;
+  final GlobalKey<dynamic> _key;
+
+  @override
+  Route<dynamic> createRoute(BuildContext context) {
+    return _TestPageRoute<dynamic>(
+        settings: this,
+        builder: (BuildContext context) {
+          // keep state during move to another location in tree
+          return KeyedSubtree(key: _key, child: builder.call(context));
+        });
+  }
+}
 
 void main() {
   testWidgets('ModalRoute scopedWillPopupCallback can inhibit back button', (WidgetTester tester) async {
@@ -318,7 +340,7 @@ void main() {
     late StateSetter contentsSetState; // call this to rebuild the route's SampleForm contents
     bool contentsEmpty = false; // when true, don't include the SampleForm in the route
 
-    final TestPageRoute<void> route = TestPageRoute<void>(
+    final _TestPageRoute<void> route = _TestPageRoute<void>(
       builder: (BuildContext context) {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
@@ -372,5 +394,62 @@ void main() {
     await tester.pump();
 
     expect(route.hasCallback, isFalse);
+  });
+
+  testWidgets('should handle new route if page moved from one navigator to another', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/89133
+    late StateSetter contentsSetState;
+    bool moveToAnotherNavigator = false;
+
+    final List<Page<dynamic>> pages = <Page<dynamic>>[
+      _TestPage(
+        key: UniqueKey(),
+        builder: (BuildContext context) {
+          return WillPopScope(
+            onWillPop: () async => true,
+            child: const Text('anchor'),
+          );
+        },
+      )
+    ];
+
+    Widget _buildNavigator(Key? key, List<Page<dynamic>> pages) {
+      return Navigator(
+        key: key,
+        pages: pages,
+        onPopPage: (Route<dynamic> route, dynamic result) {
+          return route.didPop(result);
+        },
+      );
+    }
+
+    Widget buildFrame() {
+      return MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              contentsSetState = setState;
+              if (moveToAnotherNavigator) {
+                return _buildNavigator(const ValueKey<int>(1), pages);
+              }
+              return _buildNavigator(const ValueKey<int>(2), pages);
+            },
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    await tester.pump();
+    final _TestPageRoute<dynamic> route1 = ModalRoute.of(tester.element(find.text('anchor')))! as _TestPageRoute<dynamic>;
+    expect(route1.hasCallback, isTrue);
+    moveToAnotherNavigator = true;
+    contentsSetState(() {});
+
+    await tester.pump();
+    final _TestPageRoute<dynamic> route2 = ModalRoute.of(tester.element(find.text('anchor')))! as _TestPageRoute<dynamic>;
+
+    expect(route1.hasCallback, isFalse);
+    expect(route2.hasCallback, isTrue);
   });
 }


### PR DESCRIPTION
fixed https://github.com/flutter/flutter/issues/89133

Navigator 2 allow access to pages stack and we can change it as wish. for example we can move pages to another location in tree, my case it is responsible ui, witch adaptive for large and small screens. but WillPopScope keep reference for route and not handle new location in tree. it is pr fixed it

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
