### PR TITLE
Add `deferred components` LUCI test and configure to use `android_virtual_device` dep

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1699,7 +1699,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "android_avd", "version": "31"}
+          {"dependency": "android_avd", "version": "31"},
           {"dependency": "curl"}
         ]
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1684,7 +1684,23 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk"}
+          {"dependency": "android_sdk"},
+          {"dependency": "android_avd", "version": "31"}
+        ]
+      tags: >
+        ["framework","hostonly"]
+    timeout: 60
+    scheduler: luci
+
+  - name: Linux deferred components
+    recipe: flutter/deferred_components
+    bringup: true
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk"},
+          {"dependency": "android_avd", "version": "31"}
+          {"dependency": "curl"}
         ]
       tags: >
         ["framework","hostonly"]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1685,7 +1685,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "android_avd", "version": "31"}
+          {"dependency": "android_virtual_device", "version": "31"}
         ]
       tags: >
         ["framework","hostonly"]
@@ -1699,7 +1699,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "android_avd", "version": "31"},
+          {"dependency": "android_virtual_device", "version": "31"},
           {"dependency": "curl"}
         ]
       tags: >

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -201,6 +201,7 @@
 /examples/hello_world/test_driver/smoke_web_engine.dart @yjbanov @flutter/web
 # Linux android views
 /dev/integration_tests/android_views @garyqian @flutter/android
+/dev/integration_tests/deferred_components_test @garyqian @flutter/android
 
 ## Firebase tests
 /dev/integration_tests/abstract_method_smoke_test @blasten @flutter/android

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -201,6 +201,7 @@
 /examples/hello_world/test_driver/smoke_web_engine.dart @yjbanov @flutter/web
 # Linux android views
 /dev/integration_tests/android_views @garyqian @flutter/android
+# Linux deferred components
 /dev/integration_tests/deferred_components_test @garyqian @flutter/android
 
 ## Firebase tests


### PR DESCRIPTION
This PR adds the `android_avd` dependency introduced in https://flutter-review.googlesource.com/c/recipes/+/17280 to `Linux android views` and adds `Linux deferred components`.

This needs to land after the recipes CL is landed to keep Linux android views green.

Pending approval of the recipes CL

Related engine-side PR: https://github.com/flutter/engine/pull/28411