### PR TITLE
Switch to Debian bullseye, update nodejs to npm package, add flutter desktop run dependencies

### DIFF
--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -15,8 +15,8 @@
 FROM debian:bullseye
 MAINTAINER Flutter Developers <flutter-dev@googlegroups.com>
 
-RUN apt-get update -y
-RUN apt-get upgrade -y
+RUN apt-get update -y && \
+  apt-get upgrade -y
 
 # Install basics
 RUN apt-get install -y --no-install-recommends \
@@ -64,9 +64,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   nodejs \
   npm \
   ruby \
-  ruby-dev
+  ruby-dev && \
+  apt-get clean
 
-RUN apt-get upgrade -y --no-install-recommends
 ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64"
 
 # Install the Android SDK Dependency.
@@ -131,7 +131,9 @@ RUN apt-get install -y --no-install-recommends \
   cmake \
   libgtk-3-dev \
   ninja-build \
-  pkg-config
+  pkg-config && \
+  apt-get upgrade -y --no-install-recommends && \
+  apt-get clean
 
 RUN bundle config set system 'true' && \
   bundle install --system

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -10,11 +10,9 @@
 # for performing pushes to production, and so this image is quite a bit larger
 # than strictly needed for just building Flutter apps.
 
-# Last manual update 2020-10-05 (changing this comment will re-build image)
+# Last manual update 2021-09-01 (changing this comment will re-build image)
 
-# Note: updating past stretch (Debian 9) will bump Java past version 8,
-# which will break the Android SDK.
-FROM debian:stretch
+FROM debian:bullseye
 MAINTAINER Flutter Developers <flutter-dev@googlegroups.com>
 
 RUN apt-get update -y
@@ -33,7 +31,8 @@ RUN apt-get install -y --no-install-recommends \
 
 # Add repo for chrome stable
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | \
+    tee /etc/apt/sources.list.d/google-chrome.list
 
 # Add repo for gcloud sdk and install it
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
@@ -46,25 +45,29 @@ RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
 
-# Add nodejs repository to apt sources and install it.
-ENV NODEJS_INSTALL="/opt/nodejs_install"
-RUN mkdir -p "${NODEJS_INSTALL}"
-RUN wget -q https://deb.nodesource.com/setup_10.x -O "${NODEJS_INSTALL}/nodejs_install.sh"
-RUN bash "${NODEJS_INSTALL}/nodejs_install.sh"
+# Add repo for OpenJDK 8 from JFrog.io
+RUN wget -q -O - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN echo 'deb [arch=amd64] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb bullseye main' | \
+    tee /etc/apt/sources.list.d/adoptopenjdk.list
 
-# Install the rest of the dependencies.
-RUN apt-get install -y --no-install-recommends \
-  locales \
-  gcc \
-  ruby \
-  ruby-dev \
-  nodejs \
-  lib32stdc++6 \
-  libstdc++6 \
-  libglu1-mesa \
+# Install the dependencies needed for the rest of the build.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  adoptopenjdk-8-hotspot \
   build-essential \
   default-jdk-headless \
-  google-chrome-stable
+  gcc \
+  google-chrome-stable \
+  lib32stdc++6 \
+  libglu1-mesa \
+  libstdc++6 \
+  locales \
+  nodejs \
+  npm \
+  ruby \
+  ruby-dev
+
+RUN apt-get upgrade -y --no-install-recommends
+ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64"
 
 # Install the Android SDK Dependency.
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
@@ -121,6 +124,14 @@ RUN gem install bundler -N
 # Gemfile last edited 1/6/2019 (update to trigger a rebuild of Docker image)
 COPY ci/docker_linux/Gemfile /Gemfile
 COPY ci/docker_linux/Gemfile.lock /Gemfile.lock
+
+# Install dependencies for desktop flutter run
+RUN apt-get install -y --no-install-recommends \
+  clang \
+  cmake \
+  libgtk-3-dev \
+  ninja-build \
+  pkg-config
 
 RUN bundle config set system 'true' && \
   bundle install --system


### PR DESCRIPTION
## Description

This PR updates the Dockerfile for Cirrus builds:

- Switch to a newer stable Debian build (bullseye instead of stretch)
- Eliminates the very old (10) nodejs install in favor of the npm package
- Installs OpenJDK so that Android SDK manager can run on bullseye
- Installs the prerequisites for Linux desktop `flutter run`.

The motivation for this change was to include the dependencies for Linux desktop flutter run so that I can run tests that use desktop Flutter apps, but that needs cmake 3.10 or later, and stretch doesn't have a cmake that new. Of course, there's also no openjdk-8-jre for bullseye, so I used OpenJDK from JFrog instead.

## Related Issues
 - https://github.com/flutter/flutter/issues/89323
