### PR TITLE
Increase test timeout for FlutterUITests

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -4,6 +4,8 @@
 
 @import XCTest;
 
+static const CGFloat kStandardTimeout = 120.0;
+
 @interface FlutterUITests : XCTestCase
 @property (strong) XCUIApplication *app;
 @end
@@ -22,42 +24,42 @@
 - (void)testFullScreenColdPop {
     XCUIApplication *app = self.app;
     [self waitForAndTapElement:app.buttons[@"Full Screen (Cold)"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:kStandardTimeout]);
 }
 
 - (void)testFullScreenWarm {
     XCUIApplication *app = self.app;
 
     [self waitForAndTapElement:app.buttons[@"Full Screen (Warm)"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:kStandardTimeout]);
 }
 
 - (void)testFlutterViewWarm {
     XCUIApplication *app = self.app;
 
     [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
-    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeout]);
 
     // Back navigation.
     [app.buttons[@"POP"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:kStandardTimeout]);
 }
 
 - (void)testHybridViewWarm {
@@ -65,20 +67,20 @@
 
     [self waitForAndTapElement:app.buttons[@"Hybrid View (Warm)"]];
 
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeout]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
     [self waitForAndTapElement:app.otherElements[@"Increment via Flutter"]];
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeout]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 0 times."].exists);
 
     [app.buttons[@"Increment via iOS"] tap];
-    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.staticTexts[@"Flutter button tapped 1 time."] waitForExistenceWithTimeout:kStandardTimeout]);
     XCTAssertTrue(app.staticTexts[@"Platform button tapped 1 time."].exists);
 
     // Back navigation.
     [app.navigationBars[@"Hybrid Flutter/Native"].buttons[@"Flutter iOS Demos Home"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:kStandardTimeout]);
 }
 
 - (void)testDualCold {
@@ -89,17 +91,17 @@
     // There are two marquees.
     XCUIElementQuery *marqueeQuery = [app.staticTexts matchingIdentifier:@"This is Marquee"];
     [self expectationForPredicate:[NSPredicate predicateWithFormat:@"count = 2"] evaluatedWithObject:marqueeQuery handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [self waitForExpectationsWithTimeout:kStandardTimeout handler:nil];
 
     // Back navigation.
     [app.navigationBars[@"Dual Flutter Views"].buttons[@"Flutter iOS Demos Home"] tap];
-    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([app.navigationBars[@"Flutter iOS Demos Home"] waitForExistenceWithTimeout:kStandardTimeout]);
 }
 
 - (void)waitForAndTapElement:(XCUIElement *)element {
     NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     [self expectationForPredicate:hittable evaluatedWithObject:element handler:nil];
-    [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    [self waitForExpectationsWithTimeout:kStandardTimeout handler:nil];
     [element tap];
 }
 


### PR DESCRIPTION
There has been some timeout happening, which made the test suite flaky. Increase the time-out threshold to make it less likely to happen. 

Also adding some debug log to log app information in case a timeout to help easier debugging.

See: https://github.com/flutter/flutter/issues/89175

potentially fixes https://github.com/flutter/flutter/issues/89175. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
