### PR TITLE
Use rootOverlay for CupertinoContextMenu

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -354,7 +354,7 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
         );
       },
     );
-    Overlay.of(context)!.insert(_lastOverlayEntry!);
+    Overlay.of(context, rootOverlay: true)!.insert(_lastOverlayEntry!);
     _openController.forward();
   }
 

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -122,6 +122,72 @@ void main() {
       await tester.pumpAndSettle();
       expect(_findStatic(), findsOneWidget);
     });
+
+    testWidgets('CupertinoContextMenu is in the correct position when within a nested navigator', (WidgetTester tester) async {
+      final Widget child = _getChild();
+      await tester.pumpWidget(CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 600)),
+            child: Align(
+              alignment: Alignment.bottomRight,
+              child: SizedBox(
+                width: 700,
+                height: 500,
+                child: Navigator(
+                  onGenerateRoute: (RouteSettings settings) {
+                    return CupertinoPageRoute<void>(
+                      builder: (BuildContext context) => Align(
+                        alignment: Alignment.center,
+                        child: CupertinoContextMenu(
+                          actions: const <CupertinoContextMenuAction>[
+                            CupertinoContextMenuAction(
+                              child: Text('CupertinoContextMenuAction'),
+                            ),
+                          ],
+                          child: child
+                        ),
+                      )
+                    );
+                  }
+                )
+              )
+            )
+          )
+        )
+      ));
+      expect(find.byWidget(child), findsOneWidget);
+      final Rect childRect = tester.getRect(find.byWidget(child));
+      expect(find.byType(ShaderMask), findsNothing);
+
+      // Start a press on the child.
+      final TestGesture gesture = await tester.startGesture(childRect.center);
+      await tester.pump();
+
+      // The _DecoyChild is showing directly on top of the child.
+      expect(_findDecoyChild(child), findsOneWidget);
+      Rect decoyChildRect = tester.getRect(_findDecoyChild(child));
+      expect(childRect, equals(decoyChildRect));
+
+      expect(find.byType(ShaderMask), findsOneWidget);
+
+      // After a small delay, the _DecoyChild has begun to animate.
+      await tester.pump(const Duration(milliseconds: 100));
+      decoyChildRect = tester.getRect(_findDecoyChild(child));
+      expect(childRect, isNot(equals(decoyChildRect)));
+
+      // Eventually the decoy fully scales by _kOpenSize.
+      await tester.pump(const Duration(milliseconds: 500));
+      decoyChildRect = tester.getRect(_findDecoyChild(child));
+      expect(childRect, isNot(equals(decoyChildRect)));
+      expect(decoyChildRect.width, childRect.width * _kOpenScale);
+
+      // Then the CupertinoContextMenu opens.
+      await tester.pumpAndSettle();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(_findStatic(), findsOneWidget);
+    });
   });
 
   group('CupertinoContextMenu when open', () {


### PR DESCRIPTION
When CupertinoContextMenu was used within an Overlay (usually created by Navigator) that wasn't aligned with the top-left of the screen, the child widget appeared in the wrong position while the context menu was opening. CupertinoContextMenu already uses the root Navigator, it should also use root Overlay so that the animating child is in the right position. 

Fixes #72121

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
