### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/dev/tools/gen_keycodes/README.md
+++ b/dev/tools/gen_keycodes/README.md
@@ -124,7 +124,7 @@ The planes are planned as follows:
   breaking change. Therefore, when handling an unrecognized key on a platform
   managed by Flutter, it is recommended to file a new issue to add this value
   to `keyboard_key.dart` instead of using the platform-plane value. However,
-  for a custom platform (see below), since the platfrom author has full control
+  for a custom platform (see below), since the platform author has full control
   over key mapping, such change will not cause breakage and it is recommended
   to use the platform-plane value to avoid adding platform-exclusive values
   to the framework.


### PR DESCRIPTION
fix a typo in dev/tools/gen_keycodes/README.md, platfrom >> platform

*not included because minor fixing which fixing typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
