### PR TITLE
Reduce required Windows CMake version to 3.14

### DIFF
--- a/dev/integration_tests/flutter_gallery/windows/CMakeLists.txt
+++ b/dev/integration_tests/flutter_gallery/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(flutter_gallery LANGUAGES CXX)
 
 set(BINARY_NAME "flutter_gallery")

--- a/dev/integration_tests/flutter_gallery/windows/flutter/CMakeLists.txt
+++ b/dev/integration_tests/flutter_gallery/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 

--- a/dev/integration_tests/flutter_gallery/windows/runner/CMakeLists.txt
+++ b/dev/integration_tests/flutter_gallery/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(runner LANGUAGES CXX)
 
 add_executable(${BINARY_NAME} WIN32

--- a/dev/manual_tests/windows/CMakeLists.txt
+++ b/dev/manual_tests/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(manual_tests LANGUAGES CXX)
 
 set(BINARY_NAME "manual_tests")

--- a/dev/manual_tests/windows/flutter/CMakeLists.txt
+++ b/dev/manual_tests/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 

--- a/dev/manual_tests/windows/runner/CMakeLists.txt
+++ b/dev/manual_tests/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(runner LANGUAGES CXX)
 
 add_executable(${BINARY_NAME} WIN32

--- a/examples/api/windows/CMakeLists.txt
+++ b/examples/api/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(dartpad_curve2_d_0 LANGUAGES CXX)
 
 set(BINARY_NAME "dartpad_curve2_d_0")

--- a/examples/api/windows/flutter/CMakeLists.txt
+++ b/examples/api/windows/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 

--- a/examples/api/windows/runner/CMakeLists.txt
+++ b/examples/api/windows/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(runner LANGUAGES CXX)
 
 add_executable(${BINARY_NAME} WIN32

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -22,7 +22,7 @@ import '../migrations/cmake_custom_command_migration.dart';
 import 'install_manifest.dart';
 import 'visual_studio.dart';
 
-// From https://cmake.org/cmake/help/v3.15/manual/cmake-generators.7.html#visual-studio-generators
+// From https://cmake.org/cmake/help/v3.14/manual/cmake-generators.7.html#visual-studio-generators
 // This may need to become a getter on VisualStudio in the future to support
 // future major versions of Visual Studio.
 const String _cmakeVisualStudioGeneratorIdentifier = 'Visual Studio 16 2019';

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/CMakeLists.txt.tmpl
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project({{projectName}} LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/flutter/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/CMakeLists.txt
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 project(runner LANGUAGES CXX)
 
 add_executable(${BINARY_NAME} WIN32

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/CMakeLists.txt.tmpl
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.14)
 set(PROJECT_NAME "{{projectName}}")
 project(${PROJECT_NAME} LANGUAGES CXX)
 


### PR DESCRIPTION
When we landed the CMake minimum requirement constraint for Visual
Studio 2019, we landed it with minimum version 3.15, since that's what
was shipping with the current version of VS 2019 at the time. Looking at
the release notes of earlier versions, it's clear that earlier versions
of Visual Studio 2019 shipped with version 3.14. See:
https://devblogs.microsoft.com/cppblog/visual-studio-cmake-support-clang-llvm-cmake-3-14-vcpkg-and-performance-improvements/

Looking at release notes for CMake 3.15, there are no features/fixes
introduced in that version that we are dependent on.
https://cmake.org/cmake/help/latest/release/3.15.html

Issue: https://github.com/flutter/flutter/issues/88589

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
