### PR TITLE
removed `protected` from ValueNotifiers notifyListeners

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -281,7 +281,6 @@ class ChangeNotifier implements Listenable {
   /// Surprising behavior can result when reentrantly removing a listener (e.g.
   /// in response to a notification) that has been registered multiple times.
   /// See the discussion at [removeListener].
-  @visibleForTesting
   @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {
     assert(_debugAssertNotDisposed());

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -281,7 +281,6 @@ class ChangeNotifier implements Listenable {
   /// Surprising behavior can result when reentrantly removing a listener (e.g.
   /// in response to a notification) that has been registered multiple times.
   /// See the discussion at [removeListener].
-  @protected
   @visibleForTesting
   @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {


### PR DESCRIPTION
Removes the `protected` annotation from `ChangeNotifier` `notifyListeners` to expose it for use without triggering IDE warnings. 

fixes problems discussed in https://github.com/flutter/flutter/issues/29958 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

