### PR TITLE
Fixed order dependency and removed no-shuffle tag in flutter_driver_test

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -25,9 +25,9 @@ class VMServiceFlutterDriver extends FlutterDriver {
       bool logCommunicationToFile = true,
     }) : _printCommunication = printCommunication,
       _logCommunicationToFile = logCommunicationToFile,
-      _driverId = _nextDriverId++ 
+      _driverId = _nextDriverId++
     {
-      _logFilePathName = p.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log');        
+      _logFilePathName = p.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log');
     }
 
   /// Connects to a Flutter application.

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -25,7 +25,10 @@ class VMServiceFlutterDriver extends FlutterDriver {
       bool logCommunicationToFile = true,
     }) : _printCommunication = printCommunication,
       _logCommunicationToFile = logCommunicationToFile,
-      _driverId = _nextDriverId++;
+      _driverId = _nextDriverId++ 
+    {
+      _logFilePathName = p.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log');        
+    }
 
   /// Connects to a Flutter application.
   ///
@@ -287,6 +290,12 @@ class VMServiceFlutterDriver extends FlutterDriver {
   /// Whether to log communication between host and app to `flutter_driver_commands.log`.
   final bool _logCommunicationToFile;
 
+  /// Logs are written here if _logCommunicationToFile is true.
+  late final String _logFilePathName;
+
+  /// Getter for file pathname where logs are written if _logCommunicationToFile is true.
+  String get logFilePathName => _logFilePathName;
+
 
   @override
   Future<Map<String, dynamic>> sendCommand(Command command) async {
@@ -321,7 +330,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
     if (_printCommunication)
       _log(message);
     if (_logCommunicationToFile) {
-      final f.File file = fs.file(p.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log'));
+      final f.File file = fs.file(_logFilePathName);
       file.createSync(recursive: true); // no-op if file exists
       file.writeAsStringSync('${DateTime.now()} $message\n', mode: f.FileMode.append, flush: true);
     }

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -290,10 +290,10 @@ class VMServiceFlutterDriver extends FlutterDriver {
   /// Whether to log communication between host and app to `flutter_driver_commands.log`.
   final bool _logCommunicationToFile;
 
-  /// Logs are written here if _logCommunicationToFile is true.
+  /// Logs are written here when _logCommunicationToFile is true.
   late final String _logFilePathName;
 
-  /// Getter for file pathname where logs are written if _logCommunicationToFile is true.
+  /// Getter for file pathname where logs are written when _logCommunicationToFile is true.
   String get logFilePathName => _logFilePathName;
 
 
@@ -330,6 +330,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
     if (_printCommunication)
       _log(message);
     if (_logCommunicationToFile) {
+      assert(_logFilePathName != null);
       final f.File file = fs.file(_logFilePathName);
       file.createSync(recursive: true); // no-op if file exists
       file.writeAsStringSync('${DateTime.now()} $message\n', mode: f.FileMode.append, flush: true);

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -67,10 +67,10 @@ class WebFlutterDriver extends FlutterDriver {
   /// Whether to log communication between host and app to `flutter_driver_commands.log`.
   final bool _logCommunicationToFile;
 
-  /// Logs are written here if _logCommunicationToFile is true.
+  /// Logs are written here when _logCommunicationToFile is true.
   late final String _logFilePathName;
 
-  /// Getter for file pathname where logs are written if _logCommunicationToFile is true
+  /// Getter for file pathname where logs are written when _logCommunicationToFile is true
   String get logFilePathName => _logFilePathName;
 
   /// Creates a driver that uses a connection provided by the given
@@ -138,6 +138,7 @@ class WebFlutterDriver extends FlutterDriver {
       driverLog('WebFlutterDriver', message);
     }
     if (_logCommunicationToFile) {
+      assert(_logFilePathName != null);
       final File file = fs.file(_logFilePathName);
       file.createSync(recursive: true); // no-op if file exists
       file.writeAsStringSync('${DateTime.now()} $message\n', mode: FileMode.append, flush: true);

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -35,7 +35,11 @@ class WebFlutterDriver extends FlutterDriver {
   })  : _printCommunication = printCommunication,
         _logCommunicationToFile = logCommunicationToFile,
         _startTime = DateTime.now(),
-        _driverId = _nextDriverId++;
+        _driverId = _nextDriverId++ 
+    {
+      _logFilePathName = path.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log');
+    }
+
 
   final FlutterWebConnection _connection;
   DateTime _startTime;
@@ -62,6 +66,12 @@ class WebFlutterDriver extends FlutterDriver {
 
   /// Whether to log communication between host and app to `flutter_driver_commands.log`.
   final bool _logCommunicationToFile;
+
+  /// Logs are written here if _logCommunicationToFile is true.
+  late final String _logFilePathName;
+
+  /// Getter for file pathname where logs are written if _logCommunicationToFile is true
+  String get logFilePathName => _logFilePathName;
 
   /// Creates a driver that uses a connection provided by the given
   /// [hostUrl] which would fallback to environment variable VM_SERVICE_URL.
@@ -128,7 +138,7 @@ class WebFlutterDriver extends FlutterDriver {
       driverLog('WebFlutterDriver', message);
     }
     if (_logCommunicationToFile) {
-      final File file = fs.file(path.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log'));
+      final File file = fs.file(_logFilePathName);
       file.createSync(recursive: true); // no-op if file exists
       file.writeAsStringSync('${DateTime.now()} $message\n', mode: FileMode.append, flush: true);
     }

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -35,7 +35,7 @@ class WebFlutterDriver extends FlutterDriver {
   })  : _printCommunication = printCommunication,
         _logCommunicationToFile = logCommunicationToFile,
         _startTime = DateTime.now(),
-        _driverId = _nextDriverId++ 
+        _driverId = _nextDriverId++
     {
       _logFilePathName = path.join(testOutputsDirectory, 'flutter_driver_commands_$_driverId.log');
     }

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -83,7 +83,8 @@ void main() {
 
       test('logFilePathName was set when a new driver was created', () {
         driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate, logCommunicationToFile: true);
-        expect(driver.logFilePathName, endsWith('.log'));
+        logFile = File(driver.logFilePathName);
+        expect(logFile.path, endsWith('.log'));
       });
     });
   });

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=20210721"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -17,10 +11,8 @@ import 'package:flutter_driver/src/common/error.dart';
 import 'package:flutter_driver/src/common/health.dart';
 import 'package:flutter_driver/src/common/layer_tree.dart';
 import 'package:flutter_driver/src/common/wait.dart';
-import 'package:flutter_driver/src/driver/common.dart';
 import 'package:flutter_driver/src/driver/driver.dart';
 import 'package:flutter_driver/src/driver/timeline.dart';
-import 'package:path/path.dart' as path;
 import 'package:vm_service/vm_service.dart' as vms;
 
 import '../../common.dart';
@@ -44,15 +36,12 @@ void main() {
     late FakeIsolate fakeIsolate;
     late VMServiceFlutterDriver driver;
     late File logFile;
-    int driverId = -1;
 
     setUp(() {
       fakeIsolate = FakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       fakeClient.responses['waitFor'] = makeFakeResponse(<String, dynamic>{'status':'ok'});
-      driverId += 1;
-      logFile = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
     });
 
     tearDown(() {
@@ -64,6 +53,7 @@ void main() {
     group('logCommunicationToFile', () {
       test('logCommunicationToFile = true', () async {
         driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate);
+        logFile = File(driver.logFilePathName);
 
         await driver.waitFor(find.byTooltip('foo'), timeout: _kTestTimeout);
 
@@ -80,7 +70,11 @@ void main() {
 
       test('logCommunicationToFile = false', () async {
         driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate, logCommunicationToFile: false);
-
+        logFile = File(driver.logFilePathName);
+        // clear log file if left in filetree from previous run
+        if (logFile.existsSync()) {
+          logFile.deleteSync();
+        }
         await driver.waitFor(find.byTooltip('foo'), timeout: _kTestTimeout);
 
         final bool exists = logFile.existsSync();
@@ -720,14 +714,11 @@ void main() {
     late FakeFlutterWebConnection fakeConnection;
     late WebFlutterDriver driver;
     late File logFile;
-    int driverId = -1;
 
     setUp(() {
       fakeConnection = FakeFlutterWebConnection();
       fakeConnection.supportsTimelineAction = true;
       fakeConnection.responses['waitFor'] = jsonEncode(makeFakeResponse(<String, dynamic>{'status': 'ok'}));
-      driverId += 1;
-      logFile = File(path.join(testOutputsDirectory, 'flutter_driver_commands_$driverId.log'));
     });
 
     tearDown(() {
@@ -738,6 +729,7 @@ void main() {
 
     test('logCommunicationToFile = true', () async {
       driver = WebFlutterDriver.connectedTo(fakeConnection);
+      logFile = File(driver.logFilePathName);
       await driver.waitFor(find.byTooltip('logCommunicationToFile test'), timeout: _kTestTimeout);
 
       final bool exists = logFile.existsSync();
@@ -753,6 +745,11 @@ void main() {
 
     test('logCommunicationToFile = false', () async {
       driver = WebFlutterDriver.connectedTo(fakeConnection, logCommunicationToFile: false);
+      logFile = File(driver.logFilePathName);
+      // clear log file if left in filetree from previous run
+      if (logFile.existsSync()) {
+        logFile.deleteSync();
+      }
       await driver.waitFor(find.byTooltip('logCommunicationToFile test'), timeout: _kTestTimeout);
       final bool exists = logFile.existsSync();
       expect(exists, false, reason: 'because ${logFile.path} exists');

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -80,6 +80,11 @@ void main() {
         final bool exists = logFile.existsSync();
         expect(exists, false, reason: 'because ${logFile.path} exists');
       });
+
+      test('logFilePathName was set when a new driver was created', () {
+        driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate, logCommunicationToFile: true);
+        expect(driver.logFilePathName, endsWith('.log'));
+      });
     });
   });
 


### PR DESCRIPTION
This PR fixed the problem that prevented flutter_driver_test.dart being shuffled. Part of #85160.

## The Problem
When testing if a log file was created there was unpredictable results when shuffling. Either a log file exists when it should not exist, or it does not exist when it should exist.

This happened because the test was looking for the wrong filename. Either the file existed because it had been created by another test, or it did not exist at all.

The logfile pathname is based upon the driverId inside VMServiceFlutterDriver and WebFlutterDriver respectively. The driverId is an int that starts att 0 and is incremented by 1 each time a new driver is created. In the test we could not know what driverId was for the driver we were testing as the property is private and no public getter exists. 

When the tests are running in a certain order we can predict the driverId by starting at 0 and incrementing by 1. But we cannot predict the driverId when the tests are being shuffled. We therefore cannot know what the log file pathname is, that we are testing.

This test cannot be fixed in a good way without improving the testability of VMServiceFlutterDriver and WebFlutterDriver classes.

## The Fix
Improve testability of VMServiceFlutterDriver and WebFlutterDriver classes.

Two possible solutions:
	• Exposing driverId by public getter.
	• Exposing log file pathname by public getter.

I chose the latter as the logic for constructing pathname is a concern for the VMServiceFlutterDriver and WebFlutterDriver classes.
And the test will not break if the path is changed.

### Summary
The fix is to expose the log file pathname by a public getter to make sure we are looking for the file that belongs to the particular driver.

A test was also added for the added functionality.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.