### PR TITLE
Added dismiss method to DismissibleState

### DIFF
--- a/packages/flutter/lib/src/widgets/dismissible.dart
+++ b/packages/flutter/lib/src/widgets/dismissible.dart
@@ -204,7 +204,7 @@ class Dismissible extends StatefulWidget {
   final HitTestBehavior behavior;
 
   @override
-  State<Dismissible> createState() => _DismissibleState();
+  State<Dismissible> createState() => DismissibleState();
 }
 
 class _DismissibleClipper extends CustomClipper<Rect> {
@@ -247,7 +247,8 @@ class _DismissibleClipper extends CustomClipper<Rect> {
 
 enum _FlingGestureKind { none, forward, reverse }
 
-class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+/// State for a [Dismissible].
+class DismissibleState extends State<Dismissible> with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
   @override
   void initState() {
     super.initState();
@@ -519,6 +520,11 @@ class _DismissibleState extends State<Dismissible> with TickerProviderStateMixin
     } else {
       widget.onResize?.call();
     }
+  }
+
+  /// Dimiss a dismissible.
+  void dismiss() {
+    _moveController!.forward();
   }
 
   @override

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -899,4 +899,23 @@ void main() {
     await dismissItem(tester, 0, gestureDirection: AxisDirection.up);
     expect(controller.offset, 99.9);
   });
+
+  testWidgets('DismissibleState dismiss method works as expected', (WidgetTester tester) async {
+    final GlobalKey<DismissibleState> key = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Dismissible(
+          key: key,
+          child: const Text('dismissible'),
+        )
+      )
+    );
+
+    expect(find.text('dismissible'), findsOneWidget);
+    key.currentState!.dismiss();
+    await tester.pumpAndSettle();
+    expect(find.text('dismissible'), findsNothing);
+  });
 }


### PR DESCRIPTION
This PR adds dismiss method to DismissibleState. I'm not sure if this is the ideal way to solve the issue but I'm up for suggestions.
@HansMuller @Hixie @Piinks

Fixes: #88705

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
