### PR TITLE
Remove flutter gallery test family (Linux/android) from prod pool 

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1446,37 +1446,6 @@ targets:
       task_name: flutter_gallery__transition_perf
     scheduler: luci
 
-  - name: Linux_android flutter_gallery__transition_perf_e2e
-    recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery__transition_perf_e2e
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_hybrid
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery__transition_perf_hybrid
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery__transition_perf_with_semantics
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery__transition_perf_with_semantics
-    scheduler: luci
-
   - name: Linux_android flutter_gallery_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1485,27 +1454,6 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: flutter_gallery_android__compile
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery_sksl_warmup__transition_perf
-    scheduler: luci
-
-  - name: Linux_android flutter_gallery_sksl_warmup__transition_perf_e2e
-    recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery_sksl_warmup__transition_perf_e2e
     scheduler: luci
 
   - name: Linux_android flutter_gallery_v2_chrome_run_test
@@ -3210,17 +3158,6 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
-    scheduler: luci
-
-  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
-    recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
-    timeout: 90
-    properties:
-      tags: >
-        ["devicelab","ios32","mac"]
-      task_name: flutter_gallery__transition_perf_e2e_ios32
     scheduler: luci
 
   - name: Mac_ios32 native_ui_tests_ios32

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3160,6 +3160,17 @@ targets:
       task_name: tiles_scroll_perf_ios__timeline_summary
     scheduler: luci
 
+  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 90
+    properties:
+      tags: >
+        ["devicelab","ios32","mac"]
+      task_name: flutter_gallery__transition_perf_e2e_ios32
+    scheduler: luci
+
   - name: Mac_ios32 native_ui_tests_ios32
     recipe: devicelab/devicelab_drone
     bringup: true

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1436,16 +1436,6 @@ targets:
       task_name: flutter_gallery__start_up
     scheduler: luci
 
-  - name: Linux_android flutter_gallery__transition_perf
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: flutter_gallery__transition_perf
-    scheduler: luci
-
   - name: Linux_android flutter_gallery_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
The flutter_gallery ... transition_perf family has been flaky (#88296) and enabled in staging pool: https://flutter-review.googlesource.com/c/infra/+/17400.

Linux/android ones are running through in staging (https://ci.chromium.org/p/flutter/g/devicelab_benchmark/console#), and this removes them from the prod pool to avoid affecting build dashboard.