### PR TITLE
Update dartdoc to 3.0.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 2.0.0
+    "$DART" pub global activate dartdoc 3.0.0
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v3.0.0

The TL;DR:  Do not crash when exposed to constructor tearoffs, do not document nonexistent constructors for mixins and avoid checking for them and a few other impossible language constructs, performance increases by ~2 percent.