### PR TITLE
Implement operator = and hashcode for CupertinoThemeData

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -248,6 +248,44 @@ class CupertinoTextThemeData with Diagnosticable {
   }
 
   @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+
+    // Warning: make sure these properties are in the exact same order as in
+    // hashValues() and in the raw constructor and in the order of fields in
+    // the class and in the lerp() method.
+    return other is CupertinoTextThemeData &&
+        other.textStyle == textStyle &&
+        other.actionTextStyle == actionTextStyle &&
+        other.tabLabelTextStyle == tabLabelTextStyle &&
+        other.navTitleTextStyle == navTitleTextStyle &&
+        other.navLargeTitleTextStyle == navLargeTitleTextStyle &&
+        other.navActionTextStyle == navActionTextStyle &&
+        other.pickerTextStyle == pickerTextStyle &&
+        other.dateTimePickerTextStyle == dateTimePickerTextStyle;
+  }
+
+  @override
+  int get hashCode {
+    // Warning: For the sanity of the reader, please make sure these properties
+    // are in the exact same order as in operator == and in the raw constructor
+    // and in the order of fields in the class and in the lerp() method.
+    final List<Object?> values = <Object?>[
+      textStyle,
+      actionTextStyle,
+      tabLabelTextStyle,
+      navTitleTextStyle,
+      navLargeTitleTextStyle,
+      navActionTextStyle,
+      pickerTextStyle,
+      dateTimePickerTextStyle,
+    ];
+    return hashList(values);
+  }
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const CupertinoTextThemeData defaultData = CupertinoTextThemeData();

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -346,6 +346,7 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 ///
 ///  * [CupertinoThemeData], which uses reasonable default values for
 ///    unspecified theme properties.
+@immutable
 class NoDefaultCupertinoThemeData {
   /// Creates a [NoDefaultCupertinoThemeData] styling specification.
   ///

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -292,7 +292,8 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType) return false;
+    if (other.runtimeType != runtimeType)
+      return false;
     // Warning: make sure these properties are in the exact same order as in
     // hashValues() and in the raw constructor and in the order of fields in
     // the class and in the lerp() method.
@@ -477,7 +478,8 @@ class NoDefaultCupertinoThemeData {
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType) return false;
+    if (other.runtimeType != runtimeType)
+      return false;
     // Warning: make sure these properties are in the exact same order as in
     // hashValues() and in the raw constructor and in the order of fields in
     // the class and in the lerp() method.

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -291,6 +291,37 @@ class CupertinoThemeData extends NoDefaultCupertinoThemeData with Diagnosticable
   }
 
   @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    // Warning: make sure these properties are in the exact same order as in
+    // hashValues() and in the raw constructor and in the order of fields in
+    // the class and in the lerp() method.
+    return other is CupertinoThemeData &&
+        other.brightness == brightness &&
+        other.primaryColor == primaryColor &&
+        other.primaryContrastingColor == primaryContrastingColor &&
+        other.textTheme == textTheme &&
+        other.barBackgroundColor == barBackgroundColor &&
+        other.scaffoldBackgroundColor == scaffoldBackgroundColor;
+  }
+
+  @override
+  int get hashCode {
+    // Warning: For the sanity of the reader, please make sure these properties
+    // are in the exact same order as in operator == and in the raw constructor
+    // and in the order of fields in the class and in the lerp() method.
+    final List<Object?> values = <Object?>[
+      brightness,
+      primaryColor,
+      primaryContrastingColor,
+      textTheme,
+      barBackgroundColor,
+      scaffoldBackgroundColor,
+    ];
+    return hashList(values);
+  }
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const CupertinoThemeData defaultData = CupertinoThemeData();
@@ -441,6 +472,37 @@ class NoDefaultCupertinoThemeData {
       barBackgroundColor: barBackgroundColor ?? this.barBackgroundColor,
       scaffoldBackgroundColor: scaffoldBackgroundColor ?? this.scaffoldBackgroundColor,
     );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    // Warning: make sure these properties are in the exact same order as in
+    // hashValues() and in the raw constructor and in the order of fields in
+    // the class and in the lerp() method.
+    return other is NoDefaultCupertinoThemeData &&
+        other.brightness == brightness &&
+        other.primaryColor == primaryColor &&
+        other.primaryContrastingColor == primaryContrastingColor &&
+        other.textTheme == textTheme &&
+        other.barBackgroundColor == barBackgroundColor &&
+        other.scaffoldBackgroundColor == scaffoldBackgroundColor;
+  }
+
+  @override
+  int get hashCode {
+    // Warning: For the sanity of the reader, please make sure these properties
+    // are in the exact same order as in operator == and in the raw constructor
+    // and in the order of fields in the class and in the lerp() method.
+    final List<Object?> values = <Object?>[
+      brightness,
+      primaryColor,
+      primaryContrastingColor,
+      textTheme,
+      barBackgroundColor,
+      scaffoldBackgroundColor,
+    ];
+    return hashList(values);
   }
 }
 

--- a/packages/flutter/test/cupertino/theme_test.dart
+++ b/packages/flutter/test/cupertino/theme_test.dart
@@ -206,6 +206,41 @@ void main() {
     );
   });
 
+  test('Theme operator == returns correct value for simple cases', () {
+    expect(const CupertinoThemeData(), equals(const CupertinoThemeData()));
+
+    expect(const CupertinoThemeData(brightness: Brightness.light),
+        isNot(equals(const CupertinoThemeData(brightness: Brightness.dark))));
+
+    expect(
+        const CupertinoThemeData(
+            textTheme: CupertinoTextThemeData(
+                primaryColor: CupertinoColors.activeGreen)),
+        isNot(equals(const CupertinoThemeData(
+            textTheme: CupertinoTextThemeData(
+                primaryColor: CupertinoColors.activeOrange)))));
+  });
+
+  test('hashCode behaves correctly for simple cases', () {
+    expect(const CupertinoThemeData().hashCode,
+        equals(const CupertinoThemeData().hashCode));
+
+    expect(
+        const CupertinoThemeData(brightness: Brightness.light).hashCode,
+        isNot(equals(const CupertinoThemeData(brightness: Brightness.dark))
+            .hashCode));
+
+    expect(
+        const CupertinoThemeData(
+                textTheme: CupertinoTextThemeData(
+                    primaryColor: CupertinoColors.activeGreen))
+            .hashCode,
+        isNot(equals(const CupertinoThemeData(
+                textTheme: CupertinoTextThemeData(
+                    primaryColor: CupertinoColors.activeOrange))
+            .hashCode)));
+  });
+
   late Brightness currentBrightness;
   void colorMatches(Color? componentColor, CupertinoDynamicColor expectedDynamicColor) {
     switch (currentBrightness) {

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -591,7 +591,8 @@ void main() {
           ),
         ));
 
-        expect(buildCount, 2);
+        // Widget does not rebuild as theme color remains overriden.
+        expect(buildCount, 1);
         expect(theme.primaryColor, CupertinoColors.activeOrange);
       },
     );


### PR DESCRIPTION
This fixes #71222

* Implement operator = and hashcode for CupertinoThemeData and CupertinoTextThemeData which CupertinoThemeData depends on.
* Add basic tests for CupertinoThemeData equality and hashcode.

I also manually tested the case mentioned in #71222, e.g. equality of ThemeData(cupertinoOverrideTheme: someTheme)

## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x ] I signed the [CLA].
- [ x ] I listed at least one issue that this PR fixes in the description above.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ x ] All existing and new tests are passing.

@xster could you take a look at this? :-D
