### PR TITLE
Directly specify keystore to prevent debug key signing flake in Deferred components integration test.

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -15,7 +15,8 @@
 # https://chrome-infra-packages.appspot.com/p/flutter/android/bundletool/+/vFt1jA0cUeZLmUCVR5NG2JVB-SgJ18GH_pVYKMOlfUIC
 
 bundletool_jar_path=$1
-adb_path=$2
+adb_path='adb'
+[ -z "$2" ] && adb_path=$2
 
 # Store the time to prevent capturing logs from previous runs.
 script_start_time=$($adb_path shell 'date +"%m-%d %H:%M:%S.0"')
@@ -27,12 +28,12 @@ rm -f build/app/outputs/bundle/release/run_logcat.log
 
 flutter build appbundle
 
-java -jar $bundletool_jar_path build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing
+java -jar $bundletool_jar_path build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --ks android/testing-keystore.jks --ks-key-alias testing_key --ks-pass pass:012345
 java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
 $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
-sleep 12
+sleep 20
 exit
 "
 $adb_path logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -15,8 +15,7 @@
 # https://chrome-infra-packages.appspot.com/p/flutter/android/bundletool/+/vFt1jA0cUeZLmUCVR5NG2JVB-SgJ18GH_pVYKMOlfUIC
 
 bundletool_jar_path=$1
-adb_path='adb'
-[ -z "$2" ] && adb_path=$2
+adb_path=$2
 
 # Store the time to prevent capturing logs from previous runs.
 script_start_time=$($adb_path shell 'date +"%m-%d %H:%M:%S.0"')


### PR DESCRIPTION
Bundletool seems to fail to sign with debug keystore occasionally, causing a flake in the `Linux deferred components` integration test.

This explicitly specifies the testing keystore used to build the AAB as the keystore to build APKS with. Also increases wait time in case of lagging infra.

The key being used is: https://github.com/flutter/goldens/tree/master/dev/integration_tests/assets_for_deferred_components_test

Resolves https://github.com/flutter/flutter/issues/89607