### PR TITLE
Run flutter_gallery macOS native tests on presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3183,6 +3183,25 @@ targets:
       task_name: native_ui_tests_ios
     scheduler: luci
 
+  - name: Mac native_ui_tests_macos
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode"},
+          {"dependency": "gems"}
+        ]
+      tags: >
+        ["devicelab","hostonly"]
+      task_name: native_ui_tests_macos
+    scheduler: luci
+    runIf:
+    - dev/**
+    - packages/flutter_tools/**
+    - bin/**
+
   - name: Windows build_aar_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -173,6 +173,7 @@
 /dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/native_ui_tests_ios.dart @jmagman @flutter/engine
+/dev/devicelab/bin/tasks/native_ui_tests_macos.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/plugin_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/technical_debt__cost.dart @HansMuller @flutter/framework
 /dev/devicelab/bin/tasks/web_benchmarks_canvaskit.dart @yjbanov @flutter/web

--- a/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
@@ -2,40 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
 
 Future<void> main() async {
-  deviceOperatingSystem = DeviceOperatingSystem.ios;
-
   await task(() async {
     final String projectDirectory = '${flutterDirectory.path}/dev/integration_tests/flutter_gallery';
 
     await inDirectory(projectDirectory, () async {
-      section('Build clean');
-
-      await flutter('clean');
-
       section('Build gallery app');
 
       await flutter(
         'build',
         options: <String>[
-          'ios',
+          'macos',
           '-v',
-          '--release',
-          '--config-only',
+          '--debug',
         ],
       );
     });
 
     section('Run platform unit tests');
 
-    final Device device = await devices.workingDevice;
-    if (!await runXcodeTests(projectDirectory, device.deviceId, 'native_ui_tests_ios')) {
+    if (!await runXcodeTests(projectDirectory, 'platform=macOS', 'native_ui_tests_macos')) {
       return TaskResult.failure('Platform unit tests failed');
     }
 

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -3,7 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:path/path.dart' as path;
+
+import 'host_agent.dart';
 import 'utils.dart';
 
 typedef SimulatorFunction = Future<void> Function(String deviceId);
@@ -134,4 +138,61 @@ Future<void> removeIOSimulator(String deviceId) async {
       workingDirectory: flutterDirectory.path,
     );
   }
+}
+
+Future<bool> runXcodeTests(String projectDirectory, String deviceId, String testName) async {
+  final Map<String, String> environment = Platform.environment;
+  // If not running on CI, inject the Flutter team code signing properties.
+  final String developmentTeam = environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] ?? 'S8QB4VV633';
+  final String? codeSignStyle = environment['FLUTTER_XCODE_CODE_SIGN_STYLE'];
+  final String? provisioningProfile = environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'];
+
+  final String resultBundleTemp = Directory.systemTemp.createTempSync('flutter_xcresult.').path;
+  final String resultBundlePath = path.join(resultBundleTemp, 'result');
+  final int testResultExit = await exec(
+    'xcodebuild',
+    <String>[
+      '-workspace',
+      'Runner.xcworkspace',
+      '-scheme',
+      'Runner',
+      '-configuration',
+      'Release',
+      '-destination',
+      'id=$deviceId',
+      '-resultBundlePath',
+      resultBundlePath,
+      'test',
+      'COMPILER_INDEX_STORE_ENABLE=NO',
+      'DEVELOPMENT_TEAM=$developmentTeam',
+      if (codeSignStyle != null)
+        'CODE_SIGN_STYLE=$codeSignStyle',
+      if (provisioningProfile != null)
+        'PROVISIONING_PROFILE_SPECIFIER=$provisioningProfile',
+    ],
+    workingDirectory: path.join(projectDirectory, 'ios'),
+    canFail: true,
+  );
+
+  if (testResultExit != 0) {
+    final Directory? dumpDirectory = hostAgent.dumpDirectory;
+    if (dumpDirectory != null) {
+      // Zip the test results to the artifacts directory for upload.
+      final String zipPath = path.join(dumpDirectory.path,
+          '$testName-${DateTime.now().toLocal().toIso8601String()}.zip');
+      await exec(
+        'zip',
+        <String>[
+          '-r',
+          '-9',
+          zipPath,
+          'result.xcresult',
+        ],
+        workingDirectory: resultBundleTemp,
+        canFail: true, // Best effort to get the logs.
+      );
+    }
+    return false;
+  }
+  return true;
 }

--- a/dev/integration_tests/flutter_gallery/macos/Podfile
+++ b/dev/integration_tests/flutter_gallery/macos/Podfile
@@ -31,6 +31,10 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
 end
 
 post_install do |installer|

--- a/dev/integration_tests/flutter_gallery/macos/Podfile.lock
+++ b/dev/integration_tests/flutter_gallery/macos/Podfile.lock
@@ -25,11 +25,11 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  connectivity_macos: 9f30e9d0e67a0bc08a0c563ee82310b51ca6e818
+  connectivity_macos: 5dae6ee11d320fac7c05f0d08bd08fc32b5514d9
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
 
-PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+PODFILE CHECKSUM: b5c36ba411e4471a03727d0463fa17be341876c1
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		7FE95D6B675486D860A3DBFB /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4086A70F8522279C70BBB26B /* Pods_RunnerTests.framework */; };
+		F7BDBB0E26E829B700DE9315 /* RunnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F7BDBB0D26E829B700DE9315 /* RunnerTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +38,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 33CC111A2044C6BA0003C045;
 			remoteInfo = FLX;
+		};
+		F7BDBB0F26E829B700DE9315 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33CC10E52044A3C60003C045 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 33CC10EC2044A3C60003C045;
+			remoteInfo = Runner;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -55,6 +64,7 @@
 /* Begin PBXFileReference section */
 		0A9BC03BA29AB9AC95A6B56C /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		21BDE859A3D5F26F70C3E805 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		31E9DDB21E0B961FFC0E8ADA /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
 		33CC10ED2044A3C60003C045 /* flutter_gallery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = flutter_gallery.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,10 +79,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		4086A70F8522279C70BBB26B /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8CB6E348C1DAF1D3375AF578 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9E7679472481DA711299BF04 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		B4D44CC493D5E2EC3762DAE2 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BED2A53D26C8AB5761760332 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		F7BDBB0B26E829B700DE9315 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7BDBB0D26E829B700DE9315 /* RunnerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RunnerTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +96,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				329CBB511998F0EDE915EE87 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F7BDBB0826E829B700DE9315 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7FE95D6B675486D860A3DBFB /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +126,7 @@
 			children = (
 				33FAB671232836740065AC1E /* Runner */,
 				33CEB47122A05771004F2AC0 /* Flutter */,
+				F7BDBB0C26E829B700DE9315 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
 				727549F29CB745BF02B0E8A3 /* Pods */,
@@ -113,6 +137,7 @@
 			isa = PBXGroup;
 			children = (
 				33CC10ED2044A3C60003C045 /* flutter_gallery.app */,
+				F7BDBB0B26E829B700DE9315 /* RunnerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -158,8 +183,10 @@
 				0A9BC03BA29AB9AC95A6B56C /* Pods-Runner.debug.xcconfig */,
 				BED2A53D26C8AB5761760332 /* Pods-Runner.release.xcconfig */,
 				21BDE859A3D5F26F70C3E805 /* Pods-Runner.profile.xcconfig */,
+				8CB6E348C1DAF1D3375AF578 /* Pods-RunnerTests.debug.xcconfig */,
+				9E7679472481DA711299BF04 /* Pods-RunnerTests.release.xcconfig */,
+				31E9DDB21E0B961FFC0E8ADA /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -167,8 +194,17 @@
 			isa = PBXGroup;
 			children = (
 				B4D44CC493D5E2EC3762DAE2 /* Pods_Runner.framework */,
+				4086A70F8522279C70BBB26B /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F7BDBB0C26E829B700DE9315 /* RunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				F7BDBB0D26E829B700DE9315 /* RunnerTests.m */,
+			);
+			path = RunnerTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -196,6 +232,25 @@
 			productReference = 33CC10ED2044A3C60003C045 /* flutter_gallery.app */;
 			productType = "com.apple.product-type.application";
 		};
+		F7BDBB0A26E829B700DE9315 /* RunnerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F7BDBB1426E829B700DE9315 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
+			buildPhases = (
+				D4A146852504EFCE6D36634B /* [CP] Check Pods Manifest.lock */,
+				F7BDBB0726E829B700DE9315 /* Sources */,
+				F7BDBB0826E829B700DE9315 /* Frameworks */,
+				F7BDBB0926E829B700DE9315 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F7BDBB1026E829B700DE9315 /* PBXTargetDependency */,
+			);
+			name = RunnerTests;
+			productName = RunnerTests;
+			productReference = F7BDBB0B26E829B700DE9315 /* RunnerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -220,6 +275,10 @@
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Manual;
 					};
+					F7BDBB0A26E829B700DE9315 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = 33CC10EC2044A3C60003C045;
+					};
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
@@ -237,6 +296,7 @@
 			targets = (
 				33CC10EC2044A3C60003C045 /* Runner */,
 				33CC111A2044C6BA0003C045 /* Flutter Assemble */,
+				F7BDBB0A26E829B700DE9315 /* RunnerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -248,6 +308,13 @@
 			files = (
 				33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */,
 				33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F7BDBB0926E829B700DE9315 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -330,6 +397,28 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		D4A146852504EFCE6D36634B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -343,6 +432,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F7BDBB0726E829B700DE9315 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7BDBB0E26E829B700DE9315 /* RunnerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -350,6 +447,11 @@
 			isa = PBXTargetDependency;
 			target = 33CC111A2044C6BA0003C045 /* Flutter Assemble */;
 			targetProxy = 33CC111F2044C79F0003C045 /* PBXContainerItemProxy */;
+		};
+		F7BDBB1026E829B700DE9315 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 33CC10EC2044A3C60003C045 /* Runner */;
+			targetProxy = F7BDBB0F26E829B700DE9315 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -593,6 +695,66 @@
 			};
 			name = Release;
 		};
+		F7BDBB1126E829B700DE9315 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8CB6E348C1DAF1D3375AF578 /* Pods-RunnerTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.flutterGallery.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutter_gallery.app/Contents/MacOS/flutter_gallery";
+			};
+			name = Debug;
+		};
+		F7BDBB1226E829B700DE9315 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E7679472481DA711299BF04 /* Pods-RunnerTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.flutterGallery.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutter_gallery.app/Contents/MacOS/flutter_gallery";
+			};
+			name = Release;
+		};
+		F7BDBB1326E829B700DE9315 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 31E9DDB21E0B961FFC0E8ADA /* Pods-RunnerTests.profile.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.flutterGallery.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutter_gallery.app/Contents/MacOS/flutter_gallery";
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -622,6 +784,16 @@
 				33CC111C2044C6BA0003C045 /* Debug */,
 				33CC111D2044C6BA0003C045 /* Release */,
 				338D0CEB231458BD00FA5F75 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F7BDBB1426E829B700DE9315 /* Build configuration list for PBXNativeTarget "RunnerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F7BDBB1126E829B700DE9315 /* Debug */,
+				F7BDBB1226E829B700DE9315 /* Release */,
+				F7BDBB1326E829B700DE9315 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/dev/integration_tests/flutter_gallery/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -37,6 +37,16 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F7BDBB0A26E829B700DE9315"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
+++ b/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <FlutterMacOS/FlutterMacOS.h>
+#import <XCTest/XCTest.h>
+
+@interface RunnerTests : XCTestCase
+@end
+
+@implementation RunnerTests
+
+- (void)testMenu {
+  NSMenu *applicationMenu = ((FlutterAppDelegate *)NSApplication.sharedApplication.delegate).applicationMenu;
+  XCTAssertEqual(applicationMenu.numberOfItems, 11);
+  XCTAssertEqualObjects([applicationMenu itemAtIndex:0].title, @"About flutter_gallery");
+
+  NSMenu *mainMenu = NSApplication.sharedApplication.mainMenu;
+  XCTAssertEqual([mainMenu indexOfItemWithSubmenu:applicationMenu], 0);
+
+  XCTAssertEqual([mainMenu itemWithTitle:@"Edit"].submenu.numberOfItems, 19);
+  XCTAssertEqual([mainMenu itemWithTitle:@"View"].submenu.numberOfItems, 1);
+  XCTAssertEqual([mainMenu itemWithTitle:@"Window"].submenu.numberOfItems, 6);
+
+  XCTAssertNil(NSApplication.sharedApplication.helpMenu);
+}
+
+@end


### PR DESCRIPTION
Add a new flutter_gallery macOS unit test to check that the menus are set up as expected as essentially a smoke test.  I'll be able to update this test when I implement https://github.com/flutter/flutter/issues/89077.

Make a new hostonly devicelab test to run the macOS unit test on presubmit.