### PR TITLE
Increase integration_test package minimum iOS version to 9.0

### DIFF
--- a/packages/integration_test/ios/integration_test.podspec
+++ b/packages/integration_test/ios/integration_test.podspec
@@ -20,6 +20,6 @@ LICENSE
   s.dependency 'Flutter'
   s.ios.framework  = 'UIKit'
 
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 end


### PR DESCRIPTION
Default Flutter project has been 9.0 since https://github.com/flutter/flutter/pull/62902.  A project migration was forced with https://github.com/flutter/flutter/pull/85174.  Mark the integration_test minimum version as 9.0.

See also https://github.com/flutter/flutter/pull/86840.