### PR TITLE
Turn off bringup for `Linux android views`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1618,6 +1618,7 @@ targets:
 
   - name: Linux android views
     recipe: flutter/android_views
+    presubmit: false
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1618,7 +1618,6 @@ targets:
 
   - name: Linux android views
     recipe: flutter/android_views
-    bringup: true
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
The `Linux android views` test has been consistently passing for a long time: https://ci.chromium.org/p/flutter/builders/prod/Linux%20android%20views.

This removes the flaky flag and adds it to the post-submit checks that must pass.

Next step is to move this into presubmit after it is shown to be green in postsubmit.
