### PR TITLE
Set plugin template minimum Flutter SDK to 2.5

### DIFF
--- a/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-objc.tmpl/projectName.podspec.tmpl
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
+++ b/packages/flutter_tools/templates/plugin/ios-swift.tmpl/projectName.podspec.tmpl
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin/pubspec.yaml.tmpl
@@ -5,7 +5,7 @@ homepage:
 
 environment:
   sdk: {{dartSdkVersionBounds}}
-  flutter: ">=1.20.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2325,7 +2325,7 @@ void main() {
     Logger: () => logger,
   });
 
-  testUsingContext('newly created plugin has min flutter sdk version as 1.20.0', () async {
+  testUsingContext('newly created plugin has min flutter sdk version as 2.5.0', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
@@ -2334,8 +2334,8 @@ void main() {
     final String rawPubspec = await projectDir.childFile('pubspec.yaml').readAsString();
     final Pubspec pubspec = Pubspec.parse(rawPubspec);
     final Map<String, VersionConstraint> env = pubspec.environment;
-    expect(env['flutter'].allows(Version(1, 20, 0)), true);
-    expect(env['flutter'].allows(Version(1, 19, 0)), false);
+    expect(env['flutter'].allows(Version(2, 5, 0)), true);
+    expect(env['flutter'].allows(Version(2, 4, 9)), false);
   });
 
   testUsingContext('default app uses Android SDK 30', () async {


### PR DESCRIPTION
Apps run on 2.4.0-0.0.pre and later [will be upgraded to a minimum of iOS 9.0](https://github.com/flutter/flutter/pull/85174).  Now that Flutter 2.5 has hit stable and [iOS 8 support has been dropped](https://flutter.dev/go/rfc-ios8-deprecation), change the plugin create template to `9.0`.  Up the Flutter SDK constraint to 2.5 to enforce that the 9.0 migration has happened on the app side.

Apps on versions of Flutter older than 2.5 will not be able to use these new plugins.  See discussion from last time this was done: https://github.com/flutter/flutter/pull/62605

Part of https://github.com/flutter/flutter/issues/62880.