### PR TITLE
Skip the drawShadow call in a MergeableMaterial with zero elevation

### DIFF
--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -695,12 +695,14 @@ class _RenderMergeableMaterialListBody extends RenderListBody {
 
   void _paintShadows(Canvas canvas, Rect rect) {
     // TODO(ianh): We should interpolate the border radii of the shadows the same way we do those of the visible Material slices.
-    canvas.drawShadow(
-      Path()..addRRect(kMaterialEdges[MaterialType.card]!.toRRect(rect)),
-      Colors.black,
-      elevation,
-      true, // occluding object is not (necessarily) opaque
-    );
+    if (elevation != 0) {
+      canvas.drawShadow(
+        Path()..addRRect(kMaterialEdges[MaterialType.card]!.toRRect(rect)),
+        Colors.black,
+        elevation,
+        true, // occluding object is not (necessarily) opaque
+      );
+    }
   }
 
   @override

--- a/packages/flutter/test/material/mergeable_material_test.dart
+++ b/packages/flutter/test/material/mergeable_material_test.dart
@@ -233,6 +233,36 @@ void main() {
     debugDisableShadows = true;
   });
 
+  testWidgets('MergeableMaterial skips shadow for zero elevation', (WidgetTester tester) async {
+    debugDisableShadows = false;
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MergeableMaterial(
+              elevation: 0,
+              children: <MergeableMaterialItem>[
+                MaterialSlice(
+                  key: ValueKey<String>('A'),
+                  child: SizedBox(
+                    width: 100.0,
+                    height: 100.0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byType(MergeableMaterial),
+      isNot(paints..shadow(elevation: 0.0)),
+    );
+    debugDisableShadows = true;
+  });
+
   testWidgets('MergeableMaterial merge gap', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/89490
