### PR TITLE
[integration_test] Document enterText quirk

### DIFF
--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -91,6 +91,11 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
   @override
   bool get overrideHttpClient => false;
 
+  /// In Integration Tests, avoid setting up mock handlers for text input.
+  ///
+  /// When assertions are disabled (when not in debug mode), calling
+  /// [TestTextInput.register] is required prior to calling
+  /// [WidgetTester.enterText], or the text will be silently dropped.
   @override
   bool get registerTestTextInput => false;
 


### PR DESCRIPTION
Internal: b/198505162

Calling `tester.enterText` does not work when assertions are disabled (when not in debug mode).

https://github.com/flutter/flutter/blob/619121b095d9b506451387bde027038e7a986ab8/packages/flutter/lib/src/services/text_input.dart#L1430-L1444

This PR adds some documentation around this behavior, and what users should do instead.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
