### PR TITLE
Give more freedom to developer when he use Stepper widget

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -242,12 +242,25 @@ class Stepper extends StatefulWidget {
   /// The index into [steps] of the current step whose content is displayed.
   final int currentStep;
 
+  /// give background color to header
   final Color? backgroundHeaderColor;
+
+  /// set the BoderRadius to header
   final BorderRadiusGeometry? headerRadius;
+
+  /// set the color to text of active step
   final Color? activeCircleTextColor;
+
+  /// set the background color to step
   final Color? circleColor;
+
+  /// set the underline color
   final Color? lineColor;
+
+  /// set the color of the text to inactive step
   final Color? inactiveTextColor;
+
+  /// set the color to check icon
   final Color? iconCheckColor;
 
   /// The callback called when a step is tapped, with its index passed as
@@ -380,7 +393,6 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   Widget _buildCircleChild(int index, bool oldState) {
     final StepState state =
         oldState ? _oldStates[index]! : widget.steps[index].state;
-    final bool isDarkActive = _isDark() && widget.steps[index].isActive;
     assert(state != null);
     switch (state) {
       case StepState.indexed:

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -203,8 +203,7 @@ class Stepper extends StatefulWidget {
     this.backgroundHeaderColor,
     this.headerRadius,
     this.lineColor,
-    this.activeCircleColor,
-    this.inActiveCircleColor,
+    this.circleColor,
     this.activeCircleTextColor,
     this.inactiveTextColor,
     this.iconCheckColor,
@@ -246,8 +245,7 @@ class Stepper extends StatefulWidget {
   final Color? backgroundHeaderColor;
   final BorderRadiusGeometry? headerRadius;
   final Color? activeCircleTextColor;
-  final Color? activeCircleColor;
-  final Color? inActiveCircleColor;
+  final Color? circleColor;
   final Color? lineColor;
   final Color? inactiveTextColor;
   final Color? iconCheckColor;
@@ -415,15 +413,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     if (!_isDark()) {
       return widget.steps[index].isActive
-          ? _isCurrent(index)
-              ? widget.activeCircleColor ?? Colors.grey
-              : widget.inActiveCircleColor ?? Colors.grey.withOpacity(30)
+          ? widget.circleColor ?? Colors.grey
           : colorScheme.onSurface.withOpacity(0.38);
     } else {
       return widget.steps[index].isActive
-          ? _isCurrent(index)
-              ? widget.activeCircleColor ?? Colors.grey
-              : widget.inActiveCircleColor ?? Colors.grey.withOpacity(30)
+          ? widget.circleColor ?? Colors.grey
           : colorScheme.background;
     }
   }

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -114,8 +114,6 @@ const TextStyle _kStepStyle = TextStyle(
 );
 const Color _kErrorLight = Colors.red;
 final Color _kErrorDark = Colors.red.shade400;
-const Color _kCircleActiveLight = Colors.white;
-const Color _kCircleActiveDark = Colors.black87;
 const Color _kDisabledLight = Colors.black38;
 const Color _kDisabledDark = Colors.white38;
 const double _kStepSize = 24.0;

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -68,6 +68,7 @@ class ControlsDetails {
     this.onStepCancel,
     this.onStepContinue,
   });
+
   /// Index that is active for the surrounding [Stepper] widget. This may be
   /// different from [stepIndex] if the user has just changed steps and we are
   /// currently animating toward that step.
@@ -104,7 +105,8 @@ class ControlsDetails {
 /// See also:
 ///
 ///  * [WidgetBuilder], which is similar but only takes a [BuildContext].
-typedef ControlsWidgetBuilder = Widget Function(BuildContext context, ControlsDetails details);
+typedef ControlsWidgetBuilder = Widget Function(
+    BuildContext context, ControlsDetails details);
 
 const TextStyle _kStepStyle = TextStyle(
   fontSize: 12.0,
@@ -117,7 +119,8 @@ const Color _kCircleActiveDark = Colors.black87;
 const Color _kDisabledLight = Colors.black38;
 const Color _kDisabledDark = Colors.white38;
 const double _kStepSize = 24.0;
-const double _kTriangleHeight = _kStepSize * 0.866025; // Triangle height. sqrt(3.0) / 2.0
+const double _kTriangleHeight =
+    _kStepSize * 0.866025; // Triangle height. sqrt(3.0) / 2.0
 
 /// A material step used in [Stepper]. The step can have a title and subtitle,
 /// an icon within its circle, some content and a state that governs its
@@ -138,9 +141,9 @@ class Step {
     required this.content,
     this.state = StepState.indexed,
     this.isActive = false,
-  }) : assert(title != null),
-       assert(content != null),
-       assert(state != null);
+  })  : assert(title != null),
+        assert(content != null),
+        assert(state != null);
 
   /// The title of the step that typically describes it.
   final Widget title;
@@ -197,17 +200,25 @@ class Stepper extends StatefulWidget {
     this.physics,
     this.type = StepperType.vertical,
     this.currentStep = 0,
+    this.backgroundHeaderColor,
+    this.headerRadius,
+    this.lineColor,
+    this.activeCircleColor,
+    this.inActiveCircleColor,
+    this.activeCircleTextColor,
+    this.inactiveTextColor,
+    this.iconCheckColor,
     this.onStepTapped,
     this.onStepContinue,
     this.onStepCancel,
     this.controlsBuilder,
     this.elevation,
     this.margin,
-  }) : assert(steps != null),
-       assert(type != null),
-       assert(currentStep != null),
-       assert(0 <= currentStep && currentStep < steps.length),
-       super(key: key);
+  })  : assert(steps != null),
+        assert(type != null),
+        assert(currentStep != null),
+        assert(0 <= currentStep && currentStep < steps.length),
+        super(key: key);
 
   /// The steps of the stepper whose titles, subtitles, icons always get shown.
   ///
@@ -231,6 +242,15 @@ class Stepper extends StatefulWidget {
 
   /// The index into [steps] of the current step whose content is displayed.
   final int currentStep;
+
+  final Color? backgroundHeaderColor;
+  final BorderRadiusGeometry? headerRadius;
+  final Color? activeCircleTextColor;
+  final Color? activeCircleColor;
+  final Color? inActiveCircleColor;
+  final Color? lineColor;
+  final Color? inactiveTextColor;
+  final Color? iconCheckColor;
 
   /// The callback called when a step is tapped, with its index passed as
   /// an argument.
@@ -360,28 +380,32 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   }
 
   Widget _buildCircleChild(int index, bool oldState) {
-    final StepState state = oldState ? _oldStates[index]! : widget.steps[index].state;
+    final StepState state =
+        oldState ? _oldStates[index]! : widget.steps[index].state;
     final bool isDarkActive = _isDark() && widget.steps[index].isActive;
     assert(state != null);
     switch (state) {
       case StepState.indexed:
       case StepState.disabled:
-        return Text(
-          '${index + 1}',
-          style: isDarkActive ? _kStepStyle.copyWith(color: Colors.black87) : _kStepStyle,
-        );
+        return Text('${index + 1}',
+            style:
+                TextStyle(color: widget.inactiveTextColor ?? Colors.white70));
       case StepState.editing:
         return Icon(
           Icons.edit,
-          color: isDarkActive ? _kCircleActiveDark : _kCircleActiveLight,
+          color: widget.activeCircleTextColor ?? Colors.white70,
           size: 18.0,
         );
       case StepState.complete:
-        return Icon(
-          Icons.check,
-          color: isDarkActive ? _kCircleActiveDark : _kCircleActiveLight,
-          size: 18.0,
-        );
+        return _isCurrent(index)
+            ? Text('${index + 1}',
+                style: TextStyle(
+                    color: widget.activeCircleTextColor ?? Colors.white70))
+            : Icon(
+                Icons.check,
+                color: widget.iconCheckColor ?? Colors.green,
+                size: 18.0,
+              );
       case StepState.error:
         return const Text('!', style: _kStepStyle);
     }
@@ -390,9 +414,17 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
   Color _circleColor(int index) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     if (!_isDark()) {
-      return widget.steps[index].isActive ? colorScheme.primary : colorScheme.onSurface.withOpacity(0.38);
+      return widget.steps[index].isActive
+          ? _isCurrent(index)
+              ? widget.activeCircleColor ?? Colors.grey
+              : widget.inActiveCircleColor ?? Colors.grey.withOpacity(30)
+          : colorScheme.onSurface.withOpacity(0.38);
     } else {
-      return widget.steps[index].isActive ? colorScheme.secondary : colorScheme.background;
+      return widget.steps[index].isActive
+          ? _isCurrent(index)
+              ? widget.activeCircleColor ?? Colors.grey
+              : widget.inActiveCircleColor ?? Colors.grey.withOpacity(30)
+          : colorScheme.background;
     }
   }
 
@@ -409,7 +441,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
           shape: BoxShape.circle,
         ),
         child: Center(
-          child: _buildCircleChild(index, oldState && widget.steps[index].state == StepState.error),
+          child: _buildCircleChild(
+              index, oldState && widget.steps[index].state == StepState.error),
         ),
       ),
     );
@@ -423,14 +456,17 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       child: Center(
         child: SizedBox(
           width: _kStepSize,
-          height: _kTriangleHeight, // Height of 24dp-long-sided equilateral triangle.
+          height:
+              _kTriangleHeight, // Height of 24dp-long-sided equilateral triangle.
           child: CustomPaint(
             painter: _TrianglePainter(
               color: _isDark() ? _kErrorDark : _kErrorLight,
             ),
             child: Align(
-              alignment: const Alignment(0.0, 0.8), // 0.8 looks better than the geometrical 0.33.
-              child: _buildCircleChild(index, oldState && widget.steps[index].state != StepState.error),
+              alignment: const Alignment(
+                  0.0, 0.8), // 0.8 looks better than the geometrical 0.33.
+              child: _buildCircleChild(index,
+                  oldState && widget.steps[index].state != StepState.error),
             ),
           ),
         ),
@@ -446,7 +482,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         firstCurve: const Interval(0.0, 0.6, curve: Curves.fastOutSlowIn),
         secondCurve: const Interval(0.4, 1.0, curve: Curves.fastOutSlowIn),
         sizeCurve: Curves.fastOutSlowIn,
-        crossFadeState: widget.steps[index].state == StepState.error ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+        crossFadeState: widget.steps[index].state == StepState.error
+            ? CrossFadeState.showSecond
+            : CrossFadeState.showFirst,
         duration: kThemeAnimationDuration,
       );
     } else {
@@ -481,9 +519,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
 
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
 
-    const OutlinedBorder buttonShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2)));
+    const OutlinedBorder buttonShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(2)));
     const EdgeInsets buttonPadding = EdgeInsets.symmetric(horizontal: 16.0);
 
     return Container(
@@ -498,13 +538,22 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             TextButton(
               onPressed: widget.onStepContinue,
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
-                  return states.contains(MaterialState.disabled) ? null : (_isDark() ? colorScheme.onSurface : colorScheme.onPrimary);
+                foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+                    (Set<MaterialState> states) {
+                  return states.contains(MaterialState.disabled)
+                      ? null
+                      : (_isDark()
+                          ? colorScheme.onSurface
+                          : colorScheme.onPrimary);
                 }),
-                backgroundColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
-                  return _isDark() || states.contains(MaterialState.disabled) ? null : colorScheme.primary;
+                backgroundColor: MaterialStateProperty.resolveWith<Color?>(
+                    (Set<MaterialState> states) {
+                  return _isDark() || states.contains(MaterialState.disabled)
+                      ? null
+                      : colorScheme.primary;
                 }),
-                padding: MaterialStateProperty.all<EdgeInsetsGeometry>(buttonPadding),
+                padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+                    buttonPadding),
                 shape: MaterialStateProperty.all<OutlinedBorder>(buttonShape),
               ),
               child: Text(localizations.continueButtonLabel),
@@ -641,11 +690,12 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         AnimatedCrossFade(
           firstChild: Container(height: 0.0),
           secondChild: Container(
-            margin: widget.margin ?? const EdgeInsetsDirectional.only(
-              start: 60.0,
-              end: 24.0,
-              bottom: 24.0,
-            ),
+            margin: widget.margin ??
+                const EdgeInsetsDirectional.only(
+                  start: 60.0,
+                  end: 24.0,
+                  bottom: 24.0,
+                ),
             child: Column(
               children: <Widget>[
                 widget.steps[index].content,
@@ -656,7 +706,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
           firstCurve: const Interval(0.0, 0.6, curve: Curves.fastOutSlowIn),
           secondCurve: const Interval(0.4, 1.0, curve: Curves.fastOutSlowIn),
           sizeCurve: Curves.fastOutSlowIn,
-          crossFadeState: _isCurrent(index) ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+          crossFadeState: _isCurrent(index)
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
           duration: kThemeAnimationDuration,
         ),
       ],
@@ -673,17 +725,19 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             key: _keys[i],
             children: <Widget>[
               InkWell(
-                onTap: widget.steps[i].state != StepState.disabled ? () {
-                  // In the vertical case we need to scroll to the newly tapped
-                  // step.
-                  Scrollable.ensureVisible(
-                    _keys[i].currentContext!,
-                    curve: Curves.fastOutSlowIn,
-                    duration: kThemeAnimationDuration,
-                  );
+                onTap: widget.steps[i].state != StepState.disabled
+                    ? () {
+                        // In the vertical case we need to scroll to the newly tapped
+                        // step.
+                        Scrollable.ensureVisible(
+                          _keys[i].currentContext!,
+                          curve: Curves.fastOutSlowIn,
+                          duration: kThemeAnimationDuration,
+                        );
 
-                  widget.onStepTapped?.call(i);
-                } : null,
+                        widget.onStepTapped?.call(i);
+                      }
+                    : null,
                 canRequestFocus: widget.steps[i].state != StepState.disabled,
                 child: _buildVerticalHeader(i),
               ),
@@ -698,9 +752,11 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     final List<Widget> children = <Widget>[
       for (int i = 0; i < widget.steps.length; i += 1) ...<Widget>[
         InkResponse(
-          onTap: widget.steps[i].state != StepState.disabled ? () {
-            widget.onStepTapped?.call(i);
-          } : null,
+          onTap: widget.steps[i].state != StepState.disabled
+              ? () {
+                  widget.onStepTapped?.call(i);
+                }
+              : null,
           canRequestFocus: widget.steps[i].state != StepState.disabled,
           child: Row(
             children: <Widget>[
@@ -720,10 +776,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         if (!_isLast(i))
           Expanded(
             child: Container(
-              margin: const EdgeInsets.symmetric(horizontal: 8.0),
-              height: 1.0,
-              color: Colors.grey.shade400,
-            ),
+                margin: const EdgeInsets.symmetric(horizontal: 8.0),
+                height: 1.0,
+                color: widget.lineColor ?? Colors.grey),
           ),
       ],
     ];
@@ -743,6 +798,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       children: <Widget>[
         Material(
           elevation: widget.elevation ?? 2,
+          borderRadius: widget.headerRadius ?? BorderRadius.circular(0),
+          color: widget.backgroundHeaderColor ?? Colors.white,
           child: Container(
             margin: const EdgeInsets.symmetric(horizontal: 24.0),
             child: Row(
@@ -758,7 +815,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               AnimatedSize(
                 curve: Curves.fastOutSlowIn,
                 duration: kThemeAnimationDuration,
-                child: Column(children: stepPanels, crossAxisAlignment: CrossAxisAlignment.stretch),
+                child: Column(
+                    children: stepPanels,
+                    crossAxisAlignment: CrossAxisAlignment.stretch),
               ),
               _buildVerticalControls(widget.currentStep),
             ],

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -295,7 +295,8 @@ void main() {
       ),
     );
 
-    final ScrollableState scrollableState = tester.firstState(find.byType(Scrollable));
+    final ScrollableState scrollableState =
+        tester.firstState(find.byType(Scrollable));
     expect(scrollableState.position.pixels, 0.0);
 
     await tester.tap(find.text('Step 3'));
@@ -369,6 +370,7 @@ void main() {
     expect(find.text('2'), findsOneWidget);
   });
 
+  testWidgets('Stepper test header', (WidgetTester tester) async {});
   testWidgets('Stepper custom controls test', (WidgetTester tester) async {
     bool continuePressed = false;
     void setContinue() {
@@ -448,8 +450,8 @@ void main() {
     expect(continuePressed, isTrue);
   });
 
-testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async {
-
+  testWidgets('Stepper custom indexed controls test',
+      (WidgetTester tester) async {
     int currentStep = 0;
     void setContinue() {
       currentStep += 1;
@@ -462,8 +464,7 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     Widget builder(BuildContext context, ControlsDetails details) {
       // For the purposes of testing, only render something for the active
       // step.
-      if (!details.isActive)
-        return Container();
+      if (!details.isActive) return Container();
 
       return Container(
         margin: const EdgeInsets.only(top: 16.0),
@@ -582,7 +583,7 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
               steps: <Step>[
                 Step(
                   title: const Text('Step 2'),
-                  content:  Stepper(
+                  content: Stepper(
                     type: StepperType.vertical,
                     steps: const <Step>[
                       Step(
@@ -615,23 +616,29 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     final List<String> lines = fullErrorMessage.split('\n');
     // The lines in the middle of the error message contain the stack trace
     // which will change depending on where the test is run.
-    final String errorMessage = lines.takeWhile(
-      (String line) => line != '',
-    ).join('\n');
+    final String errorMessage = lines
+        .takeWhile(
+          (String line) => line != '',
+        )
+        .join('\n');
     expect(errorMessage.length, lessThan(fullErrorMessage.length));
-    expect(errorMessage, startsWith(
-      '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞════════════════════════\n'
-      'The following assertion was thrown building Stepper(',
-    ));
+    expect(
+        errorMessage,
+        startsWith(
+          '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞════════════════════════\n'
+          'The following assertion was thrown building Stepper(',
+        ));
     // The description string of the stepper looks slightly different depending
     // on the platform and is omitted here.
-    expect(errorMessage, endsWith(
-      '):\n'
-      'Steppers must not be nested.\n'
-      'The material specification advises that one should avoid\n'
-      'embedding steppers within steppers.\n'
-      'https://material.io/archive/guidelines/components/steppers.html#steppers-usage',
-    ));
+    expect(
+        errorMessage,
+        endsWith(
+          '):\n'
+          'Steppers must not be nested.\n'
+          'The material specification advises that one should avoid\n'
+          'embedding steppers within steppers.\n'
+          'https://material.io/archive/guidelines/components/steppers.html#steppers-usage',
+        ));
   });
 
   ///https://github.com/flutter/flutter/issues/16920
@@ -697,7 +704,8 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(find.text('Text After Stepper'), findsNothing);
   });
 
-  testWidgets("Vertical Stepper can't be focused when disabled.", (WidgetTester tester) async {
+  testWidgets("Vertical Stepper can't be focused when disabled.",
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -717,13 +725,15 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     );
     await tester.pump();
 
-    final FocusNode disabledNode = Focus.of(tester.element(find.text('Step 0')), scopeOk: true);
+    final FocusNode disabledNode =
+        Focus.of(tester.element(find.text('Step 0')), scopeOk: true);
     disabledNode.requestFocus();
     await tester.pump();
     expect(disabledNode.hasPrimaryFocus, isFalse);
   });
 
-  testWidgets("Horizontal Stepper can't be focused when disabled.", (WidgetTester tester) async {
+  testWidgets("Horizontal Stepper can't be focused when disabled.",
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -743,13 +753,15 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     );
     await tester.pump();
 
-    final FocusNode disabledNode = Focus.of(tester.element(find.text('Step 0')), scopeOk: true);
+    final FocusNode disabledNode =
+        Focus.of(tester.element(find.text('Step 0')), scopeOk: true);
     disabledNode.requestFocus();
     await tester.pump();
     expect(disabledNode.hasPrimaryFocus, isFalse);
   });
 
-  testWidgets('Stepper header title should not overflow', (WidgetTester tester) async {
+  testWidgets('Stepper header title should not overflow',
+      (WidgetTester tester) async {
     const String longText =
         'A long long long long long long long long long long long long text';
 
@@ -775,7 +787,8 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Stepper header subtitle should not overflow', (WidgetTester tester) async {
+  testWidgets('Stepper header subtitle should not overflow',
+      (WidgetTester tester) async {
     const String longText =
         'A long long long long long long long long long long long long text';
 
@@ -809,8 +822,8 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
         home: Material(
           child: Stepper(
             type: StepperType.horizontal,
-            onStepCancel: () { },
-            onStepContinue: () { },
+            onStepCancel: () {},
+            onStepContinue: () {},
             steps: const <Step>[
               Step(
                 title: Text('step1'),
@@ -824,7 +837,9 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
 
     Material buttonMaterial(String label) {
       return tester.widget<Material>(
-        find.descendant(of: find.widgetWithText(TextButton, label), matching: find.byType(Material)),
+        find.descendant(
+            of: find.widgetWithText(TextButton, label),
+            matching: find.byType(Material)),
       );
     }
 
@@ -832,7 +847,8 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     // the default enabled Stepper buttons have not changed even
     // though the FlatButtons have been replaced by TextButtons.
 
-    const OutlinedBorder buttonShape = RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(2)));
+    const OutlinedBorder buttonShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(2)));
     const Rect continueButtonRect = Rect.fromLTRB(24.0, 212.0, 168.0, 260.0);
     const Rect cancelButtonRect = Rect.fromLTRB(176.0, 212.0, 292.0, 260.0);
 
@@ -841,25 +857,29 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(buttonMaterial('CONTINUE').color!.value, 0xff2196f3);
     expect(buttonMaterial('CONTINUE').textStyle!.color!.value, 0xffffffff);
     expect(buttonMaterial('CONTINUE').shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, 'CONTINUE')), continueButtonRect);
+    expect(tester.getRect(find.widgetWithText(TextButton, 'CONTINUE')),
+        continueButtonRect);
 
     expect(buttonMaterial('CANCEL').color!.value, 0);
     expect(buttonMaterial('CANCEL').textStyle!.color!.value, 0x8a000000);
     expect(buttonMaterial('CANCEL').shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, 'CANCEL')), cancelButtonRect);
+    expect(tester.getRect(find.widgetWithText(TextButton, 'CANCEL')),
+        cancelButtonRect);
 
     await tester.pumpWidget(buildFrame(ThemeData.dark()));
     await tester.pumpAndSettle(); // Complete the theme animation.
 
     expect(buttonMaterial('CONTINUE').color!.value, 0);
-    expect(buttonMaterial('CONTINUE').textStyle!.color!.value,  0xffffffff);
+    expect(buttonMaterial('CONTINUE').textStyle!.color!.value, 0xffffffff);
     expect(buttonMaterial('CONTINUE').shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, 'CONTINUE')), continueButtonRect);
+    expect(tester.getRect(find.widgetWithText(TextButton, 'CONTINUE')),
+        continueButtonRect);
 
     expect(buttonMaterial('CANCEL').color!.value, 0);
     expect(buttonMaterial('CANCEL').textStyle!.color!.value, 0xb3ffffff);
     expect(buttonMaterial('CANCEL').shape, buttonShape);
-    expect(tester.getRect(find.widgetWithText(TextButton, 'CANCEL')), cancelButtonRect);
+    expect(tester.getRect(find.widgetWithText(TextButton, 'CANCEL')),
+        cancelButtonRect);
   });
 
   testWidgets('Stepper disabled button styles', (WidgetTester tester) async {
@@ -882,7 +902,9 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
 
     Material buttonMaterial(String label) {
       return tester.widget<Material>(
-        find.descendant(of: find.widgetWithText(TextButton, label), matching: find.byType(Material)),
+        find.descendant(
+            of: find.widgetWithText(TextButton, label),
+            matching: find.byType(Material)),
       );
     }
 
@@ -908,10 +930,11 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     expect(buttonMaterial('CANCEL').textStyle!.color!.value, 0x61ffffff);
   });
 
-  testWidgets('Vertical and Horizontal Stepper physics test', (WidgetTester tester) async {
+  testWidgets('Vertical and Horizontal Stepper physics test',
+      (WidgetTester tester) async {
     const ScrollPhysics physics = NeverScrollableScrollPhysics();
 
-    for(final StepperType type in StepperType.values) {
+    for (final StepperType type in StepperType.values) {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -932,16 +955,19 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
         ),
       );
 
-      final ListView listView = tester.widget<ListView>(find.descendant(of: find.byType(Stepper), matching: find.byType(ListView)));
+      final ListView listView = tester.widget<ListView>(find.descendant(
+          of: find.byType(Stepper), matching: find.byType(ListView)));
       expect(listView.physics, physics);
     }
   });
 
   testWidgets('Stepper horizontal size test', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/pull/77732
-    Widget buildFrame({ bool isActive = true, Brightness? brightness }) {
+    Widget buildFrame({bool isActive = true, Brightness? brightness}) {
       return MaterialApp(
-        theme: brightness == Brightness.dark ? ThemeData.dark() : ThemeData.light(),
+        theme: brightness == Brightness.dark
+            ? ThemeData.dark()
+            : ThemeData.light(),
         home: Scaffold(
           body: Center(
             child: Stepper(
@@ -961,94 +987,99 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
 
     Color? circleFillColor() {
       final Finder container = find.widgetWithText(AnimatedContainer, '1');
-      return (tester.widget<AnimatedContainer>(container).decoration as BoxDecoration?)?.color;
+      return (tester.widget<AnimatedContainer>(container).decoration
+              as BoxDecoration?)
+          ?.color;
     }
 
     // Light theme
     final ColorScheme light = ThemeData.light().colorScheme;
-    await tester.pumpWidget(buildFrame(isActive: true, brightness: Brightness.light));
+    await tester
+        .pumpWidget(buildFrame(isActive: true, brightness: Brightness.light));
     expect(circleFillColor(), light.primary);
-    await tester.pumpWidget(buildFrame(isActive: false, brightness: Brightness.light));
+    await tester
+        .pumpWidget(buildFrame(isActive: false, brightness: Brightness.light));
     await tester.pumpAndSettle();
     expect(circleFillColor(), light.onSurface.withOpacity(0.38));
 
     // Dark theme
     final ColorScheme dark = ThemeData.dark().colorScheme;
-    await tester.pumpWidget(buildFrame(isActive: true, brightness: Brightness.dark));
+    await tester
+        .pumpWidget(buildFrame(isActive: true, brightness: Brightness.dark));
     await tester.pumpAndSettle();
     expect(circleFillColor(), dark.secondary);
-    await tester.pumpWidget(buildFrame(isActive: false, brightness: Brightness.dark));
+    await tester
+        .pumpWidget(buildFrame(isActive: false, brightness: Brightness.dark));
     await tester.pumpAndSettle();
     expect(circleFillColor(), dark.background);
   });
 
   testWidgets('Stepper custom elevation', (WidgetTester tester) async {
-     const double elevation = 4.0;
+    const double elevation = 4.0;
 
-     await tester.pumpWidget(
-       MaterialApp(
-         home: Material(
-           child: SizedBox(
-             width: 200,
-             height: 75,
-             child: Stepper(
-               type: StepperType.horizontal,
-               elevation: elevation,
-               steps: const <Step>[
-                 Step(
-                   title: Text('Regular title'),
-                   content: Text('Text content'),
-                 ),
-               ],
-             ),
-           ),
-         ),
-       ),
-     );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SizedBox(
+            width: 200,
+            height: 75,
+            child: Stepper(
+              type: StepperType.horizontal,
+              elevation: elevation,
+              steps: const <Step>[
+                Step(
+                  title: Text('Regular title'),
+                  content: Text('Text content'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
 
-     final Material material = tester.firstWidget<Material>(
-       find.descendant(
-         of: find.byType(Stepper),
-         matching: find.byType(Material),
-       ),
-     );
+    final Material material = tester.firstWidget<Material>(
+      find.descendant(
+        of: find.byType(Stepper),
+        matching: find.byType(Material),
+      ),
+    );
 
-     expect(material.elevation, elevation);
-   });
+    expect(material.elevation, elevation);
+  });
 
-   testWidgets('Stepper with default elevation', (WidgetTester tester) async {
+  testWidgets('Stepper with default elevation', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SizedBox(
+            width: 200,
+            height: 75,
+            child: Stepper(
+              type: StepperType.horizontal,
+              steps: const <Step>[
+                Step(
+                    title: Text('Regular title'),
+                    content: Text('Text content')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
 
-     await tester.pumpWidget(
-       MaterialApp(
-         home: Material(
-           child: SizedBox(
-             width: 200,
-             height: 75,
-             child: Stepper(
-               type: StepperType.horizontal,
-               steps: const <Step>[
-                 Step(
-                   title: Text('Regular title'),
-                   content: Text('Text content')
-                 ),
-               ],
-             ),
-           ),
-         ),
-       ),
-     );
+    final Material material = tester.firstWidget<Material>(
+      find.descendant(
+        of: find.byType(Stepper),
+        matching: find.byType(Material),
+      ),
+    );
 
-     final Material material = tester.firstWidget<Material>(
-       find.descendant(
-         of: find.byType(Stepper),
-         matching: find.byType(Material),
-       ),
-     );
+    expect(material.elevation, 2.0);
+  });
 
-     expect(material.elevation, 2.0);
-   });
-
-  testWidgets('Stepper horizontal preserves state', (WidgetTester tester) async {
+  testWidgets('Stepper horizontal preserves state',
+      (WidgetTester tester) async {
     const Color untappedColor = Colors.blue;
     const Color tappedColor = Colors.red;
     int index = 0;
@@ -1090,9 +1121,13 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     await tester.pumpWidget(widget);
 
     // Set up a getter to examine the MacGuffin's color
-    Color getColor() => tester.widget<ColoredBox>(
-      find.descendant(of: find.byKey(const Key('tappable-color')), matching: find.byType(ColoredBox)),
-    ).color;
+    Color getColor() => tester
+        .widget<ColoredBox>(
+          find.descendant(
+              of: find.byKey(const Key('tappable-color')),
+              matching: find.byType(ColoredBox)),
+        )
+        .color;
 
     // We are on step 1
     expect(find.text('Step 2 Content'), findsNothing);
@@ -1119,47 +1154,49 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
     // The color should still be `tappedColor`
     expect(getColor(), tappedColor);
   });
-       testWidgets('Stepper custom margin', (WidgetTester tester) async {
+  testWidgets('Stepper custom margin', (WidgetTester tester) async {
+    const EdgeInsetsGeometry margin = EdgeInsetsDirectional.only(
+      bottom: 20,
+      top: 20,
+    );
 
-      const EdgeInsetsGeometry margin = EdgeInsetsDirectional.only(
-        bottom: 20,
-        top: 20,
-      );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SizedBox(
+            width: 200,
+            height: 75,
+            child: Stepper(
+              margin: margin,
+              type: StepperType.vertical,
+              steps: const <Step>[
+                Step(
+                    title: Text('Regular title'),
+                    content: Text('Text content')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
 
-     await tester.pumpWidget(
-       MaterialApp(
-         home: Material(
-           child: SizedBox(
-             width: 200,
-             height: 75,
-             child: Stepper(
-               margin: margin,
-               type: StepperType.vertical,
-               steps: const <Step>[
-                 Step(
-                   title: Text('Regular title'),
-                   content: Text('Text content')
-                 ),
-               ],
-             ),
-           ),
-         ),
-       ),
-     );
+    final Stepper material = tester.firstWidget<Stepper>(
+      find.descendant(
+        of: find.byType(Material),
+        matching: find.byType(Stepper),
+      ),
+    );
 
-     final Stepper material = tester.firstWidget<Stepper>(
-       find.descendant(
-         of: find.byType(Material),
-         matching: find.byType(Stepper),
-       ),
-     );
-
-     expect(material.margin, equals(margin));
-   });
+    expect(material.margin, equals(margin));
+  });
 }
 
 class _TappableColorWidget extends StatefulWidget {
-  const _TappableColorWidget({required this.tappedColor, required this.untappedColor, Key? key,}) : super(key: key);
+  const _TappableColorWidget({
+    required this.tappedColor,
+    required this.untappedColor,
+    Key? key,
+  }) : super(key: key);
 
   final Color tappedColor;
   final Color untappedColor;
@@ -1169,7 +1206,6 @@ class _TappableColorWidget extends StatefulWidget {
 }
 
 class _TappableColorWidgetState extends State<_TappableColorWidget> {
-
   Color? color;
 
   @override
@@ -1182,7 +1218,7 @@ class _TappableColorWidgetState extends State<_TappableColorWidget> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        setState((){
+        setState(() {
           color = widget.tappedColor;
         });
       },


### PR DESCRIPTION
stepper does not give us a hand when we want to customize its header for example: 
the color, rounds it, color of active or inactive child  etc.
if we are in the current state of stepper , we must not put the check icon but we put if we are in the next state of stepper.
so I added some coool option to customize header of stepper.
There are my example 
![first](https://user-images.githubusercontent.com/37194177/132720930-796cbfcc-0822-44a2-ace1-801657e36e2f.png)
![second](https://user-images.githubusercontent.com/37194177/132720963-85ceb21f-de7a-4f27-b7db-97b6beaf2940.png)
: