### PR TITLE
Limit the retry attempts when flutter_tools runs pub get

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -27,6 +27,13 @@ const String _kPubEnvironmentKey = 'PUB_ENVIRONMENT';
 /// The console environment key used by the pub tool to find the cache directory.
 const String _kPubCacheEnvironmentKey = 'PUB_CACHE';
 
+/// The UNAVAILABLE exit code returned by the pub tool.
+/// (see https://github.com/dart-lang/pub/blob/master/lib/src/exit_codes.dart)
+const int _kPubExitCodeUnavailable = 69;
+
+/// Maximum number of retry attempts when running the pub tool.
+const int _kPubMaxRetryAttempts = 5;
+
 typedef MessageFilter = String Function(String message);
 
 /// Represents Flutter-specific data that is added to the `PUB_ENVIRONMENT`
@@ -250,7 +257,7 @@ class _DefaultPub implements Pub {
         context: context,
         directory: directory,
         failureMessage: 'pub $command failed',
-        retry: true,
+        retry: !offline,
         flutterRootOverride: flutterRootOverride,
       );
       status.stop();
@@ -303,7 +310,7 @@ class _DefaultPub implements Pub {
     int attempts = 0;
     int duration = 1;
     int code;
-    loop: while (true) {
+    while (true) {
       attempts += 1;
       code = await _processUtils.stream(
         _pubCommand(arguments),
@@ -311,15 +318,15 @@ class _DefaultPub implements Pub {
         mapFunction: filterWrapper, // may set versionSolvingFailed, lastPubMessage
         environment: await _createPubEnvironment(context, flutterRootOverride),
       );
-      String message;
-      switch (code) {
-        case 69: // UNAVAILABLE in https://github.com/dart-lang/pub/blob/master/lib/src/exit_codes.dart
+      String? message;
+      if (retry && attempts < _kPubMaxRetryAttempts) {
+        if (code == _kPubExitCodeUnavailable) {
           message = 'server unavailable';
-          break;
-        default:
-          break loop;
+        }
       }
-      assert(message != null);
+      if (message == null) {
+        break;
+      }
       versionSolvingFailed = false;
       _logger.printStatus(
         '$failureMessage ($message) -- attempting retry $attempts in $duration '

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -519,11 +519,6 @@ void main() {
       pubGetCommand,
       pubGetCommand,
       pubGetCommand,
-      pubGetCommand,
-      pubGetCommand,
-      pubGetCommand,
-      pubGetCommand,
-      pubGetCommand,
     ]);
     final BufferLogger logger = BufferLogger.test();
     final FileSystem fileSystem = MemoryFileSystem.test();
@@ -570,27 +565,10 @@ void main() {
         'pub get failed (server unavailable) -- attempting retry 2 in 2 seconds...\n'
         'pub get failed (server unavailable) -- attempting retry 3 in 4 seconds...\n' // at t=1
         'pub get failed (server unavailable) -- attempting retry 4 in 8 seconds...\n' // at t=5
-        'pub get failed (server unavailable) -- attempting retry 5 in 16 seconds...\n' // at t=13
-        'pub get failed (server unavailable) -- attempting retry 6 in 32 seconds...\n' // at t=29
-        'pub get failed (server unavailable) -- attempting retry 7 in 64 seconds...\n', // at t=61
-      );
-      time.elapse(const Duration(seconds: 200)); // from t=0 to t=200
-      expect(logger.statusText,
-        'Running "flutter pub get" in /...\n'
-        'pub get failed (server unavailable) -- attempting retry 1 in 1 second...\n'
-        'pub get failed (server unavailable) -- attempting retry 2 in 2 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 3 in 4 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 4 in 8 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 5 in 16 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 6 in 32 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 7 in 64 seconds...\n'
-        'pub get failed (server unavailable) -- attempting retry 8 in 64 seconds...\n' // at t=39
-        'pub get failed (server unavailable) -- attempting retry 9 in 64 seconds...\n' // at t=103
-        'pub get failed (server unavailable) -- attempting retry 10 in 64 seconds...\n', // at t=167
       );
     });
     expect(logger.errorText, isEmpty);
-    expect(error, isNull);
+    expect(error, 'test failed unexpectedly: Exception: pub get failed (69; no message)');
     expect(processManager, hasNoRemainingExpectations);
   });
 


### PR DESCRIPTION
* Set a maximum number of retries if pub get returns the "unavailable" error code
* Do not retry if pub get is run in offline mode

See https://github.com/flutter/flutter/issues/89759
