### PR TITLE
Remove and also ignore unnecessary imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,6 +36,9 @@ analyzer:
     # Stream and not importing dart:async
     # Please see https://github.com/flutter/flutter/pull/24528 for details.
     sdk_version_async_exported_from_core: ignore
+    # TODO(https://github.com/flutter/flutter/issues/74381):
+    # Clean up existing unnecessary imports, and remove line to ignore.
+    unnecessary_import: ignore
     # Turned off until null-safe rollout is complete.
     unnecessary_null_comparison: ignore
   exclude:

--- a/dev/integration_tests/deferred_components_test/lib/component1.dart
+++ b/dev/integration_tests/deferred_components_test/lib/component1.dart
@@ -5,7 +5,6 @@
 library component1;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 
 class LogoScreen extends StatelessWidget {

--- a/dev/integration_tests/deferred_components_test/lib/main.dart
+++ b/dev/integration_tests/deferred_components_test/lib/main.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
 import 'component1.dart' deferred as component1;

--- a/dev/tools/test/dartdoc_test.dart
+++ b/dev/tools/test/dartdoc_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:platform/platform.dart';
-import 'package:process/process.dart';
 import 'package:test/test.dart';
 
 import '../../../packages/flutter_tools/test/src/fake_process_manager.dart';


### PR DESCRIPTION
In each library where an import is removed, the library uses some elements
provided by the import, BUT there is another import which provides all of the
same elements, and at least one more which the library uses.

In this change, we remove the imports which can be simply removed in favor of
the other already present imports.

Additionally, I add an ignore to analysis_options.yaml, so that
unnecessary_import can land in Dart. After it lands, we can clean up the
remaining cases in flutter.

See https://github.com/dart-lang/sdk/issues/44569 for more information.

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/74381 is _improved_ by this issue. Not fixed.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat