### PR TITLE
Restore the default value of scrollDirection after each test in dismissible_test

### DIFF
--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -7,8 +7,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const double itemExtent = 100.0;
-Axis scrollDirection = Axis.vertical;
-DismissDirection defaultDismissDirection = DismissDirection.horizontal;
+const Axis defaultScrollDirection = Axis.vertical;
+Axis scrollDirection = defaultScrollDirection;
+const DismissDirection defaultDismissDirection = DismissDirection.horizontal;
 DismissDirection dismissDirection = defaultDismissDirection;
 late DismissDirection reportedDismissDirection;
 List<int> dismissedItems = <int>[];
@@ -230,9 +231,10 @@ void main() {
   });
 
   tearDown(() {
-    // To make sure dismissDirection does not have unpredicted values when
-    // tests are being shuffled, restore it to default value after each test.
+    // Restore the default values of dismissDirection and scrollDirection
+    // in order to ensure consistency when the test order is randomized.
     dismissDirection = defaultDismissDirection;
+    scrollDirection = defaultScrollDirection;
   });
 
   testWidgets('Horizontal drag triggers dismiss scrollDirection=vertical', (WidgetTester tester) async {


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/85160
