### PR TITLE
Expose ChangeNotifier.isDisposed

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -108,6 +108,12 @@ class ChangeNotifier implements Listenable {
   int _reentrantlyRemovedListeners = 0;
   bool _debugDisposed = false;
 
+  /// Whether or not this change notifier has been disposed.
+  ///
+  /// If a change notifier has been disposed, any calls to it's other public
+  /// methods will throw.
+  bool get isDisposed => _debugDisposed;
+
   bool _debugAssertNotDisposed() {
     assert(() {
       if (_debugDisposed) {

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -106,17 +106,17 @@ class ChangeNotifier implements Listenable {
   List<VoidCallback?> _listeners = List<VoidCallback?>.filled(0, null);
   int _notificationCallStackDepth = 0;
   int _reentrantlyRemovedListeners = 0;
-  bool _debugDisposed = false;
+  bool _isDisposed = false;
 
   /// Whether or not this change notifier has been disposed.
   ///
   /// If a change notifier has been disposed, any calls to it's other public
   /// methods will throw.
-  bool get isDisposed => _debugDisposed;
+  bool get isDisposed => _isDisposed;
 
-  bool _debugAssertNotDisposed() {
+  bool _assertNotDisposed() {
     assert(() {
-      if (_debugDisposed) {
+      if (_isDisposed) {
         throw FlutterError(
           'A $runtimeType was used after being disposed.\n'
           'Once you have called dispose() on a $runtimeType, it can no longer be used.',
@@ -144,7 +144,7 @@ class ChangeNotifier implements Listenable {
   /// so, stopping that same work.
   @protected
   bool get hasListeners {
-    assert(_debugAssertNotDisposed());
+    assert(_assertNotDisposed());
     return _count > 0;
   }
 
@@ -176,7 +176,7 @@ class ChangeNotifier implements Listenable {
   ///    the list of closures that are notified when the object changes.
   @override
   void addListener(VoidCallback listener) {
-    assert(_debugAssertNotDisposed());
+    assert(_assertNotDisposed());
     if (_count == _listeners.length) {
       if (_count == 0) {
         _listeners = List<VoidCallback?>.filled(1, null);
@@ -236,7 +236,7 @@ class ChangeNotifier implements Listenable {
   ///    changes.
   @override
   void removeListener(VoidCallback listener) {
-    assert(_debugAssertNotDisposed());
+    assert(_assertNotDisposed());
     for (int i = 0; i < _count; i++) {
       final VoidCallback? _listener = _listeners[i];
       if (_listener == listener) {
@@ -265,9 +265,9 @@ class ChangeNotifier implements Listenable {
   /// This method should only be called by the object's owner.
   @mustCallSuper
   void dispose() {
-    assert(_debugAssertNotDisposed());
+    assert(_assertNotDisposed());
     assert(() {
-      _debugDisposed = true;
+      _isDisposed = true;
       return true;
     }());
   }
@@ -291,7 +291,7 @@ class ChangeNotifier implements Listenable {
   @visibleForTesting
   @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {
-    assert(_debugAssertNotDisposed());
+    assert(_assertNotDisposed());
     if (_count == 0)
       return;
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -325,7 +325,9 @@ void main() {
 
   test('Cannot use a disposed ChangeNotifier', () {
     final TestNotifier source = TestNotifier();
+    expect(source.isDisposed, false);
     source.dispose();
+    expect(source.isDisposed, true);
     expect(() {
       source.addListener(() {});
     }, throwsFlutterError);


### PR DESCRIPTION
In many situations, it is impossible to safely call `removeListener` from a `StatefulWidget`'s `dispose` function. In many cases the stateful widget, or even the developer's app, is not in control of the change notifier and the widget may be disposed before or after the change notifier was disposed. For example, the change notifier may be exposed by a third party package that makes no guarantees about the order in which a change notifier will be disposed. See #71983 for a specific example.

Ideally, calls to `removeListener` should be safe-it shouldn't throw when the change notifier has already been disposed. However, removing the assert is theoretically a breaking change as some users may have `try...on` blocks that rely on the assert throwing in this case. To avoid a breaking change, I've instead exposed `_debugIsDisposed` which is more broadly useful than just for ensuring calls to `removeListener` are safe.

It appears that `ChangeNotifier` has been written with a philosophical belief that `_debugIsDisposed` should not be public. However, you can't have both. Either expose `isDisposed`, or make `removeListener` safe to call. Otherwise you're forcing developers in some circumstances to use sloppy and dangerous `try...on` blocks. Honestly, ideally, we'd want to expose `isDisposed` AND make calls to `removeListener` safe.

Fixes: https://github.com/flutter/flutter/issues/71983

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
