### PR TITLE
WIP: Add partial repaint macrobenchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -17,6 +17,7 @@ const String kColorFilterAndFadeRouteName = '/color_filter_and_fade';
 const String kFadingChildAnimationRouteName = '/fading_child_animation';
 const String kImageFilteredTransformAnimationRouteName = '/imagefiltered_transform_animation';
 const String kMultiWidgetConstructionRouteName = '/multi_widget_construction';
+const String kPartialRepaintRouteName = '/partial_repaint';
 const String kHeavyGridViewRouteName = '/heavy_gridview';
 const String kSimpleScrollRouteName = '/simple_scroll';
 const String kStackSizeRouteName = '/stack_size';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -19,6 +19,7 @@ import 'src/heavy_grid_view.dart';
 import 'src/large_image_changer.dart';
 import 'src/large_images.dart';
 import 'src/multi_widget_construction.dart';
+import 'src/partial_repaint.dart';
 import 'src/picture_cache.dart';
 import 'src/post_backdrop_filter.dart';
 import 'src/simple_animation.dart';
@@ -55,6 +56,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kFadingChildAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.opacity),
         kImageFilteredTransformAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.rotateFilter),
         kMultiWidgetConstructionRouteName: (BuildContext context) => const MultiWidgetConstructTable(10, 20),
+        kPartialRepaintRouteName: (BuildContext context) => const PartialRepaintPage(),
         kHeavyGridViewRouteName: (BuildContext context) => const HeavyGridViewPage(),
         kSimpleScrollRouteName: (BuildContext context) => const SimpleScroll(),
         kStackSizeRouteName: (BuildContext context) => const StackSizePage(),
@@ -175,6 +177,12 @@ class HomePage extends StatelessWidget {
               Navigator.pushNamed(context, kMultiWidgetConstructionRouteName);
             },
           ),
+          ElevatedButton(
+              key: const Key(kPartialRepaintRouteName),
+              onPressed: () {
+                Navigator.pushNamed(context, kPartialRepaintRouteName);
+              },
+              child: const Text('Partial Repaint')),
           ElevatedButton(
             key: const Key(kHeavyGridViewRouteName),
             child: const Text('Heavy Grid View'),

--- a/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
@@ -3,16 +3,9 @@ import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-class PartialRepaintPage extends StatefulWidget {
+class PartialRepaintPage extends StatelessWidget {
   const PartialRepaintPage({Key? key}) : super(key: key);
 
-  @override
-  State<StatefulWidget> createState() {
-    return _PageState();
-  }
-}
-
-class _PageState extends State<PartialRepaintPage> {
   @override
   Widget build(BuildContext context) {
     return CupertinoApp(

--- a/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
@@ -1,0 +1,96 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class PartialRepaintPage extends StatefulWidget {
+  const PartialRepaintPage({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() {
+    return _PageState();
+  }
+}
+
+class _PageState extends State<PartialRepaintPage> {
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoApp(
+      theme: const CupertinoThemeData(brightness: Brightness.light),
+      home: CupertinoPageScaffold(
+        navigationBar: const CupertinoNavigationBar(
+          middle: Text('Partial Repaint'),
+        ),
+        child: CupertinoTabScaffold(
+          tabBar: CupertinoTabBar(items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(icon: Icon(Icons.power)),
+            BottomNavigationBarItem(icon: Icon(Icons.disabled_by_default))
+          ]),
+          tabBuilder: (BuildContext context, int index) {
+            return index == 0 ? const Body() : const SizedBox();
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class Body extends StatelessWidget {
+  const Body({
+    Key? key,
+  }) : super(key: key);
+
+  Widget buildChild(int i) {
+    final BoxDecoration decoration = BoxDecoration(
+      color: Colors.red,
+      boxShadow: <BoxShadow>[
+        BoxShadow(
+          color: Colors.black.withOpacity(0.3),
+          blurRadius: 10.0,
+        ),
+      ],
+      borderRadius: BorderRadius.circular(10.0),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(3),
+      child: Container(
+        padding: const EdgeInsets.all(4),
+        child: Text(
+          'Item $i',
+          style: const TextStyle(fontSize: 11.0),
+        ),
+        decoration: decoration,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        Positioned.fill(
+          child: SingleChildScrollView(
+            child: Wrap(
+              children:
+                  List<Widget>.generate(200, (int index) => buildChild(index)),
+            ),
+          ),
+        ),
+        const Positioned.fill(
+          child: IgnorePointer(
+            child: Center(
+              child: SizedBox(
+                width: 40,
+                height: 40,
+                child: CircularProgressIndicator(
+                  strokeWidth: 5,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/partial_repaint.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';

--- a/dev/benchmarks/macrobenchmarks/test_driver/partial_repaint_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/partial_repaint_perf_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'partial_repaint_perf_perf',
+    kPartialRepaintRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}


### PR DESCRIPTION
This adds a macrobenchmark for https://github.com/flutter/engine/pull/25158. It consists of a relatively busy page with an activity indicator in the middle.

<img width="484" alt="Screen Shot 2021-09-12 at 5 09 07 PM" src="https://user-images.githubusercontent.com/96958/132992845-f199eb52-acc5-44eb-9408-9625a5efd19e.png">
