### PR TITLE
Revert "Removed default page transitions for desktop and web platforms. (#82596)"

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -546,9 +546,8 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 /// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
 /// and delegates to [buildTransitions].
 ///
-/// If a builder for the current [ThemeData.platform] is not found, then
-/// no animated transition will occur. The new page will just be displayed
-/// immediately.
+/// If a builder with a matching platform is not found, then the
+/// [FadeUpwardsPageTransitionsBuilder] is used.
 ///
 /// See also:
 ///
@@ -564,23 +563,16 @@ class PageTransitionsTheme with Diagnosticable {
   /// Constructs an object that selects a transition based on the platform.
   ///
   /// By default the list of builders is: [FadeUpwardsPageTransitionsBuilder]
-  /// for [TargetPlatform.android] and [TargetPlatform.fuchsia],
-  /// [CupertinoPageTransitionsBuilder] for [TargetPlatform.iOS], and no
-  /// animated transition for other platforms or if the app is running on the
-  /// web.
-  const PageTransitionsTheme({
-    Map<TargetPlatform, PageTransitionsBuilder> builders = kIsWeb ? _defaultWebBuilders : _defaultBuilders,
-  }) : _builders = builders;
+  /// for [TargetPlatform.android], and [CupertinoPageTransitionsBuilder] for
+  /// [TargetPlatform.iOS] and [TargetPlatform.macOS].
+  const PageTransitionsTheme({ Map<TargetPlatform, PageTransitionsBuilder> builders = _defaultBuilders }) : _builders = builders;
 
   static const Map<TargetPlatform, PageTransitionsBuilder> _defaultBuilders = <TargetPlatform, PageTransitionsBuilder>{
-    // Only have default transitions for mobile platforms
     TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
     TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-    TargetPlatform.fuchsia: FadeUpwardsPageTransitionsBuilder(),
-  };
-
-  static const Map<TargetPlatform, PageTransitionsBuilder> _defaultWebBuilders = <TargetPlatform, PageTransitionsBuilder>{
-    // By default no page transitions for web apps.
+    TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
+    TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+    TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
   };
 
   /// The [PageTransitionsBuilder]s supported by this theme.
@@ -603,8 +595,9 @@ class PageTransitionsTheme with Diagnosticable {
     if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route))
       platform = TargetPlatform.iOS;
 
-    final PageTransitionsBuilder? matchingBuilder = builders[platform];
-    return matchingBuilder?.buildTransitions<T>(route, context, animation, secondaryAnimation, child) ?? child;
+    final PageTransitionsBuilder matchingBuilder =
+      builders[platform] ?? const FadeUpwardsPageTransitionsBuilder();
+    return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
   }
 
   // Just used to the builders Map to a list with one PageTransitionsBuilder per platform

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart' show CupertinoPageRoute;
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -66,10 +65,7 @@ void main() {
 
     expect(find.text('Page 1'), isOnstage);
     expect(find.text('Page 2'), findsNothing);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('test page transition', (WidgetTester tester) async {
     final Key page2Key = UniqueKey();
@@ -150,10 +146,7 @@ void main() {
 
     // Page 1 is back where it started.
     expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets('test fullscreen dialog transition', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -213,10 +206,7 @@ void main() {
 
     // Page 1 is back where it started.
     expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets('test no back gesture on Android', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -246,10 +236,7 @@ void main() {
 
     // Page 2 didn't move
     expect(tester.getTopLeft(find.text('Page 2')), Offset.zero);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('test back gesture', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -290,10 +277,7 @@ void main() {
     await tester.pump();
 
     expect(tester.getTopLeft(find.text('Page 2')), const Offset(100.0, 0.0));
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets('back gesture while OS changes', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -378,13 +362,13 @@ void main() {
     expect(find.text('PUSH'), findsNothing);
     expect(find.text('HELLO'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 20));
-    // As no transitions are specified for macOS the drag should do nothing
-    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('PUSH'), findsOneWidget);
     expect(find.text('HELLO'), findsOneWidget);
     final Offset helloPosition6 = tester.getCenter(find.text('HELLO'));
-    expect(helloPosition5, helloPosition6);
+    expect(helloPosition5.dx, lessThan(helloPosition6.dx));
+    expect(helloPosition5.dy, helloPosition6.dy);
     expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.macOS);
-  }, skip: kIsWeb); // [intended] doesn't apply to the web.
+  });
 
   testWidgets('test no back gesture on fullscreen dialogs', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -495,10 +479,7 @@ void main() {
 
     // Page 1 is back where it started.
     expect(widget1InitialTopLeft == widget1TransientTopLeft, true);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('test edge swipe then drop back at starting point works', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -566,10 +547,7 @@ void main() {
 
     expect(find.text('Page 1'), isOnstage);
     expect(find.text('Page 2'), findsNothing);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Back swipe dismiss interrupted by route push', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/28728
@@ -664,10 +642,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('route'), findsOneWidget);
     expect(find.text('push'), findsNothing);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('During back swipe the route ignores input', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/39989
@@ -737,10 +712,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.getTopLeft(find.byKey(pageScaffoldKey)), const Offset(400, 0));
     expect(tester.getTopLeft(find.byKey(homeScaffoldKey)).dx, lessThan(0));
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('After a pop caused by a back-swipe, input reaches the exposed route', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/41024
@@ -811,10 +783,7 @@ void main() {
     await tester.tap(find.byKey(homeScaffoldKey));
     expect(homeTapCount, 2);
     expect(pageTapCount, 1);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('A MaterialPageRoute should slide out with CupertinoPageTransition when a compatible PageRoute is pushed on top of it', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/44864.
@@ -842,10 +811,7 @@ void main() {
     // Title of the first route slides to the left.
     expect(titleInitialTopLeft.dy, equals(titleTransientTopLeft.dy));
     expect(titleInitialTopLeft.dx, greaterThan(titleTransientTopLeft.dx));
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('MaterialPage works', (WidgetTester tester) async {
     final LocalKey pageKey = UniqueKey();

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -11,33 +11,17 @@ void main() {
   testWidgets('Default PageTransitionsTheme platform', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: Text('home')));
     final PageTransitionsTheme theme = Theme.of(tester.element(find.text('home'))).pageTransitionsTheme;
-
     expect(theme.builders, isNotNull);
-    if (kIsWeb) {
-      // There aren't any default transitions defined for web
-      expect(theme.builders, isEmpty);
-    } else {
-      // There should only be builders for the mobile platforms.
-      for (final TargetPlatform platform in TargetPlatform.values) {
-        switch (platform) {
-          case TargetPlatform.android:
-          case TargetPlatform.iOS:
-          case TargetPlatform.fuchsia:
-            expect(theme.builders[platform], isNotNull,
-                reason: 'theme builder for $platform is null');
-            break;
-          case TargetPlatform.linux:
-          case TargetPlatform.macOS:
-          case TargetPlatform.windows:
-            expect(theme.builders[platform], isNull,
-                reason: 'theme builder for $platform is not null');
-            break;
-        }
+    for (final TargetPlatform platform in TargetPlatform.values) {
+      if (platform == TargetPlatform.fuchsia) {
+        // No builder on Fuchsia.
+        continue;
       }
+      expect(theme.builders[platform], isNotNull, reason: 'theme builder for $platform is null');
     }
   });
 
-  testWidgets('Default PageTransitionsTheme builds a CupertinoPageTransition', (WidgetTester tester) async {
+  testWidgets('Default PageTransitionsTheme builds a CupertionPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => Material(
         child: TextButton(
@@ -61,10 +45,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
     expect(find.byType(CupertinoPageTransition), findsOneWidget);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Default PageTransitionsTheme builds a _FadeUpwardsPageTransition for android', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -97,10 +78,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
     expect(findFadeUpwardsPageTransition(), findsOneWidget);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('PageTransitionsTheme override builds a _OpenUpwardsPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -140,10 +118,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
     expect(findOpenUpwardsPageTransition(), findsOneWidget);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('PageTransitionsTheme override builds a _ZoomPageTransition', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
@@ -183,10 +158,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('page b'), findsOneWidget);
     expect(findZoomPageTransition(), findsOneWidget);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
   testWidgets('_ZoomPageTransition only cause child widget built once', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/58345
@@ -232,8 +204,5 @@ void main() {
     await tester.tap(find.text('pop'));
     await tester.pumpAndSettle();
     expect(builtCount, 1);
-  },
-    variant: TargetPlatformVariant.only(TargetPlatform.android),
-    skip: kIsWeb, // [intended] no default transitions on the web.
-  );
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1479,13 +1479,13 @@ void main() {
     // Wait for context menu to be built.
     await tester.pumpAndSettle();
     final RenderBox container = tester.renderObject(find.descendant(
-      of: find.byType(Overlay),
+      of: find.byType(FadeTransition),
       matching: find.byType(SizedBox),
     ).first);
     expect(container.size, Size.zero);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }));
 
-  testWidgets('Swapping controllers should update selection', (WidgetTester tester) async {
+  testWidgets('Sawping controllers should update selection', (WidgetTester tester) async {
     TextEditingController controller = TextEditingController(text: 'readonly');
     final OverlayEntry entry = OverlayEntry(
       builder: (BuildContext context) {

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -1836,10 +1836,7 @@ Future<void> main() async {
     expect(find.byKey(firstKey), isInCard);
     expect(find.byKey(secondKey), isOnstage);
     expect(find.byKey(secondKey), isInCard);
-  },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      skip: kIsWeb, // [intended] there are no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Heroes can transition on gesture in one frame', (WidgetTester tester) async {
     transitionFromUserGestures = true;
@@ -1882,10 +1879,7 @@ Future<void> main() async {
     expect(find.byKey(firstKey), isOnstage);
     expect(find.byKey(firstKey), isInCard);
     expect(find.byKey(secondKey), findsNothing);
-  },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      skip: kIsWeb, // [intended] there are no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Heroes animate should hide destination hero and display original hero in case of dismissed', (WidgetTester tester) async {
     transitionFromUserGestures = true;
@@ -1921,10 +1915,7 @@ Future<void> main() async {
     expect(find.byKey(firstKey), findsNothing);
     expect(find.byKey(secondKey), isOnstage);
     expect(find.byKey(secondKey), isInCard);
-  },
-      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-      skip: kIsWeb, // [intended] there are no default transitions on the web.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Handles transitions when a non-default initial route is set', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/widgets/page_transitions_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -197,7 +196,7 @@ void main() {
     settingsOffset = tester.getTopLeft(find.text('Settings'));
     expect(settingsOffset.dx, greaterThan(100.0));
     expect(settingsOffset.dy, 100.0);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS), skip: kIsWeb); // [intended] no default transitions on web.
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets("Check back gesture doesn't start during transitions", (WidgetTester tester) async {
     final GlobalKey containerKey1 = GlobalKey();
@@ -240,7 +239,7 @@ void main() {
 
     expect(find.text('Home'), isOnstage);
     expect(find.text('Settings'), findsNothing);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS), skip: kIsWeb); // [intended] no default transitions on web.
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   // Tests bug https://github.com/flutter/flutter/issues/6451
   testWidgets('Check back gesture with a persistent bottom sheet showing', (WidgetTester tester) async {
@@ -294,7 +293,7 @@ void main() {
 
     // Sheet did not call setState (since the gesture did nothing).
     expect(sheet.setStateCalled, isFalse);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS), skip: kIsWeb); // [intended] no default transitions on web.
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('Test completed future', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{


### PR DESCRIPTION
This reverts commit 43e31977 from #82596.

In that PR we removed the default transition, but the animation delay for the transition is baked into the [MaterialRouteTransitionMixin](https://github.com/flutter/flutter/blob/1422bfa7237be3efdcde2ba206db4ae962898f4c/packages/flutter/lib/src/material/page.dart#L85), as pointed out in #88221. 

Unfortunately it looks like removing this delay will be more complicated than anticipated and it would be better to revert this PR until we can come up with a better solution.
