### PR TITLE
fixes zero route transition duration crashes

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -811,10 +811,10 @@ abstract class TransitionDelegate<T> {
       final Set<RouteTransitionRecord> exitingPageRoutes = locationToExitingPageRoute.values.toSet();
       // Firstly, verifies all exiting routes have been marked.
       for (final RouteTransitionRecord exitingPageRoute in exitingPageRoutes) {
-        assert((exitingPageRoute as _RouteEntry).pendingDecision != null);
+        assert(!exitingPageRoute.isWaitingForExitingDecision || (exitingPageRoute as _RouteEntry).pendingDecision != null);
         if (pageRouteToPagelessRoutes.containsKey(exitingPageRoute)) {
           for (final RouteTransitionRecord pagelessRoute in pageRouteToPagelessRoutes[exitingPageRoute]!) {
-            assert((pagelessRoute as _RouteEntry).pendingDecision != null);
+            assert(!pagelessRoute.isWaitingForExitingDecision || (pagelessRoute as _RouteEntry).pendingDecision != null);
           }
         }
       }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3060,7 +3060,6 @@ class _RouteEntry extends RouteTransitionRecord {
     final Object? result = pendingResult;
     pendingDecision = null;
     pendingResult = null;
-    _isWaitingForExitingDecision = false;
     switch(decision) {
       case _TransitionDecision.add:
         currentState = _RouteLifecycle.add;
@@ -3078,6 +3077,7 @@ class _RouteEntry extends RouteTransitionRecord {
         remove();
         break;
     }
+    _isWaitingForExitingDecision = false;
   }
 
   bool get restorationEnabled => route.restorationScopeId.value != null;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2700,11 +2700,11 @@ enum _RouteLifecycle {
 }
 
 enum _TransitionDecision {
+  add,
+  push,
   pop,
   remove,
   complete,
-  add,
-  push,
 }
 
 typedef _RouteEntryPredicate = bool Function(_RouteEntry entry);
@@ -2946,13 +2946,18 @@ class _RouteEntry extends RouteTransitionRecord {
   }
 
   bool get willBePresent {
+    if (pendingDecision != null) {
+      return pendingDecision!.index <= _TransitionDecision.push.index;
+    }
     return currentState.index <= _RouteLifecycle.idle.index &&
            currentState.index >= _RouteLifecycle.add.index;
   }
 
   bool get isPresent {
     return currentState.index <= _RouteLifecycle.remove.index &&
-           currentState.index >= _RouteLifecycle.add.index;
+           // If there is pending exiting decision, it is still considered
+           // present until the decision is executed.
+           (currentState.index >= _RouteLifecycle.add.index || pendingDecision != null);
   }
 
   bool get isPresentForRestoration => currentState.index <= _RouteLifecycle.idle.index;

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3553,6 +3553,7 @@ void main() {
       );
 
       await tester.pumpAndSettle();
+
       expect(observations.length, 8);
       // Initial routes are pushed.
       expect(observations[0].operation, 'push');
@@ -3801,6 +3802,8 @@ class NavigatorObservation {
   final String? previous;
   final String? current;
   final String operation;
+  @override
+  String toString() => '$operation(previous = $previous, current $current)';
 }
 
 class BuilderPage extends Page<void> {


### PR DESCRIPTION
If the page update pop a page with zero duration, the Route.didPop will call Navigator.finalizeRoute synchronously which calls _flushHistoryUpdates before the _updatePage finishes. This pr defers didPop call in markForPop during TransitionDelegate.resolve and only call didpop during the _flushHistoryUpdates.

fixes https://github.com/flutter/flutter/issues/86604

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
