### PR TITLE
[flutter_tools] use test logger, which does not allow colors

### DIFF
--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -114,10 +114,7 @@ void testUsingContext(
           HttpClient: () => FakeHttpClient.any(),
           IOSSimulatorUtils: () => const NoopIOSSimulatorUtils(),
           OutputPreferences: () => OutputPreferences.test(),
-          Logger: () => BufferLogger(
-            terminal: globals.terminal,
-            outputPreferences: globals.outputPreferences,
-          ),
+          Logger: () => BufferLogger.test(),
           OperatingSystemUtils: () => FakeOperatingSystemUtils(),
           PersistentToolState: () => buildPersistentToolState(globals.fs),
           Usage: () => TestUsage(),


### PR DESCRIPTION
this fixes tests that fail for me when I run them via `dart test packages/flutter_tools` because of ASCII color codes.