### PR TITLE
InteractiveViewer with a child of zero size

### DIFF
--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -515,6 +515,10 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     // Boundaries that are partially infinite are not allowed because Matrix4's
     // rotation and translation methods don't handle infinites well.
     assert(
+      !boundaryRect.isEmpty,
+      "InteractiveViewer's child must have nonzero dimensions.",
+    );
+    assert(
       boundaryRect.isFinite ||
         (boundaryRect.left.isInfinite
         && boundaryRect.top.isInfinite

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -512,12 +512,12 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
     final RenderBox childRenderBox = _childKey.currentContext!.findRenderObject()! as RenderBox;
     final Size childSize = childRenderBox.size;
     final Rect boundaryRect = widget.boundaryMargin.inflateRect(Offset.zero & childSize);
-    // Boundaries that are partially infinite are not allowed because Matrix4's
-    // rotation and translation methods don't handle infinites well.
     assert(
       !boundaryRect.isEmpty,
       "InteractiveViewer's child must have nonzero dimensions.",
     );
+    // Boundaries that are partially infinite are not allowed because Matrix4's
+    // rotation and translation methods don't handle infinites well.
     assert(
       boundaryRect.isFinite ||
         (boundaryRect.left.isInfinite

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -234,7 +234,7 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
       expect(transformationController.value, equals(Matrix4.identity()));
-      expect(tester.takeException(), isFlutterError);
+      expect(tester.takeException(), isAssertionError);
     });
 
     testWidgets('no boundary', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -201,6 +201,42 @@ void main() {
       expect(transformationController.value, isNot(equals(Matrix4.identity())));
     });
 
+    testWidgets('child has no dimensions', (WidgetTester tester) async {
+      final TransformationController transformationController = TransformationController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                constrained: false,
+                scaleEnabled: false,
+                transformationController: transformationController,
+                child: const SizedBox(width: 0.0, height: 0.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(transformationController.value, equals(Matrix4.identity()));
+
+      // Interacting throws an error because the child has no size.
+      final Offset childOffset = tester.getTopLeft(find.byType(SizedBox));
+      final Offset childInterior = Offset(
+        childOffset.dx + 20.0,
+        childOffset.dy + 20.0,
+      );
+      final TestGesture gesture = await tester.startGesture(childOffset);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      await gesture.moveTo(childInterior);
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(transformationController.value, equals(Matrix4.identity()));
+      expect(tester.takeException(), isFlutterError);
+    });
+
     testWidgets('no boundary', (WidgetTester tester) async {
       final TransformationController transformationController = TransformationController();
       const double minScale = 0.8;


### PR DESCRIPTION
This PR adds an assertion when it detects the user has passed a zero sized child to InteractiveViewer.  This was previously resulting in infinite matrix calculations with no warning given to the user.

Fixes https://github.com/flutter/flutter/issues/88467