### PR TITLE
Initialize all bindings before starting the text_editing_action_target test suite

### DIFF
--- a/packages/flutter/test/widgets/text_editing_action_target_test.dart
+++ b/packages/flutter/test/widgets/text_editing_action_target_test.dart
@@ -93,6 +93,9 @@ class _FakeEditableTextState with TextSelectionDelegate, TextEditingActionTarget
 }
 
 void main() {
+  // Ensure that all TestRenderingFlutterBinding bindings are initialized.
+  renderer;
+
   test('moveSelectionLeft/RightByLine stays on the current line', () async {
     const String text = 'one two three\n\nfour five six';
     final _FakeEditableTextState editableTextState = _FakeEditableTextState(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90057
