### PR TITLE
Set BUILD_DIR and OBJROOT when determining if plugins support arm64 simulators

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -499,6 +499,13 @@ void _validateIosPodfile(String appPath) {
     'test_plugin_swift',
     'ios',
   ));
+
+  // Make sure no Xcode build settings are leaking derived data/build directory into the ios directory.
+  checkDirectoryNotExists(path.join(
+    appPath,
+    'ios',
+    'build',
+  ));
 }
 
 void _validateMacOSPodfile(String appPath) {

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -228,6 +228,7 @@ class XcodeProjectInterpreter {
       return null;
     }
     final Status status = _logger.startSpinner();
+    final String buildDirectory = _fileSystem.path.absolute(getIosBuildDirectory());
     final List<String> showBuildSettingsCommand = <String>[
       ...xcrunCommand(),
       'xcodebuild',
@@ -237,6 +238,8 @@ class XcodeProjectInterpreter {
       '-project',
       podXcodeProject.path,
       '-showBuildSettings',
+      'BUILD_DIR=$buildDirectory',
+      'OBJROOT=$buildDirectory',
     ];
     try {
       // showBuildSettings is reported to occasionally timeout. Here, we give it

--- a/packages/flutter_tools/templates/app_shared/ios.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app_shared/ios.tmpl/.gitignore
@@ -1,3 +1,4 @@
+**/dgph
 *.mode1v3
 *.mode2v3
 *.moved-aside

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/.gitignore
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/.gitignore
@@ -3,4 +3,5 @@
 **/Pods/
 
 # Xcode-related
+**/dgph
 **/xcuserdata/

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -695,6 +695,7 @@ Information about project "Runner":
         final Directory podXcodeProject = project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
           ..createSync(recursive: true);
 
+        final String buildDirectory = fileSystem.path.absolute('build', 'ios');
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
           kARMCheckCommand,
@@ -710,6 +711,8 @@ Information about project "Runner":
               '-project',
               podXcodeProject.path,
               '-showBuildSettings',
+              'BUILD_DIR=$buildDirectory',
+              'OBJROOT=$buildDirectory',
             ],
             stdout: '''
 Build settings for action build and target plugin1:
@@ -748,6 +751,7 @@ Build settings for action build and target plugin2:
         final Directory podXcodeProject = project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
           ..createSync(recursive: true);
 
+        final String buildDirectory = fileSystem.path.absolute('build', 'ios');
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
           kARMCheckCommand,
@@ -763,6 +767,8 @@ Build settings for action build and target plugin2:
                 '-project',
                 podXcodeProject.path,
                 '-showBuildSettings',
+                'BUILD_DIR=$buildDirectory',
+                'OBJROOT=$buildDirectory',
               ],
               exitCode: 1,
           ),
@@ -789,6 +795,7 @@ Build settings for action build and target plugin2:
         final Directory podXcodeProject = project.ios.hostAppRoot.childDirectory('Pods').childDirectory('Pods.xcodeproj')
           ..createSync(recursive: true);
 
+        final String buildDirectory = fileSystem.path.absolute('build', 'ios');
         fakeProcessManager.addCommands(<FakeCommand>[
           kWhichSysctlCommand,
           kARMCheckCommand,
@@ -804,6 +811,8 @@ Build settings for action build and target plugin2:
                 '-project',
                 podXcodeProject.path,
                 '-showBuildSettings',
+                'BUILD_DIR=$buildDirectory',
+                'OBJROOT=$buildDirectory',
               ],
               stdout: '''
 Build settings for action build and target plugin1:


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/87244 started checking plugin Xcode build settings to see if any of them do not support arm64 simulators, so the whole app can opt out of supporting those simulators.
However, when calling `xcodebuild` some files are cached to the `OBJROOT` path, which was incorrectly defaulting to `ios/build` (which is not gitignored).  Pass in the Flutter `build` directory instead for build settings `BUILD_DIR` and `OBJROOT`.

Add the `dgph` to the iOS and macOS gitignore templates since they should never be checked in, and were the type of files being generated in the build directory.
Add a directory check to `plugin_lint_mac` integration test to prevent future regressions.  This fails on master and passes on this PR.

Fixes https://github.com/flutter/flutter/issues/89912