### PR TITLE
[flutter_tools] remove non-null check from AndroidValidator

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -457,7 +457,7 @@ class AndroidLicenseValidator extends DoctorValidator {
       return exitCode == 0;
     } on ProcessException catch (e) {
       throwToolExit(_userMessages.androidCannotRunSdkManager(
-        _androidSdk.sdkManagerPath!,
+        _androidSdk.sdkManagerPath ?? '',
         e.toString(),
         _platform,
       ));

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -202,7 +202,6 @@ class AndroidValidator extends DoctorValidator {
       if (androidSdkLatestVersion.sdkLevel < kAndroidSdkMinVersion || androidSdkLatestVersion.buildToolsVersion < kAndroidSdkBuildToolsMinVersion) {
         messages.add(ValidationMessage.error(
           _userMessages.androidSdkBuildToolsOutdated(
-            _androidSdk!.sdkManagerPath,
             kAndroidSdkMinVersion,
             kAndroidSdkBuildToolsMinVersion.toString(),
             _platform,

--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -202,7 +202,7 @@ class AndroidValidator extends DoctorValidator {
       if (androidSdkLatestVersion.sdkLevel < kAndroidSdkMinVersion || androidSdkLatestVersion.buildToolsVersion < kAndroidSdkBuildToolsMinVersion) {
         messages.add(ValidationMessage.error(
           _userMessages.androidSdkBuildToolsOutdated(
-            _androidSdk!.sdkManagerPath!,
+            _androidSdk!.sdkManagerPath,
             kAndroidSdkMinVersion,
             kAndroidSdkBuildToolsMinVersion.toString(),
             _platform,

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -117,7 +117,7 @@ class UserMessages {
       'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidSdkBuildToolsOutdated(String? managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
+  String androidSdkBuildToolsOutdated(int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
       'To update the Android SDK visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
   String get androidMissingCmdTools => 'cmdline-tools component is missing\n'

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -117,7 +117,7 @@ class UserMessages {
       'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "$error".\n'
       'Try re-installing or updating your Android SDK,\n'
       'visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
-  String androidSdkBuildToolsOutdated(String managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
+  String androidSdkBuildToolsOutdated(String? managerPath, int sdkMinVersion, String buildToolsMinVersion, Platform platform) =>
       'Flutter requires Android SDK $sdkMinVersion and the Android BuildTools $buildToolsMinVersion\n'
       'To update the Android SDK visit ${_androidSdkInstallUrl(platform)} for detailed instructions.';
   String get androidMissingCmdTools => 'cmdline-tools component is missing\n'

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -410,7 +410,6 @@ Review licenses that have not been accepted (y/N)?
       ..latestVersion = sdkVersion;
 
     final String errorMessage = UserMessages().androidSdkBuildToolsOutdated(
-      sdk.sdkManagerPath,
       kAndroidSdkMinVersion,
       kAndroidSdkBuildToolsMinVersion.toString(),
       FakePlatform(),

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -338,6 +338,30 @@ Review licenses that have not been accepted (y/N)?
     expect(licenseValidator.runLicenseManager(), throwsToolExit());
   });
 
+  testWithoutContext('AndroidValidator handles a null Android sdkManagerPath', () async {
+    final AndroidSdkVersion sdkVersion = FakeAndroidSdkVersion()
+        ..sdkLevel = 28
+        ..buildToolsVersion = Version(26, 0, 3);
+    sdk
+      ..sdkManagerPath = null
+      ..latestVersion = sdkVersion
+      ..directory = fileSystem.directory('/foo/bar')
+      ..cmdlineToolsAvailable = true
+      ..licensesAvailable = false;
+
+    final ValidationResult result = await AndroidValidator(
+      androidStudio: null,
+      androidSdk: sdk,
+      fileSystem: fileSystem,
+      logger: logger,
+      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
+      processManager: processManager,
+      userMessages: UserMessages(),
+    ).validate();
+
+    expect(result.type, ValidationType.missing);
+  });
+
   testWithoutContext('detects license-only SDK installation with cmdline-tools', () async {
     sdk
       ..licensesAvailable = true

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -338,30 +338,6 @@ Review licenses that have not been accepted (y/N)?
     expect(licenseValidator.runLicenseManager(), throwsToolExit());
   });
 
-  testWithoutContext('AndroidValidator handles a null Android sdkManagerPath', () async {
-    final AndroidSdkVersion sdkVersion = FakeAndroidSdkVersion()
-        ..sdkLevel = 28
-        ..buildToolsVersion = Version(26, 0, 3);
-    sdk
-      ..sdkManagerPath = null
-      ..latestVersion = sdkVersion
-      ..directory = fileSystem.directory('/foo/bar')
-      ..cmdlineToolsAvailable = true
-      ..licensesAvailable = false;
-
-    final ValidationResult result = await AndroidValidator(
-      androidStudio: null,
-      androidSdk: sdk,
-      fileSystem: fileSystem,
-      logger: logger,
-      platform: FakePlatform()..environment = <String, String>{'HOME': '/home/me'},
-      processManager: processManager,
-      userMessages: UserMessages(),
-    ).validate();
-
-    expect(result.type, ValidationType.missing);
-  });
-
   testWithoutContext('detects license-only SDK installation with cmdline-tools', () async {
     sdk
       ..licensesAvailable = true

--- a/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/user_messages_test.dart
@@ -27,7 +27,7 @@ void main() {
     _checkInstallationURL((Platform platform) => userMessages.androidSdkInstallHelp(platform));
     _checkInstallationURL((Platform platform) => userMessages.androidMissingSdkManager('/', platform));
     _checkInstallationURL((Platform platform) => userMessages.androidCannotRunSdkManager('/', '', platform));
-    _checkInstallationURL((Platform platform) => userMessages.androidSdkBuildToolsOutdated('/', 0, '', platform));
+    _checkInstallationURL((Platform platform) => userMessages.androidSdkBuildToolsOutdated(0, '', platform));
     _checkInstallationURL((Platform platform) => userMessages.androidStudioInstallation(platform));
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90042

The bang to `_androidSdk!.sdkManagerPath` was added in https://github.com/flutter/flutter/pull/82560/files#diff-c245d623bd123a206f90dc458d73520304e81ff8d1eac06a38e2c5221a859bfaR206

However this getter intentionally returns `null` if it cannot determine the path: https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/android/android_sdk.dart#L397