### PR TITLE
internationalization: fix select with incorrect message

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -300,6 +300,11 @@ String _generateSelectMethod(Message message, String translationForMessage) {
         );
       }
     }
+  } else {
+    throw L10nException(
+      'Incorrect select message format for: ${message.resourceId}.\n'
+      'Check to see if the select message is in the proper ICU syntax format.'
+    );
   }
 
   final List<String> parameters = message.placeholders.map((Placeholder placeholder) {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1909,6 +1909,46 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           )),
         );
       });
+
+      testWithoutContext('should throw attempting to generate a select message with an incorrect message', () {
+        const String selectMessageWithoutPlaceholdersAttribute = '''
+{
+  "genderSelect": "{gender, select,}",
+  "@genderSelect": {
+    "placeholders": {
+      "gender": {}
+    }
+  }
+}''';
+
+        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+          ..createSync(recursive: true);
+        l10nDirectory.childFile(defaultTemplateArbFileName)
+          .writeAsStringSync(selectMessageWithoutPlaceholdersAttribute);
+
+        expect(
+          () {
+            LocalizationsGenerator(
+              fileSystem: fs,
+              inputPathString: defaultL10nPathString,
+              outputPathString: defaultL10nPathString,
+              templateArbFileName: defaultTemplateArbFileName,
+              outputFileString: defaultOutputFileString,
+              classNameString: defaultClassNameString,
+            )
+              ..loadResources()
+              ..writeOutputFiles(BufferLogger.test());
+          },
+          throwsA(isA<L10nException>().having(
+            (L10nException e) => e.message,
+            'message',
+            allOf(
+              contains('Incorrect select message format for'),
+              contains('Check to see if the select message is in the proper ICU syntax format.'),
+            ),
+          )),
+        );
+      });
     });
 
     testWithoutContext('intl package import should be omitted in subclass files when no plurals are included', () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1766,6 +1766,39 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           )),
         );
       });
+
+      testWithoutContext('should not fail attempting to generate a plural message with an incorrect message', () {
+        const String selectMessageWithoutPlaceholdersAttribute = '''
+{
+  "wrongPlural": "{count, plural,}",
+  "@wrongPlural": {
+    "placeholders": {
+      "count": {}
+    }
+  }
+}''';
+
+        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+          ..createSync(recursive: true);
+        l10nDirectory.childFile(defaultTemplateArbFileName)
+          .writeAsStringSync(selectMessageWithoutPlaceholdersAttribute);
+
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+        )
+          ..loadResources()
+          ..writeOutputFiles(BufferLogger.test());
+
+        final File localizationsFile = fs.file(
+          fs.path.join(syntheticL10nPackagePath, defaultOutputFileString),
+        );
+        expect(localizationsFile.existsSync(), isTrue);
+      });
     });
 
     group('select messages', () {

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1766,39 +1766,6 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           )),
         );
       });
-
-      testWithoutContext('should not fail attempting to generate a plural message with an incorrect message', () {
-        const String selectMessageWithoutPlaceholdersAttribute = '''
-{
-  "wrongPlural": "{count, plural,}",
-  "@wrongPlural": {
-    "placeholders": {
-      "count": {}
-    }
-  }
-}''';
-
-        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
-          ..createSync(recursive: true);
-        l10nDirectory.childFile(defaultTemplateArbFileName)
-          .writeAsStringSync(selectMessageWithoutPlaceholdersAttribute);
-
-        LocalizationsGenerator(
-          fileSystem: fs,
-          inputPathString: defaultL10nPathString,
-          outputPathString: defaultL10nPathString,
-          templateArbFileName: defaultTemplateArbFileName,
-          outputFileString: defaultOutputFileString,
-          classNameString: defaultClassNameString,
-        )
-          ..loadResources()
-          ..writeOutputFiles(BufferLogger.test());
-
-        final File localizationsFile = fs.file(
-          fs.path.join(syntheticL10nPackagePath, defaultOutputFileString),
-        );
-        expect(localizationsFile.existsSync(), isTrue);
-      });
     });
 
     group('select messages', () {


### PR DESCRIPTION
When the user specifies incorrect `select` message, there is a null exception thrown.

This PR fixes it.

Fixes #90094

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
