### PR TITLE
Correct font weight for Cupertino tab label

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_theme.dart
+++ b/packages/flutter/lib/src/cupertino/text_theme.dart
@@ -45,6 +45,7 @@ const TextStyle _kDefaultTabLabelTextStyle = TextStyle(
   inherit: false,
   fontFamily: '.SF Pro Text',
   fontSize: 10.0,
+  fontWeight: FontWeight.w500,
   letterSpacing: -0.24,
   color: CupertinoColors.inactiveGray,
 );

--- a/packages/flutter/test/cupertino/text_theme_test.dart
+++ b/packages/flutter/test/cupertino/text_theme_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('CupertinoTextTheme matches Apple Design resources', () {
+    // Check the default cupertino text theme against the style values
+    // Values derived from https://developer.apple.com/design/resources/.
+
+    const CupertinoTextThemeData theme = CupertinoTextThemeData();
+    const FontWeight normal = FontWeight.normal;
+    const FontWeight regular = FontWeight.w400;
+    const FontWeight medium = FontWeight.w500;
+    const FontWeight semiBold = FontWeight.w600;
+    const FontWeight bold = FontWeight.w700;
+
+    // TextStyle 17 -0.41
+    expect(theme.textStyle.fontSize, 17);
+    expect(theme.textStyle.fontFamily, '.SF Pro Text');
+    expect(theme.textStyle.letterSpacing, -0.41);
+    expect(theme.textStyle.fontWeight, null);
+
+    // ActionTextStyle 17 -0.41
+    expect(theme.actionTextStyle.fontSize, 17);
+    expect(theme.actionTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.actionTextStyle.letterSpacing, -0.41);
+    expect(theme.actionTextStyle.fontWeight, null);
+
+    // TextStyle 17 -0.41
+    expect(theme.tabLabelTextStyle.fontSize, 10);
+    expect(theme.tabLabelTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.tabLabelTextStyle.letterSpacing, -0.24);
+    expect(theme.tabLabelTextStyle.fontWeight, medium);
+
+    // NavTitle SemiBold 17 -0.41
+    expect(theme.navTitleTextStyle.fontSize, 17);
+    expect(theme.navTitleTextStyle.fontFamily, '.SF Pro Text');
+    expect(theme.navTitleTextStyle.letterSpacing, -0.41);
+    expect(theme.navTitleTextStyle.fontWeight, semiBold);
+
+    // NavLargeTitle Bold 34 0.41
+    expect(theme.navLargeTitleTextStyle.fontSize, 34);
+    expect(theme.navLargeTitleTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.navLargeTitleTextStyle.letterSpacing, 0.41);
+    expect(theme.navLargeTitleTextStyle.fontWeight, bold);
+
+    // Picker Regular 21 -0.6
+    expect(theme.pickerTextStyle.fontSize, 21);
+    expect(theme.pickerTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.pickerTextStyle.letterSpacing, -0.6);
+    expect(theme.pickerTextStyle.fontWeight, regular);
+
+    // DateTimePicker Normal 21
+    expect(theme.dateTimePickerTextStyle.fontSize, 21);
+    expect(theme.dateTimePickerTextStyle.fontFamily, '.SF Pro Display');
+    expect(theme.dateTimePickerTextStyle.letterSpacing, null);
+    expect(theme.dateTimePickerTextStyle.fontWeight, normal);
+  });
+}


### PR DESCRIPTION
Based on the sketch file from https://developer.apple.com/design/resources/ the tab bar label has a font weigh for medium / 500.

### Original iOS tab bar
![IMG_3739](https://user-images.githubusercontent.com/1446685/133385641-67e765de-38db-4c4c-8dba-1ea3e9bd088c.PNG)

### Top: Cupertino without font weight, bottom: changed font weight to medium
![Group 1](https://user-images.githubusercontent.com/1446685/133385696-95e96f19-9fe0-4f10-9626-0aa705ad7e71.png)

fixes #90108