### PR TITLE
[module_test_ios] On UITests add an additional tap on the application before tapping the element

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -100,6 +100,9 @@
     NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
     [self expectationForPredicate:hittable evaluatedWithObject:element handler:nil];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
+    // Sometimes, the element doesn't respond to the tap, it seems an XCUITest bug. Trying tap
+    // the app first to fix it.
+    [self.app tap];
     [element tap];
 }
 


### PR DESCRIPTION
Adding an additional self.app tap see if it fixes the flake. If this doesn't, we can try to add a delay.

https://github.com/flutter/flutter/issues/89175

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
