### PR TITLE
Fix overflow in stretching overscroll

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -760,10 +760,12 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
             _lastOverscrollNotification?.overscroll ?? 0.0
           );
 
-          return Transform(
-            alignment: alignment,
-            transform: Matrix4.diagonal3Values(x, y, 1.0),
-            child: widget.child,
+          return ClipRect(
+            child: Transform(
+              alignment: alignment,
+              transform: Matrix4.diagonal3Values(x, y, 1.0),
+              child: widget.child,
+            ),
           );
         },
       ),

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -308,4 +308,58 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
   });
+
+  testWidgets('Stretch does not overflow bounds of container', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/90197
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ScrollConfiguration(
+        behavior: const ScrollBehavior().copyWith(overscroll: false),
+        child: Column(
+          children: <Widget>[
+            StretchingOverscrollIndicator(
+              axisDirection: AxisDirection.down,
+              child: SizedBox(
+                height: 300,
+                child: ListView.builder(
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index){
+                    return Padding(
+                        padding: const EdgeInsets.all(10.0),
+                        child: Text('Index $index'),
+                    );
+                  },
+                ),
+              ),
+            ),
+            Opacity(
+              opacity: 0.5,
+              child: Container(
+                color: const Color(0xD0FF0000),
+                height: 100,
+              ),
+            )
+          ],
+        )
+      )
+    ));
+
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
+    // Image should not show the text overlapping the red area below the list.
+    await expectLater(
+      find.byType(Column),
+      matchesGoldenFile('overscroll_stretch.no_overflow.png'),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
 }

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -348,7 +348,7 @@ void main() {
     expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
 
     final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
-    // Overscroll the start
+    // Overscroll the start.
     await gesture.moveBy(const Offset(0.0, 200.0));
     await tester.pumpAndSettle();
     expect(find.text('Index 1'), findsOneWidget);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90197
Internal: internal b/200130013

This adds a ClipRect to prevent the stretch effect from overflowing the bounds of its parent container.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
