### PR TITLE
Fix error from bad dart-fix rule

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -2162,22 +2162,6 @@ transforms:
                   name: 'FloatingLabelBehavior'
           - kind: 'removeParameter'
             name: 'hasFloatingPlaceholder'
-      - if: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-        changes:
-          - kind: 'addParameter'
-            index: 14
-            name: 'floatingLabelBehavior'
-            style: optional_named
-            argumentValue:
-              expression: '{% hasFloatingPlaceholder %} ? {% FloatingLabelBehavior %}.auto : {% FloatingLabelBehavior %}.never'
-              requiredIf: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-              variables:
-                FloatingLabelBehavior:
-                  kind: 'import'
-                  uris: [ 'material.dart' ]
-                  name: 'FloatingLabelBehavior'
-          - kind: 'removeParameter'
-            name: 'hasFloatingPlaceholder'
     variables:
       hasFloatingPlaceholder:
         kind: 'fragment'
@@ -2216,22 +2200,6 @@ transforms:
             argumentValue:
               expression: '{% FloatingLabelBehavior %}.never'
               requiredIf: "hasFloatingPlaceholder == 'false'"
-              variables:
-                FloatingLabelBehavior:
-                  kind: 'import'
-                  uris: [ 'material.dart' ]
-                  name: 'FloatingLabelBehavior'
-          - kind: 'removeParameter'
-            name: 'hasFloatingPlaceholder'
-      - if: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-        changes:
-          - kind: 'addParameter'
-            index: 14
-            name: 'floatingLabelBehavior'
-            style: optional_named
-            argumentValue:
-              expression: '{% hasFloatingPlaceholder %} ? {% FloatingLabelBehavior %}.auto : {% FloatingLabelBehavior %}.never'
-              requiredIf: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
               variables:
                 FloatingLabelBehavior:
                   kind: 'import'
@@ -2295,22 +2263,6 @@ transforms:
                   name: 'FloatingLabelBehavior'
           - kind: 'removeParameter'
             name: 'hasFloatingPlaceholder'
-      - if: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-        changes:
-          - kind: 'addParameter'
-            index: 14
-            name: 'floatingLabelBehavior'
-            style: optional_named
-            argumentValue:
-              expression: '{% hasFloatingPlaceholder %} ? {% FloatingLabelBehavior %}.auto : {% FloatingLabelBehavior %}.never'
-              requiredIf: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-              variables:
-                FloatingLabelBehavior:
-                  kind: 'import'
-                  uris: [ 'material.dart' ]
-                  name: 'FloatingLabelBehavior'
-          - kind: 'removeParameter'
-            name: 'hasFloatingPlaceholder'
     variables:
       hasFloatingPlaceholder:
         kind: 'fragment'
@@ -2349,22 +2301,6 @@ transforms:
             argumentValue:
               expression: '{% FloatingLabelBehavior %}.never'
               requiredIf: "hasFloatingPlaceholder == 'false'"
-              variables:
-                FloatingLabelBehavior:
-                  kind: 'import'
-                  uris: [ 'material.dart' ]
-                  name: 'FloatingLabelBehavior'
-          - kind: 'removeParameter'
-            name: 'hasFloatingPlaceholder'
-      - if: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
-        changes:
-          - kind: 'addParameter'
-            index: 14
-            name: 'floatingLabelBehavior'
-            style: optional_named
-            argumentValue:
-              expression: '{% hasFloatingPlaceholder %} ? {% FloatingLabelBehavior %}.auto : {% FloatingLabelBehavior %}.never'
-              requiredIf: "hasFloatingPlaceholder != 'true' && hasFloatingPlaceholder != 'false'"
               variables:
                 FloatingLabelBehavior:
                   kind: 'import'

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -189,17 +189,21 @@ void main() {
   const InputDecoration inputDecoration = InputDecoration(hasFloatingPlaceholder: true);
   InputDecoration(hasFloatingPlaceholder: false);
   InputDecoration();
+  InputDecoration(error: '');
   InputDecoration.collapsed(hasFloatingPlaceholder: true);
   InputDecoration.collapsed(hasFloatingPlaceholder: false);
   InputDecoration.collapsed();
+  InputDecoration.collapsed(error: '');
   inputDecoration.hasFloatingPlaceholder;
   const InputDecorationTheme inputDecorationTheme = InputDecorationTheme(hasFloatingPlaceholder: true);
   InputDecorationTheme(hasFloatingPlaceholder: false);
   InputDecorationTheme();
+  InputDecorationTheme(error: '');
   inputDecorationTheme.hasFloatingPlaceholder;
   inputDecorationTheme.copyWith(hasFloatingPlaceholder: false);
   inputDecorationTheme.copyWith(hasFloatingPlaceholder: true);
   inputDecorationTheme.copyWith();
+  inputDecorationTheme.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/66482
   ThemeData(textSelectionColor: Colors.red);

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -190,17 +190,21 @@ void main() {
   const InputDecoration inputDecoration = InputDecoration(floatingLabelBehavior: FloatingLabelBehavior.auto);
   InputDecoration(floatingLabelBehavior: FloatingLabelBehavior.never);
   InputDecoration();
+  InputDecoration(error: '');
   InputDecoration.collapsed(floatingLabelBehavior: FloatingLabelBehavior.auto);
   InputDecoration.collapsed(floatingLabelBehavior: FloatingLabelBehavior.never);
   InputDecoration.collapsed();
+  InputDecoration.collapsed(error: '');
   inputDecoration.floatingLabelBehavior;
   const InputDecorationTheme inputDecorationTheme = InputDecorationTheme(floatingLabelBehavior: FloatingLabelBehavior.auto);
   InputDecorationTheme(floatingLabelBehavior: FloatingLabelBehavior.never);
   InputDecorationTheme();
+  InputDecorationTheme(error: '');
   inputDecorationTheme.floatingLabelBehavior;
   inputDecorationTheme.copyWith(floatingLabelBehavior: FloatingLabelBehavior.never);
   inputDecorationTheme.copyWith(floatingLabelBehavior: FloatingLabelBehavior.auto);
   inputDecorationTheme.copyWith();
+  inputDecorationTheme.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/66482
   ThemeData(textSelectionTheme: TextSelectionThemeData(selectionColor: Colors.red));


### PR DESCRIPTION
This fixes an error that is generated when the analyzer sees if there is a fix rule available for InputDecoration & related classes. This rule does not make sense and should be removed. Confirmed with the fix expectations, they would throw an exception otherwise.

Fixes https://github.com/dart-lang/sdk/issues/47203

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
