### PR TITLE
[conductor] fixed a small conductor messaging bug

### DIFF
--- a/dev/conductor/lib/next.dart
+++ b/dev/conductor/lib/next.dart
@@ -137,7 +137,11 @@ void runNext({
       if (unappliedCherrypicks.isEmpty) {
         stdio.printStatus('All engine cherrypicks have been auto-applied by the conductor.\n');
       } else {
-        stdio.printStatus('There were ${unappliedCherrypicks.length} cherrypicks that were not auto-applied.');
+        if (unappliedCherrypicks.length == 1) {
+          stdio.printStatus('There was ${unappliedCherrypicks.length} cherrypick that was not auto-applied.');
+        } else {
+          stdio.printStatus('There were ${unappliedCherrypicks.length} cherrypicks that were not auto-applied.');
+        }
         stdio.printStatus('These must be applied manually in the directory '
             '${state.engine.checkoutPath} before proceeding.\n');
       }
@@ -264,9 +268,12 @@ void runNext({
       } else if (unappliedCherrypicks.isEmpty) {
         stdio.printStatus('All framework cherrypicks were auto-applied by the conductor.');
       } else {
-        stdio.printStatus(
-          'There were ${unappliedCherrypicks.length} cherrypicks that were not auto-applied.',
-        );
+        if (unappliedCherrypicks.length == 1) {
+          stdio.printStatus('There was ${unappliedCherrypicks.length} cherrypick that was not auto-applied.',);
+        }
+        else {
+          stdio.printStatus('There were ${unappliedCherrypicks.length} cherrypicks that were not auto-applied.',);
+        }
         stdio.printStatus(
           'These must be applied manually in the directory '
           '${state.framework.checkoutPath} before proceeding.\n',

--- a/dev/conductor/test/next_test.dart
+++ b/dev/conductor/test/next_test.dart
@@ -751,7 +751,7 @@ void main() {
         );
         expect(
           stdio.stdout,
-          contains('There was 1 cherrypicks that was not auto-applied'),
+          contains('There was 1 cherrypick that was not auto-applied'),
         );
         expect(
           stdio.stdout,

--- a/dev/conductor/test/next_test.dart
+++ b/dev/conductor/test/next_test.dart
@@ -751,7 +751,7 @@ void main() {
         );
         expect(
           stdio.stdout,
-          contains('There were 1 cherrypicks that were not auto-applied'),
+          contains('There was 1 cherrypicks that was not auto-applied'),
         );
         expect(
           stdio.stdout,


### PR DESCRIPTION
*When the conductor encounters only one cherrypick issue with `conductor next` command, it displays as `There were 1 cherrypicks that were not auto-applied`. Not it is corrected to display `There was 1 cherrypick that was not auto-applied`*

*hot fix*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
