### PR TITLE
Add more tests for dart fixes

### DIFF
--- a/packages/flutter/test_fixes/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino.dart
@@ -12,8 +12,10 @@ void main() {
   Object object;
 
   // Change made in https://github.com/flutter/flutter/pull/41859
-  const CupertinoTextThemeData themeData = CupertinoTextThemeData(brightness: Brightness.dark);
+  CupertinoTextThemeData themeData = CupertinoTextThemeData(brightness: Brightness.dark);
   themeData.copyWith(brightness: Brightness.light);
+  themeData = CupertinoTextThemeData(error: '');
+  themeData.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/44189
   const Element element = Element(myWidget);
@@ -47,81 +49,106 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(overflow: Overflow.visible);
   const Stack stack = Stack(overflow: Overflow.clip);
+  const Stack stack = Stack(error: '');
   final behavior = stack.overflow;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidate: true);
   const Form form = Form(autovalidate: false);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidate: true);
   const FormField formField = FormField(autovalidate: false);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.of(context, nullOk: true);
   MediaQuery.of(context, nullOk: false);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.of(context, nullOk: true);
   Navigator.of(context, nullOk: false);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.of(context, nullOk: true);
   Router.of(context, nullOk: false);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.localeOf(context, nullOk: true);
   Localizations.localeOf(context, nullOk: false);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.of(context, nullOk: true);
   FocusTraversalOrder.of(context, nullOk: false);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.of(context, nullOk: true);
   FocusTraversalGroup.of(context, nullOk: false);
   Focus.of(context, nullOk: true);
   Focus.of(context, nullOk: false);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.of(context, nullOk: true);
   Shortcuts.of(context, nullOk: false);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.find(context, nullOk: true);
   Actions.find(context, nullOk: false);
   Actions.handler(context, nullOk: true);
   Actions.handler(context, nullOk: false);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.invoke(context, nullOk: true);
   Actions.invoke(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.of(context, nullOk: true);
   AnimatedList.of(context, nullOk: false);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.of(context, nullOk: true);
   SliverAnimatedList.of(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   CupertinoDynamicColor.resolve(Color(0), context, nullOk: true);
   CupertinoDynamicColor.resolve(Color(0), context, nullOk: false);
+  CupertinoDynamicColor.resolve(error: '');
+  CupertinoDynamicColor.resolveFrom(error: '');
   CupertinoDynamicColor.resolveFrom(context, nullOk: true);
   CupertinoDynamicColor.resolveFrom(context, nullOk: false);
   CupertinoUserInterfaceLevel.of(context, nullOk: true);
   CupertinoUserInterfaceLevel.of(context, nullOk: false);
+  CupertinoUserInterfaceLevel.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   CupertinoTheme.brightnessOf(context, nullOk: true);
   CupertinoTheme.brightnessOf(context, nullOk: false);
+  CupertinoTheme.brightnessOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   CupertinoThemeData.resolveFrom(context, nullOk: true);
   CupertinoThemeData.resolveFrom(context, nullOk: false);
+  CupertinoThemeData.resolveFrom(error: '');
+  NoDefaultCupertinoThemeData.resolveFrom(error: '');
   NoDefaultCupertinoThemeData.resolveFrom(context, nullOk: true);
   NoDefaultCupertinoThemeData.resolveFrom(context, nullOk: false);
   CupertinoTextThemeData.resolveFrom(context, nullOk: true);
   CupertinoTextThemeData.resolveFrom(context, nullOk: false);
+  CupertinoTextThemeData.resolveFrom(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/72043
   CupertinoTextField(maxLengthEnforced: true);
   CupertinoTextField(maxLengthEnforced: false);
+  CupertinoTextField(error: '');
+  CupertinoTextField.borderless(error: '');
   CupertinoTextField.borderless(maxLengthEnforced: true);
   CupertinoTextField.borderless(maxLengthEnforced: false);
   final CupertinoTextField textField;
@@ -129,16 +156,20 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(title: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.title;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   Draggable draggable = Draggable();
+  draggable = Draggable(error: '');
   draggable = Draggable(dragAnchor: DragAnchor.child);
   draggable = Draggable(dragAnchor: DragAnchor.pointer);
   draggable.dragAnchor;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.child);
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.pointer);
   longPressDraggable.dragAnchor;
@@ -173,16 +204,20 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipToSize: true);
   listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView.clipToSize;
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipToSize: true);
   listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipToSize;
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
-  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  notification = OverscrollIndicatorNotification(error: '');
   notification.disallowGlow();
 }

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -12,8 +12,10 @@ void main() {
   Object object;
 
   // Change made in https://github.com/flutter/flutter/pull/41859
-  const CupertinoTextThemeData themeData = CupertinoTextThemeData();
+  CupertinoTextThemeData themeData = CupertinoTextThemeData();
   themeData.copyWith();
+  themeData = CupertinoTextThemeData(error: '');
+  themeData.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/44189
   const Element element = Element(myWidget);
@@ -47,81 +49,106 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(clipBehavior: Clip.none);
   const Stack stack = Stack(clipBehavior: Clip.hardEdge);
+  const Stack stack = Stack(error: '');
   final behavior = stack.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidateMode: AutovalidateMode.always);
   const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.maybeOf(context);
   MediaQuery.of(context);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.maybeOf(context);
   Navigator.of(context);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.maybeOf(context);
   Router.of(context);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.maybeLocaleOf(context);
   Localizations.localeOf(context);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.maybeOf(context);
   FocusTraversalOrder.of(context);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.maybeOf(context);
   FocusTraversalGroup.of(context);
   Focus.maybeOf(context);
   Focus.of(context);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.maybeOf(context);
   Shortcuts.of(context);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.maybeFind(context);
   Actions.find(context);
   Actions.handler(context);
   Actions.handler(context);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.maybeInvoke(context);
   Actions.invoke(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.maybeOf(context);
   AnimatedList.of(context);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.maybeOf(context);
   SliverAnimatedList.of(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   CupertinoDynamicColor.maybeResolve(Color(0), context);
   CupertinoDynamicColor.resolve(Color(0), context);
+  CupertinoDynamicColor.resolve(error: '');
+  CupertinoDynamicColor.resolveFrom(error: '');
   CupertinoDynamicColor.resolveFrom(context);
   CupertinoDynamicColor.resolveFrom(context);
   CupertinoUserInterfaceLevel.maybeOf(context);
   CupertinoUserInterfaceLevel.of(context);
+  CupertinoUserInterfaceLevel.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   CupertinoTheme.maybeBrightnessOf(context);
   CupertinoTheme.brightnessOf(context);
+  CupertinoTheme.brightnessOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   CupertinoThemeData.resolveFrom(context);
   CupertinoThemeData.resolveFrom(context);
+  CupertinoThemeData.resolveFrom(error: '');
+  NoDefaultCupertinoThemeData.resolveFrom(error: '');
   NoDefaultCupertinoThemeData.resolveFrom(context);
   NoDefaultCupertinoThemeData.resolveFrom(context);
   CupertinoTextThemeData.resolveFrom(context);
   CupertinoTextThemeData.resolveFrom(context);
+  CupertinoTextThemeData.resolveFrom(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/72043
   CupertinoTextField(maxLengthEnforcement: MaxLengthEnforcement.enforce);
   CupertinoTextField(maxLengthEnforcement: MaxLengthEnforcement.none);
+  CupertinoTextField(error: '');
+  CupertinoTextField.borderless(error: '');
   CupertinoTextField.borderless(maxLengthEnforcement: MaxLengthEnforcement.enforce);
   CupertinoTextField.borderless(maxLengthEnforcement: MaxLengthEnforcement.none);
   final CupertinoTextField textField;
@@ -129,16 +156,20 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(label: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.label;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   Draggable draggable = Draggable();
+  draggable = Draggable(error: '');
   draggable = Draggable(dragAnchorStrategy: childDragAnchorStrategy);
   draggable = Draggable(dragAnchorStrategy: pointerDragAnchorStrategy);
   draggable.dragAnchorStrategy;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: childDragAnchorStrategy);
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: pointerDragAnchorStrategy);
   longPressDraggable.dragAnchorStrategy;
@@ -173,16 +204,20 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView.clipBehavior;
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
-  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  notification = OverscrollIndicatorNotification(error: '');
   notification.disallowIndicator();
 }

--- a/packages/flutter/test_fixes/gestures.dart
+++ b/packages/flutter/test_fixes/gestures.dart
@@ -14,40 +14,58 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66043
   VelocityTracker tracker = VelocityTracker();
   tracker = VelocityTracker(PointerDeviceKind.mouse);
+  tracker = VelocityTracker(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/81858
   DragGestureRecognizer();
   DragGestureRecognizer(kind: PointerDeviceKind.touch);
+  DragGestureRecognizer(error: '');
   VerticalDragGestureRecognizer();
   VerticalDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  VerticalDragGestureRecognizer(error: '');
   HorizontalDragGestureRecognizer();
   HorizontalDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  HorizontalDragGestureRecognizer(error: '');
   GestureRecognizer();
   GestureRecognizer(kind: PointerDeviceKind.touch);
+  GestureRecognizer(error: '');
   OneSequenceGestureRecognizer();
   OneSequenceGestureRecognizer(kind: PointerDeviceKind.touch);
+  OneSequenceGestureRecognizer(error: '');
   PrimaryPointerGestureRecognizer();
   PrimaryPointerGestureRecognizer(kind: PointerDeviceKind.touch);
+  PrimaryPointerGestureRecognizer(error: '');
   EagerGestureRecognizer();
   EagerGestureRecognizer(kind: PointerDeviceKind.touch);
+  EagerGestureRecognizer(error: '');
   ForcePressGestureRecognizer();
   ForcePressGestureRecognizer(kind: PointerDeviceKind.touch);
+  ForcePressGestureRecognizer(error: '');
   LongPressGestureRecognizer();
   LongPressGestureRecognizer(kind: PointerDeviceKind.touch);
+  LongPressGestureRecognizer(error: '');
   MultiDragGestureRecognizer();
   MultiDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  MultiDragGestureRecognizer(error: '');
   ImmediateMultiDragGestureRecognizer();
   ImmediateMultiDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  ImmediateMultiDragGestureRecognizer(error: '');
   HorizontalMultiDragGestureRecognizer();
   HorizontalMultiDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  HorizontalMultiDragGestureRecognizer(error: '');
   VerticalMultiDragGestureRecognizer();
   VerticalMultiDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  VerticalMultiDragGestureRecognizer(error: '');
   DelayedMultiDragGestureRecognizer();
   DelayedMultiDragGestureRecognizer(kind: PointerDeviceKind.touch);
+  DelayedMultiDragGestureRecognizer(error: '');
   DoubleTapGestureRecognizer();
   DoubleTapGestureRecognizer(kind: PointerDeviceKind.touch);
+  DoubleTapGestureRecognizer(error: '');
   MultiTapGestureRecognizer();
   MultiTapGestureRecognizer(kind: PointerDeviceKind.touch);
+  MultiTapGestureRecognizer(error: '');
   ScaleGestureRecognizer();
   ScaleGestureRecognizer(kind: PointerDeviceKind.touch);
+  ScaleGestureRecognizer(error: '');
 }

--- a/packages/flutter/test_fixes/gestures.dart.expect
+++ b/packages/flutter/test_fixes/gestures.dart.expect
@@ -14,40 +14,58 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66043
   VelocityTracker tracker = VelocityTracker.withKind(PointerDeviceKind.touch);
   tracker = VelocityTracker.withKind(PointerDeviceKind.mouse);
+  tracker = VelocityTracker.withKind(PointerDeviceKind.touch, error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/81858
   DragGestureRecognizer();
   DragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  DragGestureRecognizer(error: '');
   VerticalDragGestureRecognizer();
   VerticalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  VerticalDragGestureRecognizer(error: '');
   HorizontalDragGestureRecognizer();
   HorizontalDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  HorizontalDragGestureRecognizer(error: '');
   GestureRecognizer();
   GestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  GestureRecognizer(error: '');
   OneSequenceGestureRecognizer();
   OneSequenceGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  OneSequenceGestureRecognizer(error: '');
   PrimaryPointerGestureRecognizer();
   PrimaryPointerGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  PrimaryPointerGestureRecognizer(error: '');
   EagerGestureRecognizer();
   EagerGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  EagerGestureRecognizer(error: '');
   ForcePressGestureRecognizer();
   ForcePressGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  ForcePressGestureRecognizer(error: '');
   LongPressGestureRecognizer();
   LongPressGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  LongPressGestureRecognizer(error: '');
   MultiDragGestureRecognizer();
   MultiDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  MultiDragGestureRecognizer(error: '');
   ImmediateMultiDragGestureRecognizer();
   ImmediateMultiDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  ImmediateMultiDragGestureRecognizer(error: '');
   HorizontalMultiDragGestureRecognizer();
   HorizontalMultiDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  HorizontalMultiDragGestureRecognizer(error: '');
   VerticalMultiDragGestureRecognizer();
   VerticalMultiDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  VerticalMultiDragGestureRecognizer(error: '');
   DelayedMultiDragGestureRecognizer();
   DelayedMultiDragGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  DelayedMultiDragGestureRecognizer(error: '');
   DoubleTapGestureRecognizer();
   DoubleTapGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  DoubleTapGestureRecognizer(error: '');
   MultiTapGestureRecognizer();
   MultiTapGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  MultiTapGestureRecognizer(error: '');
   ScaleGestureRecognizer();
   ScaleGestureRecognizer(supportedDevices: <PointerDeviceKind>{PointerDeviceKind.touch});
+  ScaleGestureRecognizer(error: '');
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -12,11 +12,13 @@ void main() {
   Object object;
 
   // Changes made in https://github.com/flutter/flutter/pull/26259
-  const Scaffold scaffold = Scaffold(resizeToAvoidBottomPadding: true);
+  Scaffold scaffold = Scaffold(resizeToAvoidBottomPadding: true);
+  scaffold = Scaffold(error: '');
   final bool resize = scaffold.resizeToAvoidBottomPadding;
 
   // Change made in https://github.com/flutter/flutter/pull/15303
   showDialog(child: Text('Fix me.'));
+  showDialog(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/44189
   const Element element = Element(myWidget);
@@ -50,25 +52,30 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(overflow: Overflow.visible);
   const Stack stack = Stack(overflow: Overflow.clip);
+  const Stack stack = Stack(error: '');
   final behavior = stack.overflow;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidate: true);
   const Form form = Form(autovalidate: false);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidate: true);
   const FormField formField = FormField(autovalidate: false);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const TextFormField textFormField = TextFormField(autovalidate: true);
   const TextFormField textFormField = TextFormField(autovalidate: false);
+  const TextFormField textFormField = TextFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const DropdownButtonFormField dropDownButtonFormField = DropdownButtonFormField(autovalidate: true);
   const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(autovalidate: false);
+  const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var TextTheme textTheme = TextTheme(
@@ -86,6 +93,7 @@ void main() {
     subtitle: subtitleStyle,
     overline: overlineStyle,
   );
+  var TextTheme textTheme = TextTheme(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var TextTheme copiedTextTheme = TextTheme.copyWith(
@@ -103,6 +111,7 @@ void main() {
     subtitle: subtitleStyle,
     overline: overlineStyle,
   );
+  var TextTheme copiedTextTheme = TextTheme.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var style;
@@ -123,67 +132,88 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.of(context, nullOk: true);
   MediaQuery.of(context, nullOk: false);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.of(context, nullOk: true);
   Navigator.of(context, nullOk: false);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68908
   ScaffoldMessenger.of(context, nullOk: true);
   ScaffoldMessenger.of(context, nullOk: false);
+  ScaffoldMessenger.of(error: '');
+  Scaffold.of(error: '');
   Scaffold.of(context, nullOk: true);
   Scaffold.of(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.of(context, nullOk: true);
   Router.of(context, nullOk: false);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.localeOf(context, nullOk: true);
   Localizations.localeOf(context, nullOk: false);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.of(context, nullOk: true);
   FocusTraversalOrder.of(context, nullOk: false);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.of(context, nullOk: true);
   FocusTraversalGroup.of(context, nullOk: false);
   Focus.of(context, nullOk: true);
   Focus.of(context, nullOk: false);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.of(context, nullOk: true);
   Shortcuts.of(context, nullOk: false);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.find(context, nullOk: true);
   Actions.find(context, nullOk: false);
   Actions.handler(context, nullOk: true);
   Actions.handler(context, nullOk: false);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.invoke(context, nullOk: true);
   Actions.invoke(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.of(context, nullOk: true);
   AnimatedList.of(context, nullOk: false);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.of(context, nullOk: true);
   SliverAnimatedList.of(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   MaterialBasedCupertinoThemeData.resolveFrom(context, nullOk: true);
   MaterialBasedCupertinoThemeData.resolveFrom(context, nullOk: false);
+  MaterialBasedCupertinoThemeData.resolveFrom(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/72043
   TextField(maxLengthEnforced: true);
   TextField(maxLengthEnforced: false);
+  TextField(error: '');
   final TextField textField;
   textField.maxLengthEnforced;
   TextFormField(maxLengthEnforced: true);
   TextFormField(maxLengthEnforced: false);
+  TextFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(title: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.title;
 
   // Changes made in https://github.com/flutter/flutter/pull/65246
   RectangularSliderTrackShape(disabledThumbGapWidth: 2.0);
+  RectangularSliderTrackShape(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/46115
   const InputDecoration inputDecoration = InputDecoration(hasFloatingPlaceholder: true);
@@ -251,6 +281,8 @@ void main() {
     textSelectionHandleColor: Colors.yellow,
     useTextSelectionTheme: false,
   );
+  ThemeData(error: '');
+  ThemeData.raw(error: '');
   ThemeData.raw(textSelectionColor: Colors.red);
   ThemeData.raw(cursorColor: Colors.blue);
   ThemeData.raw(textSelectionHandleColor: Colors.yellow);
@@ -301,12 +333,14 @@ void main() {
   Draggable draggable = Draggable();
   draggable = Draggable(dragAnchor: DragAnchor.child);
   draggable = Draggable(dragAnchor: DragAnchor.pointer);
+  draggable = Draggable(error: '');
   draggable.dragAnchor;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.child);
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.pointer);
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable.dragAnchor;
 
   // Changes made in https://github.com/flutter/flutter/pull/64254
@@ -341,11 +375,14 @@ void main() {
   themeData = ThemeData(accentColor: Colors.red, primarySwatch: Colors.blue);
   themeData = ThemeData(accentColor: Colors.red, colorScheme: ColorScheme.light());
   themeData = ThemeData(accentColor: Colors.red, colorScheme: ColorScheme.light(), primarySwatch: Colors.blue);
+  themeData = ThemeData(error: '');
   themeData = ThemeData.raw(accentColor: Colors.red);
   themeData = ThemeData.raw(accentColor: Colors.red, primarySwatch: Colors.blue);
   themeData = ThemeData.raw(accentColor: Colors.red, colorScheme: ColorScheme.light());
   themeData = ThemeData.raw(accentColor: Colors.red, colorScheme: ColorScheme.light(), primarySwatch: Colors.blue);
+  themeData = ThemeData.raw(error: '');
   themeData = themeData.copyWith(accentColor: Colors.red);
+  themeData = themeData.copyWith(error: '');
   themeData = themeData.copyWith(accentColor: Colors.red, primarySwatch: Colors.blue);
   themeData = themeData.copyWith(accentColor: Colors.red, colorScheme: ColorScheme.light());
   themeData = themeData.copyWith(accentColor: Colors.red, colorScheme: ColorScheme.light(), primarySwatch: Colors.blue);
@@ -383,6 +420,8 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipToSize: true);
   listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView(error: '');
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
@@ -390,6 +429,7 @@ void main() {
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipToSize: true);
   listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipToSize;
 
   // Changes made in https://github.com/flutter/flutter/pull/87281
@@ -401,22 +441,27 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(error: '');
   notification.disallowGlow();
 
   // Changes made in https://github.com/flutter/flutter/pull/86198
   AppBar appBar = AppBar();
   appBar = AppBar(brightness: Brightness.light);
   appBar = AppBar(brightness: Brightness.dark);
+  appBar = AppBar(error: '');
   appBar.brightness;
 
   SliverAppBar sliverAppBar = SliverAppBar();
   sliverAppBar = SliverAppBar(brightness: Brightness.light);
   sliverAppBar = SliverAppBar(brightness: Brightness.dark);
+  sliverAppBar = SliverAppBar(error: '');
   sliverAppBar.brightness;
 
   AppBarTheme appBarTheme = AppBarTheme();
   appBarTheme = AppBarTheme(brightness: Brightness.light);
   appBarTheme = AppBarTheme(brightness: Brightness.dark);
+  appBarTheme = AppBarTheme(error: '');
+  appBarTheme = appBarTheme.copyWith(error: '');
   appBarTheme = appBarTheme.copyWith(brightness: Brightness.light);
   appBarTheme = appBarTheme.copyWith(brightness: Brightness.dark);
   appBarTheme.brightness;

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -13,11 +13,13 @@ void main() {
   Object object;
 
   // Changes made in https://github.com/flutter/flutter/pull/26259
-  const Scaffold scaffold = Scaffold(resizeToAvoidBottomInset: true);
+  Scaffold scaffold = Scaffold(resizeToAvoidBottomInset: true);
+  scaffold = Scaffold(error: '');
   final bool resize = scaffold.resizeToAvoidBottomInset;
 
   // Change made in https://github.com/flutter/flutter/pull/15303
   showDialog(builder: (context) => Text('Fix me.'));
+  showDialog(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/44189
   const Element element = Element(myWidget);
@@ -51,25 +53,30 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(clipBehavior: Clip.none);
   const Stack stack = Stack(clipBehavior: Clip.hardEdge);
+  const Stack stack = Stack(error: '');
   final behavior = stack.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidateMode: AutovalidateMode.always);
   const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const TextFormField textFormField = TextFormField(autovalidateMode: AutovalidateMode.always);
   const TextFormField textFormField = TextFormField(autovalidateMode: AutovalidateMode.disabled);
+  const TextFormField textFormField = TextFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const DropdownButtonFormField dropDownButtonFormField = DropdownButtonFormField(autovalidateMode: AutovalidateMode.always);
   const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(autovalidateMode: AutovalidateMode.disabled);
+  const DropdownButtonFormField dropdownButtonFormField = DropdownButtonFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var TextTheme textTheme = TextTheme(
@@ -87,6 +94,7 @@ void main() {
     subtitle2: subtitleStyle,
     overline: overlineStyle,
   );
+  var TextTheme textTheme = TextTheme(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var TextTheme copiedTextTheme = TextTheme.copyWith(
@@ -104,6 +112,7 @@ void main() {
     subtitle2: subtitleStyle,
     overline: overlineStyle,
   );
+  var TextTheme copiedTextTheme = TextTheme.copyWith(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/48547
   var style;
@@ -124,67 +133,88 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.maybeOf(context);
   MediaQuery.of(context);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.maybeOf(context);
   Navigator.of(context);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68908
   ScaffoldMessenger.maybeOf(context);
   ScaffoldMessenger.of(context);
+  ScaffoldMessenger.of(error: '');
+  Scaffold.of(error: '');
   Scaffold.maybeOf(context);
   Scaffold.of(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.maybeOf(context);
   Router.of(context);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.maybeLocaleOf(context);
   Localizations.localeOf(context);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.maybeOf(context);
   FocusTraversalOrder.of(context);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.maybeOf(context);
   FocusTraversalGroup.of(context);
   Focus.maybeOf(context);
   Focus.of(context);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.maybeOf(context);
   Shortcuts.of(context);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.maybeFind(context);
   Actions.find(context);
   Actions.handler(context);
   Actions.handler(context);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.maybeInvoke(context);
   Actions.invoke(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.maybeOf(context);
   AnimatedList.of(context);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.maybeOf(context);
   SliverAnimatedList.of(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68905
   MaterialBasedCupertinoThemeData.resolveFrom(context);
   MaterialBasedCupertinoThemeData.resolveFrom(context);
+  MaterialBasedCupertinoThemeData.resolveFrom(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/72043
   TextField(maxLengthEnforcement: MaxLengthEnforcement.enforce);
   TextField(maxLengthEnforcement: MaxLengthEnforcement.none);
+  TextField(error: '');
   final TextField textField;
   textField.maxLengthEnforcement;
   TextFormField(maxLengthEnforcement: MaxLengthEnforcement.enforce);
   TextFormField(maxLengthEnforcement: MaxLengthEnforcement.none);
+  TextFormField(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(label: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.label;
 
   // Changes made in https://github.com/flutter/flutter/pull/65246
   RectangularSliderTrackShape();
+  RectangularSliderTrackShape(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/46115
   const InputDecoration inputDecoration = InputDecoration(floatingLabelBehavior: FloatingLabelBehavior.auto);
@@ -238,6 +268,8 @@ void main() {
   ThemeData(
     textSelectionTheme: TextSelectionThemeData(cursorColor: Colors.blue, selectionColor: Colors.red, selectionHandleColor: Colors.yellow,),
   );
+  ThemeData(error: '');
+  ThemeData.raw(error: '');
   ThemeData.raw(textSelectionTheme: TextSelectionThemeData(selectionColor: Colors.red));
   ThemeData.raw(textSelectionTheme: TextSelectionThemeData(cursorColor: Colors.blue));
   ThemeData.raw(textSelectionTheme: TextSelectionThemeData(selectionHandleColor: Colors.yellow));
@@ -274,12 +306,14 @@ void main() {
   Draggable draggable = Draggable();
   draggable = Draggable(dragAnchorStrategy: childDragAnchorStrategy);
   draggable = Draggable(dragAnchorStrategy: pointerDragAnchorStrategy);
+  draggable = Draggable(error: '');
   draggable.dragAnchorStrategy;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: childDragAnchorStrategy);
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: pointerDragAnchorStrategy);
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable.dragAnchorStrategy;
 
   // Changes made in https://github.com/flutter/flutter/pull/64254
@@ -314,11 +348,14 @@ void main() {
   themeData = ThemeData(colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue).copyWith(secondary: Colors.red));
   themeData = ThemeData(colorScheme: ColorScheme.light().copyWith(secondary: Colors.red));
   themeData = ThemeData(colorScheme: ColorScheme.light().copyWith(primarySwatch: Colors.blue, secondary: Colors.red));
+  themeData = ThemeData(error: '');
   themeData = ThemeData.raw(colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.red));
   themeData = ThemeData.raw(colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue).copyWith(secondary: Colors.red));
   themeData = ThemeData.raw(colorScheme: ColorScheme.light().copyWith(secondary: Colors.red));
   themeData = ThemeData.raw(colorScheme: ColorScheme.light().copyWith(primarySwatch: Colors.blue, secondary: Colors.red));
+  themeData = ThemeData.raw(error: '');
   themeData = themeData.copyWith(colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.red));
+  themeData = themeData.copyWith(error: '');
   themeData = themeData.copyWith(colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blue).copyWith(secondary: Colors.red));
   themeData = themeData.copyWith(colorScheme: ColorScheme.light().copyWith(secondary: Colors.red));
   themeData = themeData.copyWith(colorScheme: ColorScheme.light().copyWith(primarySwatch: Colors.blue, secondary: Colors.red));
@@ -356,6 +393,8 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView(error: '');
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
@@ -363,6 +402,7 @@ void main() {
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/87281
@@ -374,22 +414,27 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(error: '');
   notification.disallowIndicator();
 
   // Changes made in https://github.com/flutter/flutter/pull/86198
   AppBar appBar = AppBar();
   appBar = AppBar(systemOverlayStyle: SystemUiOverlayStyle.dark);
   appBar = AppBar(systemOverlayStyle: SystemUiOverlayStyle.light);
+  appBar = AppBar(error: '');
   appBar.systemOverlayStyle;
 
   SliverAppBar sliverAppBar = SliverAppBar();
   sliverAppBar = SliverAppBar(systemOverlayStyle: SystemUiOverlayStyle.dark);
   sliverAppBar = SliverAppBar(systemOverlayStyle: SystemUiOverlayStyle.light);
+  sliverAppBar = SliverAppBar(error: '');
   sliverAppBar.systemOverlayStyle;
 
   AppBarTheme appBarTheme = AppBarTheme();
   appBarTheme = AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.dark);
   appBarTheme = AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light);
+  appBarTheme = AppBarTheme(error: '');
+  appBarTheme = appBarTheme.copyWith(error: '');
   appBarTheme = appBarTheme.copyWith(systemOverlayStyle: SystemUiOverlayStyle.dark);
   appBarTheme = appBarTheme.copyWith(systemOverlayStyle: SystemUiOverlayStyle.light);
   appBarTheme.systemOverlayStyle;

--- a/packages/flutter/test_fixes/rendering.dart
+++ b/packages/flutter/test_fixes/rendering.dart
@@ -9,11 +9,13 @@ void main() {
   RenderStack renderStack = RenderStack();
   renderStack = RenderStack(overflow: Overflow.visible);
   renderStack = RenderStack(overflow: Overflow.clip);
+  renderStack = RenderStack(error: '');
   renderStack.overflow;
 
   // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
   RenderListWheelViewport renderListWheelViewport = RenderListWheelViewport();
   renderListWheelViewport = RenderListWheelViewport(clipToSize: true);
   renderListWheelViewport = RenderListWheelViewport(clipToSize: false);
+  renderListWheelViewport = RenderListWheelViewport(error: '');
   renderListWheelViewport.clipToSize;
 }

--- a/packages/flutter/test_fixes/rendering.dart.expect
+++ b/packages/flutter/test_fixes/rendering.dart.expect
@@ -9,11 +9,13 @@ void main() {
   RenderStack renderStack = RenderStack();
   renderStack = RenderStack(clipBehavior: Clip.none);
   renderStack = RenderStack(clipBehavior: Clip.hardEdge);
+  renderStack = RenderStack(error: '');
   renderStack.clipBehavior;
 
   // Changes made in https://flutter.dev/docs/release/breaking-changes/clip-behavior
   RenderListWheelViewport renderListWheelViewport = RenderListWheelViewport();
   renderListWheelViewport = RenderListWheelViewport(clipBehavior: Clip.hardEdge);
   renderListWheelViewport = RenderListWheelViewport(clipBehavior: Clip.none);
+  renderListWheelViewport = RenderListWheelViewport(error: '');
   renderListWheelViewport.clipBehavior;
 }

--- a/packages/flutter/test_fixes/services.dart
+++ b/packages/flutter/test_fixes/services.dart
@@ -12,6 +12,12 @@ void main() {
       layoutDirection: TextDirection.ltr,
   );
   int viewId = surfaceController.id;
+  final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
+    error: '',
+  );
+  final TextureAndroidViewController textureController = TextureAndroidViewController(
+    error: '',
+  );
   final TextureAndroidViewController textureController = TextureAndroidViewController(
     viewId: 10,
     viewType: 'FixTester',
@@ -24,4 +30,5 @@ void main() {
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[SystemUiOverlay.bottom]);
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[SystemUiOverlay.top, SystemUiOverlay.bottom]);
   await SystemChrome.setEnabledSystemUIOverlays(<SystemUiOverlay>[]);
+  await SystemChrome.setEnabledSystemUIOverlays(error: '');
 }

--- a/packages/flutter/test_fixes/services.dart.expect
+++ b/packages/flutter/test_fixes/services.dart.expect
@@ -12,6 +12,12 @@ void main() {
       layoutDirection: TextDirection.ltr,
   );
   int viewId = surfaceController.viewId;
+  final SurfaceAndroidViewController surfaceController = SurfaceAndroidViewController(
+    error: '',
+  );
+  final TextureAndroidViewController textureController = TextureAndroidViewController(
+    error: '',
+  );
   final TextureAndroidViewController textureController = TextureAndroidViewController(
     viewId: 10,
     viewType: 'FixTester',
@@ -24,4 +30,5 @@ void main() {
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: <SystemUiOverlay>[SystemUiOverlay.bottom]);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: <SystemUiOverlay>[SystemUiOverlay.top, SystemUiOverlay.bottom]);
   await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: <SystemUiOverlay>[]);
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, error: '');
 }

--- a/packages/flutter/test_fixes/widgets.dart
+++ b/packages/flutter/test_fixes/widgets.dart
@@ -43,72 +43,92 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidate: true);
   const Form form = Form(autovalidate: false);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidate: true);
   const FormField formField = FormField(autovalidate: false);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidate;
 
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(overflow: Overflow.visible);
   const Stack stack = Stack(overflow: Overflow.clip);
+  const Stack stack = Stack(error: '');
   final behavior = stack.overflow;
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.of(context, nullOk: true);
   MediaQuery.of(context, nullOk: false);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.of(context, nullOk: true);
   Navigator.of(context, nullOk: false);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.of(context, nullOk: true);
   Router.of(context, nullOk: false);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.localeOf(context, nullOk: true);
   Localizations.localeOf(context, nullOk: false);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.of(context, nullOk: true);
   FocusTraversalOrder.of(context, nullOk: false);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.of(context, nullOk: true);
   FocusTraversalGroup.of(context, nullOk: false);
   Focus.of(context, nullOk: true);
   Focus.of(context, nullOk: false);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.of(context, nullOk: true);
   Shortcuts.of(context, nullOk: false);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.find(context, nullOk: true);
   Actions.find(context, nullOk: false);
   Actions.handler(context, nullOk: true);
   Actions.handler(context, nullOk: false);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.invoke(context, nullOk: true);
   Actions.invoke(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.of(context, nullOk: true);
   AnimatedList.of(context, nullOk: false);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.of(context, nullOk: true);
   SliverAnimatedList.of(context, nullOk: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(title: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.title;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   Draggable draggable = Draggable();
   draggable = Draggable(dragAnchor: DragAnchor.child);
   draggable = Draggable(dragAnchor: DragAnchor.pointer);
+  draggable = Draggable(error: '');
   draggable.dragAnchor;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.child);
   longPressDraggable = LongPressDraggable(dragAnchor: DragAnchor.pointer);
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable.dragAnchor;
 
   // Changes made in https://github.com/flutter/flutter/pull/64254
@@ -141,16 +161,20 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipToSize: true);
   listWheelScrollView = ListWheelScrollView(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: true);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipToSize: false);
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView.clipToSize;
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipToSize: true);
   listWheelViewport = ListWheelViewport(clipToSize: false);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipToSize;
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(error: '');
   notification.disallowGlow();
 }

--- a/packages/flutter/test_fixes/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets.dart.expect
@@ -43,72 +43,92 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const Form form = Form(autovalidateMode: AutovalidateMode.always);
   const Form form = Form(autovalidateMode: AutovalidateMode.disabled);
+  const Form form = Form(error: '');
   final autoMode = form.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/61648
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.always);
   const FormField formField = FormField(autovalidateMode: AutovalidateMode.disabled);
+  const FormField formField = FormField(error: '');
   final autoMode = formField.autovalidateMode;
 
   // Changes made in https://github.com/flutter/flutter/pull/66305
   const Stack stack = Stack(clipBehavior: Clip.none);
   const Stack stack = Stack(clipBehavior: Clip.hardEdge);
+  const Stack stack = Stack(error: '');
   final behavior = stack.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/68736
   MediaQuery.maybeOf(context);
   MediaQuery.of(context);
+  MediaQuery.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/70726
   Navigator.maybeOf(context);
   Navigator.of(context);
+  Navigator.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68910
   Router.maybeOf(context);
   Router.of(context);
+  Router.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68911
   Localizations.maybeLocaleOf(context);
   Localizations.localeOf(context);
+  Localizations.localeOf(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68917
   FocusTraversalOrder.maybeOf(context);
   FocusTraversalOrder.of(context);
+  FocusTraversalOrder.of(error: '');
+  FocusTraversalGroup.of(error: '');
   FocusTraversalGroup.maybeOf(context);
   FocusTraversalGroup.of(context);
   Focus.maybeOf(context);
   Focus.of(context);
+  Focus.of(error: '');
 
   // Changes made in https://github.com/flutter/flutter/pull/68921
   Shortcuts.maybeOf(context);
   Shortcuts.of(context);
+  Shortcuts.of(error: '');
+  Actions.find(error: '');
   Actions.maybeFind(context);
   Actions.find(context);
   Actions.handler(context);
   Actions.handler(context);
+  Actions.handler(error: '');
+  Actions.invoke(error: '');
   Actions.maybeInvoke(context);
   Actions.invoke(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/68925
   AnimatedList.maybeOf(context);
   AnimatedList.of(context);
+  AnimatedList.of(error: '');
+  SliverAnimatedList.of(error: '');
   SliverAnimatedList.maybeOf(context);
   SliverAnimatedList.of(context);
 
   // Changes made in https://github.com/flutter/flutter/pull/59127
   const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(label: myTitle);
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem();
+  const BottomNavigationBarItem bottomNavigationBarItem = BottomNavigationBarItem(error: '');
   bottomNavigationBarItem.label;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   Draggable draggable = Draggable();
   draggable = Draggable(dragAnchorStrategy: childDragAnchorStrategy);
   draggable = Draggable(dragAnchorStrategy: pointerDragAnchorStrategy);
+  draggable = Draggable(error: '');
   draggable.dragAnchorStrategy;
 
   // Changes made in https://github.com/flutter/flutter/pull/79160
   LongPressDraggable longPressDraggable = LongPressDraggable();
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: childDragAnchorStrategy);
   longPressDraggable = LongPressDraggable(dragAnchorStrategy: pointerDragAnchorStrategy);
+  longPressDraggable = LongPressDraggable(error: '');
   longPressDraggable.dragAnchorStrategy;
 
   // Changes made in https://github.com/flutter/flutter/pull/64254
@@ -141,16 +161,20 @@ void main() {
   ListWheelScrollView listWheelScrollView = ListWheelScrollView();
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView(error: '');
   listWheelScrollView = ListWheelScrollView.useDelegate();
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.hardEdge);
   listWheelScrollView = ListWheelScrollView.useDelegate(clipBehavior: Clip.none);
+  listWheelScrollView = ListWheelScrollView.useDelegate(error: '');
   listWheelScrollView.clipBehavior;
   ListWheelViewport listWheelViewport = ListWheelViewport();
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.hardEdge);
   listWheelViewport = ListWheelViewport(clipBehavior: Clip.none);
+  listWheelViewport = ListWheelViewport(error: '');
   listWheelViewport.clipBehavior;
 
   // Changes made in https://github.com/flutter/flutter/pull/87839
   final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(leading: true);
+  final OverscrollIndicatorNotification notification = OverscrollIndicatorNotification(error: '');
   notification.disallowIndicator();
 }


### PR DESCRIPTION
We recently found that we were missing some test coverage for dart fixes, this resulted in ugly errors for users when viewing the quick fix overlay in the IDE. (See https://github.com/dart-lang/sdk/issues/47203 and related https://github.com/flutter/flutter/pull/90217)

Since the analyzer only looks up a potential fix when there is an error/warning, having an unrelated error for each fix ensures that fix won't throw if it tries to evaluate a potential fix.

This adds such an unrelated error for each existing dart fix where relevant. :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
