### PR TITLE
Revert "Issue 88543: TextField labelText doesn't get hintTextStyle when labelTextStyle is non-null Fixed"

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2231,14 +2231,12 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       isHovering: isHovering,
     );
 
-    final TextStyle? inlineLabelStyle = decoration!.label != null ? decoration!.labelStyle : decoration!.hintStyle;
-
     // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
     // Setting TextStyle.height to 1 ensures that the label's height will equal
     // its font size.
-    final TextStyle effectiveInlineLabelStyle = themeData.fixTextFieldOutlineLabel
-      ? inlineStyle.merge(inlineLabelStyle).copyWith(height: 1)
-      : inlineStyle.merge(inlineLabelStyle);
+    final TextStyle inlineLabelStyle = themeData.fixTextFieldOutlineLabel
+      ? inlineStyle.merge(decoration!.labelStyle).copyWith(height: 1)
+      : inlineStyle.merge(decoration!.labelStyle);
     final Widget? label = decoration!.labelText == null && decoration!.label == null ? null : _Shaker(
       animation: _shakingLabelController.view,
       child: AnimatedOpacity(
@@ -2250,7 +2248,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
           curve: _kTransitionCurve,
           style: widget._labelShouldWithdraw
             ? _getFloatingLabelStyle(themeData)
-            : effectiveInlineLabelStyle,
+            : inlineLabelStyle,
           child: decoration!.label ?? Text(
             decoration!.labelText!,
             overflow: TextOverflow.ellipsis,
@@ -2373,7 +2371,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       contentPadding = decorationContentPadding ?? EdgeInsets.zero;
     } else if (!border.isOutline) {
       // 4.0: the vertical gap between the inline elements and the floating label.
-      floatingLabelHeight = (4.0 + 0.75 * effectiveInlineLabelStyle.fontSize!) * MediaQuery.textScaleFactorOf(context);
+      floatingLabelHeight = (4.0 + 0.75 * inlineLabelStyle.fontSize!) * MediaQuery.textScaleFactorOf(context);
       if (decoration!.filled == true) { // filled == null same as filled == false
         contentPadding = decorationContentPadding ?? (decorationIsDense
           ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -3422,7 +3422,7 @@ void main() {
     expect(tester.widget<Text>(find.text('suffix')).style!.color, suffixStyle.color);
     expect(tester.widget<Text>(find.text('helper')).style!.color, helperStyle.color);
     expect(tester.widget<Text>(find.text('counter')).style!.color, counterStyle.color);
-    expect(getLabelStyle(tester).color, hintStyle.color);
+    expect(getLabelStyle(tester).color, labelStyle.color);
   });
 
   testWidgets('InputDecorationTheme style overrides (focused)', (WidgetTester tester) async {
@@ -5242,68 +5242,6 @@ void main() {
     expect(getBorderWeight(tester), 1.0);
 
     // Verify that the styles were passed along
-    expect(getLabelStyle(tester).color, labelStyle.color);
-  });
-
-  testWidgets('hintStyle is used for labelText when labelText is on top of the input field and labelStyle is used for labelText when labelText moves above widget', (WidgetTester tester) async {
-    const TextStyle style16 = TextStyle(fontFamily: 'Ahem', fontSize: 16.0);
-    final TextStyle labelStyle = style16.merge(const TextStyle(color: Colors.purple));
-    final TextStyle hintStyle = style16.merge(const TextStyle(color: Colors.red));
-
-    await tester.pumpWidget(
-      buildInputDecorator(
-        isEmpty: true,
-        isFocused: false, // Label appears inline, on top of the input field.
-        decoration: InputDecoration(
-          labelText: 'label',
-          labelStyle: labelStyle,
-          hintStyle: hintStyle,
-        ),
-      ),
-    );
-
-    // Overall height for this InputDecorator is 56dps:
-    //   12 - top padding
-    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
-    //    4 - floating label / input text gap
-    //   16 - input text (ahem font size 16dps)
-    //   12 - bottom padding
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-    expect(tester.getTopLeft(find.text('label')).dy, 20.0);
-    expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
-    expect(getBorderBottom(tester), 56.0);
-    expect(getBorderWeight(tester), 1.0);
-
-    // Verify that the hintStyle was used
-    expect(getLabelStyle(tester).color, hintStyle.color);
-
-    await tester.pumpWidget(
-      buildInputDecorator(
-        isEmpty: true,
-        isFocused: true, // Label moves above (i.e., vertically adjacent to) the input field
-        decoration: InputDecoration(
-          labelText: 'label',
-          labelStyle: labelStyle,
-          hintStyle: hintStyle,
-        ),
-      ),
-    );
-
-    await tester.pumpAndSettle();
-
-    // Overall height for this InputDecorator is 56dps:
-    //   12 - top padding
-    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
-    //    4 - floating label / input text gap
-    //   16 - input text (ahem font size 16dps)
-    //   12 - bottom padding
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 56.0));
-    expect(tester.getTopLeft(find.text('label')).dy, 12.0);
-    expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
-    expect(getBorderBottom(tester), 56.0);
-    expect(getBorderWeight(tester), 2.0);
-
-    // Verify that the labelStyle was used
     expect(getLabelStyle(tester).color, labelStyle.color);
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#89386

I was expecting some small image diff tests to break due to flutter/flutter#89386, but it ended up breaking a ton, some more obvious than I thought.  I saw a few cases where the font had obviously increased in size, and some where the layout had changed due to lines now wrapping.

@varunkamanibosc Do you think there is a way that we can prevent everyone's style from changing by default here?  Or if not, we'll need to follow the [breaking change policy](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes) to notify everyone that this may change how their app looks and tell them how to fix it.

### Related
flutter/flutter#89386
b/200353466