### PR TITLE
Update dartdoc to v3.1.0.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 3.0.0
+    "$DART" pub global activate dartdoc 3.1.0
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
Release notes:  https://github.com/dart-lang/dartdoc/releases/tag/v3.1.0

No changes of note for Flutter.