### PR TITLE
Add clipBeheavior support to TextFields

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -294,6 +294,7 @@ class CupertinoTextField extends StatefulWidget {
     this.scrollController,
     this.scrollPhysics,
     this.autofillHints = const <String>[],
+
     this.restorationId,
     this.enableIMEPersonalizedLearning = true,
   }) : assert(textAlign != null),
@@ -450,6 +451,7 @@ class CupertinoTextField extends StatefulWidget {
     this.scrollController,
     this.scrollPhysics,
     this.autofillHints = const <String>[],
+    this.clipBehavior = Clip.hardEdge,
     this.restorationId,
     this.enableIMEPersonalizedLearning = true,
   }) : assert(textAlign != null),
@@ -493,6 +495,7 @@ class CupertinoTextField extends StatefulWidget {
          !identical(keyboardType, TextInputType.text),
          'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.',
        ),
+       assert(clipBehavior != null),
        assert(enableIMEPersonalizedLearning != null),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?
@@ -786,6 +789,11 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
   /// {@macro flutter.material.textfield.restorationId}
   final String? restorationId;
 
@@ -833,6 +841,7 @@ class CupertinoTextField extends StatefulWidget {
     properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: TextAlign.start));
     properties.add(DiagnosticsProperty<TextAlignVertical>('textAlignVertical', textAlignVertical, defaultValue: null));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+    properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.hardEdge));
     properties.add(DiagnosticsProperty<bool>('enableIMEPersonalizedLearning', enableIMEPersonalizedLearning, defaultValue: true));
   }
 }
@@ -1265,6 +1274,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
             scrollPhysics: widget.scrollPhysics,
             enableInteractiveSelection: widget.enableInteractiveSelection,
             autofillClient: this,
+            clipBehavior: widget.clipBehavior,
             restorationId: 'editable',
             enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
           ),

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -294,7 +294,7 @@ class CupertinoTextField extends StatefulWidget {
     this.scrollController,
     this.scrollPhysics,
     this.autofillHints = const <String>[],
-
+    this.clipBehavior = Clip.hardEdge,
     this.restorationId,
     this.enableIMEPersonalizedLearning = true,
   }) : assert(textAlign != null),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -346,6 +346,7 @@ class TextField extends StatefulWidget {
     this.scrollController,
     this.scrollPhysics,
     this.autofillHints = const <String>[],
+    this.clipBehavior = Clip.hardEdge,
     this.restorationId,
     this.enableIMEPersonalizedLearning = true,
   }) : assert(textAlign != null),
@@ -387,6 +388,7 @@ class TextField extends StatefulWidget {
          !identical(keyboardType, TextInputType.text),
          'Use keyboardType TextInputType.multiline when using TextInputAction.newline on a multiline TextField.',
        ),
+       assert(clipBehavior != null),
        assert(enableIMEPersonalizedLearning != null),
        keyboardType = keyboardType ?? (maxLines == 1 ? TextInputType.text : TextInputType.multiline),
        toolbarOptions = toolbarOptions ?? (obscureText ?
@@ -761,6 +763,11 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.services.AutofillConfiguration.autofillHints}
   final Iterable<String>? autofillHints;
 
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
   /// {@template flutter.material.textfield.restorationId}
   /// Restoration ID to save and restore the state of the text field.
   ///
@@ -823,6 +830,7 @@ class TextField extends StatefulWidget {
     properties.add(DiagnosticsProperty<TextSelectionControls>('selectionControls', selectionControls, defaultValue: null));
     properties.add(DiagnosticsProperty<ScrollController>('scrollController', scrollController, defaultValue: null));
     properties.add(DiagnosticsProperty<ScrollPhysics>('scrollPhysics', scrollPhysics, defaultValue: null));
+    properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: Clip.hardEdge));
     properties.add(DiagnosticsProperty<bool>('enableIMEPersonalizedLearning', enableIMEPersonalizedLearning, defaultValue: true));
   }
 }
@@ -1265,6 +1273,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           scrollPhysics: widget.scrollPhysics,
           autofillClient: this,
           autocorrectionTextRectColor: autocorrectionTextRectColor,
+          clipBehavior: widget.clipBehavior,
           restorationId: 'editable',
           enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
         ),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -168,7 +168,7 @@ class OverflowWidgetTextEditingController extends TextEditingController {
         WidgetSpan(
           alignment: PlaceholderAlignment.bottom,
           child: Container(
-            color: Colors.redAccent,
+            color: Color(0xffff3333),
             height: 100,
           ),
         ),
@@ -4847,28 +4847,28 @@ void main() {
   testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
         overlay(
-          child: const TextField(
+          child: const CupertinoTextField(
           ),
         ),
     );
 
-    final TextField textField = tester.firstWidget(find.byType(TextField));
+    final TextField textField = tester.firstWidget(find.byType(CupertinoTextField));
     expect(textField.clipBehavior, Clip.hardEdge);
   });
 
   testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
-    final Widget widget = overlay(
-      child: const RepaintBoundary(
+    final Widget widget = const CupertinoApp(
+      home: const RepaintBoundary(
         key: ValueKey<int>(1),
-        child: TextField(
-          controller: OverflowWidgetTextEditingController()
+        child: CupertinoTextField(
+          controller: OverflowWidgetTextEditingController(),
           clipBehavior: Clip.none,
         ),
       ),
     );
     await tester.pumpWidget(widget);
 
-    final TextField textField = tester.firstWidget(find.byType(TextField));
+    final TextField textField = tester.firstWidget(find.byType(CupertinoTextField));
     expect(textField.clipBehavior, Clip.none);
 
     await expectLater(

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
 import '../widgets/clipboard_utils.dart';
+import '../widgets/editable_text_utils.dart' show OverflowWidgetTextEditingController;
 import '../widgets/semantics_tester.dart';
 
 // On web, the context menu (aka toolbar) is provided by the browser.
@@ -150,30 +151,6 @@ class PathPointsMatcher extends Matcher {
       desc.add('$notExcluded is not excluded. ');
     }
     return desc;
-  }
-}
-
-// Simple controller that builds a WidgetSpan with 100 height.
-class OverflowWidgetTextEditingController extends TextEditingController {
-  @override
-  TextSpan buildTextSpan({
-    required BuildContext context,
-    TextStyle? style,
-    required bool withComposing,
-  }) {
-    return TextSpan(
-      style: style,
-      children: <InlineSpan>[
-        const TextSpan(text: 'Hi'),
-        WidgetSpan(
-          alignment: PlaceholderAlignment.bottom,
-          child: Container(
-            color: const Color(0xffff3333),
-            height: 100,
-          ),
-        ),
-      ],
-    );
   }
 }
 
@@ -4846,10 +4823,10 @@ void main() {
 
   testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
-        const CupertinoApp(
-          home: CupertinoTextField(
-          ),
+      const CupertinoApp(
+        home: CupertinoTextField(
         ),
+      ),
     );
 
     final CupertinoTextField textField = tester.firstWidget(find.byType(CupertinoTextField));
@@ -4860,9 +4837,15 @@ void main() {
     final Widget widget = CupertinoApp(
       home: RepaintBoundary(
         key: const ValueKey<int>(1),
-        child: CupertinoTextField(
-          controller: OverflowWidgetTextEditingController(),
-          clipBehavior: Clip.none,
+        child: Container(
+          height: 200.0,
+          width: 200.0
+          child: Center(
+            child: CupertinoTextField(
+              controller: OverflowWidgetTextEditingController(),
+              clipBehavior: Clip.none,
+            ),
+          ),
         ),
       ),
     );
@@ -4870,6 +4853,9 @@ void main() {
 
     final CupertinoTextField textField = tester.firstWidget(find.byType(CupertinoTextField));
     expect(textField.clipBehavior, Clip.none);
+
+    final EditableText editableText = tester.firstWidget(find.byType(EditableText));
+    expect(editableText.clipBehavior, Clip.none);
 
     await expectLater(
       find.byKey(const ValueKey<int>(1)),

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -164,11 +164,11 @@ class OverflowWidgetTextEditingController extends TextEditingController {
     return TextSpan(
       style: style,
       children: <InlineSpan>[
-        TextSpan(text: 'Hi'),
+        const TextSpan(text: 'Hi'),
         WidgetSpan(
           alignment: PlaceholderAlignment.bottom,
           child: Container(
-            color: Color(0xffff3333),
+            color: const Color(0xffff3333),
             height: 100,
           ),
         ),
@@ -4846,20 +4846,20 @@ void main() {
 
   testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
-        overlay(
-          child: const CupertinoTextField(
+        const CupertinoApp(
+          home: CupertinoTextField(
           ),
         ),
     );
 
-    final TextField textField = tester.firstWidget(find.byType(CupertinoTextField));
+    final CupertinoTextField textField = tester.firstWidget(find.byType(CupertinoTextField));
     expect(textField.clipBehavior, Clip.hardEdge);
   });
 
   testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
-    final Widget widget = const CupertinoApp(
-      home: const RepaintBoundary(
-        key: ValueKey<int>(1),
+    final Widget widget = CupertinoApp(
+      home: RepaintBoundary(
+        key: const ValueKey<int>(1),
         child: CupertinoTextField(
           controller: OverflowWidgetTextEditingController(),
           clipBehavior: Clip.none,
@@ -4868,7 +4868,7 @@ void main() {
     );
     await tester.pumpWidget(widget);
 
-    final TextField textField = tester.firstWidget(find.byType(CupertinoTextField));
+    final CupertinoTextField textField = tester.firstWidget(find.byType(CupertinoTextField));
     expect(textField.clipBehavior, Clip.none);
 
     await expectLater(

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -153,6 +153,30 @@ class PathPointsMatcher extends Matcher {
   }
 }
 
+// Simple controller that builds a WidgetSpan with 100 height.
+class OverflowWidgetTextEditingController extends TextEditingController {
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return TextSpan(
+      style: style,
+      children: <InlineSpan>[
+        TextSpan(text: 'Hi'),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.bottom,
+          child: Container(
+            color: Colors.redAccent,
+            height: 100,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -4818,5 +4842,38 @@ void main() {
 
     final EditableText rtlWidget = tester.widget(find.byType(EditableText));
     expect(rtlWidget.textDirection, TextDirection.rtl);
+  });
+
+  testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        overlay(
+          child: const TextField(
+          ),
+        ),
+    );
+
+    final TextField textField = tester.firstWidget(find.byType(TextField));
+    expect(textField.clipBehavior, Clip.hardEdge);
+  });
+
+  testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
+    final Widget widget = overlay(
+      child: const RepaintBoundary(
+        key: ValueKey<int>(1),
+        child: TextField(
+          controller: OverflowWidgetTextEditingController()
+          clipBehavior: Clip.none,
+        ),
+      ),
+    );
+    await tester.pumpWidget(widget);
+
+    final TextField textField = tester.firstWidget(find.byType(TextField));
+    expect(textField.clipBehavior, Clip.none);
+
+    await expectLater(
+      find.byKey(const ValueKey<int>(1)),
+      matchesGoldenFile('overflow_clipbehavior_none.cupertino.0.png'),
+    );
   });
 }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -4837,9 +4837,9 @@ void main() {
     final Widget widget = CupertinoApp(
       home: RepaintBoundary(
         key: const ValueKey<int>(1),
-        child: Container(
+        child: SizedBox(
           height: 200.0,
-          width: 200.0
+          width: 200.0,
           child: Center(
             child: CupertinoTextField(
               controller: OverflowWidgetTextEditingController(),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -568,9 +568,9 @@ void main() {
     final Widget widget = overlay(
       child: RepaintBoundary(
         key: const ValueKey<int>(1),
-        child: Container(
+        child: SizedBox(
           height: 200,
-          width: 200
+          width: 200,
           child: Center(
             child: TextField(
               controller: OverflowWidgetTextEditingController(),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -24,7 +24,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../widgets/clipboard_utils.dart';
-import '../widgets/editable_text_utils.dart' show findRenderEditable, globalize, textOffsetToPosition;
+import '../widgets/editable_text_utils.dart' show findRenderEditable, globalize, textOffsetToPosition, OverflowWidgetTextEditingController;
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
@@ -56,30 +56,6 @@ class WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliza
 
   @override
   bool shouldReload(WidgetsLocalizationsDelegate old) => false;
-}
-
-// Simple controller that builds a WidgetSpan with 100 height.
-class OverflowWidgetTextEditingController extends TextEditingController {
-  @override
-  TextSpan buildTextSpan({
-    required BuildContext context,
-    TextStyle? style,
-    required bool withComposing,
-  }) {
-    return TextSpan(
-      style: style,
-      children: <InlineSpan>[
-        const TextSpan(text: 'Hi'),
-        WidgetSpan(
-          alignment: PlaceholderAlignment.bottom,
-          child: Container(
-            color: Colors.redAccent,
-            height: 100,
-          ),
-        ),
-      ],
-    );
-  }
 }
 
 Widget overlay({ required Widget child }) {
@@ -578,10 +554,10 @@ void main() {
 
   testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
     await tester.pumpWidget(
-        overlay(
-          child: const TextField(
-          ),
+      overlay(
+        child: const TextField(
         ),
+      ),
     );
 
     final TextField textField = tester.firstWidget(find.byType(TextField));
@@ -592,9 +568,15 @@ void main() {
     final Widget widget = overlay(
       child: RepaintBoundary(
         key: const ValueKey<int>(1),
-        child: TextField(
-          controller: OverflowWidgetTextEditingController(),
-          clipBehavior: Clip.none,
+        child: Container(
+          height: 200,
+          width: 200
+          child: Center(
+            child: TextField(
+              controller: OverflowWidgetTextEditingController(),
+              clipBehavior: Clip.none,
+            ),
+          ),
         ),
       ),
     );
@@ -602,6 +584,9 @@ void main() {
 
     final TextField textField = tester.firstWidget(find.byType(TextField));
     expect(textField.clipBehavior, Clip.none);
+
+    final EditableText editableText = tester.firstWidget(find.byType(EditableText));
+    expect(editableText.clipBehavior, Clip.none);
 
     await expectLater(
       find.byKey(const ValueKey<int>(1)),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -58,6 +58,30 @@ class WidgetsLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocaliza
   bool shouldReload(WidgetsLocalizationsDelegate old) => false;
 }
 
+// Simple controller that builds a WidgetSpan with 100 height.
+class OverflowWidgetTextEditingController extends TextEditingController {
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return TextSpan(
+      style: style,
+      children: <InlineSpan>[
+        TextSpan(text: 'Hi'),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.bottom,
+          child: Container(
+            color: Colors.redAccent,
+            height: 100,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 Widget overlay({ required Widget child }) {
   final OverlayEntry entry = OverlayEntry(
     builder: (BuildContext context) {
@@ -550,6 +574,39 @@ void main() {
     final TextField textField = tester.firstWidget(find.byType(TextField));
     expect(textField.cursorWidth, 2.0);
     expect(textField.cursorRadius, const Radius.circular(3.0));
+  });
+
+  testWidgets('clipBehavior has expected defaults', (WidgetTester tester) async {
+    await tester.pumpWidget(
+        overlay(
+          child: const TextField(
+          ),
+        ),
+    );
+
+    final TextField textField = tester.firstWidget(find.byType(TextField));
+    expect(textField.clipBehavior, Clip.hardEdge);
+  });
+
+  testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
+    final Widget widget = overlay(
+      child: const RepaintBoundary(
+        key: ValueKey<int>(1),
+        child: TextField(
+          controller: OverflowWidgetTextEditingController()
+          clipBehavior: Clip.none,
+        ),
+      ),
+    );
+    await tester.pumpWidget(widget);
+
+    final TextField textField = tester.firstWidget(find.byType(TextField));
+    expect(textField.clipBehavior, Clip.none);
+
+    await expectLater(
+      find.byKey(const ValueKey<int>(1)),
+      matchesGoldenFile('overflow_clipbehavior_none.material.0.png'),
+    );
   });
 
   testWidgets('Material cursor android golden', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -69,7 +69,7 @@ class OverflowWidgetTextEditingController extends TextEditingController {
     return TextSpan(
       style: style,
       children: <InlineSpan>[
-        TextSpan(text: 'Hi'),
+        const TextSpan(text: 'Hi'),
         WidgetSpan(
           alignment: PlaceholderAlignment.bottom,
           child: Container(
@@ -590,10 +590,10 @@ void main() {
 
   testWidgets('Overflow clipBehavior none golden', (WidgetTester tester) async {
     final Widget widget = overlay(
-      child: const RepaintBoundary(
-        key: ValueKey<int>(1),
+      child: RepaintBoundary(
+        key: const ValueKey<int>(1),
         child: TextField(
-          controller: OverflowWidgetTextEditingController()
+          controller: OverflowWidgetTextEditingController(),
           clipBehavior: Clip.none,
         ),
       ),

--- a/packages/flutter/test/widgets/editable_text_utils.dart
+++ b/packages/flutter/test/widgets/editable_text_utils.dart
@@ -45,3 +45,27 @@ Offset textOffsetToPosition(WidgetTester tester, int offset) {
   expect(endpoints.length, 1);
   return endpoints[0].point + const Offset(0.0, -2.0);
 }
+
+// Simple controller that builds a WidgetSpan with 100 height.
+class OverflowWidgetTextEditingController extends TextEditingController {
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    required bool withComposing,
+  }) {
+    return TextSpan(
+      style: style,
+      children: <InlineSpan>[
+        const TextSpan(text: 'Hi'),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.bottom,
+          child: Container(
+            color: Colors.redAccent,
+            height: 100.0,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Now that we support WidgetSpan rendering in TextFields, we should open up additional parameters to control clipping in TextFields. This will allow WidgetSpans to include widgets that overflow the editable for hit-testing and visual customization purposes.

Configurable clipping already exists in lower levels such as EditableText and RenderEditable.

Part of a series of patches to support https://github.com/flutter/flutter/issues/90355

Internal report/question: https://yaqs.corp.google.com/eng/q/7281814822109315072