### PR TITLE
Fixes zero route transition duration crash

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -2697,8 +2697,11 @@ class Navigator extends StatefulWidget {
 //                           \      /     /
 //                           idle--+-----+
 //                           /  \
-//                          /    \
-//                        pop*  remove*
+//                          /    +------+
+//                         /     |      |
+//                        /      |  complete*
+//                        |      |    /
+//                       pop*  remove*
 //                        /        \
 //                       /       removing#
 //                     popping#       |
@@ -2735,6 +2738,7 @@ enum _RouteLifecycle {
   //
   // routes that should be included in route announcement and should still listen to transition changes.
   pop, // we'll want to call didPop
+  complete, // we'll want to call didComplete,
   remove, // we'll want to run didReplace/didRemove etc
   // routes should not be included in route announcement but should still listen to transition changes.
   popping, // we're waiting for the route to call finalizeRoute to switch to dispose
@@ -2875,9 +2879,21 @@ class _RouteEntry extends RouteTransitionRecord {
     assert(navigator._debugLocked);
     assert(route._navigator == navigator);
     currentState = _RouteLifecycle.popping;
-    navigator._observedRouteDeletions.add(
-      _NavigatorPopObservation(route, previousPresent),
-    );
+    if (route.didPop(pendingResult)) {
+      navigator._observedRouteDeletions.add(
+        _NavigatorPopObservation(route, previousPresent),
+      );
+    } else {
+      currentState = _RouteLifecycle.idle;
+    }
+    pendingResult = null;
+  }
+
+  void handleComplete() {
+    route.didComplete(pendingResult);
+    pendingResult = null;
+    assert(route._popCompleter.isCompleted); // implies didComplete was called
+    currentState = _RouteLifecycle.remove;
   }
 
   void handleRemoval({ required NavigatorState navigator, required Route<dynamic>? previousPresent }) {
@@ -2892,8 +2908,6 @@ class _RouteEntry extends RouteTransitionRecord {
     }
   }
 
-  bool doingPop = false;
-
   void didAdd({ required NavigatorState navigator, required bool isNewFirst}) {
     route.didAdd();
     currentState = _RouteLifecycle.idle;
@@ -2902,13 +2916,12 @@ class _RouteEntry extends RouteTransitionRecord {
     }
   }
 
+  Object? pendingResult;
+
   void pop<T>(T? result) {
     assert(isPresent);
-    doingPop = true;
-    if (route.didPop(result) && doingPop) {
-      currentState = _RouteLifecycle.pop;
-    }
-    doingPop = false;
+    pendingResult = result;
+    currentState = _RouteLifecycle.pop;
   }
 
   bool _reportRemovalToObserver = true;
@@ -2938,9 +2951,8 @@ class _RouteEntry extends RouteTransitionRecord {
       return;
     assert(isPresent);
     _reportRemovalToObserver = !isReplaced;
-    route.didComplete(result);
-    assert(route._popCompleter.isCompleted); // implies didComplete was called
-    currentState = _RouteLifecycle.remove;
+    pendingResult = result;
+    currentState = _RouteLifecycle.complete;
   }
 
   void finalize() {
@@ -3125,6 +3137,7 @@ class _NavigatorPopObservation extends _NavigatorObservation {
 
   @override
   void notify(NavigatorObserver observer) {
+    print('did pop primaryRoute ${(primaryRoute.settings as Page).key} secondaryRoute ${(secondaryRoute?.settings as Page).key}');
     observer.didPop(primaryRoute, secondaryRoute);
   }
 }
@@ -3763,8 +3776,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     assert(() { _debugLocked = false; return true; }());
   }
 
+  bool _flushingHistory = false;
+
   void _flushHistoryUpdates({bool rearrangeOverlay = true}) {
     assert(_debugLocked && !_debugUpdatingPage);
+    _flushingHistory = true;
     // Clean up the list, sending updates to the routes that changed. Notably,
     // we don't send the didChangePrevious/didChangeNext updates to those that
     // did not change at this point, because we're not yet sure exactly what the
@@ -3837,12 +3853,28 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
             navigator: this,
             previousPresent: _getRouteBefore(index, _RouteEntry.willBePresentPredicate)?.route,
           );
+          if (entry.currentState == _RouteLifecycle.dispose) {
+            // This can happen if pop finishes synchronously.
+            continue;
+          }
           assert(entry.currentState == _RouteLifecycle.popping);
           canRemoveOrAdd = true;
           break;
         case _RouteLifecycle.popping:
+          if (!seenTopActiveRoute) {
+            // It is possible that the route enters this state directly and skips
+            // _RouteLifecycle.pop. This can happen when page was popped using
+            // the imperative API.
+            if (poppedRoute != null)
+              entry.handleDidPopNext(poppedRoute);
+            poppedRoute = entry.route;
+          }
           // Will exit this state when animation completes.
           break;
+        case _RouteLifecycle.complete:
+          entry.handleComplete();
+          assert(entry.currentState == _RouteLifecycle.remove);
+          continue;
         case _RouteLifecycle.remove:
           if (!seenTopActiveRoute) {
             if (poppedRoute != null)
@@ -3877,7 +3909,6 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
       entry = previous;
       previous = index > 0 ? _history[index - 1] : null;
     }
-
     // Informs navigator observers about route changes.
     _flushObserverNotifications();
 
@@ -3910,6 +3941,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     if (bucket != null) {
       _serializableHistory.update(_history);
     }
+    _flushingHistory = false;
   }
 
   void _flushObserverNotifications() {
@@ -4844,19 +4876,21 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
       _debugLocked = true;
       return true;
     }());
-    final _RouteEntry entry = _history.lastWhere(_RouteEntry.isPresentPredicate);
+    final int index = _history.lastIndexWhere(_RouteEntry.isPresentPredicate);
+    final _RouteEntry entry = _history[index];
     if (entry.hasPage) {
-      if (widget.onPopPage!(entry.route, result))
-        entry.currentState = _RouteLifecycle.pop;
+      if (widget.onPopPage!(entry.route, result)) {
+        _observedRouteDeletions.add(
+          _NavigatorPopObservation(entry.route, _getRouteBefore(index, _RouteEntry.willBePresentPredicate)?.route),
+        );
+        entry.currentState = _RouteLifecycle.popping;
+      }
     } else {
       entry.pop<T>(result);
+      assert (entry.currentState == _RouteLifecycle.pop);
     }
-    if (entry.currentState == _RouteLifecycle.pop) {
-      // Flush the history if the route actually wants to be popped (the pop
-      // wasn't handled internally).
-      _flushHistoryUpdates(rearrangeOverlay: false);
-      assert(entry.route._popCompleter.isCompleted);
-    }
+    _flushHistoryUpdates(rearrangeOverlay: false);
+    assert(entry.route._popCompleter.isCompleted);
     assert(() {
       _debugLocked = false;
       return true;
@@ -4972,15 +5006,10 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     assert(() { wasDebugLocked = _debugLocked; _debugLocked = true; return true; }());
     assert(_history.where(_RouteEntry.isRoutePredicate(route)).length == 1);
     final _RouteEntry entry =  _history.firstWhere(_RouteEntry.isRoutePredicate(route));
-    if (entry.doingPop) {
-      // We were called synchronously from Route.didPop(), but didn't process
-      // the pop yet. Let's do that now before finalizing.
-      entry.currentState = _RouteLifecycle.pop;
-      _flushHistoryUpdates(rearrangeOverlay: false);
-    }
     assert(entry.currentState != _RouteLifecycle.pop);
     entry.finalize();
-    _flushHistoryUpdates(rearrangeOverlay: false);
+    if (!_flushingHistory)
+      _flushHistoryUpdates(rearrangeOverlay: false);
     assert(() { _debugLocked = wasDebugLocked!; return true; }());
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3137,7 +3137,6 @@ class _NavigatorPopObservation extends _NavigatorObservation {
 
   @override
   void notify(NavigatorObserver observer) {
-    print('did pop primaryRoute ${(primaryRoute.settings as Page).key} secondaryRoute ${(secondaryRoute?.settings as Page).key}');
     observer.didPop(primaryRoute, secondaryRoute);
   }
 }
@@ -3863,7 +3862,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
         case _RouteLifecycle.popping:
           if (!seenTopActiveRoute) {
             // It is possible that the route enters this state directly and skips
-            // _RouteLifecycle.pop. This can happen when page was popped using
+            // _RouteLifecycle.pop. This can happen when page is popped using
             // the imperative API.
             if (poppedRoute != null)
               entry.handleDidPopNext(poppedRoute);
@@ -5006,10 +5005,13 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     assert(() { wasDebugLocked = _debugLocked; _debugLocked = true; return true; }());
     assert(_history.where(_RouteEntry.isRoutePredicate(route)).length == 1);
     final _RouteEntry entry =  _history.firstWhere(_RouteEntry.isRoutePredicate(route));
-    assert(entry.currentState != _RouteLifecycle.pop);
+    assert(entry.currentState == _RouteLifecycle.popping);
     entry.finalize();
+    // finalizeRoute can be called during _flushHistoryUpdates if a pop
+    // finishes synchronously.
     if (!_flushingHistory)
       _flushHistoryUpdates(rearrangeOverlay: false);
+
     assert(() { _debugLocked = wasDebugLocked!; return true; }());
   }
 

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3843,29 +3843,29 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           canRemoveOrAdd = true;
           break;
         case _RouteLifecycle.pop:
-          if (!seenTopActiveRoute) {
-            if (poppedRoute != null)
-              entry.handleDidPopNext(poppedRoute);
-            poppedRoute = entry.route;
-          }
           entry.handlePop(
             navigator: this,
             previousPresent: _getRouteBefore(index, _RouteEntry.willBePresentPredicate)?.route,
           );
-          if (entry.currentState == _RouteLifecycle.dispose ||
-              entry.currentState == _RouteLifecycle.idle) {
-            // This can happen if the pop finishes synchronously or the route
-            // rejects the pop.
+          if (entry.currentState == _RouteLifecycle.dispose) {
+            // The pop is processed synchronously. This can happen if transition
+            // duration is zero.
+            if (!seenTopActiveRoute) {
+              if (poppedRoute != null)
+                entry.handleDidPopNext(poppedRoute);
+              poppedRoute = entry.route;
+            }
+            continue;
+          }
+          if (entry.currentState == _RouteLifecycle.idle) {
+            // The route rejects the pop.
             continue;
           }
           assert(entry.currentState == _RouteLifecycle.popping);
           canRemoveOrAdd = true;
-          break;
+          continue;
         case _RouteLifecycle.popping:
           if (!seenTopActiveRoute) {
-            // It is possible that the route enters this state directly and skips
-            // _RouteLifecycle.pop. This can happen when page is popped using
-            // the imperative API.
             if (poppedRoute != null)
               entry.handleDidPopNext(poppedRoute);
             poppedRoute = entry.route;

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -3852,8 +3852,10 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
             navigator: this,
             previousPresent: _getRouteBefore(index, _RouteEntry.willBePresentPredicate)?.route,
           );
-          if (entry.currentState == _RouteLifecycle.dispose) {
-            // This can happen if pop finishes synchronously.
+          if (entry.currentState == _RouteLifecycle.dispose ||
+              entry.currentState == _RouteLifecycle.idle) {
+            // This can happen if the pop finishes synchronously or the route
+            // rejects the pop.
             continue;
           }
           assert(entry.currentState == _RouteLifecycle.popping);
@@ -4889,7 +4891,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
       assert (entry.currentState == _RouteLifecycle.pop);
     }
     _flushHistoryUpdates(rearrangeOverlay: false);
-    assert(entry.route._popCompleter.isCompleted);
+    assert(() {
+      if (entry.currentState != _RouteLifecycle.idle)
+        assert(entry.route._popCompleter.isCompleted);
+      return true;
+    }());
     assert(() {
       _debugLocked = false;
       return true;

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -129,7 +129,8 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   //
   // This situation arises when dealing with the Cupertino dismiss gesture.
   @override
-  bool get finishedWhenPopped => _controller!.status == AnimationStatus.dismissed;
+  bool get finishedWhenPopped => _controller!.status == AnimationStatus.dismissed && !_popFinalized;
+  bool _popFinalized = false;
 
   /// The animation that drives the route's transition and the previous route's
   /// forward transition.
@@ -206,6 +207,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
         // removing the route and disposing it.
         if (!isActive) {
           navigator!.finalizeRoute(this);
+          _popFinalized = true;
         }
         break;
     }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -130,6 +130,7 @@ abstract class TransitionRoute<T> extends OverlayRoute<T> {
   // This situation arises when dealing with the Cupertino dismiss gesture.
   @override
   bool get finishedWhenPopped => _controller!.status == AnimationStatus.dismissed && !_popFinalized;
+
   bool _popFinalized = false;
 
   /// The animation that drives the route's transition and the previous route's

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -1629,7 +1629,6 @@ void main() {
       expect(previousRoute is PageRoute && previousRoute.settings.name == '/', isTrue);
       isPushed = true;
     };
-
     await tester.tap(find.text('/'));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -2934,6 +2933,7 @@ void main() {
       expect(secondaryAnimationOfRouteOne.status, AnimationStatus.dismissed);
       expect(primaryAnimationOfRouteOne.status, AnimationStatus.completed);
 
+      print('before pop');
       navigator.currentState!.pop();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 30));

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3925,6 +3925,9 @@ class NavigatorObservation {
   final String? previous;
   final String? current;
   final String operation;
+
+  @override
+  String toString() => 'NavigatorObservation($operation, $current, $previous)';
 }
 
 class BuilderPage extends Page<void> {

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -2972,33 +2972,26 @@ void main() {
     testWidgets('Pop no animation page does not crash', (WidgetTester tester) async {
       // Regression Test for https://github.com/flutter/flutter/issues/86604.
       Widget buildNavigator(bool secondPage) {
-        return Navigator(
-          pages: <Page<void>>[
-            const ZeroDurationPage(
-              child: Text('page1'),
-            ),
-            if (secondPage)
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Navigator(
+            pages: <Page<void>>[
               const ZeroDurationPage(
-                child: Text('page2'),
+                child: Text('page1'),
               ),
-          ],
-          onPopPage: (Route<dynamic> route, dynamic result) => false,
+              if (secondPage)
+                const ZeroDurationPage(
+                  child: Text('page2'),
+                ),
+            ],
+            onPopPage: (Route<dynamic> route, dynamic result) => false,
+          ),
         );
       }
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: buildNavigator(true),
-        ),
-      );
+      await tester.pumpWidget(buildNavigator(true));
       expect(find.text('page2'), findsOneWidget);
 
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: buildNavigator(false),
-        ),
-      );
+      await tester.pumpWidget(buildNavigator(false));
       expect(find.text('page1'), findsOneWidget);
     });
 


### PR DESCRIPTION

If the page update pop a page with zero duration, the Route.didPop will call Navigator.finalizeRoute synchronously which calls _flushHistoryUpdates before the _updatePage finishes. This pr defers didPop call in markForPop during TransitionDelegate.resolve and only call didpop during the _flushHistoryUpdates.

fixes https://github.com/flutter/flutter/issues/86604


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
