### PR TITLE
Remove bringup for Linux android views

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1619,7 +1619,6 @@ targets:
   - name: Linux android views
     recipe: flutter/android_views
     presubmit: true
-    bringup: true
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
The builder has been green for 50+ builds. This removes bringup