### PR TITLE
Fix BottomNavigationBar multiline centered text

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -691,7 +691,7 @@ class _Label extends StatelessWidget {
           ),
         ),
         alignment: Alignment.bottomCenter,
-        child: Text(item.label!),
+        child: Text(item.label!, textAlign: TextAlign.center),
       ),
     );
 
@@ -1016,9 +1016,14 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
                   removeBottom: true,
                   child: DefaultTextStyle.merge(
                     overflow: TextOverflow.ellipsis,
-                    child:  Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: _createTiles(layout),
+                    child: SizedBox.shrink(
+                      child: Center(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: _createTiles(layout),
+                        ),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
# Description
Fix multiline labels on BottomNavigationBarItem (unable to manage with new `label` property).

# Issues
- Text widget was not centered for multiline cases, 
- if _Tile had different heights (some multiline, other not), Row of _Tile wasn't vertical centered on start (CrossAxisAlignment).

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.