### PR TITLE
use the current canvaskit version number

### DIFF
--- a/bin/internal/canvaskit.version
+++ b/bin/internal/canvaskit.version
@@ -1,1 +1,1 @@
-8FgEofQBv8m7Mo6JumaVV12OZov-Mg2_lklAR2AWh1AC
+srPdrAoUIWOde-KMPE5S8koi64mejhae7NzvfR_7m3gC


### PR DESCRIPTION
Change the CanvasKit version to the current value in the [DEPS](https://github.com/flutter/engine/blob/dd28b6f1c8e68089dab16ebce9f629f309690027/DEPS#L34) file. Having a different value seems to confuse the autoroller, which wants to be able to find the "previous" value, and since this is the first time we're rolling, there is no previous value.