### PR TITLE
RangeMaintainingScrollPhysics remove overscroll maintaining when grow

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -517,8 +517,8 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
       maintainOverscroll = false;
       if (oldPosition.minScrollExtent.isFinite && oldPosition.maxScrollExtent.isFinite &&
           newPosition.minScrollExtent.isFinite && newPosition.maxScrollExtent.isFinite) {
-        // In addition, if the position changed then we don't enforce
-        // the new boundary if both new and previous bondaries entirely finite.
+        // In addition, if the position changed then we don't enforce the new
+        // boundary if both the new and previous boundaries are entirely finite.
         // A common case where the position changes while one
         // of the extents is infinite is a lazily-loaded list. (If the
         // boundaries were finite, and the position changed, then we

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -428,9 +428,9 @@ class ScrollPhysics {
 /// Scroll physics that attempt to keep the scroll position in range when the
 /// contents change dimensions suddenly.
 ///
-/// If the scroll position is already out of range, this attempts to maintain
-/// the amount of overscroll or underscroll already present _and_ the position
-/// has shrunk, meaning that some content was removed. The reason for this
+/// This attempts to maintain the amount of overscroll or underscroll already present,
+/// if the scroll position is already out of range _and_ the extents
+/// have decreased, meaning that some content was removed. The reason for this
 /// condition is that when new content is added, keeping the same overscroll
 /// would mean that instead of showing it to the user, all of it is
 /// being skipped by jumping to right to the max extent.
@@ -518,7 +518,7 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
       if (oldPosition.minScrollExtent.isFinite && oldPosition.maxScrollExtent.isFinite &&
           newPosition.minScrollExtent.isFinite && newPosition.maxScrollExtent.isFinite) {
         // In addition, if the position changed then we don't enforce
-        // the new boundary if both new and previous position are entirely finite.
+        // the new boundary if both new and previous bondaries entirely finite.
         // A common case where the position changes while one
         // of the extents is infinite is a lazily-loaded list. (If the
         // boundaries were finite, and the position changed, then we
@@ -534,22 +534,20 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
     }
     if (maintainOverscroll) {
       // Force the new position to be no more out of range than it was before, if:
-      //  * it was overscrolled
-      //  * and the position has shrunk, meaning that some content was removed. The
+      //  * it was overscrolled, and
+      //  * the extents have decreased, meaning that some content was removed. The
       //    reason for this condition is that when new content is added, keeping
       //    the same overscroll would mean that instead of showing it to the user,
       //    all of it is being skipped by jumping to right to the max extent.
-      final bool shrunk = newPosition.minScrollExtent > oldPosition.minScrollExtent ||
-                          newPosition.maxScrollExtent < oldPosition.maxScrollExtent;
-      if (shrunk) {
-        if (oldPosition.pixels < oldPosition.minScrollExtent) {
-          final double oldDelta = oldPosition.minScrollExtent - oldPosition.pixels;
-          return newPosition.minScrollExtent - oldDelta;
-        }
-        if (oldPosition.pixels > oldPosition.maxScrollExtent) {
-          final double oldDelta = oldPosition.pixels - oldPosition.maxScrollExtent;
-          return newPosition.maxScrollExtent + oldDelta;
-        }
+      if (oldPosition.pixels < oldPosition.minScrollExtent &&
+          newPosition.minScrollExtent > oldPosition.minScrollExtent) {
+        final double oldDelta = oldPosition.minScrollExtent - oldPosition.pixels;
+        return newPosition.minScrollExtent - oldDelta;
+      }
+      if (oldPosition.pixels > oldPosition.maxScrollExtent &&
+          newPosition.maxScrollExtent < oldPosition.maxScrollExtent) {
+        final double oldDelta = oldPosition.pixels - oldPosition.maxScrollExtent;
+        return newPosition.maxScrollExtent + oldDelta;
       }
     }
     // If we're not forcing the overscroll, defer to other physics.

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -433,7 +433,7 @@ class ScrollPhysics {
 /// have decreased, meaning that some content was removed. The reason for this
 /// condition is that when new content is added, keeping the same overscroll
 /// would mean that instead of showing it to the user, all of it is
-/// being skipped by jumping to right to the max extent.
+/// being skipped by jumping right to the max extent.
 ///
 /// If the scroll activity is animating the scroll position, sudden changes to
 /// the scroll dimensions are allowed to happen (so as to prevent animations
@@ -538,7 +538,7 @@ class RangeMaintainingScrollPhysics extends ScrollPhysics {
       //  * the extents have decreased, meaning that some content was removed. The
       //    reason for this condition is that when new content is added, keeping
       //    the same overscroll would mean that instead of showing it to the user,
-      //    all of it is being skipped by jumping to right to the max extent.
+      //    all of it is being skipped by jumping right to the max extent.
       if (oldPosition.pixels < oldPosition.minScrollExtent &&
           newPosition.minScrollExtent > oldPosition.minScrollExtent) {
         final double oldDelta = oldPosition.minScrollExtent - oldPosition.pixels;

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -19,7 +19,7 @@ void main() {
     final double thirty = controller.position.maxScrollExtent;
     controller.jumpTo(thirty);
     await tester.pump();
-    controller.jumpTo(thirty + 100.0); // past the end
+    controller.jumpTo(thirty + 200.0); // past the end
     await tester.pump();
     await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(31))));
     expect(controller.position.pixels, thirty + 200.0); // same distance past the end

--- a/packages/flutter/test/widgets/scroll_activity_test.dart
+++ b/packages/flutter/test/widgets/scroll_activity_test.dart
@@ -13,7 +13,21 @@ List<Widget> children(int n) {
 }
 
 void main() {
-  testWidgets('Scrolling with list view changes', (WidgetTester tester) async {
+  testWidgets('Scrolling with list view changes, leaving the overscroll', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(30))));
+    final double thirty = controller.position.maxScrollExtent;
+    controller.jumpTo(thirty);
+    await tester.pump();
+    controller.jumpTo(thirty + 100.0); // past the end
+    await tester.pump();
+    await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(31))));
+    expect(controller.position.pixels, thirty + 100.0); // has the same position, but no longer overscrolled
+    expect(await tester.pumpAndSettle(), 1); // doesn't have ballistic animation...
+    expect(controller.position.pixels, thirty + 100.0); // and ends up at the end
+  });
+
+  testWidgets('Scrolling with list view changes, remaining overscrolled', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(30))));
     final double thirty = controller.position.maxScrollExtent;
@@ -22,7 +36,7 @@ void main() {
     controller.jumpTo(thirty + 200.0); // past the end
     await tester.pump();
     await tester.pumpWidget(MaterialApp(home: ListView(controller: controller, children: children(31))));
-    expect(controller.position.pixels, thirty + 200.0); // same distance past the end
+    expect(controller.position.pixels, thirty + 200.0); // has the same position, still overscrolled
     expect(await tester.pumpAndSettle(), 8); // now it goes ballistic...
     expect(controller.position.pixels, thirty + 100.0); // and ends up at the end
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/62890

This overscroll maintaining logic was not tested and it seems it's wrong.

<strike>I'm not sure how iOS behaves in this scenario, but it seems to me like it doesn't have such concept.</strike>

UPD: Just asked my friend to test in native app and indeed it doesn't do that

<detaIls>
<summary>Video</summary>

https://user-images.githubusercontent.com/39104740/134659340-2d725c64-7637-45c8-8c94-6d6f18d15e28.MP4
</detaIls>

If viewport changes size, the content inside it should adjust to fit the viewport only after user releases the drag.
Otherwise it will cause the linked issue - if new content comes in during the overscroll, it will be skipped entirely. There's also another case - if there is a lot of content and then some of it is removed while in overscroll.

<detaIls>
<summary>Video with the patch</summary>

https://user-images.githubusercontent.com/39104740/134548353-23b167e2-997f-41d3-b602-518d29bf87d4.mp4
</detaIls>


<detaIls>
<summary>Code sample</summary>

```dart

import 'package:flutter/material.dart';

void main() {
  runApp(MaterialApp(
    home: MyHomePage(),
  ));
}

class MyHomePage extends StatefulWidget {
  MyHomePage({Key? key}) : super(key: key);

  @override
  _MyHomePageState createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  final list = [0, 1, 2];
  var loading = false;
  final colors = [
    Colors.cyan,
    Colors.indigo,
    Colors.pink,
    Colors.red,
    Colors.blue,
    Colors.yellowAccent
  ];

  @override
  void initState() {
    super.initState();
  }

  Future<void> loadMore() async {
    await Future.delayed(const Duration(seconds: 2));
    switchItems();
  }

  void switchItems() {
    setState(() {
      if (list.length < 6) {
        list.addAll([3, 4, 5]);
      } else {
        list.removeLast();
        list.removeLast();
        list.removeLast();
      }
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Row(
          children: [
            ElevatedButton(
              child: Text('switch items'),
              onPressed: loadMore,
            ),
          ],
        ),
      ),
      body: CustomScrollView(
        physics: const BouncingScrollPhysics(
            parent: RangeMaintainingScrollPhysics()),
        slivers: [
          SliverList(
            delegate: SliverChildBuilderDelegate(
              (_, index) => SizedBox(
                width: double.infinity,
                child: Container(
                  height: 400,
                  color: colors[index % 6],
                  child: Text(
                    index.toString(),
                    style: TextStyle(
                      fontSize: 30,
                    ),
                  ),
                ),
              ),
              childCount: list.length,
            ),
          )
        ],
      ),
    );
  }
}
```
</detaIls>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.
