### PR TITLE
Remove bringup for Linux deferred_components test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1616,7 +1616,7 @@ targets:
       task_name: web_size__compile_test
     scheduler: luci
 
-  - name: Linux android views
+  - name: Linux android_views
     recipe: flutter/android_views
     presubmit: true
     properties:
@@ -1630,9 +1630,8 @@ targets:
     timeout: 60
     scheduler: luci
 
-  - name: Linux deferred components
+  - name: Linux deferred_components
     recipe: flutter/deferred_components
-    bringup: true
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1616,7 +1616,7 @@ targets:
       task_name: web_size__compile_test
     scheduler: luci
 
-  - name: Linux android_views
+  - name: Linux android views
     recipe: flutter/android_views
     presubmit: true
     properties:
@@ -1630,7 +1630,7 @@ targets:
     timeout: 60
     scheduler: luci
 
-  - name: Linux deferred_components
+  - name: Linux deferred components
     recipe: flutter/deferred_components
     properties:
       dependencies: >-


### PR DESCRIPTION
`Linux deferred_components` has been green for 50+ commits: https://ci.chromium.org/p/flutter/builders/prod/Linux%20deferred%20components?limit=100