### PR TITLE
Fix nested stretch overscroll

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -700,8 +700,7 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
           }
         }
       }
-    } else if (notification is ScrollEndNotification && notification.dragDetails != null
-        || notification is ScrollUpdateNotification && notification.dragDetails != null) {
+    } else if (notification is ScrollEndNotification || notification is ScrollUpdateNotification) {
       _stretchController.scrollEnd();
     }
     _lastNotification = notification;

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -97,7 +97,7 @@ void main() {
     expect(box3.localToGlobal(Offset.zero).dy, greaterThan(510.0));
     await expectLater(
       find.byType(CustomScrollView),
-      matchesGoldenFile('overscroll_stretch.vertical.top.png'),
+      matchesGoldenFile('overscroll_stretch.vertical.start.stretched.png'),
     );
 
     await gesture.up();
@@ -110,7 +110,11 @@ void main() {
 
     // Jump to end of the list
     controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pumpAndSettle();
     expect(controller.offset, 150.0);
+    expect(box1.localToGlobal(Offset.zero).dy, -150.0);
+    expect(box2.localToGlobal(Offset.zero).dy, 100.0);
+    expect(box3.localToGlobal(Offset.zero).dy, 350.0);
     await expectLater(
       find.byType(CustomScrollView),
       matchesGoldenFile('overscroll_stretch.vertical.end.png'),
@@ -125,8 +129,16 @@ void main() {
     expect(box3.localToGlobal(Offset.zero).dy, lessThan(350.0));
     await expectLater(
       find.byType(CustomScrollView),
-      matchesGoldenFile('overscroll_stretch.vertical.bottom.png'),
+      matchesGoldenFile('overscroll_stretch.vertical.end.stretched.png'),
     );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Stretch released back
+    expect(box1.localToGlobal(Offset.zero).dy, -150.0);
+    expect(box2.localToGlobal(Offset.zero).dy, 100.0);
+    expect(box3.localToGlobal(Offset.zero).dy, 350.0);
   });
 
   testWidgets('Stretch overscroll works in reverse - vertical', (WidgetTester tester) async {
@@ -162,7 +174,7 @@ void main() {
     );
   });
 
-  testWidgets('Stretch overscroll horizontally', (WidgetTester tester) async {
+  testWidgets('Stretch overscroll works in reverse - horizontal', (WidgetTester tester) async {
     final Key box1Key = UniqueKey();
     final Key box2Key = UniqueKey();
     final Key box3Key = UniqueKey();
@@ -235,7 +247,7 @@ void main() {
     expect(box3.localToGlobal(Offset.zero).dx, greaterThan(610.0));
     await expectLater(
       find.byType(CustomScrollView),
-      matchesGoldenFile('overscroll_stretch.horizontal.left.png'),
+      matchesGoldenFile('overscroll_stretch.horizontal.start.stretched.png'),
     );
 
     await gesture.up();
@@ -248,7 +260,11 @@ void main() {
 
     // Jump to end of the list
     controller.jumpTo(controller.position.maxScrollExtent);
+    await tester.pumpAndSettle();
     expect(controller.offset, 100.0);
+    expect(box1.localToGlobal(Offset.zero).dx, -100.0);
+    expect(box2.localToGlobal(Offset.zero).dx, 200.0);
+    expect(box3.localToGlobal(Offset.zero).dx, 500.0);
     await expectLater(
       find.byType(CustomScrollView),
       matchesGoldenFile('overscroll_stretch.horizontal.end.png'),
@@ -263,8 +279,16 @@ void main() {
     expect(box3.localToGlobal(Offset.zero).dx, lessThan(500.0));
     await expectLater(
       find.byType(CustomScrollView),
-      matchesGoldenFile('overscroll_stretch.horizontal.right.png'),
+      matchesGoldenFile('overscroll_stretch.horizontal.end.stretched.png'),
     );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Stretch released back
+    expect(box1.localToGlobal(Offset.zero).dx, -100.0);
+    expect(box2.localToGlobal(Offset.zero).dx, 200.0);
+    expect(box3.localToGlobal(Offset.zero).dx, 500.0);
   });
 
   testWidgets('Disallow stretching overscroll', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90628

This fixes an issue that is appearing in customer tests where multiple nested scroll views are seeing the stretching overscroll effect fail to recede after `pumpAndSettle`.

Calling `scrollEnd` should be done regardless of whether or not we have drag details on a `ScrollUpdate-` or `ScrollEndNotification`. The stretch effect is not dependent on these details, and the scrollEnd method only proceeds to call recede when we are pulled into a stretch. Otherwise, it may be possible to get stuck in a stretched state.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
