### PR TITLE
Add DDC regression test.

### DIFF
--- a/packages/flutter/test/dart/browser_environment_test.dart
+++ b/packages/flutter/test/dart/browser_environment_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('browser')
+
+import 'package:flutter_test/flutter_test.dart';
+
+// Regression test for: https://github.com/dart-lang/sdk/issues/47207
+// Needs: https://github.com/dart-lang/sdk/commit/6c4593929f067af259113eae5dc1b3b1c04f1035 to pass.
+// Originally here: https://github.com/flutter/engine/pull/28808
+void main() {
+  test('Web library environment define exists', () {
+    expect(const bool.fromEnvironment('dart.library.html'), isTrue);
+    expect(const bool.fromEnvironment('dart.library.someFooLibrary'), isFalse);
+  });
+}


### PR DESCRIPTION
Adds a regression test for dart-lang/sdk#47207. This is tested in the Dart SDK
but since Flutter web has its own integration of the DDC compiler through a
frontend server it makes sense to test here as well.

This test requires dart-lang/sdk@6c45939 from the Dart SDK to pass.

Fixes: https://github.com/dart-lang/sdk/issues/47207
Closes: https://github.com/flutter/engine/pull/28808

Co-authored-by: Nicholas Shahan <nshahan@google.com>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
