### PR TITLE
Implemented getter to expose current url strategy for web plugins

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,3 +87,4 @@ Sergei Smitskoi <sergflutterdev@gmail.com>
 Pradumna Saraf <pradumnasaraf@gmail.com>
 Kai Yu <yk3372@gmail.com>
 Denis Grafov <grafov.denis@gmail.com>
+TheOneWithTheBraid <the-one@with-the-braid.cf>

--- a/dev/integration_tests/web_e2e_tests/test_driver/url_strategy_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/url_strategy_integration.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
@@ -27,6 +28,9 @@ void main() {
     app.main();
     await tester.pumpAndSettle();
 
+    // checking whether the previously set strategy is properly preserved
+    expect(urlStrategy, strategy);
+
     expect(strategy.getPath(), '/');
 
     final NavigatorState navigator = app.navKey.currentState!;
@@ -44,7 +48,8 @@ void main() {
 class TestUrlStrategy extends UrlStrategy {
   /// Creates a instance of [TestUrlStrategy] with an empty string as the
   /// path.
-  factory TestUrlStrategy() => TestUrlStrategy.fromEntry(const TestHistoryEntry(null, null, ''));
+  factory TestUrlStrategy() =>
+      TestUrlStrategy.fromEntry(const TestHistoryEntry(null, null, ''));
 
   /// Creates an instance of [TestUrlStrategy] and populates it with a list
   /// that has [initialEntry] as the only item.

--- a/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/js_url_strategy.dart
@@ -23,7 +23,7 @@ typedef _JsSetUrlStrategy = void Function(JsUrlStrategy?);
 /// A JavaScript hook to customize the URL strategy of a Flutter app.
 //
 // Keep this in sync with the JS name in the web engine. Find it at:
-// https://github.com/flutter/engine/blob/custom_location_strategy/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
+// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
 //
 // TODO(mdebbar): Add integration test https://github.com/flutter/flutter/issues/66852
 @JS('_flutter_web_set_location_strategy')
@@ -37,8 +37,7 @@ typedef _AddPopStateListener = ui.VoidCallback Function(html.EventListener);
 
 typedef _StringToString = String Function(String);
 
-typedef _StateOperation = void Function(
-    Object state, String title, String url);
+typedef _StateOperation = void Function(Object state, String title, String url);
 
 typedef _HistoryMove = Future<void> Function(int count);
 

--- a/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
+++ b/packages/flutter_web_plugins/lib/src/navigation/url_strategy.dart
@@ -9,10 +9,30 @@ import 'dart:ui' as ui;
 import 'js_url_strategy.dart';
 import 'utils.dart';
 
+/// Saves the current [UrlStrategy] to be accessed by [urlStrategy] or
+/// [setUrlStrategy].
+///
+/// This is particularly required for web plugins relying on valid URL
+/// encoding.
+//
+// Keep this in sync with the default url strategy in the web engine.
+// Find it at:
+// https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/window.dart#L360
+//
+UrlStrategy? _urlStrategy = const HashUrlStrategy();
+
+/// Returns the present [UrlStrategy] for handling the browser URL.
+///
+/// In case null is returned, the browser integration has been manually
+/// disabled by [setUrlStrategy].
+UrlStrategy? get urlStrategy => _urlStrategy;
+
 /// Change the strategy to use for handling browser URL.
 ///
 /// Setting this to null disables all integration with the browser history.
 void setUrlStrategy(UrlStrategy? strategy) {
+  _urlStrategy = strategy;
+
   JsUrlStrategy? jsUrlStrategy;
   if (strategy != null) {
     jsUrlStrategy = convertToJsUrlStrategy(strategy);
@@ -285,6 +305,7 @@ class BrowserPlatformLocation extends PlatformLocation {
   static const String _defaultSearch = '';
 
   html.Location get _location => html.window.location;
+
   html.History get _history => html.window.history;
 
   @override


### PR DESCRIPTION
Implemented a getter exposing the currently present UrlStrategy for the web platform as part of `flutter_web_plugins`.
This is e.g. required to fix the below-stated issue in the `url_launcher` which is not able to properly encode an in-app URL inside an HTML `anchor` element's `href`.

*List which issues are fixed by this PR. You must list at least one issue.*
- https://github.com/flutter/flutter/issues/87941

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
