### PR TITLE
Remove InlineSpan type check

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -585,9 +585,6 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
-    assert(() {
-      return _controller._textSpan.visitChildren((InlineSpan span) => span.runtimeType == TextSpan);
-    }(), 'SelectableText only supports TextSpan; Other type of InlineSpan is not allowed');
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
     assert(


### PR DESCRIPTION
Remove InlineSpan type check because it successful work with WidgetSpan

before: https://ibb.co/GCzSH9N
after: https://ibb.co/4FV3Nty

My code:
```
SelectableText.rich(
        TextSpan(children: [
          TextSpan(
            children: [
              TextSpan(
                text: "gjgjgjg",
              ),
              TextSpan(
                text: " gjgjgjg",
                style: TextStyle(fontWeight: FontWeight.bold),
              ),
            ],
          ),
          WidgetSpan(
            child: CachedNetworkImage(
              imageUrl:
                  "https://ranobehub.org/img/media/66266/conversions/poster-big.webp",
            ),
          ),
          TextSpan(
            children: [
              TextSpan(
                text: "gjgjgjg",
              ),
              TextSpan(
                text: " gjgjgjg",
                style: TextStyle(fontWeight: FontWeight.bold),
              ),
            ],
          )
        ]),
      ),
```