### PR TITLE
- add FadeInImage.placeholderFit

### DIFF
--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -67,6 +67,9 @@ class FadeInImage extends StatefulWidget {
   /// The [placeholder] and [image] may be composed in a [ResizeImage] to provide
   /// a custom decode/cache size.
   ///
+  /// The [placeholder] and [image] may be have their own BoxFit settings via [fit]
+  /// and [placeholderFit].
+  ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and
   /// [matchTextDirection] arguments must not be null.
@@ -87,6 +90,7 @@ class FadeInImage extends StatefulWidget {
     this.width,
     this.height,
     this.fit,
+    this.placeholderFit,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -146,6 +150,7 @@ class FadeInImage extends StatefulWidget {
     this.width,
     this.height,
     this.fit,
+    this.placeholderFit,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -217,6 +222,7 @@ class FadeInImage extends StatefulWidget {
     this.width,
     this.height,
     this.fit,
+    this.placeholderFit,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -294,6 +300,11 @@ class FadeInImage extends StatefulWidget {
   /// The default varies based on the other fields. See the discussion at
   /// [paintImage].
   final BoxFit? fit;
+
+  /// How to inscribe the placeholder image into the space allocated during layout.
+  ///
+  /// If not value set, it will fallback to [fit].
+  final BoxFit? placeholderFit;
 
   /// How to align the image within its bounds.
   ///
@@ -376,6 +387,7 @@ class _FadeInImageState extends State<FadeInImage> {
     required ImageProvider image,
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
+    BoxFit? fit,
     required Animation<double> opacity,
   }) {
     assert(image != null);
@@ -386,7 +398,7 @@ class _FadeInImageState extends State<FadeInImage> {
       opacity: opacity,
       width: widget.width,
       height: widget.height,
-      fit: widget.fit,
+      fit: fit,
       alignment: widget.alignment,
       repeat: widget.repeat,
       matchTextDirection: widget.matchTextDirection,
@@ -401,6 +413,7 @@ class _FadeInImageState extends State<FadeInImage> {
       image: widget.image,
       errorBuilder: widget.imageErrorBuilder,
       opacity: _imageAnimation,
+      fit: widget.fit,
       frameBuilder: (BuildContext context, Widget child, int? frame, bool wasSynchronouslyLoaded) {
         if (wasSynchronouslyLoaded) {
           _resetAnimations();
@@ -413,6 +426,7 @@ class _FadeInImageState extends State<FadeInImage> {
             image: widget.placeholder,
             errorBuilder: widget.placeholderErrorBuilder,
             opacity: _placeholderAnimation,
+            fit: widget.placeholderFit ?? widget.fit,
           ),
           placeholderProxyAnimation: _placeholderAnimation,
           isTargetLoaded: frame != null,

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -437,8 +437,8 @@ Future<void> main() async {
       });
     });
 
-    group('placeholder\'s BoxFit', () {
-      testWidgets('should be the image\'s BoxFit when not set', (WidgetTester tester) async {
+    group("placeholder's BoxFit", () {
+      testWidgets("should be the image's BoxFit when not set", (WidgetTester tester) async {
         final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
         final TestImageProvider imageProvider = TestImageProvider(targetImage);
 

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -49,6 +49,7 @@ class FadeInImageElements {
 
   RawImage get rawImage => rawImageElement.widget as RawImage;
   double get opacity => rawImage.opacity?.value ?? 1.0;
+  BoxFit? get fit => rawImage.fit;
 }
 
 class LoadTestImageProvider extends ImageProvider<Object> {
@@ -433,6 +434,37 @@ Future<void> main() async {
           await tester.pump(const Duration(milliseconds: 51));
           expect(semanticsWidget().properties.label, isEmpty);
         });
+      });
+    });
+  
+    group('placeholder\'s BoxFit', () {
+      testWidgets('should be the image\'s BoxFit when not set', (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(FadeInImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          fit: BoxFit.cover,
+        ));
+
+        expect(findFadeInImage(tester).placeholder!.fit, equals(findFadeInImage(tester).target.fit));
+        expect(findFadeInImage(tester).placeholder!.fit, equals(BoxFit.cover));
+      });
+
+      testWidgets('should be the given value when set', (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(FadeInImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          fit: BoxFit.cover,
+          placeholderFit: BoxFit.fill,
+        ));
+
+        expect(findFadeInImage(tester).target.fit, equals(BoxFit.cover));
+        expect(findFadeInImage(tester).placeholder!.fit, equals(BoxFit.fill));
       });
     });
   });

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -436,7 +436,7 @@ Future<void> main() async {
         });
       });
     });
-  
+
     group('placeholder\'s BoxFit', () {
       testWidgets('should be the image\'s BoxFit when not set', (WidgetTester tester) async {
         final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);


### PR DESCRIPTION
At the moment, `FadeInImage` doesn't allow us to specify a BoxFit for the placeholder image. It's annoying because placeholder image usually local image, and its size is totally different from the actual Image's, so is the BoxFit.

Issue #20231 was raised a long time ago without a PR.

The PR aims to solve that issue and allows developers to specify a dedicated BoxFit for the placeholder image.

I don't add any new tests or modify any existing ones because I don't find any relevant tests regarding `FadeInImage.fit`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [x] All existing and new tests are passing.

