### PR TITLE
don't allow the VisualDensity adjustment to reduce height of the padding

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -280,10 +280,10 @@ class _ButtonStyleState extends State<ButtonStyleButton> with MaterialStateMixin
     }
 
     // Per the Material Design team: don't allow the VisualDensity
-    // adjustment to reduce the width of the left/right padding. If we
+    // adjustment to reduce the width and height of the padding. If we
     // did, VisualDensity.compact, the default for desktop/web, would
-    // reduce the horizontal padding to zero.
-    final double dy = densityAdjustment.dy;
+    // reduce the padding to zero.
+    final double dy = math.max(0, densityAdjustment.dy);
     final double dx = math.max(0, densityAdjustment.dx);
     final EdgeInsetsGeometry padding = resolvedPadding!
       .add(EdgeInsets.fromLTRB(dx, dy, dx, dy))

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -739,7 +739,7 @@ void main() {
     await buildTest(const VisualDensity(horizontal: -3.0, vertical: -3.0));
     await tester.pumpAndSettle();
     childRect = tester.getRect(find.byKey(childKey));
-    expect(box.size, equals(const Size(116, 100)));
+    expect(box.size, equals(const Size(116, 116)));
     expect(childRect, equals(const Rect.fromLTRB(350, 250, 450, 350)));
 
     await buildTest(VisualDensity.standard, useText: true);


### PR DESCRIPTION
VisualDensity should not reduce ButtonStyleButton vertical padding.

Currently this buttons has different view on android and web

```
              ElevatedButton(
                style: ElevatedButton.styleFrom(
                  padding: const EdgeInsets.symmetric(vertical: 13),
                  primary: Colors.blue,
                ),
                onPressed: () {},
                child: Text('ElevatedButton'),
              ),
              SizedBox(height: 15),
              OutlinedButton(
                style: OutlinedButton.styleFrom(
                  padding: const EdgeInsets.symmetric(vertical: 13),
                  primary: Colors.white,
                ),
                onPressed: () {},
                child: Text('OutlinedButton', style: TextStyle(color: Colors.black)),
              ),
```

Android:
![image](https://user-images.githubusercontent.com/70189001/134808959-c93a4a4a-4711-48d2-8d1c-02226a3dcbf4.png)


Web:
![image](https://user-images.githubusercontent.com/70189001/134808722-7e01f0c5-1bee-4d57-949c-1ef8cef720e0.png)


After this fix:
   Android:
   ![image](https://user-images.githubusercontent.com/70189001/134808967-077ca8ee-7264-4073-a71a-1078b98d5e1d.png)

   
   Web:
   ![image](https://user-images.githubusercontent.com/70189001/134808887-416c00f5-ce11-4a38-b257-d8b42b311c05.png)