### PR TITLE
fix added for JSON not generating for failed integration tests #90799

### DIFF
--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -81,11 +81,14 @@ Future<void> integrationDriver({
 
   await driver.close();
 
+//Below mentioned code to get the response data has been moved out of the if block for pass teste so that
+//json report gets created irrespective of test fail or test pass status.
+  if (responseDataCallback != null) {
+    await responseDataCallback(response.data);
+  }
+
   if (response.allTestsPassed) {
     print('All tests passed.');
-    if (responseDataCallback != null) {
-      await responseDataCallback(response.data);
-    }
     exit(0);
   } else {
     print('Failure Details:\n${response.formattedFailureDetails}');


### PR DESCRIPTION
This pull request contains the fix for the issue [#90799 ](https://github.com/flutter/flutter/issues/90799) where json report was not getting generated in case of failed integration tests. 
The code to get the response data has been moved out of the "**if block for pass test status**" so that json report gets created irrespective of test fail or test pass status.

_if (responseDataCallback != null) {
    await responseDataCallback(response.data);
  }_

Changes are done in **packages/integration_test/lib/integration_test_driver.dart** file only.

The fix has been tested on android, iOS and Web and found to be working fine. 

**Before - integration_reponse_data.json file was not generated for failed integration tests
After - integration_reponse_data.json file is getting generated for both fail and pass integration tests.**

Please review this pull request and merge it to provide the fix in future Flutter release.