### PR TITLE
Run native_ui_tests_macos in correct directory

### DIFF
--- a/dev/devicelab/bin/tasks/native_ui_tests_ios.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_ios.dart
@@ -7,6 +7,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   deviceOperatingSystem = DeviceOperatingSystem.ios;
@@ -35,7 +36,7 @@ Future<void> main() async {
     section('Run platform unit tests');
 
     final Device device = await devices.workingDevice;
-    if (!await runXcodeTests(projectDirectory, device.deviceId, 'native_ui_tests_ios')) {
+    if (!await runXcodeTests(path.join(projectDirectory, 'ios'), 'id=${device.deviceId}', 'native_ui_tests_ios')) {
       return TaskResult.failure('Platform unit tests failed');
     }
 

--- a/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
+++ b/dev/devicelab/bin/tasks/native_ui_tests_macos.dart
@@ -6,6 +6,7 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/ios.dart';
 import 'package:flutter_devicelab/framework/task_result.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:path/path.dart' as path;
 
 Future<void> main() async {
   await task(() async {
@@ -26,7 +27,7 @@ Future<void> main() async {
 
     section('Run platform unit tests');
 
-    if (!await runXcodeTests(projectDirectory, 'platform=macOS', 'native_ui_tests_macos')) {
+    if (!await runXcodeTests(path.join(projectDirectory, 'macos'), 'platform=macOS', 'native_ui_tests_macos')) {
       return TaskResult.failure('Platform unit tests failed');
     }
 


### PR DESCRIPTION
Run macOS test from `macos` directory instead of `ios`.  Also fix destination format.
Fixes https://github.com/flutter/flutter/issues/90554.