### PR TITLE
Reland: "Fix tooltip so only one shows at a time when hovering (#90457)"

### DIFF
--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3429,8 +3429,8 @@ void main() {
       ),
     );
 
-    // Tap at the delete icon of the chip, which is at the right
-    // side of the chip
+    // Hover over the delete icon of the chip, which is at the right side of the
+    // chip
     final Offset centerOfDeleteButton = tester.getCenter(find.byKey(deleteButtonKey));
     final TestGesture hoverGesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await hoverGesture.moveTo(centerOfDeleteButton);
@@ -3441,12 +3441,11 @@ void main() {
     // Wait for some more time while pressing and holding the delete button
     await tester.pumpAndSettle();
 
-    // There should also be a chip tooltip
-    expect(findTooltipContainer('Chip Tooltip'), findsOneWidget);
+    // There should not be a chip tooltip
+    expect(findTooltipContainer('Chip Tooltip'), findsNothing);
     // There should be a delete tooltip
     expect(findTooltipContainer('Delete'), findsOneWidget);
   });
-
 
   testWidgets('intrinsicHeight implementation meets constraints', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/49478.


### PR DESCRIPTION
## Description

This reverts commit ab51a0260d29d50800ae5c9665ecb01883a9b503 and fixes the test that broke the first time it landed.

## Tests
 - Updated the chip test to have the right conditions after the fix for multiple hovers.