### PR TITLE
Remove font-weight overrides from dartdoc

### DIFF
--- a/dev/docs/assets/overrides.css
+++ b/dev/docs/assets/overrides.css
@@ -5,7 +5,6 @@ body {
   line-height: 1.5;
   color: #111;
   background-color: #fdfdfd;
-  font-weight: 300;
   -webkit-font-smoothing: auto;
 }
 
@@ -23,21 +22,9 @@ header.header-fixed nav.navbar-fixed-top {
   box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.37);
 }
 
-h1, h2 {
-  font-weight: 300;
-}
-
-h3, h4, h5, h6 {
-  font-weight: 400;
-}
-
 h1 {
   font-size: 42px !important;
   letter-spacing: -1px;
-}
-
-header h1 {
-  font-weight: 300;
 }
 
 h2 {
@@ -92,7 +79,6 @@ pre.prettyprint {
 code {
   background-color: inherit;
   font-size: 1em; /* browsers default to smaller font for code */
-  font-weight: 300;
   padding-left: 0; /* otherwise we get ragged left margins */
   padding-right: 0;
 }
@@ -123,11 +109,6 @@ dl.dl-horizontal dt {
 /* Line the material icons up with their labels */
 i.md-36 {
   vertical-align: bottom;
-}
-
-/* thinify the inherited names in lists */
-li.inherited a {
-  font-weight: 100;
 }
 
 /* address a style issue with the background of code sections */


### PR DESCRIPTION
As outlined in #47796, font-weight: 300 is just awfully unreadable especially on monitors with low DPI. Arguably Roboto is slightly fatter than other fonts at 400, but 300 is too unusable for body text.

The default dartdoc settings uses Roboto 400 which looks absolutely fine. Other Google docs also uses the 400 weight. So let's just remove the font-weight overrides altogether.

Close #47796

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- Documentation and tests irrelevant

[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
