### PR TITLE
implement plugins for custom devices

### DIFF
--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -21,6 +21,8 @@ import '../convert.dart';
 import '../device.dart';
 import '../device_port_forwarder.dart';
 import '../features.dart';
+import '../flutter_plugins.dart';
+import '../globals.dart' as globals;
 import '../project.dart';
 import '../protocol_discovery.dart';
 import 'custom_device_config.dart';
@@ -676,6 +678,76 @@ class CustomDevice extends Device {
     }
   }
 
+  Future<bool> tryConfigureNativeProject({
+    required String buildType,
+    required List<String> plugins,
+    required Directory assetBundleDir,
+    Duration? timeout,
+    Map<String, String> additionalReplacementValues = const <String, String>{}
+  }) async {
+    final List<String> interpolated = interpolateCommand(
+      _config.configureNativeProject!,
+      <String, String>{
+        'buildType': buildType,
+        'pluginList': plugins.join(';'),
+        'assetBundleDirectory': assetBundleDir.absolute.path,
+      },
+      additionalReplacementValues: additionalReplacementValues
+    );
+
+    try {
+      await _processUtils.run(
+        interpolated,
+        throwOnError: true,
+        timeout: timeout,
+        workingDirectory: FlutterProject.current()
+          .customEmbedderProjects
+          .singleWhere((CustomEmbedderProject p) => p.embedderName == _config.embedderName)
+          .baseDirectory
+          .path
+      );
+      return true;
+    } on ProcessException catch (e) {
+      _logger.printError('Error configuring plugins for custom device $id: $e');
+      return false;
+    }
+  }
+
+  Future<bool> tryBuildNativeProject({
+    required String buildType,
+    required List<String> plugins,
+    required Directory assetBundleDir,
+    Duration? timeout,
+    Map<String, String> additionalReplacementValues = const <String, String>{}
+  }) async {
+    final List<String> interpolated = interpolateCommand(
+      _config.buildNativeProject!,
+      <String, String>{
+        'buildType': buildType,
+        'pluginList': plugins.join(';'),
+        'assetBundleDirectory': assetBundleDir.absolute.path
+      },
+      additionalReplacementValues: additionalReplacementValues
+    );
+
+    try {
+      await _processUtils.run(
+        interpolated,
+        throwOnError: true,
+        timeout: timeout,
+        workingDirectory: FlutterProject.current()
+          .customEmbedderProjects
+          .singleWhere((CustomEmbedderProject p) => p.embedderName == _config.embedderName)
+          .baseDirectory
+          .path
+      );
+      return true;
+    } on ProcessException catch (e) {
+      _logger.printError('Error building plugins for custom device $id: $e');
+      return false;
+    }
+  }
+
   @override
   void clearLogs() {}
 
@@ -794,22 +866,67 @@ class CustomDevice extends Device {
         assetDirPath: assetBundleDir,
       );
 
+      if (_config.supportsPlugins) {
+        final CustomEmbedderProject project = FlutterProject.current().customEmbedderProjects.singleWhere((CustomEmbedderProject p) => p.embedderName == _config.embedderName);
+
+        if (!project.baseDirectory.existsSync()) {
+          throwToolExit('No ${_config.embedderName} project configured. See (https://github.com/flutter/flutter/wiki/Using-custom-embedders-with-the-Flutter-CLI) to learn about adding custom embedder support to a project.');
+        }
+
+        await refreshPluginsList(project.project);
+
+        final List<Map<String, Object?>> plugins = await findNativeCustomEmbedderPlugins('x-${_config.embedderName}');
+        final List<String> pluginNames = plugins
+          .map<String>((Map<String, Object?> pluginInfo) => pluginInfo['name']! as String)
+          .toList();
+
+        if (_config.configureNativeProject != null) {
+          final bool ok = await tryConfigureNativeProject(
+            buildType: debuggingOptions.buildInfo.isDebug ? 'debug' :
+              debuggingOptions.buildInfo.isProfile ? 'profile' :
+              'release',
+            assetBundleDir: globals.fs.directory(assetBundleDir),
+            plugins: pluginNames
+          );
+          if (!ok) {
+            return LaunchResult.failed();
+          }
+        }
+        if (_config.buildNativeProject != null) {
+          final bool ok = await tryBuildNativeProject(
+            buildType: debuggingOptions.buildInfo.isDebug ? 'debug' :
+              debuggingOptions.buildInfo.isProfile ? 'profile' :
+              'release',
+            assetBundleDir: globals.fs.directory(assetBundleDir),
+            plugins: pluginNames
+          );
+          if (!ok) {
+            return LaunchResult.failed();
+          }
+        }
+      }
+
       // if we have a post build step (needed for some embedders), execute it
       if (_config.postBuildCommand != null) {
         final String? packageName = package.name;
         if (packageName == null) {
           throw ToolExit('Could not start app, name for $package is unknown.');
         }
-        await _tryPostBuild(
+        final bool ok = await _tryPostBuild(
           appName: packageName,
           localPath: assetBundleDir,
         );
+        if (!ok) {
+          return LaunchResult.failed();
+        }
       }
     }
 
     // install the app on the device
     // (will invoke the uninstall and then the install command internally)
-    await installApp(package, userIdentifier: userIdentifier);
+    if (!await installApp(package, userIdentifier: userIdentifier)) {
+      return LaunchResult.failed();
+    }
 
     // finally launch the app
     return _getOrCreateAppSession(package).start(

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1430,7 +1430,13 @@ Future<List<Map<String, Object?>>> findNativeCustomEmbedderPlugins(
   String platformKey, {
   FlutterProject? project
 }) async {
-  final List<Plugin> plugins = await findPlugins(project ?? FlutterProject.current());
+  project ??= FlutterProject.current();
+
+  List<Plugin> plugins = await findPlugins(project);
+
+  // filter plugins that support our `x-...` platform, sort them lexically
+  plugins = plugins.where((Plugin p) => p.platforms.containsKey(platformKey)).toList();
   plugins.sort((Plugin left, Plugin right) => left.name.compareTo(right.name));
-  return _extractPlatformMaps(_filterNativePlugins(plugins, platformKey), platformKey);
+
+  return _extractPlatformMaps(plugins, platformKey);
 }

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -29,6 +29,7 @@ import 'cache.dart';
 import 'custom_devices/custom_devices_config.dart';
 import 'device.dart';
 import 'doctor.dart';
+import 'features.dart';
 import 'fuchsia/fuchsia_sdk.dart';
 import 'ios/ios_workflow.dart';
 import 'ios/plist_parser.dart';
@@ -269,6 +270,8 @@ FlutterProjectFactory get projectFactory {
   return context.get<FlutterProjectFactory>() ?? FlutterProjectFactory(
     logger: logger,
     fileSystem: fs,
+    featureFlags: featureFlags,
+    customDevicesConfig: customDevicesConfig
   );
 }
 

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -532,6 +532,65 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 }
 
+class CustomEmbedderPlugin extends PluginPlatform implements NativeOrDartPlugin {
+  const CustomEmbedderPlugin({
+    required this.embedderName,
+    required this.name,
+    required this.pluginPath,
+    required FileSystem fileSystem,
+    this.dartPluginClass,
+    this.defaultPackage,
+  }) : configKey = 'x-$embedderName',
+       _fileSystem = fileSystem;
+
+  factory CustomEmbedderPlugin.fromYaml({
+    required String embedderName,
+    required String name,
+    required YamlMap yaml,
+    required String pluginPath,
+    required FileSystem fileSystem
+  }) {
+    assert(validate(yaml));
+    return CustomEmbedderPlugin(
+      embedderName: embedderName,
+      name: name,
+      pluginPath: pluginPath,
+      fileSystem: fileSystem,
+      dartPluginClass: yaml[kDartPluginClass] as String?,
+      defaultPackage: yaml[kDefaultPackage] as String?
+    );
+  }
+
+  static bool validate(YamlMap yaml) {
+    if (yaml == null) {
+      return false;
+    }
+
+    return (yaml[kDartPluginClass] is String?) &&
+      (yaml[kDefaultPackage] is String?);
+  }
+
+  final String configKey;
+  final String embedderName;
+  final String name;
+  final String pluginPath;
+  final FileSystem _fileSystem;
+  final String? dartPluginClass;
+  final String? defaultPackage;
+
+  @override
+  bool isNative() => _fileSystem.directory(pluginPath).childDirectory('x-$embedderName').existsSync();
+
+  @override
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'name': name,
+      if (dartPluginClass != null) kDartPluginClass: dartPluginClass!,
+      if (defaultPackage != null) kDefaultPackage: defaultPackage!,
+    };
+  }
+}
+
 /// Contains the parameters to template a web plugin.
 ///
 /// The required fields include: [name] of the plugin, the [pluginClass] that will

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -164,7 +164,6 @@ class Plugin {
           name: name,
           yaml: platformsYaml[platformKey] as YamlMap,
           pluginPath: path,
-          fileSystem: fileSystem,
         );
       }
     }

--- a/packages/flutter_tools/static/custom-devices.schema.json
+++ b/packages/flutter_tools/static/custom-devices.schema.json
@@ -131,6 +131,53 @@
               "ssh", "pi@raspberrypi", "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64 | tr -d ' \\n\\t'"
             ],
             "required": false
+          },
+          "embedder": {
+            "description": "Name of the embedder.\nUsed to determine the directory name for platform-specific code, and will be compared against the value of the 'FLUTTER_CUSTOM_PLATFORM' environment variable to activate the correct variant of any plugin. (If the value of the 'FLUTTER_CUSTOM_PLATFORM' variable is 'flutter-pi', the flutter-pi variant of any plugin will be activated.)",
+            "type": ["string", "null"],
+            "default": "sony-embedder",
+            "required": false
+          },
+          "configureNativeProject": {
+            "description": "Command to be run to configure the compilation of the runner & any native plugins.\nWill be called by the SDK when: \n  - something about the plugin list changed (plugin added / removed)\n  - when the project should be built and 'configureNativeProject' hasn't been called yet.  - When the project should be built for a different runtime mode than the last time 'configureNativeProject' was called",
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "required": false,
+            "default": [
+              "rmdir", "/Q", "/S", "build", "&&",
+              "mkdir", "build", "&&",
+              "cd", "build", "&&",
+              "cmake",
+                "-DCMAKE_SYSTEM_NAME=Linux",
+                "-DCMAKE_SYSTEM_PROCESSOR=arm",
+                "-DCMAKE_C_COMPILER=clang",
+                "-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf",
+                "-DCMAKE_C_FLAGS=-fuse-ld=lld",
+                "-DCMAKE_CXX_COMPILER=clang",
+                "-DCMAKE_CXX_COMPILER_TARGET=arm-linux-gnueabihf",
+                "-DCMAKE_CXX_FLAGS=-fuse-ld=lld",
+                "-DCMAKE_SYSROOT=C:/Users/hannes/devel/debian_sid_arm-sysroot",
+                "-DCMAKE_BUILD_MODE=${buildType}",
+                "-DPLUGINS=${pluginList}",
+                "-DCMAKE_INSTALL_PREFIX=${assetBuildDirectory}",
+                "-GNinja",
+                ".."
+            ]
+          },
+          "buildNativeProject": {
+            "description": "Command to be run to build the runner & any native plugins.\nWill be called by the SDK any time the project should be built.",
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "required": false,
+            "default": [
+              "ninja", "-C", "build", "install"
+            ]
           }
         }
       }

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -954,7 +954,7 @@ void main() {
           logger: BufferLogger.test(),
         );
 
-        config.add(CustomDeviceConfig.exampleUnix.copyWith(id: 'testid'));
+        config.add(CustomDeviceConfig.exampleLinux.copyWith(id: 'testid'));
 
         final CommandRunner<void> runner = createCustomDevicesCommandRunner(
           config: (_, __) => config,
@@ -986,7 +986,7 @@ void main() {
           directory: fs.directory('/'),
           logger: BufferLogger.test(),
         );
-        config.add(CustomDeviceConfig.exampleUnix.copyWith(id: 'testid2'));
+        config.add(CustomDeviceConfig.exampleLinux.copyWith(id: 'testid2'));
         final Uint8List contentsBefore = fs.file('.flutter_custom_devices.json').readAsBytesSync();
 
         final CommandRunner<void> runner = createCustomDevicesCommandRunner(
@@ -1073,9 +1073,9 @@ void main() {
           directory: fs.directory('/'),
           logger: logger,
         )..add(
-          CustomDeviceConfig.exampleUnix.copyWith(id: 'testid', label: 'testlabel', enabled: true)
+          CustomDeviceConfig.exampleLinux.copyWith(id: 'testid', label: 'testlabel', enabled: true)
         )..add(
-          CustomDeviceConfig.exampleUnix.copyWith(id: 'testid2', label: 'testlabel2', enabled: false)
+          CustomDeviceConfig.exampleLinux.copyWith(id: 'testid2', label: 'testlabel2', enabled: false)
         );
 
         final CommandRunner<void> runner = createCustomDevicesCommandRunner(
@@ -1114,9 +1114,9 @@ void main() {
           directory: fs.directory('/'),
           logger: logger,
         )..add(
-          CustomDeviceConfig.exampleUnix.copyWith(id: 'testid', label: 'testlabel', enabled: true)
+          CustomDeviceConfig.exampleLinux.copyWith(id: 'testid', label: 'testlabel', enabled: true)
         )..add(
-          CustomDeviceConfig.exampleUnix.copyWith(id: 'testid2', label: 'testlabel2', enabled: false)
+          CustomDeviceConfig.exampleLinux.copyWith(id: 'testid2', label: 'testlabel2', enabled: false)
         );
 
         final Uint8List contentsBefore = fs.file('.flutter_custom_devices.json').readAsBytesSync();

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -45,7 +45,7 @@ const String defaultConfigLinux1 = r'''
       "ping": [
         "ping",
         "-w",
-        "1",
+        "3",
         "-c",
         "1",
         "raspberrypi"
@@ -71,6 +71,7 @@ const String defaultConfigLinux1 = r'''
         "ssh",
         "-o",
         "BatchMode=yes",
+        "-tt",
         "pi@raspberrypi",
         "flutter-pi \"/tmp/${appName}\""
       ],
@@ -92,6 +93,38 @@ const String defaultConfigLinux1 = r'''
         "BatchMode=yes",
         "pi@raspberrypi",
         "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64 | tr -d ' \\n\\t'"
+      ],
+      "embedder": "sony-embedder",
+      "configureNativeProject": [
+        "rm",
+        "-rf",
+        "build",
+        "&&",
+        "mkdir",
+        "build",
+        "&&",
+        "cd",
+        "build",
+        "&&",
+        "cmake",
+        "-DCMAKE_SYSTEM_NAME=Linux",
+        "-DCMAKE_SYSTEM_PROCESSOR=arm",
+        "-DCMAKE_C_COMPILER=clang",
+        "-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf",
+        "-DCMAKE_CXX_COMPILER=clang",
+        "-DCMAKE_CXX_COMPILER_TARGET=arm-linux-gnueabihf",
+        "-DCMAKE_SYSROOT=/home/hannes/devel/debian_sid_arm-sysroot",
+        "-DCMAKE_BUILD_MODE=${buildType}",
+        "-DPLUGINS=${pluginList}",
+        "-DCMAKE_INSTALL_PREFIX=${assetBundleDirectory}",
+        "-GNinja",
+        ".."
+      ],
+      "buildNativeProject": [
+        "ninja",
+        "-C",
+        "build",
+        "install"
       ]
     }
   ]
@@ -109,7 +142,7 @@ const String defaultConfigLinux2 = r'''
       "ping": [
         "ping",
         "-w",
-        "1",
+        "3",
         "-c",
         "1",
         "raspberrypi"
@@ -135,6 +168,7 @@ const String defaultConfigLinux2 = r'''
         "ssh",
         "-o",
         "BatchMode=yes",
+        "-tt",
         "pi@raspberrypi",
         "flutter-pi \"/tmp/${appName}\""
       ],
@@ -156,6 +190,38 @@ const String defaultConfigLinux2 = r'''
         "BatchMode=yes",
         "pi@raspberrypi",
         "fbgrab /tmp/screenshot.png && cat /tmp/screenshot.png | base64 | tr -d ' \\n\\t'"
+      ],
+      "embedder": "sony-embedder",
+      "configureNativeProject": [
+        "rm",
+        "-rf",
+        "build",
+        "&&",
+        "mkdir",
+        "build",
+        "&&",
+        "cd",
+        "build",
+        "&&",
+        "cmake",
+        "-DCMAKE_SYSTEM_NAME=Linux",
+        "-DCMAKE_SYSTEM_PROCESSOR=arm",
+        "-DCMAKE_C_COMPILER=clang",
+        "-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf",
+        "-DCMAKE_CXX_COMPILER=clang",
+        "-DCMAKE_CXX_COMPILER_TARGET=arm-linux-gnueabihf",
+        "-DCMAKE_SYSROOT=/home/hannes/devel/debian_sid_arm-sysroot",
+        "-DCMAKE_BUILD_MODE=${buildType}",
+        "-DPLUGINS=${pluginList}",
+        "-DCMAKE_INSTALL_PREFIX=${assetBundleDirectory}",
+        "-GNinja",
+        ".."
+      ],
+      "buildNativeProject": [
+        "ninja",
+        "-C",
+        "build",
+        "install"
       ]
     }
   ],
@@ -1142,7 +1208,7 @@ void main() {
         expect(contentsBefore, equals(backupContents));
         expect(
           fs.file('.flutter_custom_devices.json').readAsStringSync(),
-          anyOf(equals(defaultConfigLinux1), equals(defaultConfigLinux2))
+          anyOf(defaultConfigLinux1, defaultConfigLinux2)
         );
       }
     );

--- a/packages/flutter_tools/test/general.shard/android/android_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_test.dart
@@ -190,9 +190,8 @@ flutter:
   module: {}
 ''');
     fileSystem.file('.packages').createSync();
-    final FlutterProject flutterProject = FlutterProjectFactory(
+    final FlutterProject flutterProject = makeProjectFactory(
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
     ).fromDirectory(fileSystem.currentDirectory);
     final AndroidDevice device = setUpAndroidDevice(fileSystem: fileSystem);
 
@@ -204,9 +203,8 @@ flutter:
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('.packages').createSync();
     fileSystem.directory('android').createSync();
-    final FlutterProject flutterProject = FlutterProjectFactory(
+    final FlutterProject flutterProject = makeProjectFactory(
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
     ).fromDirectory(fileSystem.currentDirectory);
 
     final AndroidDevice device = setUpAndroidDevice(fileSystem: fileSystem);
@@ -218,9 +216,8 @@ flutter:
     final FileSystem fileSystem = MemoryFileSystem.test();
     fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('.packages').createSync();
-    final FlutterProject flutterProject = FlutterProjectFactory(
+    final FlutterProject flutterProject = makeProjectFactory(
       fileSystem: fileSystem,
-      logger: BufferLogger.test(),
     ).fromDirectory(fileSystem.currentDirectory);
 
     final AndroidDevice device = setUpAndroidDevice(fileSystem: fileSystem);

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -177,8 +177,7 @@ void main() {
       androidDirectory.childFile('gradlew.bat').createSync();
       androidDirectory.childFile('gradle.properties').createSync();
 
-      final FlutterProject flutterProject = FlutterProjectFactory(
-        logger: BufferLogger.test(),
+      final FlutterProject flutterProject = makeProjectFactory(
         fileSystem: fileSystem,
       ).fromDirectory(fileSystem.currentDirectory);
 

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -81,7 +81,10 @@ void main() {
     final CrashReporter crashReporter = CrashReporter(
       fileSystem: fs,
       logger: logger,
-      flutterProjectFactory: FlutterProjectFactory(fileSystem: fs, logger: logger),
+      flutterProjectFactory: makeProjectFactory(
+        fileSystem: fs,
+        logger: logger,
+      ),
     );
 
     final File file = fs.file('flutter_00.log');

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/doctor.dart';
-import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:http/http.dart';

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -9,10 +9,10 @@ import 'dart:async';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
-import 'package:flutter_tools/src/bundle.dart';
 import 'package:flutter_tools/src/bundle_builder.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device.dart';
@@ -27,6 +27,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/custom_devices_common.dart';
 import '../../src/fakes.dart';
 
 
@@ -42,11 +43,7 @@ void _writeCustomDevicesConfigFile(Directory dir, List<CustomDeviceConfig> confi
 }
 
 FlutterProject _setUpFlutterProject(Directory directory) {
-  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(
-    fileSystem: directory.fileSystem,
-    logger: BufferLogger.test(),
-  );
-  return flutterProjectFactory.fromDirectory(directory);
+  return makeProjectFactory(fileSystem: directory.fileSystem).fromDirectory(directory);
 }
 
 void main() {
@@ -638,6 +635,10 @@ class MyFakeStreamSubscription<T> extends Fake implements StreamSubscription<T> 
 }
 
 class FakeBundleBuilder extends Fake implements BundleBuilder {
+  FakeBundleBuilder([this.impl]);
+
+  final BundleBuildFunction impl;
+
   @override
   Future<void> build({
     TargetPlatform platform,
@@ -649,5 +650,21 @@ class FakeBundleBuilder extends Fake implements BundleBuilder {
     String depfilePath,
     String assetDirPath,
     @visibleForTesting BuildSystem buildSystem
-  }) async {}
+  }) async {
+    if (impl != null) {
+      return impl(
+        platform: platform,
+        buildInfo: buildInfo,
+        project: project,
+        mainPath: mainPath,
+        manifestPath: manifestPath,
+        applicationKernelFilePath: applicationKernelFilePath,
+        depfilePath: depfilePath,
+        assetDirPath: assetDirPath,
+        buildSystem: buildSystem
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_devices_plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_devices_plugins_test.dart
@@ -101,7 +101,7 @@ void main() {
             debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
             bundleBuilder: FakeBundleBuilder()
           ),
-          throwsToolExit(message: 'No testembedder project configured. See (...) to learn about adding custom embedder support to a project.'),
+          throwsToolExit(message: 'No testembedder project configured. See (https://github.com/flutter/flutter/wiki/Using-custom-embedders-with-the-Flutter-CLI) to learn about adding custom embedder support to a project.'),
         );
       },
       overrides: <Type, dynamic Function()>{

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_devices_plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_devices_plugins_test.dart
@@ -1,0 +1,306 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/asset.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/utils.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
+import 'package:flutter_tools/src/bundle_builder.dart';
+import 'package:flutter_tools/src/custom_devices/custom_device.dart';
+import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
+import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
+import 'package:flutter_tools/src/linux/application_package.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:meta/meta.dart';
+import 'package:test/fake.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/custom_devices_common.dart';
+import '../../src/fakes.dart';
+
+void main() {
+  group('custom devices plugins', () {
+    BufferLogger logger;
+    MemoryFileSystem fileSystem;
+    Directory directory;
+    CustomDevicesConfig config;
+
+    void writeAndLoadConfig(dynamic json) {
+      writeCustomDevicesConfigFile(
+        directory,
+        json: json
+      );
+
+      config = CustomDevicesConfig.test(
+        fileSystem: fileSystem,
+        directory: directory,
+        logger: logger,
+      );
+    }
+
+    List<Directory> createFakePlugins(List<String> pluginNamesOrPaths) {
+      const String pluginYamlTemplate = '''
+  flutter:
+    plugin:
+      platforms:
+        x-testembedder: {}
+  ''';
+
+      final List<Directory> directories = <Directory>[];
+      final Directory fakePubCache = fileSystem.systemTempDirectory.childDirectory('cache');
+      final File packagesFile = fileSystem.currentDirectory.childFile('.packages')
+        ..createSync(recursive: true);
+      for (final String nameOrPath in pluginNamesOrPaths) {
+        final String name = fileSystem.path.basename(nameOrPath);
+        final Directory pluginDirectory = (nameOrPath == name)
+            ? fakePubCache.childDirectory(name)
+            : fileSystem.directory(nameOrPath);
+        packagesFile.writeAsStringSync(
+            '$name:file://${pluginDirectory.childFile('lib').uri}\n',
+            mode: FileMode.writeOnlyAppend);
+        pluginDirectory.childFile('pubspec.yaml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(pluginYamlTemplate.replaceAll('PLUGIN_CLASS', sentenceCase(camelCase(name))));
+        pluginDirectory.childDirectory('x-testembedder').createSync(recursive: true);
+
+        directories.add(pluginDirectory);
+      }
+      return directories;
+    }
+
+    setUp(() {
+      logger = BufferLogger.test();
+      fileSystem = MemoryFileSystem.test();
+      directory = fileSystem.directory('custom_devices_config');
+
+      fileSystem.currentDirectory.childFile('.packages').createSync(recursive: true);
+    });
+
+    testUsingContext(
+      "building project with plugin support fails if native project directory doesn't exist",
+      () async {
+        writeAndLoadConfig(const <dynamic>[testConfigPluginsJson]);
+
+        final CustomDevice device = CustomDevice(
+          config: config.devices.single,
+          logger: logger,
+          processManager: FakeProcessManager.empty()
+        );
+
+        await expectLater(
+          device.startApp(
+            FakeLinuxApp(),
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            bundleBuilder: FakeBundleBuilder()
+          ),
+          throwsToolExit(message: 'No testembedder project configured. See (...) to learn about adding custom embedder support to a project.'),
+        );
+      },
+      overrides: <Type, dynamic Function()>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () { assert(false); },
+        CustomDevicesConfig: () => config,
+        FeatureFlags: () => TestFeatureFlags(areCustomDevicesEnabled: true)
+      },
+    );
+
+    testUsingContext(
+      'building project with plugins invokes the correct commands',
+      () async {
+        bool postBuildHasRun = false;
+
+        createFakePlugins(const <String>[
+          'ctestplugin',
+          'atestplugin',
+          'btestplugin',
+        ]);
+        writeAndLoadConfig(const <dynamic>[testConfigPluginsJson]);
+
+        // create the directory where our native project resides
+        fileSystem.directory('x-testembedder').createSync();
+
+        final CustomDevice device = CustomDevice(
+          config: config.devices.single,
+          logger: logger,
+          processManager: FakeProcessManager.list(
+            <FakeCommand>[
+              FakeCommand(
+                command: const <String>['testconfigurenativeproject', 'debug', 'atestplugin;btestplugin;ctestplugin', '/build/flutter_assets'],
+                workingDirectory: fileSystem.currentDirectory.childDirectory('x-testembedder').path,
+              ),
+              FakeCommand(
+                command: const <String>['testbuildnativeproject', 'debug', 'atestplugin;btestplugin;ctestplugin', '/build/flutter_assets'],
+                workingDirectory: fileSystem.currentDirectory.childDirectory('x-testembedder').path,
+              ),
+              FakeCommand(
+                command: const <String>['testpostbuild'],
+                exitCode: -1, // stop the building / starting of the app here
+                onRun: () => postBuildHasRun = true,
+              ),
+            ],
+          ),
+        );
+
+        expect(
+          await device.startApp(
+            FakeLinuxApp(),
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            bundleBuilder: FakeBundleBuilder()
+          ),
+          allOf(isA<LaunchResult>(), (LaunchResult r) => r.started == false)
+        );
+        expect(postBuildHasRun, true);
+      },
+      overrides: <Type, dynamic Function()>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () { assert(false); },
+        CustomDevicesConfig: () => config,
+        FeatureFlags: () => TestFeatureFlags(areCustomDevicesEnabled: true)
+      },
+    );
+
+    testUsingContext(
+      'building project with plugins fails and prints output if configureNativeProject commands fails',
+      () async {
+        writeAndLoadConfig(const <dynamic>[testConfigPluginsJson]);
+        fileSystem.directory('x-testembedder').createSync();
+
+        final CustomDevice device = CustomDevice(
+          config: config.devices.single,
+          logger: logger,
+          processManager: FakeProcessManager.list(
+            <FakeCommand>[
+              FakeCommand(
+                command: const <String>['testconfigurenativeproject', 'debug', '', '/build/flutter_assets'],
+                workingDirectory: fileSystem.currentDirectory.childDirectory('x-testembedder').path,
+                exitCode: -1,
+                stderr: 'some error'
+              )
+            ],
+          ),
+        );
+
+        expect(
+          await device.startApp(
+            FakeLinuxApp(),
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            bundleBuilder: FakeBundleBuilder()
+          ),
+          allOf(isA<LaunchResult>(), (LaunchResult r) => r.started == false)
+        );
+        expect(logger.errorText, contains('some error'));
+      },
+      overrides: <Type, dynamic Function()>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () { assert(false); },
+        CustomDevicesConfig: () => config,
+        FeatureFlags: () => TestFeatureFlags(areCustomDevicesEnabled: true)
+      },
+    );
+
+    testUsingContext(
+      'building project with plugins fails and prints output if buildNativeProject commands fails',
+      () async {
+        writeAndLoadConfig(const <dynamic>[testConfigPluginsJson]);
+        fileSystem.directory('x-testembedder').createSync();
+
+        final CustomDevice device = CustomDevice(
+          config: config.devices.single,
+          logger: logger,
+          processManager: FakeProcessManager.list(
+            <FakeCommand>[
+              FakeCommand(
+                command: const <String>['testconfigurenativeproject', 'debug', '', '/build/flutter_assets'],
+                workingDirectory: fileSystem.currentDirectory.childDirectory('x-testembedder').path,
+              ),
+              FakeCommand(
+                command: const <String>['testbuildnativeproject', 'debug', '', '/build/flutter_assets'],
+                workingDirectory: fileSystem.currentDirectory.childDirectory('x-testembedder').path,
+                exitCode: -1,
+                stderr: 'some error'
+              ),
+            ],
+          ),
+        );
+
+        expect(
+          await device.startApp(
+            FakeLinuxApp(),
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            bundleBuilder: FakeBundleBuilder()
+          ),
+          allOf(isA<LaunchResult>(), (LaunchResult r) => r.started == false)
+        );
+        expect(logger.errorText, contains('some error'));
+      },
+      overrides: <Type, dynamic Function()>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () { assert(false); },
+        CustomDevicesConfig: () => config,
+        FeatureFlags: () => TestFeatureFlags(areCustomDevicesEnabled: true)
+      },
+    );
+  });
+}
+
+class FakeLinuxApp extends Fake implements LinuxApp {
+  @override
+  String name = 'testapp';
+
+  @override
+  String executable(BuildMode buildMode) {
+    switch (buildMode) {
+      case BuildMode.debug:
+        return 'debug/executable';
+      case BuildMode.profile:
+        return 'profile/executable';
+      case BuildMode.release:
+        return 'release/executable';
+      default:
+        throw StateError('Invalid mode: $buildMode');
+    }
+  }
+}
+
+class FakeBundleBuilder extends Fake implements BundleBuilder {
+  FakeBundleBuilder([this.impl]);
+
+  final BundleBuildFunction impl;
+
+  @override
+  Future<void> build({
+    TargetPlatform platform,
+    BuildInfo buildInfo,
+    FlutterProject project,
+    String mainPath,
+    String manifestPath = defaultManifestPath,
+    String applicationKernelFilePath,
+    String depfilePath,
+    String assetDirPath,
+    @visibleForTesting BuildSystem buildSystem
+  }) async {
+    if (impl != null) {
+      return impl(
+        platform: platform,
+        buildInfo: buildInfo,
+        project: project,
+        mainPath: mainPath,
+        manifestPath: manifestPath,
+        applicationKernelFilePath: applicationKernelFilePath,
+        depfilePath: depfilePath,
+        assetDirPath: assetDirPath,
+        buildSystem: buildSystem
+      );
+    } else {
+      return;
+    }
+  }
+}

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -9,7 +9,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/devfs.dart';
-import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/github_template.dart';
 
 import '../src/common.dart';
@@ -158,7 +157,7 @@ void main() {
         final GitHubTemplateCreator creator = GitHubTemplateCreator(
           fileSystem: fs,
           logger: logger,
-          flutterProjectFactory: FlutterProjectFactory(
+          flutterProjectFactory: makeProjectFactory(
             fileSystem: fs,
             logger: logger,
           ),
@@ -182,7 +181,7 @@ void main() {
         final GitHubTemplateCreator creator = GitHubTemplateCreator(
           fileSystem: fs,
           logger: logger,
-          flutterProjectFactory: FlutterProjectFactory(
+          flutterProjectFactory: makeProjectFactory(
             fileSystem: fs,
             logger: logger,
           ),

--- a/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_device_test.dart
@@ -163,9 +163,8 @@ void main() {
 }
 
 FlutterProject setUpFlutterProject(Directory directory) {
-  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(
+  final FlutterProjectFactory flutterProjectFactory = makeProjectFactory(
     fileSystem: directory.fileSystem,
-    logger: BufferLogger.test(),
   );
   return flutterProjectFactory.fromDirectory(directory);
 }

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -242,9 +242,8 @@ void main() {
 }
 
 FlutterProject setUpFlutterProject(Directory directory) {
-  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(
+  final FlutterProjectFactory flutterProjectFactory = makeProjectFactory(
     fileSystem: directory.fileSystem,
-    logger: BufferLogger.test(),
   );
   return flutterProjectFactory.fromDirectory(directory);
 }

--- a/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugin_parsing_test.dart
@@ -55,7 +55,8 @@ void main() {
       '  pluginClass: WebSamplePlugin\n'
       '  fileName: web_plugin.dart\n'
       ' windows:\n'
-      '  pluginClass: WinSamplePlugin\n';
+      '  pluginClass: WinSamplePlugin\n'
+      ' x-testembedder: {}\n';
 
     final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
     final Plugin plugin = Plugin.fromYaml(
@@ -73,6 +74,7 @@ void main() {
     final MacOSPlugin macOSPlugin = plugin.platforms[MacOSPlugin.kConfigKey]! as MacOSPlugin;
     final WebPlugin webPlugin = plugin.platforms[WebPlugin.kConfigKey]! as WebPlugin;
     final WindowsPlugin windowsPlugin = plugin.platforms[WindowsPlugin.kConfigKey]! as WindowsPlugin;
+    final CustomEmbedderPlugin customEmbedderPlugin = plugin.platforms['x-testembedder']! as CustomEmbedderPlugin;
 
     expect(iosPlugin.pluginClass, 'ISamplePlugin');
     expect(iosPlugin.classPrefix, '');
@@ -83,6 +85,12 @@ void main() {
     expect(webPlugin.pluginClass, 'WebSamplePlugin');
     expect(webPlugin.fileName, 'web_plugin.dart');
     expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
+    expect(customEmbedderPlugin.configKey, 'x-testembedder');
+    expect(customEmbedderPlugin.embedderName, 'testembedder');
+    expect(customEmbedderPlugin.name, _kTestPluginName);
+    expect(customEmbedderPlugin.pluginPath, _kTestPluginPath);
+    expect(customEmbedderPlugin.dartPluginClass, isNull);
+    expect(customEmbedderPlugin.defaultPackage, isNull);
   });
 
   testWithoutContext('Plugin parsing of unknown fields are allowed (allows some future compatibility)', () {
@@ -103,7 +111,9 @@ void main() {
       '  pluginClass: WebSamplePlugin\n'
       '  fileName: web_plugin.dart\n'
       ' windows:\n'
-        '  pluginClass: WinSamplePlugin\n';
+      '  pluginClass: WinSamplePlugin\n'
+      ' x-testembedder:\n'
+      '  anUnknownField: ASamplePlugin\n';
 
     final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
     final Plugin plugin = Plugin.fromYaml(
@@ -121,6 +131,7 @@ void main() {
     final MacOSPlugin macOSPlugin = plugin.platforms[MacOSPlugin.kConfigKey]! as MacOSPlugin;
     final WebPlugin webPlugin = plugin.platforms[WebPlugin.kConfigKey]! as WebPlugin;
     final WindowsPlugin windowsPlugin = plugin.platforms[WindowsPlugin.kConfigKey]! as WindowsPlugin;
+    final CustomEmbedderPlugin customEmbedderPlugin = plugin.platforms['x-testembedder']! as CustomEmbedderPlugin;
 
     expect(iosPlugin.pluginClass, 'ISamplePlugin');
     expect(iosPlugin.classPrefix, '');
@@ -131,6 +142,7 @@ void main() {
     expect(webPlugin.pluginClass, 'WebSamplePlugin');
     expect(webPlugin.fileName, 'web_plugin.dart');
     expect(windowsPlugin.pluginClass, 'WinSamplePlugin');
+    expect(customEmbedderPlugin.name, _kTestPluginName);
   });
 
   testWithoutContext('Plugin parsing allows for Dart-only plugins without a pluginClass', () {
@@ -146,7 +158,9 @@ void main() {
       ' macos:\n'
       '  dartPluginClass: MSamplePlugin\n'
       ' windows:\n'
-      '  dartPluginClass: WinSamplePlugin\n';
+      '  dartPluginClass: WinSamplePlugin\n'
+      ' x-testembedder:\n'
+      '  dartPluginClass: TestEmbedderSamplePlugin\n';
 
     final YamlMap pluginYaml = loadYaml(pluginYamlRaw) as YamlMap;
     final Plugin plugin = Plugin.fromYaml(
@@ -163,6 +177,7 @@ void main() {
     final LinuxPlugin linuxPlugin = plugin.platforms[LinuxPlugin.kConfigKey]! as LinuxPlugin;
     final MacOSPlugin macOSPlugin = plugin.platforms[MacOSPlugin.kConfigKey]! as MacOSPlugin;
     final WindowsPlugin windowsPlugin = plugin.platforms[WindowsPlugin.kConfigKey]! as WindowsPlugin;
+    final CustomEmbedderPlugin customEmbedderPlugin = plugin.platforms['x-testembedder']! as CustomEmbedderPlugin;
 
     expect(androidPlugin.pluginClass, isNull);
     expect(iOSPlugin.pluginClass, isNull);
@@ -174,6 +189,7 @@ void main() {
     expect(linuxPlugin.dartPluginClass, 'LSamplePlugin');
     expect(macOSPlugin.dartPluginClass, 'MSamplePlugin');
     expect(windowsPlugin.dartPluginClass, 'WinSamplePlugin');
+    expect(customEmbedderPlugin.dartPluginClass, 'TestEmbedderSamplePlugin');
   });
 
   testWithoutContext('Plugin parsing of legacy format and multi-platform format together is not allowed '

--- a/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/windows_device_test.dart
@@ -384,9 +384,8 @@ void main() {
 }
 
 FlutterProject setUpFlutterProject(Directory directory) {
-  final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(
+  final FlutterProjectFactory flutterProjectFactory = makeProjectFactory(
     fileSystem: directory.fileSystem,
-    logger: BufferLogger.test(),
   );
   return flutterProjectFactory.fromDirectory(directory);
 }

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_tools/src/android/android_builder.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
@@ -44,6 +45,8 @@ class FakeFlutterProjectFactory extends FlutterProjectFactory {
     super(
       fileSystem: globals.fs,
       logger: globals.logger,
+      featureFlags: featureFlags,
+      customDevicesConfig: globals.customDevicesConfig
     );
 
   final Directory directoryOverride;

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -9,12 +9,18 @@ import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/context.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/custom_devices/custom_devices_config.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path; // flutter_ignore: package_path_import
 import 'package:test_api/test_api.dart' as test_package show test; // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' hide test; // ignore: deprecated_member_use
+
+import 'fakes.dart';
 
 export 'package:test_api/test_api.dart' hide test, isInstanceOf; // ignore: deprecated_member_use
 
@@ -292,4 +298,30 @@ class FileExceptionHandler {
     }
     throw exception;
   }
+}
+
+/// Creates a FlutterProjectFactory with some reasonable defaults.
+///
+/// If [logger] is `null`, creates one using [BufferLogger.test].
+/// If [fileSystem] is `null`, creates one using [MemoryFileSystem.test].
+/// If [featureFlags] is `null`, creates one using [TestFeatureFlags].
+/// If [customDevicesConfig] is `null`, creates one using [CustomDevicesConfig.test],
+/// with [fileSystem] and [logger] as the arguments.
+FlutterProjectFactory makeProjectFactory({
+  Logger? logger,
+  FileSystem? fileSystem,
+  FeatureFlags? featureFlags,
+  CustomDevicesConfig? customDevicesConfig
+}) {
+  logger ??= BufferLogger.test();
+  fileSystem ??= MemoryFileSystem.test();
+  return FlutterProjectFactory(
+    logger: logger,
+    fileSystem: fileSystem,
+    featureFlags: featureFlags ?? TestFeatureFlags(),
+    customDevicesConfig: customDevicesConfig ?? CustomDevicesConfig.test(
+      fileSystem: fileSystem,
+      logger: logger
+    ),
+  );
 }

--- a/packages/flutter_tools/test/src/custom_devices_common.dart
+++ b/packages/flutter_tools/test/src/custom_devices_common.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
+import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device_config.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:meta/meta.dart';
 
 void writeCustomDevicesConfigFile(
   Directory dir, {
@@ -60,3 +64,39 @@ const Map<String, dynamic> testConfigJson = <String, dynamic>{
   'forwardPort': <String>['testforwardport'],
   'forwardPortSuccessRegex': 'testforwardportsuccess'
 };
+
+final CustomDeviceConfig testConfigPlugins = testConfig.copyWith(
+  embedderName: 'testembedder',
+  configureNativeProject: const <String>['testconfigurenativeproject', r'${buildType}', r'${pluginList}', r'${assetBuildDirectory}'],
+  buildNativeProject: const <String>['testbuildnativeproject', r'${buildType}', r'${pluginList}', r'${assetBuildDirectory}']
+);
+
+const Map<String, dynamic> testConfigPluginsJson = <String, dynamic>{
+  'id': 'testid',
+  'label': 'testlabel',
+  'sdkNameAndVersion': 'testsdknameandversion',
+  'enabled': true,
+  'ping': <String>['testping'],
+  'pingSuccessRegex': 'testpingsuccess',
+  'postBuild': <String>['testpostbuild'],
+  'install': <String>['testinstall'],
+  'uninstall': <String>['testuninstall'],
+  'runDebug': <String>['testrundebug'],
+  'forwardPort': <String>['testforwardport'],
+  'forwardPortSuccessRegex': 'testforwardportsuccess',
+  'embedder': 'testembedder',
+  'configureNativeProject': <String>['testconfigurenativeproject', r'${buildType}', r'${pluginList}', r'${assetBundleDirectory}'],
+  'buildNativeProject': <String>['testbuildnativeproject', r'${buildType}', r'${pluginList}', r'${assetBundleDirectory}']
+};
+
+typedef BundleBuildFunction = Future<void> Function({
+  TargetPlatform? platform,
+  BuildInfo? buildInfo,
+  FlutterProject? project,
+  String? mainPath,
+  String? manifestPath,
+  String? applicationKernelFilePath,
+  String? depfilePath,
+  String? assetDirPath,
+  @visibleForTesting BuildSystem? buildSystem
+});

--- a/packages/flutter_tools/test/src/pubspec_schema.dart
+++ b/packages/flutter_tools/test/src/pubspec_schema.dart
@@ -14,6 +14,7 @@ void validatePubspecForPlugin({
   String? pluginClass,
   bool ffiPlugin = false,
   required List<String> expectedPlatforms,
+  List<String> expectedEmptyPlatforms = const <String>[],
   List<String> unexpectedPlatforms = const <String>[],
   String? androidIdentifier,
   String? webFileName,
@@ -34,6 +35,10 @@ void validatePubspecForPlugin({
     if (platform == 'web') {
       expect(platformMap['fileName'], webFileName);
     }
+  }
+  for (final String platform in expectedEmptyPlatforms) {
+    expect(platformMaps[platform], isNotNull);
+    expect(platformMaps[platform], isEmpty);
   }
   for (final String platform in unexpectedPlatforms) {
     expect(platformMaps[platform], isNull);


### PR DESCRIPTION
Implements plugin for custom devices: See https://github.com/flutter/flutter/issues/86864
See also the design doc: https://flutter.dev/go/plugin-support-for-custom-embeddings

### Summary of the changes

`custom_devices/custom_device_config.dart`:
- add 3 new keys:
  - `embedder`, the name of the embedder
  - `configureNativeProject` (should basically invoke `cmake` in the native project directory)
  - `buildNativeProject` (should basically invoke `ninja` in the native project directory)
  - native project directory is the `x-flutter-pi` subdir of the flutter project directory
  - (if the embedder is called flutter-pi)

`custom_devices/custom_device.dart`:
- add methods for invoking the `configureNativeProject` and `buildNativeProject` commands of the custom device config
- check the return value of the postBuildCommand, return LaunchResult.failed() if not successful
- check the return value of the installCommand, return LaunchResult.failed() if not successful

`flutter_plugins.dart`:
- expand writing of .flutter-plugins-dependencies for custom devices plugins
- expand the generated dart plugin registrant for custom devices plugins
  - for example, the `flutter-pi` variant of a plugin is activated if `-Dflutter.customPlatform=flutter-pi` was given as a dart define, or the `FLUTTER_CUSTOM_PLATFORM` environment variable equals `flutter-pi` (needed for debug mode)
- also creating plugin symlinks for custom devices plugins
- allow resolving platform interface resolutions for custom devices plugins
- add method to find all plugins for custom embedder with a given platform key

`project.dart`:
- expand `FlutterProjectFactory` and `FlutterProject` for custom devices support
- `FlutterProject.customEmbedderProjects` lists all custom embedder subprojects of this flutter project
- to do that, it needs to know which custom embedders are currently configured
- it gets that info from the flutter project factory (which just queries the CustomDevicesConfig)    

Tests:
- add tests for all the changes
- add makeProjectFactory inside test/src/common.dart with creates a project factory with some default arguments, make all tests use that instead of constructing a FlutterProjectFactory themselves

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
