### PR TITLE
Catch FormatException from bad simulator log output

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -858,9 +858,14 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
     // The log command predicate handles filtering, so every log eventMessage should be decoded and added.
     final Match eventMessageMatch = _unifiedLoggingEventMessageRegex.firstMatch(line);
     if (eventMessageMatch != null) {
-      final dynamic decodedJson = jsonDecode(eventMessageMatch.group(1));
-      if (decodedJson is String) {
-        _linesController.add(decodedJson);
+      final String message = eventMessageMatch.group(1);
+      try {
+        final dynamic decodedJson = jsonDecode(message);
+        if (decodedJson is String) {
+          _linesController.add(decodedJson);
+        }
+      } on FormatException {
+        globals.printError('Logger returned non-JSON response: $message');
       }
     }
   }


### PR DESCRIPTION
Sometimes the simulator log events are malformed, perhaps due to an escaping issue?  This seems relatively rare, let's just log the malformed log line and see if we get any reports.

Similar to https://github.com/flutter/flutter/pull/37958

Fixes https://github.com/flutter/flutter/issues/90899