### PR TITLE
Catch FormatException parsing XCDevice._getAllDevices

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -112,8 +112,15 @@ class XCDevice {
         throwOnError: true,
       );
       if (result.exitCode == 0) {
-        final List<dynamic> listResults = json.decode(result.stdout) as List<dynamic>;
-        _cachedListResults = listResults;
+        List<dynamic> listResults = <dynamic>[];
+        final String listOutput = result.stdout;
+        try {
+          listResults = json.decode(listOutput) as List<dynamic>;
+          _cachedListResults = listResults;
+        } on FormatException {
+          // xcdevice logs errors and crashes to stdout.
+          _logger.printError('xcdevice returned non-JSON response: $listOutput');
+        }
         return listResults;
       }
       _logger.printTrace('xcdevice returned an error:\n${result.stderr}');

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -112,16 +112,16 @@ class XCDevice {
         throwOnError: true,
       );
       if (result.exitCode == 0) {
-        List<dynamic> listResults = <dynamic>[];
         final String listOutput = result.stdout;
         try {
-          listResults = json.decode(listOutput) as List<dynamic>;
+          final List<dynamic> listResults = json.decode(listOutput) as List<dynamic>;
           _cachedListResults = listResults;
+          return listResults;
         } on FormatException {
           // xcdevice logs errors and crashes to stdout.
           _logger.printError('xcdevice returned non-JSON response: $listOutput');
+          return null;
         }
-        return listResults;
       }
       _logger.printTrace('xcdevice returned an error:\n${result.stderr}');
     } on ProcessException catch (exception) {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -680,6 +680,19 @@ void main() {
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
         });
+
+        testUsingContext('handles bad output',()  async {
+          fakeProcessManager.addCommand(const FakeCommand(
+            command: <String>['xcrun', 'xcdevice', 'list', '--timeout', '2'],
+            stdout: 'Something bad happened, not JSON',
+          ));
+
+          final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
+          expect(devices, isEmpty);
+          expect(logger.errorText, contains('xcdevice returned non-JSON response'));
+        }, overrides: <Type, Generator>{
+          Platform: () => macPlatform,
+        });
       });
 
       group('diagnostics', () {


### PR DESCRIPTION
`xcdevice` sometimes logs a stack trace to `stdout` with a 0 exit code.  Handle the malformed json and continue so as not to block additional platform device discovery.

Fixes https://github.com/flutter/flutter/issues/90913
