### PR TITLE
TextStyle.apply,copyWith,merge should support a package parameter

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -773,6 +773,17 @@ class TextStyle with Diagnosticable {
   /// How visual text overflow should be handled.
   final TextOverflow? overflow;
 
+  // Return the original value of fontFamily, without the additional
+  // "packages/$_package/" prefix.
+  String? get _fontFamily {
+    if (_package != null && fontFamily != null) {
+      final String fontFamilyPrefix = 'packages/$_package/';
+      assert(fontFamily!.startsWith(fontFamilyPrefix));
+      return fontFamily!.substring(fontFamilyPrefix.length);
+    }
+    return fontFamily;
+  }
+
   /// Creates a copy of this text style but with the given fields replaced with
   /// the new values.
   ///
@@ -786,8 +797,6 @@ class TextStyle with Diagnosticable {
     bool? inherit,
     Color? color,
     Color? backgroundColor,
-    String? fontFamily,
-    List<String>? fontFamilyFallback,
     double? fontSize,
     FontWeight? fontWeight,
     FontStyle? fontStyle,
@@ -806,6 +815,9 @@ class TextStyle with Diagnosticable {
     TextDecorationStyle? decorationStyle,
     double? decorationThickness,
     String? debugLabel,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    String? package,
     TextOverflow? overflow,
   }) {
     assert(color == null || foreground == null, _kColorForegroundWarning);
@@ -816,12 +828,11 @@ class TextStyle with Diagnosticable {
         newDebugLabel = debugLabel ?? '(${this.debugLabel}).copyWith';
       return true;
     }());
+
     return TextStyle(
       inherit: inherit ?? this.inherit,
       color: this.foreground == null && foreground == null ? color ?? this.color : null,
       backgroundColor: this.background == null && background == null ? backgroundColor ?? this.backgroundColor : null,
-      fontFamily: fontFamily ?? this.fontFamily,
-      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       fontSize: fontSize ?? this.fontSize,
       fontWeight: fontWeight ?? this.fontWeight,
       fontStyle: fontStyle ?? this.fontStyle,
@@ -840,6 +851,9 @@ class TextStyle with Diagnosticable {
       decorationStyle: decorationStyle ?? this.decorationStyle,
       decorationThickness: decorationThickness ?? this.decorationThickness,
       debugLabel: newDebugLabel,
+      fontFamily: fontFamily ?? _fontFamily,
+      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+      package: package ?? _package,
       overflow: overflow ?? this.overflow,
     );
   }
@@ -898,6 +912,7 @@ class TextStyle with Diagnosticable {
     Locale? locale,
     List<ui.Shadow>? shadows,
     List<ui.FontFeature>? fontFeatures,
+    String? package,
     TextOverflow? overflow,
   }) {
     assert(fontSizeFactor != null);
@@ -928,7 +943,7 @@ class TextStyle with Diagnosticable {
       inherit: inherit,
       color: foreground == null ? color ?? this.color : null,
       backgroundColor: background == null ? backgroundColor ?? this.backgroundColor : null,
-      fontFamily: fontFamily ?? this.fontFamily,
+      fontFamily: fontFamily ?? _fontFamily,
       fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       fontSize: fontSize == null ? null : fontSize! * fontSizeFactor + fontSizeDelta,
       fontWeight: fontWeight == null ? null : FontWeight.values[(fontWeight!.index + fontWeightDelta).clamp(0, FontWeight.values.length - 1)],
@@ -948,6 +963,7 @@ class TextStyle with Diagnosticable {
       decorationStyle: decorationStyle ?? this.decorationStyle,
       decorationThickness: decorationThickness == null ? null : decorationThickness! * decorationThicknessFactor + decorationThicknessDelta,
       overflow: overflow ?? this.overflow,
+      package: package ?? _package,
       debugLabel: modifiedDebugLabel,
     );
   }
@@ -989,8 +1005,6 @@ class TextStyle with Diagnosticable {
     return copyWith(
       color: other.color,
       backgroundColor: other.backgroundColor,
-      fontFamily: other.fontFamily,
-      fontFamilyFallback: other.fontFamilyFallback,
       fontSize: other.fontSize,
       fontWeight: other.fontWeight,
       fontStyle: other.fontStyle,
@@ -1008,8 +1022,11 @@ class TextStyle with Diagnosticable {
       decorationColor: other.decorationColor,
       decorationStyle: other.decorationStyle,
       decorationThickness: other.decorationThickness,
-      overflow: other.overflow,
       debugLabel: mergedDebugLabel,
+      fontFamily: other._fontFamily,
+      fontFamilyFallback: other.fontFamilyFallback,
+      package: other._package,
+      overflow: other.overflow,
     );
   }
 
@@ -1044,8 +1061,6 @@ class TextStyle with Diagnosticable {
         inherit: b!.inherit,
         color: Color.lerp(null, b.color, t),
         backgroundColor: Color.lerp(null, b.backgroundColor, t),
-        fontFamily: t < 0.5 ? null : b.fontFamily,
-        fontFamilyFallback: t < 0.5 ? null : b.fontFamilyFallback,
         fontSize: t < 0.5 ? null : b.fontSize,
         fontWeight: FontWeight.lerp(null, b.fontWeight, t),
         fontStyle: t < 0.5 ? null : b.fontStyle,
@@ -1057,14 +1072,17 @@ class TextStyle with Diagnosticable {
         locale: t < 0.5 ? null : b.locale,
         foreground: t < 0.5 ? null : b.foreground,
         background: t < 0.5 ? null : b.background,
-        decoration: t < 0.5 ? null : b.decoration,
         shadows: t < 0.5 ? null : b.shadows,
         fontFeatures: t < 0.5 ? null : b.fontFeatures,
+        decoration: t < 0.5 ? null : b.decoration,
         decorationColor: Color.lerp(null, b.decorationColor, t),
         decorationStyle: t < 0.5 ? null : b.decorationStyle,
         decorationThickness: t < 0.5 ? null : b.decorationThickness,
-        overflow: t < 0.5 ? null : b.overflow,
         debugLabel: lerpDebugLabel,
+        fontFamily: t < 0.5 ? null : b._fontFamily,
+        fontFamilyFallback: t < 0.5 ? null : b.fontFamilyFallback,
+        package: t < 0.5 ? null : b._package,
+        overflow: t < 0.5 ? null : b.overflow,
       );
     }
 
@@ -1073,8 +1091,6 @@ class TextStyle with Diagnosticable {
         inherit: a.inherit,
         color: Color.lerp(a.color, null, t),
         backgroundColor: Color.lerp(null, a.backgroundColor, t),
-        fontFamily: t < 0.5 ? a.fontFamily : null,
-        fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : null,
         fontSize: t < 0.5 ? a.fontSize : null,
         fontWeight: FontWeight.lerp(a.fontWeight, null, t),
         fontStyle: t < 0.5 ? a.fontStyle : null,
@@ -1092,8 +1108,11 @@ class TextStyle with Diagnosticable {
         decorationColor: Color.lerp(a.decorationColor, null, t),
         decorationStyle: t < 0.5 ? a.decorationStyle : null,
         decorationThickness: t < 0.5 ? a.decorationThickness : null,
-        overflow: t < 0.5 ? a.overflow : null,
         debugLabel: lerpDebugLabel,
+        fontFamily: t < 0.5 ? a._fontFamily : null,
+        fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : null,
+        package: t < 0.5 ? a._package : null,
+        overflow: t < 0.5 ? a.overflow : null,
       );
     }
 
@@ -1101,8 +1120,6 @@ class TextStyle with Diagnosticable {
       inherit: b.inherit,
       color: a.foreground == null && b.foreground == null ? Color.lerp(a.color, b.color, t) : null,
       backgroundColor: a.background == null && b.background == null ? Color.lerp(a.backgroundColor, b.backgroundColor, t) : null,
-      fontFamily: t < 0.5 ? a.fontFamily : b.fontFamily,
-      fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : b.fontFamilyFallback,
       fontSize: ui.lerpDouble(a.fontSize ?? b.fontSize, b.fontSize ?? a.fontSize, t),
       fontWeight: FontWeight.lerp(a.fontWeight, b.fontWeight, t),
       fontStyle: t < 0.5 ? a.fontStyle : b.fontStyle,
@@ -1128,8 +1145,11 @@ class TextStyle with Diagnosticable {
       decorationColor: Color.lerp(a.decorationColor, b.decorationColor, t),
       decorationStyle: t < 0.5 ? a.decorationStyle : b.decorationStyle,
       decorationThickness: ui.lerpDouble(a.decorationThickness ?? b.decorationThickness, b.decorationThickness ?? a.decorationThickness, t),
-      overflow: t < 0.5 ? a.overflow : b.overflow,
       debugLabel: lerpDebugLabel,
+      fontFamily: t < 0.5 ? a._fontFamily : b._fontFamily,
+      fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : b.fontFamilyFallback,
+      package: t < 0.5 ? a._package : b._package,
+      overflow: t < 0.5 ? a.overflow : b.overflow,
     );
   }
 
@@ -1264,7 +1284,6 @@ class TextStyle with Diagnosticable {
         && other.inherit == inherit
         && other.color == color
         && other.backgroundColor == backgroundColor
-        && other.fontFamily == fontFamily
         && other.fontSize == fontSize
         && other.fontWeight == fontWeight
         && other.fontStyle == fontStyle
@@ -1276,13 +1295,15 @@ class TextStyle with Diagnosticable {
         && other.locale == locale
         && other.foreground == foreground
         && other.background == background
+        && listEquals(other.shadows, shadows)
+        && listEquals(other.fontFeatures, fontFeatures)
         && other.decoration == decoration
         && other.decorationColor == decorationColor
         && other.decorationStyle == decorationStyle
         && other.decorationThickness == decorationThickness
-        && listEquals(other.shadows, shadows)
-        && listEquals(other.fontFeatures, fontFeatures)
+        && other.fontFamily == fontFamily
         && listEquals(other.fontFamilyFallback, fontFamilyFallback)
+        && other._package == _package
         && other.overflow == overflow;
   }
 
@@ -1292,7 +1313,6 @@ class TextStyle with Diagnosticable {
       inherit,
       color,
       backgroundColor,
-      fontFamily,
       fontSize,
       fontWeight,
       fontStyle,
@@ -1304,12 +1324,15 @@ class TextStyle with Diagnosticable {
       locale,
       foreground,
       background,
+      hashList(shadows),
+      hashList(fontFeatures),
       decoration,
       decorationColor,
       decorationStyle,
-      hashList(shadows),
-      hashList(fontFeatures),
+      decorationThickness,
+      fontFamily,
       hashList(fontFamilyFallback),
+      _package,
       overflow,
     ]);
   }

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -790,6 +790,7 @@ class _TextStyleProxy implements TextStyle {
     List<ui.Shadow>? shadows,
     List<ui.FontFeature>? fontFeatures,
     TextOverflow? overflow,
+    String? package,
   }) {
     throw UnimplementedError();
   }
@@ -825,6 +826,7 @@ class _TextStyleProxy implements TextStyle {
     double? decorationThickness,
     String? debugLabel,
     TextOverflow? overflow,
+    String? package,
   }) {
     throw UnimplementedError();
   }

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -495,4 +495,17 @@ void main() {
       TextLeadingDistribution.proportional,
     );
   });
+
+  test('TextStyle fontFamily and package', () {
+    expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo') != const TextStyle(fontFamily: 'fontFamily', package: 'bar'), true);
+    expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo').hashCode != const TextStyle(package: 'bar', fontFamily: 'fontFamily').hashCode, true);
+    expect(const TextStyle(fontFamily: 'fontFamily').fontFamily, 'fontFamily');
+    expect(const TextStyle(fontFamily: 'fontFamily').fontFamily, 'fontFamily');
+    expect(const TextStyle(fontFamily: 'fontFamily').copyWith(package: 'bar').fontFamily, 'packages/bar/fontFamily');
+    expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo').fontFamily, 'packages/foo/fontFamily');
+    expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo').copyWith(package: 'bar').fontFamily, 'packages/bar/fontFamily');
+    expect(const TextStyle().merge(const TextStyle(fontFamily: 'fontFamily', package: 'bar')).fontFamily, 'packages/bar/fontFamily');
+    expect(const TextStyle().apply(fontFamily: 'fontFamily', package: 'foo').fontFamily, 'packages/foo/fontFamily');
+    expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo').apply(fontFamily: 'fontFamily', package: 'bar').fontFamily, 'packages/bar/fontFamily');
+  });
 }


### PR DESCRIPTION
Added support for the (String) package parameter TextStyle apply() copyWith() and merge(). Also: reordered the named parameters for copyWith etc to match the constructor.

Fixes https://github.com/flutter/flutter/issues/89428