### PR TITLE
Add a warning about Icon.size to IconButton

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -51,19 +51,23 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 ///
 /// ### Icon sizes
 ///
-/// When creating an icon button with an [Icon], do not override the icon's size
-/// with its [Icon.size] parameter, use the icon button's [iconSize] parameter instead.
-/// For example do this:
+/// When creating an icon button with an [Icon], do not override the
+/// icon's size with its [Icon.size] parameter, use the icon button's
+/// [iconSize] parameter instead.  For example do this:
 ///
 /// ```dart
 /// IconButton(iconSize: 72, icon: Icon(Icons.favorite), ...)
 /// ```
 ///
-/// Do _not_ do this:
+/// Avoid doing this:
 ///
 /// ```dart
 /// IconButton(icon: Icon(Icons.favorite, size: 72), ...)
 /// ```
+///
+/// If you do, the button's size will be based on the default icon
+/// size, not 72, which may produce unexpected layouts and clipping
+/// issues.
 ///
 /// ### Adding a filled background
 ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -49,6 +49,22 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// ** See code in examples/api/lib/material/icon_button/icon_button.0.dart **
 /// {@end-tool}
 ///
+/// ### Icon sizes
+///
+/// When creating an icon button with an [Icon], do not override the icon's size
+/// with its [Icon.size] parameter, use the icon button's [iconSize] parameter instead.
+/// For example do this:
+///
+/// ```dart
+/// IconButton(iconSize: 72, icon: Icon(Icons.favorite), ...)
+/// ```
+///
+/// Do _not_ do this:
+///
+/// ```dart
+/// IconButton(icon: Icon(Icons.favorite, size: 72), ...)
+/// ```
+///
 /// ### Adding a filled background
 ///
 /// Icon buttons don't support specifying a background color or other


### PR DESCRIPTION
Added a warning about a confusing failure mode per https://github.com/flutter/flutter/issues/90272#issuecomment-931562858.

Fixes https://github.com/flutter/flutter/issues/90272