### PR TITLE
Enable `avoid_implementing_value_types` lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -32,10 +32,6 @@ analyzer:
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
     # TODO(https://github.com/flutter/flutter/issues/74381):
     # Clean up existing unnecessary imports, and remove line to ignore.
     unnecessary_import: ignore
@@ -70,7 +66,7 @@ linter:
     - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
-    # - avoid_implementing_value_types # not yet tested
+    - avoid_implementing_value_types
     - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -21,6 +21,11 @@ import 'framework.dart';
 /// than [Widget] as the type of their `child` property.
 ///
 /// Use [PreferredSize] to give a preferred size to an arbitrary widget.
+// (We ignore `avoid_implementing_value_types` here because the superclass
+// doesn't really implement `operator ==`, it just overrides it to _prevent_ it
+// from being implemented, which is the exact opposite of the spirit of the
+// `avoid_implementing_value_types` lint.)
+// ignore: avoid_implementing_value_types
 abstract class PreferredSizeWidget implements Widget {
   /// The size this widget would prefer if it were otherwise unconstrained.
   ///

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -11,7 +11,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -461,7 +460,7 @@ void main() {
     expect(dependentBuildCount, equals(4));
 
     // didChangeAccessibilityFeatures
-    tester.binding.window.accessibilityFeaturesTestValue = MockAccessibilityFeature();
+    tester.binding.window.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
     addTearDown(tester.binding.window.clearAccessibilityFeaturesTestValue);
 
     await tester.pump();
@@ -768,7 +767,7 @@ void main() {
 
   testWidgets('MaterialApp uses high contrast theme when appropriate', (WidgetTester tester) async {
     tester.binding.window.platformBrightnessTestValue = Brightness.light;
-    tester.binding.window.accessibilityFeaturesTestValue = MockAccessibilityFeature();
+    tester.binding.window.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -795,7 +794,7 @@ void main() {
 
   testWidgets('MaterialApp uses high contrast dark theme when appropriate', (WidgetTester tester) async {
     tester.binding.window.platformBrightnessTestValue = Brightness.dark;
-    tester.binding.window.accessibilityFeaturesTestValue = MockAccessibilityFeature();
+    tester.binding.window.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -828,7 +827,7 @@ void main() {
 
   testWidgets('MaterialApp uses dark theme when no high contrast dark theme is provided', (WidgetTester tester) async {
     tester.binding.window.platformBrightnessTestValue = Brightness.dark;
-    tester.binding.window.accessibilityFeaturesTestValue = MockAccessibilityFeature();
+    tester.binding.window.accessibilityFeaturesTestValue = FakeAccessibilityFeatures.allOn;
 
     late ThemeData appliedTheme;
 
@@ -1171,26 +1170,6 @@ class MockScrollBehavior extends ScrollBehavior {
 
   @override
   ScrollPhysics getScrollPhysics(BuildContext context) => const NeverScrollableScrollPhysics();
-}
-
-class MockAccessibilityFeature implements AccessibilityFeatures {
-  @override
-  bool get accessibleNavigation => true;
-
-  @override
-  bool get boldText => true;
-
-  @override
-  bool get disableAnimations => true;
-
-  @override
-  bool get highContrast => true;
-
-  @override
-  bool get invertColors => true;
-
-  @override
-  bool get reduceMotion => true;
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -694,6 +694,7 @@ class _TestState extends State<Test> {
 /// This class exists only to make sure that we test all the properties of the
 /// [TextStyle] class. If a property is added/removed/renamed, the analyzer will
 /// complain that this class has incorrect overrides.
+// ignore: avoid_implementing_value_types
 class _TextStyleProxy implements TextStyle {
   _TextStyleProxy(this._delegate);
 

--- a/packages/flutter/test/painting/image_test_utils.dart
+++ b/packages/flutter/test/painting/image_test_utils.dart
@@ -43,8 +43,3 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
   @override
   String toString() => '${describeIdentity(this)}()';
 }
-
-class FakeImageConfiguration implements ImageConfiguration {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -8,17 +8,12 @@ import 'dart:ui' as ui show Image;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
-class TestImageInfo implements ImageInfo {
-  const TestImageInfo(this.value, { required this.image, this.scale = 1.0, this.debugLabel });
-
-  @override
-  final ui.Image image;
-
-  @override
-  final double scale;
-
-  @override
-  final String? debugLabel;
+class TestImageInfo extends ImageInfo {
+  const TestImageInfo(this.value, {
+    required ui.Image image,
+    double scale = 1.0,
+    String? debugLabel,
+  }) : super(image: image, scale: scale, debugLabel: debugLabel);
 
   final int value;
 
@@ -29,22 +24,6 @@ class TestImageInfo implements ImageInfo {
   TestImageInfo clone() {
     return TestImageInfo(value, image: image.clone(), scale: scale, debugLabel: debugLabel);
   }
-
-  @override
-  bool isCloneOf(ImageInfo other) {
-    assert(other != null);
-    return other.image.isCloneOf(image)
-        && scale == scale
-        && other.debugLabel == debugLabel;
-  }
-
-  @override
-  void dispose() {
-    image.dispose();
-  }
-
-  @override
-  int get sizeBytes => image.height * image.width * 4;
 
   @override
   int get hashCode => hashValues(value, image, scale, debugLabel);
@@ -58,7 +37,6 @@ class TestImageInfo implements ImageInfo {
         && other.image.isCloneOf(image)
         && other.scale == scale
         && other.debugLabel == debugLabel;
-
   }
 }
 

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -158,7 +158,7 @@ Future<void> main() async {
     testWidgets('shows a cached image immediately when skipFadeOnSynchronousLoad=true', (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
-      imageProvider.resolve(FakeImageConfiguration());
+      imageProvider.resolve(ImageConfiguration.empty);
       imageProvider.complete();
 
       await tester.pumpWidget(FadeInImage(

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -33,12 +33,12 @@ void main() {
   group('VMServiceFlutterDriver with logCommunicationToFile', () {
     late FakeVmService fakeClient;
     late FakeVM fakeVM;
-    late FakeIsolate fakeIsolate;
+    late vms.Isolate fakeIsolate;
     late VMServiceFlutterDriver driver;
     late File logFile;
 
     setUp(() {
-      fakeIsolate = FakeIsolate();
+      fakeIsolate = createFakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       fakeClient.responses['waitFor'] = makeFakeResponse(<String, dynamic>{'status':'ok'});
@@ -92,12 +92,12 @@ void main() {
   group('VMServiceFlutterDriver with printCommunication', () {
     late FakeVmService fakeClient;
     late FakeVM fakeVM;
-    late FakeIsolate fakeIsolate;
+    late vms.Isolate fakeIsolate;
     late VMServiceFlutterDriver driver;
 
     setUp(() async {
       log.clear();
-      fakeIsolate = FakeIsolate();
+      fakeIsolate = createFakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       fakeClient.responses['waitFor'] = makeFakeResponse(<String, dynamic>{'status':'ok'});
@@ -122,7 +122,7 @@ void main() {
   group('VMServiceFlutterDriver.connect', () {
     late FakeVmService fakeClient;
     late FakeVM fakeVM;
-    late FakeIsolate fakeIsolate;
+    late vms.Isolate fakeIsolate;
 
     void expectLogContains(String message) {
       expect(log, anyElement(contains(message)));
@@ -130,7 +130,7 @@ void main() {
 
     setUp(() {
       log.clear();
-      fakeIsolate = FakeIsolate();
+      fakeIsolate = createFakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       vmServiceConnectFunction = (String url, Map<String, dynamic>? headers) async {
@@ -190,7 +190,7 @@ void main() {
 
     test('Connects to isolate number', () async {
       fakeIsolate.pauseEvent = vms.Event(kind: vms.EventKind.kPauseStart, timestamp: 0);
-      final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '', isolateNumber: int.parse(fakeIsolate.number));
+      final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '', isolateNumber: int.parse(fakeIsolate.number!));
       expect(driver, isNotNull);
       expect(
         fakeClient.connectionLog,
@@ -269,7 +269,7 @@ void main() {
     test('connects to unpaused when onExtensionAdded does not contain the '
       'driver extension', () async {
       fakeIsolate.pauseEvent = vms.Event(kind: vms.EventKind.kResume, timestamp: 0);
-      fakeIsolate.extensionRPCs.add('ext.flutter.driver');
+      fakeIsolate.extensionRPCs!.add('ext.flutter.driver');
 
       final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
       expect(driver, isNotNull);
@@ -280,11 +280,11 @@ void main() {
   group('VMServiceFlutterDriver', () {
     late FakeVmService fakeClient;
     late FakeVM fakeVM;
-    late FakeIsolate fakeIsolate;
+    late vms.Isolate fakeIsolate;
     late VMServiceFlutterDriver driver;
 
     setUp(() {
-      fakeIsolate = FakeIsolate();
+      fakeIsolate = createFakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate);
@@ -688,11 +688,11 @@ void main() {
   group('VMServiceFlutterDriver with custom timeout', () {
     late FakeVmService fakeClient;
     late FakeVM fakeVM;
-    late FakeIsolate fakeIsolate;
+    late vms.Isolate fakeIsolate;
     late VMServiceFlutterDriver driver;
 
     setUp(() {
-      fakeIsolate = FakeIsolate();
+      fakeIsolate = createFakeIsolate();
       fakeVM = FakeVM(fakeIsolate);
       fakeClient = FakeVmService(fakeVM);
       driver = VMServiceFlutterDriver.connectedTo(fakeClient, fakeIsolate);
@@ -1217,16 +1217,19 @@ class FakeVM extends Fake implements vms.VM {
   }
 }
 
-class FakeIsolate extends Fake implements vms.Isolate {
-  @override
-  String get number => '123';
-
-  @override
-  String get id => number;
-
-  @override
-  vms.Event? pauseEvent;
-
-  @override
-  List<String> get extensionRPCs => <String>[];
-}
+vms.Isolate createFakeIsolate() => vms.Isolate(
+  id: '123',
+  number: '123',
+  name: null,
+  isSystemIsolate: null,
+  isolateFlags: null,
+  startTime: null,
+  runnable: null,
+  livePorts: null,
+  pauseOnExit: null,
+  pauseEvent: null,
+  libraries: null,
+  breakpoints: null,
+  exceptionPauseMode: null,
+  extensionRPCs: <String>[],
+);

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -5,6 +5,8 @@
 import 'dart:typed_data' show ByteData;
 import 'dart:ui' as ui hide window;
 
+import 'package:flutter/foundation.dart';
+
 /// [SingletonFlutterWindow] that wraps another [SingletonFlutterWindow] and
 /// allows faking of some properties for testing purposes.
 ///
@@ -342,6 +344,9 @@ class TestWindow implements ui.SingletonFlutterWindow {
   ui.AccessibilityFeatures? _accessibilityFeaturesTestValue;
   /// Hides the real accessibility features and reports the given
   /// [accessibilityFeaturesTestValue] instead.
+  ///
+  /// Consider using [FakeAccessibilityFeatures] to provide specific
+  /// values for the various accessibility features under test.
   set accessibilityFeaturesTestValue(ui.AccessibilityFeatures accessibilityFeaturesTestValue) { // ignore: avoid_setters_without_getters
     _accessibilityFeaturesTestValue = accessibilityFeaturesTestValue;
     onAccessibilityFeaturesChanged?.call();
@@ -429,8 +434,85 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   /// This gives us some grace time when the dart:ui side adds something to
-  /// Window, and makes things easier when we do rolls to give us time to catch
-  /// up.
+  /// [SingletonFlutterWindow], and makes things easier when we do rolls to give
+  /// us time to catch up.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return null;
+  }
+}
+
+/// Test version of [AccessibilityFeatures] in which specific features may
+/// be set to arbitrary values.
+///
+/// By default, all features are disabled. For an instance where all the
+/// features are enabled, consider the [FakeAccessibilityFeatures.allOn]
+/// constant.
+@immutable
+// ignore: avoid_implementing_value_types
+class FakeAccessibilityFeatures implements ui.AccessibilityFeatures {
+  /// Creates a test instance of [AccessibilityFeatures].
+  ///
+  /// By default, all features are disabled.
+  const FakeAccessibilityFeatures({
+    this.accessibleNavigation = false,
+    this.invertColors = false,
+    this.disableAnimations = false,
+    this.boldText = false,
+    this.reduceMotion = false,
+    this.highContrast = false,
+  });
+
+  /// An instance of [AccessibilityFeatures] where all the features are enabled.
+  static const FakeAccessibilityFeatures allOn = FakeAccessibilityFeatures(
+    accessibleNavigation: true,
+    invertColors: true,
+    disableAnimations: true,
+    boldText: true,
+    reduceMotion: true,
+    highContrast: true,
+  );
+
+  @override
+  final bool accessibleNavigation;
+
+  @override
+  final bool invertColors;
+
+  @override
+  final bool disableAnimations;
+
+  @override
+  final bool boldText;
+
+  @override
+  final bool reduceMotion;
+
+  @override
+  final bool highContrast;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is FakeAccessibilityFeatures
+        && other.accessibleNavigation == accessibleNavigation
+        && other.invertColors == invertColors
+        && other.disableAnimations == disableAnimations
+        && other.boldText == boldText
+        && other.reduceMotion == reduceMotion
+        && other.highContrast == highContrast;
+  }
+
+  @override
+  int get hashCode => ui.hashValues(accessibleNavigation, invertColors, disableAnimations, boldText, reduceMotion, highContrast);
+
+  /// This gives us some grace time when the dart:ui side adds something to
+  /// [AccessibilityFeatures], and makes things easier when we do rolls to
+  /// give us time to catch up.
+  ///
+  /// If you would like to add to this class, changes must first be made in the
+  /// engine, followed by the framework.
   @override
   dynamic noSuchMethod(Invocation invocation) {
     return null;

--- a/packages/flutter_test/test/live_widget_controller_test.dart
+++ b/packages/flutter_test/test/live_widget_controller_test.dart
@@ -123,8 +123,8 @@ void main() {
       ]),
       ...<PointerEventRecord>[
         for (Duration t = const Duration(milliseconds: 5);
-            t < const Duration(milliseconds: 80);
-            t += const Duration(milliseconds: 16))
+             t < const Duration(milliseconds: 80);
+             t += const Duration(milliseconds: 16))
           PointerEventRecord(t, <PointerEvent>[
             PointerMoveEvent(
               timeStamp: t - const Duration(milliseconds: 1),
@@ -149,7 +149,7 @@ void main() {
     expect(timeDiffs.length, records.length);
     for (final Duration diff in timeDiffs) {
       // Allow some freedom of time delay in real world.
-      assert(diff.inMilliseconds > -1);
+      assert(diff.inMilliseconds > -1, 'timeDiffs were: $timeDiffs (offending time was ${diff.inMilliseconds}ms)');
     }
 
     const String b = '$kSecondaryMouseButton';

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -249,46 +249,6 @@ class FakeWindowPadding implements WindowPadding {
   final double bottom;
 }
 
-class FakeAccessibilityFeatures implements AccessibilityFeatures {
-  const FakeAccessibilityFeatures({
-    this.accessibleNavigation = false,
-    this.invertColors = false,
-    this.disableAnimations = false,
-    this.boldText = false,
-    this.reduceMotion = false,
-    this.highContrast = false,
-  });
-
-  @override
-  final bool accessibleNavigation;
-
-  @override
-  final bool invertColors;
-
-  @override
-  final bool disableAnimations;
-
-  @override
-  final bool boldText;
-
-  @override
-  final bool reduceMotion;
-
-  @override
-  final bool highContrast;
-
-  /// This gives us some grace time when the dart:ui side adds something to
-  /// [AccessibilityFeatures], and makes things easier when we do rolls to
-  /// give us time to catch up.
-  ///
-  /// If you would like to add to this class, changes must first be made in the
-  /// engine, followed by the framework.
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    return null;
-  }
-}
-
 class TestObserver with WidgetsBindingObserver {
   List<Locale>? locales;
   Locale? locale;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -778,6 +778,9 @@ class FakeDartDevelopmentService extends Fake implements DartDevelopmentService 
   Uri get uri => Uri.parse('http://localhost:8181');
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeAndroidDevice extends Fake implements AndroidDevice {
   FakeAndroidDevice({@required this.id});
 
@@ -837,6 +840,9 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   Category get category => Category.mobile;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeIOSDevice extends Fake implements IOSDevice {
   FakeIOSDevice({this.dds, this.portForwarder, this.logReader});
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -563,6 +563,9 @@ class FakeIOSWorkflow extends Fake implements IOSWorkflow {
   final bool canListDevices;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeAndroidDevice extends Fake implements AndroidDevice {
   @override
   final String id = 'device';

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -1021,6 +1021,9 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   Future<List<String>> getDeviceDiagnostics() async => diagnostics;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   @override
   String get name => 'name';

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -102,6 +102,9 @@ void main() {
   });
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class ScreenshotDevice extends Fake implements Device {
   @override
   Future<void> takeScreenshot(File outputFile) async {}

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -78,6 +78,9 @@ class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFa
 class FakeIOSApp extends Fake implements IOSApp { }
 class FakeAndroidApk extends Fake implements AndroidApk { }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeIOSDevice extends Fake implements IOSDevice {
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;
@@ -95,6 +98,9 @@ class FakeIOSDevice extends Fake implements IOSDevice {
   }) async => true;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeAndroidDevice extends Fake implements AndroidDevice {
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.android_arm;

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -475,6 +475,9 @@ class TestRunCommand extends RunCommand {
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   FakeDevice({bool isLocalEmulator = false, TargetPlatform targetPlatform = TargetPlatform.ios, String sdkNameAndVersion = ''})
    : _isLocalEmulator = isLocalEmulator,

--- a/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/adb_log_reader_test.dart
@@ -190,6 +190,9 @@ AndroidDevice createFakeDevice(int sdkLevel) {
   );
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeAndroidDevice extends Fake implements AndroidDevice {
   FakeAndroidDevice(this._apiVersion, this._lastLogcatTimestamp);
 

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -175,6 +175,9 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   Future<void> initLogReader() async { }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   @override
   bool isSupported() => true;

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -531,6 +531,9 @@ class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFa
 
 class FakeApplicationPackage extends Fake implements ApplicationPackage { }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   FakeDevice(this.result, {this.supportsFlutterExit = true});
 

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -283,6 +283,9 @@ WebDriverService setUpDriverService() {
   );
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   @override
   final PlatformType platformType = PlatformType.web;

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_device_test.dart
@@ -887,6 +887,9 @@ class FuchsiaModulePackage extends ApplicationPackage {
   final String name;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class MockFuchsiaDevice extends Fake implements FuchsiaDevice {
   MockFuchsiaDevice(this.id, this.portForwarder, this._ipv6);
 

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -606,6 +606,9 @@ class FakeDevFs extends Fake implements DevFS {
   Uri baseUri;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   bool disposed = false;
 

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -288,6 +288,9 @@ class FakeMDnsClient extends Fake implements MDnsClient {
   void stop() {}
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeIOSDevice extends Fake implements IOSDevice {
   @override
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.ios;

--- a/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_devtools_handler_test.dart
@@ -471,4 +471,7 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
   TargetPlatform targetPlatform = TargetPlatform.android_arm;
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device { }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2220,6 +2220,9 @@ class FakeProjectFileInvalidator extends Fake implements ProjectFileInvalidator 
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   FakeDevice({
     String sdkNameAndVersion = 'Android',

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -193,6 +193,9 @@ class FakeWebDevFS extends Fake implements WebDevFS {
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeWebDevice extends Fake implements Device {
   @override
   String get name => 'web';

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1030,8 +1030,14 @@ ResidentRunner setUpResidentRunner(FlutterDevice flutterDevice, {
   );
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeWebServerDevice extends FakeDevice implements WebServerDevice { }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   @override
   String name;
@@ -1101,6 +1107,9 @@ class FakeAppConnection extends Fake implements AppConnection {
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeChromeDevice extends Fake implements ChromiumDevice { }
 
 class FakeWipDebugger extends Fake implements WipDebugger { }

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1372,6 +1372,9 @@ class FakeResidentDevtoolsHandler extends Fake implements ResidentDevtoolsHandle
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device {
   @override
   bool isSupported() => true;

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -835,6 +835,9 @@ class MockVMService extends Fake implements vm_service.VmService {
   }
 }
 
+// Unfortunately Device, despite not being immutable, has an `operator ==`.
+// Until we fix that, we have to also ignore related lints here.
+// ignore: avoid_implementing_value_types
 class FakeDevice extends Fake implements Device { }
 
 class FakeFlutterVersion extends Fake implements FlutterVersion {


### PR DESCRIPTION
...and update code to match:

* Added a public FakeAccessibilityFeatures class so that the two places where we were creating mock ones could just use the common implementation, with a single `ignore` instead of two.

* Removed `FakeImageConfiguration` since `ImageConfiguration` is sufficient for the relevant test that used it.

* Reimplemented `TestImageInfo` as a subclass instead of an `implements` to avoid duplicating code in test.

* Removed `FakeIsolate` in favor of creating a real vm_service `Isolate`, since it's just a data class at the end of the day.

* Continued to dig the hole we began digging when we made the flutter_tools `Device` mutable with an `operator ==`.
