### PR TITLE
[bots] Do not invoke `pub global run` concurrently

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -678,7 +678,9 @@ class SampleChecker {
       if (sectionMap != null)
         sectionMap[path] = section;
     }
-    final TaskQueue<File> sampleQueue = TaskQueue<File>();
+    // TODO(dacoharkes): Remove workaround when pub global can run concurrently.
+    // https://github.com/dart-lang/pub/issues/3165
+    final TaskQueue<File> sampleQueue = TaskQueue<File>(maxJobs: 1);
     for (final Sample sample in samples) {
       final Future<File> futureFile = sampleQueue.add(() => _writeSample(sample));
       if (sampleMap != null) {


### PR DESCRIPTION
`dev/bots/analyze_sample_code.dart` freezes intermittently on the Dart Flutter HHH bot.

Follow up of #90447 #90880, and #91024.

It turns out `pub global run` does not enjoy being invoked concurrently at the moment https://github.com/dart-lang/pub/issues/3165. (Thanks @cskau-g @sigurdm @szakarias for the help!) Invocations of `pub global run` were introduced in #87231 two months ago.

We have multiple options:

1. Wait for `pub global run` to be fixed https://github.com/dart-lang/pub/issues/3165 (but we have recurring failures on the HHH bot right now).
2. Reduce the concurrency to 1 task at the time for now (this PR). And revert it back when pub is patched.
3. Invoke `import 'package:snippets/snippets.dart';` instead of using `pub global run`. However, a bunch of the logic is in `bin/snippets.dart` we would have to duplicate that logic or move it to the `lib` folder.
4. A good solution that didn't come to my mind... 

Background info: [go/flutter-hhh-analyze-freezes]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[go/flutter-hhh-analyze-freezes]: http://go/flutter-hhh-analyze-freezes
