### PR TITLE
Force building of snippets package executable.

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -31,7 +31,7 @@ function generate_docs() {
     # Run the snippets tool once to force building of the package executable,
     # since "dart pub global run" has issues with startup concurrency.
     # TODO(gspencergoog): Remove once pub issue is fixed, https://github.com/dart-lang/pub/issues/3165
-    "$DART" pub global run snippets --help > /dev/null
+    "$DART" pub global run snippets --help
 
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.

--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -28,6 +28,11 @@ function generate_docs() {
     # >>> If you update this version, also update it in dev/bots/analyze_sample_code.dart <<<
     "$DART" pub global activate snippets 0.2.3
 
+    # Run the snippets tool once to force building of the package executable,
+    # since "dart pub global run" has issues with startup concurrency.
+    # TODO(gspencergoog): Remove once pub issue is fixed, https://github.com/dart-lang/pub/issues/3165
+    "$DART" pub global run snippets --help > /dev/null
+
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.
     (cd "$FLUTTER_ROOT/dev/tools" && "$FLUTTER" pub get)


### PR DESCRIPTION
## Description

This fixes an issue with the Dart Head-Head-Head CI bot, where it was seeing failures because of concurrent execution of the snippets tool.

It adds a single run of the snippets tool right after activation to force the compiling of the package executable, which is what has trouble with concurrent invocation.

This is a temporary measure until `dart pub global run` is fixed.

## Related Issues
 - https://github.com/dart-lang/pub/issues/3165

## Related PRs
 - https://github.com/flutter/flutter/pull/91092 (this should replace that one)

## Tests
 - No tests were harmed in the making of this PR.