### PR TITLE
Use recently introduced Isolate.exit() in compute implementation

### DIFF
--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -61,7 +61,6 @@ Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { St
   resultPort.close();
   exitPort.close();
   errorPort.close();
-  isolate.kill();
   Timeline.finishSync();
   return result.future;
 }
@@ -94,8 +93,8 @@ Future<void> _spawn<Q, R>(_IsolateConfiguration<Q, FutureOr<R>> configuration) a
     flow: Flow.step(configuration.flowId),
   );
   Timeline.timeSync(
-    '${configuration.debugLabel}: returning result',
-    () { configuration.resultPort.send(result); },
+    '${configuration.debugLabel}: exiting and returning a result', () {},
     flow: Flow.step(configuration.flowId),
   );
+  Isolate.exit(configuration.resultPort, result);
 }

--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -19,7 +19,7 @@ Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { St
   final ReceivePort exitPort = ReceivePort();
   final ReceivePort errorPort = ReceivePort();
   Timeline.finishSync();
-  final Isolate isolate = await Isolate.spawn<_IsolateConfiguration<Q, FutureOr<R>>>(
+  await Isolate.spawn<_IsolateConfiguration<Q, FutureOr<R>>>(
     _spawn,
     _IsolateConfiguration<Q, FutureOr<R>>(
       callback,


### PR DESCRIPTION
Isolate.exit() provides better performance when it comes to sending some result as a last step in isolate's lifecycle.