### PR TITLE
Fix ActivateIntent overriding the spacebar for text entry

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1149,6 +1149,10 @@ class WidgetsApp extends StatefulWidget {
   /// with "s".
   static bool debugAllowBannerOverride = true;
 
+  // Any shortcuts added here have the potential to conflict with normal text
+  // input. If this should not happen and text input should take preference,
+  // then add a shortcut for the relevant key in DefaultTextEditingShortcuts
+  // mapped to DoNothingAndStopPropagationTextIntent.
   static const Map<ShortcutActivator, Intent> _defaultShortcuts = <ShortcutActivator, Intent>{
     // Activation
     SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
@@ -1206,6 +1210,11 @@ class WidgetsApp extends StatefulWidget {
   };
 
   // Default shortcuts for the macOS platform.
+  //
+  // Any shortcuts added here have the potential to conflict with normal text
+  // input. If this should not happen and text input should take preference,
+  // then add a shortcut for the relevant key in DefaultTextEditingShortcuts
+  // mapped to DoNothingAndStopPropagationTextIntent.
   static const Map<ShortcutActivator, Intent> _defaultAppleOsShortcuts = <ShortcutActivator, Intent>{
     // Activation
     SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -160,6 +160,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     child: child,
   );
 
+  static const Map<ShortcutActivator, Intent> _commonShortcuts = <ShortcutActivator, Intent>{
+    // Allows space to be used as an input instead of a shortcut by another
+    // widget. See https://github.com/flutter/flutter/issues/90907
+    SingleActivator(LogicalKeyboardKey.space): DoNothingAndStopPropagationTextIntent(),
+  };
+
   static const Map<ShortcutActivator, Intent> _androidShortcuts = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.backspace): DeleteTextIntent(),
     SingleActivator(LogicalKeyboardKey.backspace, control: true): DeleteByWordTextIntent(),
@@ -532,7 +538,7 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     SingleActivator(LogicalKeyboardKey.keyA, meta: true): DoNothingAndStopPropagationTextIntent(),
   };
 
-  static Map<ShortcutActivator, Intent> get _shortcuts {
+  static Map<ShortcutActivator, Intent> get _platformShortcuts {
     if (kIsWeb) {
       return _webShortcuts;
     }
@@ -551,5 +557,12 @@ class DefaultTextEditingShortcuts extends Shortcuts {
       case TargetPlatform.windows:
         return _windowsShortcuts;
     }
+  }
+
+  static Map<ShortcutActivator, Intent> get _shortcuts {
+    return <ShortcutActivator, Intent>{
+      ..._commonShortcuts,
+      ..._platformShortcuts,
+    };
   }
 }

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -161,9 +161,10 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   );
 
   static const Map<ShortcutActivator, Intent> _commonShortcuts = <ShortcutActivator, Intent>{
-    // Allows space to be used as an input instead of a shortcut by another
-    // widget. See https://github.com/flutter/flutter/issues/90907
+    // Allows space and enter to be used as input instead of a shortcut by
+    // another widget. See https://github.com/flutter/flutter/issues/90907
     SingleActivator(LogicalKeyboardKey.space): DoNothingAndStopPropagationTextIntent(),
+    SingleActivator(LogicalKeyboardKey.enter): DoNothingAndStopPropagationTextIntent(),
   };
 
   static const Map<ShortcutActivator, Intent> _androidShortcuts = <ShortcutActivator, Intent>{

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8702,12 +8702,19 @@ void main() {
     ));
 
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();
     expect(invoked, isFalse);
 
     focusNode.requestFocus();
     await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    expect(invoked, isTrue);
+
+    invoked = false;
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();
     expect(invoked, isTrue);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
@@ -8652,6 +8653,63 @@ void main() {
     textSelectionDelegate.copySelection(SelectionChangedCause.toolbar);
     await tester.pump();
     expect(scrollController.offset.roundToDouble(), 0.0);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/90907.
+  testWidgets("ActivateIntent doesn't block space entry", (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    bool invoked = false;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 100,
+            child: ListTile(
+              title: Actions(
+                actions: <Type, Action<Intent>>{
+                  ActivateIntent: CallbackAction<ActivateIntent>(
+                    onInvoke: (ActivateIntent intent) {
+                      invoked = true;
+                    },
+                  ),
+                },
+                child: Column(
+                  children: <Widget>[
+                    EditableText(
+                      autofocus: true,
+                      showSelectionHandles: true,
+                      maxLines: 2,
+                      controller: TextEditingController(),
+                      focusNode: FocusNode(),
+                      cursorColor: Colors.red,
+                      backgroundCursorColor: Colors.blue,
+                      style: Typography.material2018(platform: TargetPlatform.android).black.subtitle1!.copyWith(fontFamily: 'Roboto'),
+                      keyboardType: TextInputType.text,
+                    ),
+                    Focus(
+                      focusNode: focusNode,
+                      child: const Text('Hello'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    expect(invoked, isFalse);
+
+    focusNode.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    expect(invoked, isTrue);
   });
 }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -8716,7 +8716,8 @@ void main() {
     await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();
-    expect(invoked, isTrue);
+    // On the web, enter doesn't activate any controls except for buttons.
+    expect(invoked, kIsWeb ? isFalse : isTrue);
   });
 }
 


### PR DESCRIPTION
Currently, if an EditableText is wrapped in something that uses ActivateIntent, such as ListTile, then the ActivateIntent will get all of the spaces and you won't be able to type them into the field.  This PR proposes to fix it by using DoNothingAndStopPropagationTextIntent in DefaultTextEditingShortcuts, however, there are architectural implications for Flutter to consider.

### Why this solution works

  * DefaultTextEditingShortcuts is just below the Shortcuts widget in WidgetsApp, so it gets to handle the space just before ActivateIntent would otherwise get invoked.
  * These are both way at the root of the tree, so this isn't interfering with users' ability to override the spacebar themselves.
  * Because I'm using DoNothingAndStopPropagationTextIntent and not DoNothingAndStopPropagationIntent, it is only used when an EditableText is currently focused, otherwise it passes the space through.  So, the ActivateIntent will work as normal for widgets that are not wrapping an EditableText.

### Architectural implications

In general, a widget that defines Shortcuts and has no children doesn't need to worry about any other widgets "stealing" the shortcuts from it.  As a leaf, they can't be stolen from it (even with @LongCatIsLooong's OverridableAction, because it is opt-in).

A widget that defines Shortcuts and DOES have children implicitly allows those children to steal keys from it.  That is ok.  Think of a scrollable list that can be scrolled with the arrow keys, but if one of the list items is a text field and it is focused, the text field should be able to consume those arrow keys itself.

This PR doesn't affect those assumptions, because even though EditableText is a leaf, it doesn't use Shortcuts itself.  That is done in DefaultTextEditingShortcuts near the root of the tree.  It's this separation of the visual widget and its Shortcuts definitions that is tricky here.

#### Getting to the point...

In our case, our architectural concern is the competition between the [default WidgetsApp Shortcuts](https://github.com/flutter/flutter/blob/23cea26715257103a7a4d225992fc58b48bd2605/packages/flutter/lib/src/widgets/app.dart#L1671) and the [DefaultTextEditingShortcuts](https://github.com/flutter/flutter/blob/23cea26715257103a7a4d225992fc58b48bd2605/packages/flutter/lib/src/widgets/app.dart#L1676), both near the root of the tree.  If we go with this PR's approach as-is, we are basically saying that we just need to be aware of the competition between these two and not introduce any more bugs like this, say, the next time that the WidgetsApp Shortcuts adds a new shortcut for a normal text input key.

Is there anything better we could do?  Do we need to defensively put a DoNothingAndStopPropagationTextIntent into DefaultTextEditingShortcuts for every possible text input key?  Could we create a SingleActivator that catches all possible text input keys?  Is there a better way overall?

### Related issues

Fixes https://github.com/flutter/flutter/issues/90907

### TODO

 * [ ] Decide if this is the right way to go architecturally
 * [x] Tests
 * [x] Enter key as well