### PR TITLE
Add filter to ValueListenableBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -18,7 +18,7 @@ import 'framework.dart';
 ///    a [ValueListenable] changes value.
 typedef ValueWidgetBuilder<T> = Widget Function(BuildContext context, T value, Widget? child);
 
-/// Decides whether to call the [builder] of the [ValueListenableBuilder] to
+/// Decides whether to call the builder of the [ValueListenableBuilder] to
 /// rebuild the widget.
 ///
 /// The [ValueListenable<T>] values before and after an update are provided

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -176,11 +176,13 @@ class ValueListenableBuilder<T> extends StatefulWidget {
 
 class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   late T value;
+  late T _oldValue;
 
   @override
   void initState() {
     super.initState();
     value = widget.valueListenable.value;
+    _oldValue = value;
     widget.valueListenable.addListener(_valueChanged);
   }
 
@@ -189,6 +191,7 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
     if (oldWidget.valueListenable != widget.valueListenable) {
       oldWidget.valueListenable.removeListener(_valueChanged);
       value = widget.valueListenable.value;
+      _oldValue = value;
       widget.valueListenable.addListener(_valueChanged);
     }
     super.didUpdateWidget(oldWidget);
@@ -202,10 +205,10 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
 
   void _valueChanged() {
     final ValueWidgetRebuildFilter<T>? filter = widget.filter;
-    if (filter == null || filter(value, widget.valueListenable.value)) {
-      setState(() {});
+    if (filter == null || filter(_oldValue, widget.valueListenable.value)) {
+      setState(() => value = widget.valueListenable.value);
     }
-    value = widget.valueListenable.value;
+    _oldValue = widget.valueListenable.value;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -182,7 +182,7 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
   void initState() {
     super.initState();
     value = widget.valueListenable.value;
-    _oldValue = value;
+    _updateOldValue();
     widget.valueListenable.addListener(_valueChanged);
   }
 
@@ -191,7 +191,7 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
     if (oldWidget.valueListenable != widget.valueListenable) {
       oldWidget.valueListenable.removeListener(_valueChanged);
       value = widget.valueListenable.value;
-      _oldValue = value;
+      _updateOldValue();
       widget.valueListenable.addListener(_valueChanged);
     }
     super.didUpdateWidget(oldWidget);
@@ -208,7 +208,13 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
     if (filter == null || filter(_oldValue, widget.valueListenable.value)) {
       setState(() => value = widget.valueListenable.value);
     }
-    _oldValue = widget.valueListenable.value;
+    _updateOldValue();
+  }
+
+  void _updateOldValue() {
+    if (widget.filter != null) {
+      _oldValue = widget.valueListenable.value;
+    }
   }
 
   @override


### PR DESCRIPTION
Resolves #91178.

`ValueListenableBuilder` was lacking a way to evaluate the value before a rebuild. The new `filter` property resolves it by allowing to check the previous/new values to decide whether to trigger a rebuild.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
