### PR TITLE
Making AnimatedCrossFade more null safe

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -248,7 +248,7 @@ class AnimatedCrossFade extends StatefulWidget {
 }
 
 class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProviderStateMixin {
-  AnimationController? _controller;
+  late AnimationController _controller;
   late Animation<double> _firstAnimation;
   late Animation<double> _secondAnimation;
 
@@ -261,10 +261,10 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
       vsync: this,
     );
     if (widget.crossFadeState == CrossFadeState.showSecond)
-      _controller!.value = 1.0;
+      _controller.value = 1.0;
     _firstAnimation = _initAnimation(widget.firstCurve, true);
     _secondAnimation = _initAnimation(widget.secondCurve, false);
-    _controller!.addStatusListener((AnimationStatus status) {
+    _controller.addStatusListener((AnimationStatus status) {
       setState(() {
         // Trigger a rebuild because it depends on _isTransitioning, which
         // changes its value together with animation status.
@@ -273,7 +273,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
   }
 
   Animation<double> _initAnimation(Curve curve, bool inverted) {
-    Animation<double> result = _controller!.drive(CurveTween(curve: curve));
+    Animation<double> result = _controller.drive(CurveTween(curve: curve));
     if (inverted)
       result = result.drive(Tween<double>(begin: 1.0, end: 0.0));
     return result;
@@ -281,7 +281,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
 
   @override
   void dispose() {
-    _controller!.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -289,9 +289,9 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
   void didUpdateWidget(AnimatedCrossFade oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.duration != oldWidget.duration)
-      _controller!.duration = widget.duration;
+      _controller.duration = widget.duration;
     if (widget.reverseDuration != oldWidget.reverseDuration)
-      _controller!.reverseDuration = widget.reverseDuration;
+      _controller.reverseDuration = widget.reverseDuration;
     if (widget.firstCurve != oldWidget.firstCurve)
       _firstAnimation = _initAnimation(widget.firstCurve, true);
     if (widget.secondCurve != oldWidget.secondCurve)
@@ -299,24 +299,24 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
     if (widget.crossFadeState != oldWidget.crossFadeState) {
       switch (widget.crossFadeState) {
         case CrossFadeState.showFirst:
-          _controller!.reverse();
+          _controller.reverse();
           break;
         case CrossFadeState.showSecond:
-          _controller!.forward();
+          _controller.forward();
           break;
       }
     }
   }
 
   /// Whether we're in the middle of cross-fading this frame.
-  bool get _isTransitioning => _controller!.status == AnimationStatus.forward || _controller!.status == AnimationStatus.reverse;
+  bool get _isTransitioning => _controller.status == AnimationStatus.forward || _controller.status == AnimationStatus.reverse;
 
   @override
   Widget build(BuildContext context) {
     const Key kFirstChildKey = ValueKey<CrossFadeState>(CrossFadeState.showFirst);
     const Key kSecondChildKey = ValueKey<CrossFadeState>(CrossFadeState.showSecond);
-    final bool transitioningForwards = _controller!.status == AnimationStatus.completed ||
-                                       _controller!.status == AnimationStatus.forward;
+    final bool transitioningForwards = _controller.status == AnimationStatus.completed ||
+                                       _controller.status == AnimationStatus.forward;
     final Key topKey;
     Widget topChild;
     final Animation<double> topAnimation;


### PR DESCRIPTION
The `AnimatedCrossFade` does not require the internal `AnimationController` to be nullable but it's enough to be `late`.

- No tests were changed as this is only a refactor and no failing tests could have been written for the change
- Did not link to any existing issue as according to [Tree hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) those are required for non-trivial issues

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
