### PR TITLE
Update dartdoc to 4.0.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 3.1.0
+    "$DART" pub global activate dartdoc 4.0.0
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
Release notes: https://github.com/dart-lang/dartdoc/pull/2823

TL;DR: For Flutter, not much immediate impact but it does fix a crash problem that could impact Flutter later if specially formatted comment references appear in the future in Flutter or its dependencies.