### PR TITLE
Add a microbenchmark that measures performance of flutter compute.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
@@ -1,0 +1,52 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import '../common.dart';
+
+const int _kNumIterations = 10;
+const int _kNumWarmUp = 10;
+
+class Data {
+  Data(this.value);
+
+  Map<String, dynamic> toJson() => <String, dynamic>{ 'value': value };
+
+  final int value;
+}
+
+test(int length) {
+  return List<Data>.generate(length,
+      (int index) => Data(index * index));
+}
+
+void main() async {
+  assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
+
+  // Warm up lap
+  for (int i = 0; i < _kNumWarmUp; i += 1) {
+    await compute(test, 100);
+  }
+
+  final Stopwatch watch = Stopwatch();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    await compute(test, 1000000);
+  }
+  final int elapsedMicroseconds = watch.elapsedMicroseconds;
+
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  const double scale = 1000.0 / _kNumIterations;
+  printer.addResult(
+    description: 'compute',
+    value: elapsedMicroseconds * scale,
+    unit: 'ns per iteration',
+    name: 'compute_iteration',
+  );
+  printer.printToStdout();
+}

--- a/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/compute_bench.dart
@@ -2,15 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
 
 import '../common.dart';
 
 const int _kNumIterations = 10;
-const int _kNumWarmUp = 10;
+const int _kNumWarmUp = 100;
 
 class Data {
   Data(this.value);
@@ -20,17 +17,17 @@ class Data {
   final int value;
 }
 
-test(int length) {
+List<Data> test(int length) {
   return List<Data>.generate(length,
       (int index) => Data(index * index));
 }
 
-void main() async {
+Future<void> main() async {
   assert(false, "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
 
   // Warm up lap
   for (int i = 0; i < _kNumWarmUp; i += 1) {
-    await compute(test, 100);
+    await compute(test, 10);
   }
 
   final Stopwatch watch = Stopwatch();

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -54,6 +54,7 @@ TaskFunction createMicrobenchmarkTask() {
       ...await _runMicrobench('lib/gestures/velocity_tracker_bench.dart'),
       ...await _runMicrobench('lib/gestures/gesture_detector_bench.dart'),
       ...await _runMicrobench('lib/stocks/animation_bench.dart'),
+      ...await _runMicrobench('lib/language/compute_bench.dart'),
       ...await _runMicrobench('lib/language/sync_star_bench.dart'),
       ...await _runMicrobench('lib/language/sync_star_semantics_bench.dart'),
       ...await _runMicrobench('lib/foundation/all_elements_bench.dart'),


### PR DESCRIPTION
This benchmark should show performance improvements when compute implementation is switched to recently-introduced `Isolate.exit`.
