### PR TITLE
Mark Linux deferred components to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1632,6 +1632,7 @@ targets:
 
   - name: Linux deferred components
     recipe: flutter/deferred_components
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/90071
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux deferred components"
}
-->
Issue link: https://github.com/flutter/flutter/issues/91266