### PR TITLE
Mark Linux_android flutter_gallery__start_up to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1428,6 +1428,7 @@ targets:
 
   - name: Linux_android flutter_gallery__start_up
     recipe: devicelab/devicelab_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/91270
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Linux_android flutter_gallery__start_up"
}
-->
Issue link: https://github.com/flutter/flutter/issues/91270