### PR TITLE
Added: hoverColor to CheckBoxListTile and ExpansionTile, dragHandlersPosition to the ReorderableList

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -137,6 +137,7 @@ class CheckboxListTile extends StatelessWidget {
     this.contentPadding,
     this.tristate = false,
     this.shape,
+    this.hoverColor,
     this.selectedTileColor,
     this.visualDensity,
     this.focusNode,
@@ -190,6 +191,9 @@ class CheckboxListTile extends StatelessWidget {
 
   /// {@macro flutter.material.ListTile.tileColor}
   final Color? tileColor;
+
+  /// The color for the tile's [Material] when a pointer is hovering over it.
+  final Color? hoverColor;
 
   /// The primary content of the list tile.
   ///
@@ -332,6 +336,7 @@ class CheckboxListTile extends StatelessWidget {
           visualDensity: visualDensity,
           focusNode: focusNode,
           enableFeedback: enableFeedback,
+          hoverColor: hoverColor,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -63,6 +63,7 @@ class ExpansionTile extends StatefulWidget {
     this.backgroundColor,
     this.collapsedBackgroundColor,
     this.textColor,
+    this.hoverColor,
     this.collapsedTextColor,
     this.iconColor,
     this.collapsedIconColor,
@@ -108,6 +109,9 @@ class ExpansionTile extends StatefulWidget {
 
   /// The color to display behind the sublist when expanded.
   final Color? backgroundColor;
+
+  /// The color for the tile's [Material] when a pointer is hovering over it.
+  final Color? hoverColor;
 
   /// When not null, defines the background color of tile when the sublist is collapsed.
   final Color? collapsedBackgroundColor;
@@ -320,6 +324,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
               title: widget.title,
               subtitle: widget.subtitle,
               trailing: widget.trailing ?? _buildTrailingIcon(context),
+              hoverColor: widget.hoverColor,
             ),
           ),
           ClipRect(

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -49,6 +49,7 @@ class ReorderableListView extends StatefulWidget {
     this.prototypeItem,
     this.proxyDecorator,
     this.buildDefaultDragHandles = true,
+    this.dragHandlesPosition,
     this.padding,
     this.header,
     this.scrollDirection = Axis.vertical,
@@ -117,6 +118,7 @@ class ReorderableListView extends StatefulWidget {
     this.prototypeItem,
     this.proxyDecorator,
     this.buildDefaultDragHandles = true,
+    this.dragHandlesPosition,
     this.padding,
     this.header,
     this.scrollDirection = Axis.vertical,
@@ -177,6 +179,9 @@ class ReorderableListView extends StatefulWidget {
   /// ** See code in examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart **
   ///{@end-tool}
   final bool buildDefaultDragHandles;
+
+  ///poistion of the Drag Handles
+  final AlignmentDirectional? dragHandlesPosition;
 
   /// {@macro flutter.widgets.reorderable_list.padding}
   final EdgeInsets? padding;
@@ -327,10 +332,10 @@ class _ReorderableListViewState extends State<ReorderableListView> {
                   Positioned.directional(
                     textDirection: Directionality.of(context),
                     start: 0,
-                    end: 0,
+                    end: 8,
                     bottom: 8,
                     child: Align(
-                      alignment: AlignmentDirectional.bottomCenter,
+                      alignment: widget.dragHandlesPosition??AlignmentDirectional.bottomCenter,
                       child: ReorderableDragStartListener(
                         index: index,
                         child: const Icon(Icons.drag_handle),
@@ -350,7 +355,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
                     bottom: 0,
                     end: 8,
                     child: Align(
-                      alignment: AlignmentDirectional.centerEnd,
+                      alignment: widget.dragHandlesPosition??AlignmentDirectional.centerEnd,
                       child: ReorderableDragStartListener(
                         index: index,
                         child: const Icon(Icons.drag_handle),


### PR DESCRIPTION
Added dragHandlersPosition and margind to the right for horizontal lists to ReorderableList

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [n/a] I listed at least one issue that this PR fixes in the description above.
- [n/a] I updated/added relevant documentation (doc comments with `///`).
- [n/a] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
