### PR TITLE
Remove 10 second timewarp in integration test pubspec.yamls

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
@@ -103,6 +103,10 @@ class RepeatingBackgroundProject extends Project {
 
   void updateTestIsolatePhrase(String message) {
     final String newMainContents = main.replaceFirst('Isolate thread', message);
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_const_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_const_project.dart
@@ -53,6 +53,10 @@ class HotReloadConstProject extends Project {
       'final int field = 2;',
       '// final int field = 2;',
     );
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_project.dart
@@ -95,6 +95,10 @@ class HotReloadProject extends Project {
       '// printHotReloadWorked();',
       'printHotReloadWorked();',
     );
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
@@ -55,6 +55,10 @@ class MyApp extends StatelessWidget {
       'LOADED DATA',
       'SECOND DATA',
     );
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/single_widget_reload_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/single_widget_reload_project.dart
@@ -75,7 +75,11 @@ class SingleWidgetReloadProject extends Project {
       '// printHotReloadWorked();',
       'printHotReloadWorked();',
     );
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 
   void modifyFunction() {
@@ -83,6 +87,10 @@ class SingleWidgetReloadProject extends Project {
       '(((((RELOAD WORKED)))))',
       '(((((RELOAD WORKED 2)))))',
     );
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      newMainContents,
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stateless_stateful_project.dart
@@ -74,6 +74,10 @@ class HotReloadProject extends Project {
 
   void toggleState() {
     stateful = !stateful;
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), getCode(stateful));
+    writeFile(
+      fileSystem.path.join(dir.path, 'lib', 'main.dart'),
+      getCode(stateful),
+      writeFutureModifiedDate: true,
+    );
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -33,10 +33,16 @@ Directory createResolvedTempDirectorySync(String prefix) {
   return fileSystem.directory(tempDirectory.resolveSymbolicLinksSync());
 }
 
-void writeFile(String path, String content) {
-  fileSystem.file(path)
+void writeFile(String path, String content, {bool writeFutureModifiedDate = false}) {
+  final File file = fileSystem.file(path)
     ..createSync(recursive: true)
     ..writeAsStringSync(content);
+    // Some integration tests on Windows to not see this file as being modified
+    // recently enough for the hot reload to pick this change up unless the
+    // modified time is written in the future.
+    if (writeFutureModifiedDate) {
+      file.setLastModifiedSync(DateTime.now().add(const Duration(seconds: 5)));
+    }
 }
 
 void writeBytesFile(String path, List<int> content) {

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -36,15 +36,13 @@ Directory createResolvedTempDirectorySync(String prefix) {
 void writeFile(String path, String content) {
   fileSystem.file(path)
     ..createSync(recursive: true)
-    ..writeAsStringSync(content)
-    ..setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));
+    ..writeAsStringSync(content);
 }
 
 void writeBytesFile(String path, List<int> content) {
   fileSystem.file(path)
     ..createSync(recursive: true)
-    ..writeAsBytesSync(content)
-    ..setLastModifiedSync(DateTime.now().add(const Duration(seconds: 10)));
+    ..writeAsBytesSync(content);
 }
 
 void writePackages(String folder) {


### PR DESCRIPTION
While working on another PR, I found an odd problem where the integration tests were triggering `flutter pub get` when they run their apps, even though the test setup code had literally just run it. My new tests verify the output and didn't expect the line printed about running `flutter pub get` and while it's easy to skip over the line, I couldn't help but investigate what was going on.

I tracked it down to these lines of code updating the `pubspec.yaml` timestamp into the future. This means the pubspec _looks_ newer than the `pubspec.lock` file on disk, so when `flutter run` runs, its up-to-date check triggers an additional (seemingly superfluous) `pub get`.

The code was added in #48932 and [these comments](https://github.com/flutter/flutter/pull/48932/files#r372073600) suggests it was an attempt to resolve some flakey Windows tests, though it's not clear whether it worked or is still necessary (or whether there's way to fix it without this side-effect - assuming that's not what is fixing the flakes).

I figured it might be worth trying to remove to see if any flakes return. If they do and it's deemed the best fix, it would be good to at least add some additional comments about the specific problem above this code to make it clearer what it's there for.

@christopherfujino