### PR TITLE
Suppress diagnostics from // HACK comments

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -27,8 +27,9 @@ analyzer:
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
     missing_return: warning
-    # allow having TODOs in the code
+    # allow having TODO/HACK comments in the code
     todo: ignore
+    hack: ignore
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore


### PR DESCRIPTION
The Dart SDK now produces hints for some additional TODO-style comments like `// HACK`, `// FIXME`. The Flutter codebase has quite a few `// HACK` comments that now show up in the Problems list.

I suspect that for the same reasons that `TODO`s are suppressed here, that `HACK` should be also.