### PR TITLE
Marks Mac module_test_ios to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2027,7 +2027,6 @@ targets:
       - bin/**
 
   - name: Mac module_test_ios
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/89175
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac module_test_ios"
}
-->
The test has been passing for [50 consecutive runs](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac%20module_test_ios%22).
This test can be marked as unflaky.

Fixes https://github.com/flutter/flutter/issues/89175