### PR TITLE
Update number of IPHONEOS_DEPLOYMENT_TARGET in plugin_test_ios

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -179,7 +179,7 @@ class _FlutterProject {
           // The plugintest target should not have IPHONEOS_DEPLOYMENT_TARGET set.
           // See _reduceDarwinPluginMinimumVersion for details.
           final int iosDeploymentTargetCount = 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
-          if (iosDeploymentTargetCount != 9) {
+          if (iosDeploymentTargetCount != 12) {
             throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET, $iosDeploymentTargetCount found');
           }
           if (!podsProjectContent.contains(r'"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "$(inherited) i386";')) {

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -173,25 +173,21 @@ class _FlutterProject {
 
         final String podsProjectContent = podsProject.readAsStringSync();
         if (target == 'ios') {
-          // This may be a bit brittle, IPHONEOS_DEPLOYMENT_TARGET appears in the
-          // Pods Xcode project file 6 times. If this number changes, make sure
-          // it's not a regression in the IPHONEOS_DEPLOYMENT_TARGET override logic.
-          // The plugintest target should not have IPHONEOS_DEPLOYMENT_TARGET set.
-          // See _reduceDarwinPluginMinimumVersion for details.
-          final int iosDeploymentTargetCount = 'IPHONEOS_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
-          if (iosDeploymentTargetCount != 12) {
-            throw TaskResult.failure('plugintest may contain IPHONEOS_DEPLOYMENT_TARGET, $iosDeploymentTargetCount found');
+          // Plugins with versions lower than the app version should not have IPHONEOS_DEPLOYMENT_TARGET set.
+          // The plugintest plugin target should not have IPHONEOS_DEPLOYMENT_TARGET set since it has been lowered
+          // in _reduceDarwinPluginMinimumVersion to 7, which is below the target version of 9.
+          if (podsProjectContent.contains('IPHONEOS_DEPLOYMENT_TARGET = 7')) {
+            throw TaskResult.failure('Plugin build setting IPHONEOS_DEPLOYMENT_TARGET not removed');
           }
           if (!podsProjectContent.contains(r'"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "$(inherited) i386";')) {
             throw TaskResult.failure(r'EXCLUDED_ARCHS is not "$(inherited) i386"');
           }
         }
 
-        // Same for macOS, but 12.
+        // Same for macOS deployment target, but 10.8.
         // The plugintest target should not have MACOSX_DEPLOYMENT_TARGET set.
-        final int macosDeploymentTargetCount = 'MACOSX_DEPLOYMENT_TARGET'.allMatches(podsProjectContent).length;
-        if (target == 'macos' && macosDeploymentTargetCount != 12) {
-          throw TaskResult.failure('plugintest may contain MACOSX_DEPLOYMENT_TARGET, $macosDeploymentTargetCount found');
+        if (target == 'macos' && podsProjectContent.contains('MACOSX_DEPLOYMENT_TARGET = 10.8')) {
+          throw TaskResult.failure('Plugin build setting MACOSX_DEPLOYMENT_TARGET not removed');
         }
       }
     });


### PR DESCRIPTION
Change the integration test #72764 to explicitly check that the too-low plugin version number has been removed, instead of the expected build setting count.  Which, as expected, was brittle...

Follow up to https://github.com/flutter/flutter/pull/91099
Will allow this test to be turned back on https://github.com/flutter/flutter/issues/88794
```
Task result:
{
  "success": true,
  "data": null,
  "detailFiles": [],
  "benchmarkScoreKeys": [],
  "reason": "success"
}
```