### PR TITLE
Add a startup test that delays runApp

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1437,6 +1437,17 @@ targets:
       task_name: flutter_gallery__start_up
     scheduler: luci
 
+  - name: Linux_android flutter_gallery__start_up_delayed
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: flutter_gallery__start_up_delayed
+    scheduler: luci
+
   - name: Linux_android flutter_gallery_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -34,6 +34,7 @@
 /dev/devicelab/bin/tasks/flutter_gallery__image_cache_memory.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flutter_gallery__memory_nav.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flutter_gallery__start_up.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/flutter_gallery__start_up_delayed.dart @dnfield @flutter/engine
 /dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flutter_gallery__transition_perf_with_semantics.dart @zanderso @flutter/engine

--- a/dev/devicelab/bin/tasks/flutter_gallery__start_up_delayed.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__start_up_delayed.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createFlutterGalleryStartupTest(target: 'lib/delayed_main.dart'));
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -215,9 +215,10 @@ TaskFunction createPictureCachePerfE2ETest() {
   ).run;
 }
 
-TaskFunction createFlutterGalleryStartupTest() {
+TaskFunction createFlutterGalleryStartupTest({String target = 'lib/main.dart'}) {
   return StartupTest(
     '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',
+    target: target,
   ).run;
 }
 
@@ -502,10 +503,11 @@ Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations
 
 /// Measure application startup performance.
 class StartupTest {
-  const StartupTest(this.testDirectory, { this.reportMetrics = true });
+  const StartupTest(this.testDirectory, { this.reportMetrics = true, this.target = 'lib/main.dart' });
 
   final String testDirectory;
   final bool reportMetrics;
+  final String target;
 
   Future<TaskResult> run() async {
     return inDirectory<TaskResult>(testDirectory, () async {
@@ -522,6 +524,7 @@ class StartupTest {
             '-v',
             '--profile',
             '--target-platform=android-arm,android-arm64',
+            '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
           break;
@@ -531,6 +534,7 @@ class StartupTest {
             '-v',
             '--profile',
             '--target-platform=android-arm',
+            '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
           break;
@@ -540,6 +544,7 @@ class StartupTest {
             '-v',
             '--profile',
             '--target-platform=android-arm64',
+            '--target=$target',
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
           break;
@@ -548,6 +553,7 @@ class StartupTest {
             'ios',
              '-v',
             '--profile',
+            '--target=$target',
           ]);
           applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
@@ -565,6 +571,7 @@ class StartupTest {
           '--verbose',
           '--profile',
           '--trace-startup',
+          '--target=$target',
           '-d',
           device.deviceId,
           if (applicationBinaryPath != null)

--- a/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
+++ b/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
@@ -9,8 +9,8 @@ import 'gallery/app.dart';
 Object? createGarbage() {
   final List<dynamic> garbage = <dynamic>[];
   for (int index = 0; index < 1000; index += 1) {
-    List<int>? moreGarbage = List<int>.filled(1000, index);
-    if (index % 2 == 0) {
+    final List<int>? moreGarbage = List<int>.filled(1000, index);
+    if (index.isOdd) {
       garbage.add(moreGarbage);
     }
   }
@@ -23,9 +23,9 @@ void main() async {
   final List<dynamic> garbage = <dynamic>[];
   for (int index = 0; index < 20; index += 1) {
     final Object? moreGarbage = createGarbage();
-    if (index % 2 == 0) {
+    if (index.isOdd) {
       garbage.add(moreGarbage);
-      await Future<void>.delayed(Duration(milliseconds: 7));
+      await Future<void>.delayed(const Duration(milliseconds: 7));
     }
   }
 

--- a/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
+++ b/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
@@ -1,0 +1,33 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'gallery/app.dart';
+
+Object? createGarbage() {
+  final List<dynamic> garbage = <dynamic>[];
+  for (int index = 0; index < 1000; index += 1) {
+    List<int>? moreGarbage = List<int>.filled(1000, index);
+    if (index % 2 == 0) {
+      garbage.add(moreGarbage);
+    }
+  }
+  return garbage;
+}
+
+void main() async {
+  // Create some garbage, and simulate some delays between that could be
+  // plugin or network call related.
+  final List<dynamic> garbage = <dynamic>[];
+  for (int index = 0; index < 20; index += 1) {
+    final Object? moreGarbage = createGarbage();
+    if (index % 2 == 0) {
+      garbage.add(moreGarbage);
+      await Future<void>.delayed(Duration(milliseconds: 7));
+    }
+  }
+
+  runApp(const GalleryApp());
+}

--- a/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
+++ b/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
@@ -17,7 +17,7 @@ Object? createGarbage() {
   return garbage;
 }
 
-void main() async {
+Future<void> main() async {
   // Create some garbage, and simulate some delays between that could be
   // plugin or network call related.
   final List<dynamic> garbage = <dynamic>[];

--- a/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
+++ b/dev/integration_tests/flutter_gallery/lib/delayed_main.dart
@@ -9,7 +9,7 @@ import 'gallery/app.dart';
 Object? createGarbage() {
   final List<dynamic> garbage = <dynamic>[];
   for (int index = 0; index < 1000; index += 1) {
-    final List<int>? moreGarbage = List<int>.filled(1000, index);
+    final List<int> moreGarbage = List<int>.filled(1000, index);
     if (index.isOdd) {
       garbage.add(moreGarbage);
     }


### PR DESCRIPTION
Currently, all our start_up perf tests call `runApp` immediately in `main`. This test simulates doing some actual work (including async delays) to mimic using plugins/making network calls before runApp.

This benchmark is expected to improve when https://github.com/flutter/engine/pull/29015 lands. Locally on a Pixel 4, it goes from 412ms to 384ms before and after that patch.