### PR TITLE
Opacity widget's child should not be nullable

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/filtered_child_animation.dart
@@ -113,7 +113,7 @@ class _FilteredChildAnimationPageState extends State<FilteredChildAnimationPage>
       case FilterType.opacity:
         builder = (BuildContext context, Widget? child) => Opacity(
           opacity: (_controller.value * 2.0 - 1.0).abs(),
-          child: child,
+          child: child!,
         );
         break;
       case FilterType.rotateTransform:

--- a/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
@@ -204,11 +204,11 @@ class _VideoPlayPauseState extends State<VideoPlayPause> {
 class FadeAnimation extends StatefulWidget {
   const FadeAnimation({
     Key? key,
-    this.child,
+    required this.child,
     this.duration = const Duration(milliseconds: 500),
   }) : super(key: key);
 
-  final Widget? child;
+  final Widget child;
   final Duration duration;
 
   @override

--- a/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/backdrop.dart
@@ -327,7 +327,7 @@ class _BackdropState extends State<Backdrop> with SingleTickerProviderStateMixin
               controller: _controller,
               child: FadeTransition(
                 opacity: _frontOpacity,
-                child: widget.frontLayer,
+                child: widget.frontLayer!,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -1000,7 +1000,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
     final Expanded sheet = Expanded(
       child: AnimatedBuilder(
         animation: _sheetController,
-        builder: _buildSheetAnimation,
+        builder: (BuildContext context, Widget? child) => _buildSheetAnimation(context, child!),
         child: _ContextMenuSheet(
           key: widget.sheetGlobalKey,
           actions: widget.actions!,
@@ -1023,7 +1023,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
   }
 
   // Build the animation for the _ContextMenuSheet.
-  Widget _buildSheetAnimation(BuildContext context, Widget? child) {
+  Widget _buildSheetAnimation(BuildContext context, Widget child) {
     return Transform.scale(
       alignment: _ContextMenuRoute.getSheetAlignment(widget.contextMenuLocation),
       scale: _sheetScaleAnimation.value,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1001,7 +1001,7 @@ class _AppBarState extends State<AppBar> {
           else
             Opacity(
               opacity: const Interval(0.25, 1.0, curve: Curves.fastOutSlowIn).transform(widget.bottomOpacity),
-              child: widget.bottom,
+              child: widget.bottom!,
             ),
         ],
       );

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -251,7 +251,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
               // through the app bar when it is collapsed.
               alwaysIncludeSemantics: true,
               opacity: opacity,
-              child: widget.background,
+              child: widget.background!,
             ),
           ));
 
@@ -277,11 +277,11 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
         if (widget.title != null) {
           final ThemeData theme = Theme.of(context);
 
-          Widget? title;
+          Widget title;
           switch (theme.platform) {
             case TargetPlatform.iOS:
             case TargetPlatform.macOS:
-              title = widget.title;
+              title = widget.title!;
               break;
             case TargetPlatform.android:
             case TargetPlatform.fuchsia:

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -443,7 +443,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
         children: <Widget>[
           FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(_controller),
-            child: _helper,
+            child: _helper!,
           ),
           _buildError(),
         ],
@@ -456,7 +456,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
           _buildHelper(),
           FadeTransition(
             opacity: _controller,
-            child: _error,
+            child: _error!,
           ),
         ],
       );
@@ -1782,15 +1782,15 @@ class _Decorator extends RenderObjectWidget {
 class _AffixText extends StatelessWidget {
   const _AffixText({
     required this.labelIsFloating,
-    this.text,
+    required this.text,
     this.style,
-    this.child,
+    required this.child,
   });
 
   final bool labelIsFloating;
-  final String? text;
+  final String text;
   final TextStyle? style;
-  final Widget? child;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
@@ -1800,7 +1800,7 @@ class _AffixText extends StatelessWidget {
         duration: _kTransitionDuration,
         curve: _kTransitionCurve,
         opacity: labelIsFloating ? 1.0 : 0.0,
-        child: child ?? (text == null ? null : Text(text!, style: style)),
+        child: Text(text, style: style),
       ),
     );
   }
@@ -2261,17 +2261,17 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final Widget? prefix = decoration!.prefix == null && decoration!.prefixText == null ? null :
       _AffixText(
         labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.prefixText,
+        text: decoration!.prefixText!,
         style: decoration!.prefixStyle ?? hintStyle,
-        child: decoration!.prefix,
+        child: decoration!.prefix!,
       );
 
     final Widget? suffix = decoration!.suffix == null && decoration!.suffixText == null ? null :
       _AffixText(
         labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.suffixText,
+        text: decoration!.suffixText!,
         style: decoration!.suffixStyle ?? hintStyle,
-        child: decoration!.suffix,
+        child: decoration!.suffix!,
       );
 
     final Color activeColor = _getActiveColor(themeData);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1782,15 +1782,15 @@ class _Decorator extends RenderObjectWidget {
 class _AffixText extends StatelessWidget {
   const _AffixText({
     required this.labelIsFloating,
-    required this.text,
+    this.text,
     this.style,
-    required this.child,
-  });
+    this.child,
+  }): assert((text != null || child != null) && (text == null || child == null));
 
   final bool labelIsFloating;
-  final String text;
+  final String? text;
   final TextStyle? style;
-  final Widget child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {
@@ -1800,7 +1800,7 @@ class _AffixText extends StatelessWidget {
         duration: _kTransitionDuration,
         curve: _kTransitionCurve,
         opacity: labelIsFloating ? 1.0 : 0.0,
-        child: Text(text, style: style),
+        child: child ?? Text(text!, style: style),
       ),
     );
   }
@@ -2261,17 +2261,17 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final Widget? prefix = decoration!.prefix == null && decoration!.prefixText == null ? null :
       _AffixText(
         labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.prefixText!,
+        text: decoration!.prefixText,
         style: decoration!.prefixStyle ?? hintStyle,
-        child: decoration!.prefix!,
+        child: decoration!.prefix,
       );
 
     final Widget? suffix = decoration!.suffix == null && decoration!.suffixText == null ? null :
       _AffixText(
         labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.suffixText!,
+        text: decoration!.suffixText,
         style: decoration!.suffixStyle ?? hintStyle,
-        child: decoration!.suffix!,
+        child: decoration!.suffix,
       );
 
     final Color activeColor = _getActiveColor(themeData);

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1304,7 +1304,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
           if (_isExtendedFloatingActionButton(_previousChild))
             FadeTransition(
               opacity: _previousScaleAnimation,
-              child: _previousChild,
+              child: _previousChild!,
             )
           else
             ScaleTransition(
@@ -1319,7 +1319,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
             scale: _extendedCurrentScaleAnimation,
             child: FadeTransition(
               opacity: _currentScaleAnimation,
-              child: widget.child,
+              child: widget.child!,
             ),
           )
         else

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -252,7 +252,7 @@ class Opacity extends SingleChildRenderObjectWidget {
     Key? key,
     required this.opacity,
     this.alwaysIncludeSemantics = false,
-    Widget? child,
+    required Widget child,
   }) : assert(opacity != null && opacity >= 0.0 && opacity <= 1.0),
        assert(alwaysIncludeSemantics != null),
        super(key: key, child: child);

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -549,7 +549,7 @@ class _HeroFlight {
             child: RepaintBoundary(
               child: FadeTransition(
                 opacity: _heroOpacity,
-                child: child,
+                child: child!,
               ),
             ),
           ),

--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -1698,7 +1698,7 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   /// inclusive. The [curve] and [duration] arguments must not be null.
   const AnimatedOpacity({
     Key? key,
-    this.child,
+    required this.child,
     required this.opacity,
     Curve curve = Curves.linear,
     required Duration duration,
@@ -1710,7 +1710,7 @@ class AnimatedOpacity extends ImplicitlyAnimatedWidget {
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
-  final Widget? child;
+  final Widget child;
 
   /// The target opacity.
   ///

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -491,7 +491,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
     Key? key,
     required this.opacity,
     this.alwaysIncludeSemantics = false,
-    Widget? child,
+    required Widget child,
   }) : assert(opacity != null),
        super(key: key, child: child);
 

--- a/packages/flutter/test/widgets/dual_transition_builder_test.dart
+++ b/packages/flutter/test/widgets/dual_transition_builder_test.dart
@@ -32,7 +32,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(
@@ -102,7 +102,7 @@ void main() {
           ) {
             return FadeTransition(
               opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-              child: child,
+              child: child!,
             );
           },
           child: const _StatefulTestWidget(name: 'Foo'),
@@ -163,7 +163,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(
@@ -228,7 +228,7 @@ void main() {
         ) {
           return FadeTransition(
             opacity: Tween<double>(begin: 1.0, end: 0.0).animate(animation),
-            child: child,
+            child: child!,
           );
         },
         child: Container(

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -224,7 +224,7 @@ void main() {
               return FadeTransition(
                 key: fadeTransitionKey,
                 opacity: fadeAnimation,
-                child: child,
+                child: child!,
               );
             },
             child: child,


### PR DESCRIPTION
Changes Opacity widget child field state to required.

Fixes #91321
Fix for packages provided in https://github.com/flutter/packages/pull/484
Second fix to animations in https://github.com/flutter/packages/pull/489

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
