### PR TITLE
Clear asset manager caches on memory pressure

### DIFF
--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -98,6 +98,9 @@ abstract class AssetBundle {
   /// loaded, the cache will be reread from the asset bundle.
   void evict(String key) { }
 
+  /// If this is a caching asset bundle, clear all cached data.
+  void clear() { }
+
   @override
   String toString() => '${describeIdentity(this)}()';
 }
@@ -214,6 +217,12 @@ abstract class CachingAssetBundle extends AssetBundle {
   void evict(String key) {
     _stringCache.remove(key);
     _structuredDataCache.remove(key);
+  }
+
+  @override
+  void clear() {
+    _stringCache.clear();
+    _structuredDataCache.clear();
   }
 }
 

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -113,7 +113,9 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
   /// [SystemChannels.system].
   @protected
   @mustCallSuper
-  void handleMemoryPressure() { }
+  void handleMemoryPressure() {
+    rootBundle.clear();
+  }
 
   /// Handler called for messages received on the [SystemChannels.system]
   /// message channel.

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -51,8 +51,10 @@ class TestBinding extends BindingBase with SchedulerBinding, ServicesBinding {
 }
 
 void main() {
+  final TestBinding binding = TestBinding();
+
   test('Adds rootBundle LICENSES to LicenseRegistry', () async {
-    TestBinding().defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
       if (const StringCodec().decodeMessage(message) == 'NOTICES.Z' && !kIsWeb) {
         return Uint8List.fromList(gzip.encode(utf8.encode(combinedLicenses))).buffer.asByteData();
       }
@@ -75,5 +77,35 @@ void main() {
       licenses[1].paragraphs.map((LicenseParagraph p) => p.text),
       equals(<String>['L2Paragraph1', 'L2Paragraph2', 'L2Paragraph3']),
     );
+  });
+
+  test('didHaveMemoryPressure clears asset caches', () async {
+    int flutterAssetsCallCount = 0;
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
+      flutterAssetsCallCount += 1;
+      return Uint8List.fromList('test_asset_data'.codeUnits).buffer.asByteData();
+    });
+
+    await rootBundle.loadString('test_asset');
+    expect(flutterAssetsCallCount, 1);
+    await rootBundle.loadString('test_asset2');
+    expect(flutterAssetsCallCount, 2);
+    await rootBundle.loadString('test_asset');
+    expect(flutterAssetsCallCount, 2);
+    await rootBundle.loadString('test_asset2');
+    expect(flutterAssetsCallCount, 2);
+
+    final ByteData message = const JSONMessageCodec().encodeMessage(<String, dynamic>{'type': 'memoryPressure'})!;
+    await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage('flutter/system', message, (_) { });
+
+    await rootBundle.loadString('test_asset');
+    expect(flutterAssetsCallCount, 3);
+    await rootBundle.loadString('test_asset2');
+    expect(flutterAssetsCallCount, 4);
+    await rootBundle.loadString('test_asset');
+    expect(flutterAssetsCallCount, 4);
+    await rootBundle.loadString('test_asset2');
+    expect(flutterAssetsCallCount, 4);
+
   });
 }

--- a/packages/flutter/test/services/binding_test.dart
+++ b/packages/flutter/test/services/binding_test.dart
@@ -106,6 +106,5 @@ void main() {
     expect(flutterAssetsCallCount, 4);
     await rootBundle.loadString('test_asset2');
     expect(flutterAssetsCallCount, 4);
-
   });
 }


### PR DESCRIPTION
This addresses part of https://github.com/flutter/flutter/issues/3568

I do not think we will ever actually get a real fix for that issue - there's nothing stopping us from using a `SplayTreeMap` to limit the total number of entries in this cache in LRU fashion, similar to how the ImageCache works.

At the very least, we should be clearing these caches when we get memory pressure events from the OS.

GitHub says @Hixie "recently" edited these files. It's been 5 years GitHub. 5 years.