### PR TITLE
When application dies or webdriver moves out of the page with Flutter…

### DIFF
--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -276,8 +276,8 @@ class FlutterWebConnection {
         timeout: duration ?? const Duration(days: 30),
       );
     } catch (_) {
-      // Returns null if exception thrown.
-      return null;
+      throw DriverError('Failed to retrieve the result of executing flutter driver command - $script. '
+          'Maybe page with Flutter application was closed or application died.');
     } finally {
       // Resets the result.
       await _driver.execute(r'''


### PR DESCRIPTION
… application user starts to get hard to understand errors with not being possible to run the command. For example user logs out of the web app by clicking logout button which brings him to the page without flutter application. In this case Tap happens in the app but result of tap is returned as null because FlutterDriverResult variable is not avaialable on the new page without flutter app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
