### PR TITLE
Add explicit version for mac and windows openjdk.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -84,7 +84,7 @@ platform_properties:
         [
           {"dependency": "android_sdk"},
           {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"}
+          {"dependency": "open_jdk", "version": "version:11"}
         ]
       os: Mac-10.15
       device_os: N
@@ -167,7 +167,7 @@ platform_properties:
             {"dependency": "android_sdk"},
             {"dependency": "certs"},
             {"dependency": "chrome_and_driver", "version": "version:84"},
-            {"dependency": "open_jdk"}
+            {"dependency": "open_jdk", "version": "version:11"}
           ]
       os: Windows-10
       device_os: N


### PR DESCRIPTION
Gradle was updated to a more recent version that expects openjdk 11 but the openjdk version was not updated.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
