### PR TITLE
Adds `CommonFinders.bySubtype<T extends Widget>()` finder.

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -128,6 +128,21 @@ class CommonFinders {
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder byKey(Key key, { bool skipOffstage = true }) => _KeyFinder(key, skipOffstage: skipOffstage);
 
+  /// Finds widgets by searching for widgets implementing a particular type.
+  ///
+  /// This matcher accepts subtypes. For example a
+  /// `bySubtype<StatefulWidget>()` will find any stateful widget.
+  ///
+  /// ## Sample code
+  ///
+  /// ```dart
+  /// expect(find.bySubtype<IconButton>(), findsOneWidget);
+  /// ```
+  ///
+  /// If the `skipOffstage` argument is true (the default), then this skips
+  /// nodes that are [Offstage] or that are from inactive [Route]s.
+  Finder bySubtype<T extends Widget>({ bool skipOffstage = true }) => _WidgetSubtypeFinder<T>(skipOffstage: skipOffstage);
+
   /// Finds widgets by searching for widgets with a particular type.
   ///
   /// This does not do subclass tests, so for example
@@ -710,6 +725,18 @@ class _KeyFinder extends MatchFinder {
   @override
   bool matches(Element candidate) {
     return candidate.widget.key == key;
+  }
+}
+
+class _WidgetSubtypeFinder<T extends Widget> extends MatchFinder {
+  _WidgetSubtypeFinder({ bool skipOffstage = true }) : super(skipOffstage: skipOffstage);
+
+  @override
+  String get description => 'is "$T"';
+
+  @override
+  bool matches(Element candidate) {
+    return candidate.widget is T;
   }
 }
 

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -141,6 +141,9 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
+  ///
+  /// See also:
+  /// * [byType], which does not do subtype tests.
   Finder bySubtype<T extends Widget>({ bool skipOffstage = true }) => _WidgetSubtypeFinder<T>(skipOffstage: skipOffstage);
 
   /// Finds widgets by searching for widgets with a particular type.
@@ -159,6 +162,9 @@ class CommonFinders {
   ///
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
+  ///
+  /// See also:
+  /// * [bySubtype], which allows subtype tests.
   Finder byType(Type type, { bool skipOffstage = true }) => _WidgetTypeFinder(type, skipOffstage: skipOffstage);
 
   /// Finds [Icon] widgets containing icon data equal to the `icon`

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -265,6 +265,43 @@ void main() {
 
     expect(text.data, '1');
   });
+
+  testWidgets('finds multiple subtypes', (WidgetTester tester) async {
+    await tester.pumpWidget(_boilerplate(Row(children: <Widget>[
+      Column(children: <Widget>[
+        Text('Hello'),
+        Text('World'),
+      ]),
+      Column(children: <Widget>[
+        Image(image: FileImage(File('test'))),
+      ]),
+      PopUpMenuButton<int>(
+          itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[
+                const PopupMenuItem<int>(value: 1, child: Text('one')),
+              ]),
+      PopUpMenuButton<double>(
+          itemBuilder: (BuildContext context) => <PopupMenuItem<double>>[
+                const PopupMenuItem<double>(value: 3.14, child: Text('pi')),
+              ]),
+      PopUpMenuButton<String>(
+          itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
+                const PopupMenuItem<String>(value: '2', child: Text('two')),
+              ]),
+    ])));
+
+    expect(find.bySubtype<Row>(), findsOneWidget);
+    expect(find.bySubtype<Column>(), findsNWidgets(2));
+    // Finds both rows and columns.
+    expect(find.bySubtype<Flex>(), findsNWidgets(3));
+
+    // Finds only the requested generic subtypes.
+    expect(find.bySubtype<PopupMenuButton<int>>(), findsOneWidget);
+    expect(find.bySubtype<PopupMenuButton<num>>(), findsNWidgets(2));
+    expect(find.bySubtype<PopupMenuButton<Object>>(), findsNWidgets(3));
+
+    // Finds all widgets.
+    expect(find.bySubtype<Widget>(), findsNWidgets(12));
+  });
 }
 
 Widget _boilerplate(Widget child) {

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -268,22 +268,22 @@ void main() {
 
   testWidgets('finds multiple subtypes', (WidgetTester tester) async {
     await tester.pumpWidget(_boilerplate(Row(children: <Widget>[
-      Column(children: <Widget>[
+      Column(children: const <Widget>[
         Text('Hello'),
         Text('World'),
       ]),
       Column(children: <Widget>[
         Image(image: FileImage(File('test'))),
       ]),
-      PopUpMenuButton<int>(
+      PopupMenuButton<int>(
           itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[
                 const PopupMenuItem<int>(value: 1, child: Text('one')),
               ]),
-      PopUpMenuButton<double>(
+      PopupMenuButton<double>(
           itemBuilder: (BuildContext context) => <PopupMenuItem<double>>[
                 const PopupMenuItem<double>(value: 3.14, child: Text('pi')),
               ]),
-      PopUpMenuButton<String>(
+      PopupMenuButton<String>(
           itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
                 const PopupMenuItem<String>(value: '2', child: Text('two')),
               ]),

--- a/packages/flutter_test/test/finders_test.dart
+++ b/packages/flutter_test/test/finders_test.dart
@@ -11,17 +11,18 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('image', () {
     testWidgets('finds Image widgets', (WidgetTester tester) async {
-      await tester.pumpWidget(_boilerplate(
-          Image(image: FileImage(File('test')))
-      ));
+      await tester
+          .pumpWidget(_boilerplate(Image(image: FileImage(File('test')))));
       expect(find.image(FileImage(File('test'))), findsOneWidget);
     });
 
     testWidgets('finds Button widgets with Image', (WidgetTester tester) async {
-      await tester.pumpWidget(_boilerplate(
-          ElevatedButton(onPressed: null, child: Image(image: FileImage(File('test'))),)
-      ));
-      expect(find.widgetWithImage(ElevatedButton, FileImage(File('test'))), findsOneWidget);
+      await tester.pumpWidget(_boilerplate(ElevatedButton(
+        onPressed: null,
+        child: Image(image: FileImage(File('test'))),
+      )));
+      expect(find.widgetWithImage(ElevatedButton, FileImage(File('test'))),
+          findsOneWidget);
     });
   });
 
@@ -34,9 +35,10 @@ void main() {
     });
 
     testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
-      await tester.pumpWidget(_boilerplate(
-        const Text.rich(
-          TextSpan(text: 't', children: <TextSpan>[
+      await tester.pumpWidget(_boilerplate(const Text.rich(
+        TextSpan(
+          text: 't',
+          children: <TextSpan>[
             TextSpan(text: 'e'),
             TextSpan(text: 'st'),
           ],
@@ -137,15 +139,16 @@ void main() {
     });
 
     testWidgets('finds Text.rich widgets', (WidgetTester tester) async {
-      await tester.pumpWidget(_boilerplate(
-          const Text.rich(
-            TextSpan(text: 'this', children: <TextSpan>[
-              TextSpan(text: 'is'),
-              TextSpan(text: 'a'),
-              TextSpan(text: 'test'),
-            ],
-            ),
-          )));
+      await tester.pumpWidget(_boilerplate(const Text.rich(
+        TextSpan(
+          text: 'this',
+          children: <TextSpan>[
+            TextSpan(text: 'is'),
+            TextSpan(text: 'a'),
+            TextSpan(text: 'test'),
+          ],
+        ),
+      )));
 
       expect(find.textContaining(RegExp(r'isatest')), findsOneWidget);
       expect(find.textContaining('isatest'), findsOneWidget);
@@ -166,11 +169,13 @@ void main() {
   });
 
   group('semantics', () {
-    testWidgets('Throws StateError if semantics are not enabled', (WidgetTester tester) async {
+    testWidgets('Throws StateError if semantics are not enabled',
+        (WidgetTester tester) async {
       expect(() => find.bySemanticsLabel('Add'), throwsStateError);
     }, semanticsEnabled: false);
 
-    testWidgets('finds Semantically labeled widgets', (WidgetTester tester) async {
+    testWidgets('finds Semantically labeled widgets',
+        (WidgetTester tester) async {
       final SemanticsHandle semanticsHandle = tester.ensureSemantics();
       await tester.pumpWidget(_boilerplate(
         Semantics(
@@ -186,7 +191,8 @@ void main() {
       semanticsHandle.dispose();
     });
 
-    testWidgets('finds Semantically labeled widgets by RegExp', (WidgetTester tester) async {
+    testWidgets('finds Semantically labeled widgets by RegExp',
+        (WidgetTester tester) async {
       final SemanticsHandle semanticsHandle = tester.ensureSemantics();
       await tester.pumpWidget(_boilerplate(
         Semantics(
@@ -202,18 +208,19 @@ void main() {
       semanticsHandle.dispose();
     });
 
-    testWidgets('finds Semantically labeled widgets without explicit Semantics', (WidgetTester tester) async {
+    testWidgets('finds Semantically labeled widgets without explicit Semantics',
+        (WidgetTester tester) async {
       final SemanticsHandle semanticsHandle = tester.ensureSemantics();
-      await tester.pumpWidget(_boilerplate(
-        const SimpleCustomSemanticsWidget('Foo')
-      ));
+      await tester
+          .pumpWidget(_boilerplate(const SimpleCustomSemanticsWidget('Foo')));
       expect(find.bySemanticsLabel('Foo'), findsOneWidget);
       semanticsHandle.dispose();
     });
   });
 
   group('hitTestable', () {
-    testWidgets('excludes non-hit-testable widgets', (WidgetTester tester) async {
+    testWidgets('excludes non-hit-testable widgets',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         _boilerplate(IndexedStack(
           sizing: StackFit.expand,
@@ -221,13 +228,13 @@ void main() {
             GestureDetector(
               key: const ValueKey<int>(0),
               behavior: HitTestBehavior.opaque,
-              onTap: () { },
+              onTap: () {},
               child: const SizedBox.expand(),
             ),
             GestureDetector(
               key: const ValueKey<int>(1),
               behavior: HitTestBehavior.opaque,
-              onTap: () { },
+              onTap: () {},
               child: const SizedBox.expand(),
             ),
           ],
@@ -258,49 +265,51 @@ void main() {
     // candidates, it should find 1 instead of 2. If the _LastFinder wasn't
     // correctly chained after the descendant's candidates, the last element
     // with a Text widget would have been 2.
-    final Text text = find.descendant(
-      of: find.byKey(key1),
-      matching: find.byType(Text),
-    ).last.evaluate().single.widget as Text;
+    final Text text = find
+        .descendant(
+          of: find.byKey(key1),
+          matching: find.byType(Text),
+        )
+        .last
+        .evaluate()
+        .single
+        .widget as Text;
 
     expect(text.data, '1');
   });
 
   testWidgets('finds multiple subtypes', (WidgetTester tester) async {
-    await tester.pumpWidget(_boilerplate(Row(children: <Widget>[
-      Column(children: const <Widget>[
-        Text('Hello'),
-        Text('World'),
+    await tester.pumpWidget(_boilerplate(
+      Row(children: <Widget>[
+        Column(children: const <Widget>[
+          Text('Hello'),
+          Text('World'),
+        ]),
+        Column(children: <Widget>[
+          Image(image: FileImage(File('test'))),
+        ]),
+        Column(children: const <Widget>[
+          SimpleGenericWidget<int>(child: Text('one')),
+          SimpleGenericWidget<double>(child: Text('pi')),
+          SimpleGenericWidget<String>(child: Text('two')),
+        ]),
       ]),
-      Column(children: <Widget>[
-        Image(image: FileImage(File('test'))),
-      ]),
-      PopupMenuButton<int>(
-          itemBuilder: (BuildContext context) => <PopupMenuItem<int>>[
-                const PopupMenuItem<int>(value: 1, child: Text('one')),
-              ]),
-      PopupMenuButton<double>(
-          itemBuilder: (BuildContext context) => <PopupMenuItem<double>>[
-                const PopupMenuItem<double>(value: 3.14, child: Text('pi')),
-              ]),
-      PopupMenuButton<String>(
-          itemBuilder: (BuildContext context) => <PopupMenuItem<String>>[
-                const PopupMenuItem<String>(value: '2', child: Text('two')),
-              ]),
-    ])));
+    ));
 
     expect(find.bySubtype<Row>(), findsOneWidget);
-    expect(find.bySubtype<Column>(), findsNWidgets(2));
+    expect(find.bySubtype<Column>(), findsNWidgets(3));
     // Finds both rows and columns.
-    expect(find.bySubtype<Flex>(), findsNWidgets(3));
+    expect(find.bySubtype<Flex>(), findsNWidgets(4));
 
     // Finds only the requested generic subtypes.
-    expect(find.bySubtype<PopupMenuButton<int>>(), findsOneWidget);
-    expect(find.bySubtype<PopupMenuButton<num>>(), findsNWidgets(2));
-    expect(find.bySubtype<PopupMenuButton<Object>>(), findsNWidgets(3));
+    expect(find.bySubtype<SimpleGenericWidget<int>>(), findsOneWidget);
+    expect(find.bySubtype<SimpleGenericWidget<num>>(), findsNWidgets(2));
+    expect(find.bySubtype<SimpleGenericWidget<Object>>(), findsNWidgets(3));
 
     // Finds all widgets.
-    expect(find.bySubtype<Widget>(), findsNWidgets(12));
+    final int totalWidgetCount =
+        find.byWidgetPredicate((_) => true).evaluate().length;
+    expect(find.bySubtype<Widget>(), findsNWidgets(totalWidgetCount));
   });
 }
 
@@ -317,7 +326,8 @@ class SimpleCustomSemanticsWidget extends LeafRenderObjectWidget {
   final String label;
 
   @override
-  RenderObject createRenderObject(BuildContext context) => SimpleCustomSemanticsRenderObject(label);
+  RenderObject createRenderObject(BuildContext context) =>
+      SimpleCustomSemanticsRenderObject(label);
 }
 
 class SimpleCustomSemanticsRenderObject extends RenderBox {
@@ -336,6 +346,21 @@ class SimpleCustomSemanticsRenderObject extends RenderBox {
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
-    config..label = label..textDirection = TextDirection.ltr;
+    config
+      ..label = label
+      ..textDirection = TextDirection.ltr;
+  }
+}
+
+class SimpleGenericWidget<T> extends StatelessWidget {
+  const SimpleGenericWidget({required Widget child, Key? key})
+      : _child = child,
+        super(key: key);
+
+  final Widget _child;
+
+  @override
+  Widget build(BuildContext context) {
+    return _child;
   }
 }


### PR DESCRIPTION
This finder is like `byType`, but also matches subtypes, and allows you to write the type as a type argument.
That avoids having to go through hoops to create a `Type` object for, say, `PopupMenuButton<Something>`, which isn't currently a Dart type literal.
It also allows us to restrict the type to `T extends Widget`, which a `Type` object argument doesn't, so the function is slightly more type-safe than `byType`.

Fixes #91298

## Pre-launch Checklist

- [ x I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes

