### PR TITLE
Flutter plugin link updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and see the results instantly without restarting your app or losing its state.
 ### Extensible and open model
 
 Flutter works with any development tool (or none at all) but includes editor
-plug-ins for both [Visual Studio Code] and [Flutter IntelliJ] / [Android Studio]. Flutter
+plug-ins for both [Visual Studio Code] and [Flutter-IntelliJ] / [Android Studio]. Flutter
 provides [thousands of packages][Flutter packages] to speed your development,
 regardless of your target platform. And accessing other native code is easy,
 with support for both [FFI] and [platform-specific APIs][platform channels].
@@ -89,7 +89,7 @@ Information on how to get started can be found in our
 [Hot reload animation]: https://github.com/flutter/website/blob/main/src/assets/images/docs/tools/android-studio/hot-reload.gif?raw=true
 [Hot reload]: https://flutter.dev/docs/development/tools/hot-reload
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
-[Flutter IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
+[Flutter-IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
 [Android Studio]: https://flutter.dev/docs/development/tools/android-studio
 [Flutter packages]: https://pub.dev/flutter
 [FFI]: https://flutter.dev/docs/development/platform-integration/c-interop

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and see the results instantly without restarting your app or losing its state.
 ### Extensible and open model
 
 Flutter works with any development tool (or none at all) but includes editor
-plug-ins for both [Visual Studio Code] and [IntelliJ] / [Android Studio]. Flutter
+plug-ins for both [Visual Studio Code] and [Flutter IntelliJ] / [Android Studio]. Flutter
 provides [thousands of packages][Flutter packages] to speed your development,
 regardless of your target platform. And accessing other native code is easy,
 with support for both [FFI] and [platform-specific APIs][platform channels].
@@ -89,7 +89,7 @@ Information on how to get started can be found in our
 [Hot reload animation]: https://github.com/flutter/website/blob/main/src/assets/images/docs/tools/android-studio/hot-reload.gif?raw=true
 [Hot reload]: https://flutter.dev/docs/development/tools/hot-reload
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
-[IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
+[Flutter IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
 [Android Studio]: https://flutter.dev/docs/development/tools/android-studio
 [Flutter packages]: https://pub.dev/flutter
 [FFI]: https://flutter.dev/docs/development/platform-integration/c-interop

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and see the results instantly without restarting your app or losing its state.
 ### Extensible and open model
 
 Flutter works with any development tool (or none at all) but includes editor
-plug-ins for both [Visual Studio Code] and [IntelliJ / Android Studio]. Flutter
+plug-ins for both [Visual Studio Code] and [IntelliJ] / [Android-Studio]. Flutter
 provides [thousands of packages][Flutter packages] to speed your development,
 regardless of your target platform. And accessing other native code is easy,
 with support for both [FFI] and [platform-specific APIs][platform channels].
@@ -89,7 +89,8 @@ Information on how to get started can be found in our
 [Hot reload animation]: https://github.com/flutter/website/blob/main/src/assets/images/docs/tools/android-studio/hot-reload.gif?raw=true
 [Hot reload]: https://flutter.dev/docs/development/tools/hot-reload
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
-[IntelliJ / Android Studio]: https://plugins.jetbrains.com/plugin/9212-flutter
+[IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
+[Android-Studio]: https://flutter.dev/docs/development/tools/android-studio
 [Flutter packages]: https://pub.dev/flutter
 [FFI]: https://flutter.dev/docs/development/platform-integration/c-interop
 [platform channels]: https://flutter.dev/docs/development/platform-integration/platform-channels

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and see the results instantly without restarting your app or losing its state.
 
 Flutter works with any development tool (or none at all) but includes editor
 plug-ins for both [Visual Studio Code] and [IntelliJ] / [Android Studio]. Flutter
-provides [thousands of packages][Flutter packages] to speed your developmnt,
+provides [thousands of packages][Flutter packages] to speed your development,
 regardless of your target platform. And accessing other native code is easy,
 with support for both [FFI] and [platform-specific APIs][platform channels].
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ and see the results instantly without restarting your app or losing its state.
 ### Extensible and open model
 
 Flutter works with any development tool (or none at all) but includes editor
-plug-ins for both [Visual Studio Code] and [IntelliJ] / [Android-Studio]. Flutter
-provides [thousands of packages][Flutter packages] to speed your development,
+plug-ins for both [Visual Studio Code] and [IntelliJ] / [Android Studio]. Flutter
+provides [thousands of packages][Flutter packages] to speed your developmnt,
 regardless of your target platform. And accessing other native code is easy,
 with support for both [FFI] and [platform-specific APIs][platform channels].
 
@@ -90,7 +90,7 @@ Information on how to get started can be found in our
 [Hot reload]: https://flutter.dev/docs/development/tools/hot-reload
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
 [IntelliJ]: https://plugins.jetbrains.com/plugin/9212-flutter
-[Android-Studio]: https://flutter.dev/docs/development/tools/android-studio
+[Android Studio]: https://flutter.dev/docs/development/tools/android-studio
 [Flutter packages]: https://pub.dev/flutter
 [FFI]: https://flutter.dev/docs/development/platform-integration/c-interop
 [platform channels]: https://flutter.dev/docs/development/platform-integration/platform-channels


### PR DESCRIPTION
To configure Flutter plugin in Android Studio the link has been updated

I have replaced the Flutter plugin download link for Android Studio IDE it was misplaced by Visual Studio Code plugin Link.

By updating the link, Beginners will get correct information to download the Flutter plugin in Android Studio IDE.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
