### PR TITLE
Enable `avoid_print` lint.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -71,8 +71,8 @@ linter:
     - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators
-    # - avoid_positional_boolean_parameters # not yet tested
-    # - avoid_print # not yet tested
+    # - avoid_positional_boolean_parameters # would have been nice to enable this but by now there's too many places that break it
+    - avoid_print
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
     # - avoid_redundant_argument_values # not yet tested
     - avoid_relative_lib_imports

--- a/dev/analysis_options.yaml
+++ b/dev/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false # We use prints as debugging tools here all the time.

--- a/dev/automated_tests/flutter_test/flutter_gold_expectation.txt
+++ b/dev/automated_tests/flutter_test/flutter_gold_expectation.txt
@@ -1,0 +1,7 @@
+[0-9]+:[0-9]+ [+]0: Local passes non-existent baseline for new test, null expectation *
+ *No expectations provided by Skia Gold for test: library.flutter.new_golden_test.1. This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.
+ *Validate image output found at flutter/test/library/
+[0-9]+:[0-9]+ [+]1: Local passes non-existent baseline for new test, empty expectation *
+ *No expectations provided by Skia Gold for test: library.flutter.new_golden_test.2. This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.
+ *Validate image output found at flutter/test/library/
+[0-9]+:[0-9]+ [+]2: All tests passed! *

--- a/dev/automated_tests/flutter_test/flutter_gold_test.dart
+++ b/dev/automated_tests/flutter_test/flutter_gold_test.dart
@@ -1,0 +1,77 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// See also packages/flutter_goldens/test/flutter_goldens_test.dart
+
+import 'dart:typed_data';
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_goldens/flutter_goldens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:platform/platform.dart';
+
+// 1x1 colored pixel
+const List<int> _kFailPngBytes = <int>[137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0,
+  13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137,
+  0, 0, 0, 13, 73, 68, 65, 84, 120, 1, 99, 249, 207, 240, 255, 63, 0, 7, 18, 3,
+  2, 164, 147, 160, 197, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130];
+
+void main() {
+  final MemoryFileSystem fs = MemoryFileSystem();
+  final Directory basedir = fs.directory('flutter/test/library/')
+    ..createSync(recursive: true);
+  final FakeSkiaGoldClient fakeSkiaClient = FakeSkiaGoldClient()
+    ..expectationForTestValues['flutter.new_golden_test.1'] = '';
+  final FlutterLocalFileComparator comparator = FlutterLocalFileComparator(
+    basedir.uri,
+    fakeSkiaClient,
+    fs: fs,
+    platform: FakePlatform(
+      environment: <String, String>{'FLUTTER_ROOT': '/flutter'},
+      operatingSystem: 'macos'
+    ),
+  );
+
+  test('Local passes non-existent baseline for new test, null expectation', () async {
+    expect(
+      await comparator.compare(
+        Uint8List.fromList(_kFailPngBytes),
+        Uri.parse('flutter.new_golden_test.1'),
+      ),
+      isTrue,
+    );
+  });
+
+  test('Local passes non-existent baseline for new test, empty expectation', () async {
+    expect(
+      await comparator.compare(
+        Uint8List.fromList(_kFailPngBytes),
+        Uri.parse('flutter.new_golden_test.2'),
+      ),
+      isTrue,
+    );
+  });
+}
+
+// See also packages/flutter_goldens/test/flutter_goldens_test.dart
+class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
+  Map<String, String> expectationForTestValues = <String, String>{};
+  Object? getExpectationForTestThrowable;
+  @override
+  Future<String> getExpectationForTest(String testName) async {
+    if (getExpectationForTestThrowable != null) {
+      throw getExpectationForTestThrowable!;
+    }
+    return expectationForTestValues[testName] ?? '';
+  }
+
+  Map<String, List<int>> imageBytesValues = <String, List<int>>{};
+  @override
+  Future<List<int>> getImageBytes(String imageHash) async => imageBytesValues[imageHash]!;
+
+  Map<String, String> cleanTestNameValues = <String, String>{};
+  @override
+  String cleanTestName(String fileName) => cleanTestNameValues[fileName] ?? '';
+}

--- a/dev/automated_tests/flutter_test/working_directory_test.dart
+++ b/dev/automated_tests/flutter_test/working_directory_test.dart
@@ -8,5 +8,5 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 void main() {
   test('working directory is the root of this package', () {
     expect(Directory.current.path, endsWith('automated_tests'));
-   });
+  });
 }

--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -8,6 +8,8 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  flutter_goldens:
+    sdk: flutter
   integration_test:
     sdk: flutter
   test: 1.17.12

--- a/dev/conductor/core/analysis_options.yaml
+++ b/dev/conductor/core/analysis_options.yaml
@@ -1,12 +1,10 @@
-# Use the analysis options settings from the top level of the repo (not
-# the ones from above, which include the `public_member_api_docs` rule).
-
-include: ../../../analysis_options.yaml
+include: ../../analysis_options.yaml
 
 analyzer:
   exclude:
-      # Ignore protoc generated files
+    # Ignore protoc generated files
     - "lib/src/proto/*"
+
 linter:
   rules:
     avoid_catches_without_on_clauses: true

--- a/dev/conductor/ui/analysis_options.yaml
+++ b/dev/conductor/ui/analysis_options.yaml
@@ -1,7 +1,4 @@
-# Use the analysis options settings from the top level of the repo (not
-# the ones from above, which include the `public_member_api_docs` rule).
-
-include: ../../../analysis_options.yaml
+include: ../../analysis_options.yaml
 
 linter:
   rules:

--- a/dev/devicelab/analysis_options.yaml
+++ b/dev/devicelab/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: ../../analysis_options.yaml
+include: ../analysis_options.yaml
 
 linter:
   rules:

--- a/dev/integration_tests/flutter_gallery/analysis_options.yaml
+++ b/dev/integration_tests/flutter_gallery/analysis_options.yaml
@@ -1,7 +1,4 @@
-# Take our settings from the repo's main analysis_options.yaml file, but add
-# an exclude for the build directory.
-
-include: ../../../analysis_options.yaml
+include: ../../analysis_options.yaml
 
 analyzer:
   exclude:

--- a/examples/api/lib/material/autocomplete/autocomplete.0.dart
+++ b/examples/api/lib/material/autocomplete/autocomplete.0.dart
@@ -47,7 +47,7 @@ class AutocompleteBasicExample extends StatelessWidget {
         });
       },
       onSelected: (String selection) {
-        print('You just selected $selection');
+        debugPrint('You just selected $selection');
       },
     );
   }

--- a/examples/api/lib/material/autocomplete/autocomplete.1.dart
+++ b/examples/api/lib/material/autocomplete/autocomplete.1.dart
@@ -79,7 +79,7 @@ class AutocompleteBasicUserExample extends StatelessWidget {
         });
       },
       onSelected: (User selection) {
-        print('You just selected ${_displayStringForOption(selection)}');
+        debugPrint('You just selected ${_displayStringForOption(selection)}');
       },
     );
   }

--- a/examples/api/lib/material/card/card.1.dart
+++ b/examples/api/lib/material/card/card.1.dart
@@ -35,7 +35,7 @@ class MyStatelessWidget extends StatelessWidget {
         child: InkWell(
           splashColor: Colors.blue.withAlpha(30),
           onTap: () {
-            print('Card tapped.');
+            debugPrint('Card tapped.');
           },
           child: const SizedBox(
             width: 300,

--- a/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
+++ b/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
@@ -59,7 +59,7 @@ class LinkedLabelCheckbox extends StatelessWidget {
                 ),
                 recognizer: TapGestureRecognizer()
                   ..onTap = () {
-                    print('Label has been tapped.');
+                    debugPrint('Label has been tapped.');
                   },
               ),
             ),

--- a/examples/api/lib/material/floating_action_button_location/standard_fab_location.0.dart
+++ b/examples/api/lib/material/floating_action_button_location/standard_fab_location.0.dart
@@ -45,7 +45,7 @@ class MyStatelessWidget extends StatelessWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          print('FAB pressed.');
+          debugPrint('FAB pressed.');
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),

--- a/examples/api/lib/material/outlined_button/outlined_button.0.dart
+++ b/examples/api/lib/material/outlined_button/outlined_button.0.dart
@@ -34,7 +34,7 @@ class MyStatelessWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return OutlinedButton(
       onPressed: () {
-        print('Received click');
+        debugPrint('Received click');
       },
       child: const Text('Click Me'),
     );

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
@@ -64,7 +64,7 @@ class LinkedLabelRadio extends StatelessWidget {
               ),
               recognizer: TapGestureRecognizer()
                 ..onTap = () {
-                  print('Label has been tapped.');
+                  debugPrint('Label has been tapped.');
                 },
             ),
           ),

--- a/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
+++ b/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
@@ -59,7 +59,7 @@ class LinkedLabelSwitch extends StatelessWidget {
                 ),
                 recognizer: TapGestureRecognizer()
                   ..onTap = () {
-                    print('Label has been tapped.');
+                    debugPrint('Label has been tapped.');
                   },
               ),
             ),

--- a/examples/api/lib/material/text_form_field/text_form_field.1.dart
+++ b/examples/api/lib/material/text_form_field/text_form_field.1.dart
@@ -54,7 +54,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                       constraints: BoxConstraints.tight(const Size(200, 50)),
                       child: TextFormField(
                         onSaved: (String? value) {
-                          print('Value for field $index saved as "$value"');
+                          debugPrint('Value for field $index saved as "$value"');
                         },
                       ),
                     ),

--- a/examples/api/lib/widgets/actions/action_listener.0.dart
+++ b/examples/api/lib/widgets/actions/action_listener.0.dart
@@ -92,13 +92,13 @@ class MyAction extends Action<MyIntent> {
   @override
   void addActionListener(ActionListenerCallback listener) {
     super.addActionListener(listener);
-    print('Action Listener was added');
+    debugPrint('Action Listener was added');
   }
 
   @override
   void removeActionListener(ActionListenerCallback listener) {
     super.removeActionListener(listener);
-    print('Action Listener was removed');
+    debugPrint('Action Listener was removed');
   }
 
   @override

--- a/examples/api/lib/widgets/actions/actions.0.dart
+++ b/examples/api/lib/widgets/actions/actions.0.dart
@@ -34,7 +34,7 @@ class Model {
 
   int save() {
     if (isDirty.value) {
-      print('Saved Data: ${data.value}');
+      debugPrint('Saved Data: ${data.value}');
       isDirty.value = false;
     }
     return data.value;

--- a/examples/api/lib/widgets/focus_manager/focus_node.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.0.dart
@@ -57,21 +57,21 @@ class _ColorfulButtonState extends State<ColorfulButton> {
 
   KeyEventResult _handleKeyPress(FocusNode node, RawKeyEvent event) {
     if (event is RawKeyDownEvent) {
-      print('Focus node ${node.debugLabel} got key event: ${event.logicalKey}');
+      debugPrint('Focus node ${node.debugLabel} got key event: ${event.logicalKey}');
       if (event.logicalKey == LogicalKeyboardKey.keyR) {
-        print('Changing color to red.');
+        debugPrint('Changing color to red.');
         setState(() {
           _color = Colors.red;
         });
         return KeyEventResult.handled;
       } else if (event.logicalKey == LogicalKeyboardKey.keyG) {
-        print('Changing color to green.');
+        debugPrint('Changing color to green.');
         setState(() {
           _color = Colors.green;
         });
         return KeyEventResult.handled;
       } else if (event.logicalKey == LogicalKeyboardKey.keyB) {
-        print('Changing color to blue.');
+        debugPrint('Changing color to blue.');
         setState(() {
           _color = Colors.blue;
         });

--- a/examples/api/lib/widgets/focus_scope/focus.0.dart
+++ b/examples/api/lib/widgets/focus_scope/focus.0.dart
@@ -38,21 +38,21 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
 
   KeyEventResult _handleKeyPress(FocusNode node, RawKeyEvent event) {
     if (event is RawKeyDownEvent) {
-      print('Focus node ${node.debugLabel} got key event: ${event.logicalKey}');
+      debugPrint('Focus node ${node.debugLabel} got key event: ${event.logicalKey}');
       if (event.logicalKey == LogicalKeyboardKey.keyR) {
-        print('Changing color to red.');
+        debugPrint('Changing color to red.');
         setState(() {
           _color = Colors.red;
         });
         return KeyEventResult.handled;
       } else if (event.logicalKey == LogicalKeyboardKey.keyG) {
-        print('Changing color to green.');
+        debugPrint('Changing color to green.');
         setState(() {
           _color = Colors.green;
         });
         return KeyEventResult.handled;
       } else if (event.logicalKey == LogicalKeyboardKey.keyB) {
-        print('Changing color to blue.');
+        debugPrint('Changing color to blue.');
         setState(() {
           _color = Colors.blue;
         });

--- a/examples/api/lib/widgets/focus_scope/focus_scope.0.dart
+++ b/examples/api/lib/widgets/focus_scope/focus_scope.0.dart
@@ -115,7 +115,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                 // This button would be not visible, but still focusable from
                 // the foreground pane without the FocusScope.
                 ElevatedButton(
-                  onPressed: () => print('You pressed the other button!'),
+                  onPressed: () => debugPrint('You pressed the other button!'),
                   child: const Text('ANOTHER BUTTON TO FOCUS'),
                 ),
                 DefaultTextStyle(

--- a/examples/api/lib/widgets/focus_traversal/focus_traversal_group.0.dart
+++ b/examples/api/lib/widgets/focus_traversal/focus_traversal_group.0.dart
@@ -68,7 +68,7 @@ class _OrderedButtonState<T> extends State<OrderedButton<T>> {
 
   void _handleOnPressed() {
     focusNode.requestFocus();
-    print('Button ${widget.name} pressed.');
+    debugPrint('Button ${widget.name} pressed.');
     debugDumpFocusTree();
   }
 

--- a/examples/api/lib/widgets/focus_traversal/ordered_traversal_policy.0.dart
+++ b/examples/api/lib/widgets/focus_traversal/ordered_traversal_policy.0.dart
@@ -40,7 +40,7 @@ class DemoButton extends StatelessWidget {
   final double order;
 
   void _handleOnPressed() {
-    print('Button $name pressed.');
+    debugPrint('Button $name pressed.');
     debugDumpFocusTree();
   }
 

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -122,10 +122,10 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
                   cellWidth: _cellWidth,
                   builder: (BuildContext context, int row, int column) {
                     if (!_isCellVisible(row, column, viewport)) {
-                      print('removing cell ($row, $column)');
+                      debugPrint('removing cell ($row, $column)');
                       return Container(height: _cellHeight);
                     }
-                    print('building cell ($row, $column)');
+                    debugPrint('building cell ($row, $column)');
                     return Container(
                       height: _cellHeight,
                       color: row % 2 + column % 2 == 1

--- a/examples/api/lib/widgets/notification_listener/notification.0.dart
+++ b/examples/api/lib/widgets/notification_listener/notification.0.dart
@@ -45,9 +45,9 @@ class MyStatelessWidget extends StatelessWidget {
         body: NotificationListener<ScrollNotification>(
           onNotification: (ScrollNotification scrollNotification) {
             if (scrollNotification is ScrollStartNotification) {
-              print('Scrolling has started');
+              debugPrint('Scrolling has started');
             } else if (scrollNotification is ScrollEndNotification) {
-              print('Scrolling has ended');
+              debugPrint('Scrolling has ended');
             }
             // Return true to cancel the notification bubbling.
             return true;

--- a/examples/image_list/lib/main.dart
+++ b/examples/image_list/lib/main.dart
@@ -98,7 +98,7 @@ Future<void> main() async {
   final HttpServer httpServer =
       await HttpServer.bindSecure('localhost', 0, serverContext);
   final int port = httpServer.port;
-  print('Listening on port $port.');
+  debugPrint('Listening on port $port.');
 
   // Initializes bindings before using any platform channels.
   WidgetsFlutterBinding.ensureInitialized();
@@ -193,7 +193,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
     ).toList();
     final DateTime started = DateTime.now();
     Future.wait(futures).then((_) {
-      print(
+      debugPrint(
         '===image_list=== all loaded in ${DateTime.now().difference(started).inMilliseconds}ms.',
       );
     });

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -47,8 +47,8 @@ class Calculator {
       final int n = result.length;
       onResultListener('Decoded $n results');
     } catch (e, stack) {
-      print('Invalid JSON file: $e');
-      print(stack);
+      debugPrint('Invalid JSON file: $e');
+      debugPrint('$stack');
     }
   }
 

--- a/packages/flutter/lib/src/foundation/print.dart
+++ b/packages/flutter/lib/src/foundation/print.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file implements debugPrint in terms of print, so avoiding
+// calling "print" is sort of a non-starter here...
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:collection';
 

--- a/packages/flutter/test/services/text_input_utils.dart
+++ b/packages/flutter/test/services/text_input_utils.dart
@@ -42,6 +42,7 @@ class FakeTextChannel implements MethodChannel {
 
   void validateOutgoingMethodCalls(List<MethodCall> calls) {
     expect(outgoingCalls.length, calls.length);
+    final StringBuffer output = StringBuffer();
     bool hasError = false;
     for (int i = 0; i < calls.length; i++) {
       final ByteData outgoingData = codec.encodeMethodCall(outgoingCalls[i]);
@@ -50,7 +51,7 @@ class FakeTextChannel implements MethodChannel {
       final String expectedString = utf8.decode(expectedData.buffer.asUint8List());
 
       if (outgoingString != expectedString) {
-        print(
+        output.writeln(
           'Index $i did not match:\n'
           '  actual:   $outgoingString\n'
           '  expected: $expectedString',
@@ -59,7 +60,7 @@ class FakeTextChannel implements MethodChannel {
       }
     }
     if (hasError) {
-      fail('Calls did not match.');
+      fail('Calls did not match:\n$output');
     }
   }
 }

--- a/packages/flutter/test/widgets/multichild_test.dart
+++ b/packages/flutter/test/widgets/multichild_test.dart
@@ -26,7 +26,7 @@ void checkTree(WidgetTester tester, List<BoxDecoration> expectedDecorations) {
     }
     expect(child, isNull);
   } catch (e) {
-    print(renderObject.toStringDeep());
+    debugPrint(renderObject.toStringDeep());
     rethrow;
   }
 }

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -41,7 +41,7 @@ void checkTree(WidgetTester tester, List<TestParentData> expectedParentData) {
     }
     expect(child, isNull);
   } catch (e) {
-    print(renderObject.toStringDeep());
+    debugPrint(renderObject.toStringDeep());
     rethrow;
   }
 }

--- a/packages/flutter/test_private/analysis_options.yaml
+++ b/packages/flutter/test_private/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false # This is a CLI tool, so printing to the console is fine.

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -50,7 +50,7 @@ class VMServiceFlutterDriver extends FlutterDriver {
       // TODO(awdavies): Use something other than print. On fuchsia
       // `stderr`/`stdout` appear to have issues working correctly.
       driverLog = (String source, String message) {
-        print('$source: $message');
+        print('$source: $message'); // ignore: avoid_print
       };
       fuchsiaModuleTarget ??= Platform.environment['FUCHSIA_MODULE_TARGET'];
       if (fuchsiaModuleTarget == null) {

--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -222,11 +222,7 @@ class WebFlutterDriver extends FlutterDriver {
 class FlutterWebConnection {
   /// Creates a FlutterWebConnection with WebDriver
   /// and whether the WebDriver supports timeline action.
-  FlutterWebConnection(this._driver, this.supportsTimelineAction) {
-    _driver.logs.get(async_io.LogType.browser).listen((async_io.LogEntry entry) {
-      print('[${entry.level}]: ${entry.message}');
-    });
-  }
+  FlutterWebConnection(this._driver, this.supportsTimelineAction);
 
   final async_io.WebDriver _driver;
 

--- a/packages/flutter_driver/test/common.dart
+++ b/packages/flutter_driver/test/common.dart
@@ -20,7 +20,7 @@ void tryToDelete(Directory directory) {
   try {
     directory.deleteSync(recursive: true);
   } on FileSystemException catch (error) {
-    print('Failed to delete ${directory.path}: $error');
+    driverLog('test', 'Failed to delete ${directory.path}: $error');
   }
 }
 

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -385,9 +385,11 @@ class FlutterSkippingFileComparator extends FlutterGoldenFileComparator {
 
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) async {
-    print(
-      'Skipping "$golden" test : $reason'
-    );
+    // Ideally we would use markTestSkipped here but in some situations,
+    // comparators are called outside of tests.
+    // See also: https://github.com/flutter/flutter/issues/91285
+    // ignore: avoid_print
+    print('Skipping "$golden" test: $reason');
     return true;
   }
 
@@ -502,8 +504,13 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     testExpectation = await skiaClient.getExpectationForTest(testName);
 
     if (testExpectation == null || testExpectation.isEmpty) {
-      // There is no baseline for this test
-      print('No expectations provided by Skia Gold for test: $golden. '
+      // There is no baseline for this test.
+      // Ideally we would use markTestSkipped here but in some situations,
+      // comparators are called outside of tests.
+      // See also: https://github.com/flutter/flutter/issues/91285
+      // ignore: avoid_print
+      print(
+        'No expectations provided by Skia Gold for test: $golden. '
         'This may be a new test. If this is an unexpected result, check '
         'https://flutter-gold.skia.org.\n'
         'Validate image output found at $basedir'

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -8,18 +8,19 @@
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
 
+// See also dev/automated_tests/flutter_test/flutter_gold_test.dart
+
 import 'dart:async';
 import 'dart:convert';
-import 'dart:core';
 import 'dart:io' hide Directory;
 import 'dart:typed_data';
 import 'dart:ui' show hashValues, hashList;
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_goldens/flutter_goldens.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
 
@@ -40,17 +41,6 @@ const List<int> _kFailPngBytes =
   1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84,
   120, 1, 99, 249, 207, 240, 255, 63, 0, 7, 18, 3, 2, 164, 147, 160, 197, 0,
   0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130];
-
-Future<void> testWithOutput(String name, Future<void> Function() body, String expectedOutput) async {
-  test(name, () async {
-    final StringBuffer output = StringBuffer();
-    void _recordPrint(Zone self, ZoneDelegate parent, Zone zone, String line) {
-      output.write(line);
-    }
-    await runZoned<Future<void>>(body, zoneSpecification: ZoneSpecification(print: _recordPrint));
-    expect(output.toString(), expectedOutput);
-  });
-}
 
 void main() {
   late MemoryFileSystem fs;
@@ -569,7 +559,6 @@ void main() {
 
         const String hash = '55109a4bed52acc780530f7a9aeff6c0';
         fakeSkiaClient.expectationForTestValues['flutter.golden_test.1'] = hash;
-        fakeSkiaClient.expectationForTestValues['flutter.new_golden_test.1'] = '';
         fakeSkiaClient.imageBytesValues[hash] =_kTestPngBytes;
         fakeSkiaClient.cleanTestNameValues['library.flutter.golden_test.1.png'] = 'flutter.golden_test.1';
       });
@@ -583,32 +572,6 @@ void main() {
           isTrue,
         );
       });
-
-      testWithOutput('passes non-existent baseline for new test, null expectation', () async {
-        expect(
-          await comparator.compare(
-            Uint8List.fromList(_kFailPngBytes),
-            Uri.parse('flutter.new_golden_test.1'),
-          ),
-          isTrue,
-        );
-      }, 'No expectations provided by Skia Gold for test: library.flutter.new_golden_test.1. '
-         'This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.\n'
-         'Validate image output found at flutter/test/library/'
-      );
-
-      testWithOutput('passes non-existent baseline for new test, empty expectation', () async {
-        expect(
-          await comparator.compare(
-            Uint8List.fromList(_kFailPngBytes),
-            Uri.parse('flutter.new_golden_test.2'),
-          ),
-          isTrue,
-        );
-      }, 'No expectations provided by Skia Gold for test: library.flutter.new_golden_test.2. '
-        'This may be a new test. If this is an unexpected result, check https://flutter-gold.skia.org.\n'
-        'Validate image output found at flutter/test/library/'
-      );
 
       test('compare properly awaits validation & output before failing.', () async {
         final Completer<bool> completer = Completer<bool>();
@@ -713,14 +676,14 @@ class FakeProcessManager extends Fake implements ProcessManager {
     workingDirectories.add(workingDirectory);
     final ProcessResult? result = processResults[RunInvocation(command.cast<String>(), workingDirectory)];
     if (result == null && fallbackProcessResult == null) {
-      // Throwing here might gobble up the exception message if a test fails.
-      print('ProcessManager.run was called with $command ($workingDirectory) unexpectedly - $processResults.');
+      printOnFailure('ProcessManager.run was called with $command ($workingDirectory) unexpectedly - $processResults.');
       fail('See above.');
     }
     return result ?? fallbackProcessResult!;
   }
 }
 
+// See also dev/automated_tests/flutter_test/flutter_gold_test.dart
 class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
   Map<String, String> expectationForTestValues = <String, String>{};
   Object? getExpectationForTestThrowable;

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -183,9 +183,10 @@ class SkiaGoldClient {
     if (result.exitCode != 0) {
       // We do not want to throw for non-zero exit codes here, as an intentional
       // change or new golden file test expect non-zero exit codes. Logging here
-      // is meant to inform when an unexpected result occurs.
-      print('goldctl imgtest add stdout: ${result.stdout}');
-      print('goldctl imgtest add stderr: ${result.stderr}');
+      // is meant to help debugging in CI when an unexpected result occurs.
+      // See also: https://github.com/flutter/flutter/issues/91285
+      print('goldctl imgtest add stdout: ${result.stdout}'); // ignore: avoid_print
+      print('goldctl imgtest add stderr: ${result.stderr}'); // ignore: avoid_print
     }
 
     return true;
@@ -301,7 +302,10 @@ class SkiaGoldClient {
           throw const FormatException('Skia gold expectations do not match expected format.');
         expectation = jsonResponse['digest'] as String?;
       } on FormatException catch (error) {
-        print(
+        // Ideally we'd use something like package:test's printOnError, but best reliabilty
+        // in getting logs on CI for now we're just using print.
+        // See also: https://github.com/flutter/flutter/issues/91285
+        print( // ignore: avoid_print
           'Formatting error detected requesting expectations from Flutter Gold.\n'
           'error: $error\n'
           'url: $requestForExpectations\n'

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -6,6 +6,8 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:path/path.dart' as path;
+import 'package:test_api/test_api.dart'; // ignore: deprecated_member_use
+
 import '_goldens_io.dart' if (dart.library.html) '_goldens_web.dart' as _goldens;
 
 /// Compares image pixels against a golden image file.
@@ -268,6 +270,10 @@ class TrivialComparator implements GoldenFileComparator {
 
   @override
   Future<bool> compare(Uint8List imageBytes, Uri golden) {
+    // Ideally we would use markTestSkipped here but in some situations,
+    // comparators are called outside of tests.
+    // See also: https://github.com/flutter/flutter/issues/91285
+    // ignore: avoid_print
     print('Golden file comparison requested for "$golden"; skipping...');
     return Future<bool>.value(true);
   }
@@ -288,6 +294,10 @@ class _TrivialWebGoldenComparator implements WebGoldenComparator {
 
   @override
   Future<bool> compare(double width, double height, Uri golden) {
+    // Ideally we would use markTestSkipped here but in some situations,
+    // comparators are called outside of tests.
+    // See also: https://github.com/flutter/flutter/issues/91285
+    // ignore: avoid_print
     print('Golden comparison requested for "$golden"; skipping...');
     return Future<bool>.value(true);
   }

--- a/packages/flutter_test/lib/src/test_compat.dart
+++ b/packages/flutter_test/lib/src/test_compat.dart
@@ -96,7 +96,7 @@ Future<void> _runLiveTest(Suite suiteConfig, LiveTest liveTest, _Reporter report
 Future<void> _runSkippedTest(Suite suiteConfig, Test test, List<Group> parents, _Reporter reporter) async {
   final LocalTest skipped = LocalTest(test.name, test.metadata, () { }, trace: test.trace);
   if (skipped.metadata.skipReason != null) {
-    print('Skip: ${skipped.metadata.skipReason}');
+    reporter.log('Skip: ${skipped.metadata.skipReason}');
   }
   final LiveTest liveTest = skipped.load(suiteConfig);
   reporter._onTestStarted(liveTest);
@@ -334,7 +334,7 @@ class _Reporter {
       if (message.type == MessageType.skip) {
         text = '  $_yellow$text$_noColor';
       }
-      print(text);
+      log(text);
     }));
   }
 
@@ -351,8 +351,8 @@ class _Reporter {
       return;
     }
     _progressLine(_description(liveTest), suffix: ' $_bold$_red[E]$_noColor');
-    print(_indent(error.toString()));
-    print(_indent('$stackTrace'));
+    log(_indent(error.toString()));
+    log(_indent('$stackTrace'));
   }
 
   /// A callback called when the engine is finished running tests.
@@ -421,7 +421,7 @@ class _Reporter {
     buffer.write(message);
     buffer.write(_noColor);
 
-    print(buffer.toString());
+    log(buffer.toString());
   }
 
   /// Returns a representation of [duration] as `MM:SS`.
@@ -441,6 +441,13 @@ class _Reporter {
       name = '${liveTest.suite.path}: $name';
     }
     return name;
+  }
+
+  /// Print the message to the console.
+  void log(String message) {
+    // We centralize all the prints in this file through this one method so that
+    // in principle we can reroute the output easily should we need to.
+    print(message); // ignore: avoid_print
   }
 }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -416,7 +416,7 @@ Future<void> benchmarkWidgets(
   assert(() {
     if (mayRunWithAsserts)
       return true;
-    print(kDebugWarning);
+    debugPrint(kDebugWarning);
     return true;
   }());
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;

--- a/packages/flutter_tools/analysis_options.yaml
+++ b/packages/flutter_tools/analysis_options.yaml
@@ -1,12 +1,11 @@
-# Use the analysis options settings from the top level of the repo (not
-# the ones from above, which include the `public_member_api_docs` rule).
-
-include: ../../analysis_options.yaml
+include: ../analysis_options.yaml
 
 linter:
   rules:
     avoid_catches_without_on_clauses: true
     curly_braces_in_flow_control_structures: true
-    library_private_types_in_public_api: false # Tool does not have any public API
+    library_private_types_in_public_api: false # Tool does not have any public API.
+    no_runtimeType_toString: false # We use runtimeType for debugging in the tool.
     prefer_relative_imports: true
+    public_member_api_docs: false # Tool does not have any public API.
     unawaited_futures: true

--- a/packages/flutter_tools/bin/analysis_options.yaml
+++ b/packages/flutter_tools/bin/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false # These are CLI tools which print as a matter of course.

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -25,6 +25,12 @@
 /// about any additional exports that you add to this file, as doing so will
 /// increase the API surface that we have to test in Flutter tools, and the APIs
 /// in `dart:io` can sometimes be hard to use in tests.
+
+// We allow `print()` in this file as a fallback for writing to the terminal via
+// regular stdout/stderr/stdio paths. Everything else in the flutter_tools
+// library should route terminal I/O through the [Stdio] class defined below.
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:io' as io
   show

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -247,6 +247,7 @@ class Cache {
       }
     } on Exception catch (error) {
       // There is currently no logger attached since this is computed at startup.
+      // ignore: avoid_print
       print(userMessages.runnerNoRoot('$error'));
     }
     return normalize('.');

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -307,6 +307,7 @@ class DaemonDomain extends Domain {
         if (message.level == 'status') {
           // We use `print()` here instead of `stdout.writeln()` in order to
           // capture the print output for testing.
+          // ignore: avoid_print
           print(message.message);
         } else if (message.level == 'error') {
           globals.stdio.stderrWrite('${message.message}\n');

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -96,7 +96,7 @@ class MacOSDevice extends DesktopDevice {
       'open', package.applicationBundle(buildMode),
     ]).then((ProcessResult result) {
       if (result.exitCode != 0) {
-        print('Failed to foreground app; open returned ${result.exitCode}');
+        _logger.printError('Failed to foreground app; open returned ${result.exitCode}');
       }
     });
   }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2723,10 +2723,9 @@ Future<void> _ensureFlutterToolsSnapshot() async {
     '../../bin/cache/dart-sdk/bin/dart',
     snapshotArgs,
   );
-  if (snapshotResult.exitCode != 0) {
-    print(snapshotResult.stdout);
-    print(snapshotResult.stderr);
-  }
+  printOnFailure('Results of generating snapshot:');
+  printOnFailure(snapshotResult.stdout.toString());
+  printOnFailure(snapshotResult.stderr.toString());
   expect(snapshotResult.exitCode, 0);
 }
 
@@ -2768,10 +2767,9 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
     workingDirectory: workingDir,
   );
   if (expectedFailures.isEmpty) {
-    if (exec.exitCode != 0) {
-      print(exec.stdout);
-      print(exec.stderr);
-    }
+    printOnFailure('Results of running analyzer:');
+    printOnFailure(exec.stdout.toString());
+    printOnFailure(exec.stderr.toString());
     expect(exec.exitCode, 0);
     return;
   }
@@ -2825,10 +2823,9 @@ Future<void> _runFlutterTest(Directory workingDir, { String target }) async {
     args,
     workingDirectory: workingDir.path,
   );
-  if (exec.exitCode != 0) {
-    print(exec.stdout);
-    print(exec.stderr);
-  }
+  printOnFailure('Output of running flutter test:');
+  printOnFailure(exec.stdout.toString());
+  printOnFailure(exec.stderr.toString());
   expect(exec.exitCode, 0);
 }
 

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -179,7 +179,6 @@ void main() {
       expect(logContents, contains('String: an exception % --'));
       expect(logContents, contains('CrashingFlutterCommand.runCommand'));
       expect(logContents, contains('[✓] Flutter'));
-      print(globals.crashReporter.runtimeType);
 
       final CrashDetails sentDetails = (globals.crashReporter as WaitingCrashReporter)._details;
       expect(sentDetails.command, 'flutter crash');

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -28,8 +28,9 @@ void main() {
       '--no-color',
       ...arguments,
     ], workingDirectory: projectPath);
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter ${arguments.join(" ")}');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.exitCode, exitCode, reason: 'Expected to exit with non-zero exit code.');
     assertContains(result.stdout.toString(), statusTextContains);
     assertContains(result.stdout.toString(), errorTextContains);

--- a/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_size_test.dart
@@ -31,8 +31,9 @@ void main() {
       '--target-platform=android-arm64'
     ], workingDirectory: workingDirectory);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter build apk:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.stdout.toString(), contains('app-release.apk (total compressed)'));
 
     final String line = result.stdout.toString()
@@ -67,8 +68,9 @@ void main() {
       '--no-codesign',
     ], workingDirectory: workingDirectory);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter build ios:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.stdout.toString(), contains('Dart AOT symbols accounted decompressed size'));
 
     final String line = result.stdout.toString()
@@ -102,8 +104,9 @@ void main() {
       '--enable-macos-desktop',
     ], workingDirectory: workingDirectory);
 
-    print(configResult.stdout);
-    print(configResult.stderr);
+    printOnFailure('Output of flutter config:');
+    printOnFailure(configResult.stdout.toString());
+    printOnFailure(configResult.stderr.toString());
 
     final ProcessResult result = await processManager.run(<String>[
       flutterBin,
@@ -113,8 +116,9 @@ void main() {
       '--code-size-directory=${codeSizeDir.path}',
     ], workingDirectory: workingDirectory);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter build macos:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.stdout.toString(), contains('Dart AOT symbols accounted decompressed size'));
 
     final String line = result.stdout.toString()
@@ -147,8 +151,9 @@ void main() {
       '--debug',
     ], workingDirectory: fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world'));
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter build apk:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.stderr.toString(), contains('"--analyze-size" can only be used on release builds'));
 
     expect(result.exitCode, 1);

--- a/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
+++ b/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
@@ -34,7 +34,7 @@ void main() {
     final Completer<void> sawBackgroundMessage = Completer<void>.sync();
     final Completer<void> sawNewBackgroundMessage = Completer<void>.sync();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
-        print('[LOG]:"$line"');
+        printOnFailure('[LOG]:"$line"');
         if (line.contains('Main thread') && !sawForegroundMessage.isCompleted) {
           sawForegroundMessage.complete();
         }
@@ -68,7 +68,7 @@ void main() {
     final Completer<void> sawBackgroundMessage = Completer<void>.sync();
     final Completer<void> sawNewBackgroundMessage = Completer<void>.sync();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
-        print('[LOG]:"$line"');
+        printOnFailure('[LOG]:"$line"');
         if (line.contains('Isolate thread') && !sawBackgroundMessage.isCompleted) {
           sawBackgroundMessage.complete();
         }

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -33,8 +33,9 @@ void main() {
       '--no-codesign',
     ], workingDirectory: workingDirectory);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of flutter build ios:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
 
     expect(result.exitCode, 0);
 

--- a/packages/flutter_tools/test/integration.shard/cache_test.dart
+++ b/packages/flutter_tools/test/integration.shard/cache_test.dart
@@ -64,11 +64,7 @@ Future<void> main(List<String> args) async {
           await cache.lock();
           process.kill(io.ProcessSignal.sigkill);
         } finally {
-          try {
-            tempDir.deleteSync(recursive: true);
-          } on FileSystemException {
-            // Ignore filesystem exceptions when trying to delete tempdir.
-          }
+          tryToDelete(tempDir);
           Cache.flutterRoot = oldRoot;
         }
         expect(logger.statusText, isEmpty);

--- a/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deprecated_gradle_settings_test.dart
@@ -26,8 +26,10 @@ void main() {
       '--target-platform', 'android-arm',
       '--verbose',
     ], workingDirectory: woringDirectory);
-    print(result.stdout);
-    print(result.stderr);
+
+    printOnFailure('Output of flutter build apk:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
 
     expect(result.exitCode, 0);
 

--- a/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
+++ b/packages/flutter_tools/test/integration.shard/downgrade_upgrade_integration_test.dart
@@ -38,11 +38,7 @@ void main() {
   });
 
   tearDown(() {
-    try {
-      parentDirectory.deleteSync(recursive: true);
-    } on FileSystemException {
-      print('Failed to delete test directory');
-    }
+    tryToDelete(parentDirectory);
   });
 
   testWithoutContext('Can upgrade and downgrade a Flutter checkout', () async {
@@ -56,7 +52,7 @@ void main() {
       'git', 'config', '--system', 'core.longpaths', 'true',
     ]);
 
-    print('Step 1 - clone the $_kBranch of flutter into the test directory');
+    printOnFailure('Step 1 - clone the $_kBranch of flutter into the test directory');
     exitCode = await processUtils.stream(<String>[
       'git',
       'clone',
@@ -64,7 +60,7 @@ void main() {
     ], workingDirectory: parentDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 2 - switch to the $_kBranch');
+    printOnFailure('Step 2 - switch to the $_kBranch');
     exitCode = await processUtils.stream(<String>[
       'git',
       'checkout',
@@ -75,7 +71,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 3 - revert back to $_kInitialVersion');
+    printOnFailure('Step 3 - revert back to $_kInitialVersion');
     exitCode = await processUtils.stream(<String>[
       'git',
       'reset',
@@ -84,7 +80,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 4 - upgrade to the newest $_kBranch');
+    printOnFailure('Step 4 - upgrade to the newest $_kBranch');
     // This should update the persistent tool state with the sha for HEAD
     exitCode = await processUtils.stream(<String>[
       flutterBin,
@@ -94,7 +90,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 5 - verify that the version is different');
+    printOnFailure('Step 5 - verify that the version is different');
     final RunResult versionResult = await processUtils.run(<String>[
       'git',
       'describe',
@@ -104,10 +100,9 @@ void main() {
       '--tags',
     ], workingDirectory: testDirectory.path);
     expect(versionResult.stdout, isNot(contains(_kInitialVersion)));
-    print('current version is ${versionResult.stdout.trim()}\ninitial was $_kInitialVersion');
+    printOnFailure('current version is ${versionResult.stdout.trim()}\ninitial was $_kInitialVersion');
 
-    print('Step 6 - downgrade back to the initial version');
-    // Step 6. Downgrade back to initial version.
+    printOnFailure('Step 6 - downgrade back to the initial version');
     exitCode = await processUtils.stream(<String>[
        flutterBin,
       'downgrade',
@@ -116,8 +111,7 @@ void main() {
     ], workingDirectory: testDirectory.path, trace: true);
     expect(exitCode, 0);
 
-    print('Step 7 - verify downgraded version matches original version');
-    // Step 7. Verify downgraded version matches original version.
+    printOnFailure('Step 7 - verify downgraded version matches original version');
     final RunResult oldVersionResult = await processUtils.run(<String>[
       'git',
       'describe',
@@ -127,6 +121,6 @@ void main() {
       '--tags',
     ], workingDirectory: testDirectory.path);
     expect(oldVersionResult.stdout, contains(_kInitialVersion));
-    print('current version is ${oldVersionResult.stdout.trim()}\ninitial was $_kInitialVersion');
+    printOnFailure('current version is ${oldVersionResult.stdout.trim()}\ninitial was $_kInitialVersion');
   });
 }

--- a/packages/flutter_tools/test/integration.shard/exit_code_test.dart
+++ b/packages/flutter_tools/test/integration.shard/exit_code_test.dart
@@ -36,8 +36,9 @@ void main() {
       fileSystem.path.join(tempDir.path, 'main.dart'),
     ]);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of dart main.dart:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.exitCode, 0);
   });
 
@@ -55,8 +56,9 @@ void main() {
       fileSystem.path.join(tempDir.path, 'main.dart'),
     ]);
 
-    print(result.stdout);
-    print(result.stderr);
+    printOnFailure('Output of dart main.dart:');
+    printOnFailure(result.stdout.toString());
+    printOnFailure(result.stderr.toString());
     expect(result.exitCode, 1);
   });
 }

--- a/packages/flutter_tools/test/integration.shard/flutter_build_null_unsafe_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_null_unsafe_test.dart
@@ -67,7 +67,6 @@ String unsafeString = null;
 
   for (final String targetPlatform in targetPlatforms) {
     testWithoutContext('flutter build $targetPlatform --no-sound-null-safety', () {
-      print(tempDir);
       final ProcessResult result = processManager.runSync(<String>[
         flutterBin,
         ...getLocalEngineArguments(),

--- a/packages/flutter_tools/test/integration.shard/generated_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/integration.shard/generated_plugin_registrant_test.dart
@@ -138,10 +138,9 @@ Future<void> _ensureFlutterToolsSnapshot() async {
     '../../bin/cache/dart-sdk/bin/dart',
     snapshotArgs,
   );
-  if (snapshotResult.exitCode != 0) {
-    print(snapshotResult.stdout);
-    print(snapshotResult.stderr);
-  }
+  printOnFailure('Output of dart ${snapshotArgs.join(" ")}:');
+  printOnFailure(snapshotResult.stdout.toString());
+  printOnFailure(snapshotResult.stderr.toString());
   expect(snapshotResult.exitCode, 0);
 }
 
@@ -237,9 +236,8 @@ Future<void> _analyzeProject(Directory workingDir) async {
     args,
     workingDirectory: workingDir.path,
   );
-  if (exec.exitCode != 0) {
-    print(exec.stdout);
-    print(exec.stderr);
-  }
+  printOnFailure('Output of flutter analyze:');
+  printOnFailure(exec.stdout.toString());
+  printOnFailure(exec.stderr.toString());
   expect(exec.exitCode, 0);
 }

--- a/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_test.dart
@@ -108,8 +108,14 @@ void main() {
     await flutter.resume(); // we start paused so we can set up our TICK 1 listener before the app starts
     unawaited(sawTick1.future.timeout(
       const Duration(seconds: 5),
-      onTimeout: () { print('The test app is taking longer than expected to print its synchronization line...'); },
+      onTimeout: () {
+        // This print is useful for people debugging this test. Normally we would avoid printing in
+        // a test but this is an exception because it's useful ambient information.
+        // ignore: avoid_print
+        print('The test app is taking longer than expected to print its synchronization line...');
+      },
     ));
+    printOnFailure('waiting for synchronization line...');
     await sawTick1.future; // after this, app is in steady state
     await flutter.addBreakpoint(
       project.scheduledBreakpointUri,
@@ -126,19 +132,19 @@ void main() {
     );
     bool reloaded = false;
     final Future<void> reloadFuture = flutter.hotReload().then((void value) { reloaded = true; });
-    print('waiting for pause...');
+    printOnFailure('waiting for pause...');
     isolate = await flutter.waitForPause();
     expect(isolate.pauseEvent.kind, equals(EventKind.kPauseBreakpoint));
-    print('waiting for debugger message...');
+    printOnFailure('waiting for debugger message...');
     await sawDebuggerPausedMessage.future;
     expect(reloaded, isFalse);
-    print('waiting for resume...');
+    printOnFailure('waiting for resume...');
     await flutter.resume();
-    print('waiting for reload future...');
+    printOnFailure('waiting for reload future...');
     await reloadFuture;
     expect(reloaded, isTrue);
     reloaded = false;
-    print('subscription cancel...');
+    printOnFailure('subscription cancel...');
     await subscription.cancel();
   });
 
@@ -148,7 +154,7 @@ void main() {
     final Completer<void> sawDebuggerPausedMessage2 = Completer<void>();
     final StreamSubscription<String> subscription = flutter.stdout.listen(
       (String line) {
-        print('[LOG]:"$line"');
+        printOnFailure('[LOG]:"$line"');
         if (line.contains('(((TICK 1)))')) {
           expect(sawTick1.isCompleted, isFalse);
           sawTick1.complete();

--- a/packages/flutter_tools/test/integration.shard/hot_reload_with_asset_test.dart
+++ b/packages/flutter_tools/test/integration.shard/hot_reload_with_asset_test.dart
@@ -47,7 +47,7 @@ void main() {
         onSecondLoad.complete();
       }
     });
-    flutter.stdout.listen(print);
+    flutter.stdout.listen(printOnFailure);
     await flutter.run();
     await onFirstLoad.future;
 
@@ -74,7 +74,7 @@ void main() {
         onSecondLoad.complete();
       }
     });
-    flutter.stdout.listen(print);
+    flutter.stdout.listen(printOnFailure);
     await flutter.run();
     await onFirstLoad.future;
 

--- a/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/ios_content_validation_test.dart
@@ -29,7 +29,7 @@ void main() {
         'flutter',
       );
 
-      final ProcessResult createResult = processManager.runSync(<String>[
+      processManager.runSync(<String>[
         flutterBin,
         ...getLocalEngineArguments(),
         'create',
@@ -39,7 +39,6 @@ void main() {
         'objc',
         'hello',
       ], workingDirectory: tempDir.path);
-      print(createResult.stdout);
 
       projectRoot = tempDir.childDirectory('hello').path;
     });
@@ -59,7 +58,7 @@ void main() {
         File outputAppFrameworkBinary;
 
         setUpAll(() {
-          final ProcessResult buildResult = processManager.runSync(<String>[
+          processManager.runSync(<String>[
             flutterBin,
             ...getLocalEngineArguments(),
             'build',
@@ -70,7 +69,6 @@ void main() {
             '--obfuscate',
             '--split-debug-info=foo debug info/',
           ], workingDirectory: projectRoot);
-          print(buildResult.stdout);
 
           buildPath = fileSystem.directory(fileSystem.path.join(
             projectRoot,
@@ -125,7 +123,6 @@ void main() {
               infoPlistPath,
             ],
           );
-          print(bonjourServices.stdout);
           final bool bonjourServicesFound = (bonjourServices.stdout as String).contains('_dartobservatory._tcp');
           expect(bonjourServicesFound, buildMode == BuildMode.debug);
 
@@ -140,7 +137,6 @@ void main() {
               infoPlistPath,
             ],
           );
-          print(localNetworkUsage.stdout);
           final bool localNetworkUsageFound = localNetworkUsage.exitCode == 0;
           expect(localNetworkUsageFound, buildMode == BuildMode.debug);
         });
@@ -155,7 +151,6 @@ void main() {
               'arm64',
             ],
           );
-          print(symbols.stdout);
           final bool aotSymbolsFound = (symbols.stdout as String).contains('_kDartVmSnapshot');
           expect(aotSymbolsFound, buildMode != BuildMode.debug);
         });
@@ -197,7 +192,9 @@ void main() {
               // Skip bitcode stripping since we just checked that above.
             },
           );
-          print(xcodeBackendResult.stdout);
+          printOnFailure('Output of xcode_backend.sh:');
+          printOnFailure(xcodeBackendResult.stdout.toString());
+          printOnFailure(xcodeBackendResult.stderr.toString());
 
           expect(xcodeBackendResult.exitCode, 0);
           expect(outputFlutterFrameworkBinary.existsSync(), isTrue);
@@ -211,7 +208,6 @@ void main() {
             'hello',
             outputAppFrameworkBinary.path,
           ]);
-          print(grepResult.stdout);
           expect(grepResult.stdout, isNot(contains('matches')));
         });
       });
@@ -233,7 +229,6 @@ void main() {
           'FLUTTER_XCODE_ONLY_ACTIVE_ARCH': 'NO',
         },
       );
-      print(buildSimulator.stdout);
       // This test case would fail if arm64 or x86_64 simulators could not build.
       expect(buildSimulator.exitCode, 0);
 
@@ -251,7 +246,6 @@ void main() {
       final ProcessResult archs = processManager.runSync(
         <String>['file', simulatorAppFrameworkBinary.path],
       );
-      print(archs.stdout);
       expect(archs.stdout, contains('Mach-O 64-bit dynamically linked shared library x86_64'));
       expect(archs.stdout, contains('Mach-O 64-bit dynamically linked shared library arm64'));
     });

--- a/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
@@ -53,8 +53,9 @@ void main() {
       ];
       final ProcessResult result = processManager.runSync(buildCommand, workingDirectory: workingDirectory);
 
-      print(result.stdout);
-      print(result.stderr);
+      printOnFailure('Output of flutter build macos:');
+      printOnFailure(result.stdout.toString());
+      printOnFailure(result.stderr.toString());
       expect(result.exitCode, 0);
 
       expect(result.stdout, contains('Running pod install'));
@@ -134,8 +135,9 @@ void main() {
       // Build again without cleaning.
       final ProcessResult secondBuild = processManager.runSync(buildCommand, workingDirectory: workingDirectory);
 
-      print(secondBuild.stdout);
-      print(secondBuild.stderr);
+      printOnFailure('Output of second build:');
+      printOnFailure(secondBuild.stdout.toString());
+      printOnFailure(secondBuild.stderr.toString());
       expect(secondBuild.exitCode, 0);
 
       expect(secondBuild.stdout, isNot(contains('Running pod install')));

--- a/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
+++ b/packages/flutter_tools/test/integration.shard/observatory_port_test.dart
@@ -27,7 +27,7 @@ Future<void> waitForObservatoryMessage(Process process, int port) async {
   process.stdout
     .transform(utf8.decoder)
     .listen((String line) {
-      print(line);
+      printOnFailure(line);
       if (line.contains('An Observatory debugger and profiler on Flutter test device is available at')) {
         if (line.contains('http://127.0.0.1:$port')) {
           completer.complete();
@@ -38,7 +38,7 @@ Future<void> waitForObservatoryMessage(Process process, int port) async {
     });
   process.stderr
     .transform(utf8.decoder)
-    .listen(print);
+    .listen(printOnFailure);
   return completer.future;
 }
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -79,6 +79,10 @@ abstract class FlutterTestDriver {
       lastTime = time;
     }
     if (_printDebugOutputToStdOut) {
+      // This is the one place in this file that can call print. It is gated by
+      // _printDebugOutputToStdOut which should not be set to true in CI; it is
+      // intended only for use in local debugging.
+      // ignore: avoid_print
       print('$time$_logPrefix$line');
     }
   }

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -215,6 +215,10 @@ void main() {
     }
     expect(result.exitCode, 0);
   });
+
+  testWithoutContext('flutter gold skips tests where the expectations are missing', () async {
+    return _testFile('flutter_gold', automatedTestsDirectory, flutterTestDirectory, exitCode: isZero);
+  });
 }
 
 Future<void> _testFile(

--- a/packages/flutter_tools/test/integration.shard/timeline_test.dart
+++ b/packages/flutter_tools/test/integration.shard/timeline_test.dart
@@ -40,6 +40,8 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/79498
   testWithoutContext('Can connect to the timeline without getting ANR from the application', () async {
     final Timer timer = Timer(const Duration(minutes: 5), () {
+      // This message is intended to show up in CI logs.
+      // ignore: avoid_print
       print(
         'Warning: test isolate is still active after 5 minutes. This is likely an '
         'app-not-responding error and not a flake. See https://github.com/flutter/flutter/issues/79498 '

--- a/packages/flutter_tools/test/integration.shard/variable_expansion_windows.dart
+++ b/packages/flutter_tools/test/integration.shard/variable_expansion_windows.dart
@@ -4,5 +4,6 @@
 
 // Not a test file, invoked by `variable_expansion_windows_test.dart`.
 void main(List<String> args) {
-  print('args: $args');
+  // This print is used for communicating with the test host.
+  print('args: $args'); // ignore: avoid_print
 }

--- a/packages/flutter_tools/test/src/common.dart
+++ b/packages/flutter_tools/test/src/common.dart
@@ -27,6 +27,9 @@ void tryToDelete(Directory directory) {
       directory.deleteSync(recursive: true);
     }
   } on FileSystemException catch (error) {
+    // We print this so that it's visible in the logs, to get an idea of how
+    // common this problem is, and if any patterns are ever noticed by anyone.
+    // ignore: avoid_print
     print('Failed to delete ${directory.path}: $error');
   }
 }

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -127,7 +127,7 @@ void testUsingContext(
         },
         body: () {
           final String flutterRoot = getFlutterRoot();
-          return runZoned<Future<dynamic>>(() {
+          return runZonedGuarded<Future<dynamic>>(() {
             try {
               return context.run<dynamic>(
                 // Apply the overrides to the test context in the zone since their
@@ -148,9 +148,10 @@ void testUsingContext(
               _printBufferedErrors(context);
               rethrow;
             }
-          }, onError: (Object error, StackTrace stackTrace) { // ignore: deprecated_member_use
-            print(error);
-            print(stackTrace);
+          }, (Object error, StackTrace stackTrace) {
+            // When things fail, it's ok to print to the console!
+            print(error); // ignore: avoid_print
+            print(stackTrace); // ignore: avoid_print
             _printBufferedErrors(context);
             throw error;
           });
@@ -176,7 +177,9 @@ void _printBufferedErrors(AppContext testContext) {
   if (testContext.get<Logger>() is BufferLogger) {
     final BufferLogger bufferLogger = testContext.get<Logger>() as BufferLogger;
     if (bufferLogger.errorText.isNotEmpty) {
-      print(bufferLogger.errorText);
+      // This is where the logger outputting errors is implemented, so it has
+      // to use `print`.
+      print(bufferLogger.errorText); // ignore: avoid_print
     }
     bufferLogger.clear();
   }

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -38,7 +38,6 @@ void main() {
   testWithoutContext('newly added code executes during hot restart', () async {
     final Completer<void> completer = Completer<void>();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
-      print(line);
       if (line.contains('(((((RELOAD WORKED)))))')) {
         completer.complete();
       }
@@ -56,7 +55,6 @@ void main() {
   testWithoutContext('newly added code executes during hot restart - canvaskit', () async {
     final Completer<void> completer = Completer<void>();
     final StreamSubscription<String> subscription = flutter.stdout.listen((String line) {
-      print(line);
       if (line.contains('(((((RELOAD WORKED)))))')) {
         completer.complete();
       }

--- a/packages/flutter_tools/tool/analysis_options.yaml
+++ b/packages/flutter_tools/tool/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false # These are CLI tools which print as a matter of course.

--- a/packages/fuchsia_remote_debug_protocol/lib/src/common/logging.dart
+++ b/packages/fuchsia_remote_debug_protocol/lib/src/common/logging.dart
@@ -51,6 +51,7 @@ typedef LoggingFunction = void Function(LogMessage log);
 ///
 /// Exits with status code 1 if the `log` is [LoggingLevel.severe].
 void defaultLoggingFunction(LogMessage log) {
+  // ignore: avoid_print
   print('[${log.levelName}]::${log.tag}--${log.time}: ${log.message}');
   if (log.level == LoggingLevel.severe) {
     exit(1);

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -64,7 +64,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
           },
         );
       } on MissingPluginException {
-        print(r'''
+        debugPrint(r'''
 Warning: integration_test plugin was not detected.
 
 If you're running the tests with `flutter drive`, please make sure your tests
@@ -391,7 +391,7 @@ https://flutter.dev/docs/testing/integration-tests#testing-on-firebase-test-lab
         count++;
         await Future<void>.delayed(const Duration(seconds: 2));
         if (count > 20) {
-          print('delayForFrameTimings is taking longer than expected...');
+          debugPrint('delayForFrameTimings is taking longer than expected...');
         }
       }
     }

--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This is a CLI library; we use prints as part of the interface.
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/integration_test/lib/integration_test_driver_extended.dart
+++ b/packages/integration_test/lib/integration_test_driver_extended.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This is a CLI library; we use prints as part of the interface.
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -104,7 +104,6 @@ Future<void> main() async {
     testWidgets('Test traceAction', (WidgetTester tester) async {
       await integrationBinding.enableTimeline(vmService: fakeVM);
       await integrationBinding.traceAction(() async {});
-      print(integrationBinding.reportData);
       expect(integrationBinding.reportData, isNotNull);
       expect(integrationBinding.reportData!.containsKey('timeline'), true);
       expect(

--- a/packages/integration_test/test/data/fail_test_script.dart
+++ b/packages/integration_test/test/data/fail_test_script.dart
@@ -10,6 +10,8 @@ import 'package:integration_test/integration_test.dart';
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
   binding.allTestsPassed.future.then((_) {
+    // We use this print to communicate with ../binding_fail_test.dart
+    // ignore: avoid_print
     print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 

--- a/packages/integration_test/test/data/fail_then_pass_test_script.dart
+++ b/packages/integration_test/test/data/fail_then_pass_test_script.dart
@@ -10,6 +10,8 @@ import 'package:integration_test/integration_test.dart';
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
   binding.allTestsPassed.future.then((_) {
+    // We use this print to communicate with ../binding_fail_test.dart
+    // ignore: avoid_print
     print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 

--- a/packages/integration_test/test/data/pass_test_script.dart
+++ b/packages/integration_test/test/data/pass_test_script.dart
@@ -10,6 +10,8 @@ import 'package:integration_test/integration_test.dart';
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
   binding.allTestsPassed.future.then((_) {
+    // We use this print to communicate with ../binding_fail_test.dart
+    // ignore: avoid_print
     print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 

--- a/packages/integration_test/test/data/pass_then_fail_test_script.dart
+++ b/packages/integration_test/test/data/pass_then_fail_test_script.dart
@@ -10,6 +10,8 @@ import 'package:integration_test/integration_test.dart';
 Future<void> main() async {
   final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
   binding.allTestsPassed.future.then((_) {
+    // We use this print to communicate with ../binding_fail_test.dart
+    // ignore: avoid_print
     print('IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
   });
 


### PR DESCRIPTION
In general when we use `print` it's for one of these reasons:

1. We were debugging and forgot to remove it.

2. We meant to use a logging API but forgot (or didn't know it was there), and ended up using `print` instead. For example, Flutter code should usually use `debugPrint`, tests should generally be quiet but can use `printOnFailure` to do logging in the useful case, that kind of thing.

3. We are implementing a logging API. These are rare cases but for these we can use `// ignore`.

4. We are doing some sort of CLI. These tend to be in directories where we can selectively disable `avoid_print`.

5. It's some sort of CI thing, where we log excessively to help with debugging. These are all in `dev` and we can turn off `avoid_print` there universally.

This PR tends on the `avoid_print` lint, fixes a lot of cases of #1 and #2, adds ignores for #3, and sets up the analysis options for #4 and #5.
