### PR TITLE
Refactored ListTileTheme: ListTileThemeData, ThemeData.listThemeData

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -125,7 +125,7 @@ class AboutListTile extends StatelessWidget {
 
   /// Whether this list tile is part of a vertically dense list.
   ///
-  /// If this property is null, then its value is based on [ListTileTheme.dense].
+  /// If this property is null, then its value is based on [ListTileThemeData.dense].
   ///
   /// Dense list tiles default to a smaller height.
   final bool? dense;

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -214,7 +214,7 @@ class CheckboxListTile extends StatelessWidget {
 
   /// Whether this list tile is part of a vertically dense list.
   ///
-  /// If this property is null then its value is based on [ListTileTheme.dense].
+  /// If this property is null then its value is based on [ListTileThemeData.dense].
   final bool? dense;
 
   /// Whether to render icons and text in the [activeColor].
@@ -252,7 +252,7 @@ class CheckboxListTile extends StatelessWidget {
   /// If tristate is false (the default), [value] must not be null.
   final bool tristate;
 
-  /// {@macro flutter.material.ListTileTheme.shape}
+  /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -21,7 +21,7 @@ const Duration _kExpand = Duration(milliseconds: 200);
 /// [ExpansionTile] to save and restore its expanded state when it is scrolled
 /// in and out of view.
 ///
-/// This class overrides the [ListTileTheme.iconColor] and [ListTileTheme.textColor]
+/// This class overrides the [ListTileThemeData.iconColor] and [ListTileThemeData.textColor]
 /// theme properties for its [ListTile]. These colors animate between values when
 /// the tile is expanded and collapsed: between [iconColor], [collapsedIconColor] and
 /// between [textColor] and [collapsedTextColor].
@@ -176,23 +176,23 @@ class ExpansionTile extends StatefulWidget {
 
   /// The icon color of tile's expansion arrow icon when the sublist is expanded.
   ///
-  /// Used to override to the [ListTileTheme.iconColor].
+  /// Used to override to the [ListTileThemeData.iconColor].
   final Color? iconColor;
 
   /// The icon color of tile's expansion arrow icon when the sublist is collapsed.
   ///
-  /// Used to override to the [ListTileTheme.iconColor].
+  /// Used to override to the [ListTileThemeData.iconColor].
   final Color? collapsedIconColor;
 
 
   /// The color of the tile's titles when the sublist is expanded.
   ///
-  /// Used to override to the [ListTileTheme.textColor].
+  /// Used to override to the [ListTileThemeData.textColor].
   final Color? textColor;
 
   /// The color of the tile's titles when the sublist is collapsed.
   ///
-  /// Used to override to the [ListTileTheme.textColor].
+  /// Used to override to the [ListTileThemeData.textColor].
   final Color? collapsedTextColor;
 
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -101,66 +101,47 @@ class ListTileThemeData with Diagnosticable {
     this.enableFeedback,
   });
 
-  /// If true then [ListTile]s will have the vertically dense layout.
+  /// Overrides the default value of [ListTile.dense].
   final bool? dense;
 
-  /// {@template flutter.material.ListTileTheme.shape}
-  /// If specified, [shape] defines the [ListTile]'s shape.
-  /// {@endtemplate}
+  /// Overrides the default value of [ListTile.shape].
   final ShapeBorder? shape;
 
-  /// If specified, [style] defines the font used for [ListTile] titles.
+  /// Overrides the default value of [ListTile.style].
   final ListTileStyle? style;
 
-  /// If specified, the color used for icons and text when a [ListTile] is selected.
+  /// Overrides the default value of [ListTile.selectedColor].
   final Color? selectedColor;
 
-  /// If specified, the icon color used for enabled [ListTile]s that are not selected.
+  /// Overrides the default value of [ListTile.iconColor].
   final Color? iconColor;
 
-  /// If specified, the text color used for enabled [ListTile]s that are not selected.
+  /// Overrides the default value of [ListTile.textColor].
   final Color? textColor;
 
-  /// The tile's internal padding.
-  ///
-  /// Insets a [ListTile]'s contents: its [ListTile.leading], [ListTile.title],
-  /// [ListTile.subtitle], and [ListTile.trailing] widgets.
+  /// Overrides the default value of [ListTile.contentPadding].
   final EdgeInsetsGeometry? contentPadding;
 
-  /// If specified, defines the background color for `ListTile` when
-  /// [ListTile.selected] is false.
-  ///
-  /// If [ListTile.tileColor] is provided, [tileColor] is ignored.
+  /// Overrides the default value of [ListTile.tileColor].
   final Color? tileColor;
 
-  /// If specified, defines the background color for `ListTile` when
-  /// [ListTile.selected] is true.
-  ///
-  /// If [ListTile.selectedTileColor] is provided, [selectedTileColor] is ignored.
+  /// Overrides the default value of [ListTile.selectedTileColor].
   final Color? selectedTileColor;
 
-  /// The horizontal gap between the titles and the leading/trailing widgets.
-  ///
-  /// If specified, overrides the default value of [ListTile.horizontalTitleGap].
+  /// Overrides the default value of [ListTile.horizontalTitleGap].
   final double? horizontalTitleGap;
 
-  /// The minimum padding on the top and bottom of the title and subtitle widgets.
-  ///
-  /// If specified, overrides the default value of [ListTile.minVerticalPadding].
+  /// Overrides the default value of [ListTile.minVerticalPadding].
   final double? minVerticalPadding;
 
-  /// The minimum width allocated for the [ListTile.leading] widget.
-  ///
-  /// If specified, overrides the default value of [ListTile.minLeadingWidth].
+  /// Overrides the default value of [ListTile.minLeadingWidth].
   final double? minLeadingWidth;
 
-  /// If specified, defines the feedback property for `ListTile`.
-  ///
-  /// If [ListTile.enableFeedback] is provided, [enableFeedback] is ignored.
+  /// Overrides the default value of [ListTile.enableFeedback].
   final bool? enableFeedback;
 
   /// Creates a copy of this object with the given fields replaced with the
-  /// non-null parameter values.
+  /// new values.
   ListTileThemeData copyWith({
     bool? dense,
     ShapeBorder? shape,
@@ -284,12 +265,12 @@ class ListTileThemeData with Diagnosticable {
 /// The [Drawer] widget specifies a tile theme for its children which sets
 /// [style] to [ListTileStyle.drawer].
 // ignore: avoid_implementing_value_types
-class ListTileTheme extends InheritedTheme implements ListTileThemeData {
+class ListTileTheme extends InheritedTheme {
   /// Creates a list tile theme that defines the color and style parameters for
   /// descendant [ListTile]s.
   const ListTileTheme({
     Key? key,
-    this.data,
+    ListTileThemeData? data,
     bool dense = false,
     ShapeBorder? shape,
     ListTileStyle style = ListTileStyle.list,
@@ -317,6 +298,7 @@ class ListTileTheme extends InheritedTheme implements ListTileThemeData {
           horizontalTitleGap ??
           minVerticalPadding ??
           minLeadingWidth) == null),
+       _data = data,
        _dense = dense,
        _shape = shape,
        _style = style,
@@ -332,9 +314,7 @@ class ListTileTheme extends InheritedTheme implements ListTileThemeData {
        _minLeadingWidth = minLeadingWidth,
        super(key: key, child: child);
 
-  /// The configuration of this theme.
-  final ListTileThemeData? data;
-
+  final ListTileThemeData? _data;
   final bool _dense;
   final ShapeBorder? _shape;
   final ListTileStyle _style;
@@ -349,55 +329,101 @@ class ListTileTheme extends InheritedTheme implements ListTileThemeData {
   final double? _minLeadingWidth;
   final bool? _enableFeedback;
 
-  @override
-  bool get dense => data != null ? (data!.dense ?? false) : _dense;
+  /// The configuration of this theme.
+  ListTileThemeData get data {
+    return _data ?? ListTileThemeData(
+      shape: _shape,
+      selectedColor: _selectedColor,
+      iconColor: _iconColor,
+      textColor: _textColor,
+      contentPadding: _contentPadding,
+      tileColor: _tileColor,
+      selectedTileColor: _selectedTileColor,
+      enableFeedback: _enableFeedback,
+      horizontalTitleGap: _horizontalTitleGap,
+      minVerticalPadding: _minVerticalPadding,
+      minLeadingWidth: _minLeadingWidth,
+    );
+  }
 
-  @override
-  ShapeBorder? get shape => data != null ? data!.shape : _shape;
+  /// Overrides the default value of [ListTile.dense].
+  ///
+  /// This property is obsolete: please use [data.dense] instead.
+  bool get dense => _data != null ? (_data!.dense ?? false) : _dense;
 
-  @override
-  ListTileStyle get style => data != null ? (data!.style ?? ListTileStyle.list) : _style;
+  /// Overrides the default value of [ListTile.shape].
+  ///
+  /// This property is obsolete: please use [data.shape] instead.
+  ShapeBorder? get shape => _data != null ? _data!.shape : _shape;
 
-  @override
-  Color? get selectedColor => data != null ? data!.selectedColor : _selectedColor;
+  /// Overrides the default value of [ListTile.style].
+  ///
+  /// This property is obsolete: please use [data.style] instead.
+  ListTileStyle get style => _data != null ? (_data!.style ?? ListTileStyle.list) : _style;
 
-  @override
-  Color? get iconColor => data != null ? data!.iconColor : _iconColor;
+  /// Overrides the default value of [ListTile.selectedColor].
+  ///
+  /// This property is obsolete: please use [data.selectedColor] instead.
+  Color? get selectedColor => _data != null ? _data!.selectedColor : _selectedColor;
 
-  @override
-  Color? get textColor => data != null ? data!.textColor : _textColor;
+  /// Overrides the default value of [ListTile.iconColor].
+  ///
+  /// This property is obsolete: please use [data.iconColor] instead.
+  Color? get iconColor => _data != null ? _data!.iconColor : _iconColor;
 
-  @override
-  EdgeInsetsGeometry? get contentPadding => data != null ? data!.contentPadding : _contentPadding;
+  /// Overrides the default value of [ListTile.textColor].
+  ///
+  /// This property is obsolete: please use [data.textColor] instead.
+  Color? get textColor => _data != null ? _data!.textColor : _textColor;
 
-  @override
-  Color? get tileColor => data != null ? data!.tileColor : _tileColor;
+  /// Overrides the default value of [ListTile.contentPadding].
+  ///
+  /// This property is obsolete: please use [data.contentPadding] instead.
+  EdgeInsetsGeometry? get contentPadding => _data != null ? _data!.contentPadding : _contentPadding;
 
-  @override
-  Color? get selectedTileColor => data != null ? data!.selectedTileColor : _selectedTileColor;
+  /// Overrides the default value of [ListTile.tileColor].
+  ///
+  /// This property is obsolete: please use [data.tileColor] instead.
+  Color? get tileColor => _data != null ? _data!.tileColor : _tileColor;
 
-  @override
-  double? get horizontalTitleGap => data != null ? data!.horizontalTitleGap : _horizontalTitleGap;
+  /// Overrides the default value of [ListTile.selectedTileColor].
+  ///
+  /// This property is obsolete: please use [data.selectedTileColor] instead.
+  Color? get selectedTileColor => _data != null ? _data!.selectedTileColor : _selectedTileColor;
 
-  @override
-  double? get minVerticalPadding => data != null ? data!.minVerticalPadding : _minVerticalPadding;
+  /// Overrides the default value of [ListTile.horizontalTitleGap].
+  ///
+  /// This property is obsolete: please use [data.horizontalTitleGap] instead.
+  double? get horizontalTitleGap => _data != null ? _data!.horizontalTitleGap : _horizontalTitleGap;
 
-  @override
-  double? get minLeadingWidth => data != null ? data!.minLeadingWidth : _minLeadingWidth;
+  /// Overrides the default value of [ListTile.minVerticalPadding].
+  ///
+  /// This property is obsolete: please use [data.minVerticalPadding] instead.
+  double? get minVerticalPadding => _data != null ? _data!.minVerticalPadding : _minVerticalPadding;
 
-  @override
-  bool? get enableFeedback => data != null ? data!.enableFeedback : _enableFeedback;
+  /// Overrides the default value of [ListTile.minLeadingWidth].
+  ///
+  /// This property is obsolete: please use [data.minLeadingWidth] instead.
+  double? get minLeadingWidth => _data != null ? _data!.minLeadingWidth : _minLeadingWidth;
+
+  /// Overrides the default value of [ListTile.enableFeedback].
+  ///
+  /// This property is obsolete: please use [data.enableFeedback] instead.
+  bool? get enableFeedback => _data != null ? _data!.enableFeedback : _enableFeedback;
 
   /// The closest instance of this class that encloses the given context.
+  ///
+  /// If there is no enclosing [ListTileTheme] widget, then
+  /// [ThemeData.listTileTheme] is used (see [ThemeData.of]).
   ///
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// ListTileTheme theme = ListTileTheme.of(context);
+  /// ListTileThemeData theme = ListTileTheme.of(context);
   /// ```
-  static ListTileTheme of(BuildContext context) {
+  static ListTileThemeData of(BuildContext context) {
     final ListTileTheme? result = context.dependOnInheritedWidgetOfExactType<ListTileTheme>();
-    return result ?? const ListTileTheme(child: SizedBox());
+    return result?.data ?? Theme.of(context).listTileTheme;
   }
 
   /// Creates a list tile theme that controls the color and style parameters for
@@ -424,7 +450,7 @@ class ListTileTheme extends InheritedTheme implements ListTileThemeData {
     assert(child != null);
     return Builder(
       builder: (BuildContext context) {
-        final ListTileTheme parent = ListTileTheme.of(context);
+        final ListTileThemeData parent = ListTileTheme.of(context);
         return ListTileTheme(
           key: key,
           data: ListTileThemeData(
@@ -446,26 +472,6 @@ class ListTileTheme extends InheritedTheme implements ListTileThemeData {
         );
       },
     );
-  }
-
-  @override
-  ListTileThemeData copyWith({
-    bool? dense,
-    ShapeBorder? shape,
-    ListTileStyle? style,
-    Color? selectedColor,
-    Color? iconColor,
-    Color? textColor,
-    EdgeInsetsGeometry? contentPadding,
-    Color? tileColor,
-    Color? selectedTileColor,
-    double? horizontalTitleGap,
-    double? minVerticalPadding,
-    double? minLeadingWidth,
-    bool? enableFeedback,
-  }) {
-    assert(false);
-    return const ListTileThemeData();
   }
 
   @override
@@ -762,6 +768,10 @@ class ListTile extends StatelessWidget {
     this.dense,
     this.visualDensity,
     this.shape,
+    this.style,
+    this.selectedColor,
+    this.iconColor,
+    this.textColor,
     this.contentPadding,
     this.enabled = true,
     this.onTap,
@@ -859,13 +869,59 @@ class ListTile extends StatelessWidget {
   ///    widgets within a [Theme].
   final VisualDensity? visualDensity;
 
-  /// The tile's shape.
-  ///
   /// Defines the tile's [InkWell.customBorder] and [Ink.decoration] shape.
   ///
-  /// If this property is null then [ListTileTheme.shape] is used.
-  /// If that's null then a rectangular [Border] will be used.
+  /// If this property is null then [ListTileThemeData.shape] is used. If that
+  /// is also null then a rectangular [Border] will be used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
   final ShapeBorder? shape;
+
+  /// Defines the color used for icons and text when the list tile is selected.
+  ///
+  /// If this property is null then [ListTileThemeData.selectedcolor]
+  /// is used. If that is also null then [ColorScheme.primary] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final Color? selectedColor;
+
+  /// Defines the default color for [leading] and [trailing] icons.
+  ///
+  /// If this property is null then [ListTileThemeData.iconColor] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final Color? iconColor;
+
+  /// Defines the default color for the [title] and [subtitle].
+  ///
+  /// If this property is null then [ListTileThemeData.textColor] is used. If that
+  /// is also null then [ColorScheme.primary] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final Color? textColor;
+
+  /// Defines the font used for the [title].
+  ///
+  /// If this property is null then [ListTileThemeData.style] is used. If that
+  /// is also null then [ListTileStyle.list] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ListTileTheme.of], which returns the nearest [ListTileTheme]'s
+  ///   [ListTileThemeData].
+  final ListTileStyle? style;
 
   /// The tile's internal padding.
   ///
@@ -1016,10 +1072,10 @@ class ListTile extends StatelessWidget {
       return theme.disabledColor;
 
     if (selected) {
-      return tileTheme.selectedColor ?? theme.listTileTheme.selectedColor ?? theme.colorScheme.primary;
+      return selectedColor ?? tileTheme.selectedColor ?? theme.listTileTheme.selectedColor ?? theme.colorScheme.primary;
     }
 
-    final Color? color = tileTheme.iconColor ?? theme.listTileTheme.iconColor;
+    final Color? color = iconColor ?? tileTheme.iconColor ?? theme.listTileTheme.iconColor;
     if (color != null)
       return color;
 
@@ -1038,10 +1094,10 @@ class ListTile extends StatelessWidget {
       return theme.disabledColor;
 
     if (selected) {
-      return tileTheme.selectedColor ?? theme.listTileTheme.selectedColor ?? theme.colorScheme.primary;
+      return selectedColor ?? tileTheme.selectedColor ?? theme.listTileTheme.selectedColor ?? theme.colorScheme.primary;
     }
 
-    return tileTheme.textColor ?? theme.listTileTheme.textColor ?? defaultColor;
+    return textColor ?? tileTheme.textColor ?? theme.listTileTheme.textColor ?? defaultColor;
   }
 
   bool _isDenseLayout(ThemeData theme, ListTileThemeData tileTheme) {
@@ -1049,33 +1105,33 @@ class ListTile extends StatelessWidget {
   }
 
   TextStyle _titleTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
-    final TextStyle style;
-    switch(tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list) {
+    final TextStyle textStyle;
+    switch(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list) {
       case ListTileStyle.drawer:
-        style = theme.textTheme.bodyText1!;
+        textStyle = theme.textTheme.bodyText1!;
         break;
       case ListTileStyle.list:
-        style = theme.textTheme.subtitle1!;
+        textStyle = theme.textTheme.subtitle1!;
         break;
     }
-    final Color? color = _textColor(theme, tileTheme, style.color);
+    final Color? color = _textColor(theme, tileTheme, textStyle.color);
     return _isDenseLayout(theme, tileTheme)
-      ? style.copyWith(fontSize: 13.0, color: color)
-      : style.copyWith(color: color);
+      ? textStyle.copyWith(fontSize: 13.0, color: color)
+      : textStyle.copyWith(color: color);
   }
 
   TextStyle _subtitleTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
-    final TextStyle style = theme.textTheme.bodyText2!;
+    final TextStyle textStyle = theme.textTheme.bodyText2!;
     final Color? color = _textColor(theme, tileTheme, theme.textTheme.caption!.color);
     return _isDenseLayout(theme, tileTheme)
-      ? style.copyWith(color: color, fontSize: 12.0)
-      : style.copyWith(color: color);
+      ? textStyle.copyWith(color: color, fontSize: 12.0)
+      : textStyle.copyWith(color: color);
   }
 
   TextStyle _trailingAndLeadingTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
-    final TextStyle style = theme.textTheme.bodyText2!;
-    final Color? color = _textColor(theme, tileTheme, style.color);
-    return style.copyWith(color: color);
+    final TextStyle textStyle = theme.textTheme.bodyText2!;
+    final Color? color = _textColor(theme, tileTheme, textStyle.color);
+    return textStyle.copyWith(color: color);
   }
 
   Color _tileBackgroundColor(ThemeData theme, ListTileThemeData tileTheme) {

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -428,7 +428,7 @@ class ListTileTheme extends InheritedTheme {
   /// encloses the given context.
   ///
   /// If there is no enclosing [ListTileTheme] widget, then
-  /// [ThemeData.listTileTheme] is used (see [ThemeData.of]).
+  /// [ThemeData.listTileTheme] is used (see [Theme.of]).
   ///
   /// Typical usage is as follows:
   ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -264,10 +264,12 @@ class ListTileThemeData with Diagnosticable {
 ///
 /// The [Drawer] widget specifies a tile theme for its children which sets
 /// [style] to [ListTileStyle.drawer].
-// ignore: avoid_implementing_value_types
 class ListTileTheme extends InheritedTheme {
   /// Creates a list tile theme that defines the color and style parameters for
   /// descendant [ListTile]s.
+  ///
+  /// Only the [data] parameter should be used. The other parameters are
+  /// redundant (are now obsolete) and will be deprecated in a future update.
   const ListTileTheme({
     Key? key,
     ListTileThemeData? data,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -271,7 +271,7 @@ class ListTileTheme extends InheritedTheme {
   const ListTileTheme({
     Key? key,
     ListTileThemeData? data,
-    bool dense = false,
+    bool? dense,
     ShapeBorder? shape,
     ListTileStyle? style,
     Color? selectedColor,
@@ -315,7 +315,7 @@ class ListTileTheme extends InheritedTheme {
        super(key: key, child: child);
 
   final ListTileThemeData? _data;
-  final bool _dense;
+  final bool? _dense;
   final ShapeBorder? _shape;
   final ListTileStyle? _style;
   final Color? _selectedColor;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -273,7 +273,7 @@ class ListTileTheme extends InheritedTheme {
     ListTileThemeData? data,
     bool dense = false,
     ShapeBorder? shape,
-    ListTileStyle style = ListTileStyle.list,
+    ListTileStyle? style,
     Color? selectedColor,
     Color? iconColor,
     Color? textColor,
@@ -317,7 +317,7 @@ class ListTileTheme extends InheritedTheme {
   final ListTileThemeData? _data;
   final bool _dense;
   final ShapeBorder? _shape;
-  final ListTileStyle _style;
+  final ListTileStyle? _style;
   final Color? _selectedColor;
   final Color? _iconColor;
   final Color? _textColor;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -335,6 +335,7 @@ class ListTileTheme extends InheritedTheme {
   ListTileThemeData get data {
     return _data ?? ListTileThemeData(
       shape: _shape,
+      style: _style,
       selectedColor: _selectedColor,
       iconColor: _iconColor,
       textColor: _textColor,
@@ -439,6 +440,7 @@ class ListTileTheme extends InheritedTheme {
   /// ```
   static ListTileThemeData of(BuildContext context) {
     final ListTileTheme? result = context.dependOnInheritedWidgetOfExactType<ListTileTheme>();
+    print("FOUND $result");
     return result?.data ?? Theme.of(context).listTileTheme;
   }
 
@@ -513,24 +515,7 @@ class ListTileTheme extends InheritedTheme {
   }
 
   @override
-  bool updateShouldNotify(ListTileTheme oldWidget) {
-    if (data != null) {
-      return data != oldWidget.data;
-    }
-    return dense != oldWidget.dense
-        || shape != oldWidget.shape
-        || style != oldWidget.style
-        || selectedColor != oldWidget.selectedColor
-        || iconColor != oldWidget.iconColor
-        || textColor != oldWidget.textColor
-        || contentPadding != oldWidget.contentPadding
-        || tileColor != oldWidget.tileColor
-        || selectedTileColor != oldWidget.selectedTileColor
-        || enableFeedback != oldWidget.enableFeedback
-        || horizontalTitleGap != oldWidget.horizontalTitleGap
-        || minVerticalPadding != oldWidget.minVerticalPadding
-        || minLeadingWidth != oldWidget.minLeadingWidth;
-  }
+  bool updateShouldNotify(ListTileTheme oldWidget) => data != oldWidget.data;
 }
 
 /// A single fixed-height row that typically contains some text as well as
@@ -1124,6 +1109,7 @@ class ListTile extends StatelessWidget {
 
   TextStyle _titleTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
     final TextStyle textStyle;
+    print(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list);
     switch(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list) {
       case ListTileStyle.drawer:
         textStyle = theme.textTheme.bodyText1!;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -348,70 +348,84 @@ class ListTileTheme extends InheritedTheme {
 
   /// Overrides the default value of [ListTile.dense].
   ///
-  /// This property is obsolete: please use [data.dense] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.dense] property instead.
   bool get dense => _data != null ? (_data!.dense ?? false) : _dense;
 
   /// Overrides the default value of [ListTile.shape].
   ///
-  /// This property is obsolete: please use [data.shape] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.shape] property instead.
   ShapeBorder? get shape => _data != null ? _data!.shape : _shape;
 
   /// Overrides the default value of [ListTile.style].
   ///
-  /// This property is obsolete: please use [data.style] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.style] property instead.
   ListTileStyle get style => _data != null ? (_data!.style ?? ListTileStyle.list) : _style;
 
   /// Overrides the default value of [ListTile.selectedColor].
   ///
-  /// This property is obsolete: please use [data.selectedColor] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.selectedColor] property instead.
   Color? get selectedColor => _data != null ? _data!.selectedColor : _selectedColor;
 
   /// Overrides the default value of [ListTile.iconColor].
   ///
-  /// This property is obsolete: please use [data.iconColor] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.iconColor] property instead.
   Color? get iconColor => _data != null ? _data!.iconColor : _iconColor;
 
   /// Overrides the default value of [ListTile.textColor].
   ///
-  /// This property is obsolete: please use [data.textColor] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.textColor] property instead.
   Color? get textColor => _data != null ? _data!.textColor : _textColor;
 
   /// Overrides the default value of [ListTile.contentPadding].
   ///
-  /// This property is obsolete: please use [data.contentPadding] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.contentPadding] property instead.
   EdgeInsetsGeometry? get contentPadding => _data != null ? _data!.contentPadding : _contentPadding;
 
   /// Overrides the default value of [ListTile.tileColor].
   ///
-  /// This property is obsolete: please use [data.tileColor] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.tileColor] property instead.
   Color? get tileColor => _data != null ? _data!.tileColor : _tileColor;
 
   /// Overrides the default value of [ListTile.selectedTileColor].
   ///
-  /// This property is obsolete: please use [data.selectedTileColor] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.selectedTileColor] property instead.
   Color? get selectedTileColor => _data != null ? _data!.selectedTileColor : _selectedTileColor;
 
   /// Overrides the default value of [ListTile.horizontalTitleGap].
   ///
-  /// This property is obsolete: please use [data.horizontalTitleGap] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.horizontalTitleGap] property instead.
   double? get horizontalTitleGap => _data != null ? _data!.horizontalTitleGap : _horizontalTitleGap;
 
   /// Overrides the default value of [ListTile.minVerticalPadding].
   ///
-  /// This property is obsolete: please use [data.minVerticalPadding] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.minVerticalPadding] property instead.
   double? get minVerticalPadding => _data != null ? _data!.minVerticalPadding : _minVerticalPadding;
 
   /// Overrides the default value of [ListTile.minLeadingWidth].
   ///
-  /// This property is obsolete: please use [data.minLeadingWidth] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.minLeadingWidth] property instead.
   double? get minLeadingWidth => _data != null ? _data!.minLeadingWidth : _minLeadingWidth;
 
   /// Overrides the default value of [ListTile.enableFeedback].
   ///
-  /// This property is obsolete: please use [data.enableFeedback] instead.
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.enableFeedback] property instead.
   bool? get enableFeedback => _data != null ? _data!.enableFeedback : _enableFeedback;
 
-  /// The closest instance of this class that encloses the given context.
+  /// The [data] property of the closest instance of this class that
+  /// encloses the given context.
   ///
   /// If there is no enclosing [ListTileTheme] widget, then
   /// [ThemeData.listTileTheme] is used (see [ThemeData.of]).
@@ -869,7 +883,9 @@ class ListTile extends StatelessWidget {
   ///    widgets within a [Theme].
   final VisualDensity? visualDensity;
 
+  /// {@template flutter.material.ListTile.tileColor}
   /// Defines the tile's [InkWell.customBorder] and [Ink.decoration] shape.
+  /// {@endtemplate}
   ///
   /// If this property is null then [ListTileThemeData.shape] is used. If that
   /// is also null then a rectangular [Border] will be used.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -350,7 +350,7 @@ class ListTileTheme extends InheritedTheme {
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.dense] property instead.
-  bool get dense => _data != null ? (_data!.dense ?? false) : _dense;
+  bool? get dense => _data != null ? _data!.dense : _dense;
 
   /// Overrides the default value of [ListTile.shape].
   ///
@@ -362,7 +362,7 @@ class ListTileTheme extends InheritedTheme {
   ///
   /// This property is obsolete: please use the [data]
   /// [ListTileThemeData.style] property instead.
-  ListTileStyle get style => _data != null ? (_data!.style ?? ListTileStyle.list) : _style;
+  ListTileStyle? get style => _data != null ? _data!.style : _style;
 
   /// Overrides the default value of [ListTile.selectedColor].
   ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -898,7 +898,7 @@ class ListTile extends StatelessWidget {
 
   /// Defines the color used for icons and text when the list tile is selected.
   ///
-  /// If this property is null then [ListTileThemeData.selectedcolor]
+  /// If this property is null then [ListTileThemeData.selectedColor]
   /// is used. If that is also null then [ColorScheme.primary] is used.
   ///
   /// See also:

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -216,6 +216,47 @@ class ListTileThemeData with Diagnosticable {
   }
 
   @override
+  int get hashCode {
+    return hashValues(
+      dense,
+      shape,
+      style,
+      selectedColor,
+      iconColor,
+      textColor,
+      contentPadding,
+      tileColor,
+      selectedTileColor,
+      horizontalTitleGap,
+      minVerticalPadding,
+      minLeadingWidth,
+      enableFeedback,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is ListTileThemeData
+      && other.dense == dense
+      && other.shape == shape
+      && other.style == style
+      && other.selectedColor == selectedColor
+      && other.iconColor == iconColor
+      && other.textColor == textColor
+      && other.contentPadding == contentPadding
+      && other.tileColor == tileColor
+      && other.selectedTileColor == selectedTileColor
+      && other.horizontalTitleGap == horizontalTitleGap
+      && other.minVerticalPadding == minVerticalPadding
+      && other.minLeadingWidth == minLeadingWidth
+      && other.enableFeedback == enableFeedback;
+  }
+
+  @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<bool>('dense', dense, defaultValue: null));
@@ -242,6 +283,7 @@ class ListTileThemeData with Diagnosticable {
 ///
 /// The [Drawer] widget specifies a tile theme for its children which sets
 /// [style] to [ListTileStyle.drawer].
+// ignore: avoid_implementing_value_types
 class ListTileTheme extends InheritedTheme implements ListTileThemeData {
   /// Creates a list tile theme that defines the color and style parameters for
   /// descendant [ListTile]s.

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -440,7 +440,6 @@ class ListTileTheme extends InheritedTheme {
   /// ```
   static ListTileThemeData of(BuildContext context) {
     final ListTileTheme? result = context.dependOnInheritedWidgetOfExactType<ListTileTheme>();
-    print("FOUND $result");
     return result?.data ?? Theme.of(context).listTileTheme;
   }
 
@@ -1109,7 +1108,6 @@ class ListTile extends StatelessWidget {
 
   TextStyle _titleTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
     final TextStyle textStyle;
-    print(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list);
     switch(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list) {
       case ListTileStyle.drawer:
         textStyle = theme.textTheme.bodyText1!;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -883,7 +883,7 @@ class ListTile extends StatelessWidget {
   ///    widgets within a [Theme].
   final VisualDensity? visualDensity;
 
-  /// {@template flutter.material.ListTile.tileColor}
+  /// {@template flutter.material.ListTile.shape}
   /// Defines the tile's [InkWell.customBorder] and [Ink.decoration] shape.
   /// {@endtemplate}
   ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -236,7 +236,7 @@ class RadioListTile<T> extends StatelessWidget {
 
   /// Whether this list tile is part of a vertically dense list.
   ///
-  /// If this property is null then its value is based on [ListTileTheme.dense].
+  /// If this property is null then its value is based on [ListTileThemeData.dense].
   final bool? dense;
 
   /// Whether to render icons and text in the [activeColor].

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -291,7 +291,7 @@ class SwitchListTile extends StatelessWidget {
 
   /// Whether this list tile is part of a vertically dense list.
   ///
-  /// If this property is null then its value is based on [ListTileTheme.dense].
+  /// If this property is null then its value is based on [ListTileThemeData.dense].
   final bool? dense;
 
   /// The tile's internal padding.
@@ -323,7 +323,7 @@ class SwitchListTile extends StatelessWidget {
   /// By default, the value of `controlAffinity` is [ListTileControlAffinity.platform].
   final ListTileControlAffinity controlAffinity;
 
-  /// {@macro flutter.material.ListTileTheme.shape}
+  /// {@macro flutter.material.ListTile.shape}
   final ShapeBorder? shape;
 
   /// If non-null, defines the background color when [SwitchListTile.selected] is true.

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -28,6 +28,7 @@ import 'floating_action_button_theme.dart';
 import 'ink_splash.dart';
 import 'ink_well.dart' show InteractiveInkFeatureFactory;
 import 'input_decorator.dart';
+import 'list_tile.dart';
 import 'navigation_bar_theme.dart';
 import 'navigation_rail_theme.dart';
 import 'outlined_button_theme.dart';
@@ -340,6 +341,7 @@ class ThemeData with Diagnosticable {
     SwitchThemeData? switchTheme,
     ProgressIndicatorThemeData? progressIndicatorTheme,
     DrawerThemeData? drawerTheme,
+    ListTileThemeData? listTileTheme,
     @Deprecated(
       'This "fix" is now enabled by default. '
       'This feature was deprecated after v2.5.0-1.0.pre.',
@@ -485,6 +487,7 @@ class ThemeData with Diagnosticable {
     switchTheme ??= const SwitchThemeData();
     progressIndicatorTheme ??= const ProgressIndicatorThemeData();
     drawerTheme ??= const DrawerThemeData();
+    listTileTheme ??= const ListTileThemeData();
 
     fixTextFieldOutlineLabel ??= true;
     useTextSelectionTheme ??= true;
@@ -568,6 +571,7 @@ class ThemeData with Diagnosticable {
       switchTheme: switchTheme,
       progressIndicatorTheme: progressIndicatorTheme,
       drawerTheme: drawerTheme,
+      listTileTheme: listTileTheme,
       fixTextFieldOutlineLabel: fixTextFieldOutlineLabel,
       useTextSelectionTheme: useTextSelectionTheme,
       androidOverscrollIndicator: androidOverscrollIndicator,
@@ -703,6 +707,7 @@ class ThemeData with Diagnosticable {
     required this.switchTheme,
     required this.progressIndicatorTheme,
     required this.drawerTheme,
+    required this.listTileTheme,
     @Deprecated(
       'This "fix" is now enabled by default. '
       'This feature was deprecated after v2.5.0-1.0.pre.',
@@ -789,6 +794,7 @@ class ThemeData with Diagnosticable {
        assert(switchTheme != null),
        assert(progressIndicatorTheme != null),
        assert(drawerTheme != null),
+       assert(listTileTheme != null),
        assert(fixTextFieldOutlineLabel != null),
        assert(useTextSelectionTheme != null);
 
@@ -1356,6 +1362,9 @@ class ThemeData with Diagnosticable {
   /// A theme for customizing the appearance and layout of [Drawer] widgets.
   final DrawerThemeData drawerTheme;
 
+  /// A theme for customizing the appearance of [ListTile] widgets.
+  final ListTileThemeData listTileTheme;
+
   /// An obsolete flag to allow apps to opt-out of a
   /// [small fix](https://github.com/flutter/flutter/issues/54028) for the Y
   /// coordinate of the floating label in a [TextField] [OutlineInputBorder].
@@ -1517,6 +1526,7 @@ class ThemeData with Diagnosticable {
     SwitchThemeData? switchTheme,
     ProgressIndicatorThemeData? progressIndicatorTheme,
     DrawerThemeData? drawerTheme,
+    ListTileThemeData? listTileTheme,
     @Deprecated(
       'This "fix" is now enabled by default. '
       'This feature was deprecated after v2.5.0-1.0.pre.',
@@ -1609,6 +1619,7 @@ class ThemeData with Diagnosticable {
       switchTheme: switchTheme ?? this.switchTheme,
       progressIndicatorTheme: progressIndicatorTheme ?? this.progressIndicatorTheme,
       drawerTheme: drawerTheme ?? this.drawerTheme,
+      listTileTheme: listTileTheme ?? this.listTileTheme,
       fixTextFieldOutlineLabel: fixTextFieldOutlineLabel ?? this.fixTextFieldOutlineLabel,
       useTextSelectionTheme: useTextSelectionTheme ?? this.useTextSelectionTheme,
       androidOverscrollIndicator: androidOverscrollIndicator ?? this.androidOverscrollIndicator,
@@ -1771,6 +1782,7 @@ class ThemeData with Diagnosticable {
       switchTheme: SwitchThemeData.lerp(a.switchTheme, b.switchTheme, t),
       progressIndicatorTheme: ProgressIndicatorThemeData.lerp(a.progressIndicatorTheme, b.progressIndicatorTheme, t)!,
       drawerTheme: DrawerThemeData.lerp(a.drawerTheme, b.drawerTheme, t)!,
+      listTileTheme: ListTileThemeData.lerp(a.listTileTheme, b.listTileTheme, t)!,
       fixTextFieldOutlineLabel: t < 0.5 ? a.fixTextFieldOutlineLabel : b.fixTextFieldOutlineLabel,
       useTextSelectionTheme: t < 0.5 ? a.useTextSelectionTheme : b.useTextSelectionTheme,
       androidOverscrollIndicator: t < 0.5 ? a.androidOverscrollIndicator : b.androidOverscrollIndicator,
@@ -1861,6 +1873,7 @@ class ThemeData with Diagnosticable {
         && other.switchTheme == switchTheme
         && other.progressIndicatorTheme == progressIndicatorTheme
         && other.drawerTheme == drawerTheme
+        && other.listTileTheme == listTileTheme
         && other.fixTextFieldOutlineLabel == fixTextFieldOutlineLabel
         && other.useTextSelectionTheme == useTextSelectionTheme
         && other.androidOverscrollIndicator == androidOverscrollIndicator;
@@ -1950,6 +1963,7 @@ class ThemeData with Diagnosticable {
       switchTheme,
       progressIndicatorTheme,
       drawerTheme,
+      listTileTheme,
       fixTextFieldOutlineLabel,
       useTextSelectionTheme,
       androidOverscrollIndicator,
@@ -2037,6 +2051,7 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<SwitchThemeData>('switchTheme', switchTheme, defaultValue: defaultData.switchTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<ProgressIndicatorThemeData>('progressIndicatorTheme', progressIndicatorTheme, defaultValue: defaultData.progressIndicatorTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<DrawerThemeData>('drawerTheme', drawerTheme, defaultValue: defaultData.drawerTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<ListTileThemeData>('listTileTheme', listTileTheme, defaultValue: defaultData.listTileTheme, level: DiagnosticLevel.debug));
     properties.add(EnumProperty<AndroidOverscrollIndicator>('androidOverscrollIndicator', androidOverscrollIndicator, defaultValue: null, level: DiagnosticLevel.debug));
   }
 }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -51,6 +51,75 @@ class TestTextState extends State<TestText> {
 }
 
 void main() {
+  test('ListTileThemeData defaults', () {
+    const ListTileThemeData themeData = ListTileThemeData();
+    expect(themeData.dense, null);
+    expect(themeData.shape, null);
+    expect(themeData.style, null);
+    expect(themeData.selectedColor, null);
+    expect(themeData.iconColor, null);
+    expect(themeData.textColor, null);
+    expect(themeData.contentPadding, null);
+    expect(themeData.tileColor, null);
+    expect(themeData.selectedTileColor, null);
+    expect(themeData.horizontalTitleGap, null);
+    expect(themeData.minVerticalPadding, null);
+    expect(themeData.minLeadingWidth, null);
+    expect(themeData.enableFeedback, null);
+  });
+
+  testWidgets('Default ListTileThemeData debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const ListTileThemeData().debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
+
+    expect(description, <String>[]);
+  });
+
+  testWidgets('ListTileThemeData implements debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const ListTileThemeData(
+      dense: true,
+      shape: StadiumBorder(),
+      style: ListTileStyle.drawer,
+      selectedColor: Color(0x00000001),
+      iconColor: Color(0x00000002),
+      textColor: Color(0x00000003),
+      contentPadding: EdgeInsets.all(100),
+      tileColor: Color(0x00000004),
+      selectedTileColor: Color(0x00000005),
+      horizontalTitleGap: 200,
+      minVerticalPadding: 300,
+      minLeadingWidth: 400,
+      enableFeedback: true,
+    ).debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+      .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+      .map((DiagnosticsNode node) => node.toString())
+      .toList();
+
+    expect(description, <String>[
+      'dense: true',
+      'shape: StadiumBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none))',
+      'style: drawer',
+      'selectedColor: Color(0x00000001)',
+      'iconColor: Color(0x00000002)',
+      'textColor: Color(0x00000003)',
+      'contentPadding: EdgeInsets.all(100.0)',
+      'tileColor: Color(0x00000004)',
+      'selectedTileColor: Color(0x00000005)',
+      'horizontalTitleGap: 200.0',
+      'minVerticalPadding: 300.0',
+      'minLeadingWidth: 400.0',
+      'enableFeedback: true'
+    ]);
+  });
+
   testWidgets('ListTile geometry (LTR)', (WidgetTester tester) async {
     // See https://material.io/go/design-lists
 
@@ -291,11 +360,13 @@ void main() {
         home: Material(
           child: Center(
             child: ListTileTheme(
-              dense: dense,
-              shape: shape,
-              selectedColor: selectedColor,
-              iconColor: iconColor,
-              textColor: textColor,
+              data: ListTileThemeData(
+                dense: dense,
+                shape: shape,
+                selectedColor: selectedColor,
+                iconColor: iconColor,
+                textColor: textColor,
+              ),
               child: Builder(
                 builder: (BuildContext context) {
                   theme = Theme.of(context);
@@ -1727,8 +1798,10 @@ void main() {
       MaterialApp(
         home: Material(
           child: ListTileTheme(
-            tileColor: Colors.green.shade500,
-            selectedTileColor: Colors.red.shade500,
+            data: ListTileThemeData(
+              tileColor: Colors.green.shade500,
+              selectedTileColor: Colors.red.shade500,
+            ),
             child: Center(
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
@@ -1766,8 +1839,10 @@ void main() {
       MaterialApp(
         home: Material(
           child: ListTileTheme(
-            selectedTileColor: Colors.green,
-            tileColor: Colors.red,
+            data: const ListTileThemeData(
+              selectedTileColor: Colors.green,
+              tileColor: Colors.red,
+            ),
             child: Center(
               child: StatefulBuilder(
                 builder: (BuildContext context, StateSetter setState) {
@@ -1898,7 +1973,7 @@ void main() {
         MaterialApp(
           home: Material(
             child: ListTileTheme(
-              enableFeedback: enableFeedbackTheme,
+              data: const ListTileThemeData(enableFeedback: enableFeedbackTheme),
               child: ListTile(
                 title: const Text('Title'),
                 onTap: () {},
@@ -1922,7 +1997,7 @@ void main() {
         MaterialApp(
           home: Material(
             child: ListTileTheme(
-              enableFeedback: enableFeedbackTheme,
+              data: const ListTileThemeData(enableFeedback: enableFeedbackTheme),
               child: ListTile(
                 enableFeedback: enableFeedback,
                 title: const Text('Title'),
@@ -1948,7 +2023,7 @@ void main() {
           textDirection: textDirection,
           child: Material(
             child: ListTileTheme(
-              horizontalTitleGap: themeHorizontalTitleGap,
+              data: ListTileThemeData(horizontalTitleGap: themeHorizontalTitleGap),
               child: Container(
                 alignment: Alignment.topLeft,
                 child: ListTile(
@@ -2081,7 +2156,7 @@ void main() {
           textDirection: textDirection,
           child: Material(
             child: ListTileTheme(
-              minVerticalPadding: themeMinVerticalPadding,
+              data: ListTileThemeData(minVerticalPadding: themeMinVerticalPadding),
               child: Container(
                 alignment: Alignment.topLeft,
                 child: ListTile(
@@ -2127,7 +2202,7 @@ void main() {
           textDirection: textDirection,
           child: Material(
             child: ListTileTheme(
-              minLeadingWidth: themeMinLeadingWidth,
+              data: ListTileThemeData(minLeadingWidth: themeMinLeadingWidth),
               child: Container(
                 alignment: Alignment.topLeft,
                 child: ListTile(
@@ -2241,8 +2316,10 @@ void main() {
         home: Material(
           child: Center(
             child: ListTileTheme(
-              selectedColor: selectedColor,
-              textColor: defaultColor,
+              data: const ListTileThemeData(
+                selectedColor: selectedColor,
+                textColor: defaultColor,
+              ),
               child: Builder(
                 builder: (BuildContext context) {
                   theme = Theme.of(context);

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -51,6 +51,11 @@ class TestTextState extends State<TestText> {
 }
 
 void main() {
+  test('ListTileThemeData copyWith, ==, hashCode basics', () {
+    expect(const ListTileThemeData(), const ListTileThemeData().copyWith());
+    expect(const ListTileThemeData().hashCode, const ListTileThemeData().copyWith().hashCode);
+  });
+
   test('ListTileThemeData defaults', () {
     const ListTileThemeData themeData = ListTileThemeData();
     expect(themeData.dense, null);

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -1796,7 +1796,7 @@ void main() {
   });
 
   testWidgets("ListTile respects ListTileTheme's tileColor & selectedTileColor", (WidgetTester tester) async {
-    late ListTileTheme theme;
+    late ListTileThemeData theme;
     bool isSelected = false;
 
     await tester.pumpWidget(

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -346,6 +346,7 @@ void main() {
       switchTheme: const SwitchThemeData(),
       progressIndicatorTheme: const ProgressIndicatorThemeData(),
       drawerTheme: const DrawerThemeData(),
+      listTileTheme: const ListTileThemeData(),
       fixTextFieldOutlineLabel: false,
       useTextSelectionTheme: false,
       androidOverscrollIndicator: null,
@@ -443,6 +444,7 @@ void main() {
       switchTheme: const SwitchThemeData(),
       progressIndicatorTheme: const ProgressIndicatorThemeData(),
       drawerTheme: const DrawerThemeData(),
+      listTileTheme: const ListTileThemeData(),
       fixTextFieldOutlineLabel: true,
       useTextSelectionTheme: true,
       androidOverscrollIndicator: AndroidOverscrollIndicator.stretch,
@@ -521,6 +523,7 @@ void main() {
       switchTheme: otherTheme.switchTheme,
       progressIndicatorTheme: otherTheme.progressIndicatorTheme,
       drawerTheme: otherTheme.drawerTheme,
+      listTileTheme: otherTheme.listTileTheme,
       fixTextFieldOutlineLabel: otherTheme.fixTextFieldOutlineLabel,
     );
 
@@ -596,6 +599,7 @@ void main() {
     expect(themeDataCopy.switchTheme, equals(otherTheme.switchTheme));
     expect(themeDataCopy.progressIndicatorTheme, equals(otherTheme.progressIndicatorTheme));
     expect(themeDataCopy.drawerTheme, equals(otherTheme.drawerTheme));
+    expect(themeDataCopy.listTileTheme, equals(otherTheme.listTileTheme));
     expect(themeDataCopy.fixTextFieldOutlineLabel, equals(otherTheme.fixTextFieldOutlineLabel));
   });
 


### PR DESCRIPTION
Refactored ListTileTheme to make it conform to Flutter's conventions for component themes.

- Added a `ListTileThemeData` class which defines overrides for the defaults for visual ListTile properties.
- Added a ListTileTheme constructor parameter and getter: `ListTileThemeData data`. This is now the preferred way to configure a ListTileTheme.
- Added a `listTileThemeData listTileTheme` property to ThemeData. This is now the preferred way to configure ListTiles in a MaterialApp.
- Added `selectedColor`, `textColor`, `iconColor` and (ListTileStyle) `style` parameters to ListTile, so that all of the properties that can be overridden via the theme can also be set on the widget itself.

For example to configure the icon and text colors for all of the ListTiles in an app:

```dart
import 'package:flutter/material.dart';

class Home extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: <Widget>[
            ListTile(
              selected: true,
              title: Text('selected'),
              leading: Icon(Icons.android),
              trailing: Text('trailing')
            ),
            SizedBox(height: 32),
            ListTile(
              selected: false,
              title: Text('unselected'),
              leading: Icon(Icons.android),
              trailing: Icon(Icons.android),
            ),
          ],
        ),
      ),
    );
  }
}

void main() {
  runApp(
    MaterialApp(
      theme: ThemeData.light().copyWith(
        listTileTheme: ListTileThemeData(
          selectedColor: Colors.orange,
          iconColor: Colors.green,
          textColor: Colors.blue,
        ),
      ),
      home: Scaffold(body: Home())
    ),
  );
}
```

This is a non-breaking change.  In an upcoming PR all of the ListTileTheme properties, except for `data` will be deprecated and a Dart Fix script will be provided to automatically migrate code.


Fixes https://github.com/flutter/flutter/issues/31247
