### PR TITLE
skip 'generateLockfiles' for add-to-app project.

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -103,14 +103,16 @@ class FlutterPlugin implements Plugin<Project> {
         this.project = project
 
         def rootProject = project.rootProject
-        rootProject.tasks.register('generateLockfiles') {
-            rootProject.subprojects.each { subproject ->
-                def gradlew = (OperatingSystem.current().isWindows()) ?
-                    "${rootProject.projectDir}/gradlew.bat" : "${rootProject.projectDir}/gradlew"
-                rootProject.exec {
-                    workingDir rootProject.projectDir
-                    executable gradlew
-                    args ":${subproject.name}:dependencies", "--write-locks"
+        if (isFlutterAppProject()) {
+            rootProject.tasks.register('generateLockfiles') {
+                rootProject.subprojects.each { subproject ->
+                    def gradlew = (OperatingSystem.current().isWindows()) ?
+                        "${rootProject.projectDir}/gradlew.bat" : "${rootProject.projectDir}/gradlew"
+                    rootProject.exec {
+                        workingDir rootProject.projectDir
+                        executable gradlew
+                        args ":${subproject.name}:dependencies", "--write-locks"
+                    }
                 }
             }
         }


### PR DESCRIPTION
No need to run task:'generateLockfiles' for add-to-app project.
closed #90321
closed #90490

*#90321 #90490*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
