### PR TITLE
Remove extension from test file.

### DIFF
--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -14,11 +14,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../image_data.dart';
 
+/// Helper function creating a [ByteData] for testing.
+/// 
+/// The [ByteData] embeds a [scale] value which can be extracted using
+/// [scaleOf].
 ByteData testByteData(double scale) => ByteData(8)..setFloat64(0, scale);
 
-extension on ByteData {
-  double get scale => getFloat64(0);
-}
+/// Extracts the `scale` embedded in data created by [testByteData].
+double scaleOf(ByteData data) => data.getFloat64(0);
 
 const String testManifest = '''
 {
@@ -90,8 +93,8 @@ class TestAssetImage extends AssetImage {
     late ImageInfo imageInfo;
     key.bundle.load(key.name).then<void>((ByteData data) {
       final ByteData testData = data;
-      final ui.Image image = images[testData.scale]!;
-      assert(image != null, 'Expected ${testData.scale} to have a key in $images');
+      final ui.Image image = images[scaleOf(testData)]!;
+      assert(image != null, 'Expected ${scaleOf(testData)} to have a key in $images');
       imageInfo = ImageInfo(image: image, scale: key.scale);
     });
     return FakeImageStreamCompleter(


### PR DESCRIPTION
Removes an `extension` from a test, and replaces it with a static helper method.
