### PR TITLE
Add `animate` bool property to `TabController`

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -101,7 +101,7 @@ class TabController extends ChangeNotifier {
   ///
   /// The `initialIndex` must be valid given [length] and must not be null. If
   /// [length] is zero, then `initialIndex` must be 0 (the default).
-  TabController({ int initialIndex = 0, required this.length, required TickerProvider vsync })
+  TabController({ int initialIndex = 0, this.animate = true, required this.length, required TickerProvider vsync })
     : assert(length != null && length >= 0),
       assert(initialIndex != null && initialIndex >= 0 && (length == 0 || initialIndex < length)),
       _index = initialIndex,
@@ -117,14 +117,15 @@ class TabController extends ChangeNotifier {
     required int index,
     required int previousIndex,
     required AnimationController? animationController,
+    required this.animate,
     required this.length,
   }) : _index = index,
        _previousIndex = previousIndex,
        _animationController = animationController;
 
 
-  /// Creates a new [TabController] with `index`, `previousIndex`, and `length`
-  /// if they are non-null.
+  /// Creates a new [TabController] with `index`, `previousIndex` `length`, and
+  /// `animate` if they are non-null.
   ///
   /// This method is used by [DefaultTabController].
   ///
@@ -134,6 +135,7 @@ class TabController extends ChangeNotifier {
     required int? index,
     required int? length,
     required int? previousIndex,
+    required bool? animate,
   }) {
     if (index != null) {
       _animationController!.value = index.toDouble();
@@ -143,6 +145,7 @@ class TabController extends ChangeNotifier {
       length: length ?? this.length,
       animationController: _animationController,
       previousIndex: previousIndex ?? _previousIndex,
+      animate: animate ?? this.animate,
     );
   }
 
@@ -174,7 +177,7 @@ class TabController extends ChangeNotifier {
       return;
     _previousIndex = index;
     _index = value;
-    if (duration != null) {
+    if (duration != null && animate) {
       _indexIsChangingCount += 1;
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
@@ -192,6 +195,10 @@ class TabController extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  /// Determines whether tab changes will be animated in the [TabController] and
+  /// [TabBarView]. Defaults to `true` unless specified.
+  bool animate;
 
   /// The index of the currently selected tab.
   ///
@@ -331,6 +338,7 @@ class DefaultTabController extends StatefulWidget {
   const DefaultTabController({
     Key? key,
     required this.length,
+    this.animate = true,
     this.initialIndex = 0,
     required this.child,
   }) : assert(initialIndex != null),
@@ -348,6 +356,13 @@ class DefaultTabController extends StatefulWidget {
   ///
   /// Defaults to zero.
   final int initialIndex;
+
+  /// Whether to animate tab transitions or not.
+  ///
+  /// Defaults to `true` and will skip animating the [DefaultTabController] and
+  /// [TabBarView] if set to `false`, changing the state instantaneously
+  /// instead.
+  final bool animate;
 
   /// The widget below this widget in the tree.
   ///
@@ -383,6 +398,7 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Single
     _controller = TabController(
       vsync: this,
       length: widget.length,
+      animate: widget.animate,
       initialIndex: widget.initialIndex,
     );
   }
@@ -418,6 +434,7 @@ class _DefaultTabControllerState extends State<DefaultTabController> with Single
         length: widget.length,
         index: newIndex,
         previousIndex: previousIndex,
+        animate: widget.animate,
       );
     }
   }

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -124,7 +124,7 @@ class TabController extends ChangeNotifier {
        _animationController = animationController;
 
 
-  /// Creates a new [TabController] with `index`, `previousIndex` `length`, and
+  /// Creates a new [TabController] with `index`, `previousIndex`, `length`, and
   /// `animate` if they are non-null.
   ///
   /// This method is used by [DefaultTabController].
@@ -197,7 +197,7 @@ class TabController extends ChangeNotifier {
   }
 
   /// Determines whether tab changes will be animated in the [TabController] and
-  /// [TabBarView]. Defaults to `true` unless specified.
+  /// [TabBarView]. Defaults to `true`.
   bool animate;
 
   /// The index of the currently selected tab.
@@ -360,7 +360,7 @@ class DefaultTabController extends StatefulWidget {
   /// Whether to animate tab transitions or not.
   ///
   /// Defaults to `true` and will skip animating the [DefaultTabController] and
-  /// [TabBarView] if set to `false`, changing the state instantaneously
+  /// [TabBarView] if set to `false`, changing the state instantly
   /// instead.
   final bool animate;
 

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1393,7 +1393,7 @@ class _TabBarViewState extends State<TabBarView> {
     if (_pageController.page == _currentIndex!.toDouble())
       return Future<void>.value();
 
-    if(!_controller!.animate) {
+    if (!_controller!.animate) {
       _pageController.jumpToPage(_currentIndex!);
       return Future<void>.value();
     }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1393,6 +1393,11 @@ class _TabBarViewState extends State<TabBarView> {
     if (_pageController.page == _currentIndex!.toDouble())
       return Future<void>.value();
 
+    if(!_controller!.animate) {
+      _pageController.jumpToPage(_currentIndex!);
+      return Future<void>.value();
+    }
+
     final int previousIndex = _controller!.previousIndex;
     if ((_currentIndex! - previousIndex).abs() == 1) {
       _warpUnderwayCount += 1;

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1028,10 +1028,10 @@ void main() {
       length: 3,
       animate: false,
     );
-    final List<String> tabs = ['A', 'B', 'C'];
+    final List<String> tabs = <String>['A', 'B', 'C'];
     await tester.pumpWidget(boilerplate(
       child: Column(
-        children: [
+        children: <Widget>[
           TabBar(
             tabs: tabs.map<Widget>((String tab) => Tab(text: tab)).toList(),
             controller: tabController,


### PR DESCRIPTION
This PR adds an `animate` property to `TabController`. This defaults to `true` but can be set to `false` to disable `TabController` and `TabBarView` animations. They cannot be disabled independently with this change. 

When disabled `TabController` will set the animator value to the desired index and `TabBarView` will use `_pageController.jumpToPage` to transition instantly.

Fixes https://github.com/flutter/flutter/issues/16474

<details>
 <summary>Demo</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  static const String _title = 'Flutter Code Sample';

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      title: _title,
      home: TabPage(),
    );
  }
}

const List<Tab> tabs = <Tab>[
  Tab(text: 'Zeroth'),
  Tab(text: 'First'),
  Tab(text: 'Second'),
];

class TabPage extends StatefulWidget {
  const TabPage({Key? key}) : super(key: key);

  @override
  State<TabPage> createState() => _TabPageState();
}

class _TabPageState extends State<TabPage> {
  @override
  Widget build(BuildContext context) {
    return DefaultTabController(
      length: tabs.length,
      child: Builder(builder: (BuildContext context) {
        final TabController tabController = DefaultTabController.of(context)!;
        return Scaffold(
          appBar: AppBar(
            bottom: const TabBar(
              tabs: tabs,
            ),
          ),
          floatingActionButton: Switch(
              value: tabController.animate,
              onChanged: (value) =>
                  setState(() => tabController.animate = value)),
          body: TabBarView(
            children: tabs.map((Tab tab) {
              return Center(
                child: Text(
                  '${tab.text!} Tab',
                  style: Theme.of(context).textTheme.headline5,
                ),
              );
            }).toList(),
          ),
        );
      }),
    );
  }
}
```
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.