### PR TITLE
Scrollbar shouldRepaint to respect the shape

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -697,8 +697,9 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         || mainAxisMargin != oldDelegate.mainAxisMargin
         || crossAxisMargin != oldDelegate.crossAxisMargin
         || radius != oldDelegate.radius
-        || minLength != oldDelegate.minLength
+        || shape != oldDelegate.shape
         || padding != oldDelegate.padding
+        || minLength != oldDelegate.minLength
         || minOverscrollLength != oldDelegate.minOverscrollLength
         || scrollbarOrientation != oldDelegate.scrollbarOrientation;
   }
@@ -1311,9 +1312,9 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   ///
   /// Subclasses can override to configure the [scrollbarPainter].
   @protected
-  void  updateScrollbarPainter() {
+  void updateScrollbarPainter() {
     scrollbarPainter
-      ..color =  widget.thumbColor ?? const Color(0x66BCBCBC)
+      ..color = widget.thumbColor ?? const Color(0x66BCBCBC)
       ..textDirection = Directionality.of(context)
       ..thickness = widget.thickness ?? _kScrollbarThickness
       ..radius = widget.radius

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2073,6 +2073,7 @@ void main() {
       );
     }
     final ScrollbarPainter painter = createPainter();
+    expect(painter.shouldRepaint(createPainter()), false);
     expect(painter.shouldRepaint(createPainter(color: const Color(0xFFFFFFFF))), true);
     expect(painter.shouldRepaint(createPainter(fadeoutOpacityAnimation: kAlwaysDismissedAnimation)), true);
     expect(painter.shouldRepaint(createPainter(trackColor: const Color(0xFFFFFFFF))), true);

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2037,4 +2037,55 @@ void main() {
     expect(depths[0], 1);
     expect(depths[1], 0);
   });
+
+  test('ScrollbarPainter.shouldRepaint returns true when any of the properties changes', () {
+    ScrollbarPainter createPainter({
+      Color color = const Color(0xFF000000),
+      Animation<double> fadeoutOpacityAnimation = kAlwaysCompleteAnimation,
+      Color trackColor = const Color(0x00000000),
+      Color trackBorderColor = const Color(0x00000000),
+      TextDirection textDirection = TextDirection.ltr,
+      double thickness = _kThickness,
+      EdgeInsets padding = EdgeInsets.zero,
+      double mainAxisMargin = 0.0,
+      double crossAxisMargin = 0.0,
+      Radius? radius,
+      OutlinedBorder? shape,
+      double minLength = _kMinThumbExtent,
+      double? minOverscrollLength,
+      ScrollbarOrientation scrollbarOrientation = ScrollbarOrientation.top,
+    }) {
+      return ScrollbarPainter(
+        color: color,
+        fadeoutOpacityAnimation: fadeoutOpacityAnimation,
+        trackColor: trackColor,
+        trackBorderColor: trackBorderColor,
+        textDirection: textDirection,
+        thickness: thickness,
+        padding: padding,
+        mainAxisMargin: mainAxisMargin,
+        crossAxisMargin: crossAxisMargin,
+        radius: radius,
+        shape: shape,
+        minLength: minLength,
+        minOverscrollLength: minOverscrollLength,
+        scrollbarOrientation: scrollbarOrientation,
+      );
+    }
+    final ScrollbarPainter painter = createPainter();
+    expect(painter.shouldRepaint(createPainter(color: const Color(0xFFFFFFFF))), true);
+    expect(painter.shouldRepaint(createPainter(fadeoutOpacityAnimation: kAlwaysDismissedAnimation)), true);
+    expect(painter.shouldRepaint(createPainter(trackColor: const Color(0xFFFFFFFF))), true);
+    expect(painter.shouldRepaint(createPainter(trackBorderColor: const Color(0xFFFFFFFF))), true);
+    expect(painter.shouldRepaint(createPainter(textDirection: TextDirection.rtl)), true);
+    expect(painter.shouldRepaint(createPainter(thickness: _kThickness + 1.0)), true);
+    expect(painter.shouldRepaint(createPainter(padding: const EdgeInsets.all(1.0))), true);
+    expect(painter.shouldRepaint(createPainter(mainAxisMargin: 1.0)), true);
+    expect(painter.shouldRepaint(createPainter(crossAxisMargin: 1.0)), true);
+    expect(painter.shouldRepaint(createPainter(radius: const Radius.circular(1.0))), true);
+    expect(painter.shouldRepaint(createPainter(shape: const CircleBorder(side: BorderSide(width: 2.0)))), true);
+    expect(painter.shouldRepaint(createPainter(minLength: _kMinThumbExtent + 1.0)), true);
+    expect(painter.shouldRepaint(createPainter(minOverscrollLength: 1.0)), true);
+    expect(painter.shouldRepaint(createPainter(scrollbarOrientation: ScrollbarOrientation.bottom)), true);
+  });
 }


### PR DESCRIPTION
Scrollbar painter shouldRepaint didn't consider the `shape`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.