### PR TITLE
Enable `prefer_relative_imports` and fix files.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -174,9 +174,9 @@ linter:
     - prefer_is_not_empty
     - prefer_is_not_operator
     - prefer_iterable_whereType
-    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
     - prefer_null_aware_operators
-    # - prefer_relative_imports # incompatible with sub-package imports
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_paths.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_paths.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:macrobenchmarks/src/web/bench_paths_recording.dart' as recording;
-import 'package:macrobenchmarks/src/web/recorder.dart';
+import 'bench_paths_recording.dart' as recording;
+import 'recorder.dart';
 
 /// Measure the performance of path construction.
 ///

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_picture_recording.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_picture_recording.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ui';
 
-import 'package:macrobenchmarks/src/web/recorder.dart';
+import 'recorder.dart';
 
 /// Measure the performance of paint bounds estimation by recording a picture
 /// without actually rendering it.

--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -7,9 +7,6 @@ import 'dart:convert' show json;
 import 'dart:html' as html;
 import 'dart:math' as math;
 
-import 'package:macrobenchmarks/src/web/bench_text_layout.dart';
-import 'package:macrobenchmarks/src/web/bench_text_out_of_picture_bounds.dart';
-
 import 'src/web/bench_build_image.dart';
 import 'src/web/bench_build_material_checkbox.dart';
 import 'src/web/bench_card_infinite_scroll.dart';
@@ -25,6 +22,7 @@ import 'src/web/bench_pageview_scroll_linethrough.dart';
 import 'src/web/bench_paths.dart';
 import 'src/web/bench_picture_recording.dart';
 import 'src/web/bench_simple_lazy_text_scroll.dart';
+import 'src/web/bench_text_layout.dart';
 import 'src/web/bench_text_out_of_picture_bounds.dart';
 import 'src/web/bench_wrapbox_scroll.dart';
 import 'src/web/recorder.dart';

--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -4,7 +4,7 @@
 
 import 'package:args/command_runner.dart';
 
-import 'package:flutter_devicelab/framework/runner.dart';
+import '../framework/runner.dart';
 
 class TestCommand extends Command<void> {
   TestCommand() {

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -7,9 +7,10 @@ import 'dart:convert' show json, utf8, LineSplitter, JsonEncoder;
 import 'dart:io' as io;
 import 'dart:math' as math;
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:path/path.dart' as path;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+import '../common.dart';
 
 /// The number of samples used to extract metrics, such as noise, means,
 /// max/min values.

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -7,9 +7,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:path/path.dart' as path;
 
+import '../common.dart';
 import 'utils.dart';
 
 const String DeviceIdEnvName = 'FLUTTER_DEVICELAB_DEVICEID';

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -7,10 +7,10 @@ import 'dart:convert';
 // import 'dart:core' as core;
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../common.dart';
 import 'cocoon.dart';
 import 'devices.dart';
 import 'task_result.dart';

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -7,12 +7,12 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:flutter_devicelab/common.dart';
-import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import '../common.dart';
+import 'devices.dart';
 import 'host_agent.dart';
 import 'task_result.dart';
 

--- a/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
+++ b/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
@@ -6,11 +6,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_devicelab/common.dart';
-import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
+
+import '../common.dart';
+import '../framework/framework.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
 
 TaskFunction dartPluginRegistryTest({
   String? deviceIdOverride,

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -5,12 +5,13 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter_devicelab/framework/devices.dart';
-import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:flutter_devicelab/microbenchmarks.dart';
 import 'package:path/path.dart' as path;
+
+import '../framework/devices.dart';
+import '../framework/framework.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
+import '../microbenchmarks.dart';
 
 /// Creates a device lab task that runs benchmarks in
 /// `dev/benchmarks/microbenchmarks` reports results to the dashboard.

--- a/dev/devicelab/lib/tasks/new_gallery.dart
+++ b/dev/devicelab/lib/tasks/new_gallery.dart
@@ -4,12 +4,10 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/tasks/perf_tests.dart';
-
-
 import '../framework/task_result.dart';
 import '../framework/utils.dart';
 import '../versions/gallery.dart' show galleryVersion;
+import 'perf_tests.dart';
 
 class NewGalleryPerfTest extends PerfTest {
   NewGalleryPerfTest(

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -7,15 +7,15 @@ import 'dart:convert' show LineSplitter, json, utf8;
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:flutter_devicelab/framework/devices.dart';
-import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/host_agent.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
 import '../common.dart';
+import '../framework/devices.dart';
+import '../framework/framework.dart';
+import '../framework/host_agent.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
 
 /// Must match flutter_driver/lib/src/common.dart.
 ///

--- a/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
@@ -4,12 +4,13 @@
 
 import 'dart:io' show Process, Directory;
 
-import 'package:flutter_devicelab/framework/devices.dart' as adb;
-import 'package:flutter_devicelab/framework/framework.dart' show TaskFunction;
-import 'package:flutter_devicelab/framework/task_result.dart' show TaskResult;
-import 'package:flutter_devicelab/framework/utils.dart' as utils;
-import 'package:flutter_devicelab/microbenchmarks.dart' as microbenchmarks;
 import 'package:path/path.dart' as path;
+
+import '../framework/devices.dart' as adb;
+import '../framework/framework.dart' show TaskFunction;
+import '../framework/task_result.dart' show TaskResult;
+import '../framework/utils.dart' as utils;
+import '../microbenchmarks.dart' as microbenchmarks;
 
 TaskFunction runTask(adb.DeviceOperatingSystem operatingSystem) {
   return () async {

--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -4,10 +4,11 @@
 
 import 'dart:io';
 
-import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
+
+import '../framework/framework.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
 
 /// Combines several TaskFunctions with trivial success value into one.
 TaskFunction combine(List<TaskFunction> tasks) {

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -6,15 +6,16 @@ import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:io' as io;
 
-import 'package:flutter_devicelab/common.dart';
-import 'package:flutter_devicelab/framework/browser.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_static/shelf_static.dart';
+
+import '../common.dart';
+import '../framework/browser.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
 
 /// The port number used by the local benchmark server.
 const int benchmarkServerPort = 9999;

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -4,13 +4,13 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_gallery/demo/shrine/backdrop.dart';
-import 'package:flutter_gallery/demo/shrine/category_menu_page.dart';
-import 'package:flutter_gallery/demo/shrine/colors.dart';
-import 'package:flutter_gallery/demo/shrine/expanding_bottom_sheet.dart';
-import 'package:flutter_gallery/demo/shrine/home.dart';
-import 'package:flutter_gallery/demo/shrine/login.dart';
-import 'package:flutter_gallery/demo/shrine/supplemental/cut_corners_border.dart';
+import 'backdrop.dart';
+import 'category_menu_page.dart';
+import 'colors.dart';
+import 'expanding_bottom_sheet.dart';
+import 'home.dart';
+import 'login.dart';
+import 'supplemental/cut_corners_border.dart';
 
 class ShrineApp extends StatefulWidget {
   const ShrineApp({Key? key}) : super(key: key);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/backdrop.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_gallery/demo/shrine/login.dart';
+import 'login.dart';
 
 const Cubic _kAccelerateCurve = Cubic(0.548, 0.0, 0.757, 0.464);
 const Cubic _kDecelerateCurve = Cubic(0.23, 0.94, 0.41, 1.0);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/category_menu_page.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/category_menu_page.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/shrine/colors.dart';
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
 import 'package:scoped_model/scoped_model.dart';
+
+import 'colors.dart';
+import 'model/app_state_model.dart';
+import 'model/product.dart';
 
 class CategoryMenuPage extends StatelessWidget {
   const CategoryMenuPage({

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/expanding_bottom_sheet.dart
@@ -4,11 +4,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gallery/demo/shrine/colors.dart';
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
-import 'package:flutter_gallery/demo/shrine/shopping_cart.dart';
 import 'package:scoped_model/scoped_model.dart';
+
+import 'colors.dart';
+import 'model/app_state_model.dart';
+import 'model/product.dart';
+import 'shopping_cart.dart';
 
 // These curves define the emphasized easing curve.
 const Cubic _kAccelerateCurve = Cubic(0.548, 0.0, 0.757, 0.464);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/home.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/shrine/backdrop.dart';
-import 'package:flutter_gallery/demo/shrine/expanding_bottom_sheet.dart';
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
-import 'package:flutter_gallery/demo/shrine/supplemental/asymmetric_view.dart';
 import 'package:scoped_model/scoped_model.dart';
+
+import 'backdrop.dart';
+import 'expanding_bottom_sheet.dart';
+import 'model/app_state_model.dart';
+import 'model/product.dart';
+import 'supplemental/asymmetric_view.dart';
 
 class ProductPage extends StatelessWidget {
   const ProductPage({Key? key, this.category = Category.all}) : super(key: key);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/login.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_gallery/demo/shrine/colors.dart';
+import 'colors.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/model/app_state_model.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/model/app_state_model.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
-import 'package:flutter_gallery/demo/shrine/model/products_repository.dart' as product_repository;
 import 'package:scoped_model/scoped_model.dart';
+
+import 'product.dart';
+import 'products_repository.dart' as product_repository;
 
 double _salesTaxRate = 0.06;
 double _shippingCostPerItem = 7.0;

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/model/products_repository.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/model/products_repository.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
+import 'product.dart';
 
 List<Product> loadProducts(Category category) {
   const List<Product> allProducts = <Product>[

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/shrine/colors.dart';
-import 'package:flutter_gallery/demo/shrine/expanding_bottom_sheet.dart';
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
 import 'package:intl/intl.dart';
 import 'package:scoped_model/scoped_model.dart';
+
+import 'colors.dart';
+import 'expanding_bottom_sheet.dart';
+import 'model/app_state_model.dart';
+import 'model/product.dart';
 
 const double _leftColumnWidth = 60.0;
 

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/asymmetric_view.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/asymmetric_view.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
-import 'package:flutter_gallery/demo/shrine/supplemental/product_columns.dart';
+import '../model/product.dart';
+import 'product_columns.dart';
 
 class AsymmetricView extends StatelessWidget {
   const AsymmetricView({Key? key, this.products}) : super(key: key);

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/product_card.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/product_card.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
 import 'package:intl/intl.dart';
 import 'package:scoped_model/scoped_model.dart';
+
+import '../model/app_state_model.dart';
+import '../model/product.dart';
 
 class ProductCard extends StatelessWidget {
   const ProductCard({ Key? key, this.imageAspectRatio = 33 / 49, this.product })

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/product_columns.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/supplemental/product_columns.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_gallery/demo/shrine/model/product.dart';
-import 'package:flutter_gallery/demo/shrine/supplemental/product_card.dart';
+import '../model/product.dart';
+import 'product_card.dart';
 
 class TwoProductCardColumn extends StatelessWidget {
   const TwoProductCardColumn({

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine_demo.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gallery/demo/shrine/app.dart';
+import 'shrine/app.dart';
 
 class ShrineDemo extends StatelessWidget {
   const ShrineDemo({ Key? key }) : super(key: key);

--- a/dev/integration_tests/flutter_gallery/lib/gallery/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/app.dart
@@ -8,11 +8,10 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;
-import 'package:flutter_gallery/demo/shrine/model/app_state_model.dart';
 import 'package:scoped_model/scoped_model.dart';
-
 import 'package:url_launcher/url_launcher.dart';
 
+import '../demo/shrine/model/app_state_model.dart';
 import 'demos.dart';
 import 'home.dart';
 import 'options.dart';

--- a/dev/tools/gen_keycodes/lib/base_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/base_code_gen.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'package:gen_keycodes/logical_key_data.dart';
+import 'logical_key_data.dart';
 
 import 'physical_key_data.dart';
 

--- a/dev/tools/gen_keycodes/lib/logical_key_data.dart
+++ b/dev/tools/gen_keycodes/lib/logical_key_data.dart
@@ -5,11 +5,11 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:gen_keycodes/utils.dart';
 import 'package:path/path.dart' as path;
 
 import 'constants.dart';
 import 'physical_key_data.dart';
+import 'utils.dart';
 
 bool _isControlCharacter(int codeUnit) {
   return (codeUnit <= 0x1f && codeUnit >= 0x00) || (codeUnit >= 0x7f && codeUnit <= 0x9f);

--- a/dev/tools/gen_keycodes/lib/physical_key_data.dart
+++ b/dev/tools/gen_keycodes/lib/physical_key_data.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:gen_keycodes/utils.dart';
+import 'utils.dart';
 
 /// The data structure used to manage keyboard key entries.
 ///

--- a/packages/flutter/lib/analysis_options.yaml
+++ b/packages/flutter/lib/analysis_options.yaml
@@ -2,4 +2,5 @@ include: ../analysis_options.yaml
 
 linter:
   rules:
-    # - diagnostic_describe_all_properties # blocked on https://github.com/dart-lang/sdk/issues/47418
+    # diagnostic_describe_all_properties: true # blocked on https://github.com/dart-lang/sdk/issues/47418
+    prefer_relative_imports: false # doesn't really work when you have subpackages like we do here

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -9,10 +9,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_driver/driver_extension.dart';
-import 'package:flutter_driver/src/extension/wait_conditions.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../driver_extension.dart';
+import '../extension/wait_conditions.dart';
 import 'diagnostics_tree.dart';
 import 'error.dart';
 import 'find.dart';

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -13,7 +13,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_test/flutter_test.dart' show TestWindow;
 import 'package:stack_trace/stack_trace.dart' as stack_trace;
 import 'package:test_api/test_api.dart' as test_package; // ignore: deprecated_member_use
 import 'package:vector_math/vector_math_64.dart';
@@ -27,6 +26,7 @@ import 'test_async_utils.dart';
 import 'test_default_binary_messenger.dart';
 import 'test_exception_reporter.dart';
 import 'test_text_input.dart';
+import 'window.dart';
 
 /// Phases that can be reached by [WidgetTester.pumpWidget] and
 /// [TestWidgetsFlutterBinding.pump].

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -8,7 +8,10 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
+
+import 'binding.dart';
+import 'test_async_utils.dart';
+import 'widget_tester.dart';
 
 // A tuple of `key` and `location` from Web's `KeyboardEvent` class.
 //

--- a/packages/flutter_test/lib/src/test_text_input.dart
+++ b/packages/flutter_test/lib/src/test_text_input.dart
@@ -6,7 +6,10 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
+
+import 'binding.dart';
+import 'deprecated.dart';
+import 'test_async_utils.dart';
 
 export 'package:flutter/services.dart' show TextEditingValue, TextInputAction;
 

--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -10,9 +10,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
-
-import 'package:integration_test/common.dart';
 import 'package:path/path.dart' as path;
+
+import 'common.dart';
 
 /// Flutter Driver test output directory.
 ///


### PR DESCRIPTION
I left it disabled in the flutter framework itself because it doesn't like our "subpackages" (e.g. `import 'package:flutter/framework.dart'`), but I think we have other bespoke tests that enforce it there anyway so it's not a big deal.
