### PR TITLE
Add `TooltipVisibility` widget

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -158,6 +158,7 @@ export 'src/material/toggle_buttons_theme.dart';
 export 'src/material/toggleable.dart';
 export 'src/material/tooltip.dart';
 export 'src/material/tooltip_theme.dart';
+export 'src/material/tooltip_visibility.dart';
 export 'src/material/typography.dart';
 export 'src/material/user_accounts_drawer_header.dart';
 export 'widgets.dart';

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -355,7 +355,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   @override
-  void didChangeDependencies(){
+  void didChangeDependencies() {
     super.didChangeDependencies();
     _visible = TooltipVisibility.of(context);
   }
@@ -488,7 +488,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   /// Returns `false` when the tooltip shouldn't be shown or when the tooltip
   /// was already visible.
   bool ensureTooltipVisible() {
-    if(!_visible)
+    if (!_visible)
       return false;
     _showTimer?.cancel();
     _showTimer = null;
@@ -683,8 +683,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       child: widget.child,
     );
 
-    //Only check for gestures if tooltip should be visible.
-    if(_visible){
+    // Only check for gestures if tooltip should be visible.
+    if (_visible) {
       result = GestureDetector(
         behavior: HitTestBehavior.opaque,
         onLongPress: (triggerMode == TooltipTriggerMode.longPress) ?

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -70,6 +70,7 @@ import 'tooltip_visibility.dart';
 ///
 ///  * <https://material.io/design/components/tooltips.html>
 ///  * [TooltipTheme] or [ThemeData.tooltipTheme]
+///  * [TooltipVisibility]
 class Tooltip extends StatefulWidget {
   /// Creates a tooltip.
   ///

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -14,6 +14,7 @@ import 'colors.dart';
 import 'feedback.dart';
 import 'theme.dart';
 import 'tooltip_theme.dart';
+import 'tooltip_visibility.dart';
 
 /// A material design tooltip.
 ///
@@ -828,60 +829,5 @@ class _TooltipOverlay extends StatelessWidget {
         child: result,
       ),
     );
-  }
-}
-
-class _TooltipVisibilityScope extends InheritedWidget {
-  const _TooltipVisibilityScope({
-    Key? key,
-    required Widget child,
-    required this.visible,
-  }) : super(key: key, child: child);
-
-  final bool visible;
-
-  @override
-  bool updateShouldNotify(_TooltipVisibilityScope old) {
-    return old.visible != visible;
-  }
-}
-
-/// Overrides the visibility of descendant [Tooltip] widgets.
-///
-/// If disabled, the descendant [Tooltip] widgets will not display a tooltip
-/// when tapped, long-pressed, hovered by the mouse, or when
-/// `ensureTooltipVisible` is called. This only visually disables tooltips and
-/// semantics information will not be lost.
-class TooltipVisibility extends StatelessWidget {
-  /// Creates a widget that configures the visibility of [Tooltip].
-  ///
-  /// Both arguments must not be null.
-  const TooltipVisibility({
-    Key? key,
-    required this.child,
-    required this.visible,
-  }) : super(key: key);
-
-  /// The widget below this widget in the tree.
-  ///
-  /// The entire app can be wrapped in this widget to globally control [Tooltip]
-  /// visibility.
-  ///
-  /// {@macro flutter.widgets.ProxyWidget.child}
-  final Widget child;
-
-  /// Determines the visibility of [Tooltip] widets that inherit from this widget.
-  final bool visible;
-
-  /// The [visible] of the closest instance of this class that encloses the
-  /// given context. Defaults to `true` if none are found.
-  static bool of(BuildContext context) {
-    final _TooltipVisibilityScope? visibility = context.dependOnInheritedWidgetOfExactType<_TooltipVisibilityScope>();
-    return visibility?.visible ?? true;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return _TooltipVisibilityScope(child: child, visible: visible,);
   }
 }

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -436,8 +436,6 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _showTooltip({ bool immediately = false }) {
-    if(!_visible)
-      return;
     _dismissTimer?.cancel();
     _dismissTimer = null;
     if (immediately) {
@@ -676,27 +674,31 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     triggerMode = widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
     enableFeedback = widget.enableFeedback ?? tooltipTheme.enableFeedback ?? _defaultEnableFeedback;
 
-    Widget result = GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onLongPress: (triggerMode == TooltipTriggerMode.longPress) ?
-        _handlePress : null,
-      onTap: (triggerMode == TooltipTriggerMode.tap) ? _handlePress : null,
-      excludeFromSemantics: true,
-      child: Semantics(
-        label: excludeFromSemantics
-            ? null
-            : _tooltipMessage,
-        child: widget.child,
-      ),
+    Widget result = Semantics(
+      label: excludeFromSemantics
+          ? null
+          : _tooltipMessage,
+      child: widget.child,
     );
 
-    // Only check for hovering if there is a mouse connected.
-    if (_mouseIsConnected) {
-      result = MouseRegion(
-        onEnter: (_) => _handleMouseEnter(),
-        onExit: (_) => _handleMouseExit(),
+    //Only check for gestures if tooltip should be visible
+    if(_visible){
+      result = GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onLongPress: (triggerMode == TooltipTriggerMode.longPress) ?
+        _handlePress : null,
+        onTap: (triggerMode == TooltipTriggerMode.tap) ? _handlePress : null,
+        excludeFromSemantics: true,
         child: result,
       );
+      // Only check for hovering if there is a mouse connected.
+      if (_mouseIsConnected) {
+        result = MouseRegion(
+          onEnter: (_) => _handleMouseEnter(),
+          onExit: (_) => _handleMouseExit(),
+          child: result,
+        );
+      }
     }
 
     return result;

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -854,4 +854,3 @@ class TooltipDisable extends StatelessWidget {
     return _TooltipDisableScope(child: child);
   }
 }
-

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -632,9 +632,9 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     // If message is empty then no need to create a tooltip overlay to show
     // the empty black container so just return the wrapped child as is or
     // empty container if child is not specified.
-    /*if (_tooltipMessage.isEmpty || (widget.hide ?? false)) {
-      return Semantics(child: widget.child ?? const SizedBox(), label: _tooltipMessage,);
-    }*/
+    if (_tooltipMessage.isEmpty) {
+      return widget.child ?? const SizedBox();
+    }
     assert(Overlay.of(context, debugRequiredFor: widget) != null);
     final ThemeData theme = Theme.of(context);
     final TooltipThemeData tooltipTheme = TooltipTheme.of(context);
@@ -833,13 +833,6 @@ class _TooltipDisableScope extends InheritedWidget {
     required Widget child,
   }) : super(key: key, child: child);
 
-  static _TooltipDisableScope of(BuildContext context) {
-    final _TooltipDisableScope? result =
-        context.dependOnInheritedWidgetOfExactType<_TooltipDisableScope>();
-    assert(result != null, 'No _TooltipDisableScope found in context');
-    return result!;
-  }
-
   @override
   bool updateShouldNotify(_TooltipDisableScope old) {
     return false;
@@ -853,7 +846,6 @@ class TooltipDisable extends StatelessWidget {
 
   static bool existsInContext(BuildContext context) {
     final _TooltipDisableScope? disable = context.dependOnInheritedWidgetOfExactType<_TooltipDisableScope>();
-    print(disable);
     return disable != null;
   }
 

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -485,7 +485,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
 
   /// Shows the tooltip if it is not already visible.
   ///
-  /// Returns `false` when the tooltip was already visible.
+  /// Returns `false` when the tooltip shouldn't be shown or when the tooltip
+  /// was already visible.
   bool ensureTooltipVisible() {
     if(!_visible)
       return false;
@@ -682,7 +683,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       child: widget.child,
     );
 
-    //Only check for gestures if tooltip should be visible
+    //Only check for gestures if tooltip should be visible.
     if(_visible){
       result = GestureDetector(
         behavior: HitTestBehavior.opaque,

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -842,21 +842,39 @@ class _TooltipVisibilityScope extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_TooltipVisibilityScope old) {
-    return false;
+    return old.visible != visible;
   }
 }
 
+/// Overrides the visibility of descendant [Tooltip] widgets.
+///
+/// If disabled, the descendant [Tooltip] widgets will not display a tooltip
+/// when tapped, long-pressed, hovered by the mouse, or when
+/// `ensureTooltipVisible` is called. This only visually disables tooltips and
+/// semantics information will not be lost.
 class TooltipVisibility extends StatelessWidget {
+  /// Creates a widget that configures the visibility of [Tooltip].
+  ///
+  /// Both arguments must not be null.
   const TooltipVisibility({
     Key? key,
     required this.child,
     required this.visible,
   }) : super(key: key);
 
+  /// The widget below this widget in the tree.
+  ///
+  /// The entire app can be wrapped in this widget to globally control [Tooltip]
+  /// visibility.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
+  /// Determines the visibility of [Tooltip] widets that inherit from this widget.
   final bool visible;
 
+  /// The [visible] of the closest instance of this class that encloses the
+  /// given context. Defaults to `true` if none are found.
   static bool of(BuildContext context) {
     final _TooltipVisibilityScope? visibility = context.dependOnInheritedWidgetOfExactType<_TooltipVisibilityScope>();
     return visibility?.visible ?? true;

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -315,7 +315,6 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   late bool preferBelow;
   late bool excludeFromSemantics;
   late AnimationController _controller;
-  late bool _visible;
   OverlayEntry? _entry;
   Timer? _dismissTimer;
   Timer? _showTimer;
@@ -328,6 +327,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   late bool enableFeedback;
   late bool _isConcealed;
   late bool _forceRemoval;
+  late bool _visible;
 
   /// The plain text message for this tooltip.
   ///
@@ -436,6 +436,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   }
 
   void _showTooltip({ bool immediately = false }) {
+    if(!_visible)
+      return;
     _dismissTimer?.cancel();
     _dismissTimer = null;
     if (immediately) {
@@ -486,6 +488,8 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   ///
   /// Returns `false` when the tooltip was already visible.
   bool ensureTooltipVisible() {
+    if(!_visible)
+      return false;
     _showTimer?.cancel();
     _showTimer = null;
     _forceRemoval = false;
@@ -511,8 +515,6 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   static final Set<_TooltipState> _mouseIn = <_TooltipState>{};
 
   void _handleMouseEnter() {
-    if(!_visible)
-      return;
     _showTooltip();
   }
 

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -315,7 +315,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   late bool preferBelow;
   late bool excludeFromSemantics;
   late AnimationController _controller;
-  late bool _hide;
+  late bool _visible;
   OverlayEntry? _entry;
   Timer? _dismissTimer;
   Timer? _showTimer;
@@ -356,7 +356,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   @override
   void didChangeDependencies(){
     super.didChangeDependencies();
-    _hide = TooltipDisable.existsInContext(context);
+    _visible = TooltipVisibility.of(context);
   }
 
   // https://material.io/components/tooltips#specs
@@ -511,7 +511,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
   static final Set<_TooltipState> _mouseIn = <_TooltipState>{};
 
   void _handleMouseEnter() {
-    if(_hide)
+    if(!_visible)
       return;
     _showTooltip();
   }
@@ -827,30 +827,39 @@ class _TooltipOverlay extends StatelessWidget {
   }
 }
 
-class _TooltipDisableScope extends InheritedWidget {
-  const _TooltipDisableScope({
+class _TooltipVisibilityScope extends InheritedWidget {
+  const _TooltipVisibilityScope({
     Key? key,
     required Widget child,
+    required this.visible,
   }) : super(key: key, child: child);
 
+  final bool visible;
+
   @override
-  bool updateShouldNotify(_TooltipDisableScope old) {
+  bool updateShouldNotify(_TooltipVisibilityScope old) {
     return false;
   }
 }
 
-class TooltipDisable extends StatelessWidget {
-  const TooltipDisable({Key? key, required this.child}) : super(key: key);
+class TooltipVisibility extends StatelessWidget {
+  const TooltipVisibility({
+    Key? key,
+    required this.child,
+    required this.visible,
+  }) : super(key: key);
 
   final Widget child;
 
-  static bool existsInContext(BuildContext context) {
-    final _TooltipDisableScope? disable = context.dependOnInheritedWidgetOfExactType<_TooltipDisableScope>();
-    return disable != null;
+  final bool visible;
+
+  static bool of(BuildContext context) {
+    final _TooltipVisibilityScope? visibility = context.dependOnInheritedWidgetOfExactType<_TooltipVisibilityScope>();
+    return visibility?.visible ?? true;
   }
 
   @override
   Widget build(BuildContext context) {
-    return _TooltipDisableScope(child: child);
+    return _TooltipVisibilityScope(child: child, visible: visible,);
   }
 }

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -245,7 +245,7 @@ class TooltipThemeData with Diagnosticable {
 ///
 /// See also:
 ///
-///  * [TooltipVisibility], which can be used to visually disable tooltips.
+///  * [TooltipVisibility], which can be used to visually disable descendant [Tooltip]s.
 class TooltipTheme extends InheritedTheme {
   /// Creates a tooltip theme that controls the configurations for
   /// [Tooltip].

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -242,6 +242,10 @@ class TooltipThemeData with Diagnosticable {
 /// )
 /// ```
 /// {@end-tool}
+///
+/// See also:
+///
+///  * [TooltipVisibility], which can be used to visually disable tooltips.
 class TooltipTheme extends InheritedTheme {
   /// Creates a tooltip theme that controls the configurations for
   /// [Tooltip].

--- a/packages/flutter/lib/src/material/tooltip_visibility.dart
+++ b/packages/flutter/lib/src/material/tooltip_visibility.dart
@@ -23,8 +23,8 @@ class _TooltipVisibilityScope extends InheritedWidget {
 ///
 /// If disabled, the descendant [Tooltip] widgets will not display a tooltip
 /// when tapped, long-pressed, hovered by the mouse, or when
-/// `ensureTooltipVisible` is called. This only visually disables tooltips and
-/// semantics information will not be lost.
+/// `ensureTooltipVisible` is called. This only visually disables tooltips but
+/// continues to provide any semantic information that is provided.
 class TooltipVisibility extends StatelessWidget {
   /// Creates a widget that configures the visibility of [Tooltip].
   ///
@@ -43,7 +43,7 @@ class TooltipVisibility extends StatelessWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
-  /// Determines the visibility of [Tooltip] widets that inherit from this widget.
+  /// Determines the visibility of [Tooltip] widgets that inherit from this widget.
   final bool visible;
 
   /// The [visible] of the closest instance of this class that encloses the

--- a/packages/flutter/lib/src/material/tooltip_visibility.dart
+++ b/packages/flutter/lib/src/material/tooltip_visibility.dart
@@ -55,6 +55,9 @@ class TooltipVisibility extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _TooltipVisibilityScope(child: child, visible: visible,);
+    return _TooltipVisibilityScope(
+      child: child,
+      visible: visible,
+    );
   }
 }

--- a/packages/flutter/lib/src/material/tooltip_visibility.dart
+++ b/packages/flutter/lib/src/material/tooltip_visibility.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+class _TooltipVisibilityScope extends InheritedWidget {
+  const _TooltipVisibilityScope({
+    Key? key,
+    required Widget child,
+    required this.visible,
+  }) : super(key: key, child: child);
+
+  final bool visible;
+
+  @override
+  bool updateShouldNotify(_TooltipVisibilityScope old) {
+    return old.visible != visible;
+  }
+}
+
+/// Overrides the visibility of descendant [Tooltip] widgets.
+///
+/// If disabled, the descendant [Tooltip] widgets will not display a tooltip
+/// when tapped, long-pressed, hovered by the mouse, or when
+/// `ensureTooltipVisible` is called. This only visually disables tooltips and
+/// semantics information will not be lost.
+class TooltipVisibility extends StatelessWidget {
+  /// Creates a widget that configures the visibility of [Tooltip].
+  ///
+  /// Both arguments must not be null.
+  const TooltipVisibility({
+    Key? key,
+    required this.child,
+    required this.visible,
+  }) : super(key: key);
+
+  /// The widget below this widget in the tree.
+  ///
+  /// The entire app can be wrapped in this widget to globally control [Tooltip]
+  /// visibility.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  /// Determines the visibility of [Tooltip] widets that inherit from this widget.
+  final bool visible;
+
+  /// The [visible] of the closest instance of this class that encloses the
+  /// given context. Defaults to `true` if none are found.
+  static bool of(BuildContext context) {
+    final _TooltipVisibilityScope? visibility = context.dependOnInheritedWidgetOfExactType<_TooltipVisibilityScope>();
+    return visibility?.visible ?? true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _TooltipVisibilityScope(child: child, visible: visible,);
+  }
+}

--- a/packages/flutter/test/material/tooltip_visibility_test.dart
+++ b/packages/flutter/test/material/tooltip_visibility_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void _ensureTooltipVisible(GlobalKey key) {
-  // This function uses "as dynamic"to defeat the static analysis. In general
+  // This function uses "as dynamic" to defeat the static analysis. In general
   // you want to avoid using this style in your code, as it will cause the
   // analyzer to be unable to help you catch errors.
   //
@@ -217,21 +217,7 @@ Future<void> setWidgetForTooltipMode(WidgetTester tester, TooltipTriggerMode tri
   );
 }
 
-Future<void> testGestureLongPress(WidgetTester tester, Finder tooltip) async {
-  final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(tooltip));
-  await tester.pump();
-  await tester.pump(kLongPressTimeout);
-  await gestureLongPress.up();
-  await tester.pump();
-}
-
 Future<void> testGestureTap(WidgetTester tester, Finder tooltip) async {
   await tester.tap(tooltip);
   await tester.pump(const Duration(milliseconds: 10));
-}
-
-SemanticsNode findDebugSemantics(RenderObject object) {
-  if (object.debugSemantics != null)
-    return object.debugSemantics!;
-  return findDebugSemantics(object.parent! as RenderObject);
 }

--- a/packages/flutter/test/material/tooltip_visibility_test.dart
+++ b/packages/flutter/test/material/tooltip_visibility_test.dart
@@ -1,0 +1,237 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void _ensureTooltipVisible(GlobalKey key) {
+  // This function uses "as dynamic"to defeat the static analysis. In general
+  // you want to avoid using this style in your code, as it will cause the
+  // analyzer to be unable to help you catch errors.
+  //
+  // In this case, we do it because we are trying to call internal methods of
+  // the tooltip code in order to test it. Normally, the state of a tooltip is a
+  // private class, but by using a GlobalKey we can get a handle to that object
+  // and by using "as dynamic" we can bypass the analyzer's type checks and call
+  // methods that we aren't supposed to be able to know about.
+  //
+  // It's ok to do this in tests, but you really don't want to do it in
+  // production code.
+  // ignore: avoid_dynamic_calls
+  (key.currentState as dynamic).ensureTooltipVisible();
+}
+
+const String tooltipText = 'TIP';
+
+void main() {
+  testWidgets('Tooltip does not build MouseRegion when mouse is detected and in TooltipVisibility with visibility = false', (WidgetTester tester) async {
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    await gesture.moveTo(Offset.zero);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: TooltipVisibility(
+          visible: false,
+          child: Tooltip(
+            message: tooltipText,
+            child: SizedBox(
+              width: 100.0,
+              height: 100.0,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.descendant(of: find.byType(Tooltip), matching: find.byType(MouseRegion)), findsNothing);
+  });
+
+  testWidgets('Tooltip does not show when hovered when in TooltipVisibility with visible = false', (WidgetTester tester) async {
+    const Duration waitDuration = Duration.zero;
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    await gesture.moveTo(Offset.zero);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: TooltipVisibility(
+            visible: false,
+            child: Tooltip(
+              message: tooltipText,
+              waitDuration: waitDuration,
+              child: SizedBox(
+                width: 100.0,
+                height: 100.0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder tooltip = find.byType(Tooltip);
+    await gesture.moveTo(Offset.zero);
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump();
+    // Wait for it to appear.
+    await tester.pump(waitDuration);
+    expect(find.text(tooltipText), findsNothing);
+  });
+
+  testWidgets('Tooltip shows when hovered when in TooltipVisibility with visible = true', (WidgetTester tester) async {
+    const Duration waitDuration = Duration.zero;
+    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    await gesture.moveTo(Offset.zero);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: TooltipVisibility(
+            visible: true,
+            child: Tooltip(
+              message: tooltipText,
+              waitDuration: waitDuration,
+              child: SizedBox(
+                width: 100.0,
+                height: 100.0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder tooltip = find.byType(Tooltip);
+    await gesture.moveTo(Offset.zero);
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump();
+    // Wait for it to appear.
+    await tester.pump(waitDuration);
+    expect(find.text(tooltipText), findsOneWidget);
+
+    // Wait for it to disappear.
+    await gesture.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    await gesture.removePointer();
+    gesture = null;
+    expect(find.text(tooltipText), findsNothing);
+  });
+
+  testWidgets('Tooltip does not build GestureDetector when in TooltipVisibility with visibility = false', (WidgetTester tester) async {
+    await setWidgetForTooltipMode(tester, TooltipTriggerMode.tap, false);
+
+    expect(find.byType(GestureDetector), findsNothing);
+  });
+
+  testWidgets('Tooltip triggers on tap when trigger mode is tap and in TooltipVisibility with visible = true', (WidgetTester tester) async {
+    await setWidgetForTooltipMode(tester, TooltipTriggerMode.tap, true);
+
+    final Finder tooltip = find.byType(Tooltip);
+    expect(find.text(tooltipText), findsNothing);
+
+    await testGestureTap(tester, tooltip);
+    expect(find.text(tooltipText), findsOneWidget);
+  });
+
+  testWidgets('Tooltip does not trigger manually when in TooltipVisibility with visible = false', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TooltipVisibility(
+          visible: false,
+          child: Tooltip(
+            key: key,
+            message: tooltipText,
+            child: const SizedBox(width: 100.0, height: 100.0),
+          ),
+        ),
+      ),
+    );
+
+    _ensureTooltipVisible(key);
+    await tester.pump();
+    expect(find.text(tooltipText), findsNothing);
+  });
+
+  testWidgets('Tooltip triggers manually when in TooltipVisibility with visible = true', (WidgetTester tester) async {
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TooltipVisibility(
+          visible: true,
+          child: Tooltip(
+            key: key,
+            message: tooltipText,
+            child: const SizedBox(width: 100.0, height: 100.0),
+          ),
+        ),
+      ),
+    );
+
+    _ensureTooltipVisible(key);
+    await tester.pump();
+    expect(find.text(tooltipText), findsOneWidget);
+  });
+}
+
+Future<void> setWidgetForTooltipMode(WidgetTester tester, TooltipTriggerMode triggerMode, bool visibility) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: TooltipVisibility(
+        visible: visibility,
+        child: Tooltip(
+          message: tooltipText,
+          triggerMode: triggerMode,
+          child: const SizedBox(width: 100.0, height: 100.0),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> testGestureLongPress(WidgetTester tester, Finder tooltip) async {
+  final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(tooltip));
+  await tester.pump();
+  await tester.pump(kLongPressTimeout);
+  await gestureLongPress.up();
+  await tester.pump();
+}
+
+Future<void> testGestureTap(WidgetTester tester, Finder tooltip) async {
+  await tester.tap(tooltip);
+  await tester.pump(const Duration(milliseconds: 10));
+}
+
+SemanticsNode findDebugSemantics(RenderObject object) {
+  if (object.debugSemantics != null)
+    return object.debugSemantics!;
+  return findDebugSemantics(object.parent! as RenderObject);
+}


### PR DESCRIPTION
Adds a new widget to visually disable tooltips in a child subtree without losing semantics labels (based on the discussion in https://github.com/flutter/flutter/issues/66993).

<details>
 <summary>Demo</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

enum WhyFarther { harder, smarter, selfStarter, tradingCharter }

class MyApp extends StatefulWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  WhyFarther? _selection;
  bool tooltipVisibility = false;
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      //showSemanticsDebugger: true,
      home: TooltipVisibility(
        visible: tooltipVisibility,
        child: Scaffold(
          appBar: AppBar(
            title: Text("Test"),
          ),
          body: Center(
              child: TooltipVisibility(
                visible: !tooltipVisibility,
                child: PopupMenuButton<WhyFarther>(
                  tooltip: null,
                  onSelected: (WhyFarther result) {
                    setState(() {
                      _selection = result;
                    });
                  },
                  itemBuilder: (BuildContext context) => <PopupMenuEntry<WhyFarther>>[
                    const PopupMenuItem<WhyFarther>(
                      value: WhyFarther.harder,
                      child: Text('Working a lot harder'),
                    ),
                    const PopupMenuItem<WhyFarther>(
                      value: WhyFarther.smarter,
                      child: Text('Being a lot smarter'),
                    ),
                    const PopupMenuItem<WhyFarther>(
                      value: WhyFarther.selfStarter,
                      child: Text('Being a self-starter'),
                    ),
                    const PopupMenuItem<WhyFarther>(
                      value: WhyFarther.tradingCharter,
                      child: Text('Placed in charge of trading charter'),
                    ),
                  ],
                ),
              )),
          drawer: Drawer(
            child: ListView(
              children: [
                const Text("Drawer item"),
              ],
            ),
          ),
          floatingActionButton: Switch(
            value: tooltipVisibility,
            onChanged:(value) => setState(()=> tooltipVisibility = value),
          ),
        ),
      ),
    );
  }
}
```
</details>

Fixes https://github.com/flutter/flutter/issues/66993, https://github.com/flutter/flutter/issues/60418

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.