### PR TITLE
Fix visual overflow when overscrolling RenderShrinkWrappingViewport

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -1922,11 +1922,7 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     // Since the viewport is shrinkwrapped, we know that any negative overscroll
     // into the potentially infinite mainAxisExtent will overflow the end of
     // the viewport.
-    if (correctedOffset < 0.0) {
-      _hasVisualOverflow = true;
-    } else {
-      _hasVisualOverflow = false;
-    }
+    _hasVisualOverflow = correctedOffset < 0.0;
     switch (cacheExtentStyle) {
       case CacheExtentStyle.pixel:
         _calculatedCacheExtent = cacheExtent;

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -1919,7 +1919,14 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
     assert(correctedOffset.isFinite);
     _maxScrollExtent = 0.0;
     _shrinkWrapExtent = 0.0;
-    _hasVisualOverflow = false;
+    // Since the viewport is shrinkwrapped, we know that any negative overscroll
+    // into the potentially infinite mainAxisExtent will overflow the end of
+    // the viewport.
+    if (correctedOffset < 0.0) {
+      _hasVisualOverflow = true;
+    } else {
+      _hasVisualOverflow = false;
+    }
     switch (cacheExtentStyle) {
       case CacheExtentStyle.pixel:
         _calculatedCacheExtent = cacheExtent;
@@ -1928,6 +1935,7 @@ class RenderShrinkWrappingViewport extends RenderViewportBase<SliverLogicalConta
         _calculatedCacheExtent = mainAxisExtent * _cacheExtent;
         break;
     }
+
     return layoutChildSequence(
       child: firstChild,
       scrollOffset: math.max(0.0, correctedOffset),

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1877,31 +1877,34 @@ void main() {
         textDirection: TextDirection.ltr,
         child: MediaQuery(
           data: const MediaQueryData(),
-          child: Column(
-            children: <Widget>[
-              // Translucent boxes above and below the shrinkwrapped viewport
-              // make it easily discernible if the viewport is not being
-              // clipped properly.
-              Opacity(
-                opacity: 0.5,
-                child: Container(height: 100, color: const Color(0xFF00B0FF)),
-              ),
-              Container(
-                height: constrain ? 150 : null,
-                color: const Color(0xFFF44336),
-                child: ListView.builder(
-                  controller: controller,
-                  shrinkWrap: true,
-                  physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-                  itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-                  itemCount: 10,
+          child: Container(
+            color: const Color(0xFF000000),
+            child: Column(
+              children: <Widget>[
+                // Translucent boxes above and below the shrinkwrapped viewport
+                // make it easily discernible if the viewport is not being
+                // clipped properly.
+                Opacity(
+                  opacity: 0.5,
+                  child: Container(height: 100, color: const Color(0xFF00B0FF)),
                 ),
-              ),
-              Opacity(
-                opacity: 0.5,
-                child: Container(height: 100, color: const Color(0xFF00B0FF)),
-              ),
-            ],
+                Container(
+                  height: constrain ? 150 : null,
+                  color: const Color(0xFFF44336),
+                  child: ListView.builder(
+                    controller: controller,
+                    shrinkWrap: true,
+                    physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+                    itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+                    itemCount: 10,
+                  ),
+                ),
+                Opacity(
+                  opacity: 0.5,
+                  child: Container(height: 100, color: const Color(0xFF00B0FF)),
+                ),
+              ],
+            ),
           ),
         ),
       );

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1846,233 +1846,280 @@ void main() {
     });
   });
 
-  Widget _buildShrinkWrap({
-    ScrollController? controller,
-    Axis scrollDirection = Axis.vertical,
-    ScrollPhysics? physics,
-  }) {
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: const MediaQueryData(),
-        child: ListView.builder(
-          controller: controller,
-          physics: physics,
-          scrollDirection: scrollDirection,
-          shrinkWrap: true,
-          itemBuilder: (BuildContext context, int index) => SizedBox(height: 50, width: 50, child: Text('Item $index')),
-          itemCount: 20,
-          itemExtent: 50,
-        ),
-      ),
-    );
-  }
-
-  testWidgets('Constrained Shrinkwrapping viewport will not overflow on overscroll', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/89717
-    final  ScrollController controller = ScrollController();
-    await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Column(
-              children: <Widget>[
-                Container(height: 100, color: const Color(0x00000000)),
-                Container(
-                  height: 150,
-                  color: const Color(0xFFF44336),
-                  child: ListView.builder(
-                    controller: controller,
-                    shrinkWrap: true,
-                    physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-                    itemBuilder: (BuildContext context, int index) => Text('Item $index'),
-                    itemCount: 10,
-                  ),
-                ),
-                Container(height: 100, color: const Color(0x00000000)),
-              ],
-            ),
+  group('Overscrolling RenderShrinkWrappingViewport', () {
+    Widget _buildSimpleShrinkWrap({
+      ScrollController? controller,
+      Axis scrollDirection = Axis.vertical,
+      ScrollPhysics? physics,
+    }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ListView.builder(
+            controller: controller,
+            physics: physics,
+            scrollDirection: scrollDirection,
+            shrinkWrap: true,
+            itemBuilder: (BuildContext context, int index) => SizedBox(height: 50, width: 50, child: Text('Item $index')),
+            itemCount: 20,
+            itemExtent: 50,
           ),
-        )
-    );
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
+        ),
+      );
+    }
 
-    // Overscroll
-    final TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.text('Item 0')));
-    await overscrollGesture.moveBy(const Offset(0, 25));
-    await tester.pump();
-    expect(controller.offset, -25.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 125.0);
-    await expectLater(
-      find.byType(Directionality),
-      matchesGoldenFile('shrinkwrapped_overscroll.png'),
-    );
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
-  });
+    Widget _buildClippingShrinkWrap(
+      ScrollController controller, {
+      bool constrain = false,
+    }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Column(
+            children: <Widget>[
+              // Translucent boxes above and below the shrinkwrapped viewport
+              // make it easily discernible if the viewport is not being
+              // clipped properly.
+              Opacity(
+                opacity: 0.5,
+                child: Container(height: 100, color: const Color(0xFF00B0FF)),
+              ),
+              Container(
+                height: constrain ? 150 : null,
+                color: const Color(0xFFF44336),
+                child: ListView.builder(
+                  controller: controller,
+                  shrinkWrap: true,
+                  physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+                  itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+                  itemCount: 10,
+                ),
+              ),
+              Opacity(
+                opacity: 0.5,
+                child: Container(height: 100, color: const Color(0xFF00B0FF)),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
-  testWidgets('Shrinkwrap allows overscrolling on default platforms - vertical', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/10949
-    // Scrollables should overscroll by default on iOS and macOS
-    final  ScrollController controller = ScrollController();
-    await tester.pumpWidget(
-      _buildShrinkWrap(controller: controller),
-    );
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
-    // Check overscroll at both ends
-    // Start
-    TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(0, 25));
-    await tester.pump();
-    expect(controller.offset, -25.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 25.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
+    testWidgets('constrained viewport correctly clips overflow', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/89717
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildClippingShrinkWrap(controller, constrain: true)
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
+      expect(tester.getTopLeft(find.text('Item 9')).dy, 226.0);
 
-    // End
-    final double maxExtent = controller.position.maxScrollExtent;
-    controller.jumpTo(controller.position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
+      // Overscroll
+      final TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.text('Item 0')));
+      await overscrollGesture.moveBy(const Offset(0, 100));
+      await tester.pump();
+      expect(controller.offset, -100.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 200.0);
+      await expectLater(
+        find.byType(Directionality),
+        matchesGoldenFile('shrinkwrap_clipped_constrained_overscroll.png'),
+      );
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
+      expect(tester.getTopLeft(find.text('Item 9')).dy, 226.0);
+    });
 
-    overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(0, -25));
-    await tester.pump();
-    expect(controller.offset, greaterThan(maxExtent));
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 575.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+    testWidgets('correctly clips overflow without constraints', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/89717
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildClippingShrinkWrap(controller)
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
+      expect(tester.getTopLeft(find.text('Item 9')).dy, 226.0);
 
-  testWidgets('Shrinkwrap allows overscrolling on default platforms - horizontal', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/10949
-    // Scrollables should overscroll by default on iOS and macOS
-    final  ScrollController controller = ScrollController();
-    await tester.pumpWidget(
-      _buildShrinkWrap(controller: controller, scrollDirection: Axis.horizontal),
-    );
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
-    // Check overscroll at both ends
-    // Start
-    TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(25, 0));
-    await tester.pump();
-    expect(controller.offset, -25.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 25.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
+      // Overscroll
+      final TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.text('Item 0')));
+      await overscrollGesture.moveBy(const Offset(0, 100));
+      await tester.pump();
+      expect(controller.offset, -100.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 200.0);
+      await expectLater(
+        find.byType(Directionality),
+        matchesGoldenFile('shrinkwrap_clipped_overscroll.png'),
+      );
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 100.0);
+      expect(tester.getTopLeft(find.text('Item 9')).dy, 226.0);
+    });
 
-    // End
-    final double maxExtent = controller.position.maxScrollExtent;
-    controller.jumpTo(controller.position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+    testWidgets('allows overscrolling on default platforms - vertical', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/10949
+      // Scrollables should overscroll by default on iOS and macOS
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildSimpleShrinkWrap(controller: controller),
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
+      // Check overscroll at both ends
+      // Start
+      TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(0, 25));
+      await tester.pump();
+      expect(controller.offset, -25.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 25.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
 
-    overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(-25, 0));
-    await tester.pump();
-    expect(controller.offset, greaterThan(maxExtent));
-    expect(tester.getTopRight(find.text('Item 19')).dx, 775.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
+      // End
+      final double maxExtent = controller.position.maxScrollExtent;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
 
-  testWidgets('Shrinkwrap allows overscrolling per physics - vertical', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/10949
-    // Scrollables should overscroll when the scroll physics allow
-    final  ScrollController controller = ScrollController();
-    await tester.pumpWidget(
-      _buildShrinkWrap(controller: controller, physics: const BouncingScrollPhysics()),
-    );
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
-    // Check overscroll at both ends
-    // Start
-    TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(0, 25));
-    await tester.pump();
-    expect(controller.offset, -25.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 25.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
+      overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(0, -25));
+      await tester.pump();
+      expect(controller.offset, greaterThan(maxExtent));
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 575.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
-    // End
-    final double maxExtent = controller.position.maxScrollExtent;
-    controller.jumpTo(controller.position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
+    testWidgets('allows overscrolling on default platforms - horizontal', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/10949
+      // Scrollables should overscroll by default on iOS and macOS
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildSimpleShrinkWrap(controller: controller, scrollDirection: Axis.horizontal),
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
+      // Check overscroll at both ends
+      // Start
+      TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(25, 0));
+      await tester.pump();
+      expect(controller.offset, -25.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 25.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
 
-    overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(0, -25));
-    await tester.pump();
-    expect(controller.offset, greaterThan(maxExtent));
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 575.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
-  });
+      // End
+      final double maxExtent = controller.position.maxScrollExtent;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
 
-  testWidgets('Shrinkwrap allows overscrolling per physics - horizontal', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/10949
-    // Scrollables should overscroll when the scroll physics allow
-    final  ScrollController controller = ScrollController();
-    await tester.pumpWidget(
-      _buildShrinkWrap(
-        controller: controller,
-        scrollDirection: Axis.horizontal,
-        physics: const BouncingScrollPhysics(),
-      ),
-    );
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
-    // Check overscroll at both ends
-    // Start
-    TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(25, 0));
-    await tester.pump();
-    expect(controller.offset, -25.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 25.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, 0.0);
-    expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
+      overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(-25, 0));
+      await tester.pump();
+      expect(controller.offset, greaterThan(maxExtent));
+      expect(tester.getTopRight(find.text('Item 19')).dx, 775.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
-    // End
-    final double maxExtent = controller.position.maxScrollExtent;
-    controller.jumpTo(controller.position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+    testWidgets('allows overscrolling per physics - vertical', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/10949
+      // Scrollables should overscroll when the scroll physics allow
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildSimpleShrinkWrap(controller: controller, physics: const BouncingScrollPhysics()),
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
+      // Check overscroll at both ends
+      // Start
+      TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(0, 25));
+      await tester.pump();
+      expect(controller.offset, -25.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 25.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dy, 0.0);
 
-    overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
-    await overscrollGesture.moveBy(const Offset(-25, 0));
-    await tester.pump();
-    expect(controller.offset, greaterThan(maxExtent));
-    expect(tester.getTopRight(find.text('Item 19')).dx, 775.0);
-    await overscrollGesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.offset, maxExtent);
-    expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+      // End
+      final double maxExtent = controller.position.maxScrollExtent;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
+
+      overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(0, -25));
+      await tester.pump();
+      expect(controller.offset, greaterThan(maxExtent));
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 575.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getBottomLeft(find.text('Item 19')).dy, 600.0);
+    });
+
+    testWidgets('allows overscrolling per physics - horizontal', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/10949
+      // Scrollables should overscroll when the scroll physics allow
+      final  ScrollController controller = ScrollController();
+      await tester.pumpWidget(
+        _buildSimpleShrinkWrap(
+          controller: controller,
+          scrollDirection: Axis.horizontal,
+          physics: const BouncingScrollPhysics(),
+        ),
+      );
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
+      // Check overscroll at both ends
+      // Start
+      TestGesture overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(25, 0));
+      await tester.pump();
+      expect(controller.offset, -25.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 25.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0.0);
+      expect(tester.getTopLeft(find.text('Item 0')).dx, 0.0);
+
+      // End
+      final double maxExtent = controller.position.maxScrollExtent;
+      controller.jumpTo(controller.position.maxScrollExtent);
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+
+      overscrollGesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      await overscrollGesture.moveBy(const Offset(-25, 0));
+      await tester.pump();
+      expect(controller.offset, greaterThan(maxExtent));
+      expect(tester.getTopRight(find.text('Item 19')).dx, 775.0);
+      await overscrollGesture.up();
+      await tester.pumpAndSettle();
+      expect(controller.offset, maxExtent);
+      expect(tester.getTopRight(find.text('Item 19')).dx, 800.0);
+    });
   });
 
   testWidgets('Handles infinite constraints when TargetPlatform is iOS or macOS', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/89717 for real this time. :)

https://github.com/flutter/flutter/issues/89717 is a regression that was caused by #87143 while resolving #10949
#90419 originally sought to resolve it, but the test cases in that change did not account for every case of visual overflow.

This updates `hasVisualOverflow` so that the clip is properly applied when overscrolling a shrinkwrapping viewport. Seen here in the golden file test I added.

## Because these images are translucent, the images look the same on github in light mode. Switching to dark mode makes the difference clearer.

### Overflowing

![shrinkwrap_clipped_overscroll](https://user-images.githubusercontent.com/16964204/136847964-c170862c-b1a0-48f4-be9c-06bf94ebe757.png)

### Not Overflowing 🎉 

![shrinkwrap_clipped_overscroll 2](https://user-images.githubusercontent.com/16964204/136847983-2270be4e-bc79-4b9b-b51a-4c6ae6b2dda6.png)

There are a lot of tests for each of these changes, and so while I was here I cleaned then up a bit to be more organized.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
