### PR TITLE
BackButton was not showing while Scaffold has endDrawer

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -226,8 +226,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [AppBar] will imply an appropriate widget. For example, if the [AppBar] is
   /// in a [Scaffold] that also has a [Drawer], the [Scaffold] will fill this
   /// widget with an [IconButton] that opens the drawer (using [Icons.menu]). If
-  /// there's no [Drawer] and the parent [Navigator] can go back, the [AppBar]
-  /// will use a [BackButton] that calls [Navigator.maybePop].
+  /// there's only [Scaffold.endDrawer] and the parent [Navigator] can go back,
+  /// the [AppBar] will use a [BackButton] that calls [Navigator.maybePop].
   /// {@endtemplate}
   ///
   /// {@tool snippet}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -881,7 +881,7 @@ class _AppBarState extends State<AppBar> {
           tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
         );
       } else {
-        if (!hasEndDrawer && canPop)
+        if (canPop)
           leading = useCloseButton ? const CloseButton() : const BackButton();
       }
     }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2447,7 +2447,7 @@ void main() {
     expect(tester.getRect(find.byKey(key)), const Rect.fromLTRB(0, 0, 100, 56));
   });
 
-  testWidgets("AppBar with EndDrawer doesn't have leading", (WidgetTester tester) async {
+  testWidgets('AppBar with EndDrawer does have leading', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         appBar: AppBar(),
@@ -2461,7 +2461,7 @@ void main() {
 
     final Finder appBarFinder = find.byType(NavigationToolbar);
     NavigationToolbar getAppBarWidget(Finder finder) => tester.widget<NavigationToolbar>(finder);
-    expect(getAppBarWidget(appBarFinder).leading, null);
+    expect(getAppBarWidget(appBarFinder).leading, isNot(null));
   });
 
   testWidgets('AppBar.titleSpacing defaults to NavigationToolbar.kMiddleSpacing', (WidgetTester tester) async {


### PR DESCRIPTION
I just change the behavior of `BackButton` visibility, when I add `endDrawer` to the current `Scaffold` the `BackButton` is disappearing.

From the developer's perspective, I think this one is not good behavior so that I just created a PR for changing this behavior.

[Also some other developers on SO](https://stackoverflow.com/questions/66485355/flutter-2-0-appbar-back-button-disappeared-if-contains-enddrawer)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
