### PR TITLE
[ThemeData] Remove brightness from copyWith contructor

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1398,7 +1398,6 @@ class ThemeData with Diagnosticable {
   ///
   /// The [brightness] value is applied to the [colorScheme].
   ThemeData copyWith({
-    Brightness? brightness,
     VisualDensity? visualDensity,
     Color? primaryColor,
     Brightness? primaryColorBrightness,
@@ -1584,7 +1583,7 @@ class ThemeData with Diagnosticable {
       appBarTheme: appBarTheme ?? this.appBarTheme,
       scrollbarTheme: scrollbarTheme ?? this.scrollbarTheme,
       bottomAppBarTheme: bottomAppBarTheme ?? this.bottomAppBarTheme,
-      colorScheme: (colorScheme ?? this.colorScheme).copyWith(brightness: brightness),
+      colorScheme: colorScheme ?? this.colorScheme,
       dialogTheme: dialogTheme ?? this.dialogTheme,
       floatingActionButtonTheme: floatingActionButtonTheme ?? this.floatingActionButtonTheme,
       navigationBarTheme: navigationBarTheme ?? this.navigationBarTheme,

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -618,22 +618,4 @@ void main() {
     const ColorScheme lightColors = ColorScheme.light();
     expect(() => ThemeData(colorScheme: lightColors, brightness: Brightness.dark), throwsAssertionError);
   });
-
-  testWidgets('ThemeData.copyWith brightness parameter overrides ColorScheme brightness', (WidgetTester tester) async {
-    const ColorScheme lightColors = ColorScheme.light();
-    final ThemeData theme = ThemeData.from(colorScheme: lightColors).copyWith(brightness: Brightness.dark);
-
-    // The brightness parameter only overrides ColorScheme.brightness.
-    expect(theme.brightness, equals(Brightness.dark));
-    expect(theme.colorScheme.brightness, equals(Brightness.dark));
-    expect(theme.primaryColor, equals(lightColors.primary));
-    expect(theme.accentColor, equals(lightColors.secondary));
-    expect(theme.cardColor, equals(lightColors.surface));
-    expect(theme.backgroundColor, equals(lightColors.background));
-    expect(theme.canvasColor, equals(lightColors.background));
-    expect(theme.scaffoldBackgroundColor, equals(lightColors.background));
-    expect(theme.dialogBackgroundColor, equals(lightColors.background));
-    expect(theme.errorColor, equals(lightColors.error));
-    expect(theme.applyElevationOverlayColor, isFalse);
-  });
 }


### PR DESCRIPTION
This PR removes `brightness` property from the `copyWith` constructor of the `ThemeData`.

Fixes https://github.com/flutter/flutter/issues/91587

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
