### PR TITLE
[codeowners] Remove *_builders.json ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,8 +9,6 @@
 /CODEOWNERS @jmagman
 /.ci.yaml @keyonghan @caseyhillers
 /dev/ci/ @christopherfujino
-/dev/prod_builders.json @caseyhillers @christopherfujino
-/dev/try_builders.json @caseyhillers @christopherfujino
 /packages/flutter_goldens @Piinks
 /packages/flutter_goldens_client @Piinks
 /packages/flutter_test/lib/src/_goldens_io.dart @Piinks


### PR DESCRIPTION
This is no longer necessary as the migration to ci.yaml is complete