### PR TITLE
Remove unused offset from Layer.addToScene/addChildrenToScene

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -54,8 +54,8 @@ class _ProxyLayer extends Layer {
   final Layer _layer;
 
   @override
-  void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
-    _layer.addToScene(builder, layerOffset);
+  void addToScene(ui.SceneBuilder builder) {
+    _layer.addToScene(builder);
   }
 
   @override
@@ -319,8 +319,8 @@ Rect _calculateSubtreeBounds(RenderObject object) {
 /// screenshots render to the scene in the local coordinate system of the layer.
 class _ScreenshotContainerLayer extends OffsetLayer {
   @override
-  void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
-    addChildrenToScene(builder, layerOffset);
+  void addToScene(ui.SceneBuilder builder) {
+    addChildrenToScene(builder);
   }
 }
 
@@ -2665,7 +2665,7 @@ class _InspectorOverlayLayer extends Layer {
   double? _textPainterMaxWidth;
 
   @override
-  void addToScene(ui.SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {
+  void addToScene(ui.SceneBuilder builder) {
     if (!selection.active)
       return;
 
@@ -2694,7 +2694,7 @@ class _InspectorOverlayLayer extends Layer {
       _lastState = state;
       _picture = _buildPicture(state);
     }
-    builder.addPicture(layerOffset, _picture);
+    builder.addPicture(Offset.zero, _picture);
   }
 
   ui.Picture _buildPicture(_InspectorOverlayRenderState state) {

--- a/packages/flutter/test/rendering/layer_annotations_test.dart
+++ b/packages/flutter/test/rendering/layer_annotations_test.dart
@@ -845,7 +845,7 @@ class _TestAnnotatedLayer extends Layer {
   final Size? size;
 
   @override
-  EngineLayer? addToScene(SceneBuilder builder, [Offset layerOffset = Offset.zero]) {
+  EngineLayer? addToScene(SceneBuilder builder) {
     return null;
   }
 

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -608,7 +608,7 @@ class FakePicture extends Fake implements Picture {
 
 class ConcreteLayer extends Layer {
   @override
-  void addToScene(SceneBuilder builder, [ Offset layerOffset = Offset.zero ]) {}
+  void addToScene(SceneBuilder builder) {}
 }
 
 class _TestAlwaysNeedsAddToSceneLayer extends ContainerLayer {


### PR DESCRIPTION
I was recently reading this code and tried to figure out when the `childOffset` param to `addChildrenToScene` is ever non-zero to understand what code paths trigger non-retained rendering [1]. Turns out, the offset is always zero. To avoid that confusion in the future and to simplify the code, let's remove the parameter (pending checks passing to verify that it's not breaking anything).

[1] https://github.com/flutter/flutter/blob/528f77dc99e43f3eb20698cb683c25705725ced0/packages/flutter/lib/src/rendering/layer.dart#L1109-L1113

_Update:_ Some historical digging shows that three years ago it was also proposed to eliminate this param, but it was kept **unused** to preserve backwards-compatibility, see https://github.com/flutter/flutter/pull/21619#discussion_r220380344. Since our breaking change policy has evolved since then I think we should remove it if this doesn't turn out to be a breaking change per our latest breaking change policy.