### PR TITLE
Rename "*Extent" to "*Size"

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -282,111 +282,111 @@ class DraggableScrollableNotification extends Notification with ViewportNotifica
 ///
 /// The ScrollPosition knows the number of pixels a user wants to move the sheet.
 ///
-/// The [currentExtent] will never be null.
+/// The [currentSize] will never be null.
 /// The [availablePixels] will never be null, but may be `double.infinity`.
 class _DraggableSheetExtent {
   _DraggableSheetExtent({
-    required this.minExtent,
-    required this.maxExtent,
+    required this.minSize,
+    required this.maxSize,
     required this.snap,
     required this.snapSizes,
-    required this.initialExtent,
-    required this.onExtentChanged,
-    ValueNotifier<double>? currentExtent,
+    required this.initialSize,
+    required this.onSizeChanged,
+    ValueNotifier<double>? currentSize,
     bool? hasChanged,
-  })  : assert(minExtent != null),
-        assert(maxExtent != null),
-        assert(initialExtent != null),
-        assert(minExtent >= 0),
-        assert(maxExtent <= 1),
-        assert(minExtent <= initialExtent),
-        assert(initialExtent <= maxExtent),
-        _currentExtent = (currentExtent ?? ValueNotifier<double>(initialExtent))
-          ..addListener(onExtentChanged),
+  })  : assert(minSize != null),
+        assert(maxSize != null),
+        assert(initialSize != null),
+        assert(minSize >= 0),
+        assert(maxSize <= 1),
+        assert(minSize <= initialSize),
+        assert(initialSize <= maxSize),
+        _currentSize = (currentSize ?? ValueNotifier<double>(initialSize))
+          ..addListener(onSizeChanged),
         availablePixels = double.infinity,
         hasChanged = hasChanged ?? false;
 
-  final double minExtent;
-  final double maxExtent;
+  final double minSize;
+  final double maxSize;
   final bool snap;
   final List<double> snapSizes;
-  final double initialExtent;
-  final ValueNotifier<double> _currentExtent;
-  final VoidCallback onExtentChanged;
+  final double initialSize;
+  final ValueNotifier<double> _currentSize;
+  final VoidCallback onSizeChanged;
   double availablePixels;
 
-  // Used to disable snapping until the extent has changed. We do this because
-  // we don't want to snap away from the initial extent.
+  // Used to disable snapping until the user interacts with the sheet. We set
+  // this to false on initialization and after programmatic interaction with the
+  // sheet to prevent snapping away from the initial size and after animateTo/jumpTo.
   bool hasChanged;
 
-  bool get isAtMin => minExtent >= _currentExtent.value;
-  bool get isAtMax => maxExtent <= _currentExtent.value;
+  bool get isAtMin => minSize >= _currentSize.value;
+  bool get isAtMax => maxSize <= _currentSize.value;
 
-  set currentExtent(double value) {
+  set currentSize(double value) {
     assert(value != null);
     hasChanged = true;
-    _currentExtent.value = value.clamp(minExtent, maxExtent);
+    _currentSize.value = value.clamp(minSize, maxSize);
   }
-  double get currentExtent => _currentExtent.value;
-  double get currentPixels => extentToPixels(_currentExtent.value);
+  double get currentSize => _currentSize.value;
+  double get currentPixels => sizeToPixels(_currentSize.value);
 
-  double get additionalMinExtent => isAtMin ? 0.0 : 1.0;
-  double get additionalMaxExtent => isAtMax ? 0.0 : 1.0;
-  List<double> get pixelSnapSizes => snapSizes.map(extentToPixels).toList();
+  double get additionalMinSize => isAtMin ? 0.0 : 1.0;
+  double get additionalMaxSize => isAtMax ? 0.0 : 1.0;
+  List<double> get pixelSnapSizes => snapSizes.map(sizeToPixels).toList();
 
-  /// The scroll position gets inputs in terms of pixels, but the extent is
+  /// The scroll position gets inputs in terms of pixels, but the size is
   /// expected to be expressed as a number between 0..1.
   void addPixelDelta(double delta, BuildContext context) {
     if (availablePixels == 0) {
       return;
     }
-    updateExtent(currentExtent + pixelsToExtent(delta), context);
+    updateSize(currentSize + pixelsToSize(delta), context);
   }
 
-  /// Set the extent to the new value. [newExtent] should be a number between
-  /// 0..1.
-  void updateExtent(double newExtent, BuildContext context) {
-    currentExtent = newExtent;
+  /// Set the size to the new value. [newSize] should be a number between 0..1.
+  void updateSize(double newSize, BuildContext context) {
+    currentSize = newSize;
     DraggableScrollableNotification(
-      minExtent: minExtent,
-      maxExtent: maxExtent,
-      extent: currentExtent,
-      initialExtent: initialExtent,
+      minExtent: minSize,
+      maxExtent: maxSize,
+      extent: currentSize,
+      initialExtent: initialSize,
       context: context,
     ).dispatch(context);
   }
 
-  double pixelsToExtent(double pixels) {
-    return pixels / availablePixels * maxExtent;
+  double pixelsToSize(double pixels) {
+    return pixels / availablePixels * maxSize;
   }
 
-  double extentToPixels(double extent) {
-    return extent / maxExtent * availablePixels;
+  double sizeToPixels(double extent) {
+    return extent / maxSize * availablePixels;
   }
 
   void dispose() {
-    _currentExtent.removeListener(onExtentChanged);
+    _currentSize.removeListener(onSizeChanged);
   }
 
   _DraggableSheetExtent copyWith({
-    required double minExtent,
-    required double maxExtent,
+    required double minSize,
+    required double maxSize,
     required bool snap,
     required List<double> snapSizes,
-    required double initialExtent,
-    required VoidCallback onExtentChanged,
+    required double initialSize,
+    required VoidCallback onSizeChanged,
   }) {
     return _DraggableSheetExtent(
-      minExtent: minExtent,
-      maxExtent: maxExtent,
+      minSize: minSize,
+      maxSize: maxSize,
       snap: snap,
       snapSizes: snapSizes,
-      initialExtent: initialExtent,
-      onExtentChanged: onExtentChanged,
+      initialSize: initialSize,
+      onSizeChanged: onSizeChanged,
       // Use the possibly updated initialExtent if the user hasn't dragged yet.
-      currentExtent: ValueNotifier<double>(hasChanged
-          ? _currentExtent.value.clamp(minExtent, maxExtent)
-          : initialExtent),
+      currentSize: ValueNotifier<double>(hasChanged
+          ? _currentSize.value.clamp(minSize, maxSize)
+          : initialSize),
       hasChanged: hasChanged,
     );
   }
@@ -400,12 +400,12 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
   void initState() {
     super.initState();
     _extent = _DraggableSheetExtent(
-      minExtent: widget.minChildSize,
-      maxExtent: widget.maxChildSize,
+      minSize: widget.minChildSize,
+      maxSize: widget.maxChildSize,
       snap: widget.snap,
       snapSizes: _impliedSnapSizes(),
-      initialExtent: widget.initialChildSize,
-      onExtentChanged: _setExtent,
+      initialSize: widget.initialChildSize,
+      onSizeChanged: _setSize,
     );
     _scrollController = _DraggableScrollableSheetScrollController(extent: _extent);
   }
@@ -455,11 +455,11 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
         );
       }
       _extent.hasChanged = false;
-      _extent._currentExtent.value = _extent.initialExtent;
+      _extent._currentSize.value = _extent.initialSize;
     }
   }
 
-  void _setExtent() {
+  void _setSize() {
     setState(() {
       // _extent has been updated when this is called.
     });
@@ -471,7 +471,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       builder: (BuildContext context, BoxConstraints constraints) {
         _extent.availablePixels = widget.maxChildSize * constraints.biggest.height;
         final Widget sheet = FractionallySizedBox(
-          heightFactor: _extent.currentExtent,
+          heightFactor: _extent.currentSize,
           alignment: Alignment.bottomCenter,
           child: widget.builder(context, _scrollController),
         );
@@ -490,12 +490,12 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
   void _replaceExtent() {
     _extent.dispose();
     _extent = _extent.copyWith(
-      minExtent: widget.minChildSize,
-      maxExtent: widget.maxChildSize,
+      minSize: widget.minChildSize,
+      maxSize: widget.maxChildSize,
       snap: widget.snap,
       snapSizes: _impliedSnapSizes(),
-      initialExtent: widget.initialChildSize,
-      onExtentChanged: _setExtent,
+      initialSize: widget.initialChildSize,
+      onSizeChanged: _setSize,
     );
     // Modify the existing scroll controller instead of replacing it so that
     // developers listening to the controller do not have to rebuild their listeners.
@@ -584,7 +584,7 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
 /// This class is a concrete subclass of [ScrollPosition] logic that handles a
 /// single [ScrollContext], such as a [Scrollable]. An instance of this class
 /// manages [ScrollActivity] instances, which changes the
-/// [_DraggableSheetExtent.currentExtent] or visible content offset in the
+/// [_DraggableSheetExtent.currentSize] or visible content offset in the
 /// [Scrollable]'s [Viewport]
 ///
 /// See also:
@@ -624,13 +624,13 @@ class _DraggableScrollableSheetScrollPosition
   }
 
   @override
-  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
-    // We need to provide some extra extent if we haven't yet reached the max or
-    // min extents. Otherwise, a list with fewer children than the extent of
+  bool applyContentDimensions(double minScrollSize, double maxScrollSize) {
+    // We need to provide some extra size if we haven't yet reached the max or
+    // min sizes. Otherwise, a list with fewer children than the size of
     // the available space will get stuck.
     return super.applyContentDimensions(
-      minScrollExtent - extent.additionalMinExtent,
-      maxScrollExtent + extent.additionalMaxExtent,
+      minScrollSize - extent.additionalMinSize,
+      maxScrollSize + extent.additionalMaxSize,
     );
   }
 
@@ -649,7 +649,7 @@ class _DraggableScrollableSheetScrollPosition
   bool get _isAtSnapSize {
     return extent.snapSizes.any(
       (double snapSize) {
-        return (extent.currentExtent - snapSize).abs() <= extent.pixelsToExtent(physics.tolerance.distance);
+        return (extent.currentSize - snapSize).abs() <= extent.pixelsToSize(physics.tolerance.distance);
       },
     );
   }
@@ -803,7 +803,7 @@ class _ResetNotifier extends ChangeNotifier {
 
 class _InheritedResetNotifier extends InheritedNotifier<_ResetNotifier> {
   /// Creates an [InheritedNotifier] that the [DraggableScrollableSheet] will
-  /// listen to for an indication that it should change its extent.
+  /// listen to for an indication that it should reset itself back to [DraggableScrollableSheet.initialChildSize].
   ///
   /// The [child] and [notifier] properties must not be null.
   const _InheritedResetNotifier({


### PR DESCRIPTION
This PR contains a refactor only affecting private fields.

**Summary:**
Rename "*Extent" to "*Size" to reduce naming confusion.

**Motivation:**
Currently, `DraggableScrollableSheet` overloads the word "extent". It means the following two things, depending on context:
**as a double**: The current size of the sheet as a fraction of the total space available
**as a _DraggableScrollableSheetExtent**: A private object used for storing, tracking and updating the state of a sheet

The former definition is redundant to the publicly exposed term `size` (eg `DraggableScrollableSheet.minSize`). This overloaded term and mismatch between public and private naming generates confusion when updating and modifying internal code. It can also cause needless variable shadowing (eg `double _extent` shadowing `_DraggableScrollableSheetExtent _extent`).

This PR simply replaces all usage of the term `extent` under the former definition with the word `size`. While this is a fairly large refactor for a purely internal facing QoL issue, I think it's worth it-the current naming standard has made my PRs more confusing to write-I suspect others may have the same trouble?

This PR **DOES NOT** rename the `*Extent` fields of `DraggableScrollableNotification` because they are publicly exposed and thus changing them would be a breaking change for any customers using the notification class. I would like to also change these public facing fields but wanted input as to whether or not a naming change justifies breaking customers. #embraceTheYakShave?

If you consider this PR worthwhile, I'll ask Hixie for a test exemption. If not, I can just close the PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
