### PR TITLE
Add `profileRenderObjectPaints` and `profileRenderObjectLayouts` service extensions

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -153,7 +153,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
           };
         },
       );
-
       registerServiceExtension(
         name: 'debugDumpSemanticsTreeInTraversalOrder',
         callback: (Map<String, String> parameters) async {
@@ -164,7 +163,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
           };
         },
       );
-
       registerServiceExtension(
         name: 'debugDumpSemanticsTreeInInverseHitTestOrder',
         callback: (Map<String, String> parameters) async {
@@ -175,8 +173,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
           };
         },
       );
-
-      // Expose the ability to send [RenderObject] paints as [Timeline] events.
       registerBoolServiceExtension(
         name: 'profileRenderObjectPaints',
         getter: () async => debugProfilePaintsEnabled,
@@ -185,8 +181,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
             debugProfilePaintsEnabled = value;
         },
       );
-
-      // Expose the ability to send [RenderObject] layouts as [Timeline] events.
       registerBoolServiceExtension(
         name: 'profileRenderObjectLayouts',
         getter: () async => debugProfileLayoutsEnabled,

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -175,6 +175,26 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
           };
         },
       );
+
+      // Expose the ability to send [RenderObject] paints as [Timeline] events.
+      registerBoolServiceExtension(
+        name: 'profileRenderObjectPaints',
+        getter: () async => debugProfilePaintsEnabled,
+        setter: (bool value) async {
+          if (debugProfilePaintsEnabled != value)
+            debugProfilePaintsEnabled = value;
+        },
+      );
+
+      // Expose the ability to send [RenderObject] layouts as [Timeline] events.
+      registerBoolServiceExtension(
+        name: 'profileRenderObjectLayouts',
+        getter: () async => debugProfileLayoutsEnabled,
+        setter: (bool value) async {
+          if (debugProfileLayoutsEnabled != value)
+            debugProfileLayoutsEnabled = value;
+        },
+      );
     }
   }
 

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -238,6 +238,7 @@ bool debugAssertAllRenderVarsUnset(String reason, { bool debugCheckIntrinsicSize
         debugPrintMarkNeedsPaintStacks ||
         debugPrintLayouts ||
         debugCheckIntrinsicSizes != debugCheckIntrinsicSizesOverride ||
+        debugProfilePaintsEnabled ||
         debugOnProfilePaint != null) {
       throw FlutterError(reason);
     }

--- a/packages/flutter/lib/src/rendering/debug.dart
+++ b/packages/flutter/lib/src/rendering/debug.dart
@@ -111,9 +111,8 @@ bool debugProfileLayoutsEnabled = false;
 
 /// Adds [dart:developer.Timeline] events for every [RenderObject] painted.
 ///
-/// This is only enabled in debug builds. The timing information this exposes is
-/// not representative of actual paints. However, it can expose unexpected
-/// painting in the timeline.
+/// The timing information this flag exposes is not representative of actual
+/// paints. However, it can expose unexpected painting in the timeline.
 ///
 /// For details on how to use [dart:developer.Timeline] events in the Dart
 /// Observatory to optimize your app, see:
@@ -239,7 +238,6 @@ bool debugAssertAllRenderVarsUnset(String reason, { bool debugCheckIntrinsicSize
         debugPrintMarkNeedsPaintStacks ||
         debugPrintLayouts ||
         debugCheckIntrinsicSizes != debugCheckIntrinsicSizesOverride ||
-        debugProfilePaintsEnabled ||
         debugOnProfilePaint != null) {
       throw FlutterError(reason);
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -175,9 +175,9 @@ class PaintingContext extends ClipContext {
   /// into the layer subtree associated with this painting context. Otherwise,
   /// the child will be painted into the current PictureLayer for this context.
   void paintChild(RenderObject child, Offset offset) {
+    if (!kReleaseMode && debugProfilePaintsEnabled)
+      Timeline.startSync('${child.runtimeType}', arguments: timelineArgumentsIndicatingLandmarkEvent);
     assert(() {
-      if (debugProfilePaintsEnabled)
-        Timeline.startSync('${child.runtimeType}', arguments: timelineArgumentsIndicatingLandmarkEvent);
       debugOnProfilePaint?.call(child);
       return true;
     }());
@@ -189,11 +189,8 @@ class PaintingContext extends ClipContext {
       child._paintWithContext(this, offset);
     }
 
-    assert(() {
-      if (debugProfilePaintsEnabled)
-        Timeline.finishSync();
-      return true;
-    }());
+    if (!kReleaseMode && debugProfilePaintsEnabled)
+      Timeline.finishSync();
   }
 
   void _compositeChild(RenderObject child, Offset offset) {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -173,7 +173,7 @@ void main() {
     const int disabledExtensions = kIsWeb ? 2 : 0;
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 33 + widgetInspectorExtensionCount - disabledExtensions);
+    expect(binding.extensions.length, 35 + widgetInspectorExtensionCount - disabledExtensions);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;
@@ -438,6 +438,64 @@ void main() {
     result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfileBuildsEnabled, false);
+
+    expect(binding.frameScheduled, isFalse);
+  });
+
+  test('Service extensions - profileRenderObjectPaints', () async {
+    Map<String, dynamic> result;
+
+    expect(binding.frameScheduled, isFalse);
+    expect(debugProfileBuildsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfilePaintsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'true'});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfilePaintsEnabled, true);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfilePaintsEnabled, true);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'false'});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfilePaintsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfilePaintsEnabled, false);
+
+    expect(binding.frameScheduled, isFalse);
+  });
+
+  test('Service extensions - profileRenderObjectLayouts', () async {
+    Map<String, dynamic> result;
+
+    expect(binding.frameScheduled, isFalse);
+    expect(debugProfileLayoutsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileLayoutsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'true'});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfileLayoutsEnabled, true);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfileLayoutsEnabled, true);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'false'});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileLayoutsEnabled, false);
+
+    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileLayoutsEnabled, false);
 
     expect(binding.frameScheduled, isFalse);
   });

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -448,23 +448,23 @@ void main() {
     expect(binding.frameScheduled, isFalse);
     expect(debugProfileBuildsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectPaints', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfilePaintsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'true'});
+    result = await binding.testExtension('profileRenderObjectPaints', <String, String>{'enabled': 'true'});
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugProfilePaintsEnabled, true);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectPaints', <String, String>{});
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugProfilePaintsEnabled, true);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'false'});
+    result = await binding.testExtension('profileRenderObjectPaints', <String, String>{'enabled': 'false'});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfilePaintsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectPaints', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfilePaintsEnabled, false);
 
@@ -477,23 +477,23 @@ void main() {
     expect(binding.frameScheduled, isFalse);
     expect(debugProfileLayoutsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectLayouts', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfileLayoutsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'true'});
+    result = await binding.testExtension('profileRenderObjectLayouts', <String, String>{'enabled': 'true'});
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugProfileLayoutsEnabled, true);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectLayouts', <String, String>{});
     expect(result, <String, String>{'enabled': 'true'});
     expect(debugProfileLayoutsEnabled, true);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{'enabled': 'false'});
+    result = await binding.testExtension('profileRenderObjectLayouts', <String, String>{'enabled': 'false'});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfileLayoutsEnabled, false);
 
-    result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
+    result = await binding.testExtension('profileRenderObjectLayouts', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfileLayoutsEnabled, false);
 


### PR DESCRIPTION
These extensions will be exposed in DevTools to provide helpful performance debugging features. This PR also enables the `debugProfilePaintsEnabled` to be used in profile mode, where as previously it was only available in debug. This is consistent with other flags that send TimelineEvents like `debugProfileLayoutsEnabled` and `debugProfileBuildsEnabled`.