### PR TITLE
Deflake Mac plugin_test_ios

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2189,7 +2189,6 @@ targets:
 
   - name: Mac plugin_test_ios
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/88794
     timeout: 60
     properties:
       caches: >-


### PR DESCRIPTION
The `Mac plugin_test_ios` has been validated in staging for >50 runs, and it also passed >20 runs in prod as `bringup:true`.

This PR deflakes the test.

https://github.com/flutter/flutter/issues/88794