### PR TITLE
_CastError on Semantics copy in release mode

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2711,7 +2711,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (hideHandles) {
       // Hide the handles and the toolbar.
       _selectionOverlay?.hide();
-    } else if (_selectionOverlay != null && _selectionOverlay!.toolbarIsVisible) {
+    } else if (_selectionOverlay?.toolbarIsVisible ?? false) {
       // Hide only the toolbar but not the handles.
       _selectionOverlay?.hideToolbar();
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2711,7 +2711,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (hideHandles) {
       // Hide the handles and the toolbar.
       _selectionOverlay?.hide();
-    } else {
+    } else if (_selectionOverlay != null && _selectionOverlay!.toolbarIsVisible) {
       // Hide only the toolbar but not the handles.
       _selectionOverlay?.hideToolbar();
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -496,7 +496,7 @@ class TextSelectionOverlay {
   void hideToolbar() {
     assert(_toolbar != null);
     _toolbarController.stop();
-    _toolbar!.remove();
+    _toolbar?.remove();
     _toolbar = null;
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -357,7 +357,7 @@ class TextSelectionOverlay {
   /// Controls the fade-in and fade-out animations for the toolbar and handles.
   static const Duration fadeDuration = Duration(milliseconds: 150);
 
-  late AnimationController _toolbarController;
+  late final AnimationController _toolbarController;
   Animation<double> get _toolbarOpacity => _toolbarController.view;
 
   /// Retrieve current value.


### PR DESCRIPTION
### Background

We were getting reports of `_CastError` that seemed to have to do with copying.  I tracked it to [this line](https://github.com/flutter/flutter/blob/ccc82614952af8f8008b5848a3b6569e61a5f6f7/packages/flutter/lib/src/widgets/text_selection.dart#L499), where the toolbar was being hidden when it was already gone.

I was able to reproduce the error by calling copy via accessibility when the toolbar is not on the screen.

It turns out that I broke this in https://github.com/flutter/flutter/pull/76327.  Prior to that, calling `hideToolbar` was safe even if the toolbar was already hidden.

### Solution

This PR makes it safe to call `hideToolbar` without a toolbar again.  The test reproduces the bug using semantic copy.

### Related

b/201218542
Fixes a bug introduced by https://github.com/flutter/flutter/pull/76327.