### PR TITLE
[ReorderableListView] Update doc with example to make it clear `proxyDecorator` can be overriden to customise an item when it is being dragged.

### DIFF
--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
@@ -44,7 +44,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
     return ReorderableListView(
       padding: const EdgeInsets.symmetric(horizontal: 40),
       children: <Widget>[
-        for (int index = 0; index < _items.length; index++)
+        for (int index = 1; index < _items.length; index++)
           ListTile(
             key: Key('$index'),
             tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
@@ -44,7 +44,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
     return ReorderableListView(
       padding: const EdgeInsets.symmetric(horizontal: 40),
       children: <Widget>[
-        for (int index = 1; index < _items.length; index++)
+        for (int index = 0; index < _items.length; index += 1)
           ListTile(
             key: Key('$index'),
             tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -1,0 +1,84 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for ReorderableListView
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const MyStatefulWidget(),
+      ),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({Key? key}) : super(key: key);
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  final List<int> _items = List<int>.generate(50, (int index) => index);
+
+  Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (BuildContext context, Widget? child) {
+        final double animValue = Curves.easeInOut.transform(animation.value);
+        final double elevation = lerpDouble(0, 6, animValue)!;
+        return Material(
+          elevation: elevation,
+          color: Colors.blue,
+          shadowColor: Colors.blue[300],
+          child: child,
+        );
+      },
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
+    final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
+
+    return ReorderableListView(
+      padding: const EdgeInsets.symmetric(horizontal: 40),
+      proxyDecorator: _proxyDecorator,
+      children: <Widget>[
+        for (int index = 0; index < _items.length; index++)
+          ListTile(
+            key: Key('$index'),
+            tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,
+            title: Text('Item ${_items[index]}'),
+          ),
+      ],
+      onReorder: (int oldIndex, int newIndex) {
+        setState(() {
+          if (oldIndex < newIndex) {
+            newIndex -= 1;
+          }
+          final int item = _items.removeAt(oldIndex);
+          _items.insert(newIndex, item);
+        });
+      },
+    );
+  }
+}

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -36,34 +36,35 @@ class MyStatefulWidget extends StatefulWidget {
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   final List<int> _items = List<int>.generate(50, (int index) => index);
 
-  Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
-    return AnimatedBuilder(
-      animation: animation,
-      builder: (BuildContext context, Widget? child) {
-        final double animValue = Curves.easeInOut.transform(animation.value);
-        final double elevation = lerpDouble(0, 6, animValue)!;
-        return Material(
-          elevation: elevation,
-          color: Colors.blue,
-          shadowColor: Colors.blue[300],
-          child: child,
-        );
-      },
-      child: child,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
-    final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
+    final Color evenItemColor = colorScheme.primaryVariant.withOpacity(0.15);
+    final Color draggableItemColor = colorScheme.secondary;
+  
+    Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
+      return AnimatedBuilder(
+        animation: animation,
+        builder: (BuildContext context, Widget? child) {
+          final double animValue = Curves.easeInOut.transform(animation.value);
+          final double elevation = lerpDouble(0, 6, animValue)!;
+          return Material(
+            elevation: elevation,
+            color: draggableItemColor,
+            shadowColor: draggableItemColor,
+            child: child,
+          );
+        },
+        child: child,
+      );
+    }
 
     return ReorderableListView(
       padding: const EdgeInsets.symmetric(horizontal: 40),
       proxyDecorator: _proxyDecorator,
       children: <Widget>[
-        for (int index = 0; index < _items.length; index++)
+        for (int index = 1; index < _items.length; index++)
           ListTile(
             key: Key('$index'),
             tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -64,7 +64,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
       padding: const EdgeInsets.symmetric(horizontal: 40),
       proxyDecorator: _proxyDecorator,
       children: <Widget>[
-        for (int index = 1; index < _items.length; index++)
+        for (int index = 0; index < _items.length; index += 1)
           ListTile(
             key: Key('$index'),
             tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -42,7 +42,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
     final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
     final Color evenItemColor = colorScheme.primaryVariant.withOpacity(0.15);
     final Color draggableItemColor = colorScheme.secondary;
-  
+
     Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
       return AnimatedBuilder(
         animation: animation,

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -34,19 +34,16 @@ import 'theme.dart';
 /// ** See code in examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart **
 /// {@end-tool}
 ///
-/// Default [proxyDecorator] can overriden to customize an item when it is being dragged.
+/// This example demonstrates using the [proxyDecorator] callback to customize the appearance of
+/// a list item while it's being dragged.
 /// {@tool snippet}
 ///
-/// Here item's background color and shadow color customized compared to default behavior
-/// when item is being dragged.
+/// While a drag is underway, the widget returned by the [proxyDecorator] serves as a "proxy" (a substitute)
+/// for the item in the list. The proxy is created with the original list item as its child. The [proxyDecorator]
+/// in this example is similar to the default one except that it changes the proxy item's background color.
 ///
 /// ** See code in examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart **
 /// {@end-tool}
-///
-/// See also:
-///
-///  * [proxyDecorator], A callback that allows an item to be customized when it is being dragged.
-///
 class ReorderableListView extends StatefulWidget {
   /// Creates a reorderable list from a pre-built list of widgets.
   ///

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -31,9 +31,22 @@ import 'theme.dart';
 ///
 /// {@tool dartpad}
 ///
-///
 /// ** See code in examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart **
-///{@end-tool}
+/// {@end-tool}
+///
+/// Default [proxyDecorator] can overriden to customize an item when it is being dragged.
+/// {@tool snippet}
+///
+/// Here item's background color and shadow color customized compared to default behavior
+/// when item is being dragged.
+///
+/// ** See code in examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [proxyDecorator], A callback that allows an item to be customized when it is being dragged.
+///
 class ReorderableListView extends StatefulWidget {
   /// Creates a reorderable list from a pre-built list of widgets.
   ///

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -55,6 +55,33 @@ import 'transitions.dart';
 /// ```
 /// {@end-tool}
 ///
+/// Default [proxyDecorator] can overriden to customize an item when it is being dragged.
+///
+/// {@tool snippet}
+///
+/// Item's background color and shadow color customized compared to default behavior
+/// when item is being dragged.
+///
+/// ```dart
+/// Widget myProxyDecorator(Widget child, int index, Animation<double> animation) {
+///   return AnimatedBuilder(
+///     animation: animation,
+///     builder: (BuildContext context, Widget? child) {
+///       final double animValue = Curves.easeInOut.transform(animation.value);
+///       final double elevation = lerpDouble(0, 6, animValue)!;
+///       return Material(
+///         elevation: elevation,
+///         color: Colors.blue,
+///         shadowColor: Colors.blue[300],
+///         child: child,
+///       );
+///     },
+///     child: child,
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ReorderableList], a widget list that allows the user to reorder

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -57,8 +57,6 @@ import 'transitions.dart';
 ///
 /// Default [proxyDecorator] can overriden to customize an item when it is being dragged.
 ///
-/// {@tool snippet}
-///
 /// Item's background color and shadow color customized compared to default behavior
 /// when item is being dragged.
 ///
@@ -80,8 +78,6 @@ import 'transitions.dart';
 ///   );
 /// }
 /// ```
-/// {@end-tool}
-///
 /// See also:
 ///
 ///  * [ReorderableList], a widget list that allows the user to reorder

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -55,29 +55,6 @@ import 'transitions.dart';
 /// ```
 /// {@end-tool}
 ///
-/// Default [proxyDecorator] can overriden to customize an item when it is being dragged.
-///
-/// Item's background color and shadow color customized compared to default behavior
-/// when item is being dragged.
-///
-/// ```dart
-/// Widget myProxyDecorator(Widget child, int index, Animation<double> animation) {
-///   return AnimatedBuilder(
-///     animation: animation,
-///     builder: (BuildContext context, Widget? child) {
-///       final double animValue = Curves.easeInOut.transform(animation.value);
-///       final double elevation = lerpDouble(0, 6, animValue)!;
-///       return Material(
-///         elevation: elevation,
-///         color: Colors.blue,
-///         shadowColor: Colors.blue[300],
-///         child: child,
-///       );
-///     },
-///     child: child,
-///   );
-/// }
-/// ```
 /// See also:
 ///
 ///  * [ReorderableList], a widget list that allows the user to reorder


### PR DESCRIPTION
I was looking to add this "new feature" https://github.com/flutter/flutter/issues/45799
Turns out, it is already possible to add a custom background when it is being dragged by overriding default `proxyDecorator`

This fixes https://github.com/flutter/flutter/issues/45799

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
