### PR TITLE
Add `manuallyRefreshing` property to `RefreshIndicator` to reactively show or hide

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -123,7 +123,7 @@ class RefreshIndicator extends StatefulWidget {
     this.displacement = 40.0,
     this.edgeOffset = 0.0,
     required this.onRefresh,
-    this.isRefreshing = false,
+    this.manuallyRefreshing = false,
     this.color,
     this.backgroundColor,
     this.notificationPredicate = defaultScrollNotificationPredicate,
@@ -182,9 +182,9 @@ class RefreshIndicator extends StatefulWidget {
   ///
   /// Note that reactively showing the refresh indicator will not call [onRefresh]
   /// or automatically hide the indicator after the returned [Future] completes.
-  /// If `isRefreshing` has been set to `true`, it must be set to `false` through
+  /// If `manuallyRefreshing` has been set to `true`, it must be set to `false` through
   /// your own logic to hide the indicator and allow refreshing by dragging again.
-  final bool isRefreshing;
+  final bool manuallyRefreshing;
 
   /// The progress indicator's foreground color. The current theme's
   /// [ColorScheme.primary] by default.
@@ -263,7 +263,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     _scaleController = AnimationController(vsync: this);
     _scaleFactor = _scaleController.drive(_oneToZeroTween);
 
-    if (widget.isRefreshing)
+    if (widget.manuallyRefreshing)
       show();
   }
 
@@ -296,25 +296,25 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       );
     }
 
-    if (oldWidget.isRefreshing != widget.isRefreshing)
-      _reactToIsRefreshing();
+    if (oldWidget.manuallyRefreshing != widget.manuallyRefreshing)
+      _reactToManuallyRefreshing();
   }
 
-  Future<void> _reactToIsRefreshing() async {
+  Future<void> _reactToManuallyRefreshing() async {
     if (!mounted)
       return;
-    if (widget.isRefreshing) {
+    if (widget.manuallyRefreshing) {
       if (_mode == _RefreshIndicatorMode.refresh)
         return;
       if (_mode != null) {
         await _dismiss(_RefreshIndicatorMode.canceled);
-        if (!widget.isRefreshing)
+        if (!widget.manuallyRefreshing)
           return;
       }
       if (_mode == null)
         show();
     }
-    if (_mode == _RefreshIndicatorMode.refresh && !widget.isRefreshing)
+    if (_mode == _RefreshIndicatorMode.refresh && !widget.manuallyRefreshing)
       _dismiss(_RefreshIndicatorMode.done);
   }
 
@@ -498,13 +498,13 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
             _mode = _RefreshIndicatorMode.refresh;
           });
           final Future<void>? refreshResult;
-          if (!widget.isRefreshing) {
+          if (!widget.manuallyRefreshing) {
             refreshResult = widget.onRefresh();
           } else {
             refreshResult = null;
           }
           assert(() {
-            if (!widget.isRefreshing && refreshResult == null)
+            if (!widget.manuallyRefreshing && refreshResult == null)
               FlutterError.reportError(FlutterErrorDetails(
                 exception: FlutterError(
                   'The onRefresh callback returned null.\n'
@@ -518,7 +518,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
           if (refreshResult == null)
             return;
           refreshResult.whenComplete(() {
-            if (mounted && _mode == _RefreshIndicatorMode.refresh && !widget.isRefreshing) {
+            if (mounted && _mode == _RefreshIndicatorMode.refresh && !widget.manuallyRefreshing) {
               completer.complete();
               _dismiss(_RefreshIndicatorMode.done);
             }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -307,8 +307,11 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     if(widget.isRefreshing){
       if(_mode == _RefreshIndicatorMode.refresh)
         return;
-      if(_mode != null)
+      if(_mode != null) {
         await _dismiss(_RefreshIndicatorMode.canceled);
+        if(!widget.isRefreshing)
+          return;
+      }
       if(_mode == null)
         show();
     }

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -176,13 +176,13 @@ class RefreshIndicator extends StatefulWidget {
   /// [Future] must complete when the refresh operation is finished.
   final RefreshCallback onRefresh;
 
-  /// This bool can be changed to show or hide the refresh indicator reactively.
+  /// This bool can be changed to show and hide the refresh indicator reactively.
   /// Defaults to false and if set to true before [State.initState] will show
   /// the refresh indicator as soon as it is built.
   ///
   /// Note that reactively showing the refresh indicator will not call [onRefresh]
   /// or automatically hide the indicator after the returned [Future] completes.
-  /// If isRefreshing has been set to `true`, it must be set to `false` through
+  /// If `isRefreshing` has been set to `true`, it must be set to `false` through
   /// your own logic to hide the indicator and allow refreshing by dragging again.
   final bool isRefreshing;
 

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -263,7 +263,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     _scaleController = AnimationController(vsync: this);
     _scaleFactor = _scaleController.drive(_oneToZeroTween);
 
-    if(widget.isRefreshing)
+    if (widget.isRefreshing)
       show();
   }
 
@@ -296,26 +296,25 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       );
     }
 
-    if(oldWidget.isRefreshing != widget.isRefreshing){
+    if (oldWidget.isRefreshing != widget.isRefreshing)
       _reactToIsRefreshing();
-    }
   }
 
   Future<void> _reactToIsRefreshing() async {
-    if(!mounted)
+    if (!mounted)
       return;
-    if(widget.isRefreshing){
-      if(_mode == _RefreshIndicatorMode.refresh)
+    if (widget.isRefreshing) {
+      if (_mode == _RefreshIndicatorMode.refresh)
         return;
-      if(_mode != null) {
+      if (_mode != null) {
         await _dismiss(_RefreshIndicatorMode.canceled);
-        if(!widget.isRefreshing)
+        if (!widget.isRefreshing)
           return;
       }
-      if(_mode == null)
+      if (_mode == null)
         show();
     }
-    if(_mode == _RefreshIndicatorMode.refresh && !widget.isRefreshing)
+    if (_mode == _RefreshIndicatorMode.refresh && !widget.isRefreshing)
       _dismiss(_RefreshIndicatorMode.done);
   }
 
@@ -501,7 +500,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
           final Future<void>? refreshResult;
           if (!widget.isRefreshing) {
             refreshResult = widget.onRefresh();
-          } else{
+          } else {
             refreshResult = null;
           }
           assert(() {

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -902,4 +902,186 @@ void main() {
     await tester.pump(const Duration(seconds: 1)); // finish the indicator hide animation
     expect(refreshCalled, true);
   });
+
+  testWidgets('RefreshIndicator shows on inital state if isRefreshing', (WidgetTester tester) async {
+    refreshCalled = false;
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          isRefreshing: true,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+              return SizedBox(
+                height: 200.0,
+                child: Text(item),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      label: 'Refresh',
+    ));
+
+    expect(refreshCalled, false);
+    handle.dispose();
+  });
+
+  testWidgets('RefreshIndicator shows and hides on isRefreshing', (WidgetTester tester) async {
+    refreshCalled = false;
+    bool _isRefreshing = false;
+    late StateSetter setState;
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setter) {
+              setState = setter;
+              return RefreshIndicator(
+                onRefresh: refresh,
+                isRefreshing: _isRefreshing,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                    return SizedBox(
+                      height: 200.0,
+                      child: Text(item),
+                    );
+                  }).toList(),
+                ),
+              );
+            }
+        ),
+      ),
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+
+    setState(() {
+      _isRefreshing = true;
+    });
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(refreshCalled, false);
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      label: 'Refresh',
+    ));
+
+    setState(() {
+      _isRefreshing = false;
+    });
+    await tester.pumpAndSettle();
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+
+    handle.dispose();
+  });
+
+  testWidgets('RefreshIndicator hides on isRefreshing - fast switching', (WidgetTester tester) async {
+    refreshCalled = false;
+    bool _isRefreshing = false;
+    late StateSetter setState;
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setter) {
+              setState = setter;
+              return RefreshIndicator(
+                onRefresh: refresh,
+                isRefreshing: _isRefreshing,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                    return SizedBox(
+                      height: 200.0,
+                      child: Text(item),
+                    );
+                  }).toList(),
+                ),
+              );
+            }
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+
+    setState(() {
+      _isRefreshing = true;
+    });
+    await tester.pump();
+    setState(() {
+      _isRefreshing = false;
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      label: 'Refresh',
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+
+    handle.dispose();
+  });
+
+  testWidgets('RefreshIndicator shows on isRefreshing - fast switching', (WidgetTester tester) async {
+    refreshCalled = false;
+    bool _isRefreshing = true;
+    late StateSetter setState;
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setter) {
+              setState = setter;
+              return RefreshIndicator(
+                onRefresh: refresh,
+                isRefreshing: _isRefreshing,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
+                    return SizedBox(
+                      height: 200.0,
+                      child: Text(item),
+                    );
+                  }).toList(),
+                ),
+              );
+            }
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(refreshCalled, false);
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      label: 'Refresh',
+    ));
+
+    setState(() {
+      _isRefreshing = false;
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    setState(() {
+      _isRefreshing = true;
+    });
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 3));
+    expect(tester.getSemantics(find.byType(RefreshProgressIndicator)), matchesSemantics(
+      label: 'Refresh',
+    ));
+
+    handle.dispose();
+  });
 }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -910,7 +910,7 @@ void main() {
       MaterialApp(
         home: RefreshIndicator(
           onRefresh: refresh,
-          isRefreshing: true,
+          manuallyRefreshing: true,
           child: ListView(
             physics: const AlwaysScrollableScrollPhysics(),
             children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -946,7 +946,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                isRefreshing: _isRefreshing,
+                manuallyRefreshing: _isRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -996,7 +996,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                isRefreshing: _isRefreshing,
+                manuallyRefreshing: _isRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -1045,7 +1045,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                isRefreshing: _isRefreshing,
+                manuallyRefreshing: _isRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -903,7 +903,7 @@ void main() {
     expect(refreshCalled, true);
   });
 
-  testWidgets('RefreshIndicator shows on inital state if isRefreshing', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator shows on inital state if manuallyRefreshing', (WidgetTester tester) async {
     refreshCalled = false;
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -934,9 +934,9 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('RefreshIndicator shows and hides on isRefreshing', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator shows and hides on manuallyRefreshing', (WidgetTester tester) async {
     refreshCalled = false;
-    bool _isRefreshing = false;
+    bool manuallyRefreshing = false;
     late StateSetter setState;
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -946,7 +946,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                manuallyRefreshing: _isRefreshing,
+                manuallyRefreshing: manuallyRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -966,7 +966,7 @@ void main() {
     expect(find.byType(RefreshProgressIndicator), findsNothing);
 
     setState(() {
-      _isRefreshing = true;
+      manuallyRefreshing = true;
     });
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -976,7 +976,7 @@ void main() {
     ));
 
     setState(() {
-      _isRefreshing = false;
+      manuallyRefreshing = false;
     });
     await tester.pumpAndSettle();
     expect(find.byType(RefreshProgressIndicator), findsNothing);
@@ -984,9 +984,9 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('RefreshIndicator hides on isRefreshing - fast switching', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator hides on manuallyRefreshing - fast switching', (WidgetTester tester) async {
     refreshCalled = false;
-    bool _isRefreshing = false;
+    bool manuallyRefreshing = false;
     late StateSetter setState;
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -996,7 +996,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                manuallyRefreshing: _isRefreshing,
+                manuallyRefreshing: manuallyRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -1016,11 +1016,11 @@ void main() {
     expect(find.byType(RefreshProgressIndicator), findsNothing);
 
     setState(() {
-      _isRefreshing = true;
+      manuallyRefreshing = true;
     });
     await tester.pump();
     setState(() {
-      _isRefreshing = false;
+      manuallyRefreshing = false;
     });
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
@@ -1033,9 +1033,9 @@ void main() {
     handle.dispose();
   });
 
-  testWidgets('RefreshIndicator shows on isRefreshing - fast switching', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator shows on manuallyRefreshing - fast switching', (WidgetTester tester) async {
     refreshCalled = false;
-    bool _isRefreshing = true;
+    bool manuallyRefreshing = true;
     late StateSetter setState;
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -1045,7 +1045,7 @@ void main() {
               setState = setter;
               return RefreshIndicator(
                 onRefresh: refresh,
-                manuallyRefreshing: _isRefreshing,
+                manuallyRefreshing: manuallyRefreshing,
                 child: ListView(
                   physics: const AlwaysScrollableScrollPhysics(),
                   children: <String>['A', 'B', 'C', 'D', 'E', 'F'].map<Widget>((String item) {
@@ -1069,12 +1069,12 @@ void main() {
     ));
 
     setState(() {
-      _isRefreshing = false;
+      manuallyRefreshing = false;
     });
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
     setState(() {
-      _isRefreshing = true;
+      manuallyRefreshing = true;
     });
     await tester.pump();
     await tester.pump(const Duration(seconds: 3));


### PR DESCRIPTION
Adds a new boolean property to `RefreshIndicator` that can be changed to reactively trigger showing and hiding. Defaults to false and if set to true before `initState` will show the refresh indicator as soon as it is built.

<details>
 <summary>Demo</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  static const String _title = 'Flutter Code Sample';

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      title: _title,
      home: Home(),
    );
  }
}

class Home extends StatefulWidget {
  const Home({Key? key}) : super(key: key);

  @override
  State<Home> createState() => _HomeState();
}

class _HomeState extends State<Home> {
  bool refresh = true;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text("Reactive RefreshIndicator"),
      ),
      floatingActionButton: FloatingActionButton(
        child: const Icon(Icons.refresh),
        onPressed: () {
          setState(() {
            refresh = !refresh;
          });
        },
      ),
      body: RefreshIndicator(
        onRefresh: () {
          return Future.delayed(const Duration(seconds: 1));
        },
        manuallyRefreshing: refresh,
        child: ListView(
          children: [
            const SizedBox(
              height: 150,
            ),
            Text(
              'isRefreshing = $refresh',
              textAlign: TextAlign.center,
              style: Theme.of(context).textTheme.headline5,
            ),
            TextButton(
              onPressed: () async {
                await Future.delayed(const Duration(seconds: 2));
                setState(() {
                  refresh = !refresh;
                });
              },
              child: const Text("Change after 2sec"),
            ),
          ],
        ),
      ),
    );
  }
}
```
</details>

> Note that reactively showing the refresh indicator will not call `onRefresh` or automatically hide the indicator after the returned `Future` were to complete. If `isRefreshing` has been set to `true`, it must be set to `false` through your own logic to hide the indicator and allow refreshing by dragging again.

This does not break the existing API because it doesn't alter it and merely creates a new way to bypass it if needed.

**Fixes https://github.com/flutter/flutter/issues/11675**

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.