### PR TITLE
Revert "Migrate desktop_device to null safety"

### DIFF
--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'package:meta/meta.dart';
 import 'package:pool/pool.dart';
 
@@ -27,15 +29,15 @@ class BundleBuilder {
   /// The default `mainPath` is `lib/main.dart`.
   /// The default  `manifestPath` is `pubspec.yaml`
   Future<void> build({
-    required TargetPlatform platform,
-    required BuildInfo buildInfo,
-    FlutterProject? project,
-    String? mainPath,
+    @required TargetPlatform platform,
+    @required BuildInfo buildInfo,
+    FlutterProject project,
+    String mainPath,
     String manifestPath = defaultManifestPath,
-    String? applicationKernelFilePath,
-    String? depfilePath,
-    String? assetDirPath,
-    @visibleForTesting BuildSystem? buildSystem,
+    String applicationKernelFilePath,
+    String depfilePath,
+    String assetDirPath,
+    @visibleForTesting BuildSystem buildSystem
   }) async {
     project ??= FlutterProject.current();
     mainPath ??= defaultMainPath;
@@ -50,7 +52,7 @@ class BundleBuilder {
       buildDir: project.dartTool.childDirectory('flutter_build'),
       cacheDir: globals.cache.getRoot(),
       flutterRootDir: globals.fs.directory(Cache.flutterRoot),
-      engineVersion: globals.artifacts!.isLocalEngine
+      engineVersion: globals.artifacts.isLocalEngine
           ? null
           : globals.flutterVersion.engineRevision,
       defines: <String, String>{
@@ -60,7 +62,7 @@ class BundleBuilder {
         kDeferredComponents: 'false',
         ...buildInfo.toBuildSystemEnvironment(),
       },
-      artifacts: globals.artifacts!,
+      artifacts: globals.artifacts,
       fileSystem: globals.fs,
       logger: globals.logger,
       processManager: globals.processManager,
@@ -70,7 +72,7 @@ class BundleBuilder {
     final Target target = buildInfo.mode == BuildMode.debug
         ? const CopyFlutterBundle()
         : const ReleaseCopyFlutterBundle();
-    final BuildResult result = await buildSystem!.build(target, environment);
+    final BuildResult result = await buildSystem.build(target, environment);
 
     if (!result.success) {
       for (final ExceptionMeasurement measurement in result.exceptions.values) {
@@ -106,14 +108,14 @@ class BundleBuilder {
   }
 }
 
-Future<AssetBundle?> buildAssets({
-  required String manifestPath,
-  String? assetDirPath,
-  String? packagesPath,
-  TargetPlatform? targetPlatform,
+Future<AssetBundle> buildAssets({
+  String manifestPath,
+  String assetDirPath,
+  @required String packagesPath,
+  TargetPlatform targetPlatform,
 }) async {
   assetDirPath ??= getAssetBuildDirectory();
-  packagesPath ??= globals.fs.path.absolute('.packages');
+  packagesPath ??= globals.fs.path.absolute(packagesPath);
 
   // Build the asset bundle.
   final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
@@ -133,7 +135,7 @@ Future<AssetBundle?> buildAssets({
 Future<void> writeBundle(
   Directory bundleDir,
   Map<String, DevFSContent> assetEntries,
-  { Logger? loggerOverride }
+  { Logger loggerOverride }
 ) async {
   loggerOverride ??= globals.logger;
   if (bundleDir.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 
 import 'package:file/memory.dart';
@@ -16,6 +18,7 @@ import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/project.dart';
 
+import 'package:meta/meta.dart';
 import 'package:test/fake.dart';
 
 import '../src/common.dart';
@@ -47,8 +50,8 @@ void main() {
     testWithoutContext('Install checks always return true', () async {
       final FakeDesktopDevice device = setUpDesktopDevice();
 
-      expect(await device.isAppInstalled(FakeApplicationPackage()), true);
-      expect(await device.isLatestBuildInstalled(FakeApplicationPackage()), true);
+      expect(await device.isAppInstalled(null), true);
+      expect(await device.isLatestBuildInstalled(null), true);
       expect(device.category, Category.desktop);
     });
 
@@ -86,7 +89,7 @@ void main() {
         ),
       ]);
       final FakeDesktopDevice device = setUpDesktopDevice(processManager: processManager, fileSystem: fileSystem);
-      final String? executableName = device.executablePathForDevice(FakeApplicationPackage(), BuildMode.debug);
+      final String executableName = device.executablePathForDevice(null, BuildMode.debug);
       fileSystem.file(executableName).writeAsStringSync('\n');
       final FakeApplicationPackage package = FakeApplicationPackage();
       final LaunchResult result = await device.startApp(
@@ -245,7 +248,7 @@ void main() {
   testWithoutContext('createDevFSWriter returns a LocalDevFSWriter', () {
     final FakeDesktopDevice device = setUpDesktopDevice();
 
-    expect(device.createDevFSWriter(FakeApplicationPackage(), ''), isA<LocalDevFSWriter>());
+    expect(device.createDevFSWriter(null, ''), isA<LocalDevFSWriter>());
   });
 
   testWithoutContext('startApp supports dartEntrypointArgs', () async {
@@ -305,10 +308,10 @@ void main() {
 }
 
 FakeDesktopDevice setUpDesktopDevice({
-  FileSystem? fileSystem,
-  Logger? logger,
-  ProcessManager? processManager,
-  OperatingSystemUtils? operatingSystemUtils,
+  FileSystem fileSystem,
+  Logger logger,
+  ProcessManager processManager,
+  OperatingSystemUtils operatingSystemUtils,
   bool nullExecutablePathForDevice = false,
 }) {
   return FakeDesktopDevice(
@@ -323,11 +326,11 @@ FakeDesktopDevice setUpDesktopDevice({
 /// A trivial subclass of DesktopDevice for testing the shared functionality.
 class FakeDesktopDevice extends DesktopDevice {
   FakeDesktopDevice({
-    required ProcessManager processManager,
-    required Logger logger,
-    required FileSystem fileSystem,
-    required OperatingSystemUtils operatingSystemUtils,
-    this.nullExecutablePathForDevice = false,
+    @required ProcessManager processManager,
+    @required Logger logger,
+    @required FileSystem fileSystem,
+    @required OperatingSystemUtils operatingSystemUtils,
+    this.nullExecutablePathForDevice,
   }) : super(
       'dummy',
       platformType: PlatformType.linux,
@@ -339,10 +342,10 @@ class FakeDesktopDevice extends DesktopDevice {
   );
 
   /// The [mainPath] last passed to [buildForDevice].
-  String? lastBuiltMainPath;
+  String lastBuiltMainPath;
 
   /// The [buildInfo] last passed to [buildForDevice].
-  BuildInfo? lastBuildInfo;
+  BuildInfo lastBuildInfo;
 
   final bool nullExecutablePathForDevice;
 
@@ -361,8 +364,8 @@ class FakeDesktopDevice extends DesktopDevice {
   @override
   Future<void> buildForDevice(
     ApplicationPackage package, {
-    String? mainPath,
-    BuildInfo? buildInfo,
+    String mainPath,
+    BuildInfo buildInfo,
   }) async {
     lastBuiltMainPath = mainPath;
     lastBuildInfo = buildInfo;
@@ -370,7 +373,7 @@ class FakeDesktopDevice extends DesktopDevice {
 
   // Dummy implementation that just returns the build mode name.
   @override
-  String? executablePathForDevice(ApplicationPackage package, BuildMode buildMode) {
+  String executablePathForDevice(ApplicationPackage package, BuildMode buildMode) {
     if (nullExecutablePathForDevice) {
       return null;
     }


### PR DESCRIPTION
Reverts flutter/flutter#91705

The required `debuggingOptions` change needs a g3fix.  Revert this to unblock the roll.
```
ERROR: mobile/flutter/testing/driver_test/lib/orchestrator.dart

115: await device.startApp(app); The parameter 'debuggingOptions' is required. #missing_required_param
```
See also https://github.com/flutter/flutter/pull/91632#issuecomment-941809523