### PR TITLE
Win32 template: Use {{projectName}} for FileDescription instead of {{description}}

### DIFF
--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/Runner.rc.tmpl
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/Runner.rc.tmpl
@@ -90,7 +90,7 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "{{organization}}" "\0"
-            VALUE "FileDescription", "{{description}}" "\0"
+            VALUE "FileDescription", "{{projectName}}" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "{{projectName}}" "\0"
             VALUE "LegalCopyright", "Copyright (C) {{year}} {{organization}}. All rights reserved." "\0"

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -1020,6 +1020,7 @@ void main() {
     expect(resourceFile, exists);
     final String contents = resourceFile.readAsStringSync();
     expect(contents, contains('"CompanyName", "com.foo.bar"'));
+    expect(contents, contains('"FileDescription", "flutter_project"'));
     expect(contents, contains('"ProductName", "flutter_project"'));
   }, overrides: <Type, Generator>{
     FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),


### PR DESCRIPTION
Despite the name includes "description", the Windows desktop seems to use `FileDescription` in `Runner.rc` as application name in the task manager, and as a result, on the task manager, the name of the win32 template app is displayed as "A new Flutter project."

This PR will set `FileDescription` to {{projectName}} instead of {{description}}, and make the name on the task manager the same as application name.

Screenshot (The app in this top is created with the current HEAD, the app in this bottom is created with this PR.):
![image](https://user-images.githubusercontent.com/16546008/137599140-c1dbdf39-b06d-423b-a639-0d2f3c3c3199.png)

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.