### PR TITLE
Add android:exported property to support API 31 for deferred components test

### DIFF
--- a/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@ found in the LICENSE file. -->
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:exported="false"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
Targeting android sdk 31 requires an explicitly specified `android:exported` property when a component has intent filters.

Partially addresses https://github.com/flutter/flutter/issues/91266