### PR TITLE
fix: material button inconsistency

### DIFF
--- a/packages/flutter/lib/src/material/flat_button.dart
+++ b/packages/flutter/lib/src/material/flat_button.dart
@@ -64,7 +64,7 @@ class FlatButton extends MaterialButton {
        assert(autofocus != null),
        super(
          key: key,
-         height: height,
+         minHeight: height,
          minWidth: minWidth,
          onPressed: onPressed,
          onLongPress: onLongPress,
@@ -153,7 +153,7 @@ class FlatButton extends MaterialButton {
       visualDensity: visualDensity ?? theme.visualDensity,
       constraints: buttonTheme.getConstraints(this).copyWith(
         minWidth: minWidth,
-        minHeight: height,
+        minHeight: minHeight,
       ),
       shape: buttonTheme.getShape(this),
       clipBehavior: clipBehavior,

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -92,7 +92,7 @@ class MaterialButton extends StatelessWidget {
     this.materialTapTargetSize,
     this.animationDuration,
     this.minWidth,
-    this.height,
+    this.minHeight,
     this.enableFeedback = true,
     this.child,
   }) : assert(clipBehavior != null),
@@ -380,10 +380,10 @@ class MaterialButton extends StatelessWidget {
   /// Defaults to the value from the current [ButtonTheme].
   final double? minWidth;
 
-  /// The vertical extent of the button.
+  /// The smallest vertical extent that the button will occupy.
   ///
   /// Defaults to the value from the current [ButtonTheme].
-  final double? height;
+  final double? minHeight;
 
   /// Whether detected gestures should provide acoustic and/or haptic feedback.
   ///
@@ -420,7 +420,7 @@ class MaterialButton extends StatelessWidget {
       visualDensity: visualDensity ?? theme.visualDensity,
       constraints: buttonTheme.getConstraints(this).copyWith(
         minWidth: minWidth,
-        minHeight: height,
+        minHeight: minHeight,
       ),
       shape: buttonTheme.getShape(this),
       clipBehavior: clipBehavior,

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -650,15 +650,15 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('MaterialButton minWidth and height parameters', (WidgetTester tester) async {
-    Widget buildFrame({ double? minWidth, double? height, EdgeInsets padding = EdgeInsets.zero, Widget? child }) {
+  testWidgets('MaterialButton minWidth and minHeight parameters', (WidgetTester tester) async {
+    Widget buildFrame({ double? minWidth, double? minHeight, EdgeInsets padding = EdgeInsets.zero, Widget? child }) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: MaterialButton(
             padding: padding,
             minWidth: minWidth,
-            height: height,
+            minHeight: minHeight,
             onPressed: null,
             materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
             child: child,
@@ -667,14 +667,14 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildFrame(minWidth: 8.0, height: 24.0));
+    await tester.pumpWidget(buildFrame(minWidth: 8.0, minHeight: 24.0));
     expect(tester.getSize(find.byType(MaterialButton)), const Size(8.0, 24.0));
 
     await tester.pumpWidget(buildFrame(minWidth: 8.0));
     // Default minHeight constraint is 36, see RawMaterialButton.
     expect(tester.getSize(find.byType(MaterialButton)), const Size(8.0, 36.0));
 
-    await tester.pumpWidget(buildFrame(height: 8.0));
+    await tester.pumpWidget(buildFrame(minHeight: 8.0));
     // Default minWidth constraint is 88, see RawMaterialButton.
     expect(tester.getSize(find.byType(MaterialButton)), const Size(88.0, 8.0));
 
@@ -688,7 +688,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         minWidth: 0.0,
-        height: 0.0,
+        minHeight: 0.0,
         padding: const EdgeInsets.all(4.0),
       ),
     );
@@ -698,7 +698,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         minWidth: 0.0,
-        height: 0.0,
+        minHeight: 0.0,
         padding: const EdgeInsets.all(4.0),
         child: const SizedBox(width: 8.0, height: 8.0),
       ),
@@ -709,7 +709,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         minWidth: 18.0,
-        height: 18.0,
+        minHeight: 18.0,
         padding: const EdgeInsets.all(4.0),
         child: const SizedBox(width: 8.0, height: 8.0),
       ),


### PR DESCRIPTION
## Fix for issue [#92076 ](https://github.com/flutter/flutter/issues/92076)
### Changes done
1. Replaced the `height` attribute name by `minHeight` in MaterialButton for consistency reasons.
2. Updated the FlatButton implementation to make it work with the new parent change (FlatButton extends from MaterialButton).
3. Updated the material/ test folder for the testing over the MaterialButton and FlatButton.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
