### PR TITLE
Add devicelab benchmark tags support

### DIFF
--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:args/command_runner.dart';
 
 import '../framework/cocoon.dart';
@@ -22,6 +24,7 @@ class UploadResultsCommand extends Command<void> {
     );
     argParser.addOption('luci-builder', help: '[Flutter infrastructure] Name of the LUCI builder being run on.');
     argParser.addOption('task-name', help: '[Flutter infrastructure] Name of the task being run on.');
+    argParser.addOption('benchmark-tags', help: '[Flutter infrastructure] Benchmark tags to surface on Skia Perf');
     argParser.addOption('test-status', help: 'Test status: Succeeded|Failed');
     argParser.addOption('commit-time', help: 'Commit time in UNIX timestamp');
     argParser.addOption('builder-bucket', help: '[Flutter infrastructure] Luci builder bucket the test is running in.');
@@ -31,7 +34,7 @@ class UploadResultsCommand extends Command<void> {
   String get name => 'upload-metrics';
 
   @override
-  String get description => '[Flutter infrastructure] Upload results data to Cocoon';
+  String get description => '[Flutter infrastructure] Upload results data to Cocoon/Skia Perf';
 
   @override
   Future<void> run() async {
@@ -43,22 +46,23 @@ class UploadResultsCommand extends Command<void> {
     final String? testStatus = argResults!['test-status'] as String?;
     final String? commitTime = argResults!['commit-time'] as String?;
     final String? taskName = argResults!['task-name'] as String?;
+    final String? benchmarkTags = argResults!['benchmark-tags'] as String?;
     final String? builderBucket = argResults!['builder-bucket'] as String?;
 
     // Upload metrics to skia perf from test runner when `resultsPath` is specified.
     if (resultsPath != null) {
-      await uploadToSkiaPerf(resultsPath, commitTime, taskName);
+      await uploadToSkiaPerf(resultsPath, commitTime, taskName, benchmarkTags);
       print('Successfully uploaded metrics to skia perf');
     }
 
-    final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
-    return cocoon.sendTaskStatus(
-      resultsPath: resultsPath,
-      isTestFlaky: testFlakyStatus == 'True',
-      gitBranch: gitBranch,
-      builderName: builderName,
-      testStatus: testStatus,
-      builderBucket: builderBucket,
-    );
+    // final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
+    // return cocoon.sendTaskStatus(
+    //   resultsPath: resultsPath,
+    //   isTestFlaky: testFlakyStatus == 'True',
+    //   gitBranch: gitBranch,
+    //   builderName: builderName,
+    //   testStatus: testStatus,
+    //   builderBucket: builderBucket,
+    // );
   }
 }

--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -55,14 +55,14 @@ class UploadResultsCommand extends Command<void> {
       print('Successfully uploaded metrics to skia perf');
     }
 
-    // final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
-    // return cocoon.sendTaskStatus(
-    //   resultsPath: resultsPath,
-    //   isTestFlaky: testFlakyStatus == 'True',
-    //   gitBranch: gitBranch,
-    //   builderName: builderName,
-    //   testStatus: testStatus,
-    //   builderBucket: builderBucket,
-    // );
+    final Cocoon cocoon = Cocoon(serviceAccountTokenPath: serviceAccountTokenFile);
+    return cocoon.sendTaskStatus(
+      resultsPath: resultsPath,
+      isTestFlaky: testFlakyStatus == 'True',
+      gitBranch: gitBranch,
+      builderName: builderName,
+      testStatus: testStatus,
+      builderBucket: builderBucket,
+    );
   }
 }

--- a/dev/devicelab/lib/command/upload_results.dart
+++ b/dev/devicelab/lib/command/upload_results.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:args/command_runner.dart';
 
 import '../framework/cocoon.dart';

--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -29,7 +29,7 @@ Future<FlutterDestination> connectFlutterDestination() async {
   );
 }
 
-/// Parse results into Metric Points.
+/// Parse results and append additional benchmark tags into Metric Points.
 ///
 /// An example of `resultsJson`:
 ///   {
@@ -45,9 +45,18 @@ Future<FlutterDestination> connectFlutterDestination() async {
 ///       "90th_percentile_frame_build_time_millis"
 ///     ]
 ///   }
-List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, dynamic> benchmarkTagsMap) {
+///
+/// An example of `benchmarkTags`:
+///   {
+///     "arch": "intel",
+///     "device_type": "Moto G Play",
+///     "device_version": "android-25",
+///     "host_type": "linux",
+///     "host_version": "debian-10.11"
+///   }
+List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, dynamic> benchmarkTags) {
   print('Results to upload to skia perf: $resultsJson');
-  print('Benchmark tags to upload to skia perf: $benchmarkTagsMap');
+  print('Benchmark tags to upload to skia perf: $benchmarkTags');
   final List<String> scoreKeys =
       (resultsJson['BenchmarkScoreKeys'] as List<dynamic>?)?.cast<String>() ?? const <String>[];
   final Map<String, dynamic> resultData =
@@ -64,8 +73,9 @@ List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, dynamic> b
       kNameKey: builderName,
       kSubResultKey: scoreKey,
     };
+    // Append additional benchmark tags, which will surface in Skia Perf dashboards.
     tags = mergeMaps<String, String>(
-        tags, benchmarkTagsMap.map((String key, dynamic value) => MapEntry<String, String>(key, value.toString())));
+        tags, benchmarkTags.map((String key, dynamic value) => MapEntry<String, String>(key, value.toString())));
     metricPoints.add(
       MetricPoint(
         (resultData[scoreKey] as num).toDouble(),

--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:metrics_center/metrics_center.dart';
 
 /// Authenticate and connect to gcloud storage.
@@ -44,8 +45,9 @@ Future<FlutterDestination> connectFlutterDestination() async {
 ///       "90th_percentile_frame_build_time_millis"
 ///     ]
 ///   }
-List<MetricPoint> parse(Map<String, dynamic> resultsJson) {
+List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, String> benchmarkTagsMap) {
   print('Results to upload to skia perf: $resultsJson');
+  print('Benchmark tags to upload to skia perf: $benchmarkTagsMap');
   final List<String> scoreKeys =
       (resultsJson['BenchmarkScoreKeys'] as List<dynamic>?)?.cast<String>() ?? const <String>[];
   final Map<String, dynamic> resultData =
@@ -55,16 +57,18 @@ List<MetricPoint> parse(Map<String, dynamic> resultsJson) {
   final String builderName = (resultsJson['BuilderName'] as String).trim();
   final List<MetricPoint> metricPoints = <MetricPoint>[];
   for (final String scoreKey in scoreKeys) {
+    Map<String, String> tags = <String, String>{
+      kGithubRepoKey: kFlutterFrameworkRepo,
+      kGitRevisionKey: gitSha,
+      'branch': gitBranch,
+      kNameKey: builderName,
+      kSubResultKey: scoreKey,
+    };
+    tags = mergeMaps<String, String>(tags, benchmarkTagsMap);
     metricPoints.add(
       MetricPoint(
         (resultData[scoreKey] as num).toDouble(),
-        <String, String>{
-          kGithubRepoKey: kFlutterFrameworkRepo,
-          kGitRevisionKey: gitSha,
-          'branch': gitBranch,
-          kNameKey: builderName,
-          kSubResultKey: scoreKey,
-        },
+        tags,
       ),
     );
   }
@@ -102,7 +106,7 @@ Future<void> upload(
 /// 1. Run DeviceLab test, writing results to a known path
 /// 2. Request service account token from luci auth (valid for at least 3 minutes)
 /// 3. Upload results from (1) to skia perf.
-Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? taskName) async {
+Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? taskName, String? benchmarkTags) async {
   int commitTimeSinceEpoch;
   if (resultsPath == null) {
     return;
@@ -112,10 +116,11 @@ Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? t
   } else {
     commitTimeSinceEpoch = DateTime.now().millisecondsSinceEpoch;
   }
+  final Map<String, String> benchmarkTagsMap = jsonDecode(benchmarkTags ?? '{}') as Map<String, String>;
   final File resultFile = File(resultsPath);
   Map<String, dynamic> resultsJson = <String, dynamic>{};
   resultsJson = json.decode(await resultFile.readAsString()) as Map<String, dynamic>;
-  final List<MetricPoint> metricPoints = parse(resultsJson);
+  final List<MetricPoint> metricPoints = parse(resultsJson, benchmarkTagsMap);
   final FlutterDestination metricsDestination = await connectFlutterDestination();
   await upload(metricsDestination, metricPoints, commitTimeSinceEpoch, taskName);
 }

--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -45,7 +45,7 @@ Future<FlutterDestination> connectFlutterDestination() async {
 ///       "90th_percentile_frame_build_time_millis"
 ///     ]
 ///   }
-List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, String> benchmarkTagsMap) {
+List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, dynamic> benchmarkTagsMap) {
   print('Results to upload to skia perf: $resultsJson');
   print('Benchmark tags to upload to skia perf: $benchmarkTagsMap');
   final List<String> scoreKeys =
@@ -64,7 +64,8 @@ List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, String> be
       kNameKey: builderName,
       kSubResultKey: scoreKey,
     };
-    tags = mergeMaps<String, String>(tags, benchmarkTagsMap);
+    tags = mergeMaps<String, String>(
+        tags, benchmarkTagsMap.map((String key, dynamic value) => MapEntry<String, String>(key, value.toString())));
     metricPoints.add(
       MetricPoint(
         (resultData[scoreKey] as num).toDouble(),
@@ -116,7 +117,7 @@ Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? t
   } else {
     commitTimeSinceEpoch = DateTime.now().millisecondsSinceEpoch;
   }
-  final Map<String, String> benchmarkTagsMap = jsonDecode(benchmarkTags ?? '{}') as Map<String, String>;
+  final Map<String, dynamic> benchmarkTagsMap = jsonDecode(benchmarkTags ?? '{}') as Map<String, dynamic>;
   final File resultFile = File(resultsPath);
   Map<String, dynamic> resultsJson = <String, dynamic>{};
   resultsJson = json.decode(await resultFile.readAsString()) as Map<String, dynamic>;

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -24,7 +24,7 @@ class FakeFlutterDestination implements FlutterDestination {
 
 void main() {
   group('Parse', () {
-    test('succeeds', () {
+    test('without additional benchmark tags', () {
       final Map<String, dynamic> results = <String, dynamic>{
         'CommitBranch': 'master',
         'CommitSha': 'abc',
@@ -42,6 +42,35 @@ void main() {
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
       expect(metricPoints[1].value, equals(0.473));
+    });
+
+    test('with additional benchmark tags', () {
+      final Map<String, dynamic> results = <String, dynamic>{
+        'CommitBranch': 'master',
+        'CommitSha': 'abc',
+        'BuilderName': 'test',
+        'ResultData': <String, dynamic>{
+          'average_frame_build_time_millis': 0.4550425531914895,
+          '90th_percentile_frame_build_time_millis': 0.473,
+        },
+        'BenchmarkScoreKeys': <String>[
+          'average_frame_build_time_millis',
+          '90th_percentile_frame_build_time_millis',
+        ],
+      };
+      final Map<String, dynamic> tags = <String, dynamic>{
+        'arch': 'intel',
+        'device_type': 'Moto G Play',
+        'device_version': 'android-25',
+        'host_type': 'linux',
+        'host_version': 'debian-10.11'
+      };
+      final List<MetricPoint> metricPoints = parse(results, tags);
+
+      expect(metricPoints[0].value, equals(0.4550425531914895));
+      expect(metricPoints[0].tags.keys.contains('arch'), isTrue);
+      expect(metricPoints[1].value, equals(0.473));
+      expect(metricPoints[1].tags.keys.contains('device_type'), isTrue);
     });
 
     test('succeeds - null ResultData', () {

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -38,7 +38,7 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results);
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
       expect(metricPoints[1].value, equals(0.473));
@@ -52,7 +52,7 @@ void main() {
         'ResultData': null,
         'BenchmarkScoreKeys': null,
       };
-      final List<MetricPoint> metricPoints = parse(results);
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
 
       expect(metricPoints.length, 0);
     });
@@ -73,7 +73,7 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results);
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
       final FakeFlutterDestination flutterDestination = FakeFlutterDestination();
       String? taskName;
       const int commitTimeSinceEpoch = 1629220312;
@@ -97,7 +97,7 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results);
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
       final FakeFlutterDestination flutterDestination = FakeFlutterDestination();
       const String taskName = 'test';
       const int commitTimeSinceEpoch = 1629220312;


### PR DESCRIPTION
Add benchmark tags support for devicelab benchmarks.

This will be a noop for existing workflow, unless we inject `tags` from recipe. A companion CL will be submitted soon.

Related: https://github.com/flutter/flutter/issues/92203