### PR TITLE
[flutter_tools] Instruct compiler before processing bundle

### DIFF
--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -616,6 +616,12 @@ class DevFS {
     });
 
     if (bundle != null) {
+      // Mark processing of bundle started for testability of starting the compile
+      // before processing bundle.
+      _logger.printTrace('Processing bundle.');
+      // await null to give time for telling the compiler to compile.
+      await null;
+
       // The tool writes the assets into the AssetBundle working dir so that they
       // are in the same location in DevFS and the iOS simulator.
       final String assetBuildDirPrefix = _asUriPath(getAssetBuildDirectory());
@@ -636,6 +642,10 @@ class DevFS {
           assetPathsToEvict.add(archivePath);
         }
       });
+
+      // Mark processing of bundle done for testability of starting the compile
+      // before processing bundle.
+      _logger.printTrace('Bundle processing done.');
     }
     final CompilerOutput? compilerOutput = await pendingCompilerOutput;
     if (compilerOutput == null || compilerOutput.errorCount > 0) {


### PR DESCRIPTION
Currently, on recompile (say pressing 'r' on the keyboard) `generator.recompile` is called before processing the bundle in an attempt to let the compiler run in the background while processing the bundle.
Unfortunately  `generator.recompile` only puts a job on the queue, i.e. it doesn't instruct the compiler to compile yet. This only happens after the bundle has been processed and we reach `await pendingCompilerOutput`.

This PR adds an `await null` before processing the bundle. This allowed the queue to execute (i.e. actually instruct the compiler to compile) before processing the bundle which is what we want.

When processing the bundle takes a while (for a big app I've seen this take around 140 ms) this should shave off approximately that amount of time from the total hot reload time (or however long the actual compilation takes if that's less than the bundle processing time).

The PR adds a few logging entries which are used for testing the change.
A test is added to ensure the sequence of events is as expected (i.e. that we send `compile` or `recompile` to the compiler before processing the bundle).