### PR TITLE
Add atStart and atEnd properties to ScrollMetrics

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -103,7 +103,7 @@ mixin ScrollMetrics {
   /// Whether the this position is at the end of its scrollable range.
   bool get atEnd => pixels == maxScrollExtent;
 
-  /// Whether the this position is at the top or bottom of its scrollable range.
+  /// Whether the this position is at the beginning or end of its scrollable range.
   bool get atEdge => atStart || atEnd;
 
   /// The quantity of content conceptually "above" the viewport in the scrollable.

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -97,9 +97,14 @@ mixin ScrollMetrics {
   /// [maxScrollExtent].
   bool get outOfRange => pixels < minScrollExtent || pixels > maxScrollExtent;
 
-  /// Whether the [pixels] value is exactly at the [minScrollExtent] or the
-  /// [maxScrollExtent].
-  bool get atEdge => pixels == minScrollExtent || pixels == maxScrollExtent;
+  /// Whether the this position is at the start of its scrollable range.
+  bool get atStart => pixels == minScrollExtent;
+
+  /// Whether the this position is at the end of its scrollable range.
+  bool get atEnd => pixels == maxScrollExtent;
+
+  /// Whether the this position is at the top or bottom of its scrollable range.
+  bool get atEdge => atStart || atEnd;
 
   /// The quantity of content conceptually "above" the viewport in the scrollable.
   /// This is the content above the content described by [extentInside].

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -179,7 +179,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   bool get hasViewportDimension => _viewportDimension != null;
 
   /// Whether [viewportDimension], [minScrollExtent], [maxScrollExtent],
-  /// [outOfRange], and [atEdge] are available.
+  /// [outOfRange], [atStart], [atEnd], and [atEdge] are available.
   ///
   /// Set to true just before the first time [applyNewDimensions] is called.
   bool get haveDimensions => _haveDimensions;


### PR DESCRIPTION
Adds `atStart` and `atEnd` properties to ScrollMetrics, so ScrollController users can distinguish which which edge the ScrollView is at when `atEdge` is true.

Fixes #92265

Note: given that the ScrollMetrics mixin does not seem to have tests, I'm not entirely sure what the best approach is for testing this change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
