### PR TITLE
Ignore analyzer implict dynamic checks for js_util generic return type

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -75,6 +75,7 @@ void _setTestMode(_TestMode? mode) {
       // Keep as null.
       break;
   }
+  // ignore: implicit_dynamic_function
   js_util.callMethod(
     html.window,
     '_flutter_internal_update_experiment',

--- a/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart
@@ -237,12 +237,14 @@ void main() {
 
 KeyboardEvent dispatchKeyboardEvent(
     EventTarget target, String type, Map<String, dynamic> args) {
+  // ignore: implicit_dynamic_function
   final Object jsKeyboardEvent = js_util.getProperty(window, 'KeyboardEvent') as Object;
   final List<dynamic> eventArgs = <dynamic>[
     type,
     args,
   ];
 
+  // ignore: implicit_dynamic_function
   final KeyboardEvent event = js_util.callConstructor(
           jsKeyboardEvent, js_util.jsify(eventArgs) as List<dynamic>)
       as KeyboardEvent;


### PR DESCRIPTION
Disables analyzer error for implicit dynamic functions when calling `js_util` methods that have been changed to have a generic return type. My Dart change that caused the analyzer to have issues [here](https://github.com/dart-lang/sdk/commit/d17fd4b14f26df4be7e8e57a7719ad128ed2b0ff)

Fixes: https://github.com/flutter/flutter/issues/92181


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt]. 
 **no semantic changes, should be test-exempt?**
- [ ] All existing and new tests are passing.
**I don't have flutter built locally, figured it was faster to get this out for review to fix the P0 break. In the meantime figuring out how to build locally to run `flutter test`**

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
