### PR TITLE
Remove assert that prevents WidgetSpans from being used in SelectableText

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -585,9 +585,11 @@ class _SelectableTextState extends State<SelectableText> with AutomaticKeepAlive
   @override
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
-    assert(() {
-      return _controller._textSpan.visitChildren((InlineSpan span) => span.runtimeType == TextSpan);
-    }(), 'SelectableText only supports TextSpan; Other type of InlineSpan is not allowed');
+    // TODO(garyq): Assert to block WidgetSpans from being used here are removed,
+    // but we still do not yet have nice handling of things like carets, clipboard,
+    // and other features. We should add proper support. Currently, caret handling
+    // is blocked on SkParagraph switch and https://github.com/flutter/engine/pull/27010
+    // should be landed in SkParagraph after the switch is complete.
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
     assert(

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -319,7 +319,7 @@ void main() {
     expect(selectableText.enableInteractiveSelection, true);
   });
 
-  testWidgets('Rich selectable text only support TextSpan', (WidgetTester tester) async {
+  testWidgets('Rich selectable text supports WidgetSpan', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MediaQuery(
         data: MediaQueryData(),
@@ -357,7 +357,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.takeException(), isAssertionError);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('no text keyboard when widget is focused', (WidgetTester tester) async {


### PR DESCRIPTION
Partially resolves https://github.com/flutter/flutter/issues/38474

Manually removing this assert and using WidgetSpans seems to be stable in the wild. Since fully integrated selectable text/editable WidgetSpan support may take a significant effort but does not detract from simple use cases, we should remove this assert for now and gradually add richer support in as necessary. This unlocks WidgetSpan capability for anyone who does not need rich selection indexing and clipboards.

Tests coming soon.
