### PR TITLE
Added widgets/AppModel

### DIFF
--- a/examples/api/lib/widgets/app_model/app_model.0.dart
+++ b/examples/api/lib/widgets/app_model/app_model.0.dart
@@ -6,9 +6,24 @@
 
 import 'package:flutter/material.dart';
 
-// Demonstrates that changes to the AppModel _only_ cause the dependent widgets
-// to be rebuilt.
+class ShowAppModelValue extends StatelessWidget {
+  const ShowAppModelValue({ Key? key, required this.appModelKey }) : super(key: key);
 
+  final String appModelKey;
+
+  @override
+  Widget build(BuildContext context) {
+    // The AppModel.get() call here causes this widget to depend
+    // on the value of the AppModel's 'foo' key. If it's changed, with
+    // AppModel.set(), then this widget will be rebuilt.
+    final String? value = AppModel.get<String, String>(context, appModelKey);
+    return Text('$appModelKey: $value');
+  }
+}
+
+// Demonstrates that changes to the AppModel _only_ cause the dependent widgets
+// to be rebuilt. In this case that's the ShowAppModelValue widget that's
+// displaying the value of a key whose value has been updated.
 class Home extends StatefulWidget {
   const Home({ Key? key }) : super(key: key);
 
@@ -17,8 +32,8 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
-  int _fooCount = 0;
-  int _barCount = 0;
+  int _fooVersion = 0;
+  int _barVersion = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -27,38 +42,25 @@ class _HomeState extends State<Home> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Builder(
-              builder: (BuildContext context) {
-                // The AppModel.get() call here causes this widget to depend
-                // on the value of the AppModel's 'foo' key. If it's changed, with
-                // AppModel.set() (see below), then this widget will be rebuilt.
-                final String? value = AppModel.get<String, String>(context, 'foo');
-                return Text('foo: $value [$_fooCount]');
-              },
-            ),
+            const ShowAppModelValue(appModelKey: 'foo'),
             const SizedBox(height: 16),
-            Builder(
-              builder: (BuildContext context) {
-                final String? value = AppModel.get<String, String>(context, 'bar');
-                return Text('bar: $value [$_barCount]');
-              },
-            ),
+            const ShowAppModelValue(appModelKey: 'bar'),
             const SizedBox(height: 16),
             ElevatedButton(
               child: const Text('change foo'),
               onPressed: () {
-                _fooCount += 1;
+                _fooVersion += 1;
                 // Changing the AppModel's value for 'foo' causes the widgets that
-                // depend on 'foo' to be rebuilt (see above).
-                AppModel.set<String, String?>(context, 'foo', 'FOO $_fooCount'); // note: no setState()
+                // depend on 'foo' to be rebuilt.
+                AppModel.set<String, String?>(context, 'foo', 'FOO $_fooVersion'); // note: no setState()
               },
             ),
             const SizedBox(height: 16),
             ElevatedButton(
               child: const Text('change bar'),
               onPressed: () {
-                _barCount += 1;
-                AppModel.set<String, String?>(context, 'bar', 'BAR $_barCount');  // note: no setState()
+                _barVersion += 1;
+                AppModel.set<String, String?>(context, 'bar', 'BAR $_barVersion');  // note: no setState()
               },
             ),
           ],

--- a/examples/api/lib/widgets/app_model/app_model.0.dart
+++ b/examples/api/lib/widgets/app_model/app_model.0.dart
@@ -16,7 +16,7 @@ class ShowAppModelValue extends StatelessWidget {
     // The AppModel.getValue() call here causes this widget to depend
     // on the value of the AppModel's 'foo' key. If it's changed, with
     // AppModel.setValue(), then this widget will be rebuilt.
-    final String? value = AppModel.getValue<String, String>(context, appModelKey);
+    final String value = AppModel.getValue<String, String>(context, appModelKey, () => 'initial');
     return Text('$appModelKey: $value');
   }
 }

--- a/examples/api/lib/widgets/app_model/app_model.0.dart
+++ b/examples/api/lib/widgets/app_model/app_model.0.dart
@@ -1,0 +1,73 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for AppModel
+
+import 'package:flutter/material.dart';
+
+// Demonstrates that changes to the AppModel _only_ cause the dependent widgets
+// to be rebuilt.
+
+class Home extends StatefulWidget {
+  const Home({ Key? key }) : super(key: key);
+
+  @override
+  State<Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
+  int _fooCount = 0;
+  int _barCount = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Builder(
+              builder: (BuildContext context) {
+                // The AppModel.get() call here causes this widget to depend
+                // on the value of the AppModel's 'foo' key. If it's changed, with
+                // AppModel.set() (see below), then this widget will be rebuilt.
+                final String? value = AppModel.get<String, String>(context, 'foo');
+                return Text('foo: $value [$_fooCount]');
+              },
+            ),
+            const SizedBox(height: 16),
+            Builder(
+              builder: (BuildContext context) {
+                final String? value = AppModel.get<String, String>(context, 'bar');
+                return Text('bar: $value [$_barCount]');
+              },
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              child: const Text('change foo'),
+              onPressed: () {
+                _fooCount += 1;
+                // Changing the AppModel's value for 'foo' causes the widgets that
+                // depend on 'foo' to be rebuilt (see above).
+                AppModel.set<String, String?>(context, 'foo', 'FOO $_fooCount'); // note: no setState()
+              },
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              child: const Text('change bar'),
+              onPressed: () {
+                _barCount += 1;
+                AppModel.set<String, String?>(context, 'bar', 'BAR $_barCount');  // note: no setState()
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(const MaterialApp(home: Home()));
+}

--- a/examples/api/lib/widgets/app_model/app_model.0.dart
+++ b/examples/api/lib/widgets/app_model/app_model.0.dart
@@ -13,10 +13,10 @@ class ShowAppModelValue extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // The AppModel.get() call here causes this widget to depend
+    // The AppModel.getValue() call here causes this widget to depend
     // on the value of the AppModel's 'foo' key. If it's changed, with
-    // AppModel.set(), then this widget will be rebuilt.
-    final String? value = AppModel.get<String, String>(context, appModelKey);
+    // AppModel.setValue(), then this widget will be rebuilt.
+    final String? value = AppModel.getValue<String, String>(context, appModelKey);
     return Text('$appModelKey: $value');
   }
 }
@@ -52,7 +52,7 @@ class _HomeState extends State<Home> {
                 _fooVersion += 1;
                 // Changing the AppModel's value for 'foo' causes the widgets that
                 // depend on 'foo' to be rebuilt.
-                AppModel.set<String, String?>(context, 'foo', 'FOO $_fooVersion'); // note: no setState()
+                AppModel.setValue<String, String?>(context, 'foo', 'FOO $_fooVersion'); // note: no setState()
               },
             ),
             const SizedBox(height: 16),
@@ -60,7 +60,7 @@ class _HomeState extends State<Home> {
               child: const Text('change bar'),
               onPressed: () {
                 _barVersion += 1;
-                AppModel.set<String, String?>(context, 'bar', 'BAR $_barVersion');  // note: no setState()
+                AppModel.setValue<String, String?>(context, 'bar', 'BAR $_barVersion');  // note: no setState()
               },
             ),
           ],

--- a/examples/api/lib/widgets/app_model/app_model.1.dart
+++ b/examples/api/lib/widgets/app_model/app_model.1.dart
@@ -1,0 +1,58 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for AppModel
+
+import 'package:flutter/material.dart';
+
+// A single lazily constructed object that's shared with the entire
+// application via `SharedObject.of(context)`. The value of the object
+// can be changed with `SharedObject.reset(context)`. Resetting the value
+// will cause all of the widgets that depend on it to be rebuilt.
+class SharedObject {
+  SharedObject._();
+
+  static final Object _sharedObjectKey = Object();
+
+  @override
+  String toString() => 'SharedObject#$hashCode';
+
+  static void reset(BuildContext context) {
+    // Calling AppModel.set() causes dependent widgets to be rebuilt.
+    AppModel.set<Object, SharedObject>(context, _sharedObjectKey, SharedObject._());
+  }
+
+  static SharedObject of(BuildContext context) {
+    SharedObject? value = AppModel.get<Object, SharedObject>(context, _sharedObjectKey);
+    if (value == null) {
+      value = SharedObject._();
+      // Calling AppModel.init() does not cause dependent widgets to
+      // be rebuilt, so it's safe to call it from within a build method.
+      AppModel.init<Object, SharedObject>(context, _sharedObjectKey, value);
+    }
+    return value;
+  }
+}
+
+class Home extends StatelessWidget {
+  const Home({ Key? key }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          child: Text('Replace ${SharedObject.of(context)}'),
+          onPressed: () {
+            SharedObject.reset(context);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(const MaterialApp(home: Home()));
+}

--- a/examples/api/lib/widgets/app_model/app_model.1.dart
+++ b/examples/api/lib/widgets/app_model/app_model.1.dart
@@ -4,6 +4,7 @@
 
 // Flutter code sample for AppModel
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 // A single lazily constructed object that's shared with the entire
@@ -16,20 +17,20 @@ class SharedObject {
   static final Object _sharedObjectKey = Object();
 
   @override
-  String toString() => 'SharedObject#$hashCode';
+  String toString() => describeIdentity(this);
 
   static void reset(BuildContext context) {
-    // Calling AppModel.set() causes dependent widgets to be rebuilt.
-    AppModel.set<Object, SharedObject>(context, _sharedObjectKey, SharedObject._());
+    // Calling AppModel.setValue() causes dependent widgets to be rebuilt.
+    AppModel.setValue<Object, SharedObject>(context, _sharedObjectKey, SharedObject._());
   }
 
   static SharedObject of(BuildContext context) {
-    SharedObject? value = AppModel.get<Object, SharedObject>(context, _sharedObjectKey);
+    SharedObject? value = AppModel.getValue<Object, SharedObject>(context, _sharedObjectKey);
     if (value == null) {
       value = SharedObject._();
       // Calling AppModel.init() does not cause dependent widgets to
       // be rebuilt, so it's safe to call it from within a build method.
-      AppModel.init<Object, SharedObject>(context, _sharedObjectKey, value);
+      AppModel.initValue<Object, SharedObject>(context, _sharedObjectKey, value);
     }
     return value;
   }

--- a/examples/api/lib/widgets/app_model/app_model.1.dart
+++ b/examples/api/lib/widgets/app_model/app_model.1.dart
@@ -20,19 +20,14 @@ class SharedObject {
   String toString() => describeIdentity(this);
 
   static void reset(BuildContext context) {
-    // Calling AppModel.setValue() causes dependent widgets to be rebuilt.
+    // Calling AppModel.set() causes dependent widgets to be rebuilt.
     AppModel.setValue<Object, SharedObject>(context, _sharedObjectKey, SharedObject._());
   }
 
   static SharedObject of(BuildContext context) {
-    SharedObject? value = AppModel.getValue<Object, SharedObject>(context, _sharedObjectKey);
-    if (value == null) {
-      value = SharedObject._();
-      // Calling AppModel.init() does not cause dependent widgets to
-      // be rebuilt, so it's safe to call it from within a build method.
-      AppModel.initValue<Object, SharedObject>(context, _sharedObjectKey, value);
-    }
-    return value;
+    // If a value for _sharedObjectKey has never been set then the third
+    // callback parameter is used to generate an initial value.
+    return AppModel.getValue<Object, SharedObject>(context, _sharedObjectKey, () => SharedObject._());
   }
 }
 

--- a/examples/api/lib/widgets/app_model/app_model.1.dart
+++ b/examples/api/lib/widgets/app_model/app_model.1.dart
@@ -35,19 +35,31 @@ class SharedObject {
   }
 }
 
+// An example of a widget which depends on the SharedObject's value,
+// which might be provided - along with SharedObject - in a Dart package.
+class CustomWidget extends StatelessWidget {
+  const CustomWidget({ Key? key }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Will be rebuilt if the shared object's value is changed.
+    return ElevatedButton(
+      child: Text('Replace ${SharedObject.of(context)}'),
+      onPressed: () {
+        SharedObject.reset(context);
+      },
+    );
+  }
+}
+
 class Home extends StatelessWidget {
   const Home({ Key? key }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       body: Center(
-        child: ElevatedButton(
-          child: Text('Replace ${SharedObject.of(context)}'),
-          onPressed: () {
-            SharedObject.reset(context);
-          },
-        ),
+        child: CustomWidget()
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 import 'actions.dart';
+import 'app_model.dart';
 import 'banner.dart';
 import 'basic.dart';
 import 'binding.dart';
@@ -1664,17 +1665,19 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
 
     return RootRestorationScope(
       restorationId: widget.restorationScopeId,
-      child: Shortcuts(
-        debugLabel: '<Default WidgetsApp Shortcuts>',
-        shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
-        // DefaultTextEditingShortcuts is nested inside Shortcuts so that it can
-        // fall through to the defaultShortcuts.
-        child: DefaultTextEditingShortcuts(
-          child: Actions(
-            actions: widget.actions ?? WidgetsApp.defaultActions,
-            child: FocusTraversalGroup(
-              policy: ReadingOrderTraversalPolicy(),
-              child: child,
+      child: AppModel(
+        child: Shortcuts(
+          debugLabel: '<Default WidgetsApp Shortcuts>',
+          shortcuts: widget.shortcuts ?? WidgetsApp.defaultShortcuts,
+          // DefaultTextEditingShortcuts is nested inside Shortcuts so that it can
+          // fall through to the defaultShortcuts.
+          child: DefaultTextEditingShortcuts(
+            child: Actions(
+              actions: widget.actions ?? WidgetsApp.defaultActions,
+              child: FocusTraversalGroup(
+                policy: ReadingOrderTraversalPolicy(),
+                child: child,
+              ),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -12,7 +16,7 @@ import 'package:flutter/material.dart';
 /// creates a dependency on the AppModel: when the value of keyword
 /// changes with AppModel.set(), the widget will be rebuilt.
 ///
-/// An instance of this widget is created automatically by [WidgetApp].
+/// An instance of this widget is created automatically by [WidgetsApp].
 ///
 /// There are many ways to share data with a widget subtree. This
 /// class is based on [InheritedModel], which is an [InheritedWidget].

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -13,7 +13,8 @@ import 'inherited_model.dart';
 /// an [AppModel] keyword.
 typedef AppModelInitCallback<T> = T Function();
 
-/// Enables sharing key/value data with the all of the widgets below `child`.
+/// Enables sharing key/value data with its `child` and all of the
+/// child's descendants.
 ///
 /// - `AppModel.getValue(context, key, initCallback)` creates a dependency
 /// on the key and returns the value for the key from the shared data table.

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -30,9 +30,16 @@ import 'inherited_model.dart';
 /// class is based on [InheritedModel], which is an [InheritedWidget].
 /// It's intended to be used by packages that need to share a modest
 /// number of values among their own components. It obviates the
-/// need for app developers to instantiate a package-specific
-/// data sharing "umbrella" widgets to enable the use of such
-/// packages.
+/// need for app developers to instantiate package-specific
+/// data sharing "umbrella" widgets.
+///
+/// AppModel is not intended to be a substitute for Provider or any of
+/// the other general purpose application state systems. AppModel is
+/// for situations where a package's custom widgets need to share one
+/// or a handful of immutable data objects that can be lazily
+/// initialized. It exists so that packages like that can deliver
+/// custom widgets without requiring the developer to add an umbrella
+/// widget to their application.
 ///
 /// A good way to create an AppModel key that avoids potential
 /// collisions with other packages is to use a static `Object()` value.

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -133,22 +133,22 @@ class AppModel extends StatefulWidget {
 
   static bool _debugHasAppModel(_AppModelData? model, BuildContext context, String methodName) {
     assert(() {
-      if (model != null)
-        return true;
-      throw FlutterError.fromParts(
-        <DiagnosticsNode>[
-          ErrorSummary('No AppModel widget found.'),
-          ErrorDescription('AppModel.$methodName requires an AppModel widget ancestor.\n'),
-          context.describeWidget('The specific widget that could not find an AppModel ancestor was'),
-          context.describeOwnershipChain('The ownership chain for the affected widget is'),
-          ErrorHint(
-            'Typically, the AppModel widget is introduced by the MaterialApp '
-            'or WidgetsApp widget at the top of your application widget tree. It '
-            'provides a key/value map of data that is shared with the entire '
-            'application.',
-          ),
-        ],
-      );
+      if (model == null) {
+        throw FlutterError.fromParts(
+          <DiagnosticsNode>[
+            ErrorSummary('No AppModel widget found.'),
+            ErrorDescription('AppModel.$methodName requires an AppModel widget ancestor.\n'),
+            context.describeWidget('The specific widget that could not find an AppModel ancestor was'),
+            context.describeOwnershipChain('The ownership chain for the affected widget is'),
+            ErrorHint(
+              'Typically, the AppModel widget is introduced by the MaterialApp '
+              'or WidgetsApp widget at the top of your application widget tree. It '
+              'provides a key/value map of data that is shared with the entire '
+              'application.',
+            ),
+          ],
+        );
+      }
       return true;
     }());
     return true;

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -192,7 +192,7 @@ class _AppModelData extends InheritedModel<Object> {
   }
 
   @override
-  bool updateShouldNotifyDependent(_AppModelData old, Set<Object> keys) => true;
+  bool updateShouldNotifyDependent(_AppModelData old, Set<Object> keys) {
     for (final Object key in keys) {
       if (data[key] != old.data[key]) {
         return true;

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -9,10 +9,16 @@ import 'inherited_model.dart';
 
 /// Enables sharing key/value data with the all of the widgets below [child].
 ///
-/// `AppModel.set(context, key, value)` adds an entry to the shared data table.
+/// - `AppModel.set(context, key, value)` changes the value of an entry
+/// in the shared data table and forces widgets that depend on that entry
+/// to be rebuilt.
 ///
-/// `AppModel.get(context, key)` returns the value for key from the
-/// shared data table, or null if there is no table entry for the key.
+/// - `AppModel.get(context, key)` creates a dependency on the key and
+/// returns the value for the key from the shared data table.
+///
+/// - `AppModel.init(context, key, value)` changes the value of an entry
+/// in the shared data table but does not force dependent widgets to be
+/// rebuilt.
 ///
 /// A widget whose build method uses AppModel.get(context, keyword)
 /// creates a dependency on the AppModel: when the value of keyword
@@ -31,8 +37,8 @@ import 'inherited_model.dart';
 /// {@tool dartpad}
 /// The following sample demonstrates using the automatically created
 /// `AppModel`. Button presses cause changes to the values for keys
-/// 'foo', and 'bar', and that only causes the widgets that depend on
-/// those keys to be rebuilt.
+/// 'foo', and 'bar', and those changes only cause the widgets that
+/// depend on those keys to be rebuilt.
 ///
 /// ** See code in examples/api/lib/widgets/app_model/app_model.0.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -37,9 +37,7 @@ typedef AppModelInitCallback<T> = T Function();
 /// There are many ways to share data with a widget subtree. This
 /// class is based on [InheritedModel], which is an [InheritedWidget].
 /// It's intended to be used by packages that need to share a modest
-/// number of values among their own components. It obviates the
-/// need for package users to instantiate package-specific
-/// data sharing "umbrella" widgets.
+/// number of values among their own components.
 ///
 /// AppModel is not intended to be a substitute for Provider or any of
 /// the other general purpose application state systems. AppModel is
@@ -96,7 +94,7 @@ class AppModel extends StatefulWidget {
   /// an immutable value because intrinsic changes to the value will
   /// not cause dependent widgets to be rebuilt.
   ///
-  /// A Widget that depends on the app model's value for `key` should use
+  /// A widget that depends on the app model's value for `key` should use
   /// this method in their `build` methods to ensure that they are rebuilt
   /// if the value changes.
   ///

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Enables sharing key/value data with the all of the widgets below [child].
+///
+/// `AppModel.set(context, key, value)` adds an entry to the shared data table.
+///
+/// `AppModel.get(context, key)` returns the value for key from the
+/// shared data table, or null if there is no table entry for the key.
+///
+/// A widget whose build method uses AppModel.get(context, keyword)
+/// creates a dependency on the AppModel: when the value of keyword
+/// changes with AppModel.set(), the widget will be rebuilt.
+///
+/// An instance of this widget is created automatically by [WidgetApp].
+///
+/// There are many ways to share data with a widget subtree. This
+/// class is based on [InheritedModel], which is an [InheritedWidget].
+/// It's intended to be used by packages that need to share a modest
+/// number of values among their own components. It obviates the
+/// need for app developers to instantiate a package-specific
+/// data sharing "umbrella" widgets to enable the use of such
+/// packages.
+///
+/// {@tool dartpad}
+/// The following sample demonstrates using the automatically created
+/// `AppModel`. Button presses cause changes to the values for keys
+/// 'foo', and 'bar', and that only causes the widgets that depend on
+/// those keys to be rebuilt.
+///
+/// ** See code in examples/api/lib/widgets/app_model/app_model.0.dart **
+/// {@end-tool}
+class AppModel extends StatefulWidget {
+  /// Creates a widget based on [InheritedModel] that supports build
+  /// dependencies qualified by keywords. Descendant widgets create
+  /// such dependencies with [AppModel.get] and they trigger
+  /// rebuilds with [AppModel.set].
+  ///
+  /// This widget is automatically created by the [WidgetsApp].
+  const AppModel({ Key? key, required this.child }) : super(key: key);
+
+  /// The widget below this widget in the tree.
+  ///
+  /// {@macro flutter.widgets.ProxyWidget.child}
+  final Widget child;
+
+  @override
+  State<StatefulWidget> createState() => _AppModelState();
+
+  /// Returns the app model's value for [key] and ensures that each
+  /// time the value of [key] is changed with [AppModel.set], the
+  /// specified context will be rebuilt.
+  ///
+  /// If no value for [key] is found then null is returned.
+  ///
+  /// A Widget that depends on the app model's value for [key] should use this method
+  /// in their `build` methods to ensure that they are rebuilt if the value
+  /// changes.
+  static V? get<K extends Object, V>(BuildContext context, K key) {
+    final _AppModelData model = InheritedModel.inheritFrom<_AppModelData>(context, aspect: key)!;
+    return model.appModelState.get<K, V>(key);
+  }
+
+  /// Changes the app model's [value] for [key] and rebuilds any widgets
+  /// that have created a dependency on [key] with [AppModel.get].
+  ///
+  /// If [value] is `==` to the current value of [key] then nothing
+  /// is rebuilt.
+  ///
+  /// Unlike [AppModel.get], this method does _not_ create a dependency
+  /// between [context] and [key].
+  static void set<K extends Object, V>(BuildContext context, K key, V? value) {
+    final _AppModelData model = context.findAncestorWidgetOfExactType<_AppModelData>()!;
+    model.appModelState.set<K, V>(key, value);
+  }
+}
+
+class _AppModelState extends State<AppModel> {
+  late Map<Object, Object?> data;
+
+  @override
+  void initState() {
+    super.initState();
+    data = <Object, Object?>{};
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _AppModelData(appModelState: this, child: widget.child);
+  }
+
+  V? get<K extends Object, V>(K key) => data[key] as V?;
+
+  void set<K extends Object, V>(K key, V? value) {
+    if (data[key] != value) {
+      setState(() {
+        data = Map<Object, Object?>.from(data);
+        data[key] = value;
+      });
+    }
+  }
+}
+
+class _AppModelData extends InheritedModel<Object> {
+  _AppModelData({
+    Key? key,
+    required this.appModelState,
+    required Widget child
+  }) : data = appModelState.data, super(key: key, child: child);
+
+  final _AppModelState appModelState;
+  final Map<Object, Object?> data;
+
+  @override
+  bool updateShouldNotify(_AppModelData old) {
+    return data != old.data;
+  }
+
+  @override
+  bool updateShouldNotifyDependent(_AppModelData old, Set<Object> keys) {
+    for (final Object key in keys) {
+      if (data[key] != old.data[key]) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+
+import 'framework.dart';
+import 'inherited_model.dart';
 
 /// Enables sharing key/value data with the all of the widgets below [child].
 ///

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -25,9 +25,12 @@ typedef AppModelInitCallback<T> = T Function();
 /// in the shared data table and forces widgets that depend on that entry
 /// to be rebuilt.
 ///
-/// A widget whose build method uses AppModel.getValue(context, keyword, init)
-/// creates a dependency on the AppModel: when the value of keyword
-/// changes with AppModel.setValue(), the widget will be rebuilt.
+/// A widget whose build method uses AppModel.getValue(context,
+/// keyword, initCallback) creates a dependency on the AppModel. When
+/// the value of keyword changes with AppModel.setValue(), the widget
+/// will be rebuilt. The values managed by the AppModel are expected
+/// to be immutable: intrinsic changes to values will not cause
+/// dependent widgets to be rebuilt.
 ///
 /// An instance of this widget is created automatically by [WidgetsApp].
 ///
@@ -88,8 +91,10 @@ class AppModel extends StatefulWidget {
   /// time the value of `key` is changed with [AppModel.setValue], the
   /// specified context will be rebuilt.
   ///
-  /// If no value for `key` then the `init` callback is used to generate
-  /// an initial value.
+  /// If no value for `key` exists then the `init` callback is used to
+  /// generate an initial value. The callback is expected to return
+  /// an immutable value because intrinsic changes to the value will
+  /// not cause dependent widgets to be rebuilt.
   ///
   /// A Widget that depends on the app model's value for `key` should use
   /// this method in their `build` methods to ensure that they are rebuilt
@@ -108,6 +113,10 @@ class AppModel extends StatefulWidget {
   ///
   /// If `value` is `==` to the current value of `key` then nothing
   /// is rebuilt.
+  ///
+  /// The `value` is expected to be immutable because intrinsic
+  /// changes to the value will not cause dependent widgets to be
+  /// rebuilt.
   ///
   /// Unlike [AppModel.getValue], this method does _not_ create a dependency
   /// between `context` and `key`.
@@ -183,7 +192,7 @@ class _AppModelData extends InheritedModel<Object> {
   }
 
   @override
-  bool updateShouldNotifyDependent(_AppModelData old, Set<Object> keys) {
+  bool updateShouldNotifyDependent(_AppModelData old, Set<Object> keys) => true;
     for (final Object key in keys) {
       if (data[key] != old.data[key]) {
         return true;

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -34,6 +34,10 @@ import 'inherited_model.dart';
 /// data sharing "umbrella" widgets to enable the use of such
 /// packages.
 ///
+/// A good way to create an AppModel key that avoids potential
+/// collisions with other packages is to use a static `Object()` value.
+/// The `SharedObject` example below does this.
+///
 /// {@tool dartpad}
 /// The following sample demonstrates using the automatically created
 /// `AppModel`. Button presses cause changes to the values for keys

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -7,20 +7,24 @@ import 'package:flutter/foundation.dart';
 import 'framework.dart';
 import 'inherited_model.dart';
 
+/// The type of the [AppModel.getValue] `init` parameter.
+///
+/// This callback is used to lazily create the initial value for
+/// an [AppModel] keyword.
+typedef AppModelInitCallback<T> = T Function();
+
 /// Enables sharing key/value data with the all of the widgets below `child`.
+///
+/// - `AppModel.getValue(context, key, initCallback)` creates a dependency
+/// on the key and returns the value for the key from the shared data table.
+/// If no value exists for key then the initCallback is used to create
+/// the initial value.
 ///
 /// - `AppModel.setValue(context, key, value)` changes the value of an entry
 /// in the shared data table and forces widgets that depend on that entry
 /// to be rebuilt.
 ///
-/// - `AppModel.getValue(context, key)` creates a dependency on the key and
-/// returns the value for the key from the shared data table.
-///
-/// - `AppModel.initValue(context, key, value)` changes the value of an entry
-/// in the shared data table but does not force dependent widgets to be
-/// rebuilt.
-///
-/// A widget whose build method uses AppModel.getValue(context, keyword)
+/// A widget whose build method uses AppModel.getValue(context, keyword, init)
 /// creates a dependency on the AppModel: when the value of keyword
 /// changes with AppModel.setValue(), the widget will be rebuilt.
 ///
@@ -30,7 +34,7 @@ import 'inherited_model.dart';
 /// class is based on [InheritedModel], which is an [InheritedWidget].
 /// It's intended to be used by packages that need to share a modest
 /// number of values among their own components. It obviates the
-/// need for app developers to instantiate package-specific
+/// need for package users to instantiate package-specific
 /// data sharing "umbrella" widgets.
 ///
 /// AppModel is not intended to be a substitute for Provider or any of
@@ -38,8 +42,8 @@ import 'inherited_model.dart';
 /// for situations where a package's custom widgets need to share one
 /// or a handful of immutable data objects that can be lazily
 /// initialized. It exists so that packages like that can deliver
-/// custom widgets without requiring the developer to add an umbrella
-/// widget to their application.
+/// custom widgets without requiring the developer to add a
+/// package-specific umbrella widget to their application.
 ///
 /// A good way to create an AppModel key that avoids potential
 /// collisions with other packages is to use a static `Object()` value.
@@ -83,20 +87,19 @@ class AppModel extends StatefulWidget {
   /// time the value of `key` is changed with [AppModel.setValue], the
   /// specified context will be rebuilt.
   ///
-  /// If no value for `key` is found then null is returned.
+  /// If no value for `key` then the `init` callback is used to generate
+  /// an initial value.
   ///
   /// A Widget that depends on the app model's value for `key` should use
   /// this method in their `build` methods to ensure that they are rebuilt
   /// if the value changes.
   ///
-  /// The type parameter `K` is the type of the value's keyword and `V`
-  /// is the type of the value. The value type is nullable, for example
-  /// `AppModel.getValue<String, String>(key,value)` means that the key parameter
-  /// must non-null but the value parameter can be null or a string.
-  static V? getValue<K extends Object, V>(BuildContext context, K key) {
+  /// The type parameter `K` is the type of the keyword and `V`
+  /// is the type of the value.
+  static V getValue<K extends Object, V>(BuildContext context, K key, AppModelInitCallback<V> init) {
     final _AppModelData? model = InheritedModel.inheritFrom<_AppModelData>(context, aspect: key);
     assert(_debugHasAppModel(model, context, 'getValue'));
-    return model!.appModelState.getValue<K, V>(key);
+    return model!.appModelState.getValue<K, V>(key, init);
   }
 
   /// Changes the app model's `value` for `key` and rebuilds any widgets
@@ -109,33 +112,11 @@ class AppModel extends StatefulWidget {
   /// between `context` and `key`.
   ///
   /// The type parameter `K` is the type of the value's keyword and `V`
-  /// is the type of the value. The value type is nullable, for example
-  /// `AppModel.setValue<String, String>(key,value)` means that the key parameter
-  /// must non-null but the value parameter can be null or a string.
-  static void setValue<K extends Object, V>(BuildContext context, K key, V? value) {
-    final _AppModelData? model = context.findAncestorWidgetOfExactType<_AppModelData>();
+  /// is the type of the value.
+  static void setValue<K extends Object, V>(BuildContext context, K key, V value) {
+    final _AppModelData? model = context.getElementForInheritedWidgetOfExactType<_AppModelData>()?.widget as _AppModelData?;
     assert(_debugHasAppModel(model, context, 'setValue'));
     model!.appModelState.setValue<K, V>(key, value);
-  }
-
-  /// Unconditionally changes the app model's `value` for `key`.
-  ///
-  /// This method should be used to lazily initialize a value that's
-  /// needed at build time, when rebuilding dependent widgets isn't
-  /// allowed or necessary. The `SharedObject` example above
-  /// demonstrates this.
-  ///
-  /// Unlike [AppModel.setValue], this method does _not_ cause dependent widgets
-  /// to be rebuilt.
-  ///
-  /// The type parameter `K` is the type of the value's keyword and `V`
-  /// is the type of the value. The value type is nullable, for example
-  /// `AppModel.initValue<String, String>(key,value)` means that the key parameter
-  /// must non-null but the value parameter can be null or a string.
-  static void initValue<K extends Object, V>(BuildContext context, K key, V? value) {
-    final _AppModelData? model = context.findAncestorWidgetOfExactType<_AppModelData>();
-    assert(_debugHasAppModel(model, context, 'initValue'));
-    model!.appModelState.initValue<K, V>(key, value);
   }
 
   static bool _debugHasAppModel(_AppModelData? model, BuildContext context, String methodName) {
@@ -170,20 +151,18 @@ class _AppModelState extends State<AppModel> {
     return _AppModelData(appModelState: this, child: widget.child);
   }
 
-  V? getValue<K extends Object, V>(K key) => data[key] as V?;
+  V getValue<K extends Object, V>(K key, AppModelInitCallback<V> init) {
+    data[key] ??= init();
+    return data[key] as V;
+  }
 
-  void setValue<K extends Object, V>(K key, V? value) {
+  void setValue<K extends Object, V>(K key, V value) {
     if (data[key] != value) {
       setState(() {
         data = Map<Object, Object?>.from(data);
         data[key] = value;
       });
     }
-  }
-
-  void initValue<K extends Object, V>(K key, V? value) {
-    data = Map<Object, Object?>.from(data);
-    data[key] = value;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -36,6 +36,16 @@ import 'inherited_model.dart';
 ///
 /// ** See code in examples/api/lib/widgets/app_model/app_model.0.dart **
 /// {@end-tool}
+///
+/// {@tool dartpad}
+/// The following sample demonstrates how a single lazily computed
+/// value could be shared within an app. A Flutter package that
+/// provided custom widgets might use this approach to share a (possibly
+/// private) value with instances of those widgets.
+///
+/// ** See code in examples/api/lib/widgets/app_model/app_model.1.dart **
+/// {@end-tool}
+
 class AppModel extends StatefulWidget {
   /// Creates a widget based on [InheritedModel] that supports build
   /// dependencies qualified by keywords. Descendant widgets create
@@ -79,6 +89,15 @@ class AppModel extends StatefulWidget {
     final _AppModelData model = context.findAncestorWidgetOfExactType<_AppModelData>()!;
     model.appModelState.set<K, V>(key, value);
   }
+
+  /// Unconditionally changes the app model's [value] for [key].
+  ///
+  /// Unlike [AppModel.set], this method does _not_ cause dependent widgets
+  /// to be rebuilt.
+  static void init<K extends Object, V>(BuildContext context, K key, V? value) {
+    final _AppModelData model = context.findAncestorWidgetOfExactType<_AppModelData>()!;
+    model.appModelState.init<K, V>(key, value);
+  }
 }
 
 class _AppModelState extends State<AppModel> {
@@ -104,6 +123,11 @@ class _AppModelState extends State<AppModel> {
         data[key] = value;
       });
     }
+  }
+
+  void init<K extends Object, V>(K key, V? value) {
+    data = Map<Object, Object?>.from(data);
+    data[key] = value;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/app_model.dart
+++ b/packages/flutter/lib/src/widgets/app_model.dart
@@ -51,7 +51,6 @@ import 'inherited_model.dart';
 ///
 /// ** See code in examples/api/lib/widgets/app_model/app_model.1.dart **
 /// {@end-tool}
-
 class AppModel extends StatefulWidget {
   /// Creates a widget based on [InheritedModel] that supports build
   /// dependencies qualified by keywords. Descendant widgets create
@@ -84,8 +83,9 @@ class AppModel extends StatefulWidget {
   /// `AppModel.getValue<String, String>(key,value)` means that the key parameter
   /// must non-null but the value parameter can be null or a string.
   static V? getValue<K extends Object, V>(BuildContext context, K key) {
-    final _AppModelData model = InheritedModel.inheritFrom<_AppModelData>(context, aspect: key)!;
-    return model.appModelState.getValue<K, V>(key);
+    final _AppModelData? model = InheritedModel.inheritFrom<_AppModelData>(context, aspect: key);
+    assert(_debugHasAppModel(model, context, 'getValue'));
+    return model!.appModelState.getValue<K, V>(key);
   }
 
   /// Changes the app model's `value` for `key` and rebuilds any widgets
@@ -102,8 +102,9 @@ class AppModel extends StatefulWidget {
   /// `AppModel.setValue<String, String>(key,value)` means that the key parameter
   /// must non-null but the value parameter can be null or a string.
   static void setValue<K extends Object, V>(BuildContext context, K key, V? value) {
-    final _AppModelData model = context.findAncestorWidgetOfExactType<_AppModelData>()!;
-    model.appModelState.setValue<K, V>(key, value);
+    final _AppModelData? model = context.findAncestorWidgetOfExactType<_AppModelData>();
+    assert(_debugHasAppModel(model, context, 'setValue'));
+    model!.appModelState.setValue<K, V>(key, value);
   }
 
   /// Unconditionally changes the app model's `value` for `key`.
@@ -121,8 +122,32 @@ class AppModel extends StatefulWidget {
   /// `AppModel.initValue<String, String>(key,value)` means that the key parameter
   /// must non-null but the value parameter can be null or a string.
   static void initValue<K extends Object, V>(BuildContext context, K key, V? value) {
-    final _AppModelData model = context.findAncestorWidgetOfExactType<_AppModelData>()!;
-    model.appModelState.initValue<K, V>(key, value);
+    final _AppModelData? model = context.findAncestorWidgetOfExactType<_AppModelData>();
+    assert(_debugHasAppModel(model, context, 'initValue'));
+    model!.appModelState.initValue<K, V>(key, value);
+  }
+
+  static bool _debugHasAppModel(_AppModelData? model, BuildContext context, String methodName) {
+    assert(() {
+      if (model != null)
+        return true;
+      throw FlutterError.fromParts(
+        <DiagnosticsNode>[
+          ErrorSummary('No AppModel widget found.'),
+          ErrorDescription('AppModel.$methodName requires an AppModel widget ancestor.\n'),
+          context.describeWidget('The specific widget that could not find an AppModel ancestor was'),
+          context.describeOwnershipChain('The ownership chain for the affected widget is'),
+          ErrorHint(
+            'Typically, the AppModel widget is introduced by the MaterialApp '
+            'or WidgetsApp widget at the top of your application widget tree. It '
+            'provides a key/value map of data that is shared with the entire '
+            'application.',
+          ),
+        ],
+      );
+      return true;
+    }());
+    return true;
   }
 }
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -22,6 +22,7 @@ export 'src/widgets/animated_size.dart';
 export 'src/widgets/animated_switcher.dart';
 export 'src/widgets/annotated_region.dart';
 export 'src/widgets/app.dart';
+export 'src/widgets/app_model.dart';
 export 'src/widgets/async.dart';
 export 'src/widgets/autocomplete.dart';
 export 'src/widgets/autofill.dart';

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -200,6 +200,8 @@ void main() {
       '     _FocusMarker\n'
       '     Focus\n'
       '     Shortcuts\n'
+      '     _AppModelData\n'
+      '     AppModel\n'
       '     UnmanagedRestorationScope\n'
       '     RestorationScope\n'
       '     UnmanagedRestorationScope\n'

--- a/packages/flutter/test/widgets/app_model_test.dart
+++ b/packages/flutter/test/widgets/app_model_test.dart
@@ -29,13 +29,13 @@ void main() {
                     Builder(
                       builder: (BuildContext context) {
                         child1BuildCount += 1;
-                        return Text(AppModel.get<String, String>(context, 'child1Text') ?? 'null');
+                        return Text(AppModel.getValue<String, String>(context, 'child1Text') ?? 'null');
                       },
                     ),
                     Builder(
                       builder: (BuildContext context) {
                         child2BuildCount += 1;
-                        return Text(AppModel.get<String, String>(context, 'child2Text') ?? 'null');
+                        return Text(AppModel.getValue<String, String>(context, 'child2Text') ?? 'null');
                       }
                     ),
                   ],
@@ -52,11 +52,11 @@ void main() {
     expect(child2BuildCount, 1);
     expect(find.text('null').evaluate().length, 2);
 
-    // AppModel.set<String, String>(context, 'child1Text', 'child1')
+    // AppModel.setValue<String, String>(context, 'child1Text', 'child1')
     // causes the first Text widget to be rebuilt with its text to be
     // set to 'child1'. Nothing else is rebuilt.
     setAppModelValue = (BuildContext context) {
-      AppModel.set<String, String>(context, 'child1Text', 'child1');
+      AppModel.setValue<String, String>(context, 'child1Text', 'child1');
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -66,11 +66,11 @@ void main() {
     expect(find.text('child1'), findsOneWidget);
     expect(find.text('null'), findsOneWidget);
 
-    // AppModel.set<String, String>(context, 'child2Text', 'child1')
+    // AppModel.setValue<String, String>(context, 'child2Text', 'child1')
     // causes the second Text widget to be rebuilt with its text to be
     // set to 'child2'. Nothing else is rebuilt.
     setAppModelValue = (BuildContext context) {
-      AppModel.set<String, String>(context, 'child2Text', 'child2');
+      AppModel.setValue<String, String>(context, 'child2Text', 'child2');
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -83,8 +83,8 @@ void main() {
     // Resetting a key's value to the same value does not
     // cause any widgets to be rebuilt.
     setAppModelValue = (BuildContext context) {
-      AppModel.set<String, String>(context, 'child1Text', 'child1');
-      AppModel.set<String, String>(context, 'child2Text', 'child2');
+      AppModel.setValue<String, String>(context, 'child1Text', 'child1');
+      AppModel.setValue<String, String>(context, 'child2Text', 'child2');
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -95,7 +95,7 @@ void main() {
     // More of the same, resetting the values to null..
 
     setAppModelValue = (BuildContext context) {
-      AppModel.set<String, String>(context, 'child1Text', null);
+      AppModel.setValue<String, String>(context, 'child1Text', null);
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -106,7 +106,7 @@ void main() {
     expect(find.text('child2'), findsOneWidget);
 
     setAppModelValue = (BuildContext context) {
-      AppModel.set<String, String>(context, 'child2Text', null);
+      AppModel.setValue<String, String>(context, 'child2Text', null);
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -128,13 +128,13 @@ void main() {
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: () {
-              AppModel.set<String, String>(context, 'childText', 'child');
+              AppModel.setValue<String, String>(context, 'childText', 'child');
             },
             child: Center(
               child: Builder(
                 builder: (BuildContext context) {
                   childBuildCount += 1;
-                  return Text(AppModel.get<String, String>(context, 'childText') ?? 'null');
+                  return Text(AppModel.getValue<String, String>(context, 'childText') ?? 'null');
                 },
               ),
             ),
@@ -166,7 +166,7 @@ void main() {
             behavior: HitTestBehavior.opaque,
             onTap: () {
               outerTapCount += 1;
-              AppModel.set<String, String>(context, 'childText', 'child');
+              AppModel.setValue<String, String>(context, 'childText', 'child');
             },
             child: Center(
               child: AppModel(
@@ -175,9 +175,9 @@ void main() {
                     return GestureDetector(
                       onTap: () {
                         innerTapCount += 1;
-                        AppModel.set<String, String>(context, 'childText', 'child');
+                        AppModel.setValue<String, String>(context, 'childText', 'child');
                       },
-                      child: Text(AppModel.get<String, String>(context, 'childText') ?? 'null'),
+                      child: Text(AppModel.getValue<String, String>(context, 'childText') ?? 'null'),
                     );
                   },
                 ),

--- a/packages/flutter/test/widgets/app_model_test.dart
+++ b/packages/flutter/test/widgets/app_model_test.dart
@@ -29,13 +29,13 @@ void main() {
                     Builder(
                       builder: (BuildContext context) {
                         child1BuildCount += 1;
-                        return Text(AppModel.getValue<String, String>(context, 'child1Text') ?? 'null');
+                        return Text(AppModel.getValue<String, String>(context, 'child1Text', () => 'null'));
                       },
                     ),
                     Builder(
                       builder: (BuildContext context) {
                         child2BuildCount += 1;
-                        return Text(AppModel.getValue<String, String>(context, 'child2Text') ?? 'null');
+                        return Text(AppModel.getValue<String, String>(context, 'child2Text', () => 'null'));
                       }
                     ),
                   ],
@@ -95,7 +95,7 @@ void main() {
     // More of the same, resetting the values to null..
 
     setAppModelValue = (BuildContext context) {
-      AppModel.setValue<String, String>(context, 'child1Text', null);
+      AppModel.setValue<String, String>(context, 'child1Text', 'null');
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -106,7 +106,7 @@ void main() {
     expect(find.text('child2'), findsOneWidget);
 
     setAppModelValue = (BuildContext context) {
-      AppModel.setValue<String, String>(context, 'child2Text', null);
+      AppModel.setValue<String, String>(context, 'child2Text', 'null');
     };
     await tester.tap(find.byType(GestureDetector));
     await tester.pump();
@@ -134,7 +134,7 @@ void main() {
               child: Builder(
                 builder: (BuildContext context) {
                   childBuildCount += 1;
-                  return Text(AppModel.getValue<String, String>(context, 'childText') ?? 'null');
+                  return Text(AppModel.getValue<String, String>(context, 'childText', () => 'null'));
                 },
               ),
             ),
@@ -177,7 +177,7 @@ void main() {
                         innerTapCount += 1;
                         AppModel.setValue<String, String>(context, 'childText', 'child');
                       },
-                      child: Text(AppModel.getValue<String, String>(context, 'childText') ?? 'null'),
+                      child: Text(AppModel.getValue<String, String>(context, 'childText', () => 'null')),
                     );
                   },
                 ),

--- a/packages/flutter/test/widgets/app_model_test.dart
+++ b/packages/flutter/test/widgets/app_model_test.dart
@@ -1,0 +1,205 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AppModel basics', (WidgetTester tester) async {
+    int columnBuildCount = 0;
+    int child1BuildCount = 0;
+    int child2BuildCount = 0;
+    late void Function(BuildContext context) setAppModelValue;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AppModel(
+          child: Builder(
+            builder: (BuildContext context) {
+              columnBuildCount += 1;
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  setAppModelValue.call(context);
+                },
+                child: Column(
+                  children: <Widget>[
+                    Builder(
+                      builder: (BuildContext context) {
+                        child1BuildCount += 1;
+                        return Text(AppModel.get<String, String>(context, 'child1Text') ?? 'null');
+                      },
+                    ),
+                    Builder(
+                      builder: (BuildContext context) {
+                        child2BuildCount += 1;
+                        return Text(AppModel.get<String, String>(context, 'child2Text') ?? 'null');
+                      }
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 1);
+    expect(child2BuildCount, 1);
+    expect(find.text('null').evaluate().length, 2);
+
+    // AppModel.set<String, String>(context, 'child1Text', 'child1')
+    // causes the first Text widget to be rebuilt with its text to be
+    // set to 'child1'. Nothing else is rebuilt.
+    setAppModelValue = (BuildContext context) {
+      AppModel.set<String, String>(context, 'child1Text', 'child1');
+    };
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 2);
+    expect(child2BuildCount, 1);
+    expect(find.text('child1'), findsOneWidget);
+    expect(find.text('null'), findsOneWidget);
+
+    // AppModel.set<String, String>(context, 'child2Text', 'child1')
+    // causes the second Text widget to be rebuilt with its text to be
+    // set to 'child2'. Nothing else is rebuilt.
+    setAppModelValue = (BuildContext context) {
+      AppModel.set<String, String>(context, 'child2Text', 'child2');
+    };
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 2);
+    expect(child2BuildCount, 2);
+    expect(find.text('child1'), findsOneWidget);
+    expect(find.text('child2'), findsOneWidget);
+
+    // Resetting a key's value to the same value does not
+    // cause any widgets to be rebuilt.
+    setAppModelValue = (BuildContext context) {
+      AppModel.set<String, String>(context, 'child1Text', 'child1');
+      AppModel.set<String, String>(context, 'child2Text', 'child2');
+    };
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 2);
+    expect(child2BuildCount, 2);
+
+    // More of the same, resetting the values to null..
+
+    setAppModelValue = (BuildContext context) {
+      AppModel.set<String, String>(context, 'child1Text', null);
+    };
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 3);
+    expect(child2BuildCount, 2);
+    expect(find.text('null'), findsOneWidget);
+    expect(find.text('child2'), findsOneWidget);
+
+    setAppModelValue = (BuildContext context) {
+      AppModel.set<String, String>(context, 'child2Text', null);
+    };
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(columnBuildCount, 1);
+    expect(child1BuildCount, 3);
+    expect(child2BuildCount, 3);
+    expect(find.text('null').evaluate().length, 2);
+  });
+
+  testWidgets('WidgetsApp AppModel ', (WidgetTester tester) async {
+    int parentBuildCount = 0;
+    int childBuildCount = 0;
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xff00ff00),
+        builder: (BuildContext context, Widget? child) {
+          parentBuildCount += 1;
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              AppModel.set<String, String>(context, 'childText', 'child');
+            },
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  childBuildCount += 1;
+                  return Text(AppModel.get<String, String>(context, 'childText') ?? 'null');
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(find.text('null'), findsOneWidget);
+    expect(parentBuildCount, 1);
+    expect(childBuildCount, 1);
+
+    await tester.tap(find.byType(GestureDetector));
+    await tester.pump();
+    expect(parentBuildCount, 1);
+    expect(childBuildCount, 2);
+    expect(find.text('child'), findsOneWidget);
+  });
+
+  testWidgets('WidgetsApp AppModel Shadowing', (WidgetTester tester) async {
+    int innerTapCount = 0;
+    int outerTapCount = 0;
+
+    await tester.pumpWidget(
+      WidgetsApp(
+        color: const Color(0xff00ff00),
+        builder: (BuildContext context, Widget? child) {
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              outerTapCount += 1;
+              AppModel.set<String, String>(context, 'childText', 'child');
+            },
+            child: Center(
+              child: AppModel(
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return GestureDetector(
+                      onTap: () {
+                        innerTapCount += 1;
+                        AppModel.set<String, String>(context, 'childText', 'child');
+                      },
+                      child: Text(AppModel.get<String, String>(context, 'childText') ?? 'null'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(find.text('null'), findsOneWidget);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pump();
+    expect(outerTapCount, 1);
+    expect(innerTapCount, 0);
+    expect(find.text('null'), findsOneWidget);
+
+    await tester.tap(find.text('null'));
+    await tester.pump();
+    expect(outerTapCount, 1);
+    expect(innerTapCount, 1);
+    expect(find.text('child'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Enables sharing key/value data with the all of the widgets below a child. Values must be immutable.

- `AppModel.setValue(context, key, value)` changes the value of an entry in the shared data table and forces widgets that depend on that entry to be rebuilt.

- `AppModel.getValue(context, key, initCallback)` creates a dependency on the key and returns the value for the key from the shared data table. If not value was defined for the key then the init callback is used to create one.

A widget whose build method uses AppModel.get(context, keyword, init) creates a dependency on the AppModel: when the value of keyword changes with AppModel.set(), the widget will be rebuilt.

An instance of this widget is created automatically by `WidgetsApp`.

AppModel is not intended to be a substitute for Provider or any of the other general purpose application state systems. AppModel is for situations where a package's custom widgets need to share one or a handful of immutable data objects, and where those objects can be lazily initialized. It exists so that packages like that can deliver custom widgets without requiring the developer to add an umbrella widget to their application.