### PR TITLE
[web] use local CanvasKit bundle in all e2e tests

### DIFF
--- a/dev/integration_tests/web_e2e_tests/web/index.html
+++ b/dev/integration_tests/web_e2e_tests/web/index.html
@@ -5,6 +5,12 @@ found in the LICENSE file. -->
 <html>
     <head>
         <title>Web Integration Tests</title>
+        <script>
+          // Use the local CanvasKit bundle instead of the CDN to reduce test flakiness.
+          window.flutterConfiguration = {
+            canvasKitBaseUrl: "/canvaskit/"
+          };
+        </script>
     </head>
     <body>
         <script src="main.dart.js"></script>


### PR DESCRIPTION
Use local CanvasKit bundle in all e2e tests instead of the CDN to reduce test flakiness.

Progress towards https://github.com/flutter/flutter/issues/86375
Fixes https://github.com/flutter/flutter/issues/86125