### PR TITLE
[Cupertino] Fix dark mode for `CupertinoContextMenu` and unnecessary divider at the last item

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -5,7 +5,7 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show Divider;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -5,9 +5,9 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
-import 'package:flutter/material.dart' show Divider;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/material/divider.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -19,7 +19,7 @@ const double _kOpenScale = 1.1;
 // static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
 const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
   color: Color(0xFFDDDDDD),
-  darkColor: Color(0xFF3F3F40),
+  darkColor: Color(0xFF373738),
 );
 
 typedef _DismissCallback = void Function(
@@ -1176,7 +1176,7 @@ class _ContextMenuSheet extends StatelessWidget {
                       actions[i],
                       const Divider(
                         color: _kBackgroundColorPressed,
-                        height: 1,
+                        height: .9,
                       ),
                    ],
                   ),

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -5,13 +5,22 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
+
 // The scale of the child at the time that the CupertinoContextMenu opens.
 // This value was eyeballed from a physical device running iOS 13.1.2.
 const double _kOpenScale = 1.1;
+
+// static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+  color: Color(0xFFDDDDDD),
+  darkColor: Color(0xFF3F3F40),
+);
 
 typedef _DismissCallback = void Function(
   BuildContext context,
@@ -1151,7 +1160,7 @@ class _ContextMenuSheet extends StatelessWidget {
 
   // Get the children, whose order depends on orientation and
   // contextMenuLocation.
-  List<Widget> get children {
+  List<Widget> getChildren(BuildContext context) {
     final Flexible menu = Flexible(
       fit: FlexFit.tight,
       flex: 2,
@@ -1160,7 +1169,19 @@ class _ContextMenuSheet extends StatelessWidget {
           borderRadius: const BorderRadius.all(Radius.circular(13.0)),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: actions,
+            children: <Widget>[
+              for (int i = 0; i < actions.length - 1; i++)
+                 Column(
+                   children: <Widget>[
+                      actions[i],
+                      const Divider(
+                        color: _kBackgroundColorPressed,
+                        height: 1,
+                      ),
+                   ],
+                  ),
+                actions.last,
+            ],
           ),
         ),
       ),
@@ -1195,7 +1216,7 @@ class _ContextMenuSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: children,
+      children: getChildren(context),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -7,7 +7,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/src/material/divider.dart';
 import 'package:flutter/widgets.dart';
 
 import 'colors.dart';
@@ -1174,7 +1173,7 @@ class _ContextMenuSheet extends StatelessWidget {
                  Column(
                    children: <Widget>[
                       actions[i],
-                      const Divider(
+                      Container(
                         color: _kBackgroundColorPressed,
                         height: .9,
                       ),

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -49,8 +49,17 @@ class CupertinoContextMenuAction extends StatefulWidget {
 }
 
 class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction> {
-  static const Color _kBackgroundColor = Color(0xFFEEEEEE);
-  static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  // static const Color _kBackgroundColor = Color(0xFFEEEEEE);
+  static const Color _kBackgroundColor = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFEEEEEE),
+    darkColor: Color(0xFF212122),
+  );
+  // static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  static const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFDDDDDD),
+    darkColor: Color(0xFF3F3F40),
+  );
+
   static const double _kButtonHeight = 56.0;
   static const TextStyle _kActionSheetActionStyle = TextStyle(
     fontFamily: '.SF UI Text',
@@ -86,6 +95,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
     if (widget.isDefaultAction) {
       return _kActionSheetActionStyle.copyWith(
         fontWeight: FontWeight.w600,
+        color: CupertinoDynamicColor.resolve(CupertinoColors.label, context)
       );
     }
     if (widget.isDestructiveAction) {
@@ -93,9 +103,10 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
         color: CupertinoColors.destructiveRed,
       );
     }
-    return _kActionSheetActionStyle;
+    return _kActionSheetActionStyle.copyWith(
+        color: CupertinoDynamicColor.resolve(CupertinoColors.label, context)
+      );
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -114,10 +125,9 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
           button: true,
           child: Container(
             decoration: BoxDecoration(
-              color: _isPressed ? _kBackgroundColorPressed : _kBackgroundColor,
-              border: const Border(
-                bottom: BorderSide(color: _kBackgroundColorPressed),
-              ),
+              color: _isPressed
+              ? CupertinoDynamicColor.resolve(_kBackgroundColorPressed, context)
+              : CupertinoDynamicColor.resolve(_kBackgroundColor, context),
             ),
             padding: const EdgeInsets.symmetric(
               vertical: 16.0,

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -88,7 +88,7 @@ void main() {
     await gestureLight.up();
     await tester.pump();
     expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
-    
+
     await tester.pumpWidget(_getApp(isDark: true));
     expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
 

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -5,15 +5,24 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
   // Constants taken from _ContextMenuActionState.
-  const Color _kBackgroundColor = Color(0xFFEEEEEE);
-  const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
-  const Color _kRegularActionColor = CupertinoColors.black;
+  const CupertinoDynamicColor _kBackgroundColor = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFEEEEEE),
+    darkColor: Color(0xFF212122),
+  );
+  // static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  const CupertinoDynamicColor _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFDDDDDD),
+    darkColor: Color(0xFF3F3F40),
+  );
   const Color _kDestructiveActionColor = CupertinoColors.destructiveRed;
   const FontWeight _kDefaultActionWeight = FontWeight.w600;
 
-  Widget _getApp({VoidCallback? onPressed, bool isDestructiveAction = false, bool isDefaultAction = false}) {
+  Widget _getApp({VoidCallback? onPressed, bool isDestructiveAction = false,
+                  bool isDefaultAction = false, bool isDark = false}) {
     final UniqueKey actionKey = UniqueKey();
     final CupertinoContextMenuAction action = CupertinoContextMenuAction(
       key: actionKey,
@@ -25,22 +34,15 @@ void main() {
     );
 
     return CupertinoApp(
+      theme: CupertinoThemeData(
+        brightness: isDark ? Brightness.dark : Brightness.light,
+      ),
       home: CupertinoPageScaffold(
         child: Center(
           child: action,
         ),
       ),
     );
-  }
-
-  BoxDecoration _getDecoration(WidgetTester tester) {
-    final Finder finder = find.descendant(
-      of: find.byType(CupertinoContextMenuAction),
-      matching: find.byType(Container),
-    );
-    expect(finder, findsOneWidget);
-    final Container container = tester.widget(finder);
-    return container.decoration! as BoxDecoration;
   }
 
   TextStyle _getTextStyle(WidgetTester tester) {
@@ -76,22 +78,34 @@ void main() {
 
   testWidgets('turns grey when pressed and held', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp());
-    expect(_getDecoration(tester).color, _kBackgroundColor);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
 
-    final Offset actionCenter = tester.getCenter(find.byType(CupertinoContextMenuAction));
-    final TestGesture gesture = await tester.startGesture(actionCenter);
+    final Offset actionCenterLight = tester.getCenter(find.byType(CupertinoContextMenuAction));
+    final TestGesture gestureLight = await tester.startGesture(actionCenterLight);
     await tester.pump();
-    expect(_getDecoration(tester).color, _kBackgroundColorPressed);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColorPressed.color));
 
-    await gesture.up();
+    await gestureLight.up();
     await tester.pump();
-    expect(_getDecoration(tester).color, _kBackgroundColor);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
+    
+    await tester.pumpWidget(_getApp(isDark: true));
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
+
+    final Offset actionCenterDark = tester.getCenter(find.byType(CupertinoContextMenuAction));
+    final TestGesture gestureDark = await tester.startGesture(actionCenterDark);
+    await tester.pump();
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColorPressed.darkColor));
+
+    await gestureDark.up();
+    await tester.pump();
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
   });
 
   testWidgets('icon and textStyle colors are correct out of the box', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp());
-    expect(_getTextStyle(tester).color, _kRegularActionColor);
-    expect(_getIcon(tester).color, _kRegularActionColor);
+    expect(_getTextStyle(tester).color, CupertinoColors.label);
+    expect(_getIcon(tester).color,  CupertinoColors.label);
   });
 
   testWidgets('icon and textStyle colors are correct for destructive actions', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
   final TestWidgetsFlutterBinding binding =
     TestWidgetsFlutterBinding.ensureInitialized() as TestWidgetsFlutterBinding;
@@ -190,6 +192,83 @@ void main() {
   });
 
   group('CupertinoContextMenu when open', () {
+    testWidgets('Can adapt to light and dark mode', (WidgetTester tester) async {
+      const Size portraitScreenSize = Size(600.0, 800.0);
+      await binding.setSurfaceSize(portraitScreenSize);
+
+      final Widget child =  Container(
+              width: 300.0,
+              height: 100.0,
+              color: const Color(0xFF0000FF),
+            );
+      // Pump a CupertinoContextMenu with Brightness.light
+      await tester.pumpWidget(
+        CupertinoApp(
+          theme: const CupertinoThemeData(
+            brightness: Brightness.light,
+          ),
+          home: CupertinoPageScaffold(
+            child: Align(
+              child: CupertinoContextMenu(
+              actions: const <CupertinoContextMenuAction>[
+              CupertinoContextMenuAction(
+                child: Text('CupertinoContextMenuAction'),
+                ),
+              ],
+            child: child,
+            ),
+          ),
+        ),
+      ));
+      expect(find.byType(CupertinoContextMenuAction), findsNothing);
+      final Rect childRect1 = tester.getRect(find.byWidget(child));
+      final TestGesture gesture1 = await tester.startGesture(childRect1.center);
+      await tester.pumpAndSettle();
+      await gesture1.up();
+      await tester.pumpAndSettle();
+
+      // The position of the action is in the center of the screen.
+      expect(find.byType(CupertinoContextMenuAction), findsOneWidget);
+      expect(find.byType(CupertinoContextMenuAction),
+          paints..rect(color: const Color(0xFFEEEEEE)));
+
+      // Close the CupertinoContextMenu.
+      await tester.tapAt(const Offset(1.0, 1.0));
+      await tester.pumpAndSettle();
+      expect(find.byType(CupertinoContextMenuAction), findsNothing);
+
+      // Pump a CupertinoContextMenu with Brightness.dark
+      await tester.pumpWidget(
+        CupertinoApp(
+          theme: const CupertinoThemeData(
+            brightness: Brightness.dark,
+          ),
+          home: CupertinoPageScaffold(
+            child: Align(
+              child: CupertinoContextMenu(
+              actions: const <CupertinoContextMenuAction>[
+              CupertinoContextMenuAction(
+                child: Text('CupertinoContextMenuAction'),
+                ),
+              ],
+            child: child,
+            ),
+          ),
+        ),
+      ));
+      expect(find.byType(CupertinoContextMenuAction), findsNothing);
+      final Rect childRect2 = tester.getRect(find.byWidget(child));
+      final TestGesture gesture2 = await tester.startGesture(childRect2.center);
+      await tester.pumpAndSettle();
+      await gesture2.up();
+      await tester.pumpAndSettle();
+
+      // The position of the action is in the center of the screen.
+      expect(find.byType(CupertinoContextMenuAction), findsOneWidget);
+      expect(find.byType(CupertinoContextMenuAction),
+          paints..rect(color: const Color(0xFF212122)));
+    });
+
     testWidgets('Can close CupertinoContextMenu by background tap', (WidgetTester tester) async {
       final Widget child = _getChild();
       await tester.pumpWidget(_getContextMenu(child: child));


### PR DESCRIPTION
Here is my fix for `CupertinoContextMenu`, 
It partially fixes https://github.com/flutter/flutter/issues/43211 (dark theme now works tho shadow work is pending)
and completely fixes https://github.com/flutter/flutter/issues/92182

### Preview

https://user-images.githubusercontent.com/48603081/138452610-8cbfdc1b-4ae4-4ca0-a358-98b1b27dfbb1.mp4




Color sampling could be improved, I tried best I could by eyeballing. Since I am working with color sampling for the first time

Here is a quick comparison 


| iOS | Flutter  |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/138451975-a5f85489-dbd2-47aa-b42f-b2f0c8dda4ee.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/138452677-50cf4db6-0616-4de6-bcca-062f9e86f96d.png" height="450"  /> |


| iOS | Flutter  |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/138451981-dcdbe315-9d74-4850-8e99-9d3074b42563.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/138452690-cd30c4d5-08e8-4abf-aeed-bc0463508b36.png" height="450" /> |




Of course, `CupertinoContextMenu` appearance isn't exactly like native iOS. but that's unrelated to this PR. See https://github.com/flutter/flutter/issues/92260 for more details.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
