### PR TITLE
Ignore `Scaffold` drawer callbacks when value doesn't change

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1960,17 +1960,21 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   bool get isEndDrawerOpen => _endDrawerOpened.value;
 
   void _drawerOpenedCallback(bool isOpened) {
-    setState(() {
-      _drawerOpened.value = isOpened;
-    });
-    widget.onDrawerChanged?.call(isOpened);
+    if (_drawerOpened.value != isOpened) {
+      setState(() {
+        _drawerOpened.value = isOpened;
+      });
+      widget.onDrawerChanged?.call(isOpened);
+    }
   }
 
   void _endDrawerOpenedCallback(bool isOpened) {
-    setState(() {
-      _endDrawerOpened.value = isOpened;
-    });
-    widget.onEndDrawerChanged?.call(isOpened);
+    if (_endDrawerOpened.value != isOpened) {
+      setState(() {
+        _endDrawerOpened.value = isOpened;
+      });
+      widget.onEndDrawerChanged?.call(isOpened);
+    }
   }
 
   /// Opens the [Drawer] (if any).

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -50,6 +50,40 @@ void main() {
     expect(false, isEndDrawerOpen);
   });
 
+  testWidgets('Scaffold drawer callback test - only call when changed', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/87914
+    bool onDrawerChangedCalled = false;
+    bool onEndDrawerChangedCalled = false;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        drawer: Container(
+          color: Colors.blue,
+        ),
+        onDrawerChanged: (bool isOpen) {
+          onDrawerChangedCalled = true;
+        },
+        endDrawer: Container(
+          color: Colors.green,
+        ),
+        onEndDrawerChanged: (bool isOpen) {
+          onEndDrawerChangedCalled = true;
+        },
+        body: Container(),
+      ),
+    ));
+
+    await tester.flingFrom(Offset.zero, const Offset(10.0, 0.0), 10.0);
+    expect(false, onDrawerChangedCalled);
+
+    await tester.pumpAndSettle();
+
+    final double width = tester.getSize(find.byType(MaterialApp)).width;
+    await tester.flingFrom(Offset(width - 1, 0.0), const Offset(-10.0, 0.0), 10.0);
+    await tester.pumpAndSettle();
+    expect(false, onEndDrawerChangedCalled);
+  });
+
   testWidgets('Scaffold control test', (WidgetTester tester) async {
     final Key bodyKey = UniqueKey();
     Widget boilerplate(Widget child) {


### PR DESCRIPTION
Ignores `Scaffold` drawer callbacks if the underlying boolean value doesn't change. The callbacks should only be triggered if the drawer opens or closes.

Fixes https://github.com/flutter/flutter/issues/87914

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.