### PR TITLE
Add scaleX and scaleY Parameters in Transform.Scale.

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1266,7 +1266,7 @@ class Transform extends SingleChildRenderObjectWidget {
   ///
   /// The `scaleX` argument provides the scalar by which to multiply the `x` axis, and the `scaleY` argument provides the scalar by which to multiply the `y` axis. Either may be omitted, in which case that axis defaults to 1.0.
   ///
-  /// For convenience, instead of providing `scaleX` and `scaleY`, the `scale` parameter may be used, which will scale the child uniformly.
+  /// For convenience, to scale the child uniformly, instead of providing `scaleX` and `scaleY`, the `scale` parameter may be used.
   ///
   /// At least one of `scale`, `scaleX`, and `scaleY` must be non-null. If `scale` is provided, the other two must be null; similarly, if it is not provided, one of the other two must be.
   ///

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1302,8 +1302,8 @@ class Transform extends SingleChildRenderObjectWidget {
     this.transformHitTests = true,
     this.filterQuality,
     Widget? child,
-  })  : assert(!(scale == null && scaleX == null && scaleY == null), "In Transform.Scale, You have to at least provide 'scale' or both of 'scaleX' and 'scaleY'"),
-        assert(scale == null || (scaleX == null && scaleY == null), "In Transform.Scale, you should either provide 'scale' or both of 'scaleX' and 'scaleY' but not all three"),
+  })  : assert(!(scale == null && scaleX == null && scaleY == null), "In Transform.scale(), You have to at least provide 'scale' or both of 'scaleX' and 'scaleY'"),
+        assert(scale == null || (scaleX == null && scaleY == null), "In Transform.scale(), you should either provide 'scale' or both of 'scaleX' and 'scaleY' but not all three"),
         transform = Matrix4.diagonal3Values(scale ?? scaleX ?? 1.0, scale ?? scaleY ?? 1.0, 1.0),
         super(key: key, child: child);
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1264,9 +1264,9 @@ class Transform extends SingleChildRenderObjectWidget {
 
   /// Creates a widget that scales its child along the 2D plane.
   ///
-  /// The `scaleX` and `scaleY` provide the scalars to multply the `x` and `y` axes.
+  /// The `scaleX` and `scaleY` provide the scalars to multiply the `x` and `y` axes.
   ///
-  /// If `scale` is set then it overrides `scaleX` and `scaleY` and the child is scaled uniformly.
+  /// The `scale` provides the scalar to multiply both `x` and `y` axes and scales the child uniformly.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is
   /// the center of the box.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1264,11 +1264,11 @@ class Transform extends SingleChildRenderObjectWidget {
 
   /// Creates a widget that scales its child along the 2D plane.
   ///
-  /// The `scaleX` and `scaleY` provide the scalars to multiply the `x` and `y` axes.
+  /// The `scaleX` argument provides the scalar by which to multiply the `x` axis, and the `scaleY` argument provides the scalar by which to multiply the `y` axis. Either may be omitted, in which case that axis defaults to 1.0.
   ///
-  /// The `scale` provides the scalar to multiply both `x` and `y` axes and scales the child uniformly.
+  /// For convenience, instead of providing `scaleX` and `scaleY`, the `scale` parameter may be used, which will scale the child uniformly.
   ///
-  /// Please note that, you can provide either only `scale` or both `scaleX` and `scaleY`, but all three parameters cannot be left null.
+  /// At least one of `scale`, `scaleX`, and `scaleY` must be non-null. If `scale` is provided, the other two must be null; similarly, if it is not provided, one of the other two must be.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is
   /// the center of the box.
@@ -1304,8 +1304,8 @@ class Transform extends SingleChildRenderObjectWidget {
     this.transformHitTests = true,
     this.filterQuality,
     Widget? child,
-  })  : assert(!(scale == null && scaleX == null && scaleY == null), "In Transform.scale(), You have to at least provide 'scale' or both of 'scaleX' and 'scaleY'"),
-        assert(scale == null || (scaleX == null && scaleY == null), "In Transform.scale(), you should either provide 'scale' or both of 'scaleX' and 'scaleY' but not all three"),
+  })  : assert(!(scale == null && scaleX == null && scaleY == null), "At least one of 'scale', 'scaleX' and 'scaleY' is required to be non-null"),
+        assert(scale == null || (scaleX == null && scaleY == null), "If 'scale' is non-null then 'scaleX' and 'scaleY' must be left null"),
         transform = Matrix4.diagonal3Values(scale ?? scaleX ?? 1.0, scale ?? scaleY ?? 1.0, 1.0),
         super(key: key, child: child);
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1295,15 +1295,16 @@ class Transform extends SingleChildRenderObjectWidget {
   Transform.scale({
     Key? key,
     double? scale,
-    double scaleX = 1.0,
-    double scaleY = 1.0,
+    double? scaleX,
+    double? scaleY,
     this.origin,
     this.alignment = Alignment.center,
     this.transformHitTests = true,
     this.filterQuality,
     Widget? child,
-  })  : transform =
-            Matrix4.diagonal3Values(scale ?? scaleX, scale ?? scaleY, 1.0),
+  })  : assert(!(scale == null && scaleX == null && scaleY == null), "In Transform.Scale, You have to at least provide 'scale' or both of 'scaleX' and 'scaleY'"),
+        assert(scale == null || (scaleX == null && scaleY == null), "In Transform.Scale, you should either provide 'scale' or both of 'scaleX' and 'scaleY' but not all three"),
+        transform = Matrix4.diagonal3Values(scale ?? scaleX ?? 1.0, scale ?? scaleY ?? 1.0, 1.0),
         super(key: key, child: child);
 
   /// The matrix to transform the child by during painting.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1268,7 +1268,7 @@ class Transform extends SingleChildRenderObjectWidget {
   ///
   /// For convenience, to scale the child uniformly, instead of providing `scaleX` and `scaleY`, the `scale` parameter may be used.
   ///
-  /// At least one of `scale`, `scaleX`, and `scaleY` must be non-null. If `scale` is provided, the other two must be null; similarly, if it is not provided, one of the other two must be.
+  /// At least one of `scale`, `scaleX`, and `scaleY` must be non-null. If `scale` is provided, the other two must be null; similarly, if it is not provided, one of the other two must be provided.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is
   /// the center of the box.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1267,6 +1267,8 @@ class Transform extends SingleChildRenderObjectWidget {
   /// The `scaleX` and `scaleY` provide the scalars to multiply the `x` and `y` axes.
   ///
   /// The `scale` provides the scalar to multiply both `x` and `y` axes and scales the child uniformly.
+  /// 
+  /// Please note that, you can provide either only `scale` or both `scaleX` and `scaleY`, but all three parameters cannot be left null.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is
   /// the center of the box.

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1267,7 +1267,7 @@ class Transform extends SingleChildRenderObjectWidget {
   /// The `scaleX` and `scaleY` provide the scalars to multiply the `x` and `y` axes.
   ///
   /// The `scale` provides the scalar to multiply both `x` and `y` axes and scales the child uniformly.
-  /// 
+  ///
   /// Please note that, you can provide either only `scale` or both `scaleX` and `scaleY`, but all three parameters cannot be left null.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -1262,10 +1262,11 @@ class Transform extends SingleChildRenderObjectWidget {
        alignment = null,
        super(key: key, child: child);
 
-  /// Creates a widget that scales its child uniformly.
+  /// Creates a widget that scales its child along the 2D plane.
   ///
-  /// The `scale` argument must not be null. It gives the scalar by which
-  /// to multiply the `x` and `y` axes.
+  /// The `scaleX` and `scaleY` provide the scalars to multply the `x` and `y` axes.
+  ///
+  /// If `scale` is set then it overrides `scaleX` and `scaleY` and the child is scaled uniformly.
   ///
   /// The [alignment] controls the origin of the scale; by default, this is
   /// the center of the box.
@@ -1293,14 +1294,17 @@ class Transform extends SingleChildRenderObjectWidget {
   ///    over a given duration.
   Transform.scale({
     Key? key,
-    required double scale,
+    double? scale,
+    double scaleX = 1.0,
+    double scaleY = 1.0,
     this.origin,
     this.alignment = Alignment.center,
     this.transformHitTests = true,
     this.filterQuality,
     Widget? child,
-  }) : transform = Matrix4.diagonal3Values(scale, scale, 1.0),
-       super(key: key, child: child);
+  })  : transform =
+            Matrix4.diagonal3Values(scale ?? scaleX, scale ?? scaleY, 1.0),
+        super(key: key, child: child);
 
   /// The matrix to transform the child by during painting.
   final Matrix4 transform;

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -506,7 +506,7 @@ void main() {
     );
   });
 
-  testWidgets('Transform.scale() does not accept all three scale, scaleX and scaleY parameters', (tester) async {
+  testWidgets("Transform.scale() does not accept all three 'scale', 'scaleX' and 'scaleY' parameters", (WidgetTester tester) async {
     await expectLater(() {
       tester.pumpWidget(Directionality(
           textDirection: TextDirection.ltr,
@@ -515,7 +515,7 @@ void main() {
               scale: 1.0,
               scaleX: 1.0,
               scaleY: 1.0,
-              child: Container(
+              child: const SizedBox(
                 height: 100,
                 width: 100,
               ),
@@ -524,13 +524,13 @@ void main() {
     }, throwsAssertionError);
   });
 
-  testWidgets("Transform.scale() needs at least 'scale' or both of 'scaleX' and 'scaleY' otherwise throws AssertionError", (tester) async {
+  testWidgets("Transform.scale() needs at least 'scale' or both of 'scaleX' and 'scaleY' otherwise throws AssertionError", (WidgetTester tester) async {
     await expectLater(() {
       tester.pumpWidget(Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
             child: Transform.scale(
-              child: Container(
+              child: const SizedBox(
                 height: 100,
                 width: 100,
               ),
@@ -539,10 +539,10 @@ void main() {
     }, throwsAssertionError);
   });
 
-  testWidgets("Transform.scale() scales widget uniformly with scale parameter", (tester) async {
-    double _scale = 1.5;
-    double _height = 100;
-    double _width = 150;
+  testWidgets("Transform.scale() scales widget uniformly with 'scale' parameter", (WidgetTester tester) async {
+    const double _scale = 1.5;
+    const double _height = 100;
+    const double _width = 150;
     await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,
         child: SizedBox(
@@ -554,21 +554,22 @@ void main() {
               child: Container(
                 height: _height,
                 width: _width,
+                color: Colors.blue,
               ),
             ),
           ),
         )));
 
-    Size _target = Size(_width * _scale, _height * _scale);
+    Size _target = const Size(_width * _scale, _height * _scale);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });
 
-  testWidgets("Transform.scale() scales widget according to 'scaleX' and 'scaleY'", (tester) async {
-    double _scaleX = 1.5;
-    double _scaleY = 1.2;
-    double _height = 100;
-    double _width = 150;
+  testWidgets("Transform.scale() scales widget according to 'scaleX' and 'scaleY'", (WidgetTester tester) async {
+    const double _scaleX = 1.5;
+    const double _scaleY = 1.2;
+    const double _height = 100;
+    const double _width = 150;
     await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,
         child: SizedBox(
@@ -581,12 +582,13 @@ void main() {
               child: Container(
                 height: _height,
                 width: _width,
+                color: Colors.blue,
               ),
             ),
           ),
         )));
 
-    Size _target = Size(_width * _scaleX, _height * _scaleY);
+    Size _target = const Size(_width * _scaleX, _height * _scaleY);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -560,7 +560,7 @@ void main() {
           ),
         )));
 
-    final Size _target = const Size(_width * _scale, _height * _scale);
+    const Size _target = Size(_width * _scale, _height * _scale);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });
@@ -588,7 +588,7 @@ void main() {
           ),
         )));
 
-    final Size _target = const Size(_width * _scaleX, _height * _scaleY);
+    const Size _target = Size(_width * _scaleX, _height * _scaleY);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -505,6 +505,91 @@ void main() {
       matchesGoldenFile('transform_golden.BitmapRotate.png'),
     );
   });
+
+  testWidgets('Transform.scale() does not accept all three scale, scaleX and scaleY parameters', (tester) async {
+    await expectLater(() {
+      tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Transform.scale(
+              scale: 1.0,
+              scaleX: 1.0,
+              scaleY: 1.0,
+              child: Container(
+                height: 100,
+                width: 100,
+              ),
+            ),
+          )));
+    }, throwsAssertionError);
+  });
+
+  testWidgets("Transform.scale() needs at least 'scale' or both of 'scaleX' and 'scaleY' otherwise throws AssertionError", (tester) async {
+    await expectLater(() {
+      tester.pumpWidget(Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: Transform.scale(
+              child: Container(
+                height: 100,
+                width: 100,
+              ),
+            ),
+          )));
+    }, throwsAssertionError);
+  });
+
+  testWidgets("Transform.scale() scales widget uniformly with scale parameter", (tester) async {
+    double _scale = 1.5;
+    double _height = 100;
+    double _width = 150;
+    await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          height: 400,
+          width: 400,
+          child: Center(
+            child: Transform.scale(
+              scale: _scale,
+              child: Container(
+                height: _height,
+                width: _width,
+              ),
+            ),
+          ),
+        )));
+        
+    Size _target = Size(_width * _scale, _height * _scale);
+
+    expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
+  });
+
+  testWidgets("Transform.scale() scales widget according to 'scaleX' and 'scaleY'", (tester) async {
+    double _scaleX = 1.5;
+    double _scaleY = 1.2;
+    double _height = 100;
+    double _width = 150;
+    await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          height: 400,
+          width: 400,
+          child: Center(
+            child: Transform.scale(
+              scaleX: _scaleX,
+              scaleY: _scaleY,
+              child: Container(
+                height: _height,
+                width: _width,
+              ),
+            ),
+          ),
+        )));
+
+    Size _target = Size(_width * _scaleX, _height * _scaleY);
+
+    expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
+  });
 }
 
 class TestRectPainter extends CustomPainter {

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -554,13 +554,13 @@ void main() {
               child: Container(
                 height: _height,
                 width: _width,
-                color: Colors.blue,
+                decoration: const BoxDecoration(),
               ),
             ),
           ),
         )));
 
-    Size _target = const Size(_width * _scale, _height * _scale);
+    final Size _target = const Size(_width * _scale, _height * _scale);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });
@@ -582,13 +582,13 @@ void main() {
               child: Container(
                 height: _height,
                 width: _width,
-                color: Colors.blue,
+                decoration: const BoxDecoration(),
               ),
             ),
           ),
         )));
 
-    Size _target = const Size(_width * _scaleX, _height * _scaleY);
+    final Size _target = const Size(_width * _scaleX, _height * _scaleY);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));
   });

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -506,7 +506,7 @@ void main() {
     );
   });
 
-  testWidgets("Transform.scale() does not accept all three 'scale', 'scaleX' and 'scaleY' parameters", (WidgetTester tester) async {
+  testWidgets("Transform.scale() does not accept all three 'scale', 'scaleX' and 'scaleY' parameters to be non-null", (WidgetTester tester) async {
     await expectLater(() {
       tester.pumpWidget(Directionality(
           textDirection: TextDirection.ltr,
@@ -524,7 +524,7 @@ void main() {
     }, throwsAssertionError);
   });
 
-  testWidgets("Transform.scale() needs at least 'scale' or both of 'scaleX' and 'scaleY' otherwise throws AssertionError", (WidgetTester tester) async {
+  testWidgets("Transform.scale() needs at least one of 'scale', 'scaleX' and 'scaleY' to be non-null, otherwise throws AssertionError", (WidgetTester tester) async {
     await expectLater(() {
       tester.pumpWidget(Directionality(
           textDirection: TextDirection.ltr,

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -558,7 +558,7 @@ void main() {
             ),
           ),
         )));
-        
+
     Size _target = Size(_width * _scale, _height * _scale);
 
     expect(tester.getBottomRight(find.byType(Container)), _target.bottomRight(tester.getTopLeft(find.byType(Container))));


### PR DESCRIPTION
Added scaleX and scaleY parameters in Transform.Scale. The scale parameter acts the same by overriding scaleX and scaleY.
Also edited the Tooltip help.

Addresses feature request #92342 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
