### PR TITLE
Allow changing the alignment of AnimatedSwitcher

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -235,8 +235,15 @@ class AnimatedSwitcher extends StatefulWidget {
   /// each other.
   ///
   /// This is an [AnimatedSwitcherLayoutBuilder] function.
-  static Widget defaultLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
-    return _alignedStack(currentChild, previousChildren, Alignment.center);
+  static Widget defaultLayoutBuilder(Widget? currentChild, List<Widget> previousChildren,
+      [Alignment alignment = Alignment.center]) {
+    return Stack(
+      alignment: alignment,
+      children: <Widget>[
+        ...previousChildren,
+        if (currentChild != null) currentChild,
+      ],
+    );
   }
 
   /// Returns an [AnimatedSwitcherLayoutBuilder] where the relative position
@@ -248,17 +255,9 @@ class AnimatedSwitcher extends StatefulWidget {
   /// largest of the child or a previous child.
   static AnimatedSwitcherLayoutBuilder customAlignedLayoutBuilder({required Alignment alignment}) {
     return (Widget? currentChild, List<Widget> previousChildren) {
-      return _alignedStack(currentChild, previousChildren, alignment);
+      return defaultLayoutBuilder(currentChild, previousChildren, alignment);
     };
   }
-
-  static Widget _alignedStack(Widget? currentChild, List<Widget> previousChildren, Alignment alignment) => Stack(
-        alignment: Alignment.center,
-        children: <Widget>[
-          ...previousChildren,
-          if (currentChild != null) currentChild,
-        ],
-      );
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -236,13 +236,7 @@ class AnimatedSwitcher extends StatefulWidget {
   ///
   /// This is an [AnimatedSwitcherLayoutBuilder] function.
   static Widget defaultLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
-    return Stack(
-      alignment: Alignment.center,
-      children: <Widget>[
-        ...previousChildren,
-        if (currentChild != null) currentChild,
-      ],
-    );
+    return _alignedStack(currentChild, previousChildren, Alignment.center);
   }
 
   /// Returns an [AnimatedSwitcherLayoutBuilder] where the relative position
@@ -254,15 +248,17 @@ class AnimatedSwitcher extends StatefulWidget {
   /// largest of the child or a previous child.
   static AnimatedSwitcherLayoutBuilder customAlignedLayoutBuilder({required Alignment alignment}) {
     return (Widget? currentChild, List<Widget> previousChildren) {
-      return Stack(
-        alignment: alignment,
+      return _alignedStack(currentChild, previousChildren, alignment);
+    };
+  }
+
+  static Widget _alignedStack(Widget? currentChild, List<Widget> previousChildren, Alignment alignment) => Stack(
+        alignment: Alignment.center,
         children: <Widget>[
           ...previousChildren,
           if (currentChild != null) currentChild,
         ],
       );
-    };
-  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -245,6 +245,25 @@ class AnimatedSwitcher extends StatefulWidget {
     );
   }
 
+  /// Returns an [AnimatedSwitcherLayoutBuilder] where the relative position
+  /// of the children is set by the passed [Alignment] parameter. If
+  /// [Alignment.center] is passed, the returned function equals
+  /// [defaultLayoutBuilder].
+  ///
+  /// The new child is placed in a [Stack] that sizes itself to match the
+  /// largest of the child or a previous child.
+  static AnimatedSwitcherLayoutBuilder customAlignedLayoutBuilder({required Alignment alignment}) {
+    return (Widget? currentChild, List<Widget> previousChildren) {
+      return Stack(
+        alignment: alignment,
+        children: <Widget>[
+          ...previousChildren,
+          if (currentChild != null) currentChild,
+        ],
+      );
+    };
+  }
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -250,6 +250,15 @@ class AnimatedSwitcher extends StatefulWidget {
   /// of the children is set by the passed [Alignment] parameter. If
   /// [Alignment.center] is passed, the returned function equals
   /// [defaultLayoutBuilder].
+  /// 
+  /// Example:
+  /// ```dart
+  ///AnimatedSwitcher(
+  ///  ...
+  ///  layoutBuilder: AnimatedSwitcher.customAlignedLayoutBuilder(alignment: Alignment.topCenter),
+  ///  ...
+  ///),
+  /// ```
   ///
   /// The new child is placed in a [Stack] that sizes itself to match the
   /// largest of the child or a previous child.


### PR DESCRIPTION
Using the [AnimatedSwitcher](https://api.flutter.dev/flutter/widgets/AnimatedSwitcher-class.html), the children are cross-faded while being centered on top of each other. There is currently no way to align the children differently without writing out the entire `AnimatedSwitcherLayoutBuilder` as such:

```dart
AnimatedSwitcher(
  ...
  layoutBuilder: (child, previousChildren) => Stack(
    alignment: otherAlignment,
    children: <Widget>[
      ...previousChildren,
      if (child != null) child,
    ],
  ),
  ...
),
```

A `customAlignedLayoutBuilder` was therefore added as a static function that itself returns an `AnimatedSwitcherLayoutBuilder`. It requires an `Alignment` parameter and allows a more maintainable and less verbose and error-prone implementation of the `layoutBuilder`. It will be usable as such:

```dart
AnimatedSwitcher(
  ...
  layoutBuilder: AnimatedSwitcher.customAlignedLayoutBuilder(alignment: Alignment.topCenter),
  ...
),
```

This parallels the implementation of `AnimatedSwitcher.defaultLayoutBuilder`. If `Alignment.center` is passed, the `AnimatedSwitcherLayoutBuilder` corresponds to `AnimatedSwitcher.defaultLayoutBuilder`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
