### PR TITLE
Make the overflow indicator optional in RenderFlex

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -289,6 +289,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline? textBaseline,
     Clip clipBehavior = Clip.none,
+    bool debugOverflow = true,
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
        assert(mainAxisSize != null),
@@ -301,7 +302,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
        _textDirection = textDirection,
        _verticalDirection = verticalDirection,
        _textBaseline = textBaseline,
-       _clipBehavior = clipBehavior {
+       _clipBehavior = clipBehavior,
+       _debugOverflow = debugOverflow {
     addAll(children);
   }
 
@@ -486,7 +488,20 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   double _overflow = 0;
   // Check whether any meaningful overflow is present. Values below an epsilon
   // are treated as not overflowing.
-  bool get _hasOverflow => _overflow > precisionErrorTolerance;
+  bool get _hasOverflow => _debugOverflow && _overflow > precisionErrorTolerance;
+
+  /// Indicates if the overflow indicator has to be shown in debug mode.
+  ///
+  /// Defaults to true.
+  bool get debugOverflow => _debugOverflow;
+  bool _debugOverflow;
+  set debugOverflow(bool value) {
+    assert(value != null);
+    if (_debugOverflow != value) {
+      _debugOverflow = value;
+      markNeedsPaint();
+    }
+  }
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
@@ -1170,6 +1185,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(EnumProperty<VerticalDirection>('verticalDirection', verticalDirection, defaultValue: null));
     properties.add(EnumProperty<TextBaseline>('textBaseline', textBaseline, defaultValue: null));
+    properties.add(EnumProperty<bool>('debugOverflow', debugOverflow, defaultValue: true));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4324,6 +4324,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.verticalDirection = VerticalDirection.down,
     this.textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
     this.clipBehavior = Clip.none,
+    this.debugOverflow = true,
     List<Widget> children = const <Widget>[],
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
@@ -4429,6 +4430,11 @@ class Flex extends MultiChildRenderObjectWidget {
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
+  /// Indicates if the overflow indicator has to be shown in debug mode.
+  ///
+  /// Defaults to true.
+  final bool debugOverflow;
+
   bool get _needTextDirection {
     assert(direction != null);
     switch (direction) {
@@ -4472,6 +4478,7 @@ class Flex extends MultiChildRenderObjectWidget {
       verticalDirection: verticalDirection,
       textBaseline: textBaseline,
       clipBehavior: clipBehavior,
+      debugOverflow: debugOverflow,
     );
   }
 
@@ -4485,7 +4492,8 @@ class Flex extends MultiChildRenderObjectWidget {
       ..textDirection = getEffectiveTextDirection(context)
       ..verticalDirection = verticalDirection
       ..textBaseline = textBaseline
-      ..clipBehavior = clipBehavior;
+      ..clipBehavior = clipBehavior
+      ..debugOverflow = debugOverflow;
   }
 
   @override
@@ -4498,6 +4506,7 @@ class Flex extends MultiChildRenderObjectWidget {
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(EnumProperty<VerticalDirection>('verticalDirection', verticalDirection, defaultValue: VerticalDirection.down));
     properties.add(EnumProperty<TextBaseline>('textBaseline', textBaseline, defaultValue: null));
+    properties.add(EnumProperty<bool>('debugOverflow', debugOverflow, defaultValue: true));
   }
 }
 
@@ -4699,6 +4708,7 @@ class Row extends Flex {
     TextDirection? textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline? textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
+    bool debugOverflow = true,
     List<Widget> children = const <Widget>[],
   }) : super(
     children: children,
@@ -4710,6 +4720,7 @@ class Row extends Flex {
     textDirection: textDirection,
     verticalDirection: verticalDirection,
     textBaseline: textBaseline,
+    debugOverflow: debugOverflow,
   );
 }
 
@@ -4899,6 +4910,7 @@ class Column extends Flex {
     TextDirection? textDirection,
     VerticalDirection verticalDirection = VerticalDirection.down,
     TextBaseline? textBaseline,
+    bool debugOverflow = true,
     List<Widget> children = const <Widget>[],
   }) : super(
     children: children,
@@ -4910,6 +4922,7 @@ class Column extends Flex {
     textDirection: textDirection,
     verticalDirection: verticalDirection,
     textBaseline: textBaseline,
+    debugOverflow: debugOverflow,
   );
 }
 

--- a/packages/flutter/test/rendering/flex_overflow_test.dart
+++ b/packages/flutter/test/rendering/flex_overflow_test.dart
@@ -53,4 +53,24 @@ void main() {
 
     expect(find.byType(Column), isNot(paints..rect()));
   });
+
+  testWidgets('Flex overflow indicator not shown if debugOverflow is false', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: SizedBox(
+          height: 100.0,
+          child: Column(
+            debugOverflow: false,
+            children: const <Widget>[
+              SizedBox(width: 200.0, height: 200.0),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+
+    expect(find.byType(Column), isNot(paints..rect()));
+  });
 }


### PR DESCRIPTION
This PR adds a boolean named `debugOverflow`, used in `RenderFlex` to opt-out from painting the overflow indicator, if it's set to false.

Fixes #92372 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat