### PR TITLE
Adds BorderStyle property to TabPageSelector

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1508,7 +1508,8 @@ class _TabBarViewState extends State<TabBarView> {
   }
 }
 
-/// Displays a single circle with the specified border and background colors.
+/// Displays a single circle with the specified size, border style, border color
+/// and background colors.
 ///
 /// Used by [TabPageSelector] to indicate the selected page.
 class TabPageSelectorIndicator extends StatelessWidget {
@@ -1520,6 +1521,7 @@ class TabPageSelectorIndicator extends StatelessWidget {
     required this.backgroundColor,
     required this.borderColor,
     required this.size,
+    this.borderStyle = BorderStyle.solid,
   }) : assert(backgroundColor != null),
        assert(borderColor != null),
        assert(size != null),
@@ -1534,6 +1536,11 @@ class TabPageSelectorIndicator extends StatelessWidget {
   /// The indicator circle's diameter.
   final double size;
 
+  /// The indicator circle's border style.
+  ///
+  /// Defaults to [BorderStyle.solid] if value is not specified.
+  final BorderStyle borderStyle;
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -1542,14 +1549,15 @@ class TabPageSelectorIndicator extends StatelessWidget {
       margin: const EdgeInsets.all(4.0),
       decoration: BoxDecoration(
         color: backgroundColor,
-        border: Border.all(color: borderColor),
+        border: Border.all(color: borderColor, style: borderStyle),
         shape: BoxShape.circle,
       ),
     );
   }
 }
 
-/// Displays a row of small circular indicators, one per tab.
+/// Uses [TabPageSelectorIndicator] to display a row of small circular
+/// indicators, one per tab.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=Q628ue9Cq7U}
 ///
@@ -1566,6 +1574,7 @@ class TabPageSelector extends StatelessWidget {
     this.indicatorSize = 12.0,
     this.color,
     this.selectedColor,
+    this.borderStyle,
   }) : assert(indicatorSize != null && indicatorSize > 0.0),
        super(key: key);
 
@@ -1589,6 +1598,11 @@ class TabPageSelector extends StatelessWidget {
   /// If this parameter is null, then the indicator is filled with the theme's
   /// [ColorScheme.secondary].
   final Color? selectedColor;
+
+  /// The indicator circle's border style.
+  ///
+  /// Defaults to [BorderStyle.solid] if value is not specified.
+  final BorderStyle? borderStyle;
 
   Widget _buildTabIndicator(
     int tabIndex,
@@ -1624,6 +1638,7 @@ class TabPageSelector extends StatelessWidget {
       backgroundColor: background,
       borderColor: selectedColorTween.end!,
       size: indicatorSize,
+      borderStyle: borderStyle ?? BorderStyle.solid,
     );
   }
 

--- a/packages/flutter/test/material/page_selector_test.dart
+++ b/packages/flutter/test/material/page_selector_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 const Color kSelectedColor = Color(0xFF00FF00);
 const Color kUnselectedColor = Colors.transparent;
 
-Widget buildFrame(TabController tabController, { Color? color, Color? selectedColor, double indicatorSize = 12.0 }) {
+Widget buildFrame(TabController tabController, { Color? color, Color? selectedColor, double indicatorSize = 12.0, BorderStyle? borderStyle }) {
   return Localizations(
     locale: const Locale('en', 'US'),
     delegates: const <LocalizationsDelegate<dynamic>>[
@@ -31,6 +31,7 @@ Widget buildFrame(TabController tabController, { Color? color, Color? selectedCo
                     color: color,
                     selectedColor: selectedColor,
                     indicatorSize: indicatorSize,
+                    borderStyle: borderStyle,
                   ),
                   Flexible(
                     child: TabBarView(
@@ -225,4 +226,46 @@ void main() {
     expect(tester.getSize(find.byType(TabPageSelector)).height, 24.0);
   });
 
+    testWidgets('PageSelector circle border', (WidgetTester tester) async {
+    final TabController tabController = TabController(
+      vsync: const TestVSync(),
+      initialIndex: 1,
+      length: 3,
+    );
+
+    Iterable<TabPageSelectorIndicator> indicators;
+
+    // Default border
+    await tester.pumpWidget(buildFrame(tabController));
+    indicators = tester.widgetList(
+      find.descendant(
+        of: find.byType(TabPageSelector),
+        matching: find.byType(TabPageSelectorIndicator),
+      ),
+    );
+    for (final TabPageSelectorIndicator indicator in indicators)
+      expect(indicator.borderStyle, BorderStyle.solid);
+
+    // No border
+    await tester.pumpWidget(buildFrame(tabController, borderStyle: BorderStyle.none));
+    indicators = tester.widgetList(
+      find.descendant(
+        of: find.byType(TabPageSelector),
+        matching: find.byType(TabPageSelectorIndicator),
+      ),
+    );
+    for (final TabPageSelectorIndicator indicator in indicators)
+      expect(indicator.borderStyle, BorderStyle.none);
+
+    // Solid border
+    await tester.pumpWidget(buildFrame(tabController, borderStyle: BorderStyle.solid));
+    indicators = tester.widgetList(
+      find.descendant(
+        of: find.byType(TabPageSelector),
+        matching: find.byType(TabPageSelectorIndicator),
+      ),
+    );
+    for (final TabPageSelectorIndicator indicator in indicators)
+      expect(indicator.borderStyle, BorderStyle.solid);
+  });
 }


### PR DESCRIPTION
Currently, TabPageSelector adds a default border to the circles it generates. This does not fit all UI designs. This PR adds BorderStyle property to TabPageSelector.

Fixes: #92328 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
