### PR TITLE
[Cupertino] fix dark mode for `ContextMenuAction`

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -122,7 +122,9 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
           button: true,
           child: Container(
             decoration: BoxDecoration(
-              color: _isPressed ? _kBackgroundColorPressed : _kBackgroundColor,
+              color: _isPressed
+                ? CupertinoDynamicColor.resolve(_kBackgroundColorPressed, context)
+                : CupertinoDynamicColor.resolve(_kBackgroundColor, context),
             ),
             padding: const EdgeInsets.symmetric(
               vertical: 16.0,

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -49,8 +49,14 @@ class CupertinoContextMenuAction extends StatefulWidget {
 }
 
 class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction> {
-  static const Color _kBackgroundColor = Color(0xFFEEEEEE);
-  static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  static const Color _kBackgroundColor = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFEEEEEE),
+    darkColor: Color(0xFF212122),
+  );
+  static const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFDDDDDD),
+    darkColor: Color(0xFF3F3F40),
+  );
   static const double _kButtonHeight = 56.0;
   static const TextStyle _kActionSheetActionStyle = TextStyle(
     fontFamily: '.SF UI Text',
@@ -93,7 +99,9 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
         color: CupertinoColors.destructiveRed,
       );
     }
-    return _kActionSheetActionStyle;
+    return _kActionSheetActionStyle.copyWith(
+        color: CupertinoDynamicColor.resolve(CupertinoColors.label, context)
+    );
   }
 
 

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -100,7 +100,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
       );
     }
     return _kActionSheetActionStyle.copyWith(
-        color: CupertinoDynamicColor.resolve(CupertinoColors.label, context)
+      color: CupertinoDynamicColor.resolve(CupertinoColors.label, context)
     );
   }
 

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -104,7 +104,6 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
     );
   }
 
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -25,7 +25,7 @@ void main() {
     VoidCallback? onPressed,
     bool isDestructiveAction = false,
     bool isDefaultAction = false,
-    bool isDark = false,
+    Brightness? brightness,
   }) {
     final UniqueKey actionKey = UniqueKey();
     final CupertinoContextMenuAction action = CupertinoContextMenuAction(
@@ -39,7 +39,7 @@ void main() {
 
     return CupertinoApp(
       theme: CupertinoThemeData(
-        brightness: isDark ? Brightness.dark : Brightness.light,
+        brightness: brightness ?? Brightness.light,
       ),
       home: CupertinoPageScaffold(
         child: Center(
@@ -93,7 +93,7 @@ void main() {
     await tester.pump();
     expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
 
-    await tester.pumpWidget(_getApp(isDark: true));
+    await tester.pumpWidget(_getApp(brightness: Brightness.dark));
     expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
 
     final Offset actionCenterDark = tester.getCenter(find.byType(CupertinoContextMenuAction));

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -5,15 +5,24 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
   // Constants taken from _ContextMenuActionState.
-  const Color _kBackgroundColor = Color(0xFFEEEEEE);
-  const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
-  const Color _kRegularActionColor = CupertinoColors.black;
+  const CupertinoDynamicColor _kBackgroundColor = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFEEEEEE),
+    darkColor: Color(0xFF212122),
+  );
+  // static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+  const CupertinoDynamicColor _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFDDDDDD),
+    darkColor: Color(0xFF3F3F40),
+  );
   const Color _kDestructiveActionColor = CupertinoColors.destructiveRed;
   const FontWeight _kDefaultActionWeight = FontWeight.w600;
 
-  Widget _getApp({VoidCallback? onPressed, bool isDestructiveAction = false, bool isDefaultAction = false}) {
+  Widget _getApp({VoidCallback? onPressed, bool isDestructiveAction = false,
+                  bool isDefaultAction = false, bool isDark = false}) {
     final UniqueKey actionKey = UniqueKey();
     final CupertinoContextMenuAction action = CupertinoContextMenuAction(
       key: actionKey,
@@ -25,22 +34,15 @@ void main() {
     );
 
     return CupertinoApp(
+      theme: CupertinoThemeData(
+        brightness: isDark ? Brightness.dark : Brightness.light,
+      ),
       home: CupertinoPageScaffold(
         child: Center(
           child: action,
         ),
       ),
     );
-  }
-
-  BoxDecoration _getDecoration(WidgetTester tester) {
-    final Finder finder = find.descendant(
-      of: find.byType(CupertinoContextMenuAction),
-      matching: find.byType(Container),
-    );
-    expect(finder, findsOneWidget);
-    final Container container = tester.widget(finder);
-    return container.decoration! as BoxDecoration;
   }
 
   TextStyle _getTextStyle(WidgetTester tester) {
@@ -76,22 +78,34 @@ void main() {
 
   testWidgets('turns grey when pressed and held', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp());
-    expect(_getDecoration(tester).color, _kBackgroundColor);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
 
-    final Offset actionCenter = tester.getCenter(find.byType(CupertinoContextMenuAction));
-    final TestGesture gesture = await tester.startGesture(actionCenter);
+    final Offset actionCenterLight = tester.getCenter(find.byType(CupertinoContextMenuAction));
+    final TestGesture gestureLight = await tester.startGesture(actionCenterLight);
     await tester.pump();
-    expect(_getDecoration(tester).color, _kBackgroundColorPressed);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColorPressed.color));
 
-    await gesture.up();
+    await gestureLight.up();
     await tester.pump();
-    expect(_getDecoration(tester).color, _kBackgroundColor);
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.color));
+
+    await tester.pumpWidget(_getApp(isDark: true));
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
+
+    final Offset actionCenterDark = tester.getCenter(find.byType(CupertinoContextMenuAction));
+    final TestGesture gestureDark = await tester.startGesture(actionCenterDark);
+    await tester.pump();
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColorPressed.darkColor));
+
+    await gestureDark.up();
+    await tester.pump();
+    expect(find.byType(CupertinoContextMenuAction), paints..rect(color: _kBackgroundColor.darkColor));
   });
 
   testWidgets('icon and textStyle colors are correct out of the box', (WidgetTester tester) async {
     await tester.pumpWidget(_getApp());
-    expect(_getTextStyle(tester).color, _kRegularActionColor);
-    expect(_getIcon(tester).color, _kRegularActionColor);
+    expect(_getTextStyle(tester).color, CupertinoColors.label);
+    expect(_getIcon(tester).color,  CupertinoColors.label);
   });
 
   testWidgets('icon and textStyle colors are correct for destructive actions', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -21,8 +21,12 @@ void main() {
   const Color _kDestructiveActionColor = CupertinoColors.destructiveRed;
   const FontWeight _kDefaultActionWeight = FontWeight.w600;
 
-  Widget _getApp({VoidCallback? onPressed, bool isDestructiveAction = false,
-                  bool isDefaultAction = false, bool isDark = false}) {
+  Widget _getApp({
+    VoidCallback? onPressed,
+    bool isDestructiveAction = false,
+    bool isDefaultAction = false,
+    bool isDark = false,
+  }) {
     final UniqueKey actionKey = UniqueKey();
     final CupertinoContextMenuAction action = CupertinoContextMenuAction(
       key: actionKey,


### PR DESCRIPTION
It partially fixes https://github.com/flutter/flutter/issues/43211 (dark theme now works tho flash effect is pending)

### Preview

https://user-images.githubusercontent.com/48603081/138452610-8cbfdc1b-4ae4-4ca0-a358-98b1b27dfbb1.mp4

| iOS | Flutter  |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/138451975-a5f85489-dbd2-47aa-b42f-b2f0c8dda4ee.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/138452677-50cf4db6-0616-4de6-bcca-062f9e86f96d.png" height="450"  /> |


| iOS | Flutter  |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/138451981-dcdbe315-9d74-4850-8e99-9d3074b42563.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/138452690-cd30c4d5-08e8-4abf-aeed-bc0463508b36.png" height="450" /> |




Of course, `CupertinoContextMenu` appearance isn't exactly like native iOS. but that's unrelated to this PR. See https://github.com/flutter/flutter/issues/92260 for more details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
