### PR TITLE
[Cupertino] Exclude border for last action item in `CupertinoContextMenu`

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -1169,7 +1169,7 @@ class _ContextMenuSheet extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
               actions.first,
-              for (Widget action in actions.skip(1)) 
+              for (Widget action in actions.skip(1))
                 DecoratedBox(
                   decoration: BoxDecoration(
                     border: Border(

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -15,10 +15,9 @@ import 'colors.dart';
 // This value was eyeballed from a physical device running iOS 13.1.2.
 const double _kOpenScale = 1.1;
 
-// static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
-const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
-  color: Color(0xFFDDDDDD),
-  darkColor: Color(0xFF373738),
+const Color _borderColor = CupertinoDynamicColor.withBrightness(
+  color: Color(0xFFA9A9AF),
+  darkColor: Color(0xFF57585A),
 );
 
 typedef _DismissCallback = void Function(
@@ -1160,7 +1159,7 @@ class _ContextMenuSheet extends StatelessWidget {
   // Get the children, whose order depends on orientation and
   // contextMenuLocation.
   List<Widget> getChildren(BuildContext context) {
-    final Flexible menu = Flexible(
+    final Widget menu = Flexible(
       fit: FlexFit.tight,
       flex: 2,
       child: IntrinsicHeight(
@@ -1169,20 +1168,20 @@ class _ContextMenuSheet extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              for (int i = 0; i < actions.length - 1; i++)
-                 Column(
-                   children: <Widget>[
-                      DecoratedBox(
-                        decoration: const BoxDecoration(
-                          border:  Border(
-                            bottom: BorderSide(color: _kBackgroundColorPressed),
-                          ),
-                        ),
-                        child: actions[i],
-                      ),
-                   ],
-                 ),
-              actions.last,
+              actions.first,
+              for (Widget action in actions.skip(1)) 
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      top: BorderSide(
+                        color: CupertinoDynamicColor.resolve(_borderColor, context),
+                        width: 0.5,
+                      )
+                    ),
+                  ),
+                  position: DecorationPosition.foreground,
+                  child: action,
+                ),
             ],
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -9,9 +9,17 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
+
 // The scale of the child at the time that the CupertinoContextMenu opens.
 // This value was eyeballed from a physical device running iOS 13.1.2.
 const double _kOpenScale = 1.1;
+
+// static const Color _kBackgroundColorPressed = Color(0xFFDDDDDD);
+const Color _kBackgroundColorPressed = CupertinoDynamicColor.withBrightness(
+  color: Color(0xFFDDDDDD),
+  darkColor: Color(0xFF373738),
+);
 
 typedef _DismissCallback = void Function(
   BuildContext context,
@@ -1151,7 +1159,7 @@ class _ContextMenuSheet extends StatelessWidget {
 
   // Get the children, whose order depends on orientation and
   // contextMenuLocation.
-  List<Widget> get children {
+  List<Widget> getChildren(BuildContext context) {
     final Flexible menu = Flexible(
       fit: FlexFit.tight,
       flex: 2,
@@ -1160,7 +1168,22 @@ class _ContextMenuSheet extends StatelessWidget {
           borderRadius: const BorderRadius.all(Radius.circular(13.0)),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: actions,
+            children: <Widget>[
+              for (int i = 0; i < actions.length - 1; i++)
+                 Column(
+                   children: <Widget>[
+                      DecoratedBox(
+                        decoration: const BoxDecoration(
+                          border:  Border(
+                            bottom: BorderSide(color: _kBackgroundColorPressed),
+                          ),
+                        ),
+                        child: actions[i],
+                      ),
+                   ],
+                 ),
+              actions.last,
+            ],
           ),
         ),
       ),
@@ -1195,7 +1218,7 @@ class _ContextMenuSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: children,
+      children: getChildren(context),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -115,9 +115,6 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
           child: Container(
             decoration: BoxDecoration(
               color: _isPressed ? _kBackgroundColorPressed : _kBackgroundColor,
-              border: const Border(
-                bottom: BorderSide(color: _kBackgroundColorPressed),
-              ),
             ),
             padding: const EdgeInsets.symmetric(
               vertical: 16.0,

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -200,45 +198,61 @@ void main() {
   group('CupertinoContextMenu when open', () {
     testWidgets('Last action does not have border', (WidgetTester tester) async {
       final Widget child  = _getChild();
-      const Size screenSize = Size(800.0, 600.0);
       await tester.pumpWidget(CupertinoApp(
         home: CupertinoPageScaffold(
-          child: MediaQuery(
-            data: const MediaQueryData(size: screenSize),
-            child: Align(
-              child: CupertinoContextMenu(
-                actions: const <CupertinoContextMenuAction>[
-                  CupertinoContextMenuAction(
-                    child: Text('CupertinoContextMenuAction One'),
-                  ),
-                  CupertinoContextMenuAction(
-                    child: Text('CupertinoContextMenuAction Two'),
-                  ),
-                ],
-                child: child,
-              ),
+          child: Center(
+            child: CupertinoContextMenu(
+              actions: const <CupertinoContextMenuAction>[
+                CupertinoContextMenuAction(
+                  child: Text('CupertinoContextMenuAction One'),
+                ),
+              ],
+              child: child,
             ),
           ),
         ),
       ));
 
       // Open the CupertinoContextMenu
-      final Rect childRect = tester.getRect(find.byWidget(child));
-      final TestGesture gesture = await tester.startGesture(childRect.center);
+      final TestGesture firstGesture = await tester.startGesture(tester.getCenter(find.byWidget(child)));
       await tester.pumpAndSettle();
-      await gesture.up();
+      await firstGesture.up();
       await tester.pumpAndSettle();
       expect(_findStatic(), findsOneWidget);
 
-      // We expected three DecoratedBox
-      // First child has two DecoratedBox, for border and background color.
-      // Last child should only have one DecoratedBox for background color, no border.
-      expect(_findStaticChildDecoration(tester), findsNWidgets(3));
+      expect(_findStaticChildDecoration(tester), findsNWidgets(1));
 
       // Close the CupertinoContextMenu.
       await tester.tapAt(const Offset(1.0, 1.0));
       await tester.pumpAndSettle();
       expect(_findStatic(), findsNothing);
+
+      await tester.pumpWidget(CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: CupertinoContextMenu(
+              actions: const <CupertinoContextMenuAction>[
+                CupertinoContextMenuAction(
+                  child: Text('CupertinoContextMenuAction One'),
+                ),
+                CupertinoContextMenuAction(
+                  child: Text('CupertinoContextMenuAction Two'),
+                ),
+              ],
+              child: child,
+            ),
+          ),
+        ),
+      ));
+
+      // Open the CupertinoContextMenu
+      final TestGesture secondGesture = await tester.startGesture(tester.getCenter(find.byWidget(child)));
+      await tester.pumpAndSettle();
+      await secondGesture.up();
+      await tester.pumpAndSettle();
+      expect(_findStatic(), findsOneWidget);
+
+      expect(_findStaticChildDecoration(tester), findsNWidgets(3));
     });
 
     testWidgets('Can close CupertinoContextMenu by background tap', (WidgetTester tester) async {


### PR DESCRIPTION
### Description
fixes https://github.com/flutter/flutter/issues/92182

Fixes last CupertinoContextMenu action item getting extra border 


This problem surfaced when fixing https://github.com/flutter/flutter/issues/43211, the last divider more clearly visible in dark mode

### Preview
![Screenshot 2021-10-29 at 5 31 47 PM](https://user-images.githubusercontent.com/48603081/139453687-5183c726-c80f-41ca-8e62-2afd7ef4ac43.png)

Of course, `CupertinoContextMenu` appearance isn't exactly like native iOS. but that's unrelated to this PR. See https://github.com/flutter/flutter/issues/92260 for more details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
