### PR TITLE
[release_dashboard] Add clean confirmation prompt on conductor status

### DIFF
--- a/dev/conductor/ui/lib/widgets/common/dialog_prompt.dart
+++ b/dev/conductor/ui/lib/widgets/common/dialog_prompt.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Widget that prompts an alert dialogue to the current window and forces the user to choose between two options.
+Future<String?> dialogPrompt(
+    {required BuildContext context,
+    required String title,
+    required String content,
+    required String leftOption,
+    required String rightOption}) {
+  return showDialog<String>(
+    context: context,
+    builder: (BuildContext context) => AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context, leftOption),
+          child: Text(leftOption),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, rightOption),
+          child: Text(rightOption),
+        ),
+      ],
+    ),
+  );
+}

--- a/dev/conductor/ui/lib/widgets/conductor_status.dart
+++ b/dev/conductor/ui/lib/widgets/conductor_status.dart
@@ -137,8 +137,6 @@ class ConductorStatusState extends State<ConductorStatus> {
         ),
         const SizedBox(height: 30.0),
         Center(
-          // TODO(Yugue): Add regex validation for each parameter input
-          // before Continue button is enabled, https://github.com/flutter/flutter/issues/91925.
           child: ElevatedButton(
             key: const Key('conductorClean'),
             style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.red)),

--- a/dev/conductor/ui/lib/widgets/conductor_status.dart
+++ b/dev/conductor/ui/lib/widgets/conductor_status.dart
@@ -6,6 +6,7 @@ import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
 
+import 'common/dialog_prompt.dart';
 import 'common/tooltip.dart';
 
 /// Displays the current conductor state.
@@ -98,46 +99,60 @@ class ConductorStatusState extends State<ConductorStatus> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        Table(
+          columnWidths: const <int, TableColumnWidth>{
+            0: FixedColumnWidth(200.0),
+          },
+          children: <TableRow>[
+            for (String headerElement in ConductorStatus.headerElements)
+              TableRow(
+                children: <Widget>[
+                  Text('$headerElement:'),
+                  SelectableText((currentStatus[headerElement] == null || currentStatus[headerElement] == '')
+                      ? 'Unknown'
+                      : currentStatus[headerElement]! as String),
+                ],
+              ),
+          ],
+        ),
+        const SizedBox(height: 20.0),
+        Wrap(
           children: <Widget>[
-            Table(
-              columnWidths: const <int, TableColumnWidth>{
-                0: FixedColumnWidth(200.0),
-              },
-              children: <TableRow>[
-                for (String headerElement in ConductorStatus.headerElements)
-                  TableRow(
-                    children: <Widget>[
-                      Text('$headerElement:'),
-                      SelectableText((currentStatus[headerElement] == null || currentStatus[headerElement] == '')
-                          ? 'Unknown'
-                          : currentStatus[headerElement]! as String),
-                    ],
-                  ),
+            Column(
+              children: <Widget>[
+                RepoInfoExpansion(engineOrFramework: 'engine', currentStatus: currentStatus),
+                const SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'engine', currentStatus: currentStatus),
               ],
             ),
-            const SizedBox(height: 20.0),
-            Wrap(
+            const SizedBox(width: 20.0),
+            Column(
               children: <Widget>[
-                Column(
-                  children: <Widget>[
-                    RepoInfoExpansion(engineOrFramework: 'engine', currentStatus: currentStatus),
-                    const SizedBox(height: 10.0),
-                    CherrypickTable(engineOrFramework: 'engine', currentStatus: currentStatus),
-                  ],
-                ),
-                const SizedBox(width: 20.0),
-                Column(
-                  children: <Widget>[
-                    RepoInfoExpansion(engineOrFramework: 'framework', currentStatus: currentStatus),
-                    const SizedBox(height: 10.0),
-                    CherrypickTable(engineOrFramework: 'framework', currentStatus: currentStatus),
-                  ],
-                ),
+                RepoInfoExpansion(engineOrFramework: 'framework', currentStatus: currentStatus),
+                const SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'framework', currentStatus: currentStatus),
               ],
-            )
+            ),
           ],
+        ),
+        const SizedBox(height: 30.0),
+        Center(
+          // TODO(Yugue): Add regex validation for each parameter input
+          // before Continue button is enabled, https://github.com/flutter/flutter/issues/91925.
+          child: ElevatedButton(
+            key: const Key('conductorClean'),
+            style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.red)),
+            onPressed: () {
+              dialogPrompt(
+                context: context,
+                title: 'Are you sure you want to clean up the persistent state file?',
+                content: 'This will abort a work in progress release.',
+                leftOption: 'Yes',
+                rightOption: 'No',
+              );
+            },
+            child: const Text('Clean'),
+          ),
         ),
       ],
     );

--- a/dev/conductor/ui/test/widgets/common/dialog_prompt_test.dart
+++ b/dev/conductor/ui/test/widgets/common/dialog_prompt_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_ui/widgets/common/dialog_prompt.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The dialog prompt appears upon clicking on a button', (WidgetTester tester) async {
+    const String title = 'Are you sure you want to clean up the persistent state file?';
+    const String content = 'This will abort a work in progress release.';
+    const String leftOption = 'Yes';
+    const String rightOption = 'No';
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Builder(
+          builder: (BuildContext context) {
+            return Column(
+              children: <Widget>[
+                ElevatedButton(
+                  onPressed: () {
+                    dialogPrompt(
+                      context: context,
+                      title: title,
+                      content: content,
+                      leftOption: leftOption,
+                      rightOption: rightOption,
+                    );
+                  },
+                  child: const Text('Clean'),
+                )
+              ],
+            );
+          },
+        ),
+      ),
+    ));
+
+    expect(find.byType(ElevatedButton), findsOneWidget);
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(content), findsOneWidget);
+    expect(find.text(leftOption), findsOneWidget);
+    expect(find.text(rightOption), findsOneWidget);
+  });
+}


### PR DESCRIPTION
*Added a Clean button to delete the release state file. It is currently not connected with `conductor clean` CLI command yet.*

Here is a recording of the workflow:

https://user-images.githubusercontent.com/20194490/138928386-2ec37cdc-913b-475c-9a8e-5d06f01a49bb.mov



*[Issue](https://github.com/flutter/flutter/issues/91119)*



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
