### PR TITLE
Run flutter tester with arch -x86_64 on arm64 Mac

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -97,6 +97,7 @@ class FlutterTesterTestDevice extends TestDevice {
     final List<String> command = <String>[
       // Until an arm64 flutter tester binary is available, force to run in Rosetta
       // to avoid "unexpectedly got a signal in sigtramp" crash.
+      // https://github.com/flutter/flutter/issues/88106
       if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) ...<String>[
         '/usr/bin/arch',
         '-x86_64',

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -16,6 +16,7 @@ import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/os.dart';
 import '../base/platform.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -46,7 +47,13 @@ class FlutterTesterTestDevice extends TestDevice {
   })  : assert(shellPath != null), // Please provide the path to the shell in the SKY_SHELL environment variable.
         assert(!debuggingOptions.startPaused || enableObservatory),
         _gotProcessObservatoryUri = enableObservatory
-            ? Completer<Uri>() : (Completer<Uri>()..complete(null));
+            ? Completer<Uri>() : (Completer<Uri>()..complete(null)),
+        _operatingSystemUtils = OperatingSystemUtils(
+          fileSystem: fileSystem,
+          logger: logger,
+          platform: platform,
+          processManager: processManager,
+        );
 
   /// Used for logging to identify the test that is currently being executed.
   final int id;
@@ -70,6 +77,7 @@ class FlutterTesterTestDevice extends TestDevice {
 
   Process _process;
   HttpServer _server;
+  final OperatingSystemUtils _operatingSystemUtils;
 
   /// Starts the device.
   ///
@@ -87,6 +95,12 @@ class FlutterTesterTestDevice extends TestDevice {
     logger.printTrace('test $id: test harness socket server is running at port:${_server.port}');
 
     final List<String> command = <String>[
+      // Until an arm64 flutter tester binary is available, force to run in Rosetta
+      // to avoid "unexpectedly got a signal in sigtramp" crash.
+      if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) ...<String>[
+        '/usr/bin/arch',
+        '-x86_64',
+      ],
       shellPath,
       if (enableObservatory) ...<String>[
         // Some systems drive the _FlutterPlatform class in an unusual way, where


### PR DESCRIPTION
On ARM Macs, run the flutter_tester process with `arch -x86_64`.  It's already running in Rosetta, but we've had reports that this process fails with `rosetta error: unexpectedly got a signal in sigtramp` unless it's run with `arch -x86_64`. I don't really understand why, except that it's some Rosetta bug.

Fixes https://github.com/flutter/flutter/issues/88106

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
