### PR TITLE
[conductor] added cocoonRoot getter

### DIFF
--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -64,6 +64,29 @@ Directory get localFlutterRoot {
   return _flutterRoot!;
 }
 
+Directory? _cocoonRoot;
+
+/// Getter method to get the local cocoon root directory.
+Directory get localCocoonRoot {
+  if (_cocoonRoot != null) {
+    return _cocoonRoot!;
+  }
+  String filePath;
+  const FileSystem fileSystem = LocalFileSystem();
+  const Platform platform = LocalPlatform();
+
+  filePath = platform.script.toFilePath();
+  final String checkoutsDirname = fileSystem.path.normalize(
+    fileSystem.path.join(
+      fileSystem.path.dirname(filePath),
+      '..', // cocoon/release_dashboard
+      '..', // cocoon
+    ),
+  );
+  _cocoonRoot = fileSystem.directory(checkoutsDirname);
+  return _cocoonRoot!;
+}
+
 bool assertsEnabled() {
   // Verify asserts enabled
   bool assertsEnabled = false;
@@ -100,9 +123,8 @@ String? getValueFromEnvOrArgs(
   if (allowNull) {
     return null;
   }
-  throw ConductorException(
-    'Expected either the CLI arg --$name or the environment variable $envName '
-    'to be provided!');
+  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
+      'to be provided!');
 }
 
 /// Return multiple values from the environment or fall back to [argResults].
@@ -128,9 +150,8 @@ List<String> getValuesFromEnvOrArgs(
     return argValues;
   }
 
-  throw ConductorException(
-    'Expected either the CLI arg --$name or the environment variable $envName '
-    'to be provided!');
+  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
+      'to be provided!');
 }
 
 /// Translate CLI arg names to env variable names.


### PR DESCRIPTION
*After the desktop conductor has been moved to cocoon, the origin `localFlutterRoot` getter called by the app does not work inside the cocoon directory anymore. Another getter method `localCocoonRoot` is created.*

The desktop will call `localCocoonRoot` getter inside in `startContext` initialization.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
