### PR TITLE
Add extra benchmark metrics to test name in addition to builder name

### DIFF
--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -24,6 +24,27 @@ class FakeFlutterDestination implements FlutterDestination {
 
 void main() {
   group('Parse', () {
+    test('duplicate entries for both builder name and test name', () {
+      final Map<String, dynamic> results = <String, dynamic>{
+        'CommitBranch': 'master',
+        'CommitSha': 'abc',
+        'BuilderName': 'Linux test',
+        'ResultData': <String, dynamic>{
+          'average_frame_build_time_millis': 0.4550425531914895,
+        },
+        'BenchmarkScoreKeys': <String>[
+          'average_frame_build_time_millis',
+        ],
+      };
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'test');
+
+      expect(metricPoints.length, 2);
+      expect(metricPoints[0].value, equals(0.4550425531914895));
+      expect(metricPoints[0].tags[kNameKey], 'Linux test');
+      expect(metricPoints[1].value, equals(0.4550425531914895));
+      expect(metricPoints[1].tags[kNameKey], 'test');
+    });
+
     test('without additional benchmark tags', () {
       final Map<String, dynamic> results = <String, dynamic>{
         'CommitBranch': 'master',
@@ -38,10 +59,10 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'task abc');
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
-      expect(metricPoints[1].value, equals(0.473));
+      expect(metricPoints[2].value, equals(0.473));
     });
 
     test('with additional benchmark tags', () {
@@ -65,12 +86,12 @@ void main() {
         'host_type': 'linux',
         'host_version': 'debian-10.11'
       };
-      final List<MetricPoint> metricPoints = parse(results, tags);
+      final List<MetricPoint> metricPoints = parse(results, tags, 'task abc');
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
       expect(metricPoints[0].tags.keys.contains('arch'), isTrue);
-      expect(metricPoints[1].value, equals(0.473));
-      expect(metricPoints[1].tags.keys.contains('device_type'), isTrue);
+      expect(metricPoints[2].value, equals(0.473));
+      expect(metricPoints[2].tags.keys.contains('device_type'), isTrue);
     });
 
     test('succeeds - null ResultData', () {
@@ -81,7 +102,7 @@ void main() {
         'ResultData': null,
         'BenchmarkScoreKeys': null,
       };
-      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'tetask abcst');
 
       expect(metricPoints.length, 0);
     });
@@ -102,9 +123,9 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'task abc');
       final FakeFlutterDestination flutterDestination = FakeFlutterDestination();
-      String? taskName;
+      const String taskName = 'default';
       const int commitTimeSinceEpoch = 1629220312;
 
       await upload(flutterDestination, metricPoints, commitTimeSinceEpoch, taskName);
@@ -126,7 +147,7 @@ void main() {
           '90th_percentile_frame_build_time_millis',
         ],
       };
-      final List<MetricPoint> metricPoints = parse(results, <String, String>{});
+      final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'task abc');
       final FakeFlutterDestination flutterDestination = FakeFlutterDestination();
       const String taskName = 'test';
       const int commitTimeSinceEpoch = 1629220312;


### PR DESCRIPTION
Existing metrics are uploaded to benchmark names containing host info, such as `Linux android_semantics_integration_test`.

However, the host info is not necessary now because host and device tags are being collected ( https://github.com/flutter/flutter/pull/92141), which means we can easily filter metrics by host/device tags. This makes it possible to use `android_semantics_integration_test` as the benchmark name by skipping the host info.

On the other hand, there are benchmarks independent of host, see more context: https://github.com/flutter/flutter/issues/74522. Additionally, all existing benchmarks are uniquely mapped to their corresponding task name.

This PR prepares for host deprecation in benchmarks: adding an extra metric entry under `task name` for the same `benchmark`. Once we have enough data (at least 14 commit data points, namely 14 benchmark results), we can stop sending metrics to the original benchmark names containing host info.

We will send a PSA once we are ready to use new benchmark names.

Related: https://github.com/flutter/flutter/issues/74522, https://github.com/flutter/flutter/issues/92203

