### PR TITLE
Migrate test to moved FlutterPlayStoreSplitApplication

### DIFF
--- a/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterPlayStoreSplitApplication"
+        android:name="io.flutter.embedding.android.FlutterPlayStoreSplitApplication"
         android:label="deferred_components_test"
         android:extractNativeLibs="false">
         <activity

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -35,7 +35,7 @@ am start -n io.flutter.integration.deferred_components_test/.MainActivity
 sleep 30
 exit
 "
-$adb_path logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
+$adb_path logcat -d -t "$script_start_time" > build/app/outputs/bundle/release/run_logcat.log
 echo ""
 if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferred code"; then
   echo "All tests passed."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -32,7 +32,7 @@ java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/rele
 
 $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
-sleep 20
+sleep 30
 exit
 "
 $adb_path logcat -d -t "$script_start_time" -s "flutter" > build/app/outputs/bundle/release/run_logcat.log
@@ -41,5 +41,6 @@ if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferr
   echo "All tests passed."
   exit 0
 fi
+cat build/app/outputs/bundle/release/run_logcat.log
 echo "Failure: Deferred component did not load."
 exit 1


### PR DESCRIPTION
https://github.com/flutter/engine/pull/29241 moves FlutterPlayStoreSplitApplication to the embedding package as we look to remove the v1 embedding. This updates the integration test to reflect this change.

Adds better debug logging for https://github.com/flutter/flutter/issues/91266