### PR TITLE
[flutter_conductor] Lift rev parse in conductor

### DIFF
--- a/dev/conductor/core/bin/cli.dart
+++ b/dev/conductor/core/bin/cli.dart
@@ -26,7 +26,7 @@ Future<void> main(List<String> args) async {
   );
   final Checkouts checkouts = Checkouts(
     fileSystem: fileSystem,
-    parentDirectory: localFlutterRoot.parent,
+    parentDirectory: _localFlutterRoot.parent,
     platform: platform,
     processManager: processManager,
     stdio: stdio,
@@ -42,7 +42,7 @@ Future<void> main(List<String> args) async {
   final String conductorVersion = (await const Git(processManager).getOutput(
     <String>['rev-parse'],
     'Get the revision of the current Flutter SDK',
-    workingDirectory: localFlutterRoot.path,
+    workingDirectory: _localFlutterRoot.path,
   )).trim();
 
   <Command<void>>[
@@ -54,7 +54,7 @@ Future<void> main(List<String> args) async {
     ),
     CodesignCommand(
       checkouts: checkouts,
-      flutterRoot: localFlutterRoot,
+      flutterRoot: _localFlutterRoot,
     ),
     StatusCommand(
       checkouts: checkouts,
@@ -68,7 +68,7 @@ Future<void> main(List<String> args) async {
     ),
     CandidatesCommand(
       checkouts: checkouts,
-      flutterRoot: localFlutterRoot,
+      flutterRoot: _localFlutterRoot,
     ),
     NextCommand(
       checkouts: checkouts,
@@ -88,7 +88,7 @@ Future<void> main(List<String> args) async {
   }
 }
 
-Directory get localFlutterRoot {
+Directory get _localFlutterRoot {
   String filePath;
   const FileSystem fileSystem = LocalFileSystem();
   const Platform platform = LocalPlatform();

--- a/dev/conductor/core/bin/cli.dart
+++ b/dev/conductor/core/bin/cli.dart
@@ -39,6 +39,12 @@ Future<void> main(List<String> args) async {
     usageLineLength: 80,
   );
 
+  final String conductorVersion = (await const Git(processManager).getOutput(
+    <String>['rev-parse'],
+    'Get the revision of the current Flutter SDK',
+    workingDirectory: localFlutterRoot.path,
+  )).trim();
+
   <Command<void>>[
     RollDevCommand(
       checkouts: checkouts,
@@ -55,7 +61,7 @@ Future<void> main(List<String> args) async {
     ),
     StartCommand(
       checkouts: checkouts,
-      flutterRoot: localFlutterRoot,
+      conductorVersion: conductorVersion,
     ),
     CleanCommand(
       checkouts: checkouts,

--- a/dev/conductor/core/bin/cli.dart
+++ b/dev/conductor/core/bin/cli.dart
@@ -87,3 +87,21 @@ Future<void> main(List<String> args) async {
     io.exit(1);
   }
 }
+
+Directory get localFlutterRoot {
+  String filePath;
+  const FileSystem fileSystem = LocalFileSystem();
+  const Platform platform = LocalPlatform();
+
+  filePath = platform.script.toFilePath();
+  final String checkoutsDirname = fileSystem.path.normalize(
+    fileSystem.path.join(
+      fileSystem.path.dirname(filePath), // flutter/dev/conductor/core/bin
+      '..', // flutter/dev/conductor/core
+      '..', // flutter/dev/conductor
+      '..', // flutter/dev
+      '..', // flutter
+    ),
+  );
+  return fileSystem.directory(checkoutsDirname);
+}

--- a/dev/conductor/core/lib/conductor_core.dart
+++ b/dev/conductor/core/lib/conductor_core.dart
@@ -7,6 +7,7 @@
 export 'src/candidates.dart';
 export 'src/clean.dart';
 export 'src/codesign.dart';
+export 'src/git.dart';
 export 'src/globals.dart';
 export 'src/next.dart' hide kStateOption, kYesFlag;
 export 'src/repository.dart';

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -3,9 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:args/args.dart';
-import 'package:file/file.dart';
-import 'package:file/local.dart';
-import 'package:platform/platform.dart';
 
 import 'proto/conductor_state.pb.dart' as pb;
 

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -42,6 +42,7 @@ class ConductorException implements Exception {
 }
 
 Directory? _flutterRoot;
+// TODO(fujino): this shouldn't be global
 Directory get localFlutterRoot {
   if (_flutterRoot != null) {
     return _flutterRoot!;

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -41,30 +41,6 @@ class ConductorException implements Exception {
   String toString() => 'Exception: $message';
 }
 
-Directory? _flutterRoot;
-// TODO(fujino): this shouldn't be global
-Directory get localFlutterRoot {
-  if (_flutterRoot != null) {
-    return _flutterRoot!;
-  }
-  String filePath;
-  const FileSystem fileSystem = LocalFileSystem();
-  const Platform platform = LocalPlatform();
-
-  filePath = platform.script.toFilePath();
-  final String checkoutsDirname = fileSystem.path.normalize(
-    fileSystem.path.join(
-      fileSystem.path.dirname(filePath),
-      '..', // flutter/dev/conductor/core
-      '..', // flutter/dev/conductor
-      '..', // flutter/dev
-      '..', // flutter
-    ),
-  );
-  _flutterRoot = fileSystem.directory(checkoutsDirname);
-  return _flutterRoot!;
-}
-
 bool assertsEnabled() {
   // Verify asserts enabled
   bool assertsEnabled = false;

--- a/dev/conductor/core/lib/src/proto/conductor_state.proto
+++ b/dev/conductor/core/lib/src/proto/conductor_state.proto
@@ -109,7 +109,8 @@ message ConductorState {
   // The current [ReleasePhase] that has yet to be completed.
   ReleasePhase currentPhase = 9;
 
-  // Commit hash of the Conductor tool.
+  // A string used to validate that the current conductor is the same version
+  // that created the [ConductorState] object.
   string conductorVersion = 10;
 
   // One of x, y, z, m, or n.

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -34,7 +34,7 @@ const String kStateOption = 'state-file';
 class StartCommand extends Command<void> {
   StartCommand({
     required this.checkouts,
-    required this.flutterRoot,
+    required this.conductorVersion,
   })  : platform = checkouts.platform,
         processManager = checkouts.processManager,
         fileSystem = checkouts.fileSystem,
@@ -105,10 +105,7 @@ class StartCommand extends Command<void> {
 
   final Checkouts checkouts;
 
-  /// The root directory of the Flutter repository that houses the Conductor.
-  ///
-  /// This directory is used to check the git revision of the Conductor.
-  final Directory flutterRoot;
+  final String conductorVersion;
   final FileSystem fileSystem;
   final Platform platform;
   final ProcessManager processManager;
@@ -191,7 +188,7 @@ class StartCommand extends Command<void> {
       engineCherrypickRevisions: engineCherrypickRevisions,
       engineMirror: engineMirror,
       engineUpstream: engineUpstream,
-      flutterRoot: flutterRoot,
+      conductorVersion: conductorVersion,
       frameworkCherrypickRevisions: frameworkCherrypickRevisions,
       frameworkMirror: frameworkMirror,
       frameworkUpstream: frameworkUpstream,
@@ -219,7 +216,7 @@ class StartContext {
     required this.frameworkCherrypickRevisions,
     required this.frameworkMirror,
     required this.frameworkUpstream,
-    required this.flutterRoot,
+    required this.conductorVersion,
     required this.incrementLetter,
     required this.processManager,
     required this.releaseChannel,
@@ -236,33 +233,13 @@ class StartContext {
   final List<String> frameworkCherrypickRevisions;
   final String frameworkMirror;
   final String frameworkUpstream;
-  final Directory flutterRoot;
+  final String conductorVersion;
   final String incrementLetter;
   final Git git;
   final ProcessManager processManager;
   final String releaseChannel;
   final File stateFile;
   final Stdio stdio;
-
-  /// Git revision for the currently running Conductor.
-  Future<String> get conductorVersion async {
-    if (_conductorVersion != null) {
-      return Future<String>.value(_conductorVersion);
-    }
-    _conductorVersion = (await git.getOutput(
-      <String>['rev-parse', 'HEAD'],
-      'look up the current revision.',
-      workingDirectory: flutterRoot.path,
-    )).trim();
-    if (_conductorVersion == null || _conductorVersion!.isEmpty) {
-      throw ConductorException(
-        'Failed to determine the git revision of the Flutter SDK\n'
-        'Working directory: ${flutterRoot.path}'
-      );
-    }
-    return _conductorVersion!;
-  }
-  String? _conductorVersion;
 
   Future<void> run() async {
     if (stateFile.existsSync()) {

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -397,7 +397,7 @@ class StartContext {
 
     state.currentPhase = ReleasePhase.APPLY_ENGINE_CHERRYPICKS;
 
-    state.conductorVersion = await conductorVersion;
+    state.conductorVersion = conductorVersion;
 
     stdio.printTrace('Writing state to file ${stateFile.path}...');
 

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -25,6 +25,7 @@ void main() {
     const String candidateBranch = 'flutter-1.2-candidate.3';
     const String releaseChannel = 'stable';
     const String revision = 'abcd1234';
+    const String conductorVersion = 'deadbeef';
     late Checkouts checkouts;
     late MemoryFileSystem fileSystem;
     late FakePlatform platform;
@@ -66,7 +67,7 @@ void main() {
       );
       final StartCommand command = StartCommand(
         checkouts: checkouts,
-        flutterRoot: fileSystem.directory(flutterRoot),
+        conductorVersion: conductorVersion,
       );
       return CommandRunner<void>('codesign-test', '')..addCommand(command);
     }
@@ -252,10 +253,6 @@ void main() {
         commands: <FakeCommand>[
           ...engineCommands,
           ...frameworkCommands,
-          const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision,
-          ),
         ],
       );
 
@@ -301,7 +298,7 @@ void main() {
       expect(state.framework.startingGitHead, revision3);
       expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
-      expect(state.conductorVersion, revision);
+      expect(state.conductorVersion, conductorVersion);
       expect(state.incrementLevel, incrementLevel);
     });
 
@@ -436,10 +433,6 @@ void main() {
         commands: <FakeCommand>[
           ...engineCommands,
           ...frameworkCommands,
-          const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision,
-          ),
         ],
       );
 
@@ -483,7 +476,7 @@ void main() {
       expect(state.framework.candidateBranch, candidateBranch);
       expect(state.framework.startingGitHead, revision3);
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
-      expect(state.conductorVersion, revision);
+      expect(state.conductorVersion, conductorVersion);
       expect(state.incrementLevel, incrementLevel);
     });
   }, onPlatform: <String, dynamic>{


### PR DESCRIPTION
Remove `localFlutterRoot` from globals (turns out tests weren't depending on it) and update `StartContext` just to take in a `String conductorVersion` to write to the state file.