### PR TITLE
Leader not always dirty

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2354,7 +2354,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
       _clipRectLayer.layer = null;
       _paintContents(context, offset);
     }
-    _paintHandleLayers(context, getEndpointsForSelection(selection!));
+    if (selection!.isValid) {
+      _paintHandleLayers(context, getEndpointsForSelection(selection!));
+    }
   }
 
   final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2121,10 +2121,10 @@ class LayerLink {
   ///
   /// When the [FollowerLayer] no longer wants to follow the [LeaderLayer],
   /// [LayerLinkHandle.dispose] must be called to disconnect the link.
-  LayerLinkHandle registerFollower() {
+  _LayerLinkHandle _registerFollower() {
     assert(_connectedFollowers >= 0);
     _connectedFollowers++;
-    return LayerLinkHandle._(this);
+    return _LayerLinkHandle(this);
   }
 
   /// Returns the [LeaderLayer] currently connected to this link.
@@ -2158,8 +2158,8 @@ class LayerLink {
 /// [LeaderLayer].
 ///
 /// If the link is no longer needed, [dispose] must be called to disconnect it.
-class LayerLinkHandle {
-  LayerLinkHandle._(this._link);
+class _LayerLinkHandle {
+  _LayerLinkHandle(this._link);
 
   LayerLink? _link;
 
@@ -2330,7 +2330,7 @@ class FollowerLayer extends ContainerLayer {
     assert(value != null);
     if (value != _link && _leaderHandle != null) {
       _leaderHandle!.dispose();
-      _leaderHandle = value.registerFollower();
+      _leaderHandle = value._registerFollower();
     }
     _link = value;
   }
@@ -2378,12 +2378,12 @@ class FollowerLayer extends ContainerLayer {
   ///  * [unlinkedOffset], for when the layer is not linked.
   Offset? linkedOffset;
 
-  LayerLinkHandle? _leaderHandle;
+  _LayerLinkHandle? _leaderHandle;
 
   @override
   void attach(Object owner) {
     super.attach(owner);
-    _leaderHandle = _link.registerFollower();
+    _leaderHandle = _link._registerFollower();
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2328,9 +2328,9 @@ class FollowerLayer extends ContainerLayer {
   LayerLink get link => _link;
   set link(LayerLink value) {
     assert(value != null);
-    if (value != _link && _leaderHandler != null) {
-      _leaderHandler!.dispose();
-      _leaderHandler = value.registerFollower();
+    if (value != _link && _leaderHandle != null) {
+      _leaderHandle!.dispose();
+      _leaderHandle = value.registerFollower();
     }
     _link = value;
   }
@@ -2378,19 +2378,19 @@ class FollowerLayer extends ContainerLayer {
   ///  * [unlinkedOffset], for when the layer is not linked.
   Offset? linkedOffset;
 
-  LayerLinkHandle? _leaderHandler;
+  LayerLinkHandle? _leaderHandle;
 
   @override
   void attach(Object owner) {
     super.attach(owner);
-    _leaderHandler = _link.registerFollower();
+    _leaderHandle = _link.registerFollower();
   }
 
   @override
   void detach() {
     super.detach();
-    _leaderHandler?.dispose();
-    _leaderHandler = null;
+    _leaderHandle?.dispose();
+    _leaderHandle = null;
   }
 
   Offset? _lastOffset;
@@ -2412,7 +2412,7 @@ class FollowerLayer extends ContainerLayer {
 
   @override
   bool findAnnotations<S extends Object>(AnnotationResult<S> result, Offset localPosition, { required bool onlyFirst }) {
-    if (_leaderHandler!.leader == null) {
+    if (_leaderHandle!.leader == null) {
       if (showWhenUnlinked!) {
         return super.findAnnotations(result, localPosition - unlinkedOffset!, onlyFirst: onlyFirst);
       }
@@ -2491,7 +2491,7 @@ class FollowerLayer extends ContainerLayer {
   void _establishTransform() {
     assert(link != null);
     _lastTransform = null;
-    final LeaderLayer? leader = _leaderHandler!.leader;
+    final LeaderLayer? leader = _leaderHandle!.leader;
     // Check to see if we are linked.
     if (leader == null)
       return;
@@ -2553,7 +2553,7 @@ class FollowerLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(link != null);
     assert(showWhenUnlinked != null);
-    if (_leaderHandler!.leader == null && !showWhenUnlinked!) {
+    if (_leaderHandle!.leader == null && !showWhenUnlinked!) {
       _lastTransform = null;
       _lastOffset = null;
       _inverseDirty = true;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2109,9 +2109,6 @@ class LayerLink {
   int _connectedFollowers = 0;
 
   /// Whether a [LeaderLayer] is currently connected to this link.
-  ///
-  /// The connected [LeaderLayer] can be obtained from the [LayerLinkHandle]
-  /// returned by [registerFollower].
   bool get leaderConnected => _leader != null;
 
   /// Called by the [FollowerLayer] to establish a link to a [LeaderLayer].
@@ -2130,9 +2127,6 @@ class LayerLink {
   /// Returns the [LeaderLayer] currently connected to this link.
   ///
   /// Valid in debug mode only. Returns null in all other modes.
-  ///
-  /// Use [registerFollower] to obtain the connected [LeaderLayer] for non-debug
-  /// purposes.
   LeaderLayer? get debugLeader {
     LeaderLayer? result;
     if (kDebugMode) {

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -291,7 +291,6 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Subclasses may override this to true to disable retained rendering.
   @protected
-  @visibleForTesting
   bool get alwaysNeedsAddToScene => false;
 
   /// Whether this or any descendant layer in the subtree needs [addToScene].

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2167,7 +2167,9 @@ class LayerLinkHandle {
   LeaderLayer? get leader => _link!._leader;
 
   /// Disconnects the link between the [FollowerLayer] owning this handle and
-  /// the [leader];
+  /// the [leader].
+  ///
+  /// The [LayerLinkHandle] becomes unusable after calling this method.
   void dispose() {
     assert(_link!._connectedFollowers > 0);
     _link!._connectedFollowers--;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -291,6 +291,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
 
   /// Subclasses may override this to true to disable retained rendering.
   @protected
+  @visibleForTesting
   bool get alwaysNeedsAddToScene => false;
 
   /// Whether this or any descendant layer in the subtree needs [addToScene].
@@ -2104,11 +2105,44 @@ class PhysicalModelLayer extends ContainerLayer {
 ///  * [RenderLeaderLayer] and [RenderFollowerLayer], the corresponding
 ///    render objects.
 class LayerLink {
-  /// The currently-registered [LeaderLayer], if any.
-  LeaderLayer? get leader => _leader;
   LeaderLayer? _leader;
 
-  /// The total size of [leader]'s contents.
+  int _connectedFollowers = 0;
+
+  /// Whether a [LeaderLayer] is currently connected to this link.
+  ///
+  /// The connected [LeaderLayer] can be obtained from the [LayerLinkHandle]
+  /// returned by [registerFollower].
+  bool get leaderConnected => _leader != null;
+
+  /// Called by the [FollowerLayer] to establish a link to a [LeaderLayer].
+  ///
+  /// The returned [LayerLinkHandle] provides access to the leader via
+  /// [LayerLinkHandle.leader].
+  ///
+  /// When the [FollowerLayer] no longer wants to follow the [LeaderLayer],
+  /// [LayerLinkHandle.dispose] must be called to disconnect the link.
+  LayerLinkHandle registerFollower() {
+    assert(_connectedFollowers >= 0);
+    _connectedFollowers++;
+    return LayerLinkHandle._(this);
+  }
+
+  /// Returns the [LeaderLayer] currently connected to this link.
+  ///
+  /// Valid in debug mode only. Returns null in all other modes.
+  ///
+  /// Use [connect] to obtain the connected [LeaderLayer] for non-debug
+  /// purposes.
+  LeaderLayer? get debugLeader {
+    LeaderLayer? result;
+    if (kDebugMode) {
+      result = _leader;
+    }
+    return result;
+  }
+
+  /// The total size of the content of the connected [LeaderLayer].
   ///
   /// Generally this should be set by the [RenderObject] that paints on the
   /// registered [leader] layer (for instance a [RenderLeaderLayer] that shares
@@ -2118,6 +2152,28 @@ class LayerLink {
 
   @override
   String toString() => '${describeIdentity(this)}(${ _leader != null ? "<linked>" : "<dangling>" })';
+}
+
+/// A handle provided by [LayerLink.registerFollower] to a calling
+/// [FollowerLayer] to establish a link between that [FollowerLayer] and a
+/// [LeaderLayer].
+///
+/// If the link is no longer needed, [dispose] must be called to disconnect it.
+class LayerLinkHandle {
+  LayerLinkHandle._(this._link);
+
+  LayerLink? _link;
+
+  /// The currently-registered [LeaderLayer], if any.
+  LeaderLayer? get leader => _link!._leader;
+
+  /// Disconnects the link between the [FollowerLayer] owning this handle and
+  /// the [leader];
+  void dispose() {
+    assert(_link!._connectedFollowers > 0);
+    _link!._connectedFollowers--;
+    _link = null;
+  }
 }
 
 /// A composited layer that can be followed by a [FollowerLayer].
@@ -2134,18 +2190,22 @@ class LeaderLayer extends ContainerLayer {
   ///
   /// The [offset] property must be non-null before the compositing phase of the
   /// pipeline.
-  LeaderLayer({ required LayerLink link, this.offset = Offset.zero }) : assert(link != null), _link = link;
+  LeaderLayer({ required LayerLink link, Offset offset = Offset.zero }) : assert(link != null), _link = link, _offset = offset;
 
   /// The object with which this layer should register.
   ///
   /// The link will be established when this layer is [attach]ed, and will be
   /// cleared when this layer is [detach]ed.
   LayerLink get link => _link;
+  LayerLink _link;
   set link(LayerLink value) {
     assert(value != null);
+    if (_link == value) {
+      return;
+    }
+    _link._leader = null;
     _link = value;
   }
-  LayerLink _link;
 
   /// Offset from parent in the parent's coordinate system.
   ///
@@ -2154,23 +2214,34 @@ class LeaderLayer extends ContainerLayer {
   ///
   /// The [offset] property must be non-null before the compositing phase of the
   /// pipeline.
-  Offset offset;
+  Offset get offset => _offset;
+  Offset _offset;
+  set offset(Offset value) {
+    assert(value != null);
+    if (value == _offset) {
+      return;
+    }
+    _offset = value;
+    if (!alwaysNeedsAddToScene) {
+      markNeedsAddToScene();
+    }
+  }
 
   /// {@macro flutter.rendering.FollowerLayer.alwaysNeedsAddToScene}
   @override
-  bool get alwaysNeedsAddToScene => true;
+  bool get alwaysNeedsAddToScene => _link._connectedFollowers > 0;
 
   @override
   void attach(Object owner) {
     super.attach(owner);
-    assert(link.leader == null);
+    assert(link._leader == null);
     _lastOffset = null;
     link._leader = this;
   }
 
   @override
   void detach() {
-    assert(link.leader == this);
+    assert(link._leader == this);
     link._leader = null;
     _lastOffset = null;
     super.detach();
@@ -2256,6 +2327,10 @@ class FollowerLayer extends ContainerLayer {
   LayerLink get link => _link;
   set link(LayerLink value) {
     assert(value != null);
+    if (value != _link && _leaderHandler != null) {
+      _leaderHandler!.dispose();
+      _leaderHandler = value.registerFollower();
+    }
     _link = value;
   }
   LayerLink _link;
@@ -2302,6 +2377,21 @@ class FollowerLayer extends ContainerLayer {
   ///  * [unlinkedOffset], for when the layer is not linked.
   Offset? linkedOffset;
 
+  LayerLinkHandle? _leaderHandler;
+
+  @override
+  void attach(Object owner) {
+    super.attach(owner);
+    _leaderHandler = _link.registerFollower();
+  }
+
+  @override
+  void detach() {
+    super.detach();
+    _leaderHandler?.dispose();
+    _leaderHandler = null;
+  }
+
   Offset? _lastOffset;
   Matrix4? _lastTransform;
   Matrix4? _invertedTransform;
@@ -2321,7 +2411,7 @@ class FollowerLayer extends ContainerLayer {
 
   @override
   bool findAnnotations<S extends Object>(AnnotationResult<S> result, Offset localPosition, { required bool onlyFirst }) {
-    if (link.leader == null) {
+    if (_leaderHandler!.leader == null) {
       if (showWhenUnlinked!) {
         return super.findAnnotations(result, localPosition - unlinkedOffset!, onlyFirst: onlyFirst);
       }
@@ -2400,7 +2490,7 @@ class FollowerLayer extends ContainerLayer {
   void _establishTransform() {
     assert(link != null);
     _lastTransform = null;
-    final LeaderLayer? leader = link.leader;
+    final LeaderLayer? leader = _leaderHandler!.leader;
     // Check to see if we are linked.
     if (leader == null)
       return;
@@ -2462,7 +2552,7 @@ class FollowerLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(link != null);
     assert(showWhenUnlinked != null);
-    if (link.leader == null && !showWhenUnlinked!) {
+    if (_leaderHandler!.leader == null && !showWhenUnlinked!) {
       _lastTransform = null;
       _lastOffset = null;
       _inverseDirty = true;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2144,7 +2144,7 @@ class LayerLink {
   /// The total size of the content of the connected [LeaderLayer].
   ///
   /// Generally this should be set by the [RenderObject] that paints on the
-  /// registered [leader] layer (for instance a [RenderLeaderLayer] that shares
+  /// registered [LeaderLayer] (for instance a [RenderLeaderLayer] that shares
   /// this link with its followers). This size may be outdated before and during
   /// layout.
   Size? leaderSize;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2131,7 +2131,7 @@ class LayerLink {
   ///
   /// Valid in debug mode only. Returns null in all other modes.
   ///
-  /// Use [connect] to obtain the connected [LeaderLayer] for non-debug
+  /// Use [registerFollower] to obtain the connected [LeaderLayer] for non-debug
   /// purposes.
   LeaderLayer? get debugLeader {
     LeaderLayer? result;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -5287,7 +5287,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   @override
   bool hitTest(BoxHitTestResult result, { required Offset position }) {
     // Disables the hit testing if this render object is hidden.
-    if (link.leader == null && !showWhenUnlinked)
+    if (!link.leaderConnected && !showWhenUnlinked)
       return false;
     // RenderFollowerLayer objects don't check if they are
     // themselves hit, because it's confusing to think about
@@ -5311,8 +5311,8 @@ class RenderFollowerLayer extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     final Size? leaderSize = link.leaderSize;
     assert(
-      link.leaderSize != null || (link.leader == null || leaderAnchor == Alignment.topLeft),
-      '$link: layer is linked to ${link.leader} but a valid leaderSize is not set. '
+      link.leaderSize != null || (!link.leaderConnected || leaderAnchor == Alignment.topLeft),
+      '$link: layer is linked to ${link.debugLeader} but a valid leaderSize is not set. '
       'leaderSize is required when leaderAnchor is not Alignment.topLeft '
       '(current value is $leaderAnchor).',
     );

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9979,7 +9979,7 @@ void main() {
       ),
     );
 
-    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+    expect(tester.layers.any((Layer layer) => layer.debugSubtreeNeedsAddToScene!), isFalse);
   });
 
   testWidgets('Focused TextField does not push any layers with alwaysNeedsAddToScene', (WidgetTester tester) async {
@@ -9996,7 +9996,7 @@ void main() {
     await tester.showKeyboard(find.byType(TextField));
 
     expect(focusNode.hasFocus, isTrue);
-    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+    expect(tester.layers.any((Layer layer) => layer.debugSubtreeNeedsAddToScene!), isFalse);
   });
 
   testWidgets('TextField does not push any layers with alwaysNeedsAddToScene after toolbar is dismissed', (WidgetTester tester) async {
@@ -10034,6 +10034,6 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(find.text('Copy'), findsNothing); // Toolbar is not visible
 
-    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+    expect(tester.layers.any((Layer layer) => layer.debugSubtreeNeedsAddToScene!), isFalse);
   });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9967,4 +9967,73 @@ void main() {
       containsPair('hintText', 'placeholder text'),
     );
   });
+
+  testWidgets('TextField at rest does not push any layers with alwaysNeedsAddToScene', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+  });
+
+  testWidgets('Focused TextField does not push any layers with alwaysNeedsAddToScene', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(focusNode: focusNode),
+          ),
+        ),
+      ),
+    );
+    await tester.showKeyboard(find.byType(TextField));
+
+    expect(focusNode.hasFocus, isTrue);
+    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+  });
+
+  testWidgets('TextField does not push any layers with alwaysNeedsAddToScene after toolbar is dismissed', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(focusNode: focusNode),
+          ),
+        ),
+      ),
+    );
+
+    await tester.showKeyboard(find.byType(TextField));
+
+    // Bring up the toolbar.
+    const String testValue = 'A B C';
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: testValue,
+      ),
+    );
+    await tester.pump();
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    state.renderEditable.selectWordsInRange(from: Offset.zero, cause: SelectionChangedCause.tap);
+    expect(state.showToolbar(), true);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Copy'), findsOneWidget); // Toolbar is visible
+
+    // Hide the toolbar
+    focusNode.unfocus();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text('Copy'), findsNothing); // Toolbar is not visible
+
+    expect(tester.layers.any((Layer layer) => layer.alwaysNeedsAddToScene), isFalse);
+  });
 }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10035,5 +10035,5 @@ void main() {
     expect(find.text('Copy'), findsNothing); // Toolbar is not visible
 
     expect(tester.layers.any((Layer layer) => layer.debugSubtreeNeedsAddToScene!), isFalse);
-  });
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 }

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -182,8 +182,10 @@ void main() {
   });
 
   test('leader layers are not dirty when all followers disconnects', () {
+    final ContainerLayer root = ContainerLayer()..attach(Object());
     final LayerLink link = LayerLink();
-    final LeaderLayer leaderLayer = LeaderLayer(link: link)..attach(Object());
+    final LeaderLayer leaderLayer = LeaderLayer(link: link);
+    root.append(leaderLayer);
 
     // Does not need add to scene when nothing is connected to link.
     leaderLayer.debugMarkClean();
@@ -191,24 +193,26 @@ void main() {
     expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
 
     // Connecting a follower requires adding to scene.
-    final LayerLinkHandle handle1 = link.registerFollower();
+    final FollowerLayer follower1 = FollowerLayer(link: link);
+    root.append(follower1);
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
     expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
 
-    final LayerLinkHandle handle2 = link.registerFollower();
+    final FollowerLayer follower2 = FollowerLayer(link: link);
+    root.append(follower2);
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
     expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
 
     // Disconnecting one follower, still needs add to scene.
-    handle2.dispose();
+    follower2.remove();
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
     expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
 
     // Disconnecting all followers goes back to not requiring add to scene.
-    handle1.dispose();
+    follower1.remove();
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
     expect(leaderLayer.debugSubtreeNeedsAddToScene, false);


### PR DESCRIPTION
Prior to this change, `LeaderLayer`s had `alwaysNeedsAddToScene` unconditionally set to true, but they only need to always be added to scene _while_ actually connected to a FollowerLayer. This change makes it so and with that allows retained (= raster cachable) rendering of subtrees that contain `LeaderLayer`s, which are currently not connected to a follower. 

Change is motivated by customer "money": Fading in a route with a textfield was thrashing the raster cache because the textfield was adding a `LeaderLayer` that prevented retained rendering due to its `alwaysNeedsAddToScene` flag. The `LeaderLayer` is used to properly position toolbars and selection handles. However, when both are not visible (and their corresponding FollowerLayers are therefore not in the tree) there was no reason for this behavior. Raster caching the textfield (along any other content) during the fade transition is desirable for performance reason. This change also adds tests to ensure that a textfield without selection handles and toolbars visible remains raster-cachable.

Helps with b/203470598

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
