### PR TITLE
Fixes issue where navigating to new route breaks FocusNode of previou…

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -575,8 +575,8 @@ class _FocusState extends State<Focus> {
         if (widget.skipTraversal != null) {
           focusNode.skipTraversal = widget.skipTraversal;
         }
-        if (widget.canRequestFocus != null) {
-          focusNode.canRequestFocus = widget.canRequestFocus;
+        if (widget._canRequestFocus != null) {
+          focusNode.canRequestFocus = widget._canRequestFocus!;
         }
         focusNode.descendantsAreFocusable = widget.descendantsAreFocusable;
       }

--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -488,8 +488,8 @@ class _FocusState extends State<Focus> {
     if (widget.skipTraversal != null) {
       focusNode.skipTraversal = widget.skipTraversal;
     }
-    if (widget.canRequestFocus != null) {
-      focusNode.canRequestFocus = widget.canRequestFocus;
+    if (widget._canRequestFocus != null) {
+      focusNode.canRequestFocus = widget._canRequestFocus!;
     }
     _couldRequestFocus = focusNode.canRequestFocus;
     _descendantsWereFocusable = focusNode.descendantsAreFocusable;

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1925,5 +1925,36 @@ void main() {
       final TestSemantics expectedSemantics = TestSemantics.root();
       expect(semantics, hasSemantics(expectedSemantics));
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/92693
+    testWidgets('Setting parent FocusScope.canRequestFocus to false, does not set descendant Focus._internalNode._canRequestFocus to false', (WidgetTester tester) async {
+      final FocusNode childFocusNode = FocusNode(debugLabel: 'node 1');
+
+      Widget buildFocusTree({required bool parentCanRequestFocus}) {
+        return FocusScope(
+          canRequestFocus: parentCanRequestFocus,
+          child: Column(
+            children: <Widget>[
+              Focus(
+                focusNode: childFocusNode,
+                child: Container(),
+              ),
+            ],
+          ),
+        );
+      }
+
+      /// Expect: childFocusNode.canRequestFocus is true when parent canRequestFocus is true
+      await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: true));
+      expect(childFocusNode.canRequestFocus, isTrue);
+
+      /// Expect: childFocusNode.canRequestFocus is false when parent canRequestFocus is false
+      await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: false));
+      expect(childFocusNode.canRequestFocus, isFalse);
+
+      /// Expect: childFocusNode.canRequestFocus is true again when parent canRequestFocus is true
+      await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: true));
+      expect(childFocusNode.canRequestFocus, isTrue);
+    });
   });
 }

--- a/packages/flutter/test/widgets/focus_scope_test.dart
+++ b/packages/flutter/test/widgets/focus_scope_test.dart
@@ -1944,15 +1944,15 @@ void main() {
         );
       }
 
-      /// Expect: childFocusNode.canRequestFocus is true when parent canRequestFocus is true
+      // childFocusNode.canRequestFocus is true when parent canRequestFocus is true
       await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: true));
       expect(childFocusNode.canRequestFocus, isTrue);
 
-      /// Expect: childFocusNode.canRequestFocus is false when parent canRequestFocus is false
+      // childFocusNode.canRequestFocus is false when parent canRequestFocus is false
       await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: false));
       expect(childFocusNode.canRequestFocus, isFalse);
 
-      /// Expect: childFocusNode.canRequestFocus is true again when parent canRequestFocus is true
+      // childFocusNode.canRequestFocus is true again when parent canRequestFocus is changed back to true
       await tester.pumpWidget(buildFocusTree(parentCanRequestFocus: true));
       expect(childFocusNode.canRequestFocus, isTrue);
     });


### PR DESCRIPTION
Issue caused by https://github.com/flutter/flutter/pull/90843 - solution to issue described in comment: https://github.com/flutter/flutter/pull/90843#issuecomment-953392413

The issue is that focusNode.canRequestFocus = widget.canRequestFocus, uses https://github.com/flutter/flutter/blob/856aded5b21705d75756f09022d276d5b7f65152/packages/flutter/lib/src/widgets/focus_scope.dart#L254 which effectively makes this line focusNode.canRequestFocus = focusNode.canRequestFocus. Since FocusNode.canRequestFocus also traverses ancestor FocusScopes, these FocusNodes becomes permanently unfocusable.

## Related Issues
 - https://github.com/flutter/flutter/issues/92693

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
