### PR TITLE
[flutter_releases] conductor fixes

### DIFF
--- a/dev/conductor/bin/conductor
+++ b/dev/conductor/bin/conductor
@@ -38,6 +38,6 @@ REPO_DIR="$BIN_DIR/../../.."
 DART_BIN="$REPO_DIR/bin/dart"
 
 # Ensure pub get has been run in the repo before running the conductor
-(cd "$REPO_DIR/dev/conductor/core"; $DART_BIN pub get 1>&2)
+(cd "$REPO_DIR/dev/conductor/core"; "$DART_BIN" pub get 1>&2)
 
 "$DART_BIN" --enable-asserts "$REPO_DIR/dev/conductor/core/bin/cli.dart" "$@"

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -54,7 +54,8 @@ Directory get localFlutterRoot {
   final String checkoutsDirname = fileSystem.path.normalize(
     fileSystem.path.join(
       fileSystem.path.dirname(filePath),
-      '..', // flutter/dev/tools
+      '..', // flutter/dev/conductor/core
+      '..', // flutter/dev/conductor
       '..', // flutter/dev
       '..', // flutter
     ),


### PR DESCRIPTION
Cherrypick of: https://github.com/flutter/flutter/pull/92617 to fix the conductor's bash entrypoint to work on a path with spaces

And part of: https://github.com/flutter/flutter/pull/92064 to fix the hard-coded relative path of the conductor entrypoint.

This PR will only affect tests and is not part of a release, but will unblock future releases.