### PR TITLE
[flutter_tools] Fix bundle file not found when flavor contains uppercase characters (#91582)

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -873,6 +873,11 @@ File findBundleFile(FlutterProject project, BuildInfo buildInfo, Logger logger, 
       getBundleDirectory(project)
         .childDirectory('${buildInfo.lowerCasedFlavor}${camelCase('_${buildInfo.modeName}')}')
         .childFile('app-${buildInfo.lowerCasedFlavor}-${buildInfo.modeName}.aab'));
+
+    // The Android Gradle plugin 4.1.0 does only lowercase the first character of flavor name.
+    fileCandidates.add(getBundleDirectory(project)
+        .childDirectory('${buildInfo.uncapitalizedFlavor}${camelCase('_${buildInfo.modeName}')}')
+        .childFile('app-${buildInfo.uncapitalizedFlavor}-${buildInfo.modeName}.aab'));
   }
   for (final File bundleFile in fileCandidates) {
     if (bundleFile.existsSync()) {

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -193,9 +193,13 @@ class BuildInfo {
   String get modeName => getModeName(mode);
   String get friendlyModeName => getFriendlyModeName(mode);
 
-  /// the flavor name in the output files is lower-cased (see flutter.gradle),
+  /// the flavor name in the output apk files is lower-cased (see flutter.gradle),
   /// so the lower cased flavor name is used to compute the output file name
   String? get lowerCasedFlavor => flavor?.toLowerCase();
+
+  /// the flavor name in the output bundle files has the first character lower-cased,
+  /// so the uncapitalized flavor name is used to compute the output file name
+  String? get uncapitalizedFlavor => flavor?.uncapitalize();
 
   /// Convert to a structured string encoded structure appropriate for usage
   /// in build system [Environment.defines].
@@ -1007,4 +1011,8 @@ String getNameForHostPlatformArch(HostPlatform platform) {
     case HostPlatform.windows_x64:
       return 'x64';
   }
+}
+
+extension on String {
+  String uncapitalize() => isEmpty ? this : substring(0, 1).toLowerCase() + substring(1);
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
@@ -305,6 +305,34 @@ void main() {
     expect(bundle.path, '/build/app/outputs/bundle/foo_barDebug/app-foo_bar-debug.aab');
   });
 
+  testWithoutContext(
+      'Finds app bundle when flavor contains underscores and uppercase letters in release mode - Gradle 4.1', () {
+    final FlutterProject project = generateFakeAppBundle('foo_BarRelease', 'app-foo_Bar-release.aab', fileSystem);
+    final File bundle = findBundleFile(
+      project,
+      const BuildInfo(BuildMode.release, 'Foo_Bar', treeShakeIcons: false),
+      BufferLogger.test(),
+      TestUsage(),
+    );
+
+    expect(bundle, isNotNull);
+    expect(bundle.path, '/build/app/outputs/bundle/foo_BarRelease/app-foo_Bar-release.aab');
+  });
+
+  testWithoutContext(
+      'Finds app bundle when flavor contains underscores and uppercase letters in debug mode - Gradle 4.1', () {
+    final FlutterProject project = generateFakeAppBundle('foo_BarDebug', 'app-foo_Bar-debug.aab', fileSystem);
+    final File bundle = findBundleFile(
+      project,
+      const BuildInfo(BuildMode.debug, 'Foo_Bar', treeShakeIcons: false),
+      BufferLogger.test(),
+      TestUsage(),
+    );
+
+    expect(bundle, isNotNull);
+    expect(bundle.path, '/build/app/outputs/bundle/foo_BarDebug/app-foo_Bar-debug.aab');
+  });
+
   testWithoutContext('AAB not found', () {
     final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
     final TestUsage testUsage = TestUsage();


### PR DESCRIPTION
This PR fixes issue #91582 

## Pre-launch Checklist

- [✓] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✓] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✓] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [?] I signed the [CLA]. (I think, I signed a CLA once for another Google project)
- [✓] I listed at least one issue that this PR fixes in the description above.
- [✓] I updated/added relevant documentation (doc comments with `///`).
- [✓] I added new tests to check the change I am making.
- [✓] All existing and new tests are passing.
