### PR TITLE
Update Data Table Class with Borders Like Table Widgets (#36837)

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -391,6 +391,7 @@ class DataTable extends StatelessWidget {
     this.dividerThickness,
     required this.rows,
     this.checkboxHorizontalMargin,
+    this.border,
   }) : assert(columns != null),
        assert(columns.isNotEmpty),
        assert(sortColumnIndex == null || (sortColumnIndex >= 0 && sortColumnIndex < columns.length)),
@@ -614,6 +615,9 @@ class DataTable extends StatelessWidget {
   /// of the table and the checkbox, as well as the margin between the checkbox
   /// and the content in the first data column. This value defaults to 24.0.
   final double? checkboxHorizontalMargin;
+
+  /// The style to use when painting the boundary and interior divisions of the table.
+  final TableBorder? border;
 
   // Set by the constructor to the index of the only Column that is
   // non-numeric, if there is exactly one, otherwise null.
@@ -1022,6 +1026,7 @@ class DataTable extends StatelessWidget {
         child: Table(
           columnWidths: tableColumns.asMap(),
           children: tableRows,
+          border: border,
         ),
       ),
     );

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1670,4 +1670,69 @@ void main() {
     expect(find.widgetWithText(TableRowInkWell, 'Bug'), findsNothing);
     expect(find.widgetWithText(TableRowInkWell, 'GitHub'), findsNothing);
   });
+
+  testWidgets('DataTable set interior border test', (WidgetTester tester) async {
+    const List<DataColumn> columns = <DataColumn>[
+      DataColumn(label: Text('column1')),
+      DataColumn(label: Text('column2')),
+    ];
+
+    const List<DataCell> cells = <DataCell>[
+      DataCell(Text('cell1')),
+      DataCell(Text('cell2')),
+    ];
+
+    const List<DataRow> rows = <DataRow>[
+      DataRow(cells: cells),
+      DataRow(cells: cells),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DataTable(
+            border: TableBorder.all(width: 2, color: Colors.red),
+            columns: columns,
+            rows: rows,
+          ),
+        ),
+      ),
+    );
+
+    final Finder finder = find.byType(DataTable);
+    expect(tester.getSize(finder), equals(const Size(800, 600)));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DataTable(
+            border: TableBorder.all(color: Colors.red),
+            columns: columns,
+            rows: rows,
+          ),
+        ),
+      ),
+    );
+
+    Table table = tester.widget(find.byType(Table));
+    TableBorder? tableBorder = table.border;
+    expect(tableBorder!.top.color, Colors.red);
+    expect(tableBorder.bottom.width, 1);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: DataTable(
+            columns: columns,
+            rows: rows,
+          ),
+        ),
+      ),
+    );
+
+    table = tester.widget(find.byType(Table));
+    tableBorder = table.border;
+    expect(tableBorder?.bottom.width, null);
+    expect(tableBorder?.top.color, null);
+  });
 }


### PR DESCRIPTION
Adds boundary and interior divisions to DataTable.

fixes #36837