### PR TITLE
InputDecorator floating label origin no longer depends on ThemeData.fixTextFieldOutlineLabel

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -516,12 +516,10 @@ class _Decoration {
     this.helperError,
     this.counter,
     this.container,
-    this.fixTextFieldOutlineLabel = false,
   }) : assert(contentPadding != null),
        assert(isCollapsed != null),
        assert(floatingLabelHeight != null),
-       assert(floatingLabelProgress != null),
-       assert(fixTextFieldOutlineLabel != null);
+       assert(floatingLabelProgress != null);
 
   final EdgeInsetsGeometry contentPadding;
   final bool isCollapsed;
@@ -543,7 +541,6 @@ class _Decoration {
   final Widget? helperError;
   final Widget? counter;
   final Widget? container;
-  final bool fixTextFieldOutlineLabel;
 
   @override
   bool operator ==(Object other) {
@@ -571,8 +568,7 @@ class _Decoration {
         && other.suffixIcon == suffixIcon
         && other.helperError == helperError
         && other.counter == counter
-        && other.container == container
-        && other.fixTextFieldOutlineLabel == fixTextFieldOutlineLabel;
+        && other.container == container;
   }
 
   @override
@@ -597,7 +593,6 @@ class _Decoration {
       helperError,
       counter,
       container,
-      fixTextFieldOutlineLabel,
     );
   }
 }
@@ -1518,9 +1513,7 @@ class _RenderDecoration extends RenderBox {
       final bool isOutlineBorder = decoration.border != null && decoration.border!.isOutline;
       // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
       // Center the scaled label relative to the border.
-      final double floatingY = decoration.fixTextFieldOutlineLabel
-        ? isOutlineBorder ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top
-        : isOutlineBorder ? -labelHeight * 0.25 : contentPadding.top;
+      final double floatingY = isOutlineBorder ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top;
       final double scale = lerpDouble(1.0, _kFinalLabelScale, t)!;
       final double dx;
       switch (textDirection) {
@@ -2161,10 +2154,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       .merge(widget.baseStyle)
       .merge(defaultStyle)
       .merge(style)
-      // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
-      // Setting TextStyle.height to 1 ensures that the label's height will equal
-      // its font size.
-      .copyWith(height: themeData.fixTextFieldOutlineLabel ? 1 : null);
+      .copyWith(height: 1);
   }
 
   // The base style for the inline hint when they're displayed "inline",
@@ -2198,10 +2188,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     return themeData.textTheme.subtitle1!
       .merge(widget.baseStyle)
-      // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
-      // Setting TextStyle.height to 1 ensures that the label's height will equal
-      // its font size.
-      .copyWith(height: themeData.fixTextFieldOutlineLabel ? 1 : null)
+      .copyWith(height: 1)
       .merge(getFallbackTextStyle())
       .merge(style);
   }
@@ -2472,8 +2459,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         suffixIcon: suffixIcon,
         helperError: helperError,
         counter: counter,
-        container: container,
-        fixTextFieldOutlineLabel: themeData.fixTextFieldOutlineLabel,
+        container: container
       ),
       textDirection: textDirection,
       textBaseline: textBaseline,

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5322,4 +5322,32 @@ void main() {
     // Verify that the styles were passed along
     expect(getLabelStyle(tester).color, labelStyle.color);
   });
+
+  testWidgets("InputDecorator's floating label origin no longer depends on ThemeData.fixTextFieldOutlineLabel", (WidgetTester tester) async {
+    Widget buildFrame(bool fixTextFieldOutlineLabel) {
+      return buildInputDecorator(
+        isEmpty: true,
+        theme: ThemeData.light().copyWith(
+          fixTextFieldOutlineLabel: fixTextFieldOutlineLabel,
+        ),
+        decoration: const InputDecoration(
+          labelText: 'label',
+          enabledBorder: OutlineInputBorder(),
+          floatingLabelBehavior: FloatingLabelBehavior.always,
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(false));
+    await tester.pumpAndSettle();
+
+    // floatingLabelHeight = 12 (ahem font size 16dps * 0.75 = 12)
+    // labelY = -floatingLabelHeight/2 + borderWidth/2
+    expect(tester.getTopLeft(find.text('label')).dy, -5.5);
+
+    await tester.pumpWidget(buildFrame(true));
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('label')).dy, -5.5);
+
+  });
 }


### PR DESCRIPTION
The deprecation message for ThemeData.fixTextFieldOutlineLabel says:

> No longer used by the framework, please remove any reference to it.

It's truly no longer used by the framework; removed the last dependency. Of course the API will remain until the deprecation times out.

(This PR is essentially a copy of https://github.com/flutter/flutter/pull/92028)