### PR TITLE
Improve error message for uninitialized channel

### DIFF
--- a/packages/flutter/lib/src/services/platform_channel.dart
+++ b/packages/flutter/lib/src/services/platform_channel.dart
@@ -129,7 +129,17 @@ class MethodChannel {
   /// The messenger used by this channel to send platform messages.
   ///
   /// The messenger may not be null.
-  BinaryMessenger get binaryMessenger => _binaryMessenger ?? ServicesBinding.instance!.defaultBinaryMessenger;
+  BinaryMessenger get binaryMessenger {
+    assert(
+      _binaryMessenger != null || ServicesBinding.instance != null,
+      'Cannot use this MethodChannel before the binary messenger has been initialized. '
+      'This happens when you invoke platform methods before the WidgetsFlutterBinding '
+      'has been initialized. You can fix this by either calling WidgetsFlutterBinding.ensureInitialized() '
+      'before this or by passing a custom BinaryMessenger instance to MethodChannel().',
+    );
+
+    return _binaryMessenger ?? ServicesBinding.instance!.defaultBinaryMessenger;
+  }
   final BinaryMessenger? _binaryMessenger;
 
   /// Backend implementation of [invokeMethod].

--- a/packages/flutter/test/services/use_platform_channel_without_initialization_test.dart
+++ b/packages/flutter/test/services/use_platform_channel_without_initialization_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // We need a separate test file for this test case (instead of including it
+  // in platform_channel_test.dart) since we rely on the WidgetsFlutterBinding
+  // not being initialized and we call ensureInitialized() in the other test
+  // file.
+  test('throws assertion error iff WidgetsFlutterBinding is not yet initialized', () {
+    const MethodChannel methodChannel = MethodChannel('mock');
+
+    // Ensure that accessing the binary messenger before initialization reports
+    // a helpful error message.
+    expect(() => methodChannel.binaryMessenger, throwsA(isA<AssertionError>()
+        .having((AssertionError e) => e.message, 'message', contains('WidgetsFlutterBinding.ensureInitialized()'))));
+
+    TestWidgetsFlutterBinding.ensureInitialized();
+    expect(() => methodChannel.binaryMessenger, returnsNormally);
+  });
+}

--- a/packages/flutter/test/services/use_platform_channel_without_initialization_test.dart
+++ b/packages/flutter/test/services/use_platform_channel_without_initialization_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
When using a `MethodChannel` (without a custom binary messenger) before the default services binding is initialized, a null operator is used on a null value (`ServicesBinding.instance!`). This error message is not helpful for users (see e.g. https://github.com/simolus3/moor/issues/1521 and https://github.com/simolus3/sqlite3.dart/issues/55).

An assertion guards against using a `MethodChannel.setMethodCallHandler` to avoid the failing null check there, but other usages of the `BinaryMessenger` getter are unprotected and can cause the confusing error message.

Unfortunately, I couldn't find a good way to test this easily as the services binding is usually available in tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
