### PR TITLE
Add DisplayFeatureSubScreen widget

### DIFF
--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -173,34 +173,36 @@ class DisplayFeatureSubScreen extends StatelessWidget {
       Rect wantedBounds, Iterable<Rect> avoidBounds) {
     Iterable<Rect> subScreens = <Rect>[wantedBounds];
     for (final Rect bounds in avoidBounds) {
-      subScreens = subScreens.expand((Rect screen) sync* {
+      subScreens = subScreens.expand((Rect screen) {
+        final List<Rect> results = <Rect>[];
         if (screen.top >= bounds.top && screen.bottom <= bounds.bottom) {
           // Display feature splits the screen vertically
           if (screen.left < bounds.left) {
             // There is a smaller sub-screen, left of the display feature
-            yield Rect.fromLTWH(screen.left, screen.top,
-                bounds.left - screen.left, screen.height);
+            results.add(Rect.fromLTWH(screen.left, screen.top,
+                bounds.left - screen.left, screen.height));
           }
           if (screen.right > bounds.right) {
             // There is a smaller sub-screen, right of the display feature
-            yield Rect.fromLTWH(bounds.right, screen.top,
-                screen.right - bounds.right, screen.height);
+            results.add(Rect.fromLTWH(bounds.right, screen.top,
+                screen.right - bounds.right, screen.height));
           }
         } else if (screen.left >= bounds.left && screen.right <= bounds.right) {
           // Display feature splits the sub-screen horizontally
           if (screen.top < bounds.top) {
             // There is a smaller sub-screen, above the display feature
-            yield Rect.fromLTWH(
-                screen.left, screen.top, screen.width, bounds.top - screen.top);
+            results.add(Rect.fromLTWH(
+                screen.left, screen.top, screen.width, bounds.top - screen.top));
           }
           if (screen.bottom > bounds.bottom) {
             // There is a smaller sub-screen, below the display feature
-            yield Rect.fromLTWH(screen.left, bounds.bottom, screen.width,
-                screen.bottom - bounds.bottom);
+            results.add(Rect.fromLTWH(screen.left, bounds.bottom, screen.width,
+                screen.bottom - bounds.bottom));
           }
         } else {
-          yield screen;
+          results.add(screen);
         }
+        return results;
       });
     }
     return subScreens;

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -16,8 +16,8 @@ import 'media_query.dart';
 /// Positions [child] such that it avoids overlapping any [DisplayFeature] that
 /// splits the screen into sub-screens.
 ///
-/// A [DisplayFeature] splits the screen into sub-screens both these conditions
-/// are met:
+/// A [DisplayFeature] splits the screen into sub-screens when both these
+/// conditions are met:
 ///
 ///   * it obstructs the screen, meaning the area it occupies is not 0. Display
 ///     features of type [DisplayFeatureType.fold] can have height 0 or width 0

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show DisplayFeature;
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 import 'media_query.dart';
 
@@ -16,22 +16,24 @@ import 'media_query.dart';
 /// splits the screen into sub-screens.
 ///
 /// A [DisplayFeature] splits the screen into sub-screens if
-///  - it obstructs the screen, meaning the area it occupies is not 0. Display
-///  features of type [DisplayFeatureType.fold] can have height 0 or width 0 and
-///  not be obstructing the screen.
-///  - it is at least as tall as the screen, producing a left and right
-///  sub-screen or
-///  - it is at least as wide as the screen, producing a top and bottom
-///  sub-screen
+///
+///   * it obstructs the screen, meaning the area it occupies is not 0. Display
+///     features of type [DisplayFeatureType.fold] can have height 0 or width 0
+///     and not be obstructing the screen.
+///   * it is at least as tall as the screen, producing a left and right
+///     sub-screen or
+///   * it is at least as wide as the screen, producing a top and bottom
+///     sub-screen
 ///
 /// After determining the sub-screens, the closest one to [anchorPoint] is used
 /// to render the [child].
 ///
 /// If no [anchorPoint] is provided, then [Directionality] is used:
-///  * for [TextDirection.ltr], [anchorPoint] is `Offset.zero`, which will cause
-///  the [child] to appear in the top-left sub-screen.
-///  * for [TextDirection.rtl], [anchorPoint] is `Offset(double.maxFinite, 0)`,
-///  which will cause the [child] to appear in the top-right sub-screen.
+///
+///   * for [TextDirection.ltr], [anchorPoint] is `Offset.zero`, which will
+///     cause the [child] to appear in the top-left sub-screen.
+///   * for [TextDirection.rtl], [anchorPoint] is `Offset(double.maxFinite, 0)`,
+///     which will cause the [child] to appear in the top-right sub-screen.
 ///
 /// If no [anchorPoint] is provided, and there is no [Directionality] ancestor
 /// widget in the tree, then the widget throws during build.
@@ -77,15 +79,17 @@ class DisplayFeatureSubScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    assert(anchorPoint!=null || debugCheckHasDirectionality(
+        context,
+        why: 'to determine which sub-screen DisplayFeatureSubScreen uses',
+        alternative: "Alternatively, consider specifying the 'anchorPoint' argument on the DisplayFeatureSubScreen",
+    ));
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     final Size parentSize = mediaQuery.size;
     final Rect wantedBounds = Offset.zero & parentSize;
-    final Offset _anchorPoint =
-        _finiteOffset(anchorPoint ?? _fallbackAnchorPoint(context));
-    final Iterable<Rect> subScreens =
-        _subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
-    final Rect closestSubScreen =
-        _closestToAnchorPoint(subScreens, _anchorPoint);
+    final Offset _anchorPoint = _finiteOffset(anchorPoint ?? _fallbackAnchorPoint(context));
+    final Iterable<Rect> subScreens = _subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
+    final Rect closestSubScreen = _closestToAnchorPoint(subScreens, _anchorPoint);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -117,8 +121,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
   }
 
   /// Returns the closest sub-screen to the [anchorPoint]
-  static Rect _closestToAnchorPoint(
-      Iterable<Rect> subScreens, Offset anchorPoint) {
+  static Rect _closestToAnchorPoint(Iterable<Rect> subScreens, Offset anchorPoint) {
     return subScreens.fold(subScreens.first,
         (Rect previousValue, Rect element) {
       final double previousDistance =
@@ -175,8 +178,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
 
   /// Returns sub-screens resulted by dividing [wantedBounds] along items of
   /// [avoidBounds] that are at least as high or as wide.
-  static Iterable<Rect> _subScreensInBounds(
-      Rect wantedBounds, Iterable<Rect> avoidBounds) {
+  static Iterable<Rect> _subScreensInBounds(Rect wantedBounds, Iterable<Rect> avoidBounds) {
     Iterable<Rect> subScreens = <Rect>[wantedBounds];
     for (final Rect bounds in avoidBounds) {
       subScreens = subScreens.expand((Rect screen) {

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -6,7 +6,6 @@ import 'dart:ui' show DisplayFeature;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -16,36 +15,77 @@ import 'overlay.dart';
 /// Positions [child] such that it avoids overlapping any [DisplayFeature] that
 /// splits the screen into sub-screens.
 ///
-/// After determining the sub-screens, the closest one to [anchorPoint] is used
-/// render the [child].
+/// A [DisplayFeature] splits the screen into sub-screens if it is at least as
+/// tall, producing a left and right sub-screen, or at least as wide, producing
+/// a top and bottom sub-screen. This applies to sub-screens as well.
 ///
-/// If no [anchorPoint] is provided, then [Directionality] is used. If no
-/// [Directionality] and no [anchorPoint] are provided, then the top-left screen
-/// is used.
+/// After determining the sub-screens, the closest one to [anchorPoint] is used
+/// to render the [child].
+///
+/// If no [anchorPoint] is provided, then [Directionality] is used:
+///  * for [TextDirection.ltr], [anchorPoint] is `Offset.zero`, leading the
+///  sub-screen in the top-left to be used.
+///  * for [TextDirection.rtl], [anchorPoint] is `Offset(double.maxFinite, 0)`,
+///  leading the subscreen in the top-right to be used.
+///
+/// If no [anchorPoint] is provided, and there is no [Directionality] ancestor
+/// widget is in the tree, then the widget throws during build.
+///
+/// In order to determine how the child intersects with
+/// [MediaQueryData.displayFeatures] this widget also needs to know its own
+/// size and position relative to the screen edge. The [padding] can be used to
+/// directly specify this information. If it is not provided, the first
+/// [Overlay] is used to determine this information. If no [Overlay] parent
+/// exists, [DisplayFeatureSubScreen] assumes it is positioned at [Offset.zero]
+/// with the size [MediaQueryData.size].
 ///
 /// See also:
 ///
 ///  * [showDialog], which is a way to display a DialogRoute.
 ///  * [showCupertinoDialog], which displays an iOS-style dialog.
 class DisplayFeatureSubScreen extends StatelessWidget {
-  /// Creates a widget that positions its child so that it avoids display features.
+  /// Creates a widget that positions its child so that it avoids display
+  /// features.
   const DisplayFeatureSubScreen({
     Key? key,
     required this.child,
     this.anchorPoint,
+    this.padding,
   }) : super(key: key);
 
   /// The child that will avoid the display features.
   final Widget child;
 
-  /// The anchor point used to pick the closest area that has no display features.
+  /// The anchor point used to pick the closest area that has no display
+  /// features.
+  ///
+  /// If the anchor point sits inside one of these areas, then that area is
+  /// picked. If not, then the area with the closest edge to the point is used.
+  ///
   /// `Offset(0,0)` is the top-left corner of the available screen space. For
   /// a dual-screen device, this is the top-left corner of the left screen.
   final Offset? anchorPoint;
 
+  /// The distance from the edge of the screen, used to determine how
+  /// [DisplayFeatureSubScreen] intersects [MediaQueryData.displayFeatures].
+  ///
+  /// When [DisplayFeatureSubScreen] is not the root layout and the distance
+  /// from the screen edge increases due to padding added by parent layout, the
+  /// [padding] needs to be updated.
+  ///
+  /// When [padding] is not provided, [DisplayFeatureSubScreen] assumes it is
+  /// a direct child inside [Overlay] and uses the position and size of the
+  /// [Overlay] as the distance to the edge of the screen.
+  ///
+  /// If no [padding] is provided and no [Overlay] parent exists in the tree,
+  /// [DisplayFeatureSubScreen] assumes there is no distance to the edge of the
+  /// screen and that the available space for layout is [MediaQueryData.size].
+  final EdgeInsets? padding;
+
   @override
   Widget build(BuildContext context) {
-    final List<Rect> safeAreas = _safeAreasInNavigator(context);
+    final Rect availableSpace = _availableSpace(context);
+    final Iterable<Rect> safeAreas = _safeAreasInBounds(context, availableSpace);
     final Rect safeArea = anchorPoint == null
         ? _firstSafeArea(safeAreas, context)
         : _closestToAnchorPoint(safeAreas, _finiteOffset(anchorPoint!));
@@ -63,18 +103,20 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     );
   }
 
-  static Rect _firstSafeArea(List<Rect> safeAreas, BuildContext context) {
-    final TextDirection? textDirection = Directionality.maybeOf(context);
-    if (textDirection == TextDirection.rtl)
-      return _closestToAnchorPoint(safeAreas, const Offset(double.maxFinite, 0));
-    else
-      return _closestToAnchorPoint(safeAreas, Offset.zero);
+  static Rect _firstSafeArea(Iterable<Rect> safeAreas, BuildContext context) {
+    final TextDirection textDirection = Directionality.of(context);
+    switch (textDirection) {
+      case TextDirection.rtl:
+        return _closestToAnchorPoint(safeAreas, const Offset(double.maxFinite, 0));
+      case TextDirection.ltr:
+        return _closestToAnchorPoint(safeAreas, Offset.zero);
+    }
   }
 
-  static Rect _closestToAnchorPoint(List<Rect> safeAreas, Offset anchorPoint) {
+  static Rect _closestToAnchorPoint(Iterable<Rect> safeAreas, Offset anchorPoint) {
     return safeAreas.fold(safeAreas.first, (Rect previousValue, Rect element) {
-      final double previousDistance = (previousValue.center - anchorPoint).distanceSquared;
-      final double elementDistance = (element.center - anchorPoint).distanceSquared;
+      final double previousDistance = _distanceFromPointToRect(anchorPoint, previousValue);
+      final double elementDistance = _distanceFromPointToRect(anchorPoint, element);
       if (previousDistance < elementDistance)
         return previousValue;
       else
@@ -82,30 +124,73 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     });
   }
 
-  static List<Rect> _safeAreasInNavigator(BuildContext context) {
-    final RenderObject? renderObject = Overlay.of(context)?.context.findRenderObject();
-    Rect? navigatorBounds;
-    final Vector3? translation = renderObject?.getTransformTo(null).getTranslation();
-    if (translation != null) {
-      navigatorBounds = renderObject?.paintBounds.shift(Offset(translation.x, translation.y));
-    }
-    List<Rect> avoidBounds;
-    if (navigatorBounds == null) {
-      final Size screenSize = MediaQuery.of(context).size;
-      navigatorBounds = Rect.fromLTWH(0, 0, screenSize.width, screenSize.height);
-      avoidBounds = MediaQuery.of(context).displayFeatures
-          .map((DisplayFeature displayFeature) => displayFeature.bounds)
-          .toList();
+  static double _distanceFromPointToRect(Offset point, Rect rect){
+    // Cases for point position relative to rect:
+    // 1  2  3
+    // 4 [R] 5
+    // 6  7  8
+    if (point.dx < rect.left) {
+      if (point.dy < rect.top) {
+        // Case 1
+        return (point - rect.topLeft).distance;
+      } else if (point.dy > rect.bottom){
+        // Case 6
+        return (point - rect.bottomLeft).distance;
+      } else {
+        // Case 4
+        return rect.left - point.dx;
+      }
+    } else if (point.dx > rect.right) {
+      if (point.dy < rect.top) {
+        // Case 3
+        return (point - rect.topRight).distance;
+      } else if (point.dy > rect.bottom){
+        // Case 8
+        return (point - rect.bottomRight).distance;
+      } else {
+        // Case 5
+        return point.dx - rect.right;
+      }
     } else {
-      avoidBounds = MediaQuery.of(context).displayFeatures
-          .where((DisplayFeature displayFeature) => displayFeature.bounds.overlaps(navigatorBounds!))
-          .map((DisplayFeature displayFeature) => displayFeature.bounds.shift(-navigatorBounds!.topLeft))
-          .toList();
+      if (point.dy < rect.top) {
+        // Case 2
+        return rect.top - point.dy;
+      } else if (point.dy > rect.bottom){
+        // Case 7
+        return point.dy - rect.bottom;
+      } else {
+        // Case R
+        return 0;
+      }
     }
-    return _safeAreas(Rect.fromLTWH(0, 0, navigatorBounds.width, navigatorBounds.height), avoidBounds);
   }
 
-  static List<Rect> _safeAreas(Rect screen, List<Rect> avoidBounds) {
+  Rect _availableSpace(BuildContext context){
+    if (padding != null) {
+      return padding!.deflateRect(Offset.zero & MediaQuery.of(context).size);
+    } else {
+      final RenderObject? renderObject = Overlay.of(context)?.context.findRenderObject();
+      if (renderObject != null) {
+        final RenderBox box = renderObject as RenderBox;
+        if (box.hasSize && box.size.isFinite) {
+          return MatrixUtils.transformRect(
+            box.getTransformTo(null),
+            Offset.zero & box.size,
+          );
+        }
+      }
+    }
+    return Offset.zero & MediaQuery.of(context).size;
+  }
+
+  static Iterable<Rect> _safeAreasInBounds(BuildContext context, Rect bounds) {
+    final Iterable<Rect> avoidBounds = MediaQuery.of(context).displayFeatures
+        .where((DisplayFeature displayFeature) => displayFeature.bounds.overlaps(bounds))
+        .map((DisplayFeature displayFeature) => displayFeature.bounds.shift(-bounds.topLeft));
+    return _safeAreas(Rect.fromLTWH(0, 0, bounds.width, bounds.height), avoidBounds);
+  }
+
+  static Iterable<Rect> _safeAreas(Rect screen, Iterable<Rect> avoidBounds) {
     Iterable<Rect> areas = <Rect>[screen];
     for (final Rect bounds in avoidBounds) {
       areas = areas.expand((Rect area) sync* {
@@ -134,7 +219,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
         }
       });
     }
-    return areas.toList();
+    return areas;
   }
 
   static Offset _finiteOffset(Offset offset){
@@ -146,12 +231,9 @@ class DisplayFeatureSubScreen extends StatelessWidget {
   }
 
   static double _finiteNumber(double nr){
-    if (nr.isInfinite && nr.isNegative) {
-      return -double.maxFinite;
-    } else if (nr.isInfinite && !nr.isNegative) {
-      return double.maxFinite;
-    } else {
+    if (!nr.isInfinite) {
       return nr;
     }
+    return nr.isNegative ? -double.maxFinite : double.maxFinite;
   }
 }

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -87,9 +87,9 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     final Size parentSize = mediaQuery.size;
     final Rect wantedBounds = Offset.zero & parentSize;
-    final Offset _anchorPoint = _finiteOffset(anchorPoint ?? _fallbackAnchorPoint(context));
+    final Offset resolvedAnchorPoint = _finiteOffset(anchorPoint ?? _fallbackAnchorPoint(context));
     final Iterable<Rect> subScreens = _subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
-    final Rect closestSubScreen = _closestToAnchorPoint(subScreens, _anchorPoint);
+    final Rect closestSubScreen = _closestToAnchorPoint(subScreens, resolvedAnchorPoint);
 
     return Padding(
       padding: EdgeInsets.only(

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -15,9 +15,14 @@ import 'media_query.dart';
 /// Positions [child] such that it avoids overlapping any [DisplayFeature] that
 /// splits the screen into sub-screens.
 ///
-/// A [DisplayFeature] splits the screen into sub-screens if it is at least as
-/// tall as the screen, producing a left and right sub-screen, or at least as
-/// wide as the screen, producing a top and bottom sub-screen.
+/// A [DisplayFeature] splits the screen into sub-screens if
+///  - it obstructs the screen, meaning the area it occupies is not 0. Display
+///  features of type [DisplayFeatureType.fold] can have height 0 or width 0 and
+///  not be obstructing the screen.
+///  - it is at least as tall as the screen, producing a left and right
+///  sub-screen or
+///  - it is at least as wide as the screen, producing a top and bottom
+///  sub-screen
 ///
 /// After determining the sub-screens, the closest one to [anchorPoint] is used
 /// to render the [child].
@@ -107,7 +112,8 @@ class DisplayFeatureSubScreen extends StatelessWidget {
   }
 
   static Iterable<Rect> _avoidBounds(MediaQueryData mediaQuery) {
-    return mediaQuery.displayFeatures.map((DisplayFeature e) => e.bounds);
+    return mediaQuery.displayFeatures.map((DisplayFeature d) => d.bounds)
+        .where((Rect r) => r.shortestSide > 0);
   }
 
   /// Returns the closest sub-screen to the [anchorPoint]

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -235,7 +235,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
         } else {
           newSubScreens.add(screen);
         }
-      };
+      }
       subScreens = newSubScreens;
     }
     return subScreens;

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -1,0 +1,157 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show DisplayFeature;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'media_query.dart';
+import 'overlay.dart';
+
+/// Positions [child] such that it avoids overlapping any [DisplayFeature] that
+/// splits the screen into sub-screens.
+///
+/// After determining the sub-screens, the closest one to [anchorPoint] is used
+/// render the [child].
+///
+/// If no [anchorPoint] is provided, then [Directionality] is used. If no
+/// [Directionality] and no [anchorPoint] are provided, then the top-left screen
+/// is used.
+///
+/// See also:
+///
+///  * [showDialog], which is a way to display a DialogRoute.
+///  * [showCupertinoDialog], which displays an iOS-style dialog.
+class DisplayFeatureSubScreen extends StatelessWidget {
+  /// Creates a widget that positions its child so that it avoids display features.
+  const DisplayFeatureSubScreen({
+    Key? key,
+    required this.child,
+    this.anchorPoint,
+  }) : super(key: key);
+
+  /// The child that will avoid the display features.
+  final Widget child;
+
+  /// The anchor point used to pick the closest area that has no display features.
+  /// `Offset(0,0)` is the top-left corner of the available screen space. For
+  /// a dual-screen device, this is the top-left corner of the left screen.
+  final Offset? anchorPoint;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Rect> safeAreas = _safeAreasInNavigator(context);
+    final Rect safeArea = anchorPoint == null
+        ? _firstSafeArea(safeAreas, context)
+        : _closestToAnchorPoint(safeAreas, _finiteOffset(anchorPoint!));
+
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Padding(
+        padding: EdgeInsets.only(left: safeArea.left, top: safeArea.top),
+        child: SizedBox(
+          width: safeArea.width,
+          height: safeArea.height,
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  static Rect _firstSafeArea(List<Rect> safeAreas, BuildContext context) {
+    final TextDirection? textDirection = Directionality.maybeOf(context);
+    if (textDirection == TextDirection.rtl)
+      return _closestToAnchorPoint(safeAreas, const Offset(double.maxFinite, 0));
+    else
+      return _closestToAnchorPoint(safeAreas, Offset.zero);
+  }
+
+  static Rect _closestToAnchorPoint(List<Rect> safeAreas, Offset anchorPoint) {
+    return safeAreas.fold(safeAreas.first, (Rect previousValue, Rect element) {
+      final double previousDistance = (previousValue.center - anchorPoint).distanceSquared;
+      final double elementDistance = (element.center - anchorPoint).distanceSquared;
+      if (previousDistance < elementDistance)
+        return previousValue;
+      else
+        return element;
+    });
+  }
+
+  static List<Rect> _safeAreasInNavigator(BuildContext context) {
+    final RenderObject? renderObject = Overlay.of(context)?.context.findRenderObject();
+    Rect? navigatorBounds;
+    final Vector3? translation = renderObject?.getTransformTo(null).getTranslation();
+    if (translation != null) {
+      navigatorBounds = renderObject?.paintBounds.shift(Offset(translation.x, translation.y));
+    }
+    List<Rect> avoidBounds;
+    if (navigatorBounds == null) {
+      final Size screenSize = MediaQuery.of(context).size;
+      navigatorBounds = Rect.fromLTWH(0, 0, screenSize.width, screenSize.height);
+      avoidBounds = MediaQuery.of(context).displayFeatures
+          .map((DisplayFeature displayFeature) => displayFeature.bounds)
+          .toList();
+    } else {
+      avoidBounds = MediaQuery.of(context).displayFeatures
+          .where((DisplayFeature displayFeature) => displayFeature.bounds.overlaps(navigatorBounds!))
+          .map((DisplayFeature displayFeature) => displayFeature.bounds.shift(-navigatorBounds!.topLeft))
+          .toList();
+    }
+    return _safeAreas(Rect.fromLTWH(0, 0, navigatorBounds.width, navigatorBounds.height), avoidBounds);
+  }
+
+  static List<Rect> _safeAreas(Rect screen, List<Rect> avoidBounds) {
+    Iterable<Rect> areas = <Rect>[screen];
+    for (final Rect bounds in avoidBounds) {
+      areas = areas.expand((Rect area) sync* {
+        if (area.top >= bounds.top && area.bottom <= bounds.bottom) {
+          // Display feature splits the area vertically
+          if (area.left < bounds.left) {
+            // There is a smaller area, left of the display feature
+            yield Rect.fromLTWH(area.left, area.top, bounds.left - area.left, area.height);
+          }
+          if (area.right > bounds.right) {
+            // There is a smaller area, right of the display feature
+            yield Rect.fromLTWH(bounds.right, area.top, area.right - bounds.right, area.height);
+          }
+        } else if (area.left >= bounds.left && area.right <= bounds.right) {
+          // Display feature splits the area horizontally
+          if (area.top < bounds.top) {
+            // There is a smaller area, above the display feature
+            yield Rect.fromLTWH(area.left, area.top, area.width, bounds.top - area.top);
+          }
+          if (area.bottom > bounds.bottom) {
+            // There is a smaller area, below the display feature
+            yield Rect.fromLTWH(area.left, bounds.bottom, area.width, area.bottom - bounds.bottom);
+          }
+        } else {
+          yield area;
+        }
+      });
+    }
+    return areas.toList();
+  }
+
+  static Offset _finiteOffset(Offset offset){
+    if (offset.isFinite) {
+      return offset;
+    } else {
+      return Offset(_finiteNumber(offset.dx), _finiteNumber(offset.dy));
+    }
+  }
+
+  static double _finiteNumber(double nr){
+    if (nr.isInfinite && nr.isNegative) {
+      return -double.maxFinite;
+    } else if (nr.isInfinite && !nr.isNegative) {
+      return double.maxFinite;
+    } else {
+      return nr;
+    }
+  }
+}

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'dart:ui' show Brightness;
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
@@ -585,7 +584,8 @@ class MediaQueryData {
   ///  position the child to match the selected sub-screen.
   MediaQueryData removeDisplayFeatures(Rect subScreen) {
     assert(subScreen.left >= 0.0 && subScreen.top >= 0.0 &&
-        subScreen.right <= size.width && subScreen.bottom <= size.height);
+        subScreen.right <= size.width && subScreen.bottom <= size.height,
+        "'subScreen' argument cannot be outside the bounds of the screen");
     if (subScreen.size == size && subScreen.topLeft == Offset.zero)
       return this;
     final double rightInset = size.width - subScreen.right;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -575,13 +575,14 @@ class MediaQueryData {
   /// Returns unmodified [MediaQueryData] if the sub-screen coincides with the
   /// available screen space.
   ///
-  /// Throws if the given sub-screen is outside the available screen space.
+  /// Asserts in debug mode, if the given sub-screen is outside the available
+  /// screen space.
   ///
   /// See also:
   ///
   ///  * [DisplayFeatureSubScreen], which removes the display features that
-  ///  split the screen, from the [MediaQuery] and adds a [Padding] widget to
-  ///  position the child to match the selected sub-screen.
+  ///    split the screen, from the [MediaQuery] and adds a [Padding] widget to
+  ///    position the child to match the selected sub-screen.
   MediaQueryData removeDisplayFeatures(Rect subScreen) {
     assert(subScreen.left >= 0.0 && subScreen.top >= 0.0 &&
         subScreen.right <= size.width && subScreen.bottom <= size.height,
@@ -609,8 +610,9 @@ class MediaQueryData {
         right: math.max(0.0, viewInsets.right - rightInset),
         bottom: math.max(0.0, viewInsets.bottom - bottomInset),
       ),
-      displayFeatures: displayFeatures.where((ui.DisplayFeature displayFeature) =>
-          subScreen.overlaps(displayFeature.bounds)).toList(),
+      displayFeatures: displayFeatures.where(
+        (ui.DisplayFeature displayFeature) => subScreen.overlaps(displayFeature.bounds)
+      ).toList(),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'dart:ui' show Brightness;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 
@@ -564,6 +565,52 @@ class MediaQueryData {
       boldText: boldText,
       gestureSettings: gestureSettings,
       displayFeatures: displayFeatures,
+    );
+  }
+
+  /// Creates a copy of this media query data by removing [displayFeatures] that
+  /// are completely outside the given sub-screen and adjusting the [padding],
+  /// [viewInsets] and [viewPadding] to be zero on the sides that are not
+  /// included in the sub-screen.
+  ///
+  /// Returns unmodified [MediaQueryData] if the sub-screen coincides with the
+  /// available screen space.
+  ///
+  /// Throws if the given sub-screen is outside the available screen space.
+  ///
+  /// See also:
+  ///
+  ///  * [DisplayFeatureSubScreen], which removes the display features that
+  ///  split the screen, from the [MediaQuery] and adds a [Padding] widget to
+  ///  position the child to match the selected sub-screen.
+  MediaQueryData removeDisplayFeatures(Rect subScreen) {
+    assert(subScreen.left >= 0.0 && subScreen.top >= 0.0 &&
+        subScreen.right <= size.width && subScreen.bottom <= size.height);
+    if (subScreen.size == size && subScreen.topLeft == Offset.zero)
+      return this;
+    final double rightInset = size.width - subScreen.right;
+    final double bottomInset = size.height - subScreen.bottom;
+    return copyWith(
+      padding: EdgeInsets.only(
+        left: math.max(0.0, padding.left - subScreen.left),
+        top: math.max(0.0, padding.top - subScreen.top),
+        right: math.max(0.0, padding.right - rightInset),
+        bottom: math.max(0.0, padding.bottom - bottomInset),
+      ),
+      viewPadding: EdgeInsets.only(
+        left: math.max(0.0, viewPadding.left - subScreen.left),
+        top: math.max(0.0, viewPadding.top - subScreen.top),
+        right: math.max(0.0, viewPadding.right - rightInset),
+        bottom: math.max(0.0, viewPadding.bottom - bottomInset),
+      ),
+      viewInsets: EdgeInsets.only(
+        left: math.max(0.0, viewInsets.left - subScreen.left),
+        top: math.max(0.0, viewInsets.top - subScreen.top),
+        right: math.max(0.0, viewInsets.right - rightInset),
+        bottom: math.max(0.0, viewInsets.bottom - bottomInset),
+      ),
+      displayFeatures: displayFeatures.where((ui.DisplayFeature displayFeature) =>
+          subScreen.overlaps(displayFeature.bounds)).toList(),
     );
   }
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -36,6 +36,7 @@ export 'src/widgets/debug.dart';
 export 'src/widgets/default_text_editing_shortcuts.dart';
 export 'src/widgets/desktop_text_selection_toolbar_layout_delegate.dart';
 export 'src/widgets/dismissible.dart';
+export 'src/widgets/display_feature_sub_screen.dart';
 export 'src/widgets/disposable_build_context.dart';
 export 'src/widgets/drag_target.dart';
 export 'src/widgets/draggable_scrollable_sheet.dart';

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -5,214 +5,316 @@
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('DisplayFeatureSubScreen no directionality, no anchor', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(390, 0, 410, 600),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
+  group('DisplayFeatureSubScreen', () {
+    testWidgets('without Directionality or anchor', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(390, 0, 410, 600),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
 
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      // With no Directionality or anchorpoint, the widget throws
+      final String message = tester.takeException().toString();
+      expect(message, contains('Directionality'));
+    });
+
+    testWidgets('with anchorPoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(390, 0, 410, 600),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset(600, 300),
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      // anchorPoint is in the middle of the right screen
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(390.0));
+      expect(renderBox.size.height, equals(600.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
+    });
+
+    testWidgets('with infinity anchorpoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(390, 0, 410, 600),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset.infinite,
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      // anchorPoint is infinite, so the bottom-most & right-most screen is chosen
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(390.0));
+      expect(renderBox.size.height, equals(600.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
+    });
+
+    testWidgets('with horizontal hinge and anchorPoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(0, 290, 800, 310),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset(1000, 1000),
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(800.0));
+      expect(renderBox.size.height, equals(290.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(0,310)));
+    });
+
+    testWidgets('with multiple display features and anchorPoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(0, 290, 800, 310),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(390, 0, 410, 600),
+              type: DisplayFeatureType.hinge,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset(1000, 1000),
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(390.0));
+      expect(renderBox.size.height, equals(290.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,310)));
+    });
+
+    testWidgets('with non-splitting display features and anchorPoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            // Top notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 0, 700, 100),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+            // Bottom notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 500, 700, 600),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const Directionality(
+            textDirection: TextDirection.ltr,
+            child: DisplayFeatureSubScreen(
+              child: SizedBox(
+                key: childKey,
+                width: double.infinity,
+                height: double.infinity,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The display features provided are not wide enough to produce sub-screens
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(800.0));
+      expect(renderBox.size.height, equals(600.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
+    });
+
+    testWidgets('with padding', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            // Top notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 0, 700, 100),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+            // Bottom notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 500, 700, 600),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const Padding(
+            padding: EdgeInsets.all(100),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: DisplayFeatureSubScreen(
+                padding: EdgeInsets.all(100),
+                child: SizedBox(
+                  key: childKey,
+                  width: double.infinity,
+                  height: double.infinity,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The display features provided are not wide enough to produce sub-screens
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(600.0));
+      expect(renderBox.size.height, equals(400.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(100, 100)));
+    });
+
+    testWidgets('with Overlay at [100,100]', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            // Top notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 0, 700, 100),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+            // Bottom notch
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(100, 500, 700, 600),
+              type: DisplayFeatureType.cutout,
+              state: DisplayFeatureState.unknown,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: Padding(
+            padding: const EdgeInsets.all(100),
+            child: MaterialApp(
+              navigatorKey: navigatorKey,
+              home: Container(),
+            ),
+          ),
+        ),
+      );
+
+      navigatorKey.currentState!.push(MaterialPageRoute<void>(builder: (_){
+        return const DisplayFeatureSubScreen(
           child: SizedBox(
             key: childKey,
             width: double.infinity,
             height: double.infinity,
           ),
-        ),
-      ),
-    );
+        );
+      }));
 
-    // With no Directionality or anchorpoint, the default anchorpoint is Offset.zero
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(390.0));
-    expect(renderBox.size.height, equals(600.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
-  });
+      await tester.pumpAndSettle();
 
-  testWidgets('DisplayFeatureSubScreen anchorPoint', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(390, 0, 410, 600),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
-
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
-          anchorPoint: Offset(600, 300),
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        ),
-      ),
-    );
-
-    // anchorPoint is in the middle of the right screen
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(390.0));
-    expect(renderBox.size.height, equals(600.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
-  });
-
-  testWidgets('DisplayFeatureSubScreen anchorpoint infinity', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(390, 0, 410, 600),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
-
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
-          anchorPoint: Offset.infinite,
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        ),
-      ),
-    );
-
-    // anchorPoint is infinite, so the bottom-most & right-most screen is chosen
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(390.0));
-    expect(renderBox.size.height, equals(600.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
-  });
-
-  testWidgets('DisplayFeatureSubScreen anchorPoint horizontal hinge', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(0, 290, 800, 310),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
-
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
-          anchorPoint: Offset(1000, 1000),
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        ),
-      ),
-    );
-
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(290.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(0,310)));
-  });
-
-  testWidgets('DisplayFeatureSubScreen anchorPoint multiple display features', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(0, 290, 800, 310),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(390, 0, 410, 600),
-            type: DisplayFeatureType.hinge,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
-
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
-          anchorPoint: Offset(1000, 1000),
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        ),
-      ),
-    );
-
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(390.0));
-    expect(renderBox.size.height, equals(290.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,310)));
-  });
-
-  testWidgets('DisplayFeatureSubScreen anchorPoint non-splitting display features', (WidgetTester tester) async {
-    const Key childKey = Key('childKey');
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-        displayFeatures: <DisplayFeature>[
-          // Top notch
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(100, 0, 700, 100),
-            type: DisplayFeatureType.cutout,
-            state: DisplayFeatureState.unknown,
-          ),
-          // Bottom notch
-          const DisplayFeature(
-            bounds: Rect.fromLTRB(100, 500, 700, 600),
-            type: DisplayFeatureType.cutout,
-            state: DisplayFeatureState.unknown,
-          ),
-        ]
-    );
-
-    await tester.pumpWidget(
-      MediaQuery(
-        data: mediaQuery,
-        child: const DisplayFeatureSubScreen(
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        ),
-      ),
-    );
-
-    // The display features provided are not wide enough to produce sub-screens
-    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(600.0));
-    expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
+      // The display features provided are not wide enough to produce sub-screens
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(600.0));
+      expect(renderBox.size.height, equals(400.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(100, 100)));
+    });
   });
 }

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -1,0 +1,218 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DisplayFeatureSubScreen no directionality, no anchor', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    // With no Directionality or anchorpoint, the default anchorpoint is Offset.zero
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
+  });
+
+  testWidgets('DisplayFeatureSubScreen anchorPoint', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset(600, 300),
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    // anchorPoint is in the middle of the right screen
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
+  });
+
+  testWidgets('DisplayFeatureSubScreen anchorpoint infinity', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset.infinite,
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    // anchorPoint is infinite, so the bottom-most & right-most screen is chosen
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,0)));
+  });
+
+  testWidgets('DisplayFeatureSubScreen anchorPoint horizontal hinge', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset(1000, 1000),
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(290.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(0,310)));
+  });
+
+  testWidgets('DisplayFeatureSubScreen anchorPoint multiple display features', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.hinge,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          anchorPoint: Offset(1000, 1000),
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(290.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(410,310)));
+  });
+
+  testWidgets('DisplayFeatureSubScreen anchorPoint non-splitting display features', (WidgetTester tester) async {
+    const Key childKey = Key('childKey');
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          // Top notch
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(100, 0, 700, 100),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          ),
+          // Bottom notch
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(100, 500, 700, 600),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          ),
+        ]
+    );
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: mediaQuery,
+        child: const DisplayFeatureSubScreen(
+          child: SizedBox(
+            key: childKey,
+            width: double.infinity,
+            height: double.infinity,
+          ),
+        ),
+      ),
+    );
+
+    // The display features provided are not wide enough to produce sub-screens
+    final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+    expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
+  });
+}

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -218,57 +218,5 @@ void main() {
       expect(renderBox.size.height, equals(600.0));
       expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
     });
-
-    testWidgets('with Overlay at [100,100]', (WidgetTester tester) async {
-      const Key childKey = Key('childKey');
-      final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-          displayFeatures: <DisplayFeature>[
-            // Top notch
-            const DisplayFeature(
-              bounds: Rect.fromLTRB(100, 0, 700, 100),
-              type: DisplayFeatureType.cutout,
-              state: DisplayFeatureState.unknown,
-            ),
-            // Bottom notch
-            const DisplayFeature(
-              bounds: Rect.fromLTRB(100, 500, 700, 600),
-              type: DisplayFeatureType.cutout,
-              state: DisplayFeatureState.unknown,
-            ),
-          ]
-      );
-
-      await tester.pumpWidget(
-        MediaQuery(
-          data: mediaQuery,
-          child: Padding(
-            padding: const EdgeInsets.all(100),
-            child: MaterialApp(
-              navigatorKey: navigatorKey,
-              home: Container(),
-            ),
-          ),
-        ),
-      );
-
-      navigatorKey.currentState!.push(MaterialPageRoute<void>(builder: (_){
-        return const DisplayFeatureSubScreen(
-          child: SizedBox(
-            key: childKey,
-            width: double.infinity,
-            height: double.infinity,
-          ),
-        );
-      }));
-
-      await tester.pumpAndSettle();
-
-      // The display features provided are not wide enough to produce sub-screens
-      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-      expect(renderBox.size.width, equals(600.0));
-      expect(renderBox.size.height, equals(400.0));
-      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(100, 100)));
-    });
   });
 }

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -5,7 +5,6 @@
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -219,52 +219,6 @@ void main() {
       expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
     });
 
-    testWidgets('with padding', (WidgetTester tester) async {
-      const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
-          displayFeatures: <DisplayFeature>[
-            // Top notch
-            const DisplayFeature(
-              bounds: Rect.fromLTRB(100, 0, 700, 100),
-              type: DisplayFeatureType.cutout,
-              state: DisplayFeatureState.unknown,
-            ),
-            // Bottom notch
-            const DisplayFeature(
-              bounds: Rect.fromLTRB(100, 500, 700, 600),
-              type: DisplayFeatureType.cutout,
-              state: DisplayFeatureState.unknown,
-            ),
-          ]
-      );
-
-      await tester.pumpWidget(
-        MediaQuery(
-          data: mediaQuery,
-          child: const Padding(
-            padding: EdgeInsets.all(100),
-            child: Directionality(
-              textDirection: TextDirection.ltr,
-              child: DisplayFeatureSubScreen(
-                padding: EdgeInsets.all(100),
-                child: SizedBox(
-                  key: childKey,
-                  width: double.infinity,
-                  height: double.infinity,
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      // The display features provided are not wide enough to produce sub-screens
-      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
-      expect(renderBox.size.width, equals(600.0));
-      expect(renderBox.size.height, equals(400.0));
-      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(100, 100)));
-    });
-
     testWidgets('with Overlay at [100,100]', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
       final GlobalKey<NavigatorState> navigatorKey = GlobalKey();

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -760,4 +760,158 @@ void main() {
     expect(settingsA, equals(settingsC));
     expect(settingsA, isNot(settingsB));
   });
+
+  testWidgets('MediaQuery.removeDisplayFeatures removes specified display features and padding', (WidgetTester tester) async {
+    const Size size = Size(82.0, 40.0);
+    const double devicePixelRatio = 2.0;
+    const double textScaleFactor = 1.2;
+    const EdgeInsets padding = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 6.0, right: 8.0, left: 10.0, bottom: 12.0);
+    const EdgeInsets viewInsets = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
+    const List<DisplayFeature> displayFeatures = <DisplayFeature>[
+      DisplayFeature(
+        bounds: Rect.fromLTRB(40, 0, 42, 40),
+        type: DisplayFeatureType.hinge,
+        state: DisplayFeatureState.postureFlat,
+      ),
+      DisplayFeature(
+        bounds: Rect.fromLTRB(70, 10, 74, 14),
+        type: DisplayFeatureType.cutout,
+        state: DisplayFeatureState.unknown,
+      ),
+    ];
+
+    // A section of the screen that intersects no display feature or padding area
+    const Rect subScreen = Rect.fromLTRB(20, 10, 40, 20);
+
+    late MediaQueryData subScreenMediaQuery;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: size,
+          devicePixelRatio: devicePixelRatio,
+          textScaleFactor: textScaleFactor,
+          padding: padding,
+          viewPadding: viewPadding,
+          viewInsets: viewInsets,
+          alwaysUse24HourFormat: true,
+          accessibleNavigation: true,
+          invertColors: true,
+          disableAnimations: true,
+          boldText: true,
+          highContrast: true,
+          displayFeatures: displayFeatures,
+        ),
+        child: Builder(
+          builder: (BuildContext context) {
+            return MediaQuery(
+              data: MediaQuery.of(context).removeDisplayFeatures(subScreen),
+              child: Builder(
+                builder: (BuildContext context) {
+                  subScreenMediaQuery = MediaQuery.of(context);
+                  return Container();
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(subScreenMediaQuery.size, size);
+    expect(subScreenMediaQuery.devicePixelRatio, devicePixelRatio);
+    expect(subScreenMediaQuery.textScaleFactor, textScaleFactor);
+    expect(subScreenMediaQuery.padding, EdgeInsets.zero);
+    expect(subScreenMediaQuery.viewPadding, EdgeInsets.zero);
+    expect(subScreenMediaQuery.viewInsets, EdgeInsets.zero);
+    expect(subScreenMediaQuery.alwaysUse24HourFormat, true);
+    expect(subScreenMediaQuery.accessibleNavigation, true);
+    expect(subScreenMediaQuery.invertColors, true);
+    expect(subScreenMediaQuery.disableAnimations, true);
+    expect(subScreenMediaQuery.boldText, true);
+    expect(subScreenMediaQuery.highContrast, true);
+    expect(subScreenMediaQuery.displayFeatures, isEmpty);
+  });
+
+  testWidgets('MediaQuery.removePadding only removes specified display features and padding', (WidgetTester tester) async {
+    const Size size = Size(82.0, 40.0);
+    const double devicePixelRatio = 2.0;
+    const double textScaleFactor = 1.2;
+    const EdgeInsets padding = EdgeInsets.only(top: 1.0, right: 2.0, left: 3.0, bottom: 4.0);
+    const EdgeInsets viewPadding = EdgeInsets.only(top: 6.0, right: 8.0, left: 46.0, bottom: 12.0);
+    const EdgeInsets viewInsets = EdgeInsets.only(top: 5.0, right: 6.0, left: 7.0, bottom: 8.0);
+    const DisplayFeature cutoutDisplayFeature = DisplayFeature(
+      bounds: Rect.fromLTRB(70, 10, 74, 14),
+      type: DisplayFeatureType.cutout,
+      state: DisplayFeatureState.unknown,
+    );
+    const List<DisplayFeature> displayFeatures = <DisplayFeature>[
+      DisplayFeature(
+        bounds: Rect.fromLTRB(40, 0, 42, 40),
+        type: DisplayFeatureType.hinge,
+        state: DisplayFeatureState.postureFlat,
+      ),
+      cutoutDisplayFeature,
+    ];
+
+    // A section of the screen that does contain display features and padding
+    const Rect subScreen = Rect.fromLTRB(42, 0, 82, 40);
+
+    late MediaQueryData subScreenMediaQuery;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: size,
+          devicePixelRatio: devicePixelRatio,
+          textScaleFactor: textScaleFactor,
+          padding: padding,
+          viewPadding: viewPadding,
+          viewInsets: viewInsets,
+          alwaysUse24HourFormat: true,
+          accessibleNavigation: true,
+          invertColors: true,
+          disableAnimations: true,
+          boldText: true,
+          highContrast: true,
+          displayFeatures: displayFeatures,
+        ),
+        child: Builder(
+          builder: (BuildContext context) {
+            return MediaQuery(
+              data: MediaQuery.of(context).removeDisplayFeatures(subScreen),
+              child: Builder(
+                builder: (BuildContext context) {
+                  subScreenMediaQuery = MediaQuery.of(context);
+                  return Container();
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(subScreenMediaQuery.size, size);
+    expect(subScreenMediaQuery.devicePixelRatio, devicePixelRatio);
+    expect(subScreenMediaQuery.textScaleFactor, textScaleFactor);
+    expect(
+      subScreenMediaQuery.padding,
+      const EdgeInsets.only(top: 1.0, right: 2.0, bottom: 4.0),
+    );
+    expect(
+      subScreenMediaQuery.viewPadding,
+      const EdgeInsets.only(top: 6.0, left:4.0, right: 8.0, bottom: 12.0),
+    );
+    expect(
+      subScreenMediaQuery.viewInsets,
+      const EdgeInsets.only(top: 5.0, right: 6.0, bottom: 8.0),
+    );
+    expect(subScreenMediaQuery.alwaysUse24HourFormat, true);
+    expect(subScreenMediaQuery.accessibleNavigation, true);
+    expect(subScreenMediaQuery.invertColors, true);
+    expect(subScreenMediaQuery.disableAnimations, true);
+    expect(subScreenMediaQuery.boldText, true);
+    expect(subScreenMediaQuery.highContrast, true);
+    expect(subScreenMediaQuery.displayFeatures, <DisplayFeature>[cutoutDisplayFeature]);
+  });
 }


### PR DESCRIPTION
This PR adds the `DisplayFeatureSubScreen` widget which positions its `child` such that it avoids overlapping any `DisplayFeature` that splits the screen into sub-screens. In practical terms, it helps with displaying content on only one of the screens on dual-screen foldables.

This widget is needed for making modal routes and dialogs avoid overlapping display features.

Here is an example of the widget placing a dialog on one of the screens, instead of the middle of the screen (where the example device has a display feature):

<img width="1491" alt="hinge-aware-dialog-right" src="https://user-images.githubusercontent.com/1402046/109838243-a7d54f80-7c4e-11eb-9537-949c1c3c080a.png">

This is split from a larger PR for foldable support in order to make it easier to review (https://github.com/flutter/flutter/pull/77156). 

Issues that will be fixed by this PR:
- https://github.com/flutter/flutter/issues/49411

Depends on:
- Foldable MediaQuery support https://github.com/flutter/flutter/pull/92906
- Engine support: https://github.com/flutter/engine/pull/29447
- Framework integration of the engine support: https://github.com/flutter/flutter/pull/89511

PRs that depend on this:
- https://github.com/flutter/flutter/pull/92909

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
