### PR TITLE
Add TwoPane widget

### DIFF
--- a/packages/flutter/lib/src/widgets/two_pane.dart
+++ b/packages/flutter/lib/src/widgets/two_pane.dart
@@ -4,10 +4,8 @@
 
 import 'dart:ui' show DisplayFeature;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
-
 import 'basic.dart';
+import 'debug.dart';
 import 'framework.dart';
 import 'media_query.dart';
 

--- a/packages/flutter/lib/src/widgets/two_pane.dart
+++ b/packages/flutter/lib/src/widgets/two_pane.dart
@@ -8,7 +8,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
 import 'basic.dart';
-import 'container.dart';
 import 'framework.dart';
 import 'media_query.dart';
 
@@ -47,18 +46,29 @@ import 'media_query.dart';
 ///
 /// This widget is similar to [Flex] and also takes [textDirection] and
 /// [verticalDirection] parameters, which are used for deciding in what order
-/// the panes are laid out (e.g [TextDirection.ltr] would position [pane1] on
-/// the left and [pane2] on the right).
+/// the panes are laid out (e.g [TextDirection.ltr] would position [startPane]
+/// on the left and [endPane] on the right).
 ///
 /// The [panePriority] parameter can be used to display only one pane on screens
-/// without any separating [DisplayFeature], by using [TwoPanePriority.pane1]
-/// or [TwoPanePriority.pane2]. When [TwoPanePriority.both] is used or when the
+/// without any separating [DisplayFeature], by using [TwoPanePriority.start]
+/// or [TwoPanePriority.end]. When [TwoPanePriority.both] is used or when the
 /// screen has a separating [DisplayFeature], both panes are visible.
 ///
 /// Similarly to [SafeArea] and [DisplayFeatureSubScreen], this widget assumes
-/// there is no added padding between it and the first [MediaQuery] ancestor.
+/// there is no distance between it and the first [MediaQuery] ancestor. If this
+/// is not true, the bounds of display features will not align with the
+/// separation between the two panes. The [inset] parameter can be used to align
+/// TwoPane with the real position of display features. The [inset] parameter is
+/// the padding between TwoPane and the edges of the screen.
+///
 /// Pane widgets are wrapped in modified [MediaQuery] parents, removing padding,
 /// insets and display features that no longer intersect with them.
+///
+/// If not provided, [textDirection] defaults to the ambient [Directionality].
+/// If none are provided, then the widget asserts during build in debug mode.
+/// The resolved [direction] of TwoPane is [Axis.horizontal] when there are
+/// display features separating the screen into two horizontal sub-screens, in
+/// which case the provided [direction] is ignored.
 ///
 /// See also
 ///
@@ -70,13 +80,14 @@ class TwoPane extends StatelessWidget {
   /// Create a layout that shows two pane widgets side by side.
   const TwoPane({
     Key? key,
-    required this.pane1,
-    required this.pane2,
+    required this.startPane,
+    required this.endPane,
     this.paneProportion = 0.5,
     this.textDirection,
     this.verticalDirection = VerticalDirection.down,
     this.direction = Axis.horizontal,
     this.panePriority = TwoPanePriority.both,
+    this.inset = EdgeInsets.zero,
   }) : super(key: key);
 
   /// The first pane.
@@ -95,9 +106,9 @@ class TwoPane extends StatelessWidget {
   ///   * The first pane is at the bottom when [verticalDirection] is
   ///     [VerticalDirection.up]
   ///
-  /// If [panePriority] is [TwoPanePriority.pane1], this is the only pane
+  /// If [panePriority] is [TwoPanePriority.start], this is the only pane
   /// visible.
-  final Widget pane1;
+  final Widget startPane;
 
   /// The second pane.
   ///
@@ -115,9 +126,9 @@ class TwoPane extends StatelessWidget {
   ///   * The second pane is at the top when [verticalDirection] is
   ///     [VerticalDirection.up]
   ///
-  /// If [panePriority] is [TwoPanePriority.pane2], this is the only pane
+  /// If [panePriority] is [TwoPanePriority.end], this is the only pane
   /// visible.
-  final Widget pane2;
+  final Widget endPane;
 
   /// Proportion of the available space occupied by the first pane. The second
   /// pane takes over the rest of the screen.
@@ -129,6 +140,10 @@ class TwoPane extends StatelessWidget {
   final double paneProportion;
 
   /// Same as [Flex.textDirection].
+  ///
+  /// If the resolved [direction] is [Axis.horizontal], [textDirection] defaults
+  /// to the ambient [Directionality]. If none is provided, then the widget
+  /// asserts during build in debug mode.
   final TextDirection? textDirection;
 
   /// Same as [Flex.verticalDirection].
@@ -155,199 +170,315 @@ class TwoPane extends StatelessWidget {
   /// Defaults to [TwoPanePriority.both].
   final TwoPanePriority panePriority;
 
-  TextDirection? _getTextDirection(BuildContext context) =>
-      textDirection ?? Directionality.maybeOf(context);
+  /// The padding between TwoPane and the edges of the screen.
+  ///
+  /// Used to align TwoPane with the real position of display features. It
+  /// measures the distance between TwoPane and the ambient MediaQuery.
+  ///
+  /// Defaults to [EdgeInsets.zero].
+  final EdgeInsets inset;
+
+  TextDirection _resolveTextDirection(BuildContext context) =>
+      textDirection ?? Directionality.of(context);
 
   @override
   Widget build(BuildContext context) {
-    final MediaQueryData? mediaQuery = MediaQuery.maybeOf(context);
-    final DisplayFeature? displayFeature = _separatingDisplayFeature(mediaQuery);
+    assert(textDirection != null || debugCheckHasDirectionality(
+      context,
+      why: 'to determine what pane goes on the right or left side. The real '
+          'direction of TwoPane is horizontal when there are display features '
+          'separating the screen into two horizontal sub-screens, in which case '
+          'the provided "direction" is ignored.',
+      alternative: "Alternatively, consider specifying the 'textDirection' argument on the TwoPane.",
+    ));
+    final TextDirection resolvedTextDirection = _resolveTextDirection(context);
 
-    late Axis _direction;
-    late int pane1Flex;
-    late int pane2Flex;
-    late Widget _pane1;
-    late Widget _pane2;
-    late Widget _delimiter;
-    final TextDirection? _textDirection = _getTextDirection(context);
+    final MediaQueryData? mediaQuery = MediaQuery.maybeOf(context);
+    late Rect? displayFeatureBounds;
+    late final Size size;
+    late final Axis resolvedDirection;
+    late final int startPaneFlex;
+    late final int endPaneFlex;
+    late final Widget resolvedStartPane;
+    late final Widget resolvedEndPane;
+    late final Widget resolvedDelimiter;
+    late final TwoPanePriority resolvedPanePriority;
     const int fractionBase = 1000000000000;
 
-    if (mediaQuery == null || displayFeature == null) {
-      // The display is continuous, nothing is overridden.
-      _direction = direction;
-      pane1Flex = (fractionBase * paneProportion).toInt();
-      pane2Flex = fractionBase - pane1Flex;
-      _pane1 = pane1;
-      _pane2 = pane2;
-      _delimiter = Container();
+    if (mediaQuery == null){
+      resolvedDirection = direction;
+      resolvedPanePriority = panePriority;
     } else {
-      // The display has a seam that splits it in two panels.
-      final Size size = mediaQuery.size;
-      final Rect seam = displayFeature.bounds;
-
-      if (seam.width < seam.height) {
-        // Seam is tall. Panels are left and right.
-        _direction = Axis.horizontal;
-        _delimiter = Container(width: seam.size.width);
-        assert(_textDirection != null);
-        final int leftPane = (seam.left * fractionBase).toInt();
-        final int rightPane = ((size.width - seam.right) * fractionBase).toInt();
-        if (_textDirection == TextDirection.ltr) {
-          pane1Flex = leftPane;
-          pane2Flex = rightPane;
-        } else {
-          pane1Flex = rightPane;
-          pane2Flex = leftPane;
-        }
+      final Rect position = inset.deflateRect(Offset.zero & mediaQuery.size);
+      size = position.size;
+      final Iterable<DisplayFeature> separatingDisplayFeatures = _separatingDisplayFeatures(mediaQuery.displayFeatures, position);
+      resolvedDirection = _resolveDirection(separatingDisplayFeatures, position);
+      final DisplayFeature? displayFeature = _firstDisplayFeature(separatingDisplayFeatures, resolvedDirection, resolvedTextDirection, verticalDirection);
+      if (displayFeature == null) {
+        displayFeatureBounds = null;
+        resolvedPanePriority = panePriority;
       } else {
-        // Seam is wide. Panels are above and below.
-        _direction = Axis.vertical;
-        _delimiter = Container(height: seam.size.height);
-        final int topPane = (seam.top * fractionBase).toInt();
-        final int bottomPane = ((size.height - seam.bottom) * fractionBase).toInt();
-        if (verticalDirection == VerticalDirection.down) {
-          pane1Flex = topPane;
-          pane2Flex = bottomPane;
-        } else {
-          pane1Flex = bottomPane;
-          pane2Flex = topPane;
-        }
+        displayFeatureBounds = displayFeature.bounds.intersect(position).shift(-position.topLeft);
+        resolvedPanePriority = TwoPanePriority.both;
       }
     }
 
-    if (mediaQuery==null || panePriority != TwoPanePriority.both) {
-      _pane1 = pane1;
-      _pane2 = pane2;
-    } else if (_direction == Axis.vertical) {
-      final bool pane1Top = verticalDirection == VerticalDirection.down;
-      _pane1 = MediaQuery(
-        data: _removeMediaQueryPaddingAndInset(
-          mediaQuery: mediaQuery,
-          removeBottom: pane1Top,
-          removeTop: !pane1Top,
-        ),
-        child: pane1,
-      );
-      _pane2 = MediaQuery(
-        data: _removeMediaQueryPaddingAndInset(
-          mediaQuery: mediaQuery,
-          removeBottom: !pane1Top,
-          removeTop: pane1Top,
-        ),
-        child: pane2,
-      );
+    if (mediaQuery == null || resolvedPanePriority != TwoPanePriority.both) {
+      // Only showing one pane or there is no padding to remove from pane MediaQueries
+      startPaneFlex = (fractionBase * paneProportion).toInt();
+      endPaneFlex = fractionBase - startPaneFlex;
+      resolvedStartPane = startPane;
+      resolvedEndPane = endPane;
+      resolvedDelimiter = const SizedBox();
     } else {
-      assert(_textDirection != null);
-      final bool pane1Left = _textDirection == TextDirection.ltr;
-      _pane1 = MediaQuery(
-        data: _removeMediaQueryPaddingAndInset(
-          mediaQuery: mediaQuery,
-          removeRight: pane1Left,
-          removeLeft: !pane1Left,
-        ),
-        child: pane1,
-      );
-      _pane2 = MediaQuery(
-        data: _removeMediaQueryPaddingAndInset(
-          mediaQuery: mediaQuery,
-          removeRight: !pane1Left,
-          removeLeft: pane1Left,
-        ),
-        child: pane2,
-      );
+      // We are showing both panes
+      switch (resolvedDirection){
+        case Axis.horizontal: {
+          // Panels are left and right.
+          late final Rect seam;
+          if (displayFeatureBounds == null) {
+            // Simulate a display feature using paneProportion
+            // This is then used to remove padding from pane MediaQueries
+            seam = Rect.fromLTWH(paneProportion*size.width, 0, 0, size.height);
+          } else {
+            seam = displayFeatureBounds;
+          }
+          resolvedDelimiter = SizedBox(width: seam.size.width);
+          final int leftFlex = (seam.left * fractionBase).toInt();
+          final int rightFlex = ((size.width - seam.right) * fractionBase).toInt();
+          final Rect leftScreen = Offset.zero & Size(seam.left, size.height);
+          final Rect rightScreen = seam.topRight & Size(size.width - seam.right, size.height);
+          switch (resolvedTextDirection){
+            case TextDirection.ltr: {
+              startPaneFlex = leftFlex;
+              endPaneFlex = rightFlex;
+              resolvedStartPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(leftScreen),
+                child: startPane,
+              );
+              resolvedEndPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(rightScreen),
+                child: endPane,
+              );
+            }
+            break;
+            case TextDirection.rtl: {
+              startPaneFlex = rightFlex;
+              endPaneFlex = leftFlex;
+              resolvedStartPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(rightScreen),
+                child: startPane,
+              );
+              resolvedEndPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(leftScreen),
+                child: endPane,
+              );
+            }
+            break;
+          }
+        }
+        break;
+        case Axis.vertical: {
+          // Panels are top and bottom.
+          late final Rect seam;
+          if (displayFeatureBounds == null) {
+            // Simulate a display feature using paneProportion
+            // This is then used to remove padding from pane MediaQueries
+            seam = Rect.fromLTWH(0, paneProportion*size.height, size.width, 0);
+          } else {
+            seam = displayFeatureBounds;
+          }
+          resolvedDelimiter = SizedBox(height: seam.size.height);
+          final int topPane = (seam.top * fractionBase).toInt();
+          final int bottomPane = ((size.height - seam.bottom) * fractionBase).toInt();
+          final Rect topScreen = Offset.zero & Size(size.width, seam.top);
+          final Rect bottomScreen = seam.bottomLeft & Size(size.width, size.height - seam.bottom);
+          switch (verticalDirection) {
+            case VerticalDirection.down: {
+              startPaneFlex = topPane;
+              endPaneFlex = bottomPane;
+              resolvedStartPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(topScreen),
+                child: startPane,
+              );
+              resolvedEndPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(bottomScreen),
+                child: endPane,
+              );
+            }
+            break;
+            case VerticalDirection.up: {
+              startPaneFlex = bottomPane;
+              endPaneFlex = topPane;
+              resolvedStartPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(bottomScreen),
+                child: startPane,
+              );
+              resolvedEndPane = MediaQuery(
+                data: mediaQuery.removeDisplayFeatures(topScreen),
+                child: endPane,
+              );
+            }
+            break;
+          }
+        }
+        break;
+      }
     }
 
     return Flex(
-      direction: _direction,
+      direction: resolvedDirection,
       crossAxisAlignment: CrossAxisAlignment.stretch,
-      textDirection: _textDirection,
+      textDirection: resolvedTextDirection,
       verticalDirection: verticalDirection,
-      mainAxisAlignment: panePriority != TwoPanePriority.both
+      mainAxisAlignment: resolvedPanePriority != TwoPanePriority.both
           ? MainAxisAlignment.center
           : MainAxisAlignment.start,
       children: <Widget>[
-        if (panePriority != TwoPanePriority.pane2)
-          Expanded(
-            flex: pane1Flex,
-            child: _pane1,
-          ),
-        if (panePriority == TwoPanePriority.both)
-          _delimiter,
-        if (panePriority != TwoPanePriority.pane1)
-          Expanded(
-            flex: pane2Flex,
-            child: _pane2,
-          ),
+        if (resolvedPanePriority != TwoPanePriority.end)
+          KeyedSubtree.wrap( Expanded(
+            flex: startPaneFlex,
+            child: resolvedStartPane,
+          ), 1),
+        if (resolvedPanePriority == TwoPanePriority.both)
+          resolvedDelimiter,
+        if (resolvedPanePriority != TwoPanePriority.start)
+          KeyedSubtree.wrap( Expanded(
+            flex: endPaneFlex,
+            child: resolvedEndPane,
+          ), 2),
       ],
     );
   }
 
-  DisplayFeature? _separatingDisplayFeature(MediaQueryData? mediaQuery) {
-    if (mediaQuery == null) {
-      return null;
-    } else {
-      for (final DisplayFeature displayFeature in mediaQuery.displayFeatures) {
-        final bool largeEnough = displayFeature.bounds.width >=
-            mediaQuery.size.width ||
-            displayFeature.bounds.height >= mediaQuery.size.height;
-        final bool makesTwoVerticalAreas = displayFeature.bounds.top > 0 &&
-            displayFeature.bounds.bottom < mediaQuery.size.height;
-        final bool makesTwoHorizontalAreas = displayFeature.bounds.left > 0 &&
-            displayFeature.bounds.right < mediaQuery.size.width;
-        final bool makesTwoAreas = makesTwoHorizontalAreas ||
-            makesTwoVerticalAreas;
-        if (largeEnough && makesTwoAreas) {
-          return displayFeature;
-        }
+  /// Determines what direction to use while laying out panes.
+  ///
+  /// It first looks for separating display features.
+  ///
+  ///   * If one is found, the direction is determined by how it splits the
+  ///     screen into sub-screens.
+  ///   * If multiple are found in the same direction, the same rule applies.
+  ///   * If multiple are found in both directions, then the provided
+  ///     [direction] is used.
+  Axis _resolveDirection(Iterable<DisplayFeature> displayFeatures, Rect position) {
+    final Iterable<DisplayFeature> separatingFeatures = _separatingDisplayFeatures(displayFeatures, position);
+    bool verticalSubScreensExist = false;
+    bool horizontalSubScreensExist = false;
+    for (final DisplayFeature displayFeature in separatingFeatures){
+      if (_splitsHorizontally(displayFeature.bounds, position)) {
+        horizontalSubScreensExist = true;
       }
-      return null;
+      if (_splitsVertically(displayFeature.bounds, position)) {
+        verticalSubScreensExist = true;
+      }
+    }
+    if (verticalSubScreensExist && !horizontalSubScreensExist) {
+      return Axis.vertical;
+    } else if (horizontalSubScreensExist && !verticalSubScreensExist) {
+      return Axis.horizontal;
+    } else {
+      return direction;
     }
   }
 
-  MediaQueryData _removeMediaQueryPaddingAndInset({
-    required MediaQueryData mediaQuery,
-    bool removeLeft = false,
-    bool removeTop = false,
-    bool removeRight = false,
-    bool removeBottom = false,
-  }){
-    return mediaQuery.copyWith(
-      padding: mediaQuery.padding.copyWith(
-        left: removeLeft ? 0.0 : null,
-        top: removeTop ? 0.0 : null,
-        right: removeRight ? 0.0 : null,
-        bottom: removeBottom ? 0.0 : null,
-      ),
-      viewPadding: mediaQuery.viewPadding.copyWith(
-        left: removeLeft ? 0.0 : null,
-        top: removeTop ? 0.0 : null,
-        right: removeRight ? 0.0 : null,
-        bottom: removeBottom ? 0.0 : null,
-      ),
-      viewInsets: mediaQuery.viewInsets.copyWith(
-        left: removeLeft ? 0.0 : null,
-        top: removeTop ? 0.0 : null,
-        right: removeRight ? 0.0 : null,
-        bottom: removeBottom ? 0.0 : null,
-      ),
-      systemGestureInsets: mediaQuery.systemGestureInsets.copyWith(
-        left: removeLeft ? 0.0 : null,
-        top: removeTop ? 0.0 : null,
-        right: removeRight ? 0.0 : null,
-        bottom: removeBottom ? 0.0 : null,
-      ),
-    );
+  /// Retrieves the first [DisplayFeature] that splits the screen into separate
+  /// sub-screens.
+  ///
+  /// In case there are multiple display features, [textDirection] or
+  /// [verticalDirection] are used to determine the first one, according
+  /// [direction].
+  static DisplayFeature? _firstDisplayFeature(Iterable<DisplayFeature> displayFeatures,
+      Axis direction, TextDirection textDirection, VerticalDirection verticalDirection) {
+    if (displayFeatures.isEmpty) {
+      return null;
+    }
+    DisplayFeature result = displayFeatures.first;
+    for (final DisplayFeature displayFeature in displayFeatures){
+      switch (direction) {
+        case Axis.horizontal: {
+          switch (textDirection) {
+            case TextDirection.ltr: {
+              if (displayFeature.bounds.left < result.bounds.left) {
+                result = displayFeature;
+              }
+            }
+            break;
+            case TextDirection.rtl: {
+              if (displayFeature.bounds.right > result.bounds.right) {
+                result = displayFeature;
+              }
+            }
+            break;
+          }
+        }
+        break;
+        case Axis.vertical: {
+          switch (verticalDirection) {
+            case VerticalDirection.down: {
+              if (displayFeature.bounds.top < result.bounds.top) {
+                result = displayFeature;
+              }
+            }
+            break;
+            case VerticalDirection.up: {
+              if (displayFeature.bounds.bottom > result.bounds.bottom) {
+                result = displayFeature;
+              }
+            }
+            break;
+          }
+        }
+        break;
+      }
+    }
+    return result;
+  }
+
+  /// Returns only the display features that separate the screen into
+  /// sub-screens.
+  ///
+  /// A [DisplayFeature] separates the screen into sub-screens when both these
+  /// conditions are met:
+  ///
+  ///   * it obstructs the screen, meaning the area it occupies is not 0. Display
+  ///     features of type [DisplayFeatureType.fold] can have height 0 or width 0
+  ///     and not be obstructing the screen.
+  ///   * it is at least as tall as the screen, producing a left and right
+  ///     sub-screen or it is at least as wide as the screen, producing a top and
+  ///     bottom sub-screen.
+  static Iterable<DisplayFeature> _separatingDisplayFeatures(Iterable<DisplayFeature> displayFeatures, Rect position) {
+    final List<DisplayFeature> result = <DisplayFeature>[];
+    for (final DisplayFeature displayFeature in displayFeatures) {
+      final Rect bounds = displayFeature.bounds;
+      if (_splitsHorizontally(bounds, position) || _splitsVertically(bounds, position)) {
+        result.add(displayFeature);
+      }
+    }
+    return result;
+  }
+
+  static bool _splitsHorizontally(Rect bounds, Rect position){
+    final bool tallEnough = bounds.top <= position.top && bounds.bottom >= position.bottom;
+    final bool splitsHorizontally = bounds.left > position.left && bounds.right < position.right;
+    return tallEnough && splitsHorizontally;
+  }
+
+  static bool _splitsVertically(Rect bounds, Rect position){
+    final bool wideEnough = bounds.left <= position.left && bounds.right >= position.right;
+    final bool splitsVertically = bounds.top > position.top && bounds.bottom < position.bottom;
+    return wideEnough && splitsVertically;
   }
 }
 
-/// Describes which pane to show or if both should be shown.
+/// Describes if showing both panes at the same time or which one if only one is
+/// shown.
 enum TwoPanePriority {
   /// Show both panes
   both,
 
   /// Show only the first pane
-  pane1,
+  start,
 
   /// Show only the second pane
-  pane2,
+  end,
 }

--- a/packages/flutter/lib/src/widgets/two_pane.dart
+++ b/packages/flutter/lib/src/widgets/two_pane.dart
@@ -1,0 +1,314 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show DisplayFeature;
+
+import 'package:flutter/foundation.dart';
+
+import 'basic.dart';
+import 'container.dart';
+import 'framework.dart';
+import 'media_query.dart';
+
+/// A widget that displays 2 children side-by-side or one below the other, while
+/// also avoiding any hinge or fold that the screen might contain.
+///
+///  * By "hinge" we mean any [DisplayFeature] reported by [MediaQueryData.displayFeatures]
+///  that completely splits the screen area in 2 parts. For phones with a
+///  continuous screen that folds, the "fold" area is 0-width and does not visualy
+///  create 2 separate screens.
+///  * On screens with a hinge, the 2 panes are positioned on each side of the
+///  hinge. In this case, both [paneProportion] and [direction] are ignored.
+///  * On screens without a hinge, [paneProportion] is used for deciding how
+///  much space each pane uses and [direction] is used for deciding if the 2
+///  panes are laid out horizontally or vertically.
+///
+/// This widget is similar to [Flex], in that it also takes [textDirection] and
+/// [verticalDirection] parameters, which are used for deciding in what order the
+/// panes are laid out (e.g left to right would position pane 1 on the left and
+/// pane 2 on the right).
+///
+/// For narrow screens where you want to display only one pane, you can use [panePriority]
+/// to pick either [TwoPanePriority.pane1] or [TwoPanePriority.pane2].
+///
+/// In addition, this widget also wraps children in [MediaQuery] parents that
+/// makes sense for their side of the screen. For example, let's consider a flip
+/// phone with a notch at the top of the screen. The hinge is horizontal, so the
+/// 2 halves of the screen are one at the top and one at the bottom. In this case
+/// the top pane will have top padding in order to avoid the notch, but the bottom
+/// pane does not have top padding, since it does not have the notch.
+///
+/// See also
+///
+///  * [DisplayFeature] and [MediaQueryData.displayFeatures], to further
+///  understand display features, such as hinge areas
+class TwoPane extends StatelessWidget {
+  /// Create a layout that shows both child widgets or just one of them according
+  /// to available space and device form factor.
+  const TwoPane({
+    Key? key,
+    required this.pane1,
+    required this.pane2,
+    this.paneProportion = 0.5,
+    this.textDirection,
+    this.verticalDirection = VerticalDirection.down,
+    this.direction = Axis.horizontal,
+    this.panePriority = TwoPanePriority.both,
+    this.padding = EdgeInsets.zero,
+  }) : super(key: key);
+
+  /// First pane, which can sit on the left for left to right layouts,
+  /// or at the top for top to bottom layouts.
+  /// If [panePriority] is [TwoPanePriority.pane1], this is the only pane visible.
+  final Widget pane1;
+
+  /// Second pane, which can sit on the right for left to right layouts,
+  /// or at the bottom for top to bottom layouts.
+  /// If [panePriority] is [TwoPanePriority.pane2], this is the only pane visible.
+  final Widget pane2;
+
+  /// Proportion of the screen ocupied by the first pane. The second pane takes
+  /// over the rest of the screen. A value of 0.5 will make the 2 panes equal.
+  /// This property is ignored for displays with a hinge, in which case each
+  /// pane takes over one screen.
+  final double paneProportion;
+
+  /// Same as [Flex.textDirection]
+  final TextDirection? textDirection;
+
+  /// Same as [Flex.verticalDirection]
+  ///
+  /// Defaults to [VerticalDirection.down]
+  final VerticalDirection verticalDirection;
+
+  /// Same as [Flex.direction]
+  ///
+  /// This property is ignored for displays with a hinge, in which case the
+  /// direction is [Axis.horizontal] for vertical hinges and [Axis.vertical] for
+  /// horizontal hinges.
+  ///
+  /// Defaults to [Axis.horizontal]
+  final Axis direction;
+
+  /// Whether to show only one pane and which one, or both. This is useful for
+  /// defining behaviour on narrow devices, where the 2 panes cannot be shown at
+  /// the same time.
+  ///
+  /// Defaults to [TwoPanePriority.both]
+  final TwoPanePriority panePriority;
+
+  /// The distance from the edge of the screen, used to determine how [TwoPane]
+  /// intersects [MediaQueryData.displayFeatures].
+  ///
+  /// When [TwoPane] is not the root layout and the distance from the screen
+  /// edge increases, the [padding] needs to take into account the extra space.
+  ///
+  /// For example, when TwoPane is the body of a Scaffold, the appbar adds extra
+  /// spacing between TwoPane and the edge of the screen. If TwoPane is used
+  /// with a [Axis.vertical] [direction], the separation between the two panes
+  /// will not align with [DisplayFeature]s unless the [padding] also includes
+  /// the height of the appbar.
+  ///
+  /// Defaults to [MediaQueryData.padding].
+  final EdgeInsets padding;
+
+  TextDirection? _getTextDirection(BuildContext context) =>
+      textDirection ?? Directionality.maybeOf(context);
+
+  @override
+  Widget build(BuildContext context) {
+    final MediaQueryData? mediaQuery = MediaQuery.maybeOf(context);
+    final DisplayFeature? displayFeature = _separatingDisplayFeature(mediaQuery);
+
+    late Axis _direction;
+    late int pane1Flex;
+    late int pane2Flex;
+    late Widget _pane1;
+    late Widget _pane2;
+    late Widget _delimiter;
+    final TextDirection? _textDirection = _getTextDirection(context);
+    const int fractionBase = 1000000000000;
+
+    if (mediaQuery == null || displayFeature == null) {
+      // The display is continuous, nothing is overridden.
+      _direction = direction;
+      pane1Flex = (fractionBase * paneProportion).toInt();
+      pane2Flex = fractionBase - pane1Flex;
+      _pane1 = pane1;
+      _pane2 = pane2;
+      _delimiter = Container();
+    } else {
+      // The display has a seam that splits it in two panels.
+      // final EdgeInsets padding = this.padding;
+      final Size size = Size(
+          mediaQuery.size.width - padding.horizontal,
+          mediaQuery.size.height - padding.vertical);
+      final Rect seam = displayFeature.bounds.translate(-padding.left, -padding.top);
+
+      if (seam.width < seam.height) {
+        // Seam is tall. Panels are left and right.
+        _direction = Axis.horizontal;
+        _delimiter = Container(width: seam.size.width);
+        assert(_textDirection != null);
+        final int leftPane = (seam.left * fractionBase).toInt();
+        final int rightPane = ((size.width - seam.right) * fractionBase).toInt();
+        if (_textDirection == TextDirection.ltr) {
+          pane1Flex = leftPane;
+          pane2Flex = rightPane;
+        } else {
+          pane1Flex = rightPane;
+          pane2Flex = leftPane;
+        }
+      } else {
+        // Seam is wide. Panels are above and below.
+        _direction = Axis.vertical;
+        _delimiter = Container(height: seam.size.height);
+        final int topPane = (seam.top * fractionBase).toInt();
+        final int bottomPane = ((size.height - seam.bottom) * fractionBase).toInt();
+        if (verticalDirection == VerticalDirection.down) {
+          pane1Flex = topPane;
+          pane2Flex = bottomPane;
+        } else {
+          pane1Flex = bottomPane;
+          pane2Flex = topPane;
+        }
+      }
+    }
+
+    if (mediaQuery==null || panePriority != TwoPanePriority.both) {
+      _pane1 = pane1;
+      _pane2 = pane2;
+    } else if (_direction == Axis.vertical) {
+      final bool pane1Top = verticalDirection == VerticalDirection.down;
+      _pane1 = MediaQuery(
+        data: _removeMediaQueryPaddingAndInset(
+          mediaQuery: mediaQuery,
+          removeBottom: pane1Top,
+          removeTop: !pane1Top,
+        ),
+        child: pane1,
+      );
+      _pane2 = MediaQuery(
+        data: _removeMediaQueryPaddingAndInset(
+          mediaQuery: mediaQuery,
+          removeBottom: !pane1Top,
+          removeTop: pane1Top,
+        ),
+        child: pane2,
+      );
+    } else {
+      assert(_textDirection != null);
+      final bool pane1Left = _textDirection == TextDirection.ltr;
+      _pane1 = MediaQuery(
+        data: _removeMediaQueryPaddingAndInset(
+          mediaQuery: mediaQuery,
+          removeRight: pane1Left,
+          removeLeft: !pane1Left,
+        ),
+        child: pane1,
+      );
+      _pane2 = MediaQuery(
+        data: _removeMediaQueryPaddingAndInset(
+          mediaQuery: mediaQuery,
+          removeRight: !pane1Left,
+          removeLeft: pane1Left,
+        ),
+        child: pane2,
+      );
+    }
+
+    return Flex(
+      direction: _direction,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      textDirection: _textDirection,
+      verticalDirection: verticalDirection,
+      mainAxisAlignment: panePriority != TwoPanePriority.both
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      children: <Widget>[
+        if (panePriority != TwoPanePriority.pane2)
+          Expanded(
+            flex: pane1Flex,
+            child: _pane1,
+          ),
+        if (panePriority == TwoPanePriority.both)
+          _delimiter,
+        if (panePriority != TwoPanePriority.pane1)
+          Expanded(
+            flex: pane2Flex,
+            child: _pane2,
+          ),
+      ],
+    );
+  }
+
+  DisplayFeature? _separatingDisplayFeature(MediaQueryData? mediaQuery) {
+    if (mediaQuery == null) {
+      return null;
+    } else {
+      for (final DisplayFeature displayFeature in mediaQuery.displayFeatures) {
+        final bool largeEnough = displayFeature.bounds.width >=
+            mediaQuery.size.width ||
+            displayFeature.bounds.height >= mediaQuery.size.height;
+        final bool makesTwoVerticalAreas = displayFeature.bounds.top > 0 &&
+            displayFeature.bounds.bottom < mediaQuery.size.height;
+        final bool makesTwoHorizontalAreas = displayFeature.bounds.left > 0 &&
+            displayFeature.bounds.right < mediaQuery.size.width;
+        final bool makesTwoAreas = makesTwoHorizontalAreas ||
+            makesTwoVerticalAreas;
+        if (largeEnough && makesTwoAreas) {
+          return displayFeature;
+        }
+      }
+      return null;
+    }
+  }
+
+  MediaQueryData _removeMediaQueryPaddingAndInset({
+    required MediaQueryData mediaQuery,
+    bool removeLeft = false,
+    bool removeTop = false,
+    bool removeRight = false,
+    bool removeBottom = false,
+  }){
+    return mediaQuery.copyWith(
+      padding: mediaQuery.padding.copyWith(
+        left: removeLeft ? 0.0 : null,
+        top: removeTop ? 0.0 : null,
+        right: removeRight ? 0.0 : null,
+        bottom: removeBottom ? 0.0 : null,
+      ),
+      viewPadding: mediaQuery.viewPadding.copyWith(
+        left: removeLeft ? 0.0 : null,
+        top: removeTop ? 0.0 : null,
+        right: removeRight ? 0.0 : null,
+        bottom: removeBottom ? 0.0 : null,
+      ),
+      viewInsets: mediaQuery.viewInsets.copyWith(
+        left: removeLeft ? 0.0 : null,
+        top: removeTop ? 0.0 : null,
+        right: removeRight ? 0.0 : null,
+        bottom: removeBottom ? 0.0 : null,
+      ),
+      systemGestureInsets: mediaQuery.systemGestureInsets.copyWith(
+        left: removeLeft ? 0.0 : null,
+        top: removeTop ? 0.0 : null,
+        right: removeRight ? 0.0 : null,
+        bottom: removeBottom ? 0.0 : null,
+      ),
+    );
+  }
+}
+
+/// Describes which pane to show or if both should be shown.
+enum TwoPanePriority {
+  /// Show both panes
+  both,
+
+  /// Show only the first pane
+  pane1,
+
+  /// Show only the second pane
+  pane2,
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -130,6 +130,7 @@ export 'src/widgets/ticker_provider.dart';
 export 'src/widgets/title.dart';
 export 'src/widgets/transitions.dart';
 export 'src/widgets/tween_animation_builder.dart';
+export 'src/widgets/two_pane.dart';
 export 'src/widgets/unique_widget.dart';
 export 'src/widgets/value_listenable_builder.dart';
 export 'src/widgets/viewport.dart';

--- a/packages/flutter/test/widgets/two_pane_test.dart
+++ b/packages/flutter/test/widgets/two_pane_test.dart
@@ -1,0 +1,1261 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class OrderPainter extends CustomPainter {
+  const OrderPainter(this.index);
+
+  final int index;
+
+  static List<int> log = <int>[];
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    log.add(index);
+  }
+
+  @override
+  bool shouldRepaint(OrderPainter old) => false;
+}
+
+Widget log(int index) => CustomPaint(painter: OrderPainter(index));
+
+void main() {
+  // NO DIRECTION
+
+  testWidgets('TwoPane - no textDirection', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    dynamic exception;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      exception ??= details.exception;
+    };
+
+    // Default is direction is Axis.horizontal so this should fail, asking for a direction.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    FlutterError.onError = oldHandler;
+    expect(exception, isAssertionError);
+    expect(exception.toString(), contains('textDirection'));
+    expect(OrderPainter.log, <int>[]);
+  });
+
+  testWidgets('TwoPane pane priority pane1 - no textDirection', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      panePriority: TwoPanePriority.pane1,
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1]);
+  });
+
+  testWidgets('TwoPane pane priority pane2 - no textDirection', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      panePriority: TwoPanePriority.pane2,
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[2]);
+  });
+
+  testWidgets('TwoPane separating display feature overrides params', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out left and right of the display feature, at size
+    // 390x600, located at 0,0 and 410,0.
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        textDirection: TextDirection.ltr,
+        direction: Axis.vertical,
+        verticalDirection: VerticalDirection.up,
+        paneProportion: 0.1,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(410.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane non-separating display feature is ignored', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 600 pixel-wide notch at the top of the screen, does not affect TwoPane
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(100, 0, 700, 100),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is NOT overridden by the display feature
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        direction: Axis.vertical,
+        paneProportion: 0.1,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(60.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(540.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(60.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  // Horizontal - LTR
+
+  testWidgets('TwoPane - LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5 and default direction is Axis.horizontal,
+    // so each pane should be 400x600.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      textDirection: TextDirection.ltr,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(400.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane - Directionality LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5 and default direction is Axis.horizontal,
+    // so each pane should be 400x600.
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: TwoPane(
+        key: twoPaneKey,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(400.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane with paneProportion - LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default direction is Axis.horizontal, and with paneProportion 0.25 panes
+    // should be 200x600 and 600x600.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      textDirection: TextDirection.ltr,
+      paneProportion: 0.25,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(200.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(600.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(200.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane removes MediaQuery paddings and insets - LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      padding: const EdgeInsets.all(10),
+      viewPadding: const EdgeInsets.all(10),
+      viewInsets: const EdgeInsets.all(10),
+      systemGestureInsets: const EdgeInsets.all(10),
+    );
+
+    late MediaQueryData unpaddedPane1;
+    late MediaQueryData unpaddedPane2;
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        textDirection: TextDirection.ltr,
+        pane1: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane1 = MediaQuery.of(context);
+            return log(1);
+          },
+        ),
+        pane2: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane2 = MediaQuery.of(context);
+            return log(2);
+          },
+        ),
+      ),
+    ));
+
+    expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature - LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out left and right of the display feature, at size
+    // 390x600, located at 0,0 and 410,0.
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        textDirection: TextDirection.ltr,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(410.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature with padding - LTR', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      displayFeatures: <DisplayFeature>[
+        const DisplayFeature(
+          bounds: Rect.fromLTRB(390, 0, 410, 600),
+          type: DisplayFeatureType.cutout,
+          state: DisplayFeatureState.unknown,
+        )
+      ],
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out left and right of the display feature
+    // Panes "lose" the space occupied by the padding. Top padding
+    // affects both panes and left padding affects the left pane.
+    // Pane1: 290x500, Pane2: 390x500
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 100, left: 100),
+        child: TwoPane(
+          key: twoPaneKey,
+          textDirection: TextDirection.ltr,
+          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          padding: const EdgeInsets.only(top: 100, left: 100),
+        ),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(500.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(290.0));
+    expect(renderBox.size.height, equals(500.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(500.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(310.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  // Horizontal - RTL
+
+  testWidgets('TwoPane - RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5 and default direction is Axis.horizontal,
+    // so each pane should be 400x600.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      textDirection: TextDirection.rtl,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(400.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane - Directionality RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5 and default direction is Axis.horizontal,
+    // so each pane should be 400x600.
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.rtl,
+      child: TwoPane(
+        key: twoPaneKey,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(400.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(400.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane with paneProportion - RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default direction is Axis.horizontal, and with paneProportion 0.25 panes
+    // should be 200x600 and 600x600.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      textDirection: TextDirection.rtl,
+      paneProportion: 0.25,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(200.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(600.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane removes MediaQuery paddings and insets - RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      padding: const EdgeInsets.all(10),
+      viewPadding: const EdgeInsets.all(10),
+      viewInsets: const EdgeInsets.all(10),
+      systemGestureInsets: const EdgeInsets.all(10),
+    );
+
+    late MediaQueryData unpaddedPane1;
+    late MediaQueryData unpaddedPane2;
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        textDirection: TextDirection.rtl,
+        pane1: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane1 = MediaQuery.of(context);
+            return log(1);
+          },
+        ),
+        pane2: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane2 = MediaQuery.of(context);
+            return log(2);
+          },
+        ),
+      ),
+    ));
+
+    expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
+    expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature - RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(390, 0, 410, 600),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out left and right of the display feature, at size
+    // 390x600, located at 0,0 and 410,0.
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        textDirection: TextDirection.rtl,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(410.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(600.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature with padding - RTL', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      displayFeatures: <DisplayFeature>[
+        const DisplayFeature(
+          bounds: Rect.fromLTRB(390, 0, 410, 600),
+          type: DisplayFeatureType.cutout,
+          state: DisplayFeatureState.unknown,
+        )
+      ],
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out left and right of the display feature
+    // Panes "lose" the space occupied by the padding. Top padding
+    // affects both panes and left padding affects the left pane.
+    // Pane1: 390x500 , Pane2: 290x500
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 100, left: 100),
+        child: TwoPane(
+          key: twoPaneKey,
+          textDirection: TextDirection.rtl,
+          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          padding: const EdgeInsets.only(top: 100, left: 100),
+        ),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(500.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(390.0));
+    expect(renderBox.size.height, equals(500.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(310.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(290.0));
+    expect(renderBox.size.height, equals(500.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  // Vertical - down
+
+  testWidgets('TwoPane - down', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5 and default direction is down,
+    // so each pane should be 800x300.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      direction: Axis.vertical,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(300.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(300.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(300.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane with paneProportion - down', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default direction is down. Panes should be should be 800x150 and 800x450.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      direction: Axis.vertical,
+      paneProportion: 0.25,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(150.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(450.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(150.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane removes MediaQuery paddings and insets - down', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      padding: const EdgeInsets.all(10),
+      viewPadding: const EdgeInsets.all(10),
+      viewInsets: const EdgeInsets.all(10),
+      systemGestureInsets: const EdgeInsets.all(10),
+    );
+
+    late MediaQueryData unpaddedPane1;
+    late MediaQueryData unpaddedPane2;
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        direction: Axis.vertical,
+        pane1: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane1 = MediaQuery.of(context);
+            return log(1);
+          },
+        ),
+        pane2: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane2 = MediaQuery.of(context);
+            return log(2);
+          },
+        ),
+      ),
+    ));
+
+    expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature - down', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide horizontal display feature splitting the display up-down
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Vertical direction default is down
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out above and below the display feature, at size
+    // 800x290, located at top 0,0 and 310,0.
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(310.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature with padding - down', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide horizontal display feature splitting the display up-down
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Default vertical direction is down
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out above and below the display feature
+    // Panes "lose" the space occupied by the padding. Left padding
+    // affects both panes and top padding affects the top pane.
+    // Pane1: 700x190 , Pane2: 700x290
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 100, left: 100),
+        child: TwoPane(
+          key: twoPaneKey,
+          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          padding: const EdgeInsets.only(top: 100, left: 100),
+        ),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(500.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(190.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(210.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  // Vertical - up
+
+  testWidgets('TwoPane - up', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Default paneProportion is 0.5,
+    // so each pane should be 800x300.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      direction: Axis.vertical,
+      verticalDirection: VerticalDirection.up,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(300.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(300.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(300.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane with paneProportion - up', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+
+    // TwoPane always occupies available space: 800x600.
+    // Panes should be should be 800x150 and 800x450.
+    await tester.pumpWidget(TwoPane(
+      key: twoPaneKey,
+      direction: Axis.vertical,
+      verticalDirection: VerticalDirection.up,
+      paneProportion: 0.25,
+      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(150.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(450.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(450.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane removes MediaQuery paddings and insets - up', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    // A 20 pixel-wide vertical display feature splitting the display left-right
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+      padding: const EdgeInsets.all(10),
+      viewPadding: const EdgeInsets.all(10),
+      viewInsets: const EdgeInsets.all(10),
+      systemGestureInsets: const EdgeInsets.all(10),
+    );
+
+    late MediaQueryData unpaddedPane1;
+    late MediaQueryData unpaddedPane2;
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        direction: Axis.vertical,
+        verticalDirection: VerticalDirection.up,
+        pane1: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane1 = MediaQuery.of(context);
+            return log(1);
+          },
+        ),
+        pane2: Builder(
+          builder: (BuildContext context) {
+            unpaddedPane2 = MediaQuery.of(context);
+            return log(2);
+          },
+        ),
+      ),
+    ));
+
+    expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
+    expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature - up', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide horizontal display feature splitting the display up-down
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out above and below the display feature, at size
+    // 800x290, located at top 0,0 and 310,0.
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: TwoPane(
+        key: twoPaneKey,
+        verticalDirection: VerticalDirection.up,
+        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(600.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(310.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(800.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+
+  testWidgets('TwoPane separating display feature with padding - up', (WidgetTester tester) async {
+    OrderPainter.log.clear();
+    const Key twoPaneKey = Key('twoPane');
+    const Key pane1Key = Key('pane1');
+    const Key pane2Key = Key('pane2');
+    // A 20 pixel-wide horizontal display feature splitting the display up-down
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+        displayFeatures: <DisplayFeature>[
+          const DisplayFeature(
+            bounds: Rect.fromLTRB(0, 290, 800, 310),
+            type: DisplayFeatureType.cutout,
+            state: DisplayFeatureState.unknown,
+          )
+        ]
+    );
+
+    // Default pane priority is "both"
+    // Default vertical direction is down
+    // Pane proportion and direction is overridden by the display feature
+    // Panes will be laid out above and below the display feature
+    // Panes "lose" the space occupied by the padding. Left padding
+    // affects both panes and top padding affects the top pane.
+    // Pane2: 700x290, Pane2: 700x190
+    await tester.pumpWidget(MediaQuery(
+      data: mediaQuery,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 100, left: 100),
+        child: TwoPane(
+          key: twoPaneKey,
+          verticalDirection: VerticalDirection.up,
+          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          padding: const EdgeInsets.only(top: 100, left: 100),
+        ),
+      ),
+    ));
+
+    RenderBox renderBox;
+    BoxParentData boxParentData;
+
+    renderBox = tester.renderObject(find.byKey(twoPaneKey));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(500.0));
+
+    renderBox = tester.renderObject(find.byKey(pane1Key));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(290.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(210.0));
+
+    renderBox = tester.renderObject(find.byKey(pane2Key));
+    expect(renderBox.size.width, equals(700.0));
+    expect(renderBox.size.height, equals(190.0));
+    boxParentData = renderBox.parentData! as BoxParentData;
+    expect(boxParentData.offset.dx, equals(0.0));
+    expect(boxParentData.offset.dy, equals(0.0));
+
+    expect(OrderPainter.log, <int>[1, 2]);
+  });
+}

--- a/packages/flutter/test/widgets/two_pane_test.dart
+++ b/packages/flutter/test/widgets/two_pane_test.dart
@@ -30,89 +30,18 @@ Widget log(int index) => CustomPaint(painter: OrderPainter(index));
 void main() {
   // NO DIRECTION
 
-  testWidgets('TwoPane - no textDirection', (WidgetTester tester) async {
-    OrderPainter.log.clear();
-    const Key twoPaneKey = Key('twoPane');
-    const Key pane1Key = Key('pane1');
-    const Key pane2Key = Key('pane2');
+  testWidgets('without Directionality or textDirection', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const TwoPane(
+        startPane: SizedBox(),
+        endPane: SizedBox(),
+      ),
+    );
 
-    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
-    dynamic exception;
-    FlutterError.onError = (FlutterErrorDetails details) {
-      exception ??= details.exception;
-    };
-
-    // Default is direction is Axis.horizontal so this should fail, asking for a direction.
-    await tester.pumpWidget(TwoPane(
-      key: twoPaneKey,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-    ));
-
-    FlutterError.onError = oldHandler;
-    expect(exception, isAssertionError);
-    expect(exception.toString(), contains('textDirection'));
-    expect(OrderPainter.log, <int>[]);
-  });
-
-  testWidgets('TwoPane pane priority pane1 - no textDirection', (WidgetTester tester) async {
-    OrderPainter.log.clear();
-    const Key twoPaneKey = Key('twoPane');
-    const Key pane1Key = Key('pane1');
-    const Key pane2Key = Key('pane2');
-
-    await tester.pumpWidget(TwoPane(
-      key: twoPaneKey,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-      panePriority: TwoPanePriority.pane1,
-    ));
-
-    RenderBox renderBox;
-    BoxParentData boxParentData;
-
-    renderBox = tester.renderObject(find.byKey(twoPaneKey));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(600.0));
-
-    renderBox = tester.renderObject(find.byKey(pane1Key));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(600.0));
-    boxParentData = renderBox.parentData! as BoxParentData;
-    expect(boxParentData.offset.dx, equals(0.0));
-    expect(boxParentData.offset.dy, equals(0.0));
-
-    expect(OrderPainter.log, <int>[1]);
-  });
-
-  testWidgets('TwoPane pane priority pane2 - no textDirection', (WidgetTester tester) async {
-    OrderPainter.log.clear();
-    const Key twoPaneKey = Key('twoPane');
-    const Key pane1Key = Key('pane1');
-    const Key pane2Key = Key('pane2');
-
-    await tester.pumpWidget(TwoPane(
-      key: twoPaneKey,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-      panePriority: TwoPanePriority.pane2,
-    ));
-
-    RenderBox renderBox;
-    BoxParentData boxParentData;
-
-    renderBox = tester.renderObject(find.byKey(twoPaneKey));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(600.0));
-
-    renderBox = tester.renderObject(find.byKey(pane2Key));
-    expect(renderBox.size.width, equals(800.0));
-    expect(renderBox.size.height, equals(600.0));
-    boxParentData = renderBox.parentData! as BoxParentData;
-    expect(boxParentData.offset.dx, equals(0.0));
-    expect(boxParentData.offset.dy, equals(0.0));
-
-    expect(OrderPainter.log, <int>[2]);
+    // With no Directionality or textDirection, the widget throws
+    final String message = tester.takeException().toString();
+    expect(message, contains('Directionality'));
+    expect(message, contains('textDirection'));
   });
 
   testWidgets('TwoPane separating display feature overrides params', (WidgetTester tester) async {
@@ -121,7 +50,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -143,8 +72,8 @@ void main() {
         direction: Axis.vertical,
         verticalDirection: VerticalDirection.up,
         paneProportion: 0.1,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -178,7 +107,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 600 pixel-wide notch at the top of the screen, does not affect TwoPane
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(100, 0, 700, 100),
@@ -195,9 +124,10 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         direction: Axis.vertical,
+        textDirection: TextDirection.ltr,
         paneProportion: 0.1,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -239,8 +169,8 @@ void main() {
     await tester.pumpWidget(TwoPane(
       key: twoPaneKey,
       textDirection: TextDirection.ltr,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -278,8 +208,9 @@ void main() {
       textDirection: TextDirection.ltr,
       child: TwoPane(
         key: twoPaneKey,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        textDirection: TextDirection.ltr,
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -318,8 +249,8 @@ void main() {
       key: twoPaneKey,
       textDirection: TextDirection.ltr,
       paneProportion: 0.25,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -348,11 +279,10 @@ void main() {
     OrderPainter.log.clear();
     const Key twoPaneKey = Key('twoPane');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       padding: const EdgeInsets.all(10),
       viewPadding: const EdgeInsets.all(10),
       viewInsets: const EdgeInsets.all(10),
-      systemGestureInsets: const EdgeInsets.all(10),
     );
 
     late MediaQueryData unpaddedPane1;
@@ -362,13 +292,13 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         textDirection: TextDirection.ltr,
-        pane1: Builder(
+        startPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane1 = MediaQuery.of(context);
             return log(1);
           },
         ),
-        pane2: Builder(
+        endPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane2 = MediaQuery.of(context);
             return log(2);
@@ -380,11 +310,9 @@ void main() {
     expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
     expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
     expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
-    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
     expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
     expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
     expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
-    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
 
     expect(OrderPainter.log, <int>[1, 2]);
   });
@@ -395,7 +323,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -414,8 +342,8 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         textDirection: TextDirection.ltr,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -449,7 +377,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       displayFeatures: <DisplayFeature>[
         const DisplayFeature(
           bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -472,8 +400,9 @@ void main() {
         child: TwoPane(
           key: twoPaneKey,
           textDirection: TextDirection.ltr,
-          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          inset: const EdgeInsets.only(top: 100, left: 100),
+          startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
         ),
       ),
     ));
@@ -516,8 +445,8 @@ void main() {
     await tester.pumpWidget(TwoPane(
       key: twoPaneKey,
       textDirection: TextDirection.rtl,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -555,8 +484,8 @@ void main() {
       textDirection: TextDirection.rtl,
       child: TwoPane(
         key: twoPaneKey,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -595,8 +524,8 @@ void main() {
       key: twoPaneKey,
       textDirection: TextDirection.rtl,
       paneProportion: 0.25,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -625,11 +554,10 @@ void main() {
     OrderPainter.log.clear();
     const Key twoPaneKey = Key('twoPane');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       padding: const EdgeInsets.all(10),
       viewPadding: const EdgeInsets.all(10),
       viewInsets: const EdgeInsets.all(10),
-      systemGestureInsets: const EdgeInsets.all(10),
     );
 
     late MediaQueryData unpaddedPane1;
@@ -639,13 +567,13 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         textDirection: TextDirection.rtl,
-        pane1: Builder(
+        startPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane1 = MediaQuery.of(context);
             return log(1);
           },
         ),
-        pane2: Builder(
+        endPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane2 = MediaQuery.of(context);
             return log(2);
@@ -657,11 +585,9 @@ void main() {
     expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
     expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(0, 10, 10, 10));
     expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
-    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(0, 10, 10, 10));
     expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
     expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 10, 0, 10));
     expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
-    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 0, 10));
 
     expect(OrderPainter.log, <int>[1, 2]);
   });
@@ -672,7 +598,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -691,8 +617,8 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         textDirection: TextDirection.rtl,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -726,7 +652,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       displayFeatures: <DisplayFeature>[
         const DisplayFeature(
           bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -749,8 +675,9 @@ void main() {
         child: TwoPane(
           key: twoPaneKey,
           textDirection: TextDirection.rtl,
-          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          inset: const EdgeInsets.only(top: 100, left: 100),
+          startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
         ),
       ),
     ));
@@ -793,8 +720,9 @@ void main() {
     await tester.pumpWidget(TwoPane(
       key: twoPaneKey,
       direction: Axis.vertical,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      textDirection: TextDirection.ltr,
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -830,9 +758,10 @@ void main() {
     await tester.pumpWidget(TwoPane(
       key: twoPaneKey,
       direction: Axis.vertical,
+      textDirection: TextDirection.ltr,
       paneProportion: 0.25,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -861,11 +790,10 @@ void main() {
     OrderPainter.log.clear();
     const Key twoPaneKey = Key('twoPane');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       padding: const EdgeInsets.all(10),
       viewPadding: const EdgeInsets.all(10),
       viewInsets: const EdgeInsets.all(10),
-      systemGestureInsets: const EdgeInsets.all(10),
     );
 
     late MediaQueryData unpaddedPane1;
@@ -875,13 +803,14 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         direction: Axis.vertical,
-        pane1: Builder(
+        textDirection: TextDirection.ltr,
+        startPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane1 = MediaQuery.of(context);
             return log(1);
           },
         ),
-        pane2: Builder(
+        endPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane2 = MediaQuery.of(context);
             return log(2);
@@ -893,11 +822,9 @@ void main() {
     expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
     expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
     expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
-    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
     expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
     expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
     expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
-    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
 
     expect(OrderPainter.log, <int>[1, 2]);
   });
@@ -908,7 +835,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide horizontal display feature splitting the display up-down
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -927,8 +854,9 @@ void main() {
       data: mediaQuery,
       child: TwoPane(
         key: twoPaneKey,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        textDirection: TextDirection.ltr,
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -962,7 +890,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide horizontal display feature splitting the display up-down
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -985,8 +913,10 @@ void main() {
         padding: const EdgeInsets.only(top: 100, left: 100),
         child: TwoPane(
           key: twoPaneKey,
-          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          textDirection: TextDirection.ltr,
+          inset: const EdgeInsets.only(top: 100, left: 100),
+          startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
         ),
       ),
     ));
@@ -1030,8 +960,9 @@ void main() {
       key: twoPaneKey,
       direction: Axis.vertical,
       verticalDirection: VerticalDirection.up,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      textDirection: TextDirection.ltr,
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -1067,10 +998,11 @@ void main() {
     await tester.pumpWidget(TwoPane(
       key: twoPaneKey,
       direction: Axis.vertical,
+      textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
       paneProportion: 0.25,
-      pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-      pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+      startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+      endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
     ));
 
     RenderBox renderBox;
@@ -1099,11 +1031,10 @@ void main() {
     OrderPainter.log.clear();
     const Key twoPaneKey = Key('twoPane');
     // A 20 pixel-wide vertical display feature splitting the display left-right
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
       padding: const EdgeInsets.all(10),
       viewPadding: const EdgeInsets.all(10),
       viewInsets: const EdgeInsets.all(10),
-      systemGestureInsets: const EdgeInsets.all(10),
     );
 
     late MediaQueryData unpaddedPane1;
@@ -1113,14 +1044,15 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         direction: Axis.vertical,
+        textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        pane1: Builder(
+        startPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane1 = MediaQuery.of(context);
             return log(1);
           },
         ),
-        pane2: Builder(
+        endPane: Builder(
           builder: (BuildContext context) {
             unpaddedPane2 = MediaQuery.of(context);
             return log(2);
@@ -1132,11 +1064,9 @@ void main() {
     expect(unpaddedPane1.padding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
     expect(unpaddedPane1.viewPadding, const EdgeInsets.fromLTRB(10, 0, 10, 10));
     expect(unpaddedPane1.viewInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
-    expect(unpaddedPane1.systemGestureInsets, const EdgeInsets.fromLTRB(10, 0, 10, 10));
     expect(unpaddedPane2.padding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
     expect(unpaddedPane2.viewPadding, const EdgeInsets.fromLTRB(10, 10, 10, 0));
     expect(unpaddedPane2.viewInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
-    expect(unpaddedPane2.systemGestureInsets, const EdgeInsets.fromLTRB(10, 10, 10, 0));
 
     expect(OrderPainter.log, <int>[1, 2]);
   });
@@ -1147,7 +1077,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide horizontal display feature splitting the display up-down
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -1166,8 +1096,9 @@ void main() {
       child: TwoPane(
         key: twoPaneKey,
         verticalDirection: VerticalDirection.up,
-        pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-        pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+        textDirection: TextDirection.ltr,
+        startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+        endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
       ),
     ));
 
@@ -1201,7 +1132,7 @@ void main() {
     const Key pane1Key = Key('pane1');
     const Key pane2Key = Key('pane2');
     // A 20 pixel-wide horizontal display feature splitting the display up-down
-    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance!.window).copyWith(
+    final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
         displayFeatures: <DisplayFeature>[
           const DisplayFeature(
             bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -1215,18 +1146,21 @@ void main() {
     // Default vertical direction is down
     // Pane proportion and direction is overridden by the display feature
     // Panes will be laid out above and below the display feature
-    // Panes "lose" the space occupied by the padding. Left padding
-    // affects both panes and top padding affects the top pane.
-    // Pane2: 700x290, Pane2: 700x190
+    // Panes "lose" the space occupied by the padding. Left and right padding
+    // affects both panes and top padding affects the top pane and bottom
+    // padding affects the bottom pane
+    // Pane2: 694x236, Pane2: 694x238
     await tester.pumpWidget(MediaQuery(
       data: mediaQuery,
       child: Padding(
-        padding: const EdgeInsets.only(top: 100, left: 100),
+        padding: const EdgeInsets.only(left: 52, right: 54, top: 52, bottom: 54),
         child: TwoPane(
           key: twoPaneKey,
+          textDirection: TextDirection.ltr,
           verticalDirection: VerticalDirection.up,
-          pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
-          pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
+          inset: const EdgeInsets.only(left: 52, right: 54, top: 52, bottom: 54),
+          startPane: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
+          endPane: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
         ),
       ),
     ));
@@ -1235,19 +1169,19 @@ void main() {
     BoxParentData boxParentData;
 
     renderBox = tester.renderObject(find.byKey(twoPaneKey));
-    expect(renderBox.size.width, equals(700.0));
-    expect(renderBox.size.height, equals(500.0));
+    expect(renderBox.size.width, equals(694.0));
+    expect(renderBox.size.height, equals(494.0));
 
     renderBox = tester.renderObject(find.byKey(pane1Key));
-    expect(renderBox.size.width, equals(700.0));
-    expect(renderBox.size.height, equals(290.0));
+    expect(renderBox.size.width, equals(694.0));
+    expect(renderBox.size.height, equals(236.0));
     boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dx, equals(0.0));
-    expect(boxParentData.offset.dy, equals(210.0));
+    expect(boxParentData.offset.dy, equals(258.0));
 
     renderBox = tester.renderObject(find.byKey(pane2Key));
-    expect(renderBox.size.width, equals(700.0));
-    expect(renderBox.size.height, equals(190.0));
+    expect(renderBox.size.width, equals(694.0));
+    expect(renderBox.size.height, equals(238.0));
     boxParentData = renderBox.parentData! as BoxParentData;
     expect(boxParentData.offset.dx, equals(0.0));
     expect(boxParentData.offset.dy, equals(0.0));

--- a/packages/flutter/test/widgets/two_pane_test.dart
+++ b/packages/flutter/test/widgets/two_pane_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/two_pane_test.dart
+++ b/packages/flutter/test/widgets/two_pane_test.dart
@@ -474,7 +474,6 @@ void main() {
           textDirection: TextDirection.ltr,
           pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
           pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-          padding: const EdgeInsets.only(top: 100, left: 100),
         ),
       ),
     ));
@@ -752,7 +751,6 @@ void main() {
           textDirection: TextDirection.rtl,
           pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
           pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-          padding: const EdgeInsets.only(top: 100, left: 100),
         ),
       ),
     ));
@@ -989,7 +987,6 @@ void main() {
           key: twoPaneKey,
           pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
           pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-          padding: const EdgeInsets.only(top: 100, left: 100),
         ),
       ),
     ));
@@ -1230,7 +1227,6 @@ void main() {
           verticalDirection: VerticalDirection.up,
           pane1: SizedBox(key: pane1Key, width: 100.0, height: 100.0, child: log(1)),
           pane2: SizedBox(key: pane2Key, width: 100.0, height: 100.0, child: log(2)),
-          padding: const EdgeInsets.only(top: 100, left: 100),
         ),
       ),
     ));


### PR DESCRIPTION
This PR adds the `TwoPane` widget which helps with creating layouts on foldable and large screen devices. The goal is to provide an easy way to write two-pane layouts that show less or more content according to available space, while at the same time reacting to existing display features on the device.

Here is an image of what the simplest usage of the widget will produce on 3 different platforms and available screen space:

<img width="1265" alt="Screenshot 2021-11-02 at 14 23 37" src="https://user-images.githubusercontent.com/1402046/139845570-c502a7fb-043a-4dc5-ba42-e97d93476081.png">

This is split from a larger PR for foldable support in order to make it easier to review (https://github.com/flutter/flutter/pull/77156). 

Issues that will be fixed by this PR:
- https://github.com/flutter/flutter/issues/49411

Depends on:
- Foldable MediaQuery support https://github.com/flutter/flutter/pull/92906
- Engine support: https://github.com/flutter/engine/pull/29447
- Framework integration of the engine support: https://github.com/flutter/flutter/pull/89511

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
