### PR TITLE
Marks Mac_ios platform_view_ios__start_up to be unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3366,7 +3366,6 @@ targets:
     scheduler: luci
 
   - name: Mac_ios platform_view_ios__start_up
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/92422
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_ios platform_view_ios__start_up"
}
-->
The test has been passing for [50 consecutive runs](https://ci.chromium.org/p/flutter/builders/staging/Mac_ios%20platform_view_ios__start_up?limit=100) (except infra failure due to bot capacity)
This test can be marked as unflaky.

https://github.com/flutter/flutter/issues/92422