### PR TITLE
Update docs to point to assets-for-api-docs cupertino css file 

### DIFF
--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -4,7 +4,7 @@
 @import 'https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Sharp|Material+Icons+Round';
 </style>
 
-<link href="https://flutter.github.io/assets-for-api-docs/assets/cupertino/assets/cupertino.css" rel="stylesheet" type="text/css">
+<link href="https://flutter.github.io/assets-for-api-docs/assets/cupertino/cupertino.css" rel="stylesheet" type="text/css">
 
 <link href="../assets/overrides.css" rel="stylesheet" type="text/css">
 

--- a/dev/docs/styles.html
+++ b/dev/docs/styles.html
@@ -4,7 +4,7 @@
 @import 'https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Sharp|Material+Icons+Round';
 </style>
 
-<link href="https://flutter.github.io/cupertino_icons/css/icons.css" rel="stylesheet" type="text/css">
+<link href="https://flutter.github.io/assets-for-api-docs/assets/cupertino/assets/cupertino.css" rel="stylesheet" type="text/css">
 
 <link href="../assets/overrides.css" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
https://flutter.github.io/cupertino_icons/css/icons.css is a 404 since `cupertino_icons` package location moved to `packages` https://github.com/flutter/packages/commit/f195e9b.

This broke the [`CupertinoIcons` class documentation](https://api.flutter.dev/flutter/cupertino/CupertinoIcons-class.html), which do not show the glyphs, just the name of the icon. 

The missing style guide should point to [packages/cupertino_icons/css/icons.css](https://github.com/flutter/packages/blob/c5e4b74691cca32a5a133857407f9555c5e1242e/third_party/packages/cupertino_icons/css/icons.css).

Update css file link to `assets-for-api-docs` variant https://github.com/flutter/assets-for-api-docs/pull/171 (this change dependent on those assets being published first).

Cupertino icon part of https://github.com/flutter/flutter/issues/88754.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
