### PR TITLE
TextField border gap padding improvement

### DIFF
--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -420,7 +420,7 @@ class OutlineInputBorder extends InputBorder {
     // Currently, BorderRadius only supports circular radii.
     const double cornerArcSweep = math.pi / 2.0;
     final double tlCornerArcSweep = start < scaledRRect.tlRadiusX
-      ? math.acos(1 - start / scaledRRect.tlRadiusX)
+      ? math.acos((1 - start / scaledRRect.tlRadiusX).clamp(0.0, 1.0))
       : math.pi / 2.0;
 
     final Path path = Path()

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -416,6 +416,8 @@ class OutlineInputBorder extends InputBorder {
       scaledRRect.blRadiusX * 2.0,
     );
 
+    // This assumes that the radius is circular (x and y radius are equal).
+    // Currently, BorderRadius only supports circular radii.
     const double cornerArcSweep = math.pi / 2.0;
     final double tlCornerArcSweep = start < scaledRRect.tlRadiusX
       ? math.acos(1 - start / scaledRRect.tlRadiusX)

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -437,7 +437,9 @@ class OutlineInputBorder extends InputBorder {
       path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
     } else if (start + extent < scaledRRect.width) {
       final double dx = scaledRRect.width - (start + extent);
-      final double sweep = math.asin((1 - dx / scaledRRect.trRadiusX).clamp(0.0, 1.0));
+      final double sweep = math.asin(
+        (1 - dx / scaledRRect.trRadiusX).clamp(0.0, 1.0),
+      );
       path.addArc(trCorner, trCornerArcStart + sweep, trCornerArcSweep - sweep);
     }
 

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -418,12 +418,11 @@ class OutlineInputBorder extends InputBorder {
 
     const double cornerArcSweep = math.pi / 2.0;
     final double tlCornerArcSweep = start < scaledRRect.tlRadiusX
-      ? math.asin((start / scaledRRect.tlRadiusX).clamp(-1.0, 1.0))
+      ? math.acos(1 - start / scaledRRect.tlRadiusX)
       : math.pi / 2.0;
 
     final Path path = Path()
-      ..addArc(tlCorner, math.pi, tlCornerArcSweep)
-      ..moveTo(scaledRRect.left + scaledRRect.tlRadiusX, scaledRRect.top);
+      ..addArc(tlCorner, math.pi, tlCornerArcSweep);
 
     if (start > scaledRRect.tlRadiusX)
       path.lineTo(scaledRRect.left + start, scaledRRect.top);
@@ -432,7 +431,7 @@ class OutlineInputBorder extends InputBorder {
     const double trCornerArcSweep = cornerArcSweep;
     if (start + extent < scaledRRect.width - scaledRRect.trRadiusX) {
       path
-        ..relativeMoveTo(extent, 0.0)
+        ..moveTo(scaledRRect.left + start + extent, scaledRRect.top)
         ..lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top)
         ..addArc(trCorner, trCornerArcStart, trCornerArcSweep);
     } else if (start + extent < scaledRRect.width) {

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -417,9 +417,7 @@ class OutlineInputBorder extends InputBorder {
     );
 
     const double cornerArcSweep = math.pi / 2.0;
-    final double tlCornerArcSweep = start < scaledRRect.tlRadiusX
-      ? math.acos(1 - start / scaledRRect.tlRadiusX)
-      : math.pi / 2.0;
+    final double tlCornerArcSweep = math.acos((1 - start / scaledRRect.tlRadiusX).clamp(0.0, 1.0));
 
     final Path path = Path()
       ..addArc(tlCorner, math.pi, tlCornerArcSweep);
@@ -430,13 +428,12 @@ class OutlineInputBorder extends InputBorder {
     const double trCornerArcStart = (3 * math.pi) / 2.0;
     const double trCornerArcSweep = cornerArcSweep;
     if (start + extent < scaledRRect.width - scaledRRect.trRadiusX) {
-      path
-        ..moveTo(scaledRRect.left + start + extent, scaledRRect.top)
-        ..lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top)
-        ..addArc(trCorner, trCornerArcStart, trCornerArcSweep);
+      path.moveTo(scaledRRect.left + start + extent, 0.0);
+      path.lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top);
+      path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
     } else if (start + extent < scaledRRect.width) {
       final double dx = scaledRRect.width - (start + extent);
-      final double sweep = math.acos(dx / scaledRRect.trRadiusX);
+      final double sweep = math.asin((1 - dx / scaledRRect.trRadiusX).clamp(0.0, 1.0));
       path.addArc(trCorner, trCornerArcStart + sweep, trCornerArcSweep - sweep);
     }
 

--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -432,7 +432,7 @@ class OutlineInputBorder extends InputBorder {
     const double trCornerArcStart = (3 * math.pi) / 2.0;
     const double trCornerArcSweep = cornerArcSweep;
     if (start + extent < scaledRRect.width - scaledRRect.trRadiusX) {
-      path.moveTo(scaledRRect.left + start + extent, 0.0);
+      path.moveTo(scaledRRect.left + start + extent, scaledRRect.top);
       path.lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top);
       path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
     } else if (start + extent < scaledRRect.width) {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7,7 +7,6 @@
 @Tags(<String>['reduced-test-set'])
 
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7,6 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -3841,6 +3842,53 @@ void main() {
   testWidgets(
     'InputDecorator OutlineBorder focused label with icon',
     (WidgetTester tester) async {
+      // This is a regression test for https://github.com/flutter/flutter/issues/82321
+      Widget buildFrame(TextDirection textDirection) {
+        return MaterialApp(
+          home: Scaffold(
+            body: Container(
+              padding: const EdgeInsets.all(16.0),
+              alignment: Alignment.center,
+              child: Directionality(
+                textDirection: textDirection,
+                child: RepaintBoundary(
+                  child: InputDecorator(
+                    isFocused: true,
+                    isEmpty: true,
+                    decoration: InputDecoration(
+                      filled: true,
+                      fillColor: const Color(0xFF00FF00),
+                      labelText: 'label text',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(30.0),
+                        gapPadding: 0.0,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame(TextDirection.ltr));
+      await expectLater(
+        find.byType(InputDecorator),
+        matchesGoldenFile('input_decorator.outline_label.ltr.png'),
+      );
+
+      await tester.pumpWidget(buildFrame(TextDirection.rtl));
+      await expectLater(
+        find.byType(InputDecorator),
+        matchesGoldenFile('input_decorator.outline_label.rtl.png'),
+      );
+    },
+  );
+
+  testWidgets(
+    'InputDecorator OutlineBorder focused label with icon',
+    (WidgetTester tester) async {
       // Regression test for https://github.com/flutter/flutter/issues/18111
 
       Widget buildFrame(TextDirection textDirection) {
@@ -4452,6 +4500,98 @@ void main() {
           // Top-left arc
           Offset(inputDecoratorWidth, 0.0 + smallerBorderRadiusScaled),
           Offset(inputDecoratorWidth - smallerBorderRadiusScaled, 0.0),
+        ],
+      )
+      ..restore(),
+    );
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/55317
+
+  testWidgets('rounded OutlineInputBorder with zero padding just wraps the label', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/82321
+    const double borderRadius = 30.0;
+    const String labelText = 'label text';
+
+    // Overall height for this InputDecorator is 56dps:
+    //   12 - top padding
+    //   12 - floating label (ahem font size 16dps * 0.75 = 12)
+    //    4 - floating label / input text gap
+    //   16 - input text (ahem font size 16dps)
+    //   12 - bottom padding
+    const double inputDecoratorHeight = 56.0;
+    const double inputDecoratorWidth = 800.0;
+
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: InputDecoration(
+          filled: true,
+          fillColor: const Color(0xFF00FF00),
+          labelText: labelText,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(borderRadius),
+            gapPadding: 0.0,
+          ),
+        ),
+      ),
+    );
+
+    const double denominator = borderRadius * 2.0;
+    const double borderRadiusScaled = borderRadius / denominator * inputDecoratorHeight;
+
+    expect(find.text(labelText), findsOneWidget);
+    final Rect labelRect = tester.getRect(find.text(labelText));
+
+    expect(findBorderPainter(), paints
+      ..save()
+      ..path(
+        style: PaintingStyle.fill,
+        color: const Color(0xFF00FF00),
+        includes: <Offset>[
+          // The border should draw along the four edges of the
+          // InputDecorator.
+
+          // Top center
+          const Offset(inputDecoratorWidth / 2.0, 0.0),
+          // Bottom center
+          const Offset(inputDecoratorWidth / 2.0, inputDecoratorHeight),
+          // Left center
+          const Offset(0.0, inputDecoratorHeight / 2.0),
+          // Right center
+          const Offset(inputDecoratorWidth, inputDecoratorHeight / 2.0),
+
+          // The border path should contain points where each rounded corner
+          // ends.
+
+          // Bottom-right arc
+          const Offset(inputDecoratorWidth, inputDecoratorHeight - borderRadiusScaled),
+          const Offset(inputDecoratorWidth - borderRadiusScaled, inputDecoratorHeight),
+          // Top-right arc
+          const Offset(inputDecoratorWidth,0.0 + borderRadiusScaled),
+          const Offset(inputDecoratorWidth - borderRadiusScaled, 0.0),
+          // Bottom-left arc
+          const Offset(0.0, inputDecoratorHeight - borderRadiusScaled),
+          const Offset(0.0 + borderRadiusScaled, inputDecoratorHeight),
+          // Top-left arc
+          const Offset(0.0,0.0 + borderRadiusScaled),
+          const Offset(0.0 + borderRadiusScaled, 0.0),
+
+          // Gap edges
+          // gap start x = radius - radius * cos(arc sweep)
+          // gap start y = radius - radius * sin(arc sweep)
+          const Offset(39.49999999999999, 32.284366616798906),
+          Offset(39.49999999999999 + labelRect.width, 0.0),
+        ],
+        excludes: const <Offset>[
+          // The border should not contain the corner points, since the border
+          // is rounded.
+
+          // Top-left
+          Offset.zero,
+          // Top-right
+          Offset(inputDecoratorWidth, 0.0),
+          // Bottom-left
+          Offset(0.0, inputDecoratorHeight),
+          // Bottom-right
+          Offset(inputDecoratorWidth, inputDecoratorHeight),
         ],
       )
       ..restore(),


### PR DESCRIPTION
Previously, the calculations for the border gap weren't quite right in all cases, and would sometimes result in extra unwanted padding.  Here's an example where gapPadding is set to zero, meaning that the border should just touch the label, but it didn't:

```dart
          child: TextField(
            decoration: InputDecoration(
              labelText: 'Hello label',
              border: OutlineInputBorder(
                borderRadius: BorderRadius.circular(32.0),
                gapPadding: 0.0,
             ),
            ),
          ),
```

<img width="209" alt="Screen Shot 2021-11-02 at 3 31 14 PM" src="https://user-images.githubusercontent.com/389558/139961179-15b85712-63a6-487e-abdb-f4fbfc0eb68b.png">

With this PR, the same code gives the correct result:

<img width="244" alt="Screen Shot 2021-11-02 at 3 30 25 PM" src="https://user-images.githubusercontent.com/389558/139961177-81074b77-fbef-454f-ae34-d8e843815c46.png">

### Todos
  - [x] Test.
  - [x] Make sure the current math doesn't break any other cases.
  - [x] Check other code paths and make sure they don't need their math updated as well.

### Related issues

Fixes https://github.com/flutter/flutter/issues/82321
Old PR that may have caused this bug: https://github.com/flutter/flutter/pull/34515