### PR TITLE
Add Help menu to macOS create template

### DIFF
--- a/dev/integration_tests/flutter_gallery/macos/Runner/Base.lproj/MainMenu.xib
+++ b/dev/integration_tests/flutter_gallery/macos/Runner/Base.lproj/MainMenu.xib
@@ -323,6 +323,10 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Help" id="EPT-qC-fAb">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Help" systemMenu="help" id="rJ0-wn-3NY"/>
+                </menuItem>
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>

--- a/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
+++ b/dev/integration_tests/flutter_gallery/macos/RunnerTests/RunnerTests.m
@@ -24,7 +24,10 @@
   XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"View"].submenu.numberOfItems, 1);
   XCTAssertGreaterThanOrEqual([mainMenu itemWithTitle:@"Window"].submenu.numberOfItems, 1);
 
-  XCTAssertNil(NSApplication.sharedApplication.helpMenu);
+  NSMenu *helpMenu = NSApplication.sharedApplication.helpMenu;
+  XCTAssertNotNil(helpMenu);
+  // Only the help menu search text box.
+  XCTAssertEqual(helpMenu.numberOfItems, 0);
 }
 
 @end

--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/Base.lproj/MainMenu.xib
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/Base.lproj/MainMenu.xib
@@ -323,6 +323,10 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Help" id="EPT-qC-fAb">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Help" systemMenu="help" id="rJ0-wn-3NY"/>
+                </menuItem>
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>


### PR DESCRIPTION
Add an empty help menu to the default macOS template to get the help menu item search (`cmd+?` shortcut) by default.

https://user-images.githubusercontent.com/682784/131193561-b1637f52-6a65-42d5-ad1c-864690c6660d.mov

Fixes https://github.com/flutter/flutter/issues/89077

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
