### PR TITLE
Stop sending metrics to builder name

### DIFF
--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -63,31 +63,18 @@ List<MetricPoint> parse(Map<String, dynamic> resultsJson, Map<String, dynamic> b
       resultsJson['ResultData'] as Map<String, dynamic>? ?? const <String, dynamic>{};
   final String gitBranch = (resultsJson['CommitBranch'] as String).trim();
   final String gitSha = (resultsJson['CommitSha'] as String).trim();
-  final String builderName = (resultsJson['BuilderName'] as String).trim();
   final List<MetricPoint> metricPoints = <MetricPoint>[];
   for (final String scoreKey in scoreKeys) {
     Map<String, String> tags = <String, String>{
       kGithubRepoKey: kFlutterFrameworkRepo,
       kGitRevisionKey: gitSha,
       'branch': gitBranch,
-      kNameKey: builderName,
+      kNameKey: taskName,
       kSubResultKey: scoreKey,
     };
     // Append additional benchmark tags, which will surface in Skia Perf dashboards.
     tags = mergeMaps<String, String>(
         tags, benchmarkTags.map((String key, dynamic value) => MapEntry<String, String>(key, value.toString())));
-    metricPoints.add(
-      MetricPoint(
-        (resultData[scoreKey] as num).toDouble(),
-        tags,
-      ),
-    );
-
-    // Add an extra entry under test name. This way we have duplicate metrics
-    // under both builder name and test name. Once we have enough data and update
-    // existing alerts to point to test name, we can deprecate builder name ones.
-    // https://github.com/flutter/flutter/issues/74522#issuecomment-942575581
-    tags[kNameKey] = taskName;
     metricPoints.add(
       MetricPoint(
         (resultData[scoreKey] as num).toDouble(),

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -38,11 +38,9 @@ void main() {
       };
       final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'test');
 
-      expect(metricPoints.length, 2);
+      expect(metricPoints.length, 1);
       expect(metricPoints[0].value, equals(0.4550425531914895));
-      expect(metricPoints[0].tags[kNameKey], 'Linux test');
-      expect(metricPoints[1].value, equals(0.4550425531914895));
-      expect(metricPoints[1].tags[kNameKey], 'test');
+      expect(metricPoints[0].tags[kNameKey], 'test');
     });
 
     test('without additional benchmark tags', () {
@@ -62,7 +60,7 @@ void main() {
       final List<MetricPoint> metricPoints = parse(results, <String, String>{}, 'task abc');
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
-      expect(metricPoints[2].value, equals(0.473));
+      expect(metricPoints[1].value, equals(0.473));
     });
 
     test('with additional benchmark tags', () {
@@ -90,8 +88,8 @@ void main() {
 
       expect(metricPoints[0].value, equals(0.4550425531914895));
       expect(metricPoints[0].tags.keys.contains('arch'), isTrue);
-      expect(metricPoints[2].value, equals(0.473));
-      expect(metricPoints[2].tags.keys.contains('device_type'), isTrue);
+      expect(metricPoints[1].value, equals(0.473));
+      expect(metricPoints[1].tags.keys.contains('device_type'), isTrue);
     });
 
     test('succeeds - null ResultData', () {


### PR DESCRIPTION
This is a following up of https://github.com/flutter/flutter/pull/92530.

More than 14 commit data points have been collected, and we are ready to deprecate sending data to old benchmark names. This will not affect existing alerts which are independent of benchmark names.

With this PR, users of Skia Perf are expected to view trending charts based on new benchmark names (the test names). We need to send a PSA before this lands.

Related issue: https://github.com/flutter/flutter/issues/74522, https://github.com/flutter/flutter/issues/92203