### PR TITLE
Replace text directionality control characters with escape sequences in the semantics_tester

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -635,12 +635,9 @@ class SemanticsTester {
     if (nodeData.actions != 0)
       buf.writeln('  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
     if (node.label != null && node.label.isNotEmpty) {
-      final String escapedLabel = node.label.replaceAll('\n', r'\n');
-      if (escapedLabel != node.label) {
-        buf.writeln("  label: r'$escapedLabel',");
-      } else {
-        buf.writeln("  label: '$escapedLabel',");
-      }
+      // Escape newlines and text directionality control characters.
+      final String escapedLabel = node.label.replaceAll('\n', r'\n').replaceAll('\u202a', r'\u202a').replaceAll('\u202c', r'\u202c');
+      buf.writeln("  label: '$escapedLabel',");
     }
     if (node.value != null && node.value.isNotEmpty)
       buf.writeln("  value: '${node.value}',");

--- a/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
@@ -132,7 +132,7 @@ void _tests() {
                                   tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
                                   flags: <SemanticsFlag>[SemanticsFlag.hasCheckedState, SemanticsFlag.isChecked, SemanticsFlag.isSelected],
                                   actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.decrease],
-                                  label: '‪Interactive text‬',
+                                  label: '\u202aInteractive text\u202c',
                                   value: 'test-value',
                                   increasedValue: 'test-increasedValue',
                                   decreasedValue: 'test-decreasedValue',


### PR DESCRIPTION
semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
previously contained unescaped control characters inside its source code.
The Dart analyzer will soon add a warning about those characters.
