### PR TITLE
Suppress created file list for new "flutter create" projects

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -289,19 +289,46 @@ class CreateCommand extends CreateBase {
     int generatedFileCount = 0;
     switch (template) {
       case FlutterProjectType.app:
-        generatedFileCount += await generateApp('app', relativeDir, templateContext, overwrite: overwrite);
+        generatedFileCount += await generateApp(
+          'app',
+          relativeDir,
+          templateContext,
+          overwrite: overwrite,
+          printStatusWhenWriting: !creatingNewProject,
+        );
         break;
       case FlutterProjectType.skeleton:
-        generatedFileCount += await generateApp('skeleton', relativeDir, templateContext, overwrite: overwrite);
+        generatedFileCount += await generateApp(
+          'skeleton',
+          relativeDir,
+          templateContext,
+          overwrite: overwrite,
+          printStatusWhenWriting: !creatingNewProject,
+        );
         break;
       case FlutterProjectType.module:
-        generatedFileCount += await _generateModule(relativeDir, templateContext, overwrite: overwrite);
+        generatedFileCount += await _generateModule(
+          relativeDir,
+          templateContext,
+          overwrite: overwrite,
+          printStatusWhenWriting: !creatingNewProject,
+        );
         break;
       case FlutterProjectType.package:
-        generatedFileCount += await _generatePackage(relativeDir, templateContext, overwrite: overwrite);
+        generatedFileCount += await _generatePackage(
+          relativeDir,
+          templateContext,
+          overwrite: overwrite,
+          printStatusWhenWriting: !creatingNewProject,
+        );
         break;
       case FlutterProjectType.plugin:
-        generatedFileCount += await _generatePlugin(relativeDir, templateContext, overwrite: overwrite);
+        generatedFileCount += await _generatePlugin(
+          relativeDir,
+          templateContext,
+          overwrite: overwrite,
+          printStatusWhenWriting: !creatingNewProject,
+        );
         break;
     }
     if (sampleCode != null) {
@@ -367,13 +394,24 @@ Your $application code is in $relativeAppMain.
     return FlutterCommandResult.success();
   }
 
-  Future<int> _generateModule(Directory directory, Map<String, dynamic> templateContext, { bool overwrite = false }) async {
+  Future<int> _generateModule(
+    Directory directory,
+    Map<String, dynamic> templateContext, {
+    bool overwrite = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     int generatedCount = 0;
     final String description = argResults.wasParsed('description')
         ? stringArg('description')
         : 'A new flutter module project.';
     templateContext['description'] = description;
-    generatedCount += await renderTemplate(globals.fs.path.join('module', 'common'), directory, templateContext, overwrite: overwrite);
+    generatedCount += await renderTemplate(
+      globals.fs.path.join('module', 'common'),
+      directory,
+      templateContext,
+      overwrite: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
     if (boolArg('pub')) {
       await pub.get(
         context: PubContext.create,
@@ -390,13 +428,24 @@ Your $application code is in $relativeAppMain.
     return generatedCount;
   }
 
-  Future<int> _generatePackage(Directory directory, Map<String, dynamic> templateContext, { bool overwrite = false }) async {
+  Future<int> _generatePackage(
+    Directory directory,
+    Map<String, dynamic> templateContext, {
+    bool overwrite = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     int generatedCount = 0;
     final String description = argResults.wasParsed('description')
         ? stringArg('description')
         : 'A new Flutter package project.';
     templateContext['description'] = description;
-    generatedCount += await renderTemplate('package', directory, templateContext, overwrite: overwrite);
+    generatedCount += await renderTemplate(
+      'package',
+      directory,
+      templateContext,
+      overwrite: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
     if (boolArg('pub')) {
       await pub.get(
         context: PubContext.createPackage,
@@ -408,7 +457,12 @@ Your $application code is in $relativeAppMain.
     return generatedCount;
   }
 
-  Future<int> _generatePlugin(Directory directory, Map<String, dynamic> templateContext, { bool overwrite = false }) async {
+  Future<int> _generatePlugin(
+    Directory directory,
+    Map<String, dynamic> templateContext, {
+    bool overwrite = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     // Plugins only add a platform if it was requested explicitly by the user.
     if (!argResults.wasParsed('platforms')) {
       for (final String platform in kAllCreatePlatforms) {
@@ -430,7 +484,13 @@ Your $application code is in $relativeAppMain.
         ? stringArg('description')
         : 'A new flutter plugin project.';
     templateContext['description'] = description;
-    generatedCount += await renderTemplate('plugin', directory, templateContext, overwrite: overwrite);
+    generatedCount += await renderTemplate(
+      'plugin',
+      directory,
+      templateContext,
+      overwrite: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
 
     if (boolArg('pub')) {
       await pub.get(
@@ -461,7 +521,14 @@ Your $application code is in $relativeAppMain.
     templateContext['pluginProjectName'] = projectName;
     templateContext['androidPluginIdentifier'] = androidPluginIdentifier;
 
-    generatedCount += await generateApp('app', project.example.directory, templateContext, overwrite: overwrite, pluginExampleApp: true);
+    generatedCount += await generateApp(
+      'app',
+      project.example.directory,
+      templateContext,
+      overwrite: overwrite,
+      pluginExampleApp: true,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
     return generatedCount;
   }
 

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -404,8 +404,12 @@ abstract class CreateBase extends FlutterCommand {
   /// If `overwrite` is true, overwrites existing files, `overwrite` defaults to `false`.
   @protected
   Future<int> renderTemplate(
-      String templateName, Directory directory, Map<String, Object> context,
-      {bool overwrite = false}) async {
+    String templateName,
+    Directory directory,
+    Map<String, Object> context, {
+    bool overwrite = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     final Template template = await Template.fromName(
       templateName,
       fileSystem: globals.fs,
@@ -413,7 +417,12 @@ abstract class CreateBase extends FlutterCommand {
       templateRenderer: globals.templateRenderer,
       templateManifest: _templateManifest,
     );
-    return template.render(directory, context, overwriteExisting: overwrite);
+    return template.render(
+      directory,
+      context,
+      overwriteExisting: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
   }
 
   /// Merges named templates into a single template, output to `directory`.
@@ -423,8 +432,12 @@ abstract class CreateBase extends FlutterCommand {
   /// If `overwrite` is true, overwrites existing files, `overwrite` defaults to `false`.
   @protected
   Future<int> renderMerged(
-      List<String> names, Directory directory, Map<String, Object> context,
-      {bool overwrite = false}) async {
+    List<String> names,
+    Directory directory,
+    Map<String, Object> context, {
+    bool overwrite = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     final Template template = await Template.merged(
       names,
       directory,
@@ -433,7 +446,12 @@ abstract class CreateBase extends FlutterCommand {
       templateRenderer: globals.templateRenderer,
       templateManifest: _templateManifest,
     );
-    return template.render(directory, context, overwriteExisting: overwrite);
+    return template.render(
+      directory,
+      context,
+      overwriteExisting: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
+    );
   }
 
   /// Generate application project in the `directory` using `templateContext`.
@@ -441,14 +459,20 @@ abstract class CreateBase extends FlutterCommand {
   /// If `overwrite` is true, overwrites existing files, `overwrite` defaults to `false`.
   @protected
   Future<int> generateApp(
-      String templateName, Directory directory, Map<String, Object> templateContext,
-      {bool overwrite = false, bool pluginExampleApp = false}) async {
+    String templateName,
+    Directory directory,
+    Map<String, Object> templateContext, {
+    bool overwrite = false,
+    bool pluginExampleApp = false,
+    bool printStatusWhenWriting = true,
+  }) async {
     int generatedCount = 0;
     generatedCount += await renderMerged(
       <String>[templateName, 'app_shared'],
       directory,
       templateContext,
       overwrite: overwrite,
+      printStatusWhenWriting: printStatusWhenWriting,
     );
     final FlutterProject project = FlutterProject.fromDirectory(directory);
     if (templateContext['android'] == true) {


### PR DESCRIPTION
Suppress long list of created files on a new `flutter create`. When `flutter create` is run again for the same project, it _does_ show the (hopefully much shorter) file creation list.

### App
```
$ flutter create test_123
Creating project test_123...
Running "flutter pub get" in test_123...                         1,409ms
Wrote 128 files.

All done!
In order to run your application, type:

  $ cd test_123
  $ flutter run

Your application code is in test_123/lib/main.dart.
```
Remove a file, then re-`flutter create` shows the created files (I don't know why it says "Wrote 4 files" when only one was created, it has the same behavior on master...)
```
$ rm test_123/lib/main.dart
$ flutter create test_123
Recreating project test_123...
  test_123/lib/main.dart (created)
Running "flutter pub get" in test_123...                           464ms
Wrote 4 files.

All done!
In order to run your application, type:

  $ cd test_123
  $ flutter run

Your application code is in test_123/lib/main.dart.
```
### Plugin
```
$ flutter create -t plugin test_123
Creating project test_123...
Running "flutter pub get" in test_123...                         1,192ms
Running "flutter pub get" in example...                          1,087ms
Wrote 27 files.

All done!

Your plugin code is in test_123/lib/test_123.dart.

Your example app code is in test_123/example/lib/main.dart.


You've created a plugin project that doesn't yet support any platforms.


To add platforms, run `flutter create -t plugin --platforms <platforms> .` under test_123.
For more information, see https://flutter.dev/go/plugin-platforms.
```
### Module
```
$ flutter create -t module test_123
Creating project test_123...
Running "flutter pub get" in test_123...                         1,058ms
Wrote 12 files.

All done!
Your module code is in test_123/lib/main.dart.
```
### Package
```
$ flutter create -t package test_123
Creating project test_123...
Running "flutter pub get" in test_123...                         1,084ms
Wrote 13 files.

All done!
Your package code is in test_123/lib/test_123.dart
```

Fixes https://github.com/flutter/flutter/issues/93036

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.