### PR TITLE
Add golden tests for default and overriden `expandedTitleScale` in `FlexibleSpaceBar`

### DIFF
--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -647,9 +647,10 @@ void main() {
     await tester.pumpAndSettle();
 
     final Finder flexibleSpaceBar = find.ancestor(of: find.byType(FlexibleSpaceBar), matching: find.byType(RepaintBoundary).first);
+    // This should match the default behavior
     await expectLater(
         flexibleSpaceBar,
-        matchesGoldenFile('flexible_space_bar.expanded_title_scale_override.collapsed.png')
+        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
     );
 
     // We drag down to fully expand the space bar.

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -542,6 +542,126 @@ void main() {
     );
   });
 
+  testWidgets('FlexibleSpaceBar scaled title', (WidgetTester tester) async {
+    const double titleFontSize = 20.0;
+    const double height = 300.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              const SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                stretch: true,
+                flexibleSpace: RepaintBoundary(
+                  child: FlexibleSpaceBar(
+                    title: Text(
+                      'X',
+                      style: TextStyle(fontSize: titleFontSize,),
+                    ),
+                    centerTitle: false,
+                  ),
+                ),
+              ),
+              SliverList(
+                delegate: SliverChildListDelegate(
+                  <Widget>[
+                    for (int i = 0; i < 3; i++)
+                      SizedBox(
+                        height: 200.0,
+                        child: Center(child: Text('Item $i')),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // We drag up to fully collapse the space bar.
+    await tester.drag(find.text('Item 0'), const Offset(0, -600.0));
+    await tester.pumpAndSettle();
+
+    final Finder flexibleSpaceBar = find.ancestor(of: find.byType(FlexibleSpaceBar), matching: find.byType(RepaintBoundary).first);
+    await expectLater(
+        flexibleSpaceBar,
+        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
+    );
+
+    // We drag down to fully expand the space bar.
+    await tester.drag(find.text('Item 2'), const Offset(0, 600.0));
+    await tester.pumpAndSettle();
+
+    await expectLater(
+        flexibleSpaceBar,
+        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.expanded.png')
+    );
+  });
+
+  testWidgets('FlexibleSpaceBar scaled title - override expandedTitleScale', (WidgetTester tester) async {
+    const double titleFontSize = 20.0;
+    const double height = 300.0;
+    const double expandedTitleScale = 3.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              const SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                stretch: true,
+                flexibleSpace: RepaintBoundary(
+                  child: FlexibleSpaceBar(
+                    title: Text(
+                      'X',
+                      style: TextStyle(fontSize: titleFontSize,),
+                    ),
+                    centerTitle: false,
+                    expandedTitleScale: expandedTitleScale,
+                  ),
+                ),
+              ),
+              SliverList(
+                delegate: SliverChildListDelegate(
+                  <Widget>[
+                    for (int i = 0; i < 3; i++)
+                      SizedBox(
+                        height: 200.0,
+                        child: Center(child: Text('Item $i')),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // We drag up to fully collapse the space bar.
+    await tester.drag(find.text('Item 0'), const Offset(0, -600.0));
+    await tester.pumpAndSettle();
+
+    final Finder flexibleSpaceBar = find.ancestor(of: find.byType(FlexibleSpaceBar), matching: find.byType(RepaintBoundary).first);
+    await expectLater(
+        flexibleSpaceBar,
+        matchesGoldenFile('flexible_space_bar.expanded_title_scale_override.collapsed.png')
+    );
+
+    // We drag down to fully expand the space bar.
+    await tester.drag(find.text('Item 2'), const Offset(0, 600.0));
+    await tester.pumpAndSettle();
+
+    await expectLater(
+        flexibleSpaceBar,
+        matchesGoldenFile('flexible_space_bar.expanded_title_scale_override.expanded.png')
+    );
+  });
+
   testWidgets('FlexibleSpaceBar test titlePadding defaults', (WidgetTester tester) async {
     Widget buildFrame(TargetPlatform platform, bool? centerTitle) {
       return MaterialApp(

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -571,7 +571,7 @@ void main() {
               SliverList(
                 delegate: SliverChildListDelegate(
                   <Widget>[
-                    for (int i = 0; i < 3; i++)
+                    for (int i = 0; i < 3; i += 1)
                       SizedBox(
                         height: 200.0,
                         child: Center(child: Text('Item $i')),
@@ -591,8 +591,8 @@ void main() {
 
     final Finder flexibleSpaceBar = find.ancestor(of: find.byType(FlexibleSpaceBar), matching: find.byType(RepaintBoundary).first);
     await expectLater(
-        flexibleSpaceBar,
-        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
+      flexibleSpaceBar,
+      matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
     );
 
     // We drag down to fully expand the space bar.
@@ -600,8 +600,8 @@ void main() {
     await tester.pumpAndSettle();
 
     await expectLater(
-        flexibleSpaceBar,
-        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.expanded.png')
+      flexibleSpaceBar,
+      matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.expanded.png')
     );
   });
 
@@ -632,7 +632,7 @@ void main() {
               SliverList(
                 delegate: SliverChildListDelegate(
                   <Widget>[
-                    for (int i = 0; i < 3; i++)
+                    for (int i = 0; i < 3; i += 1)
                       SizedBox(
                         height: 200.0,
                         child: Center(child: Text('Item $i')),
@@ -653,8 +653,8 @@ void main() {
     final Finder flexibleSpaceBar = find.ancestor(of: find.byType(FlexibleSpaceBar), matching: find.byType(RepaintBoundary).first);
     // This should match the default behavior
     await expectLater(
-        flexibleSpaceBar,
-        matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
+      flexibleSpaceBar,
+      matchesGoldenFile('flexible_space_bar.expanded_title_scale_default.collapsed.png')
     );
 
     // We drag down to fully expand the space bar.
@@ -662,8 +662,8 @@ void main() {
     await tester.pumpAndSettle();
 
     await expectLater(
-        flexibleSpaceBar,
-        matchesGoldenFile('flexible_space_bar.expanded_title_scale_override.expanded.png')
+      flexibleSpaceBar,
+      matchesGoldenFile('flexible_space_bar.expanded_title_scale_override.expanded.png')
     );
   });
 


### PR DESCRIPTION
Adds golden tests for default and overriden `expandedTitleScale` in `FlexibleSpaceBar` (see https://github.com/flutter/flutter/pull/92160).
### Collapsed
<img src="https://user-images.githubusercontent.com/68219924/140335961-055137a6-a67b-4bc8-8a37-4da5d59e03cc.png" height="200" />

### Expanded default vs overriden to `3.0`
<img src="https://user-images.githubusercontent.com/68219924/140335965-60cd0c6f-bd81-45e6-831a-00c1b3a862d8.png" height="200" /> <img src="https://user-images.githubusercontent.com/68219924/140335967-a109885d-413e-47e4-835e-12a77f4a88d6.png" height="200" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.