### PR TITLE
Dynamic logcat piping for deferred components test

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -46,10 +46,7 @@ do
   echo "Waiting for $x seconds"
   # We use an increasing delay here as the emulator can lag and take a long time to finish running the app.
   # Delay of 20s produces ~5-10% flakes, 30s produces ~2% flakes roughly.
-  $adb_path shell "
   sleep 10
-  exit
-  "
   x=$(( $x + 10 ))
 done
 echo "Failure: Deferred component did not load."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -45,7 +45,7 @@ do
     fi
     # add timeout
     current_time=$(date +%s)
-    if [[ $(( $current_time - $script_start_time_seconds )) -ge 150 ]]; then
+    if [[ $((current_time - script_start_time_seconds)) -ge 150 ]]; then
       echo "Failure: Deferred component did not load."
       exit 1
     fi

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -39,17 +39,18 @@ exit
 x=20
 while [ $x -le 120 ]
 do
+  $adb_path logcat -d -t "$script_start_time" > build/app/outputs/bundle/release/run_logcat.log
+  if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferred code"; then
+    echo "All tests passed."
+    exit 0
+  fi
+  echo "Waiting for $x seconds"
   # We use an increasing delay here as the emulator can lag and take a long time to finish running the app.
   # Delay of 20s produces ~5-10% flakes, 30s produces ~2% flakes roughly.
   $adb_path shell "
   sleep 10
   exit
   "
-  echo ""
-  if $adb_path logcat -d -t "$script_start_time" | grep -q "Running deferred code"; then
-    echo "All tests passed."
-    exit 0
-  fi
   x=$(( $x + 10 ))
 done
 echo "Failure: Deferred component did not load."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -19,6 +19,7 @@ adb_path=$2
 
 # Store the time to prevent capturing logs from previous runs.
 script_start_time=$($adb_path shell 'date +"%m-%d %H:%M:%S.0"')
+script_start_time_seconds=$(date +%s)
 
 $adb_path uninstall "io.flutter.integration.deferred_components_test"
 
@@ -32,22 +33,23 @@ java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/rele
 
 $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
-sleep 20
 exit
 "
-x=20
-while [ $x -le 120 ]
+while read LOGLINE
 do
-  $adb_path logcat -d -t "$script_start_time" > build/app/outputs/bundle/release/run_logcat.log
-  if cat build/app/outputs/bundle/release/run_logcat.log | grep -q "Running deferred code"; then
-    echo "All tests passed."
-    exit 0
-  fi
-  echo "Waiting for $x seconds"
-  # We use an increasing delay here as the emulator can lag and take a long time to finish running the app.
-  # Delay of 20s produces ~5-10% flakes, 30s produces ~2% flakes roughly.
-  sleep 10
-  x=$(( $x + 10 ))
-done
+    if [[ "${LOGLINE}" == *"Running deferred code"* ]]; then
+        echo "Found ${LOGLINE}"
+        pkill -P $$
+        echo "All tests passed."
+        exit 0
+    fi
+    # add timeout
+    current_time=$(date +%s)
+    if [[ $(( $current_time - $script_start_time_seconds )) -ge 150 ]]; then
+      echo "Failure: Deferred component did not load."
+      exit 1
+    fi
+done < <(adb logcat -T "$script_start_time")
+
 echo "Failure: Deferred component did not load."
 exit 1

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -30,7 +30,6 @@ flutter build appbundle
 java -jar $bundletool_jar_path build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --ks android/testing-keystore.jks --ks-key-alias testing_key --ks-pass pass:012345
 java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
-
 $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
 sleep 20

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -30,9 +30,12 @@ flutter build appbundle
 java -jar $bundletool_jar_path build-apks --bundle=build/app/outputs/bundle/release/app-release.aab --output=build/app/outputs/bundle/release/app-release.apks --local-testing --ks android/testing-keystore.jks --ks-key-alias testing_key --ks-pass pass:012345
 java -jar $bundletool_jar_path install-apks --apks=build/app/outputs/bundle/release/app-release.apks
 
+# TODO(garyq): Periodically check for the completed result rather than use a hard delay
+# We use a long delay here as the emulator can lag and take a long time to finish running the app.
+# Delay of 20s produces ~5-10% flakes, 30s produces ~2% flakes roughly.
 $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
-sleep 30
+sleep 60
 exit
 "
 $adb_path logcat -d -t "$script_start_time" > build/app/outputs/bundle/release/run_logcat.log

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -43,11 +43,11 @@ do
         echo "All tests passed."
         exit 0
     fi
-    # add timeout
+    # Timeout if expected log not found
     current_time=$(date +%s)
     if [[ $((current_time - script_start_time_seconds)) -ge 150 ]]; then
-      echo "Failure: Deferred component did not load."
-      exit 1
+        echo "Failure: Deferred component did not load."
+        exit 1
     fi
 done < <(adb logcat -T "$script_start_time")
 


### PR DESCRIPTION
After monitoring the deferred components test and adding additional logging, https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20deferred%20components/201/overview revealed that the flake was simply caused by not waiting long enough when the emulator lags particularly hard.

This large increase in delay should weed out the remaining flakiness.

Should fix https://github.com/flutter/flutter/issues/91266