### PR TITLE
Update minimum required version to Xcode 12.3

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -18,11 +18,11 @@ import '../base/version.dart';
 import '../build_info.dart';
 import '../ios/xcodeproj.dart';
 
-Version get xcodeRequiredVersion => Version(12, 0, 1, text: '12.0.1');
+Version get xcodeRequiredVersion => Version(12, 3, null, text: '12.3');
 
 /// Diverging this number from the minimum required version will provide a doctor
 /// warning, not error, that users should upgrade Xcode.
-Version get xcodeRecommendedVersion => Version(13, 0, 0, text: '13.0.0');
+Version get xcodeRecommendedVersion => Version(13, null, null, text: '13');
 
 /// SDK name passed to `xcrun --sdk`. Corresponds to undocumented Xcode
 /// SUPPORTED_PLATFORMS values.

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -148,7 +148,7 @@ void main() {
 
         testWithoutContext('xcodeVersionSatisfactory is true when version meets minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(12, 0, 1);
+          xcodeProjectInterpreter.version = Version(12, 3, null);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
         });
@@ -162,21 +162,21 @@ void main() {
 
         testWithoutContext('xcodeVersionSatisfactory is true when minor version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(12, 3, 0);
+          xcodeProjectInterpreter.version = Version(12, 5, 0);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
         });
 
         testWithoutContext('xcodeVersionSatisfactory is true when patch version exceeds minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(12, 0, 2);
+          xcodeProjectInterpreter.version = Version(12, 3, 1);
 
           expect(xcode.isRequiredVersionSatisfactory, isTrue);
         });
 
         testWithoutContext('isRecommendedVersionSatisfactory is false when version is less than minimum', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(11, 0, 0);
+          xcodeProjectInterpreter.version = Version(12, null, null);
 
           expect(xcode.isRecommendedVersionSatisfactory, isFalse);
         });
@@ -232,7 +232,7 @@ void main() {
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
           xcodeProjectInterpreter.isInstalled = true;
-          xcodeProjectInterpreter.version = Version(12, 0, 1);
+          xcodeProjectInterpreter.version = Version(12, 3, null);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);

--- a/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_validator_test.dart
@@ -56,20 +56,20 @@ void main() {
       final ValidationResult result = await validator.validate();
       expect(result.type, ValidationType.partial);
       expect(result.messages.last.type, ValidationMessageType.error);
-      expect(result.messages.last.message, contains('Flutter requires a minimum Xcode version of 12.0.1'));
+      expect(result.messages.last.message, contains('Flutter requires a minimum Xcode version of 12.3'));
     });
 
     testWithoutContext('Emits partial status when Xcode below recommended version', () async {
       final ProcessManager processManager = FakeProcessManager.any();
       final Xcode xcode = Xcode.test(
         processManager: processManager,
-        xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager, version: Version(12, 0, 1)),
+        xcodeProjectInterpreter: XcodeProjectInterpreter.test(processManager: processManager, version: Version(12, 4, null)),
       );
       final XcodeValidator validator = XcodeValidator(xcode: xcode, userMessages: UserMessages());
       final ValidationResult result = await validator.validate();
       expect(result.type, ValidationType.partial);
       expect(result.messages.last.type, ValidationMessageType.hint);
-      expect(result.messages.last.message, contains('Flutter recommends a minimum Xcode version of 13.0.0'));
+      expect(result.messages.last.message, contains('Flutter recommends a minimum Xcode version of 13'));
     });
 
     testWithoutContext('Emits partial status when Xcode EULA not signed', () async {

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -294,10 +294,10 @@ class FakeXcodeProjectInterpreter implements XcodeProjectInterpreter {
   bool get isInstalled => true;
 
   @override
-  String get versionText => 'Xcode 12.0.1';
+  String get versionText => 'Xcode 12.3';
 
   @override
-  Version get version => Version(12, 0, 1);
+  Version get version => Version(12, 3, null);
 
   @override
   Future<Map<String, String>> getBuildSettings(


### PR DESCRIPTION
Upgrade minimum Xcode version enforced by the tool to Xcode 12.3 (released December 2020), which contains the macOS Big Sur SDK needed to unblock #84453.  Once users are on 12.3, the engine builders can be upgraded (but not before that, to avoid bitcode submission issues).

Fixes https://github.com/flutter/flutter/issues/93093

Previous Xcode bump at https://github.com/flutter/flutter/pull/77025.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
