### PR TITLE
[Tree hygiene] Unused code in attachToRenderTree()

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1115,7 +1115,6 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
       element._newWidget = this;
       element.markNeedsBuild();
     }
-    return element!;
   }
 
   @override


### PR DESCRIPTION
This is a trivial change to the code.

The `return` value is unused because the code that will be executed is inside the if-else condition.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.