### PR TITLE
Use baseline value to get position in next line

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -161,16 +161,6 @@ class VerticalCaretMovementRun extends BidirectionalIterator<TextPosition> {
     return _isValid;
   }
 
-  // Computes the vertical distance from the `from` line's bottom to the `to`
-  // lines top.
-  double _lineDistance(int from, int to) {
-    double lineHeight = 0;
-    for (int index = from + 1; index < to; index += 1) {
-      lineHeight += _lineMetrics[index].height;
-    }
-    return lineHeight;
-  }
-
   final Map<int, MapEntry<Offset, TextPosition>> _positionCache = <int, MapEntry<Offset, TextPosition>>{};
 
   MapEntry<Offset, TextPosition> _getTextPositionForLine(int lineNumber) {
@@ -181,11 +171,8 @@ class VerticalCaretMovementRun extends BidirectionalIterator<TextPosition> {
       return cachedPosition;
     }
     assert(lineNumber != _currentLine);
-    final double distanceY = lineNumber > _currentLine
-      ? _lineMetrics[_currentLine].descent + _lineMetrics[lineNumber].ascent + _lineDistance(_currentLine, lineNumber)
-      : - _lineMetrics[_currentLine].ascent - _lineMetrics[lineNumber].descent - _lineDistance(lineNumber, _currentLine);
 
-    final Offset newOffset = _currentOffset.translate(0, distanceY);
+    final Offset newOffset = Offset(_currentOffset.dx, _lineMetrics[lineNumber].baseline);
     final TextPosition closestPosition = _editable._textPainter.getPositionForOffset(newOffset);
     final MapEntry<Offset, TextPosition> position = MapEntry<Offset, TextPosition>(newOffset, closestPosition);
     _positionCache[lineNumber] = position;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2405,17 +2405,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     // TODO(LongCatIsLooong): include line boundaries information in
     // ui.LineMetrics, then we can get rid of this.
     final Offset offset = _textPainter.getOffsetForCaret(startPosition, Rect.zero);
-    int line = 0;
-    double accumulatedHeight = 0;
     for (final ui.LineMetrics lineMetrics in metrics) {
-      if (accumulatedHeight + lineMetrics.height > offset.dy) {
-        return MapEntry<int, Offset>(line, Offset(offset.dx, lineMetrics.baseline));
+      if (lineMetrics.baseline + lineMetrics.descent > offset.dy) {
+        return MapEntry<int, Offset>(lineMetrics.lineNumber, Offset(offset.dx, lineMetrics.baseline));
       }
-      line += 1;
-      accumulatedHeight += lineMetrics.height;
     }
     assert(false, 'unable to find the line for $startPosition');
-    return MapEntry<int, Offset>(math.max(0, metrics.length - 1), Offset(offset.dx, accumulatedHeight));
+    return MapEntry<int, Offset>(
+      math.max(0, metrics.length - 1),
+      Offset(offset.dx, metrics.isNotEmpty ? metrics.last.baseline + metrics.last.descent : 0.0),
+    );
   }
 
   /// Starts a [VerticalCaretMovementRun] at the given location in the text, for

--- a/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
@@ -57,7 +57,12 @@ void main() {
   final TextEditingController controller = TextEditingController(text: testText);
 
   final FocusNode focusNode = FocusNode();
-  Widget buildEditableText({ TextAlign textAlign = TextAlign.left, bool readOnly = false, bool obscured = false }) {
+  Widget buildEditableText({
+    TextAlign textAlign = TextAlign.left,
+    bool readOnly = false,
+    bool obscured = false,
+    TextStyle style = const TextStyle(fontSize: 10.0),
+  }) {
     return MaterialApp(
       home: Align(
         alignment: Alignment.topLeft,
@@ -69,7 +74,7 @@ void main() {
             showSelectionHandles: true,
             autofocus: true,
             focusNode: focusNode,
-            style: const TextStyle(fontSize: 10),
+            style: style,
             textScaleFactor: 1,
             // Avoid the cursor from taking up width.
             cursorWidth: 0,
@@ -1592,6 +1597,32 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 3,   // Would have been 4 if the run wasn't interrupted.
             ));
+          }, variant: TargetPlatformVariant.all());
+
+          testWidgets('long run with fractional text height', (WidgetTester tester) async {
+            controller.text = "${'źdźbło\n' * 99}źdźbło";
+            controller.selection = const TextSelection.collapsed(offset: 2);
+            await tester.pumpWidget(buildEditableText(style: const TextStyle(fontSize: 13.0, height: 1.17)));
+
+            for (int i = 1; i < 99; i++) {
+              await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowDown));
+              await tester.pump();
+              expect(
+                controller.selection,
+                TextSelection.collapsed(offset: 2 + i * 7),
+                reason: 'line $i',
+              );
+            }
+
+            for (int i = 99; i < 1; i--) {
+              await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowUp));
+              await tester.pump();
+              expect(
+                controller.selection,
+                TextSelection.collapsed(offset: 2 + i * 7),
+                reason: 'line $i',
+              );
+            }
           }, variant: TargetPlatformVariant.all());
         });
       });

--- a/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
@@ -1600,11 +1600,11 @@ void main() {
           }, variant: TargetPlatformVariant.all());
 
           testWidgets('long run with fractional text height', (WidgetTester tester) async {
-            controller.text = "${'źdźbło\n' * 99}źdźbło";
+            controller.text = "${'źdźbło\n' * 49}źdźbło";
             controller.selection = const TextSelection.collapsed(offset: 2);
             await tester.pumpWidget(buildEditableText(style: const TextStyle(fontSize: 13.0, height: 1.17)));
 
-            for (int i = 1; i < 99; i++) {
+            for (int i = 1; i <= 49; i++) {
               await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowDown));
               await tester.pump();
               expect(
@@ -1614,12 +1614,12 @@ void main() {
               );
             }
 
-            for (int i = 99; i < 1; i--) {
+            for (int i = 49; i >= 1; i--) {
               await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowUp));
               await tester.pump();
               expect(
                 controller.selection,
-                TextSelection.collapsed(offset: 2 + i * 7),
+                TextSelection.collapsed(offset: 2 + (i - 1) * 7),
                 reason: 'line $i',
               );
             }


### PR DESCRIPTION
## Description

This PR simplifies the way the vertical offset of the previous/next line is obtained when traversing text using up/down arrow keys and fixes an issue where in successive jumps, error would accumulate.

As vertical runs start at baseline of the current line, use baseline already provided in the text metrics from the TextPainter instead of translating the offset using ascents/descents. It's much shorter, fixes the accumulating error and also allows to support more complex metrics (e.g. a customised TextPainter might add some space between paragraphs which wouldn't be included in ascent/descent values).

Also use metrics baseline and line number values in _lineNumberFor().

## Testing

Added the following test in packages/flutter/test/widgets/editable_text_shortcuts_tests.dart:
```
testWidgets('long run with fractional text height', (WidgetTester tester) async {
```

The relevant tests are passing:
```
% ../../bin/flutter test test/rendering/editable_test.dart
00:04 +39: All tests passed!
% ../../bin/flutter test test/rendering/editable_gesture_test.dart
00:03 +1: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_test.dart
00:19 +209: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_show_on_screen_test.dart
00:06 +17: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_shortcuts_tests.dart
00:37 +372: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_cursor_test.dart
00:09 +25: All tests passed!
% ../../bin/flutter test test/widgets/text_selection_test.dart      
00:05 +27: All tests passed!
% ../../bin/flutter test test/widgets/selectable_text_test.dart 
00:18 +155 ~2: All tests passed!
% ../../bin/flutter test test/material/text_form_field_test.dart
00:07 +28: All tests passed!
% ../../bin/flutter test test/material/text_field_test.dart
00:37 +329: All tests passed!
% ../../bin/flutter test test/cupertino/text_field_test.dart
00:18 +122: All tests passed!
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
