### PR TITLE
Update minSdkVersion to 19 in multidex_project

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -179,7 +179,7 @@ class MultidexProject extends Project {
       defaultConfig {
           // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
           applicationId "com.example.multidextest2"
-          minSdkVersion 16
+          minSdkVersion 19
           targetSdkVersion 30
           versionCode flutterVersionCode.toInteger()
           versionName flutterVersionName


### PR DESCRIPTION
This should make the tree green again. One of the tests was failing because an external dependency (firestore) of one of the tests now requires a higher minSdk (19 instead of 16)

Fixes issue:
- https://github.com/flutter/flutter/issues/93133

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
