### PR TITLE
Add flag to use adjusted value for newIndex in onReorder callback for ReorderableList widgets

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -45,6 +45,7 @@ class ReorderableListView extends StatefulWidget {
     Key? key,
     required List<Widget> children,
     required this.onReorder,
+    this.useAdjustedOnReorderNewIndex = false,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -113,6 +114,7 @@ class ReorderableListView extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.useAdjustedOnReorderNewIndex = false,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -149,6 +151,9 @@ class ReorderableListView extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorder}
   final ReorderCallback onReorder;
+
+  /// {@macro flutter.widgets.reorderable_list.useAdjustedOnReorderNewIndex}
+  final bool useAdjustedOnReorderNewIndex;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -242,8 +247,13 @@ class ReorderableListView extends StatefulWidget {
 class _ReorderableListViewState extends State<ReorderableListView> {
   Widget _wrapWithSemantics(Widget child, int index) {
     void reorder(int startIndex, int endIndex) {
-      if (startIndex != endIndex)
+      if (startIndex == endIndex)
+        return;
+      if (!widget.useAdjustedOnReorderNewIndex || endIndex < startIndex) {
         widget.onReorder(startIndex, endIndex);
+        return;
+      }
+      widget.onReorder(startIndex, endIndex - 1);
     }
 
     // First, determine which semantics actions apply.
@@ -461,6 +471,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
             prototypeItem: widget.prototypeItem,
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
+            useAdjustedOnReorderNewIndex: widget.useAdjustedOnReorderNewIndex,
             proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
           ),
         ),

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -172,7 +172,7 @@ class ReorderableList extends StatefulWidget {
   /// An opt-in flag to use the adjusted value for new index in [onReorder].
   /// When set to true you will no longer need to subtract one from the new index
   /// if the item has been reordered to a position with a higher index.
-  /// 
+  ///
   /// See https://github.com/flutter/flutter/issues/24786 for more.
   /// {@endtemplate}
   final bool useAdjustedOnReorderNewIndex;

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -115,6 +115,7 @@ class ReorderableList extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.useAdjustedOnReorderNewIndex = false,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -166,6 +167,15 @@ class ReorderableList extends StatefulWidget {
   /// of the items.
   /// {@endtemplate}
   final ReorderCallback onReorder;
+
+  /// {@template flutter.widgets.reorderable_list.useAdjustedOnReorderNewIndex}
+  /// An opt-in flag to use the adjusted value for new index in [onReorder].
+  /// When set to true you will no longer need to subtract one from the new index
+  /// if the item has been reordered to a position with a higher index.
+  /// 
+  /// See https://github.com/flutter/flutter/issues/24786 for more.
+  /// {@endtemplate}
+  final bool useAdjustedOnReorderNewIndex;
 
   /// {@template flutter.widgets.reorderable_list.proxyDecorator}
   /// A callback that allows the app to add an animated decoration around
@@ -401,6 +411,7 @@ class SliverReorderableList extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.useAdjustedOnReorderNewIndex = false,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -419,6 +430,9 @@ class SliverReorderableList extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorder}
   final ReorderCallback onReorder;
+
+  /// {@macro flutter.widgets.reorderable_list.useAdjustedOnReorderNewIndex}
+  final bool useAdjustedOnReorderNewIndex;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -693,7 +707,16 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     final int fromIndex = _dragIndex!;
     final int toIndex = _insertIndex!;
     if (fromIndex != toIndex) {
-      widget.onReorder.call(fromIndex, toIndex);
+      if (widget.useAdjustedOnReorderNewIndex) {
+        widget.onReorder.call(
+          fromIndex,
+          toIndex > fromIndex
+            ? toIndex - 1
+            : toIndex
+        );
+      } else {
+        widget.onReorder.call(fromIndex, toIndex);
+      }
     }
     _dragReset();
   }


### PR DESCRIPTION
Adds an opt-in flag to use the adjusted value for the `newIndex` in `onReorder` for `ReorderableListView` and the underlying `SliverReorderableList`. Starting off with opt-in since this will be a breaking change (see https://github.com/flutter/flutter/pull/59103)

From gallery `reorderable_list_demo.dart`:
```dart
  void _onReorder(int oldIndex, int newIndex) {
    setState(() {
      // This part becomes unnecessary
      // if (newIndex > oldIndex) {
      //   newIndex -= 1;
      // }
      final _ListItem item = _items.removeAt(oldIndex);
      _items.insert(newIndex, item);
    });
  }
```

Starts off the breaking change to fix https://github.com/flutter/flutter/issues/24786

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat