### PR TITLE
Revert "Bump Gallery version"

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = '9eb785cb997ff56c46e933c1c591f0a6f31454f6';
+const String galleryVersion = '40b00d316fbf911788c50599a53213dc291b0627';


### PR DESCRIPTION
Reverts flutter/flutter#93173

Reverted as part of the revert of https://github.com/flutter/flutter/pull/93204