### PR TITLE
Use num on plural

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -87,7 +87,7 @@ List<String> generateMethodParameters(Message message) {
   assert(message.placeholders.isNotEmpty);
   final Placeholder? countPlaceholder = message.isPlural ? message.getCountPlaceholder() : null;
   return message.placeholders.map((Placeholder placeholder) {
-    final String? type = placeholder == countPlaceholder ? 'int' : placeholder.type;
+    final String? type = placeholder == countPlaceholder ? 'num' : placeholder.type;
     return '$type ${placeholder.name}';
   }).toList();
 }
@@ -226,7 +226,7 @@ String _generatePluralMethod(Message message, String translationForMessage) {
   }
 
   final List<String> parameters = message.placeholders.map((Placeholder placeholder) {
-    final String? placeholderType = placeholder == countPlaceholder ? 'int' : placeholder.type;
+    final String? placeholderType = placeholder == countPlaceholder ? 'num' : placeholder.type;
     return '$placeholderType ${placeholder.name}';
   }).toList();
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -2620,4 +2620,47 @@ String orderNumber(int number) {
 AppLocalizations lookupAppLocalizations(Locale locale) {
 '''));
   });
+
+  // Regression test for https://github.com/flutter/flutter/pull/93228
+  testWithoutContext('should use num type for plural', () {
+    const String arbFile = '''
+{
+  "tryToPollute": "{count, plural, =0{零} =1{一} other{其他}}",
+  "@tryToPollute": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "withoutType": "{count, plural, =0{零} =1{一} other{其他}}",
+  "@withoutType": {
+    "placeholders": {
+      "count": {}
+    }
+  }
+}''';
+
+    final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+      ..createSync(recursive: true);
+    l10nDirectory.childFile(defaultTemplateArbFileName)
+        .writeAsStringSync(arbFile);
+
+    LocalizationsGenerator(
+      fileSystem: fs,
+      inputPathString: defaultL10nPathString,
+      outputPathString: defaultL10nPathString,
+      templateArbFileName: defaultTemplateArbFileName,
+      outputFileString: defaultOutputFileString,
+      classNameString: defaultClassNameString,
+    )
+      ..loadResources()
+      ..writeOutputFiles(BufferLogger.test());
+
+    final String localizationsFile = fs.file(
+      fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
+    ).readAsStringSync();
+    expect(localizationsFile, containsIgnoringWhitespace(r'String tryToPollute(num count) {'));
+    expect(localizationsFile, containsIgnoringWhitespace(r'String withoutType(num count) {'));
+  });
 }


### PR DESCRIPTION
Using num for plural argument type. The rationale for this change is here: https://github.com/flutter/flutter/issues/93227#issuecomment-963721391

Fixes #93227

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

