### PR TITLE
Fix scroll offset when caret larger than viewport

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2147,7 +2147,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     if (!_isMultiline) {
       additionalOffset = rect.width >= editableSize.width
         // Center `rect` if it's oversized.
-        ? editableSize.width / 2 - rect.center.dx
+        ? rect.center.dx - editableSize.width / 2
         // Valid additional offsets range from (rect.right - size.width)
         // to (rect.left). Pick the closest one if out of range.
         : 0.0.clamp(rect.right - editableSize.width, rect.left);
@@ -2163,7 +2163,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       );
 
       additionalOffset = expandedRect.height >= editableSize.height
-        ? editableSize.height / 2 - expandedRect.center.dy
+        ? expandedRect.center.dy - editableSize.height / 2
         : 0.0.clamp(expandedRect.bottom - editableSize.height, expandedRect.top);
       unitOffset = const Offset(0, 1);
     }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5818,7 +5818,7 @@ void main() {
   });
 
   testWidgets('bringIntoView centers the viewport on caret when the caret is wider than the viewport', (WidgetTester tester) async {
-    const String text = 'to cóż że ze Szwecji';
+    const String text = 'to coz ze ze Szwecji';
     final TextEditingController controller = TextEditingController(text: text);
 
     await tester.pumpWidget(MaterialApp(
@@ -5831,7 +5831,7 @@ void main() {
             showSelectionHandles: true,
             controller: controller,
             focusNode: FocusNode(),
-            style: const TextStyle(fontFamily: 'Ahem', fontSize: 48.0),
+            style: const TextStyle(fontFamily: 'Ahem', fontSize: 48.0, height: 1.0),
             cursorColor: Colors.blue,
             cursorWidth: 48.0,
             backgroundCursorColor: Colors.grey,
@@ -5868,7 +5868,7 @@ void main() {
   });
 
   testWidgets('bringIntoView centers the viewport on caret when the caret is taller than the viewport', (WidgetTester tester) async {
-    const String text = 'to\ncóż\nże\nze\nSzwecji';
+    const String text = 'to\ncoz\nze\nze\nSzwecji';
     final TextEditingController controller = TextEditingController(text: text);
 
     await tester.pumpWidget(MaterialApp(
@@ -5882,7 +5882,7 @@ void main() {
             maxLines: null,
             controller: controller,
             focusNode: FocusNode(),
-            style: const TextStyle(fontFamily: 'Roboto', fontSize: 48.0),
+            style: const TextStyle(fontFamily: 'Ahem', fontSize: 48.0, height: 1.0),
             cursorColor: Colors.blue,
             backgroundCursorColor: Colors.grey,
             selectionControls: materialTextSelectionControls,

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5812,10 +5812,109 @@ void main() {
     state.bringIntoView(TextPosition(offset: controller.text.length));
 
     await tester.pumpAndSettle();
-    // The SingleChildScrollView is scrolled instead of the EditableText to
-    // reveal the caret.
+    // The SingleChildScrollView is scrolled instead of the EditableText to reveal the caret.
     expect(outerController.offset, outerController.position.maxScrollExtent);
     expect(editableScrollController.offset, 0);
+  });
+
+  testWidgets('bringIntoView centers the viewport on caret when the caret is wider than the viewport', (WidgetTester tester) async {
+    const String text = 'to cóż że ze Szwecji';
+    final TextEditingController controller = TextEditingController(text: text);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 32.0,
+          height: 100.0,
+          child: EditableText(
+            showSelectionHandles: true,
+            controller: controller,
+            focusNode: FocusNode(),
+            style: const TextStyle(fontFamily: 'Ahem', fontSize: 48.0),
+            cursorColor: Colors.blue,
+            cursorWidth: 48.0,
+            backgroundCursorColor: Colors.grey,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+          ),
+        ),
+      ),
+    ));
+
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    final RenderEditable renderEditable = state.renderEditable;
+    final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+
+    expect(scrollable.controller!.position.viewportDimension, equals(32.0));
+    expect(scrollable.controller!.offset, 0.0);
+    expect(renderEditable.maxScrollExtent, equals(977.0));
+
+    state.bringIntoView(const TextPosition(offset: 2));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 2 * 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 5));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 5 * 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 7));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 7 * 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 9));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 9 * 48.0 + 48.0 / 2 - 32.0 / 2);
+  });
+
+  testWidgets('bringIntoView centers the viewport on caret when the caret is taller than the viewport', (WidgetTester tester) async {
+    const String text = 'to\ncóż\nże\nze\nSzwecji';
+    final TextEditingController controller = TextEditingController(text: text);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 500.0,
+          height: 32.0,
+          child: EditableText(
+            showSelectionHandles: true,
+            maxLines: null,
+            controller: controller,
+            focusNode: FocusNode(),
+            style: const TextStyle(fontFamily: 'Roboto', fontSize: 48.0),
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            selectionControls: materialTextSelectionControls,
+            keyboardType: TextInputType.text,
+          ),
+        ),
+      ),
+    ));
+
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    final RenderEditable renderEditable = state.renderEditable;
+    final Scrollable scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+
+    expect(scrollable.controller!.position.viewportDimension, equals(32.0));
+    expect(scrollable.controller!.offset, 0.0);
+    expect(renderEditable.maxScrollExtent, equals(208.0));
+
+    state.bringIntoView(const TextPosition(offset: 3));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 7));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 2 * 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 10));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 3 * 48.0 + 48.0 / 2 - 32.0 / 2);
+
+    state.bringIntoView(const TextPosition(offset: 13));
+    await tester.pumpAndSettle();
+    expect(scrollable.controller!.offset, 4 * 48.0 + 48.0 / 2 - 32.0 / 2);
   });
 
   testWidgets('bringIntoView does nothing if the physics prohibits implicit scrolling', (WidgetTester tester) async {
@@ -5843,7 +5942,6 @@ void main() {
         ),
       ));
     }
-
 
     await buildWithPhysics();
     expect(scrollController.offset, 0);


### PR DESCRIPTION
## Description

This PR fixes invalid offset scrolled to when the caret is wider or taller than the viewport. This happens when:
- multiline EditableText (vertical scroll): the font size is larger than the widget size (or there's a WidgetSpan with e.g. a taller image)
- one-line EditableText (horizontal scroll): cursorWidth set to something larger than the widget's width

## Testing

Added the following test in packages/flutter/test/widgets/editable_text_test.dart:
```
  testWidgets('bringIntoView centers the viewport on caret when the caret is wider than the viewport', (WidgetTester tester) async {
  testWidgets('bringIntoView centers the viewport on caret when the caret is taller than the viewport', (WidgetTester tester) async {
```

The relevant tests are passing:
```
% ../../bin/flutter test test/rendering/editable_test.dart
00:04 +39: All tests passed!
% ../../bin/flutter test test/rendering/editable_gesture_test.dart
00:03 +1: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_test.dart
00:20 +211: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_show_on_screen_test.dart
00:06 +17: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_shortcuts_tests.dart
00:27 +366: All tests passed!
% ../../bin/flutter test test/widgets/editable_text_cursor_test.dart
00:11 +25: All tests passed!
% ../../bin/flutter test test/widgets/text_selection_test.dart
00:06 +27: All tests passed!
% ../../bin/flutter test test/widgets/selectable_text_test.dart
00:20 +155 ~2: All tests passed!
% ../../bin/flutter test test/material/text_form_field_test.dart
00:08 +28: All tests passed!
% ../../bin/flutter test test/material/text_field_test.dart
00:38 +329: All tests passed!
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
