### PR TITLE
[ci.yaml] Mark roller flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -250,6 +250,7 @@ targets:
 
   - name: Linux ci_yaml flutter roller
     recipe: infra/ci_yaml
+    bringup: true # TODO(chillers): https://github.com/flutter/flutter/issues/93225
     timeout: 30
     properties:
       tags: >


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/93225

We need to roll flutter/recipes forward to get the new compatible version from Fuchsia for auto-rolling (sets bot commit instead of CR+2)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
