### PR TITLE
Support for MaterialTapTargetSize within ToggleButtons

### DIFF
--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -1578,9 +1578,10 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
 
 /// A widget to pad the area around a [ToggleButtons]'s children.
 ///
-/// Redirect taps that occur in the padded area around the child to the center
-/// of the child. This increases the size of the widget and it's "tap target",
-/// but not its material or its ink splashes.
+/// This widget is based on a similar one using in [ButtonStyleButton] but it
+/// only redirects taps along one axis to ensure the correct button is tapped
+/// within the [ToggleButtons]. This increases the size of the widget and it's
+/// "tap target", but not its material or its ink splashes.
 class _InputPadding extends SingleChildRenderObjectWidget {
   const _InputPadding({
     Key? key,

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -717,8 +717,7 @@ class ToggleButtons extends StatelessWidget {
     switch (resolvedTapTargetSize) {
       case MaterialTapTargetSize.padded:
         return ConstrainedBox(
-          // TODO: This makes it work but constrains the max height which we don't actually want.
-          constraints: const BoxConstraints(maxHeight: kMinInteractiveDimension),
+          constraints: const BoxConstraints(),
           child: _InputPadding(
             minSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),
             child: result,

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -727,7 +727,6 @@ class ToggleButtons extends StatelessWidget {
       case MaterialTapTargetSize.shrinkWrap:
         return result;
     }
-    return result;
   }
 
   @override

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -716,13 +716,10 @@ class ToggleButtons extends StatelessWidget {
     final MaterialTapTargetSize resolvedTapTargetSize = tapTargetSize ?? theme.materialTapTargetSize;
     switch (resolvedTapTargetSize) {
       case MaterialTapTargetSize.padded:
-        return ConstrainedBox(
-          constraints: const BoxConstraints(),
-          child: _InputPadding(
-            minSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),
-            direction: direction,
-            child: result,
-          ),
+        return _InputPadding(
+          minSize: const Size(kMinInteractiveDimension, kMinInteractiveDimension),
+          direction: direction,
+          child: result,
         );
       case MaterialTapTargetSize.shrinkWrap:
         return result;
@@ -1686,8 +1683,11 @@ class _RenderInputPadding extends RenderShiftedBox {
 
   @override
   bool hitTest(BoxHitTestResult result, { required Offset position }) {
-    if (super.hitTest(result, position: position)) {
-      return true;
+    // The super.hitTest() method also checks hitTestChildren(). We don't
+    // want that in this case because we've padded around the children per
+    // tapTargetSize.
+    if (!size.contains(position)) {
+      return false;
     }
 
     // Only adjust one axis to ensure the correct button is tapped.

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -238,7 +238,7 @@ class ToggleButtons extends StatelessWidget {
   /// If the [tapTargetSize] is larger than [constraints], the buttons will
   /// include a transparent margin that responds to taps.
   ///
-  /// Always defaults to [ThemeData.materialTapTargetSize].
+  /// Defaults to [ThemeData.materialTapTargetSize].
   final MaterialTapTargetSize? tapTargetSize;
 
   /// The [TextStyle] to apply to any text in these toggle buttons.
@@ -1577,8 +1577,11 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
 ///
 /// This widget is based on a similar one using in [ButtonStyleButton] but it
 /// only redirects taps along one axis to ensure the correct button is tapped
-/// within the [ToggleButtons]. This increases the size of the widget and it's
-/// "tap target", but not its material or its ink splashes.
+/// within the [ToggleButtons].
+///
+/// This ensures that a widget takes up at least as much space as the minSize
+/// parameter to ensure adequate tap target size, while keeping the widget
+/// visually smaller to the user.
 class _InputPadding extends SingleChildRenderObjectWidget {
   const _InputPadding({
     Key? key,

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -1575,7 +1575,7 @@ class _SelectToggleButtonRenderObject extends RenderShiftedBox {
 
 /// A widget to pad the area around a [ToggleButtons]'s children.
 ///
-/// This widget is based on a similar one using in [ButtonStyleButton] but it
+/// This widget is based on a similar one used in [ButtonStyleButton] but it
 /// only redirects taps along one axis to ensure the correct button is tapped
 /// within the [ToggleButtons].
 ///
@@ -1591,7 +1591,6 @@ class _InputPadding extends SingleChildRenderObjectWidget {
   }) : super(key: key, child: child);
 
   final Size minSize;
-
   final Axis direction;
 
   @override
@@ -1602,6 +1601,7 @@ class _InputPadding extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(BuildContext context, covariant _RenderInputPadding renderObject) {
     renderObject.minSize = minSize;
+    renderObject.direction = direction;
   }
 }
 

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -1591,6 +1591,96 @@ void main() {
     },
   );
 
+  testWidgets('Tap target size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
+    Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
+      return Theme(
+        data: ThemeData(materialTapTargetSize: tapTargetSize),
+        child: Material(
+          child: boilerplate(
+            child: ToggleButtons(
+              key: key,
+              constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+              isSelected: const <bool>[false, true, false],
+              onPressed: (int index) {},
+              children: const <Widget>[
+                Text('First'),
+                Text('Second'),
+                Text('Third'),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    final Key key1 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.padded, key1));
+    expect(tester.getSize(find.byKey(key1)), const Size(228.0, 48.0));
+
+    final Key key2 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.shrinkWrap, key2));
+    expect(tester.getSize(find.byKey(key2)), const Size(228.0, 34.0));
+  });
+
+  testWidgets('Tap target size is configurable', (WidgetTester tester) async {
+    Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
+      return Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            key: key,
+            tapTargetSize: tapTargetSize,
+            constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+            isSelected: const <bool>[false, true, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('First'),
+              Text('Second'),
+              Text('Third'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final Key key1 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.padded, key1));
+    expect(tester.getSize(find.byKey(key1)), const Size(228.0, 48.0));
+
+    final Key key2 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.shrinkWrap, key2));
+    expect(tester.getSize(find.byKey(key2)), const Size(228.0, 34.0));
+  });
+
+  testWidgets('Tap target size is configurable for vertical axis', (WidgetTester tester) async {
+    Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
+      return Material(
+        child: boilerplate(
+          child: ToggleButtons(
+            key: key,
+            tapTargetSize: tapTargetSize,
+            constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+            direction: Axis.vertical,
+            isSelected: const <bool>[false, true, false],
+            onPressed: (int index) {},
+            children: const <Widget>[
+              Text('1'),
+              Text('2'),
+              Text('3'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final Key key1 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.padded, key1));
+    expect(tester.getSize(find.byKey(key1)), const Size(48.0, 100.0));
+
+    final Key key2 = UniqueKey();
+    await tester.pumpWidget(buildFrame(MaterialTapTargetSize.shrinkWrap, key2));
+    expect(tester.getSize(find.byKey(key2)), const Size(34.0, 100.0));
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/73725
   testWidgets('Border radius paint test when there is only one button', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();


### PR DESCRIPTION
This change adds a MaterialTapTargetSize param to the ToggleButtons widget (and also hooks into the ThemeData.materialTapTargetSize property) so that ToggleButtons can benefit from the same behavior as regular buttons (standard tap target size while being visibly smaller on screen).

Fixes #93249

https://user-images.githubusercontent.com/2364772/140784973-4f3c0cfe-2b40-4ba9-b0ef-d3ccd5a8840f.mov

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
