### PR TITLE
[conductor] add cleanContext

### DIFF
--- a/dev/conductor/core/lib/src/clean.dart
+++ b/dev/conductor/core/lib/src/clean.dart
@@ -49,7 +49,7 @@ class CleanCommand extends Command<void> {
       'This will abort a work in progress release.';
 
   @override
-  void run() {
+  Future<void> run() {
     final ArgResults argumentResults = argResults!;
     final File stateFile = checkouts.fileSystem.file(argumentResults[kStateOption]);
     if (!stateFile.existsSync()) {
@@ -66,7 +66,6 @@ class CleanCommand extends Command<void> {
       // Only proceed if the first character of stdin is 'y' or 'Y'
       if (response.isEmpty || response[0].toLowerCase() != 'y') {
         stdio.printStatus('Aborting clean operation.');
-        return;
       }
     }
     stdio.printStatus('Deleting persistent state file ${stateFile.path}...');
@@ -74,7 +73,7 @@ class CleanCommand extends Command<void> {
     final RunContext context = RunContext(
       stateFile: stateFile,
     );
-    context.run();
+    return context.run();
   }
 }
 
@@ -88,7 +87,7 @@ class RunContext {
 
   final File stateFile;
 
-  void run() {
-    stateFile.deleteSync();
+  Future<void> run() {
+    return stateFile.delete();
   }
 }

--- a/dev/conductor/core/lib/src/clean.dart
+++ b/dev/conductor/core/lib/src/clean.dart
@@ -53,8 +53,7 @@ class CleanCommand extends Command<void> {
     final ArgResults argumentResults = argResults!;
     final File stateFile = checkouts.fileSystem.file(argumentResults[kStateOption]);
     if (!stateFile.existsSync()) {
-      throw ConductorException(
-          'No persistent state file found at ${stateFile.path}!');
+      throw ConductorException('No persistent state file found at ${stateFile.path}!');
     }
 
     if (!(argumentResults[kYesFlag] as bool)) {
@@ -71,6 +70,25 @@ class CleanCommand extends Command<void> {
       }
     }
     stdio.printStatus('Deleting persistent state file ${stateFile.path}...');
+
+    final RunContext context = RunContext(
+      stateFile: stateFile,
+    );
+    context.run();
+  }
+}
+
+/// Context for cleaning up persistent state file.
+///
+/// This is a frontend-agnostic implementation.
+class RunContext {
+  RunContext({
+    required this.stateFile,
+  });
+
+  final File stateFile;
+
+  void run() {
     stateFile.deleteSync();
   }
 }

--- a/dev/conductor/core/test/clean_test.dart
+++ b/dev/conductor/core/test/clean_test.dart
@@ -15,6 +15,7 @@ void main() {
   group('clean command', () {
     const String flutterRoot = '/flutter';
     const String checkoutsParentDirectory = '$flutterRoot/dev/tools/';
+    const String stateFilePath = '/state-file.json';
 
     late MemoryFileSystem fileSystem;
     late FakePlatform platform;
@@ -47,24 +48,36 @@ void main() {
     });
 
     test('throws if no state file found', () async {
-      const String stateFile = '/state-file.json';
-
       await expectLater(
         () async => runner.run(<String>[
           'clean',
           '--$kStateOption',
-          stateFile,
+          stateFilePath,
           '--$kYesFlag',
         ]),
         throwsExceptionWith(
-          'No persistent state file found at $stateFile',
+          'No persistent state file found at $stateFilePath',
         ),
       );
     });
 
-    test('deletes state file', () async {
-      final File stateFile = fileSystem.file('/state-file.json');
-      stateFile.writeAsStringSync('{}');
+    test('deletes an empty state file', () async {
+      final File stateFile = fileSystem.file(stateFilePath);
+      stateFile.writeAsStringSync('');
+
+      await runner.run(<String>[
+        'clean',
+        '--$kStateOption',
+        stateFile.path,
+        '--$kYesFlag',
+      ]);
+
+      expect(stateFile.existsSync(), false);
+    });
+
+    test('deletes a state file with content', () async {
+      final File stateFile = fileSystem.file(stateFilePath);
+      stateFile.writeAsStringSync('{status: pending}');
 
       await runner.run(<String>[
         'clean',


### PR DESCRIPTION
*Refactored `clearn.dart` to support the frontend calling `RunContext`*

*[Issue](https://github.com/flutter/flutter/issues/91119)*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
