### PR TITLE
Mark web_canvaskit_tests_5 as flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1289,6 +1289,7 @@ targets:
       - bin/
 
   - name: Linux web_canvaskit_tests_5
+    bringup: true # https://github.com/flutter/flutter/issues/93226
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Task `Linux web_canvaskit_tests_5` has been failing consistently, and caused tree red.

Examples:
https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20web_canvaskit_tests_5/143/overview
https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20web_canvaskit_tests_5/142/overview

Related: https://github.com/flutter/flutter/issues/93263