### PR TITLE
Force the color used by WidgetApp's Title to be fully opaque.

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1631,7 +1631,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
           assert(title != null, 'onGenerateTitle must return a non-null String');
           return Title(
             title: title,
-            color: widget.color,
+            color: widget.color.withOpacity(1.0),
             child: result,
           );
         },
@@ -1639,7 +1639,7 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     } else {
       title = Title(
         title: widget.title,
-        color: widget.color,
+        color: widget.color.withOpacity(1.0),
         child: result,
       );
     }

--- a/packages/flutter/test/widgets/app_title_test.dart
+++ b/packages/flutter/test/widgets/app_title_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 const Color kTitleColor = Color(0xFF333333);
 const String kTitleString = 'Hello World';
 
-Future<void> pumpApp(WidgetTester tester, { GenerateAppTitle? onGenerateTitle }) async {
+Future<void> pumpApp(WidgetTester tester, { GenerateAppTitle? onGenerateTitle, Color? color }) async {
   await tester.pumpWidget(
     WidgetsApp(
       supportedLocales: const <Locale>[
@@ -16,7 +16,7 @@ Future<void> pumpApp(WidgetTester tester, { GenerateAppTitle? onGenerateTitle })
         Locale('en', 'GB'),
       ],
       title: kTitleString,
-      color: kTitleColor,
+      color: color ?? kTitleColor,
       onGenerateTitle: onGenerateTitle,
       onGenerateRoute: (RouteSettings settings) {
         return PageRouteBuilder<void>(
@@ -34,6 +34,15 @@ void main() {
     await pumpApp(tester);
     expect(tester.widget<Title>(find.byType(Title)).title, kTitleString);
     expect(tester.widget<Title>(find.byType(Title)).color, kTitleColor);
+  });
+
+  testWidgets('Specified color is made opaque for Title', (WidgetTester tester) async {
+    // The Title widget can only handle fully opaque colors, the WidgetApp should
+    // ensure it only uses a fully opaque version of its color for the title.
+    const Color transparentBlue = Color(0xDD0000ff);
+    const Color opaqueBlue = Color(0xFF0000ff);
+    await pumpApp(tester, color: transparentBlue);
+    expect(tester.widget<Title>(find.byType(Title)).color, opaqueBlue);
   });
 
   testWidgets('onGenerateTitle handles changing locales', (WidgetTester tester) async {


### PR DESCRIPTION
There is a requirement on the `Title` widget that the color specified is fully opaque. However, the `WidgetApp` will try to use a color that may be transparent for its title widget. This PR makes the color used by WidgetApp for the Title to be fully opaque.

Fixes: #93052

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
