### PR TITLE
[web] exclude bitrotten context_menu_action_test.dart from CanvasKit shard

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -132,6 +132,7 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
     'test/widgets/html_element_view_test.dart',
     'test/cupertino/scaffold_test.dart',
     'test/rendering/platform_view_test.dart',
+    'test/cupertino/context_menu_action_test.dart',
   ],
 };
 


### PR DESCRIPTION
It seems this test has bitrotten while waiting for the `bringup: true` flag to be flipped. Temporarily adding it to the list of known failing tests to fix the red tree.
