### PR TITLE
Add Border customization to CheckboxListTile (reprise)

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -301,8 +301,9 @@ class Checkbox extends StatefulWidget {
   /// compatibility.
   /// {@endtemplate}
   ///
-  /// If this property is null then [CheckboxThemeData.side] of [ThemeData.checkboxTheme]
-  /// is used. If that's null then the side will be width 2.
+  /// If this property is null, then [CheckboxThemeData.side] of
+  /// [ThemeData.checkboxTheme] is used. If that is also null, then the side
+  /// will be width 2.
   final BorderSide? side;
 
   /// The width of a checkbox widget.

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -138,6 +138,7 @@ class CheckboxListTile extends StatelessWidget {
     this.tristate = false,
     this.shape,
     this.selectedTileColor,
+    this.side,
     this.visualDensity,
     this.focusNode,
     this.enableFeedback,
@@ -258,6 +259,15 @@ class CheckboxListTile extends StatelessWidget {
   /// If non-null, defines the background color when [CheckboxListTile.selected] is true.
   final Color? selectedTileColor;
 
+  /// {@macro flutter.material.checkbox.side}
+  ///
+  /// The given value is passed directly to [Checkbox.side].
+  ///
+  /// If this property is null, then [CheckboxThemeData.side] of
+  /// [ThemeData.checkboxTheme] is used. If that is also null, then the side
+  /// will be width 2.
+  final BorderSide? side;
+
   /// Defines how compact the list tile's layout will be.
   ///
   /// {@macro flutter.material.themedata.visualDensity}
@@ -298,6 +308,7 @@ class CheckboxListTile extends StatelessWidget {
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       autofocus: autofocus,
       tristate: tristate,
+      side: side,
     );
     Widget? leading, trailing;
     switch (controlAffinity) {

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -321,6 +321,45 @@ void main() {
     expect(textColor('title'), activeColor);
   });
 
+  testWidgets('CheckboxListTile respects checkbox side', (WidgetTester tester) async {
+    Widget buildApp(BorderSide side) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return CheckboxListTile(
+                value: false,
+                onChanged: (bool? newValue) {},
+                side: side,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    const BorderSide side1 = BorderSide(
+      color: Color(0xfff44336),
+    );
+    await tester.pumpWidget(buildApp(side1));
+    expect(tester.widget<CheckboxListTile>(find.byType(CheckboxListTile)).side, side1);
+    expect(tester.widget<Checkbox>(find.byType(Checkbox)).side, side1);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+      ..drrect(color: const Color(0xfff44336)),
+    );
+    const BorderSide side2 = BorderSide(
+      color: Color(0xff424242),
+    );
+    await tester.pumpWidget(buildApp(side2));
+    expect(tester.widget<Checkbox>(find.byType(Checkbox)).side, side2);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+      ..drrect(color: const Color(0xff424242)),
+    );
+  });
+
   testWidgets('CheckboxListTile respects visualDensity', (WidgetTester tester) async {
     const Key key = Key('test');
     Future<void> buildTest(VisualDensity visualDensity) async {


### PR DESCRIPTION
This adds the ability to customize the border of a Checkbox in a CheckboxListTile by passing the side parameter.

Fixes #53420

This is just an existing, approved PR, https://github.com/flutter/flutter/pull/89023, which seemed to be having merge trouble. 

The author is https://github.com/creativecreatorormaybenot



