### PR TITLE
Revert "mark flaky (#93266)"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1289,7 +1289,6 @@ targets:
       - bin/
 
   - name: Linux web_canvaskit_tests_5
-    bringup: true # https://github.com/flutter/flutter/issues/93226
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
This reverts commit d6dd2fa78d1f232aeee1cc36eb241fce576a97c2.

This shard is no longer failing. The breakage was fixed in https://github.com/flutter/flutter/pull/93268.
