### PR TITLE
[web] lock Chromium CIPD package version to Chrome 96

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -84,7 +84,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       os: Mac-10.15
@@ -167,7 +167,7 @@ platform_properties:
           [
             {"dependency": "android_sdk", "version": "version:29.0"},
             {"dependency": "certs"},
-            {"dependency": "chrome_and_driver", "version": "version:84"},
+            {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
             {"dependency": "open_jdk"}
           ]
       os: Windows-10
@@ -196,7 +196,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -215,7 +215,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "clang"},
@@ -235,7 +235,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "clang"},
@@ -468,7 +468,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -490,7 +490,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -512,7 +512,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -534,7 +534,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -556,7 +556,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -578,7 +578,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -601,7 +601,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -624,7 +624,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -647,7 +647,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -670,7 +670,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -713,7 +713,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -740,7 +740,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -765,7 +765,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -790,7 +790,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -815,7 +815,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -886,7 +886,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -904,7 +904,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"}
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
         ]
       tags: >
         ["devicelab"]
@@ -922,7 +922,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -943,7 +943,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -964,7 +964,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -985,7 +985,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -1006,7 +1006,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -1027,7 +1027,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1048,7 +1048,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1069,7 +1069,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1090,7 +1090,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1111,7 +1111,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1132,7 +1132,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1153,7 +1153,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1174,7 +1174,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1195,7 +1195,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1215,7 +1215,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1235,7 +1235,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1255,7 +1255,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1275,7 +1275,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1295,7 +1295,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1315,7 +1315,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1335,7 +1335,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1355,7 +1355,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -1920,7 +1920,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1940,7 +1940,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1960,7 +1960,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1980,7 +1980,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2387,7 +2387,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2412,7 +2412,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2437,7 +2437,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2462,7 +2462,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2541,7 +2541,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "goldctl"}
@@ -3478,7 +3478,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3499,7 +3499,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3518,7 +3518,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3537,7 +3537,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3649,7 +3649,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3673,7 +3673,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3692,7 +3692,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3729,7 +3729,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3753,7 +3753,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3777,7 +3777,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3801,7 +3801,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3825,7 +3825,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3846,7 +3846,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3870,7 +3870,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3894,7 +3894,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3918,7 +3918,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3942,7 +3942,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -4007,7 +4007,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -84,7 +84,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       os: Mac-10.15
@@ -167,7 +167,7 @@ platform_properties:
           [
             {"dependency": "android_sdk", "version": "version:29.0"},
             {"dependency": "certs"},
-            {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+            {"dependency": "chrome_and_driver", "version": "927388"},
             {"dependency": "open_jdk"}
           ]
       os: Windows-10
@@ -196,7 +196,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -215,7 +215,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "clang"},
@@ -235,7 +235,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "clang"},
@@ -468,7 +468,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -490,7 +490,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -512,7 +512,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -534,7 +534,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -556,7 +556,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -578,7 +578,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -601,7 +601,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -624,7 +624,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -647,7 +647,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -670,7 +670,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -713,7 +713,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -740,7 +740,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -765,7 +765,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -790,7 +790,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -815,7 +815,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "clang"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
@@ -886,7 +886,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -904,7 +904,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"}
+          {"dependency": "chrome_and_driver", "version": "927388"}
         ]
       tags: >
         ["devicelab"]
@@ -922,7 +922,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -943,7 +943,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -964,7 +964,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -985,7 +985,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -1006,7 +1006,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_long_running_tests
@@ -1027,7 +1027,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1048,7 +1048,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1069,7 +1069,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1090,7 +1090,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1111,7 +1111,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1132,7 +1132,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1153,7 +1153,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1174,7 +1174,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_tests
@@ -1195,7 +1195,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1215,7 +1215,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1235,7 +1235,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1255,7 +1255,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1275,7 +1275,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1295,7 +1295,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1315,7 +1315,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1335,7 +1335,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "goldctl"}
         ]
       shard: web_canvaskit_tests
@@ -1355,7 +1355,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
@@ -1920,7 +1920,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1940,7 +1940,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1960,7 +1960,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1980,7 +1980,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2387,7 +2387,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2412,7 +2412,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2437,7 +2437,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2462,7 +2462,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2541,7 +2541,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "goldctl"}
@@ -3478,7 +3478,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3499,7 +3499,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3518,7 +3518,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3537,7 +3537,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3649,7 +3649,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3673,7 +3673,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3692,7 +3692,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3729,7 +3729,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3753,7 +3753,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3777,7 +3777,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3801,7 +3801,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3825,7 +3825,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3846,7 +3846,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3870,7 +3870,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3894,7 +3894,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3918,7 +3918,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3942,7 +3942,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -4007,7 +4007,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "kkOzlCHhXTi3TpU7miUzqSOCVa_2RJVb09kfze0a6z0C"},
+          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -84,7 +84,6 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       os: Mac-10.15
@@ -167,7 +166,6 @@ platform_properties:
           [
             {"dependency": "android_sdk", "version": "version:29.0"},
             {"dependency": "certs"},
-            {"dependency": "chrome_and_driver", "version": "927388"},
             {"dependency": "open_jdk"}
           ]
       os: Windows-10
@@ -1920,7 +1918,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1940,7 +1937,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1960,7 +1956,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -1980,7 +1975,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2387,7 +2381,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2412,7 +2405,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2437,7 +2429,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2462,7 +2453,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "gems"},
@@ -2541,7 +2531,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"},
           {"dependency": "goldctl"}
@@ -3478,7 +3467,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3499,7 +3487,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3518,7 +3505,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3537,7 +3523,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3649,7 +3634,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3673,7 +3657,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3692,7 +3675,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3729,7 +3711,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3753,7 +3734,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3777,7 +3757,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3801,7 +3780,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3825,7 +3803,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"}
         ]
       tags: >
@@ -3846,7 +3823,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3870,7 +3846,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3894,7 +3869,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3918,7 +3892,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -3942,7 +3915,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
           {"dependency": "open_jdk"},
           {"dependency": "goldctl"},
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -4006,9 +3978,6 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "927388"},
-          {"dependency": "open_jdk"},
           {"dependency": "goldctl"}
         ]
       shard: web_tool_tests


### PR DESCRIPTION
Update test Chromium version to the CIPD package corresponding to Chromium 96. Add Chromium versions in some dependencies that didn't specify it.