### PR TITLE
Use adb variable instead of direct command

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -39,14 +39,15 @@ while read LOGLINE
 do
     if [[ "${LOGLINE}" == *"Running deferred code"* ]]; then
         echo "Found ${LOGLINE}"
-        pkill -P $$
         echo "All tests passed."
+        pkill -P $$
         exit 0
     fi
     # Timeout if expected log not found
     current_time=$(date +%s)
     if [[ $((current_time - script_start_time_seconds)) -ge 150 ]]; then
         echo "Failure: Deferred component did not load."
+        pkill -P $$
         exit 1
     fi
 done < <($adb_path logcat -T "$script_start_time")

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -49,7 +49,7 @@ do
         echo "Failure: Deferred component did not load."
         exit 1
     fi
-done < <(adb logcat -T "$script_start_time")
+done < <($adb_path logcat -T "$script_start_time")
 
 echo "Failure: Deferred component did not load."
 exit 1


### PR DESCRIPTION
Follow up/fix to https://github.com/flutter/flutter/pull/93080 as it made the test go red: https://ci.chromium.org/p/flutter/builders/staging/Linux%20deferred%20components

The test script depends on a passed in adb command parameter due to needing specific versions of adb to function.

This uses the variable instead of the direct command.