### PR TITLE
Track timeout from app run start in deferred components integration test

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -37,7 +37,6 @@ exit
 run_start_time_seconds=$(date +%s)
 while read LOGLINE
 do
-    echo LOGLINE
     if [[ "${LOGLINE}" == *"Running deferred code"* ]]; then
         echo "Found ${LOGLINE}"
         echo "All tests passed."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -46,7 +46,7 @@ do
     # Timeout if expected log not found
     current_time=$(date +%s)
     if [[ $((current_time - script_start_time_seconds)) -ge 150 ]]; then
-        echo "Failure: Deferred component did not load."
+        echo "Failure: Timed out, deferred component did not load."
         pkill -P $$
         exit 1
     fi

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -37,6 +37,7 @@ exit
 "
 while read LOGLINE
 do
+    echo LOGLINE
     if [[ "${LOGLINE}" == *"Running deferred code"* ]]; then
         echo "Found ${LOGLINE}"
         echo "All tests passed."

--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -19,7 +19,6 @@ adb_path=$2
 
 # Store the time to prevent capturing logs from previous runs.
 script_start_time=$($adb_path shell 'date +"%m-%d %H:%M:%S.0"')
-script_start_time_seconds=$(date +%s)
 
 $adb_path uninstall "io.flutter.integration.deferred_components_test"
 
@@ -35,6 +34,7 @@ $adb_path shell "
 am start -n io.flutter.integration.deferred_components_test/.MainActivity
 exit
 "
+run_start_time_seconds=$(date +%s)
 while read LOGLINE
 do
     echo LOGLINE
@@ -46,7 +46,7 @@ do
     fi
     # Timeout if expected log not found
     current_time=$(date +%s)
-    if [[ $((current_time - script_start_time_seconds)) -ge 150 ]]; then
+    if [[ $((current_time - run_start_time_seconds)) -ge 150 ]]; then
         echo "Failure: Timed out, deferred component did not load."
         pkill -P $$
         exit 1


### PR DESCRIPTION
In CI, the build takes significantly longer, so we need to track the timeout from after the app is started to make sure varying build times do not cause flakes.

Confirmed to pass on a real CI run: 

https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/36d27fa4f528ff05b17cab5fdcf353e37b0436fdccd824759e2b04e956d6dedf/+/build.proto?server=chromium-swarm.appspot.com

https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/garyq_google.com/7d92bdebb4be50cf19ca5cef217fc7ae69b48f2caf35145056be54bd0369c7c0/+/build.proto?server=chromium-swarm.appspot.com