### PR TITLE
Replaced the reference to `primaryVariant` in code example.

### DIFF
--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -39,8 +39,8 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    final Color oddItemColor = colorScheme.primary.withOpacity(0.05);
-    final Color evenItemColor = colorScheme.primaryVariant.withOpacity(0.15);
+    final Color oddItemColor = colorScheme.secondary.withOpacity(0.05);
+    final Color evenItemColor = colorScheme.secondary.withOpacity(0.15);
     final Color draggableItemColor = colorScheme.secondary;
 
     Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {


### PR DESCRIPTION
As part of the preparation to switching over to the new [M3 ColorScheme](https://github.com/flutter/flutter/issues/89852), we are removing any usage of the soon to be deprecated colors from the framework. A reference to `primaryVariant` snuck into a new ReorderableListView example. This replaces it with a reference `secondary`.
