### PR TITLE
Ignore upcoming warning for unnecessary override

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -346,6 +346,7 @@ class FlutterPlatform extends PlatformPlugin {
   }
 
   @override
+  // ignore: override_on_non_overriding_member
   StreamChannel<dynamic> loadChannel(String path, SuitePlatform platform) {
     if (_testCount > 0) {
       // Fail if there will be a port conflict.

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -485,6 +485,7 @@ class FlutterWebPlatform extends PlatformPlugin {
   }
 
   @override
+  // ignore: override_on_non_overriding_member
   StreamChannel<dynamic> loadChannel(String path, SuitePlatform platform) =>
       throw UnimplementedError();
 


### PR DESCRIPTION
See https://github.com/dart-lang/test/pull/1631

This method will be removed from the `PlatformPlugin` interface, which
means that the override annotations will surface diagnostics. This will
not impact flutter externally until the version of `test_core` that is
pinned is updated, however it does impact internal users where this code
will be used with the latest `test_core` before it is rolled here.

Preemptively ignore the diagnostic that will surface when this code is
used with the upcoming version of `PlatformPlugin` to allow a non-atomic
roll. The ignores and annotations will be removed once `test_core` has
been published and can be rolled to the flutter repo.