### PR TITLE
Allow full locale to be generated from .arb files and remove `@@locale` matching .arb file name requirement

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1151,7 +1151,6 @@ class LocalizationsGenerator {
   String _generateCode() {
     bool isBaseClassLocale(LocaleInfo locale, String language) {
       return locale.languageCode == language
-          && locale.countryCode == null
           && locale.scriptCode == null;
     }
 

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -466,20 +466,8 @@ class AppResourceBundle {
             // If @@locale was not defined, use the filename locale suffix.
             localeString = parserLocaleString;
           } else {
-            // If the localeString was defined in @@locale and in the filename, verify to
-            // see if the parsed locale matches, throw an error if it does not. This
-            // prevents developers from confusing issues when both @@locale and
-            // "_{locale}" is specified in the filename.
-            if (localeString != parserLocaleString) {
-              throw L10nException(
-                'The locale specified in @@locale and the arb filename do not match. \n'
-                'Please make sure that they match, since this prevents any confusion \n'
-                'with which locale to use. Otherwise, specify the locale in either the \n'
-                'filename of the @@locale key only.\n'
-                'Current @@locale value: $localeString\n'
-                'Current filename extension: $parserLocaleString'
-              );
-            }
+            final Locale? parseLocale = Locale.tryParse(localeString);
+            localeString = parseLocale.toString().replaceAll('-', '_');
           }
           break;
         }
@@ -538,22 +526,6 @@ class AppResourceBundleCollection {
         languageToLocales[bundle.locale.languageCode]!.add(bundle.locale);
       }
     }
-
-    languageToLocales.forEach((String language, List<LocaleInfo> listOfCorrespondingLocales) {
-      final List<String> localeStrings = listOfCorrespondingLocales.map((LocaleInfo locale) {
-        return locale.toString();
-      }).toList();
-      if (!localeStrings.contains(language)) {
-        throw L10nException(
-          'Arb file for a fallback, $language, does not exist, even though \n'
-          'the following locale(s) exist: $listOfCorrespondingLocales. \n'
-          'When locales specify a script code or country code, a \n'
-          'base locale (without the script code or country code) should \n'
-          'exist as the fallback. Please create a {fileName}_$language.arb \n'
-          'file.'
-        );
-      }
-    });
 
     return AppResourceBundleCollection._(directory, localeToBundle, languageToLocales);
   }

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1014,51 +1014,6 @@ flutter:
       expect(generator.supportedLocales.contains(LocaleInfo.fromString('zh')), true);
     });
 
-    testWithoutContext('correctly requires @@locale property in arb file to match the filename locale suffix', () {
-      const String arbFileWithEnLocale = '''
-{
-  "@@locale": "en",
-  "title": "Stocks",
-  "@title": {
-    "description": "Title for the Stocks application"
-  }
-}''';
-
-      const String arbFileWithZhLocale = '''
-{
-  "@@locale": "zh",
-  "title": "标题",
-  "@title": {
-    "description": "Title for the Stocks application"
-  }
-}''';
-
-      final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
-        ..createSync(recursive: true);
-      l10nDirectory.childFile('app_es.arb')
-        .writeAsStringSync(arbFileWithEnLocale);
-      l10nDirectory.childFile('app_am.arb')
-        .writeAsStringSync(arbFileWithZhLocale);
-
-      expect(
-        () {
-          LocalizationsGenerator(
-            fileSystem: fs,
-            inputPathString: defaultL10nPathString,
-            outputPathString: defaultL10nPathString,
-            templateArbFileName: 'app_es.arb',
-            outputFileString: defaultOutputFileString,
-            classNameString: defaultClassNameString,
-          ).loadResources();
-        },
-        throwsA(isA<L10nException>().having(
-          (L10nException e) => e.message,
-          'message',
-          contains('The locale specified in @@locale and the arb filename do not match.'),
-        )),
-      );
-    });
-
     testWithoutContext("throws when arb file's locale could not be determined", () {
       fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
         ..createSync(recursive: true)
@@ -1117,30 +1072,6 @@ flutter:
       );
     });
 
-    testWithoutContext('throws when the base locale does not exist', () {
-      final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
-        ..createSync(recursive: true);
-      l10nDirectory.childFile('app_en_US.arb')
-        .writeAsStringSync(singleMessageArbFileString);
-
-      expect(
-        () {
-          LocalizationsGenerator(
-            fileSystem: fs,
-            inputPathString: defaultL10nPathString,
-            outputPathString: defaultL10nPathString,
-            templateArbFileName: 'app_en_US.arb',
-            outputFileString: defaultOutputFileString,
-            classNameString: defaultClassNameString,
-          ).loadResources();
-        },
-        throwsA(isA<L10nException>().having(
-          (L10nException e) => e.message,
-          'message',
-          contains('Arb file for a fallback, en, does not exist'),
-        )),
-      );
-    });
   });
 
   group('writeOutputFiles', () {
@@ -1262,7 +1193,7 @@ flutter:
   /// **'The price of this item is: \${price}'**'''));
     });
 
-    testWithoutContext('should generate a file per language', () {
+    testWithoutContext('should generate a file per arb', () {
       const String singleEnCaMessageArbFileString = '''
 {
   "title": "Canadian Title"
@@ -1283,13 +1214,8 @@ flutter:
         ..writeOutputFiles(BufferLogger.test());
 
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart')), true);
+      expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en_CA.dart')), true);
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en_US.dart')), false);
-
-      final String englishLocalizationsFile = fs.file(
-        fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart')
-      ).readAsStringSync();
-      expect(englishLocalizationsFile, contains('class AppLocalizationsEnCa extends AppLocalizationsEn'));
-      expect(englishLocalizationsFile, contains('class AppLocalizationsEn extends AppLocalizations'));
     });
 
     testWithoutContext('language imports are sorted when preferredSupportedLocaleString is given', () {


### PR DESCRIPTION
Here removed remove `@@locale` matching .arb file name requirement as per request in https://github.com/flutter/flutter/issues/92731 
and allow full locale files to be generated to avoid creating a fallback class.

- Remove   `@@locale` matching .arb file name requirement test  and base locale test 
- Updated the test where one file will be generated for each language (which is now generated for each .arb)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
