### PR TITLE
Use kDebugMode in error_widget.0.dart example

### DIFF
--- a/examples/api/lib/widgets/framework/error_widget.0.dart
+++ b/examples/api/lib/widgets/framework/error_widget.0.dart
@@ -5,20 +5,14 @@
 // Flutter code sample for ErrorWidget
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 void main() {
   // Set the ErrorWidget's builder before the app is started.
   ErrorWidget.builder = (FlutterErrorDetails details) {
-    // This is how to tell if you're in debug mode: Assertions are only executed in
-    // debug mode.
-    bool inDebug = false;
-    assert(() {
-      inDebug = true;
-      return true;
-    }());
     // If we're in debug mode, use the normal error widget which shows the error
     // message:
-    if (inDebug) {
+    if (kDebugMode) {
       return ErrorWidget(details.exception);
     }
     // In release builds, show a yellow-on-blue message instead:

--- a/examples/api/lib/widgets/framework/error_widget.0.dart
+++ b/examples/api/lib/widgets/framework/error_widget.0.dart
@@ -4,8 +4,8 @@
 
 // Flutter code sample for ErrorWidget
 
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   // Set the ErrorWidget's builder before the app is started.


### PR DESCRIPTION
Fixes #97479

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
 
