### PR TITLE
Disable pause-on-exceptions for (outgoing) isolates during hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -603,14 +603,19 @@ class HotRunner extends ResidentRunner {
             // are not thread-safe, and thus must be run on the same thread that
             // would be blocked by the pause. Simply un-pausing is not sufficient,
             // because this does not prevent the isolate from immediately hitting
-            // a breakpoint, for example if the breakpoint was placed in a loop
-            // or in a frequently called method. Instead, all breakpoints are first
-            // disabled and then the isolate resumed.
-            final List<Future<void>> breakpointRemoval = <Future<void>>[
+            // a breakpoint (for example if the breakpoint was placed in a loop
+            // or in a frequently called method) or an exception. Instead, all
+            // breakpoints are first disabled and exception pause mode set to
+            // None, and then the isolate resumed.
+            // These settings to not need restoring as Hot Restart results in
+            // new isolates, which will be configured by the editor as they are
+            // started.
+            final List<Future<void>> breakpointAndExceptionRemoval = <Future<void>>[
+              device.vmService.service.setExceptionPauseMode(isolate.id, 'None'),
               for (final vm_service.Breakpoint breakpoint in isolate.breakpoints)
                 device.vmService.service.removeBreakpoint(isolate.id, breakpoint.id)
             ];
-            await Future.wait(breakpointRemoval);
+            await Future.wait(breakpointAndExceptionRemoval);
             await device.vmService.service.resume(view.uiIsolate.id);
           }
         }));

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -906,7 +906,7 @@ void main() {
     Usage: () => TestUsage(),
   }));
 
-  testUsingContext('ResidentRunner can remove breakpoints from paused isolate during hot restart', () => testbed.run(() async {
+  testUsingContext('ResidentRunner can remove breakpoints and exception-pause-mode from paused isolate during hot restart', () => testbed.run(() async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
       listViews,
       listViews,
@@ -921,6 +921,13 @@ void main() {
       FakeVmServiceRequest(
         method: 'getVM',
         jsonResponse: vm_service.VM.parse(<String, Object>{}).toJson(),
+      ),
+      const FakeVmServiceRequest(
+        method: 'setExceptionPauseMode',
+        args: <String, String>{
+          'isolateId': '1',
+          'mode': 'None',
+        }
       ),
       const FakeVmServiceRequest(
         method: 'removeBreakpoint',

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -187,6 +187,28 @@ void main() {
 
     await dap.client.terminate();
   });
+
+  testWithoutContext('can hot restart when exceptions occur on outgoing isolates', () async {
+    final BasicProjectThatThrows _project = BasicProjectThatThrows();
+    await _project.setUpIn(tempDir);
+
+    // Launch the app and wait for it to stop at an exception.
+    await Future.wait(<Future<Object>>[
+      dap.client.event('stopped'),
+      dap.client.start(
+        exceptionPauseMode: 'All', // Ensure we stop on all exceptions
+        launch: () => dap.client.launch(
+          cwd: _project.dir.path,
+          toolArgs: <String>['-d', 'flutter-tester'],
+        ),
+      ),
+    ], eagerError: true);
+
+    // Ensure hot restart fully completes.
+    await dap.client.hotRestart();
+
+    await dap.client.terminate();
+  });
 }
 
 /// Extracts the output from a set of [OutputEventBody], removing any

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -56,6 +56,10 @@ class DapTestClient {
   Stream<OutputEventBody> get outputEvents => events('output')
       .map((Event e) => OutputEventBody.fromJson(e.body! as Map<String, Object?>));
 
+  /// Returns a stream of [StoppedEventBody] events.
+  Stream<StoppedEventBody> get stoppedEvents => events('stopped')
+      .map((Event e) => StoppedEventBody.fromJson(e.body! as Map<String, Object?>));
+
   /// Returns a stream of the string output from [OutputEventBody] events.
   Stream<String> get output => outputEvents.map((OutputEventBody output) => output.output);
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -202,7 +202,7 @@ class DapTestClient {
       } else {
         completer.completeError(message);
       }
-    } else if (message is Event) {
+    } else if (message is Event && !_eventController.isClosed) {
       _eventController.add(message);
 
       // When we see a terminated event, close the event stream so if any

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -172,10 +172,11 @@ class DapTestClient {
   Future<void> start({
     String? program,
     String? cwd,
+    String exceptionPauseMode = 'None',
     Future<Object?> Function()? launch,
   }) {
     return Future.wait(<Future<Object?>>[
-      initialize(),
+      initialize(exceptionPauseMode: exceptionPauseMode),
       launch?.call() ?? this.launch(program: program, cwd: cwd),
     ], eagerError: true);
   }

--- a/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
@@ -53,6 +53,68 @@ class BasicProject extends Project {
   int get topLevelFunctionBreakpointLine => lineContaining(main, '// TOP LEVEL BREAKPOINT');
 }
 
+/// A project that throws multiple exceptions during Widget builds.
+///
+/// A repro for the issue at https://github.com/Dart-Code/Dart-Code/issues/3448
+/// where Hot Restart could become stuck on exceptions and never complete.
+class BasicProjectThatThrows extends Project {
+
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: ">=2.12.0-0 <3.0.0"
+
+  dependencies:
+    flutter:
+      sdk: flutter
+  ''';
+
+  @override
+  final String main = r'''
+  import 'package:flutter/material.dart';
+
+  void a() {
+    throw Exception('a');
+  }
+
+  void b() {
+    try {
+      a();
+    } catch (e) {
+      throw Exception('b');
+    }
+  }
+
+  void c() {
+    try {
+      b();
+    } catch (e) {
+      throw Exception('c');
+    }
+  }
+
+  void main() {
+    runApp(App());
+  }
+
+  class App extends StatelessWidget {
+    @override
+    Widget build(BuildContext context) {
+      c();
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        title: 'Study Flutter',
+        theme: ThemeData(
+          primarySwatch: Colors.green,
+        ),
+        home: Container(),
+      );
+    }
+  }
+  ''';
+}
+
 class BasicProjectWithTimelineTraces extends Project {
   @override
   final String pubspec = '''


### PR DESCRIPTION
This is a (proper) fix for https://github.com/Dart-Code/Dart-Code/issues/3448. The issue is that during a hot restart, all existing isolates must exit. There was existing code to resume them, and remove all breakpoints (so they don't get stuck), however they were still able to pause on exceptions if the user had enabled this.

This change removes the pause-on-exception behaviour in addition to the breakpoints. A previous fix for this was implemented in Dart-Code's DAP, but that was VS Code-specific, and VS Code will soon move to the Flutter SDK DAP so it needed either reproducing in the DAP or here (here makes more sense because it's the same issue as breakpoints, and the DAP base classes don't currently expose a way to set this only for specific isolates).

This is safe to do because editors need to set this flag per-isolate anyway, so when these isolates disappear and new ones are created, the editors will already re-send this setting.

Fixes https://github.com/Dart-Code/Dart-Code/issues/3448.
Fixes https://github.com/Dart-Code/Dart-Code/issues/3631.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
