### PR TITLE
Added Material 3 colors to ColorScheme.

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/app.dart
@@ -112,9 +112,7 @@ TextTheme _buildShrineTextTheme(TextTheme base) {
 
 const ColorScheme kShrineColorScheme = ColorScheme(
   primary: kShrinePink100,
-  primaryVariant: kShrineBrown900,
   secondary: kShrinePink50,
-  secondaryVariant: kShrineBrown900,
   surface: kShrineSurfaceWhite,
   background: kShrineBackgroundWhite,
   error: kShrineErrorRed,

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -14,6 +14,106 @@
 
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'light'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'dark'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'highContrastLight'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: 'highContrastDark'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Remove 'primaryVariant' and 'secondaryVariant'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'removeParameter'
+        name: 'primaryVariant'
+      - kind: 'removeParameter'
+        name: 'secondaryVariant'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Migrate 'primaryVariant' to 'primaryContainer'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      getter: 'primaryVariant'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'rename'
+        newName: 'primaryContainer'
+
+  # Changes made in https://github.com/flutter/flutter/pull/93427
+  - title: "Migrate 'secondaryVariant' to 'secondaryContainer'"
+    date: 2021-11-19
+    element:
+      uris: [ 'material.dart' ]
+      getter: 'secondaryVariant'
+      inClass: 'ColorScheme'
+    changes:
+      - kind: 'rename'
+        newName: 'secondaryContainer'
+
   # Changes made in https://github.com/flutter/flutter/pull/93396
   - title: "Remove 'primaryColorBrightness'"
     date: 2021-11-11

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -8,8 +8,8 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'theme_data.dart';
 
-/// A set of twelve colors based on the
-/// [Material spec](https://material.io/design/color/the-color-system.html)
+/// A set of colors based on the
+/// [Material spec](https://m3.material.io/styles/color/the-color-system/key-colors-tones)
 /// that can be used to configure the color properties of most components.
 ///
 /// The [Theme] has a color scheme, [ThemeData.colorScheme], which is constructed
@@ -19,15 +19,32 @@ class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance.
   const ColorScheme({
     required this.primary,
-    required this.secondary,
-    required this.surface,
-    required this.background,
-    required this.error,
     required this.onPrimary,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    required this.secondary,
     required this.onSecondary,
-    required this.onSurface,
-    required this.onBackground,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    required this.error,
     required this.onError,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    required this.background,
+    required this.onBackground,
+    required this.surface,
+    required this.onSurface,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     required this.brightness,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -50,6 +67,23 @@ class ColorScheme with Diagnosticable {
        assert(onBackground != null),
        assert(onError != null),
        assert(brightness != null),
+       _primaryContainer = primaryContainer,
+       _onPrimaryContainer = onPrimaryContainer,
+       _secondaryContainer = secondaryContainer,
+       _onSecondaryContainer = onSecondaryContainer,
+       _tertiary = tertiary,
+       _onTertiary = onTertiary,
+       _tertiaryContainer = tertiaryContainer,
+       _onTertiaryContainer = onTertiaryContainer,
+       _errorContainer = errorContainer,
+       _onErrorContainer = onErrorContainer,
+       _outline = outline,
+       _surfaceVariant = surfaceVariant,
+       _onSurfaceVariant = onSurfaceVariant,
+       _inverseSurface = inverseSurface,
+       _inverseOnSurface = inverseOnSurface,
+       _inversePrimary = inversePrimary,
+       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -57,15 +91,32 @@ class ColorScheme with Diagnosticable {
   /// [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.light({
     this.primary = const Color(0xff6200ee),
-    this.secondary = const Color(0xff03dac6),
-    this.surface = Colors.white,
-    this.background = Colors.white,
-    this.error = const Color(0xffb00020),
     this.onPrimary = Colors.white,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    this.secondary = const Color(0xff03dac6),
     this.onSecondary = Colors.black,
-    this.onSurface = Colors.black,
-    this.onBackground = Colors.black,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    this.error = const Color(0xffb00020),
     this.onError = Colors.white,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    this.background = Colors.white,
+    this.onBackground = Colors.black,
+    this.surface = Colors.white,
+    this.onSurface = Colors.black,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     this.brightness = Brightness.light,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -88,6 +139,23 @@ class ColorScheme with Diagnosticable {
        assert(onBackground != null),
        assert(onError != null),
        assert(brightness != null),
+       _primaryContainer = primaryContainer,
+       _onPrimaryContainer = onPrimaryContainer,
+       _secondaryContainer = secondaryContainer,
+       _onSecondaryContainer = onSecondaryContainer,
+       _tertiary = tertiary,
+       _onTertiary = onTertiary,
+       _tertiaryContainer = tertiaryContainer,
+       _onTertiaryContainer = onTertiaryContainer,
+       _errorContainer = errorContainer,
+       _onErrorContainer = onErrorContainer,
+       _outline = outline,
+       _surfaceVariant = surfaceVariant,
+       _onSurfaceVariant = onSurfaceVariant,
+       _inverseSurface = inverseSurface,
+       _inverseOnSurface = inverseOnSurface,
+       _inversePrimary = inversePrimary,
+       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -95,15 +163,32 @@ class ColorScheme with Diagnosticable {
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.dark({
     this.primary = const Color(0xffbb86fc),
-    this.secondary = const Color(0xff03dac6),
-    this.surface = const Color(0xff121212),
-    this.background = const Color(0xff121212),
-    this.error = const Color(0xffcf6679),
     this.onPrimary = Colors.black,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    this.secondary = const Color(0xff03dac6),
     this.onSecondary = Colors.black,
-    this.onSurface = Colors.white,
-    this.onBackground = Colors.white,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    this.error = const Color(0xffcf6679),
     this.onError = Colors.black,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    this.background = const Color(0xff121212),
+    this.onBackground = Colors.white,
+    this.surface = const Color(0xff121212),
+    this.onSurface = Colors.white,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     this.brightness = Brightness.dark,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -126,6 +211,23 @@ class ColorScheme with Diagnosticable {
        assert(onBackground != null),
        assert(onError != null),
        assert(brightness != null),
+       _primaryContainer = primaryContainer,
+       _onPrimaryContainer = onPrimaryContainer,
+       _secondaryContainer = secondaryContainer,
+       _onSecondaryContainer = onSecondaryContainer,
+       _tertiary = tertiary,
+       _onTertiary = onTertiary,
+       _tertiaryContainer = tertiaryContainer,
+       _onTertiaryContainer = onTertiaryContainer,
+       _errorContainer = errorContainer,
+       _onErrorContainer = onErrorContainer,
+       _outline = outline,
+       _surfaceVariant = surfaceVariant,
+       _onSurfaceVariant = onSurfaceVariant,
+       _inverseSurface = inverseSurface,
+       _inverseOnSurface = inverseOnSurface,
+       _inversePrimary = inversePrimary,
+       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -133,15 +235,32 @@ class ColorScheme with Diagnosticable {
   /// matches the [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.highContrastLight({
     this.primary = const Color(0xff0000ba),
-    this.secondary = const Color(0xff66fff9),
-    this.surface = Colors.white,
-    this.background = Colors.white,
-    this.error = const Color(0xff790000),
     this.onPrimary = Colors.white,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    this.secondary = const Color(0xff66fff9),
     this.onSecondary = Colors.black,
-    this.onSurface = Colors.black,
-    this.onBackground = Colors.black,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    this.error = const Color(0xff790000),
     this.onError = Colors.white,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    this.background = Colors.white,
+    this.onBackground = Colors.black,
+    this.surface = Colors.white,
+    this.onSurface = Colors.black,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     this.brightness = Brightness.light,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -164,6 +283,23 @@ class ColorScheme with Diagnosticable {
        assert(onBackground != null),
        assert(onError != null),
        assert(brightness != null),
+       _primaryContainer = primaryContainer,
+       _onPrimaryContainer = onPrimaryContainer,
+       _secondaryContainer = secondaryContainer,
+       _onSecondaryContainer = onSecondaryContainer,
+       _tertiary = tertiary,
+       _onTertiary = onTertiary,
+       _tertiaryContainer = tertiaryContainer,
+       _onTertiaryContainer = onTertiaryContainer,
+       _errorContainer = errorContainer,
+       _onErrorContainer = onErrorContainer,
+       _outline = outline,
+       _surfaceVariant = surfaceVariant,
+       _onSurfaceVariant = onSurfaceVariant,
+       _inverseSurface = inverseSurface,
+       _inverseOnSurface = inverseOnSurface,
+       _inversePrimary = inversePrimary,
+       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -171,15 +307,32 @@ class ColorScheme with Diagnosticable {
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.highContrastDark({
     this.primary = const Color(0xffefb7ff),
-    this.secondary = const Color(0xff66fff9),
-    this.surface = const Color(0xff121212),
-    this.background = const Color(0xff121212),
-    this.error = const Color(0xff9b374d),
     this.onPrimary = Colors.black,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    this.secondary = const Color(0xff66fff9),
     this.onSecondary = Colors.black,
-    this.onSurface = Colors.white,
-    this.onBackground = Colors.white,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    this.error = const Color(0xff9b374d),
     this.onError = Colors.black,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    this.background = const Color(0xff121212),
+    this.onBackground = Colors.white,
+    this.surface = const Color(0xff121212),
+    this.onSurface = Colors.white,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     this.brightness = Brightness.dark,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -202,6 +355,23 @@ class ColorScheme with Diagnosticable {
        assert(onBackground != null),
        assert(onError != null),
        assert(brightness != null),
+       _primaryContainer = primaryContainer,
+       _onPrimaryContainer = onPrimaryContainer,
+       _secondaryContainer = secondaryContainer,
+       _onSecondaryContainer = onSecondaryContainer,
+       _tertiary = tertiary,
+       _onTertiary = onTertiary,
+       _tertiaryContainer = tertiaryContainer,
+       _onTertiaryContainer = onTertiaryContainer,
+       _errorContainer = errorContainer,
+       _onErrorContainer = onErrorContainer,
+       _outline = outline,
+       _surfaceVariant = surfaceVariant,
+       _onSurfaceVariant = onSurfaceVariant,
+       _inverseSurface = inverseSurface,
+       _inverseOnSurface = inverseOnSurface,
+       _inversePrimary = inversePrimary,
+       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -248,26 +418,28 @@ class ColorScheme with Diagnosticable {
   /// The color displayed most frequently across your app’s screens and components.
   final Color primary;
 
-  /// An accent color that, when used sparingly, calls attention to parts
-  /// of your app.
-  final Color secondary;
-
-  /// The background color for widgets like [Card].
-  final Color surface;
-
-  /// A color that typically appears behind scrollable content.
-  final Color background;
-
-  /// The color to use for input validation errors, e.g. for
-  /// [InputDecoration.errorText].
-  final Color error;
-
   /// A color that's clearly legible when drawn on [primary].
   ///
   /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [primary]
   /// and [onPrimary] is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onPrimary;
+
+  final Color? _primaryContainer;
+  /// A color used for elements needing less emphasis than [primary].
+  Color get primaryContainer => _primaryContainer ?? primary;
+
+  final Color? _onPrimaryContainer;
+  /// A color that's clearly legible when drawn on [primaryContainer].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [primaryContainer] and [onPrimaryContainer] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get onPrimaryContainer => _onPrimaryContainer ?? onPrimary;
+
+  /// An accent color used for less prominent components in the UI, such as
+  /// filter chips, while expanding the opportunity for color expression.
+  final Color secondary;
 
   /// A color that's clearly legible when drawn on [secondary].
   ///
@@ -276,12 +448,73 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onSecondary;
 
-  /// A color that's clearly legible when drawn on [surface].
+  final Color? _secondaryContainer;
+  /// A color used for elements needing less emphasis than [secondary].
+  Color get secondaryContainer => _secondaryContainer ?? secondary;
+
+  final Color? _onSecondaryContainer;
+  /// A color that's clearly legible when drawn on [secondaryContainer].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [surface]
-  /// and [onSurface] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [secondaryContainer] and [onSecondaryContainer] is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
-  final Color onSurface;
+  Color get onSecondaryContainer => _onSecondaryContainer ?? onSecondary;
+
+  final Color? _tertiary;
+  /// A color used as a contrasting accent that can be balance [primary]
+  /// and [secondary] colors or bring heightened attention to an element,
+  /// such as an input field.
+  Color get tertiary => _tertiary ?? secondary;
+
+  final Color? _onTertiary;
+  /// A color that's clearly legible when drawn on [tertiary].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [tertiary] and [onTertiary] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get onTertiary => _onTertiary ?? onSecondary;
+
+  final Color? _tertiaryContainer;
+  /// A color used for elements needing less emphasis than [tertiary].
+  Color get tertiaryContainer => _tertiaryContainer ?? tertiary;
+
+  final Color? _onTertiaryContainer;
+  /// A color that's clearly legible when drawn on [tertiaryContainer].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [tertiaryContainer] and [onTertiaryContainer] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get onTertiaryContainer => _onTertiaryContainer ?? onTertiary;
+
+  /// The color to use for input validation errors, e.g. for
+  /// [InputDecoration.errorText].
+  final Color error;
+
+  /// A color that's clearly legible when drawn on [error].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [error]
+  /// and [onError] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  final Color onError;
+
+  final Color? _errorContainer;
+  /// A color used for error elements needing less emphasis than [error].
+  Color get errorContainer => _errorContainer ?? error;
+
+  final Color? _onErrorContainer;
+  /// A color that's clearly legible when drawn on [errorContainer].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [errorContainer] and [onErrorContainer] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get onErrorContainer => _onErrorContainer ?? onError;
+
+  final Color? _outline;
+  /// A utility color that creates boundaries and emphasis to improve usability.
+  Color get outline => _outline ?? onBackground;
+
+  /// A color that typically appears behind scrollable content.
+  final Color background;
 
   /// A color that's clearly legible when drawn on [background].
   ///
@@ -290,12 +523,52 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onBackground;
 
-  /// A color that's clearly legible when drawn on [error].
+  /// The background color for widgets like [Card].
+  final Color surface;
+
+  /// A color that's clearly legible when drawn on [surface].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [error]
-  /// and [onError] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [surface]
+  /// and [onSurface] is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
-  final Color onError;
+  final Color onSurface;
+
+  final Color? _surfaceVariant;
+  /// A color variant of [surface] that can be used for differentiation against
+  /// a component using [surface].
+  Color get surfaceVariant => _surfaceVariant ?? surface;
+
+  final Color? _onSurfaceVariant;
+  /// A color that's clearly legible when drawn on [surfaceVariant].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [surfaceVariant] and [onSurfaceVariant] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get onSurfaceVariant => _onSurfaceVariant ?? onSurface;
+
+  final Color? _inverseSurface;
+  /// A surface color used for displaying the reverse of what’s seen in the
+  /// surrounding UI, for example in a SnackBar to bring attention to
+  /// an alert.
+  Color get inverseSurface => _inverseSurface ?? onSurface;
+
+  final Color? _inverseOnSurface;
+  /// A color that's clearly legible when drawn on [inverseSurface].
+  ///
+  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
+  /// [inverseSurface] and [onInverseSurface] is recommended. See
+  /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
+  Color get inverseOnSurface => _inverseOnSurface ?? surface;
+
+  final Color? _inversePrimary;
+  /// An accent color used for displaying the reverse of what’s seen in the
+  /// surrounding UI, for example in a SnackBar to bring attention to
+  /// an alert.
+  Color get inversePrimary => _inversePrimary ?? onPrimary;
+
+  final Color? _shadow;
+  /// A color use to paint the drop shadows of elevated components.
+  Color get shadow => _shadow ?? onBackground;
 
   /// The overall brightness of this color scheme.
   final Brightness brightness;
@@ -320,15 +593,32 @@ class ColorScheme with Diagnosticable {
   /// replaced by the non-null parameter values.
   ColorScheme copyWith({
     Color? primary,
-    Color? secondary,
-    Color? surface,
-    Color? background,
-    Color? error,
     Color? onPrimary,
+    Color? primaryContainer,
+    Color? onPrimaryContainer,
+    Color? secondary,
     Color? onSecondary,
-    Color? onSurface,
-    Color? onBackground,
+    Color? secondaryContainer,
+    Color? onSecondaryContainer,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? tertiaryContainer,
+    Color? onTertiaryContainer,
+    Color? error,
     Color? onError,
+    Color? errorContainer,
+    Color? onErrorContainer,
+    Color? outline,
+    Color? background,
+    Color? onBackground,
+    Color? surface,
+    Color? onSurface,
+    Color? surfaceVariant,
+    Color? onSurfaceVariant,
+    Color? inverseSurface,
+    Color? inverseOnSurface,
+    Color? inversePrimary,
+    Color? shadow,
     Brightness? brightness,
     @Deprecated(
       'Use primary or primaryContainer instead. '
@@ -342,16 +632,33 @@ class ColorScheme with Diagnosticable {
     Color? secondaryVariant,
   }) {
     return ColorScheme(
-      primary: primary ?? this.primary,
-      secondary: secondary ?? this.secondary,
-      surface: surface ?? this.surface,
-      background: background ?? this.background,
-      error: error ?? this.error,
-      onPrimary: onPrimary ?? this.onPrimary,
-      onSecondary: onSecondary ?? this.onSecondary,
-      onSurface: onSurface ?? this.onSurface,
-      onBackground: onBackground ?? this.onBackground,
-      onError: onError ?? this.onError,
+      primary : primary ?? this.primary,
+      onPrimary : onPrimary ?? this.onPrimary,
+      primaryContainer : primaryContainer ?? this.primaryContainer,
+      onPrimaryContainer : onPrimaryContainer ?? this.onPrimaryContainer,
+      secondary : secondary ?? this.secondary,
+      onSecondary : onSecondary ?? this.onSecondary,
+      secondaryContainer : secondaryContainer ?? this.secondaryContainer,
+      onSecondaryContainer : onSecondaryContainer ?? this.onSecondaryContainer,
+      tertiary : tertiary ?? this.tertiary,
+      onTertiary : onTertiary ?? this.onTertiary,
+      tertiaryContainer : tertiaryContainer ?? this.tertiaryContainer,
+      onTertiaryContainer : onTertiaryContainer ?? this.onTertiaryContainer,
+      error : error ?? this.error,
+      onError : onError ?? this.onError,
+      errorContainer : errorContainer ?? this.errorContainer,
+      onErrorContainer : onErrorContainer ?? this.onErrorContainer,
+      outline : outline ?? this.outline,
+      background : background ?? this.background,
+      onBackground : onBackground ?? this.onBackground,
+      surface : surface ?? this.surface,
+      onSurface : onSurface ?? this.onSurface,
+      surfaceVariant : surfaceVariant ?? this.surfaceVariant,
+      onSurfaceVariant : onSurfaceVariant ?? this.onSurfaceVariant,
+      inverseSurface : inverseSurface ?? this.inverseSurface,
+      inverseOnSurface : inverseOnSurface ?? this.inverseOnSurface,
+      inversePrimary : inversePrimary ?? this.inversePrimary,
+      shadow : shadow ?? this.shadow,
       brightness: brightness ?? this.brightness,
       primaryVariant: primaryVariant ?? this.primaryVariant,
       secondaryVariant: secondaryVariant ?? this.secondaryVariant,
@@ -364,15 +671,32 @@ class ColorScheme with Diagnosticable {
   static ColorScheme lerp(ColorScheme a, ColorScheme b, double t) {
     return ColorScheme(
       primary: Color.lerp(a.primary, b.primary, t)!,
-      secondary: Color.lerp(a.secondary, b.secondary, t)!,
-      surface: Color.lerp(a.surface, b.surface, t)!,
-      background: Color.lerp(a.background, b.background, t)!,
-      error: Color.lerp(a.error, b.error, t)!,
       onPrimary: Color.lerp(a.onPrimary, b.onPrimary, t)!,
+      primaryContainer: Color.lerp(a.primaryContainer, b.primaryContainer, t),
+      onPrimaryContainer: Color.lerp(a.onPrimaryContainer, b.onPrimaryContainer, t),
+      secondary: Color.lerp(a.secondary, b.secondary, t)!,
       onSecondary: Color.lerp(a.onSecondary, b.onSecondary, t)!,
-      onSurface: Color.lerp(a.onSurface, b.onSurface, t)!,
-      onBackground: Color.lerp(a.onBackground, b.onBackground, t)!,
+      secondaryContainer: Color.lerp(a.secondaryContainer, b.secondaryContainer, t),
+      onSecondaryContainer: Color.lerp(a.onSecondaryContainer, b.onSecondaryContainer, t),
+      tertiary: Color.lerp(a.tertiary, b.tertiary, t),
+      onTertiary: Color.lerp(a.onTertiary, b.onTertiary, t),
+      tertiaryContainer: Color.lerp(a.tertiaryContainer, b.tertiaryContainer, t),
+      onTertiaryContainer: Color.lerp(a.onTertiaryContainer, b.onTertiaryContainer, t),
+      error: Color.lerp(a.error, b.error, t)!,
       onError: Color.lerp(a.onError, b.onError, t)!,
+      errorContainer: Color.lerp(a.errorContainer, b.errorContainer, t),
+      onErrorContainer: Color.lerp(a.onErrorContainer, b.onErrorContainer, t),
+      outline: Color.lerp(a.outline, b.outline, t),
+      background: Color.lerp(a.background, b.background, t)!,
+      onBackground: Color.lerp(a.onBackground, b.onBackground, t)!,
+      surface: Color.lerp(a.surface, b.surface, t)!,
+      onSurface: Color.lerp(a.onSurface, b.onSurface, t)!,
+      surfaceVariant: Color.lerp(a.surfaceVariant, b.surfaceVariant, t),
+      onSurfaceVariant: Color.lerp(a.onSurfaceVariant, b.onSurfaceVariant, t),
+      inverseSurface: Color.lerp(a.inverseSurface, b.inverseSurface, t),
+      inverseOnSurface: Color.lerp(a.inverseOnSurface, b.inverseOnSurface, t),
+      inversePrimary: Color.lerp(a.inversePrimary, b.inversePrimary, t),
+      shadow: Color.lerp(a.shadow, b.shadow, t),
       brightness: t < 0.5 ? a.brightness : b.brightness,
       primaryVariant: Color.lerp(a.primaryVariant, b.primaryVariant, t),
       secondaryVariant: Color.lerp(a.secondaryVariant, b.secondaryVariant, t),
@@ -386,38 +710,72 @@ class ColorScheme with Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     return other is ColorScheme
-        && other.primary == primary
-        && other.secondary == secondary
-        && other.surface == surface
-        && other.background == background
-        && other.error == error
-        && other.onPrimary == onPrimary
-        && other.onSecondary == onSecondary
-        && other.onSurface == onSurface
-        && other.onBackground == onBackground
-        && other.onError == onError
-        && other.brightness == brightness
-        && other.primaryVariant == primaryVariant
-        && other.secondaryVariant == secondaryVariant;
+      && other.primary == primary
+      && other.onPrimary == onPrimary
+      && other.primaryContainer == primaryContainer
+      && other.onPrimaryContainer == onPrimaryContainer
+      && other.secondary == secondary
+      && other.onSecondary == onSecondary
+      && other.secondaryContainer == secondaryContainer
+      && other.onSecondaryContainer == onSecondaryContainer
+      && other.tertiary == tertiary
+      && other.onTertiary == onTertiary
+      && other.tertiaryContainer == tertiaryContainer
+      && other.onTertiaryContainer == onTertiaryContainer
+      && other.error == error
+      && other.onError == onError
+      && other.errorContainer == errorContainer
+      && other.onErrorContainer == onErrorContainer
+      && other.outline == outline
+      && other.background == background
+      && other.onBackground == onBackground
+      && other.surface == surface
+      && other.onSurface == onSurface
+      && other.surfaceVariant == surfaceVariant
+      && other.onSurfaceVariant == onSurfaceVariant
+      && other.inverseSurface == inverseSurface
+      && other.inverseOnSurface == inverseOnSurface
+      && other.inversePrimary == inversePrimary
+      && other.shadow == shadow
+      && other.brightness == brightness
+      && other.primaryVariant == primaryVariant
+      && other.secondaryVariant == secondaryVariant;
   }
 
   @override
   int get hashCode {
-    return hashValues(
+    return hashList(<Object?>[
       primary,
-      secondary,
-      surface,
-      background,
-      error,
       onPrimary,
+      primaryContainer,
+      onPrimaryContainer,
+      secondary,
       onSecondary,
-      onSurface,
-      onBackground,
+      secondaryContainer,
+      onSecondaryContainer,
+      tertiary,
+      onTertiary,
+      tertiaryContainer,
+      onTertiaryContainer,
+      error,
       onError,
+      errorContainer,
+      onErrorContainer,
+      outline,
+      background,
+      onBackground,
+      surface,
+      onSurface,
+      surfaceVariant,
+      onSurfaceVariant,
+      inverseSurface,
+      inverseOnSurface,
+      inversePrimary,
+      shadow,
       brightness,
       primaryVariant,
       secondaryVariant,
-    );
+    ]);
   }
 
   @override
@@ -425,15 +783,32 @@ class ColorScheme with Diagnosticable {
     super.debugFillProperties(properties);
     const ColorScheme defaultScheme = ColorScheme.light();
     properties.add(ColorProperty('primary', primary, defaultValue: defaultScheme.primary));
-    properties.add(ColorProperty('secondary', secondary, defaultValue: defaultScheme.secondary));
-    properties.add(ColorProperty('surface', surface, defaultValue: defaultScheme.surface));
-    properties.add(ColorProperty('background', background, defaultValue: defaultScheme.background));
-    properties.add(ColorProperty('error', error, defaultValue: defaultScheme.error));
     properties.add(ColorProperty('onPrimary', onPrimary, defaultValue: defaultScheme.onPrimary));
+    properties.add(ColorProperty('primaryContainer', primaryContainer, defaultValue: defaultScheme.primaryContainer));
+    properties.add(ColorProperty('onPrimaryContainer', onPrimaryContainer, defaultValue: defaultScheme.onPrimaryContainer));
+    properties.add(ColorProperty('secondary', secondary, defaultValue: defaultScheme.secondary));
     properties.add(ColorProperty('onSecondary', onSecondary, defaultValue: defaultScheme.onSecondary));
-    properties.add(ColorProperty('onSurface', onSurface, defaultValue: defaultScheme.onSurface));
-    properties.add(ColorProperty('onBackground', onBackground, defaultValue: defaultScheme.onBackground));
+    properties.add(ColorProperty('secondaryContainer', secondaryContainer, defaultValue: defaultScheme.secondaryContainer));
+    properties.add(ColorProperty('onSecondaryContainer', onSecondaryContainer, defaultValue: defaultScheme.onSecondaryContainer));
+    properties.add(ColorProperty('tertiary', tertiary, defaultValue: defaultScheme.tertiary));
+    properties.add(ColorProperty('onTertiary', onTertiary, defaultValue: defaultScheme.onTertiary));
+    properties.add(ColorProperty('tertiaryContainer', tertiaryContainer, defaultValue: defaultScheme.tertiaryContainer));
+    properties.add(ColorProperty('onTertiaryContainer', onTertiaryContainer, defaultValue: defaultScheme.onTertiaryContainer));
+    properties.add(ColorProperty('error', error, defaultValue: defaultScheme.error));
     properties.add(ColorProperty('onError', onError, defaultValue: defaultScheme.onError));
+    properties.add(ColorProperty('errorContainer', errorContainer, defaultValue: defaultScheme.errorContainer));
+    properties.add(ColorProperty('onErrorContainer', onErrorContainer, defaultValue: defaultScheme.onErrorContainer));
+    properties.add(ColorProperty('outline', outline, defaultValue: defaultScheme.outline));
+    properties.add(ColorProperty('background', background, defaultValue: defaultScheme.background));
+    properties.add(ColorProperty('onBackground', onBackground, defaultValue: defaultScheme.onBackground));
+    properties.add(ColorProperty('surface', surface, defaultValue: defaultScheme.surface));
+    properties.add(ColorProperty('onSurface', onSurface, defaultValue: defaultScheme.onSurface));
+    properties.add(ColorProperty('surfaceVariant', surfaceVariant, defaultValue: defaultScheme.surfaceVariant));
+    properties.add(ColorProperty('onSurfaceVariant', onSurfaceVariant, defaultValue: defaultScheme.onSurfaceVariant));
+    properties.add(ColorProperty('inverseSurface', inverseSurface, defaultValue: defaultScheme.inverseSurface));
+    properties.add(ColorProperty('inverseOnSurface', inverseOnSurface, defaultValue: defaultScheme.inverseOnSurface));
+    properties.add(ColorProperty('inversePrimary', inversePrimary, defaultValue: defaultScheme.inversePrimary));
+    properties.add(ColorProperty('shadow', shadow, defaultValue: defaultScheme.shadow));
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: defaultScheme.brightness));
     properties.add(ColorProperty('primaryVariant', primaryVariant, defaultValue: defaultScheme.primaryVariant));
     properties.add(ColorProperty('secondaryVariant', secondaryVariant, defaultValue: defaultScheme.secondaryVariant));

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -17,6 +17,16 @@ import 'theme_data.dart';
 @immutable
 class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance.
+  ///
+  /// For the color parameters that are nullable, it is still recommended
+  /// that applications provide values for them. They are only nullable due
+  /// to backwards compatibility concerns.
+  ///
+  /// If a color is not provided, the closest fallback color from the given
+  /// colors will be used for it (e.g. [primaryContainer] will default
+  /// to [primary]). Material 3 makes use of these colors for many component
+  /// defaults, so for the best results the application should supply colors
+  /// for all the parameters.
   const ColorScheme({
     required this.brightness,
     required this.primary,
@@ -423,8 +433,8 @@ class ColorScheme with Diagnosticable {
 
   /// A color that's clearly legible when drawn on [primary].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [primary]
-  /// and [onPrimary] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [primary] and [onPrimary] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onPrimary;
 
@@ -435,8 +445,9 @@ class ColorScheme with Diagnosticable {
   final Color? _onPrimaryContainer;
   /// A color that's clearly legible when drawn on [primaryContainer].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [primaryContainer] and [onPrimaryContainer] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [primaryContainer] and [onPrimaryContainer] of at least 4.5:1
+  /// is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onPrimaryContainer => _onPrimaryContainer ?? onPrimary;
 
@@ -446,8 +457,8 @@ class ColorScheme with Diagnosticable {
 
   /// A color that's clearly legible when drawn on [secondary].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [secondary]
-  /// and [onSecondary] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [secondary] and [onSecondary] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onSecondary;
 
@@ -458,8 +469,9 @@ class ColorScheme with Diagnosticable {
   final Color? _onSecondaryContainer;
   /// A color that's clearly legible when drawn on [secondaryContainer].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [secondaryContainer] and [onSecondaryContainer] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [secondaryContainer] and [onSecondaryContainer] of at least 4.5:1 is
+  /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onSecondaryContainer => _onSecondaryContainer ?? onSecondary;
 
@@ -472,8 +484,8 @@ class ColorScheme with Diagnosticable {
   final Color? _onTertiary;
   /// A color that's clearly legible when drawn on [tertiary].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [tertiary] and [onTertiary] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [tertiary] and [onTertiary] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onTertiary => _onTertiary ?? onSecondary;
 
@@ -484,8 +496,9 @@ class ColorScheme with Diagnosticable {
   final Color? _onTertiaryContainer;
   /// A color that's clearly legible when drawn on [tertiaryContainer].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [tertiaryContainer] and [onTertiaryContainer] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [tertiaryContainer] and [onTertiaryContainer] of at least 4.5:1 is
+  /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onTertiaryContainer => _onTertiaryContainer ?? onTertiary;
 
@@ -495,8 +508,8 @@ class ColorScheme with Diagnosticable {
 
   /// A color that's clearly legible when drawn on [error].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [error]
-  /// and [onError] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [error] and [onError] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onError;
 
@@ -507,8 +520,9 @@ class ColorScheme with Diagnosticable {
   final Color? _onErrorContainer;
   /// A color that's clearly legible when drawn on [errorContainer].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [errorContainer] and [onErrorContainer] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [errorContainer] and [onErrorContainer] of at least 4.5:1 is
+  /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onErrorContainer => _onErrorContainer ?? onError;
 
@@ -517,8 +531,8 @@ class ColorScheme with Diagnosticable {
 
   /// A color that's clearly legible when drawn on [background].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [background]
-  /// and [onBackground] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [background] and [onBackground] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onBackground;
 
@@ -527,8 +541,8 @@ class ColorScheme with Diagnosticable {
 
   /// A color that's clearly legible when drawn on [surface].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for [surface]
-  /// and [onSurface] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [surface] and [onSurface] of at least 4.5:1 is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   final Color onSurface;
 
@@ -540,8 +554,9 @@ class ColorScheme with Diagnosticable {
   final Color? _onSurfaceVariant;
   /// A color that's clearly legible when drawn on [surfaceVariant].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [surfaceVariant] and [onSurfaceVariant] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [surfaceVariant] and [onSurfaceVariant] of at least 4.5:1 is
+  /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onSurfaceVariant => _onSurfaceVariant ?? onSurface;
 
@@ -562,15 +577,15 @@ class ColorScheme with Diagnosticable {
   final Color? _onInverseSurface;
   /// A color that's clearly legible when drawn on [inverseSurface].
   ///
-  /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [inverseSurface] and [onInverseSurface] is recommended. See
+  /// To ensure that an app is accessible, a contrast ratio between
+  /// [inverseSurface] and [onInverseSurface] of at least 4.5:1 is
+  /// recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onInverseSurface => _onInverseSurface ?? surface;
 
   final Color? _inversePrimary;
-  /// An accent color used for displaying the reverse of what’s seen in the
-  /// surrounding UI, for example in a SnackBar to bring attention to
-  /// an alert.
+  /// An accent color used for displaying a highlight color on [inverseSurface]
+  /// backgrounds, like button text in a SnackBar.
   Color get inversePrimary => _inversePrimary ?? onPrimary;
 
   final Color? _primaryVariant;

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -18,6 +18,7 @@ import 'theme_data.dart';
 class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance.
   const ColorScheme({
+    required this.brightness,
     required this.primary,
     required this.onPrimary,
     Color? primaryContainer,
@@ -34,18 +35,17 @@ class ColorScheme with Diagnosticable {
     required this.onError,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     required this.background,
     required this.onBackground,
     required this.surface,
     required this.onSurface,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
+    Color? outline,
+    Color? shadow,
     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    required this.brightness,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -56,17 +56,17 @@ class ColorScheme with Diagnosticable {
       'This feature was deprecated after v2.6.0-0.0.pre.'
     )
     Color? secondaryVariant,
-  }) : assert(primary != null),
-       assert(secondary != null),
-       assert(surface != null),
-       assert(background != null),
-       assert(error != null),
+  }) : assert(brightness != null),
+       assert(primary != null),
        assert(onPrimary != null),
+       assert(secondary != null),
        assert(onSecondary != null),
-       assert(onSurface != null),
-       assert(onBackground != null),
+       assert(error != null),
        assert(onError != null),
-       assert(brightness != null),
+       assert(background != null),
+       assert(onBackground != null),
+       assert(surface != null),
+       assert(onSurface != null),
        _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -77,19 +77,20 @@ class ColorScheme with Diagnosticable {
        _onTertiaryContainer = onTertiaryContainer,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
-       _outline = outline,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
+       _outline = outline,
+       _shadow = shadow,
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
   /// Create a ColorScheme based on a purple primary color that matches the
   /// [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.light({
+    this.brightness = Brightness.light,
     this.primary = const Color(0xff6200ee),
     this.onPrimary = Colors.white,
     Color? primaryContainer,
@@ -106,18 +107,17 @@ class ColorScheme with Diagnosticable {
     this.onError = Colors.white,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     this.background = Colors.white,
     this.onBackground = Colors.black,
     this.surface = Colors.white,
     this.onSurface = Colors.black,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
+    Color? outline,
+    Color? shadow,
     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    this.brightness = Brightness.light,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -128,17 +128,17 @@ class ColorScheme with Diagnosticable {
       'This feature was deprecated after v2.6.0-0.0.pre.'
     )
     Color? secondaryVariant = const Color(0xff018786),
-  }) : assert(primary != null),
-       assert(secondary != null),
-       assert(surface != null),
-       assert(background != null),
-       assert(error != null),
+  }) : assert(brightness != null),
+       assert(primary != null),
        assert(onPrimary != null),
+       assert(secondary != null),
        assert(onSecondary != null),
-       assert(onSurface != null),
-       assert(onBackground != null),
+       assert(error != null),
        assert(onError != null),
-       assert(brightness != null),
+       assert(background != null),
+       assert(onBackground != null),
+       assert(surface != null),
+       assert(onSurface != null),
        _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -149,19 +149,20 @@ class ColorScheme with Diagnosticable {
        _onTertiaryContainer = onTertiaryContainer,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
-       _outline = outline,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
+       _outline = outline,
+       _shadow = shadow,
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
   /// Create the recommended dark color scheme that matches the
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.dark({
+    this.brightness = Brightness.dark,
     this.primary = const Color(0xffbb86fc),
     this.onPrimary = Colors.black,
     Color? primaryContainer,
@@ -178,18 +179,17 @@ class ColorScheme with Diagnosticable {
     this.onError = Colors.black,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     this.background = const Color(0xff121212),
     this.onBackground = Colors.white,
     this.surface = const Color(0xff121212),
     this.onSurface = Colors.white,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
+    Color? outline,
+    Color? shadow,
     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    this.brightness = Brightness.dark,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -200,17 +200,17 @@ class ColorScheme with Diagnosticable {
       'This feature was deprecated after v2.6.0-0.0.pre.'
     )
     Color? secondaryVariant = const Color(0xff03dac6),
-  }) : assert(primary != null),
-       assert(secondary != null),
-       assert(surface != null),
-       assert(background != null),
-       assert(error != null),
+  }) : assert(brightness != null),
+       assert(primary != null),
        assert(onPrimary != null),
+       assert(secondary != null),
        assert(onSecondary != null),
-       assert(onSurface != null),
-       assert(onBackground != null),
+       assert(error != null),
        assert(onError != null),
-       assert(brightness != null),
+       assert(background != null),
+       assert(onBackground != null),
+       assert(surface != null),
+       assert(onSurface != null),
        _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -221,19 +221,20 @@ class ColorScheme with Diagnosticable {
        _onTertiaryContainer = onTertiaryContainer,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
-       _outline = outline,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
+       _outline = outline,
+       _shadow = shadow,
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
   /// Create a high contrast ColorScheme based on a purple primary color that
   /// matches the [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.highContrastLight({
+    this.brightness = Brightness.light,
     this.primary = const Color(0xff0000ba),
     this.onPrimary = Colors.white,
     Color? primaryContainer,
@@ -250,18 +251,17 @@ class ColorScheme with Diagnosticable {
     this.onError = Colors.white,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     this.background = Colors.white,
     this.onBackground = Colors.black,
     this.surface = Colors.white,
     this.onSurface = Colors.black,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
+    Color? outline,
+    Color? shadow,
     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    this.brightness = Brightness.light,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -272,17 +272,17 @@ class ColorScheme with Diagnosticable {
       'This feature was deprecated after v2.6.0-0.0.pre.'
     )
     Color? secondaryVariant = const Color(0xff018786),
-  }) : assert(primary != null),
-       assert(secondary != null),
-       assert(surface != null),
-       assert(background != null),
-       assert(error != null),
+  }) : assert(brightness != null),
+       assert(primary != null),
        assert(onPrimary != null),
+       assert(secondary != null),
        assert(onSecondary != null),
-       assert(onSurface != null),
-       assert(onBackground != null),
+       assert(error != null),
        assert(onError != null),
-       assert(brightness != null),
+       assert(background != null),
+       assert(onBackground != null),
+       assert(surface != null),
+       assert(onSurface != null),
        _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -293,19 +293,20 @@ class ColorScheme with Diagnosticable {
        _onTertiaryContainer = onTertiaryContainer,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
-       _outline = outline,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
+       _outline = outline,
+       _shadow = shadow,
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
   /// Create a high contrast ColorScheme based on the dark
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.highContrastDark({
+    this.brightness = Brightness.dark,
     this.primary = const Color(0xffefb7ff),
     this.onPrimary = Colors.black,
     Color? primaryContainer,
@@ -322,18 +323,17 @@ class ColorScheme with Diagnosticable {
     this.onError = Colors.black,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     this.background = const Color(0xff121212),
     this.onBackground = Colors.white,
     this.surface = const Color(0xff121212),
     this.onSurface = Colors.white,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
+    Color? outline,
+    Color? shadow,
     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    this.brightness = Brightness.dark,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -344,17 +344,17 @@ class ColorScheme with Diagnosticable {
       'This feature was deprecated after v2.6.0-0.0.pre.'
     )
     Color? secondaryVariant = const Color(0xff66fff9),
-  }) : assert(primary != null),
-       assert(secondary != null),
-       assert(surface != null),
-       assert(background != null),
-       assert(error != null),
+  }) : assert(brightness != null),
+       assert(primary != null),
        assert(onPrimary != null),
+       assert(secondary != null),
        assert(onSecondary != null),
-       assert(onSurface != null),
-       assert(onBackground != null),
+       assert(error != null),
        assert(onError != null),
-       assert(brightness != null),
+       assert(background != null),
+       assert(onBackground != null),
+       assert(surface != null),
+       assert(onSurface != null),
        _primaryContainer = primaryContainer,
        _onPrimaryContainer = onPrimaryContainer,
        _secondaryContainer = secondaryContainer,
@@ -365,13 +365,13 @@ class ColorScheme with Diagnosticable {
        _onTertiaryContainer = onTertiaryContainer,
        _errorContainer = errorContainer,
        _onErrorContainer = onErrorContainer,
-       _outline = outline,
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
+       _outline = outline,
+       _shadow = shadow,
        _inverseSurface = inverseSurface,
        _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
-       _shadow = shadow,
        _primaryVariant = primaryVariant,
        _secondaryVariant = secondaryVariant;
 
@@ -414,6 +414,9 @@ class ColorScheme with Diagnosticable {
   }
 
   static Brightness _brightnessFor(Color color) => ThemeData.estimateBrightnessForColor(color);
+
+  /// The overall brightness of this color scheme.
+  final Brightness brightness;
 
   /// The color displayed most frequently across your app’s screens and components.
   final Color primary;
@@ -509,10 +512,6 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onErrorContainer => _onErrorContainer ?? onError;
 
-  final Color? _outline;
-  /// A utility color that creates boundaries and emphasis to improve usability.
-  Color get outline => _outline ?? onBackground;
-
   /// A color that typically appears behind scrollable content.
   final Color background;
 
@@ -546,6 +545,14 @@ class ColorScheme with Diagnosticable {
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get onSurfaceVariant => _onSurfaceVariant ?? onSurface;
 
+  final Color? _outline;
+  /// A utility color that creates boundaries and emphasis to improve usability.
+  Color get outline => _outline ?? onBackground;
+
+  final Color? _shadow;
+  /// A color use to paint the drop shadows of elevated components.
+  Color get shadow => _shadow ?? onBackground;
+
   final Color? _inverseSurface;
   /// A surface color used for displaying the reverse of what’s seen in the
   /// surrounding UI, for example in a SnackBar to bring attention to
@@ -566,13 +573,6 @@ class ColorScheme with Diagnosticable {
   /// an alert.
   Color get inversePrimary => _inversePrimary ?? onPrimary;
 
-  final Color? _shadow;
-  /// A color use to paint the drop shadows of elevated components.
-  Color get shadow => _shadow ?? onBackground;
-
-  /// The overall brightness of this color scheme.
-  final Brightness brightness;
-
   final Color? _primaryVariant;
   /// A darker version of the primary color.
   @Deprecated(
@@ -592,6 +592,7 @@ class ColorScheme with Diagnosticable {
   /// Creates a copy of this color scheme with the given fields
   /// replaced by the non-null parameter values.
   ColorScheme copyWith({
+    Brightness? brightness,
     Color? primary,
     Color? onPrimary,
     Color? primaryContainer,
@@ -608,18 +609,17 @@ class ColorScheme with Diagnosticable {
     Color? onError,
     Color? errorContainer,
     Color? onErrorContainer,
-    Color? outline,
     Color? background,
     Color? onBackground,
     Color? surface,
     Color? onSurface,
     Color? surfaceVariant,
     Color? onSurfaceVariant,
-    Color? inverseSurface,
+    Color? outline,
+    Color? shadow,
+     Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
-    Color? shadow,
-    Brightness? brightness,
     @Deprecated(
       'Use primary or primaryContainer instead. '
       'This feature was deprecated after v2.6.0-0.0.pre.'
@@ -632,6 +632,7 @@ class ColorScheme with Diagnosticable {
     Color? secondaryVariant,
   }) {
     return ColorScheme(
+      brightness: brightness ?? this.brightness,
       primary : primary ?? this.primary,
       onPrimary : onPrimary ?? this.onPrimary,
       primaryContainer : primaryContainer ?? this.primaryContainer,
@@ -648,18 +649,17 @@ class ColorScheme with Diagnosticable {
       onError : onError ?? this.onError,
       errorContainer : errorContainer ?? this.errorContainer,
       onErrorContainer : onErrorContainer ?? this.onErrorContainer,
-      outline : outline ?? this.outline,
       background : background ?? this.background,
       onBackground : onBackground ?? this.onBackground,
       surface : surface ?? this.surface,
       onSurface : onSurface ?? this.onSurface,
       surfaceVariant : surfaceVariant ?? this.surfaceVariant,
       onSurfaceVariant : onSurfaceVariant ?? this.onSurfaceVariant,
+      outline : outline ?? this.outline,
+      shadow : shadow ?? this.shadow,
       inverseSurface : inverseSurface ?? this.inverseSurface,
       onInverseSurface : onInverseSurface ?? this.onInverseSurface,
       inversePrimary : inversePrimary ?? this.inversePrimary,
-      shadow : shadow ?? this.shadow,
-      brightness: brightness ?? this.brightness,
       primaryVariant: primaryVariant ?? this.primaryVariant,
       secondaryVariant: secondaryVariant ?? this.secondaryVariant,
     );
@@ -670,6 +670,7 @@ class ColorScheme with Diagnosticable {
   /// {@macro dart.ui.shadow.lerp}
   static ColorScheme lerp(ColorScheme a, ColorScheme b, double t) {
     return ColorScheme(
+      brightness: t < 0.5 ? a.brightness : b.brightness,
       primary: Color.lerp(a.primary, b.primary, t)!,
       onPrimary: Color.lerp(a.onPrimary, b.onPrimary, t)!,
       primaryContainer: Color.lerp(a.primaryContainer, b.primaryContainer, t),
@@ -686,18 +687,17 @@ class ColorScheme with Diagnosticable {
       onError: Color.lerp(a.onError, b.onError, t)!,
       errorContainer: Color.lerp(a.errorContainer, b.errorContainer, t),
       onErrorContainer: Color.lerp(a.onErrorContainer, b.onErrorContainer, t),
-      outline: Color.lerp(a.outline, b.outline, t),
       background: Color.lerp(a.background, b.background, t)!,
       onBackground: Color.lerp(a.onBackground, b.onBackground, t)!,
       surface: Color.lerp(a.surface, b.surface, t)!,
       onSurface: Color.lerp(a.onSurface, b.onSurface, t)!,
       surfaceVariant: Color.lerp(a.surfaceVariant, b.surfaceVariant, t),
       onSurfaceVariant: Color.lerp(a.onSurfaceVariant, b.onSurfaceVariant, t),
+      outline: Color.lerp(a.outline, b.outline, t),
+      shadow: Color.lerp(a.shadow, b.shadow, t),
       inverseSurface: Color.lerp(a.inverseSurface, b.inverseSurface, t),
       onInverseSurface: Color.lerp(a.onInverseSurface, b.onInverseSurface, t),
       inversePrimary: Color.lerp(a.inversePrimary, b.inversePrimary, t),
-      shadow: Color.lerp(a.shadow, b.shadow, t),
-      brightness: t < 0.5 ? a.brightness : b.brightness,
       primaryVariant: Color.lerp(a.primaryVariant, b.primaryVariant, t),
       secondaryVariant: Color.lerp(a.secondaryVariant, b.secondaryVariant, t),
     );
@@ -710,6 +710,7 @@ class ColorScheme with Diagnosticable {
     if (other.runtimeType != runtimeType)
       return false;
     return other is ColorScheme
+      && other.brightness == brightness
       && other.primary == primary
       && other.onPrimary == onPrimary
       && other.primaryContainer == primaryContainer
@@ -726,18 +727,17 @@ class ColorScheme with Diagnosticable {
       && other.onError == onError
       && other.errorContainer == errorContainer
       && other.onErrorContainer == onErrorContainer
-      && other.outline == outline
       && other.background == background
       && other.onBackground == onBackground
       && other.surface == surface
       && other.onSurface == onSurface
       && other.surfaceVariant == surfaceVariant
       && other.onSurfaceVariant == onSurfaceVariant
+      && other.outline == outline
+      && other.shadow == shadow
       && other.inverseSurface == inverseSurface
       && other.onInverseSurface == onInverseSurface
       && other.inversePrimary == inversePrimary
-      && other.shadow == shadow
-      && other.brightness == brightness
       && other.primaryVariant == primaryVariant
       && other.secondaryVariant == secondaryVariant;
   }
@@ -745,6 +745,7 @@ class ColorScheme with Diagnosticable {
   @override
   int get hashCode {
     return hashList(<Object?>[
+      brightness,
       primary,
       onPrimary,
       primaryContainer,
@@ -761,18 +762,17 @@ class ColorScheme with Diagnosticable {
       onError,
       errorContainer,
       onErrorContainer,
-      outline,
       background,
       onBackground,
       surface,
       onSurface,
       surfaceVariant,
       onSurfaceVariant,
+      outline,
+      shadow,
       inverseSurface,
       onInverseSurface,
       inversePrimary,
-      shadow,
-      brightness,
       primaryVariant,
       secondaryVariant,
     ]);
@@ -782,6 +782,7 @@ class ColorScheme with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const ColorScheme defaultScheme = ColorScheme.light();
+    properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: defaultScheme.brightness));
     properties.add(ColorProperty('primary', primary, defaultValue: defaultScheme.primary));
     properties.add(ColorProperty('onPrimary', onPrimary, defaultValue: defaultScheme.onPrimary));
     properties.add(ColorProperty('primaryContainer', primaryContainer, defaultValue: defaultScheme.primaryContainer));
@@ -798,18 +799,17 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('onError', onError, defaultValue: defaultScheme.onError));
     properties.add(ColorProperty('errorContainer', errorContainer, defaultValue: defaultScheme.errorContainer));
     properties.add(ColorProperty('onErrorContainer', onErrorContainer, defaultValue: defaultScheme.onErrorContainer));
-    properties.add(ColorProperty('outline', outline, defaultValue: defaultScheme.outline));
     properties.add(ColorProperty('background', background, defaultValue: defaultScheme.background));
     properties.add(ColorProperty('onBackground', onBackground, defaultValue: defaultScheme.onBackground));
     properties.add(ColorProperty('surface', surface, defaultValue: defaultScheme.surface));
     properties.add(ColorProperty('onSurface', onSurface, defaultValue: defaultScheme.onSurface));
     properties.add(ColorProperty('surfaceVariant', surfaceVariant, defaultValue: defaultScheme.surfaceVariant));
     properties.add(ColorProperty('onSurfaceVariant', onSurfaceVariant, defaultValue: defaultScheme.onSurfaceVariant));
+    properties.add(ColorProperty('outline', outline, defaultValue: defaultScheme.outline));
+    properties.add(ColorProperty('shadow', shadow, defaultValue: defaultScheme.shadow));
     properties.add(ColorProperty('inverseSurface', inverseSurface, defaultValue: defaultScheme.inverseSurface));
     properties.add(ColorProperty('onInverseSurface', onInverseSurface, defaultValue: defaultScheme.onInverseSurface));
     properties.add(ColorProperty('inversePrimary', inversePrimary, defaultValue: defaultScheme.inversePrimary));
-    properties.add(ColorProperty('shadow', shadow, defaultValue: defaultScheme.shadow));
-    properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: defaultScheme.brightness));
     properties.add(ColorProperty('primaryVariant', primaryVariant, defaultValue: defaultScheme.primaryVariant));
     properties.add(ColorProperty('secondaryVariant', secondaryVariant, defaultValue: defaultScheme.secondaryVariant));
   }

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -9,7 +9,7 @@ import 'colors.dart';
 import 'theme_data.dart';
 
 /// A set of colors based on the
-/// [Material spec](https://m3.material.io/styles/color/the-color-system/key-colors-tones)
+/// [Material spec](https://m3.material.io/styles/color/the-color-system/color-roles)
 /// that can be used to configure the color properties of most components.
 ///
 /// The [Theme] has a color scheme, [ThemeData.colorScheme], which is constructed
@@ -461,7 +461,7 @@ class ColorScheme with Diagnosticable {
   Color get onSecondaryContainer => _onSecondaryContainer ?? onSecondary;
 
   final Color? _tertiary;
-  /// A color used as a contrasting accent that can be balance [primary]
+  /// A color used as a contrasting accent that can balance [primary]
   /// and [secondary] colors or bring heightened attention to an element,
   /// such as an input field.
   Color get tertiary => _tertiary ?? secondary;
@@ -556,7 +556,7 @@ class ColorScheme with Diagnosticable {
   /// A color that's clearly legible when drawn on [inverseSurface].
   ///
   /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [inverseSurface] and [onInverseSurface] is recommended. See
+  /// [inverseSurface] and [inverseOnSurface] is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
   Color get inverseOnSurface => _inverseOnSurface ?? surface;
 

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -632,7 +632,7 @@ class ColorScheme with Diagnosticable {
     Color? onSurfaceVariant,
     Color? outline,
     Color? shadow,
-     Color? inverseSurface,
+    Color? inverseSurface,
     Color? onInverseSurface,
     Color? inversePrimary,
     @Deprecated(

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -42,7 +42,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     required this.brightness,
@@ -81,7 +81,7 @@ class ColorScheme with Diagnosticable {
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _inverseSurface = inverseSurface,
-       _inverseOnSurface = inverseOnSurface,
+       _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
        _shadow = shadow,
        _primaryVariant = primaryVariant,
@@ -114,7 +114,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     this.brightness = Brightness.light,
@@ -153,7 +153,7 @@ class ColorScheme with Diagnosticable {
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _inverseSurface = inverseSurface,
-       _inverseOnSurface = inverseOnSurface,
+       _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
        _shadow = shadow,
        _primaryVariant = primaryVariant,
@@ -186,7 +186,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     this.brightness = Brightness.dark,
@@ -225,7 +225,7 @@ class ColorScheme with Diagnosticable {
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _inverseSurface = inverseSurface,
-       _inverseOnSurface = inverseOnSurface,
+       _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
        _shadow = shadow,
        _primaryVariant = primaryVariant,
@@ -258,7 +258,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     this.brightness = Brightness.light,
@@ -297,7 +297,7 @@ class ColorScheme with Diagnosticable {
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _inverseSurface = inverseSurface,
-       _inverseOnSurface = inverseOnSurface,
+       _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
        _shadow = shadow,
        _primaryVariant = primaryVariant,
@@ -330,7 +330,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     this.brightness = Brightness.dark,
@@ -369,7 +369,7 @@ class ColorScheme with Diagnosticable {
        _surfaceVariant = surfaceVariant,
        _onSurfaceVariant = onSurfaceVariant,
        _inverseSurface = inverseSurface,
-       _inverseOnSurface = inverseOnSurface,
+       _onInverseSurface = onInverseSurface,
        _inversePrimary = inversePrimary,
        _shadow = shadow,
        _primaryVariant = primaryVariant,
@@ -552,13 +552,13 @@ class ColorScheme with Diagnosticable {
   /// an alert.
   Color get inverseSurface => _inverseSurface ?? onSurface;
 
-  final Color? _inverseOnSurface;
+  final Color? _onInverseSurface;
   /// A color that's clearly legible when drawn on [inverseSurface].
   ///
   /// To ensure that an app is accessible, a contrast ratio of 4.5:1 for
-  /// [inverseSurface] and [inverseOnSurface] is recommended. See
+  /// [inverseSurface] and [onInverseSurface] is recommended. See
   /// <https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html>.
-  Color get inverseOnSurface => _inverseOnSurface ?? surface;
+  Color get onInverseSurface => _onInverseSurface ?? surface;
 
   final Color? _inversePrimary;
   /// An accent color used for displaying the reverse of what’s seen in the
@@ -616,7 +616,7 @@ class ColorScheme with Diagnosticable {
     Color? surfaceVariant,
     Color? onSurfaceVariant,
     Color? inverseSurface,
-    Color? inverseOnSurface,
+    Color? onInverseSurface,
     Color? inversePrimary,
     Color? shadow,
     Brightness? brightness,
@@ -656,7 +656,7 @@ class ColorScheme with Diagnosticable {
       surfaceVariant : surfaceVariant ?? this.surfaceVariant,
       onSurfaceVariant : onSurfaceVariant ?? this.onSurfaceVariant,
       inverseSurface : inverseSurface ?? this.inverseSurface,
-      inverseOnSurface : inverseOnSurface ?? this.inverseOnSurface,
+      onInverseSurface : onInverseSurface ?? this.onInverseSurface,
       inversePrimary : inversePrimary ?? this.inversePrimary,
       shadow : shadow ?? this.shadow,
       brightness: brightness ?? this.brightness,
@@ -694,7 +694,7 @@ class ColorScheme with Diagnosticable {
       surfaceVariant: Color.lerp(a.surfaceVariant, b.surfaceVariant, t),
       onSurfaceVariant: Color.lerp(a.onSurfaceVariant, b.onSurfaceVariant, t),
       inverseSurface: Color.lerp(a.inverseSurface, b.inverseSurface, t),
-      inverseOnSurface: Color.lerp(a.inverseOnSurface, b.inverseOnSurface, t),
+      onInverseSurface: Color.lerp(a.onInverseSurface, b.onInverseSurface, t),
       inversePrimary: Color.lerp(a.inversePrimary, b.inversePrimary, t),
       shadow: Color.lerp(a.shadow, b.shadow, t),
       brightness: t < 0.5 ? a.brightness : b.brightness,
@@ -734,7 +734,7 @@ class ColorScheme with Diagnosticable {
       && other.surfaceVariant == surfaceVariant
       && other.onSurfaceVariant == onSurfaceVariant
       && other.inverseSurface == inverseSurface
-      && other.inverseOnSurface == inverseOnSurface
+      && other.onInverseSurface == onInverseSurface
       && other.inversePrimary == inversePrimary
       && other.shadow == shadow
       && other.brightness == brightness
@@ -769,7 +769,7 @@ class ColorScheme with Diagnosticable {
       surfaceVariant,
       onSurfaceVariant,
       inverseSurface,
-      inverseOnSurface,
+      onInverseSurface,
       inversePrimary,
       shadow,
       brightness,
@@ -806,7 +806,7 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('surfaceVariant', surfaceVariant, defaultValue: defaultScheme.surfaceVariant));
     properties.add(ColorProperty('onSurfaceVariant', onSurfaceVariant, defaultValue: defaultScheme.onSurfaceVariant));
     properties.add(ColorProperty('inverseSurface', inverseSurface, defaultValue: defaultScheme.inverseSurface));
-    properties.add(ColorProperty('inverseOnSurface', inverseOnSurface, defaultValue: defaultScheme.inverseOnSurface));
+    properties.add(ColorProperty('onInverseSurface', onInverseSurface, defaultValue: defaultScheme.onInverseSurface));
     properties.add(ColorProperty('inversePrimary', inversePrimary, defaultValue: defaultScheme.inversePrimary));
     properties.add(ColorProperty('shadow', shadow, defaultValue: defaultScheme.shadow));
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: defaultScheme.brightness));

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -19,9 +19,7 @@ class ColorScheme with Diagnosticable {
   /// Create a ColorScheme instance.
   const ColorScheme({
     required this.primary,
-    required this.primaryVariant,
     required this.secondary,
-    required this.secondaryVariant,
     required this.surface,
     required this.background,
     required this.error,
@@ -31,10 +29,18 @@ class ColorScheme with Diagnosticable {
     required this.onBackground,
     required this.onError,
     required this.brightness,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant,
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant,
   }) : assert(primary != null),
-       assert(primaryVariant != null),
        assert(secondary != null),
-       assert(secondaryVariant != null),
        assert(surface != null),
        assert(background != null),
        assert(error != null),
@@ -43,15 +49,15 @@ class ColorScheme with Diagnosticable {
        assert(onSurface != null),
        assert(onBackground != null),
        assert(onError != null),
-       assert(brightness != null);
+       assert(brightness != null),
+       _primaryVariant = primaryVariant,
+       _secondaryVariant = secondaryVariant;
 
   /// Create a ColorScheme based on a purple primary color that matches the
   /// [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.light({
     this.primary = const Color(0xff6200ee),
-    this.primaryVariant = const Color(0xff3700b3),
     this.secondary = const Color(0xff03dac6),
-    this.secondaryVariant = const Color(0xff018786),
     this.surface = Colors.white,
     this.background = Colors.white,
     this.error = const Color(0xffb00020),
@@ -61,10 +67,18 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.black,
     this.onError = Colors.white,
     this.brightness = Brightness.light,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant = const Color(0xff3700b3),
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant = const Color(0xff018786),
   }) : assert(primary != null),
-       assert(primaryVariant != null),
        assert(secondary != null),
-       assert(secondaryVariant != null),
        assert(surface != null),
        assert(background != null),
        assert(error != null),
@@ -73,15 +87,15 @@ class ColorScheme with Diagnosticable {
        assert(onSurface != null),
        assert(onBackground != null),
        assert(onError != null),
-       assert(brightness != null);
+       assert(brightness != null),
+       _primaryVariant = primaryVariant,
+       _secondaryVariant = secondaryVariant;
 
   /// Create the recommended dark color scheme that matches the
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.dark({
     this.primary = const Color(0xffbb86fc),
-    this.primaryVariant = const Color(0xff3700B3),
     this.secondary = const Color(0xff03dac6),
-    this.secondaryVariant = const Color(0xff03dac6),
     this.surface = const Color(0xff121212),
     this.background = const Color(0xff121212),
     this.error = const Color(0xffcf6679),
@@ -91,10 +105,18 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.white,
     this.onError = Colors.black,
     this.brightness = Brightness.dark,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant = const Color(0xff3700B3),
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant = const Color(0xff03dac6),
   }) : assert(primary != null),
-       assert(primaryVariant != null),
        assert(secondary != null),
-       assert(secondaryVariant != null),
        assert(surface != null),
        assert(background != null),
        assert(error != null),
@@ -103,16 +125,15 @@ class ColorScheme with Diagnosticable {
        assert(onSurface != null),
        assert(onBackground != null),
        assert(onError != null),
-       assert(brightness != null);
-
+       assert(brightness != null),
+       _primaryVariant = primaryVariant,
+       _secondaryVariant = secondaryVariant;
 
   /// Create a high contrast ColorScheme based on a purple primary color that
   /// matches the [baseline Material color scheme](https://material.io/design/color/the-color-system.html#color-theme-creation).
   const ColorScheme.highContrastLight({
     this.primary = const Color(0xff0000ba),
-    this.primaryVariant = const Color(0xff000088),
     this.secondary = const Color(0xff66fff9),
-    this.secondaryVariant = const Color(0xff018786),
     this.surface = Colors.white,
     this.background = Colors.white,
     this.error = const Color(0xff790000),
@@ -122,27 +143,35 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.black,
     this.onError = Colors.white,
     this.brightness = Brightness.light,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant = const Color(0xff000088),
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant = const Color(0xff018786),
   }) : assert(primary != null),
-        assert(primaryVariant != null),
-        assert(secondary != null),
-        assert(secondaryVariant != null),
-        assert(surface != null),
-        assert(background != null),
-        assert(error != null),
-        assert(onPrimary != null),
-        assert(onSecondary != null),
-        assert(onSurface != null),
-        assert(onBackground != null),
-        assert(onError != null),
-        assert(brightness != null);
+       assert(secondary != null),
+       assert(surface != null),
+       assert(background != null),
+       assert(error != null),
+       assert(onPrimary != null),
+       assert(onSecondary != null),
+       assert(onSurface != null),
+       assert(onBackground != null),
+       assert(onError != null),
+       assert(brightness != null),
+       _primaryVariant = primaryVariant,
+       _secondaryVariant = secondaryVariant;
 
   /// Create a high contrast ColorScheme based on the dark
   /// [baseline Material color scheme](https://material.io/design/color/dark-theme.html#ui-application).
   const ColorScheme.highContrastDark({
     this.primary = const Color(0xffefb7ff),
-    this.primaryVariant = const Color(0xffbe9eff),
     this.secondary = const Color(0xff66fff9),
-    this.secondaryVariant = const Color(0xff66fff9),
     this.surface = const Color(0xff121212),
     this.background = const Color(0xff121212),
     this.error = const Color(0xff9b374d),
@@ -152,19 +181,29 @@ class ColorScheme with Diagnosticable {
     this.onBackground = Colors.white,
     this.onError = Colors.black,
     this.brightness = Brightness.dark,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant = const Color(0xffbe9eff),
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant = const Color(0xff66fff9),
   }) : assert(primary != null),
-        assert(primaryVariant != null),
-        assert(secondary != null),
-        assert(secondaryVariant != null),
-        assert(surface != null),
-        assert(background != null),
-        assert(error != null),
-        assert(onPrimary != null),
-        assert(onSecondary != null),
-        assert(onSurface != null),
-        assert(onBackground != null),
-        assert(onError != null),
-        assert(brightness != null);
+       assert(secondary != null),
+       assert(surface != null),
+       assert(background != null),
+       assert(error != null),
+       assert(onPrimary != null),
+       assert(onSecondary != null),
+       assert(onSurface != null),
+       assert(onBackground != null),
+       assert(onError != null),
+       assert(brightness != null),
+       _primaryVariant = primaryVariant,
+       _secondaryVariant = secondaryVariant;
 
   /// Create a color scheme from a [MaterialColor] swatch.
   ///
@@ -209,15 +248,9 @@ class ColorScheme with Diagnosticable {
   /// The color displayed most frequently across your app’s screens and components.
   final Color primary;
 
-  /// A darker version of the primary color.
-  final Color primaryVariant;
-
   /// An accent color that, when used sparingly, calls attention to parts
   /// of your app.
   final Color secondary;
-
-  /// A darker version of the secondary color.
-  final Color secondaryVariant;
 
   /// The background color for widgets like [Card].
   final Color surface;
@@ -267,13 +300,27 @@ class ColorScheme with Diagnosticable {
   /// The overall brightness of this color scheme.
   final Brightness brightness;
 
+  final Color? _primaryVariant;
+  /// A darker version of the primary color.
+  @Deprecated(
+    'Use primary or primaryContainer instead. '
+    'This feature was deprecated after v2.6.0-0.0.pre.'
+  )
+  Color get primaryVariant => _primaryVariant ?? primary;
+
+  final Color? _secondaryVariant;
+  /// A darker version of the secondary color.
+  @Deprecated(
+    'Use secondary or secondaryContainer instead. '
+    'This feature was deprecated after v2.6.0-0.0.pre.'
+  )
+  Color get secondaryVariant => _secondaryVariant ?? secondary;
+
   /// Creates a copy of this color scheme with the given fields
   /// replaced by the non-null parameter values.
   ColorScheme copyWith({
     Color? primary,
-    Color? primaryVariant,
     Color? secondary,
-    Color? secondaryVariant,
     Color? surface,
     Color? background,
     Color? error,
@@ -283,12 +330,20 @@ class ColorScheme with Diagnosticable {
     Color? onBackground,
     Color? onError,
     Brightness? brightness,
+    @Deprecated(
+      'Use primary or primaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? primaryVariant,
+    @Deprecated(
+      'Use secondary or secondaryContainer instead. '
+      'This feature was deprecated after v2.6.0-0.0.pre.'
+    )
+    Color? secondaryVariant,
   }) {
     return ColorScheme(
       primary: primary ?? this.primary,
-      primaryVariant: primaryVariant ?? this.primaryVariant,
       secondary: secondary ?? this.secondary,
-      secondaryVariant: secondaryVariant ?? this.secondaryVariant,
       surface: surface ?? this.surface,
       background: background ?? this.background,
       error: error ?? this.error,
@@ -298,6 +353,8 @@ class ColorScheme with Diagnosticable {
       onBackground: onBackground ?? this.onBackground,
       onError: onError ?? this.onError,
       brightness: brightness ?? this.brightness,
+      primaryVariant: primaryVariant ?? this.primaryVariant,
+      secondaryVariant: secondaryVariant ?? this.secondaryVariant,
     );
   }
 
@@ -307,9 +364,7 @@ class ColorScheme with Diagnosticable {
   static ColorScheme lerp(ColorScheme a, ColorScheme b, double t) {
     return ColorScheme(
       primary: Color.lerp(a.primary, b.primary, t)!,
-      primaryVariant: Color.lerp(a.primaryVariant, b.primaryVariant, t)!,
       secondary: Color.lerp(a.secondary, b.secondary, t)!,
-      secondaryVariant: Color.lerp(a.secondaryVariant, b.secondaryVariant, t)!,
       surface: Color.lerp(a.surface, b.surface, t)!,
       background: Color.lerp(a.background, b.background, t)!,
       error: Color.lerp(a.error, b.error, t)!,
@@ -319,6 +374,8 @@ class ColorScheme with Diagnosticable {
       onBackground: Color.lerp(a.onBackground, b.onBackground, t)!,
       onError: Color.lerp(a.onError, b.onError, t)!,
       brightness: t < 0.5 ? a.brightness : b.brightness,
+      primaryVariant: Color.lerp(a.primaryVariant, b.primaryVariant, t),
+      secondaryVariant: Color.lerp(a.secondaryVariant, b.secondaryVariant, t),
     );
   }
 
@@ -330,9 +387,7 @@ class ColorScheme with Diagnosticable {
       return false;
     return other is ColorScheme
         && other.primary == primary
-        && other.primaryVariant == primaryVariant
         && other.secondary == secondary
-        && other.secondaryVariant == secondaryVariant
         && other.surface == surface
         && other.background == background
         && other.error == error
@@ -341,16 +396,16 @@ class ColorScheme with Diagnosticable {
         && other.onSurface == onSurface
         && other.onBackground == onBackground
         && other.onError == onError
-        && other.brightness == brightness;
+        && other.brightness == brightness
+        && other.primaryVariant == primaryVariant
+        && other.secondaryVariant == secondaryVariant;
   }
 
   @override
   int get hashCode {
     return hashValues(
       primary,
-      primaryVariant,
       secondary,
-      secondaryVariant,
       surface,
       background,
       error,
@@ -360,6 +415,8 @@ class ColorScheme with Diagnosticable {
       onBackground,
       onError,
       brightness,
+      primaryVariant,
+      secondaryVariant,
     );
   }
 
@@ -368,9 +425,7 @@ class ColorScheme with Diagnosticable {
     super.debugFillProperties(properties);
     const ColorScheme defaultScheme = ColorScheme.light();
     properties.add(ColorProperty('primary', primary, defaultValue: defaultScheme.primary));
-    properties.add(ColorProperty('primaryVariant', primaryVariant, defaultValue: defaultScheme.primaryVariant));
     properties.add(ColorProperty('secondary', secondary, defaultValue: defaultScheme.secondary));
-    properties.add(ColorProperty('secondaryVariant', secondaryVariant, defaultValue: defaultScheme.secondaryVariant));
     properties.add(ColorProperty('surface', surface, defaultValue: defaultScheme.surface));
     properties.add(ColorProperty('background', background, defaultValue: defaultScheme.background));
     properties.add(ColorProperty('error', error, defaultValue: defaultScheme.error));
@@ -380,5 +435,7 @@ class ColorScheme with Diagnosticable {
     properties.add(ColorProperty('onBackground', onBackground, defaultValue: defaultScheme.onBackground));
     properties.add(ColorProperty('onError', onError, defaultValue: defaultScheme.onError));
     properties.add(DiagnosticsProperty<Brightness>('brightness', brightness, defaultValue: defaultScheme.brightness));
+    properties.add(ColorProperty('primaryVariant', primaryVariant, defaultValue: defaultScheme.primaryVariant));
+    properties.add(ColorProperty('secondaryVariant', secondaryVariant, defaultValue: defaultScheme.secondaryVariant));
   }
 }

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.inverseSurface, scheme.onSurface);
-    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.light);
@@ -75,7 +75,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.inverseSurface, scheme.onSurface);
-    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.dark);
@@ -114,7 +114,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.inverseSurface, scheme.onSurface);
-    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.light);
@@ -153,7 +153,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.inverseSurface, scheme.onSurface);
-    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
     expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.dark);

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -12,6 +12,7 @@ void main() {
     // with the new Material 3 colors defaulting to values from the M2
     // baseline.
     const ColorScheme scheme = ColorScheme.light();
+    expect(scheme.brightness, Brightness.light);
     expect(scheme.primary, const Color(0xff6200ee));
     expect(scheme.onPrimary, const Color(0xffffffff));
     expect(scheme.primaryContainer, scheme.primary);
@@ -28,18 +29,17 @@ void main() {
     expect(scheme.onError, const Color(0xffffffff));
     expect(scheme.errorContainer, scheme.error);
     expect(scheme.onErrorContainer, scheme.onError);
-    expect(scheme.outline, scheme.onBackground);
     expect(scheme.background, const Color(0xffffffff));
     expect(scheme.onBackground, const Color(0xff000000));
     expect(scheme.surface, const Color(0xffffffff));
     expect(scheme.onSurface, const Color(0xff000000));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
-    expect(scheme.shadow, scheme.onBackground);
-    expect(scheme.brightness, Brightness.light);
 
     expect(scheme.primaryVariant, const Color(0xff3700b3));
     expect(scheme.secondaryVariant, const Color(0xff018786));
@@ -51,6 +51,7 @@ void main() {
     // with the new Material 3 colors defaulting to values from the M2
     // baseline.
     const ColorScheme scheme = ColorScheme.dark();
+    expect(scheme.brightness, Brightness.dark);
     expect(scheme.primary, const Color(0xffbb86fc));
     expect(scheme.onPrimary, const Color(0xff000000));
     expect(scheme.primaryContainer, scheme.primary);
@@ -67,18 +68,17 @@ void main() {
     expect(scheme.onError, const Color(0xff000000));
     expect(scheme.errorContainer, scheme.error);
     expect(scheme.onErrorContainer, scheme.onError);
-    expect(scheme.outline, scheme.onBackground);
     expect(scheme.background, const Color(0xff121212));
     expect(scheme.onBackground, const Color(0xffffffff));
     expect(scheme.surface, const Color(0xff121212));
     expect(scheme.onSurface, const Color(0xffffffff));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
-    expect(scheme.shadow, scheme.onBackground);
-    expect(scheme.brightness, Brightness.dark);
 
     expect(scheme.primaryVariant, const Color(0xff3700b3));
     expect(scheme.secondaryVariant, const Color(0xff03dac6));
@@ -90,6 +90,7 @@ void main() {
     // with the new Material 3 colors defaulting to values from the M2
     // baseline.
     const ColorScheme scheme = ColorScheme.highContrastLight();
+    expect(scheme.brightness, Brightness.light);
     expect(scheme.primary, const Color(0xff0000ba));
     expect(scheme.onPrimary, const Color(0xffffffff));
     expect(scheme.primaryContainer, scheme.primary);
@@ -106,18 +107,17 @@ void main() {
     expect(scheme.onError, const Color(0xffffffff));
     expect(scheme.errorContainer, scheme.error);
     expect(scheme.onErrorContainer, scheme.onError);
-    expect(scheme.outline, scheme.onBackground);
     expect(scheme.background, const Color(0xffffffff));
     expect(scheme.onBackground, const Color(0xff000000));
     expect(scheme.surface, const Color(0xffffffff));
     expect(scheme.onSurface, const Color(0xff000000));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
-    expect(scheme.shadow, scheme.onBackground);
-    expect(scheme.brightness, Brightness.light);
 
     expect(scheme.primaryVariant, const Color(0xff000088));
     expect(scheme.secondaryVariant, const Color(0xff018786));
@@ -129,6 +129,7 @@ void main() {
     // with the new Material 3 colors defaulting to values from the M2
     // baseline.
     const ColorScheme scheme = ColorScheme.highContrastDark();
+    expect(scheme.brightness, Brightness.dark);
     expect(scheme.primary, const Color(0xffefb7ff));
     expect(scheme.onPrimary, const Color(0xff000000));
     expect(scheme.primaryContainer, scheme.primary);
@@ -145,18 +146,17 @@ void main() {
     expect(scheme.onError, const Color(0xff000000));
     expect(scheme.errorContainer, scheme.error);
     expect(scheme.onErrorContainer, scheme.onError);
-    expect(scheme.outline, scheme.onBackground);
     expect(scheme.background, const Color(0xff121212));
     expect(scheme.onBackground, const Color(0xffffffff));
     expect(scheme.surface, const Color(0xff121212));
     expect(scheme.onSurface, const Color(0xffffffff));
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
-    expect(scheme.shadow, scheme.onBackground);
-    expect(scheme.brightness, Brightness.dark);
 
     expect(scheme.primaryVariant, const Color(0xffbe9eff));
     expect(scheme.secondaryVariant, const Color(0xff66fff9));

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -9,76 +9,156 @@ void main() {
   test('light scheme matches the spec', () {
     // Colors should match the Material Design baseline default theme:
     // https://material.io/design/color/dark-theme.html#ui-application
+    // with the new Material 3 colors defaulting to values from the M2
+    // baseline.
     const ColorScheme scheme = ColorScheme.light();
     expect(scheme.primary, const Color(0xff6200ee));
-    expect(scheme.primaryVariant, const Color(0xff3700b3));
-    expect(scheme.secondary, const Color(0xff03dac6));
-    expect(scheme.secondaryVariant, const Color(0xff018786));
-    expect(scheme.background, const Color(0xffffffff));
-    expect(scheme.surface, const Color(0xffffffff));
-    expect(scheme.error, const Color(0xffb00020));
     expect(scheme.onPrimary, const Color(0xffffffff));
+    expect(scheme.primaryContainer, scheme.primary);
+    expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.secondary, const Color(0xff03dac6));
     expect(scheme.onSecondary, const Color(0xff000000));
-    expect(scheme.onBackground, const Color(0xff000000));
-    expect(scheme.onSurface, const Color(0xff000000));
+    expect(scheme.secondaryContainer, scheme.secondary);
+    expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.tertiary, scheme.secondary);
+    expect(scheme.onTertiary, scheme.onSecondary);
+    expect(scheme.tertiaryContainer, scheme.tertiary);
+    expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.error, const Color(0xffb00020));
     expect(scheme.onError, const Color(0xffffffff));
+    expect(scheme.errorContainer, scheme.error);
+    expect(scheme.onErrorContainer, scheme.onError);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.background, const Color(0xffffffff));
+    expect(scheme.onBackground, const Color(0xff000000));
+    expect(scheme.surface, const Color(0xffffffff));
+    expect(scheme.onSurface, const Color(0xff000000));
+    expect(scheme.surfaceVariant, scheme.surface);
+    expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.inverseSurface, scheme.onSurface);
+    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.inversePrimary, scheme.onPrimary);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.light);
+
+    expect(scheme.primaryVariant, const Color(0xff3700b3));
+    expect(scheme.secondaryVariant, const Color(0xff018786));
   });
 
   test('dark scheme matches the spec', () {
     // Colors should match the Material Design baseline dark theme:
     // https://material.io/design/color/dark-theme.html#ui-application
+    // with the new Material 3 colors defaulting to values from the M2
+    // baseline.
     const ColorScheme scheme = ColorScheme.dark();
     expect(scheme.primary, const Color(0xffbb86fc));
-    expect(scheme.primaryVariant, const Color(0xff3700b3));
-    expect(scheme.secondary, const Color(0xff03dac6));
-    expect(scheme.secondaryVariant, const Color(0xff03dac6));
-    expect(scheme.background, const Color(0xff121212));
-    expect(scheme.surface, const Color(0xff121212));
-    expect(scheme.error, const Color(0xffcf6679));
     expect(scheme.onPrimary, const Color(0xff000000));
+    expect(scheme.primaryContainer, scheme.primary);
+    expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.secondary, const Color(0xff03dac6));
     expect(scheme.onSecondary, const Color(0xff000000));
-    expect(scheme.onBackground, const Color(0xffffffff));
-    expect(scheme.onSurface, const Color(0xffffffff));
+    expect(scheme.secondaryContainer, scheme.secondary);
+    expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.tertiary, scheme.secondary);
+    expect(scheme.onTertiary, scheme.onSecondary);
+    expect(scheme.tertiaryContainer, scheme.tertiary);
+    expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.error, const Color(0xffcf6679));
     expect(scheme.onError, const Color(0xff000000));
+    expect(scheme.errorContainer, scheme.error);
+    expect(scheme.onErrorContainer, scheme.onError);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.background, const Color(0xff121212));
+    expect(scheme.onBackground, const Color(0xffffffff));
+    expect(scheme.surface, const Color(0xff121212));
+    expect(scheme.onSurface, const Color(0xffffffff));
+    expect(scheme.surfaceVariant, scheme.surface);
+    expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.inverseSurface, scheme.onSurface);
+    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.inversePrimary, scheme.onPrimary);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.dark);
+
+    expect(scheme.primaryVariant, const Color(0xff3700b3));
+    expect(scheme.secondaryVariant, const Color(0xff03dac6));
   });
 
   test('high contrast light scheme matches the spec', () {
     // Colors are based off of the Material Design baseline default theme:
     // https://material.io/design/color/dark-theme.html#ui-application
+    // with the new Material 3 colors defaulting to values from the M2
+    // baseline.
     const ColorScheme scheme = ColorScheme.highContrastLight();
     expect(scheme.primary, const Color(0xff0000ba));
-    expect(scheme.primaryVariant, const Color(0xff000088));
-    expect(scheme.secondary, const Color(0xff66fff9));
-    expect(scheme.secondaryVariant, const Color(0xff018786));
-    expect(scheme.background, const Color(0xffffffff));
-    expect(scheme.surface, const Color(0xffffffff));
-    expect(scheme.error, const Color(0xff790000));
     expect(scheme.onPrimary, const Color(0xffffffff));
+    expect(scheme.primaryContainer, scheme.primary);
+    expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.secondary, const Color(0xff66fff9));
     expect(scheme.onSecondary, const Color(0xff000000));
-    expect(scheme.onBackground, const Color(0xff000000));
-    expect(scheme.onSurface, const Color(0xff000000));
+    expect(scheme.secondaryContainer, scheme.secondary);
+    expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.tertiary, scheme.secondary);
+    expect(scheme.onTertiary, scheme.onSecondary);
+    expect(scheme.tertiaryContainer, scheme.tertiary);
+    expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.error, const Color(0xff790000));
     expect(scheme.onError, const Color(0xffffffff));
+    expect(scheme.errorContainer, scheme.error);
+    expect(scheme.onErrorContainer, scheme.onError);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.background, const Color(0xffffffff));
+    expect(scheme.onBackground, const Color(0xff000000));
+    expect(scheme.surface, const Color(0xffffffff));
+    expect(scheme.onSurface, const Color(0xff000000));
+    expect(scheme.surfaceVariant, scheme.surface);
+    expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.inverseSurface, scheme.onSurface);
+    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.inversePrimary, scheme.onPrimary);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.light);
+
+    expect(scheme.primaryVariant, const Color(0xff000088));
+    expect(scheme.secondaryVariant, const Color(0xff018786));
   });
 
   test('high contrast dark scheme matches the spec', () {
     // Colors are based off of the Material Design baseline dark theme:
     // https://material.io/design/color/dark-theme.html#ui-application
+    // with the new Material 3 colors defaulting to values from the M2
+    // baseline.
     const ColorScheme scheme = ColorScheme.highContrastDark();
     expect(scheme.primary, const Color(0xffefb7ff));
-    expect(scheme.primaryVariant, const Color(0xffbe9eff));
-    expect(scheme.secondary, const Color(0xff66fff9));
-    expect(scheme.secondaryVariant, const Color(0xff66fff9));
-    expect(scheme.background, const Color(0xff121212));
-    expect(scheme.surface, const Color(0xff121212));
-    expect(scheme.error, const Color(0xff9b374d));
     expect(scheme.onPrimary, const Color(0xff000000));
+    expect(scheme.primaryContainer, scheme.primary);
+    expect(scheme.onPrimaryContainer, scheme.onPrimary);
+    expect(scheme.secondary, const Color(0xff66fff9));
     expect(scheme.onSecondary, const Color(0xff000000));
-    expect(scheme.onBackground, const Color(0xffffffff));
-    expect(scheme.onSurface, const Color(0xffffffff));
+    expect(scheme.secondaryContainer, scheme.secondary);
+    expect(scheme.onSecondaryContainer, scheme.onSecondary);
+    expect(scheme.tertiary, scheme.secondary);
+    expect(scheme.onTertiary, scheme.onSecondary);
+    expect(scheme.tertiaryContainer, scheme.tertiary);
+    expect(scheme.onTertiaryContainer, scheme.onTertiary);
+    expect(scheme.error, const Color(0xff9b374d));
     expect(scheme.onError, const Color(0xff000000));
+    expect(scheme.errorContainer, scheme.error);
+    expect(scheme.onErrorContainer, scheme.onError);
+    expect(scheme.outline, scheme.onBackground);
+    expect(scheme.background, const Color(0xff121212));
+    expect(scheme.onBackground, const Color(0xffffffff));
+    expect(scheme.surface, const Color(0xff121212));
+    expect(scheme.onSurface, const Color(0xffffffff));
+    expect(scheme.surfaceVariant, scheme.surface);
+    expect(scheme.onSurfaceVariant, scheme.onSurface);
+    expect(scheme.inverseSurface, scheme.onSurface);
+    expect(scheme.inverseOnSurface, scheme.surface);
+    expect(scheme.inversePrimary, scheme.onPrimary);
+    expect(scheme.shadow, scheme.onBackground);
     expect(scheme.brightness, Brightness.dark);
+
+    expect(scheme.primaryVariant, const Color(0xffbe9eff));
+    expect(scheme.secondaryVariant, const Color(0xff66fff9));
   });
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -507,4 +507,15 @@ void main() {
   themeData = ThemeData.raw(primaryColorBrightness: Brightness.dark);
   themeData = themeData.copyWith(primaryColorBrightness: Brightness.dark);
   themeData.primaryColorBrightness; // Removing field reference not supported.
+
+  // Changes made in https://github.com/flutter/flutter/pull/93427
+  ColorScheme colorScheme = ColorScheme();
+  colorScheme = ColorScheme(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme = ColorScheme.light(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme = ColorScheme.dark(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme = ColorScheme.highContrastLight(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme = ColorScheme.highContrastDark(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme = colorScheme.copyWith(primaryVariant: Colors.black, secondaryVariant: Colors.white);
+  colorScheme.primaryVariant;
+  colorScheme.secondaryVariant;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -480,4 +480,15 @@ void main() {
   themeData = ThemeData.raw();
   themeData = themeData.copyWith();
   themeData.primaryColorBrightness; // Removing field reference not supported.
+
+  // Changes made in https://github.com/flutter/flutter/pull/93427
+  ColorScheme colorScheme = ColorScheme();
+  colorScheme = ColorScheme();
+  colorScheme = ColorScheme.light();
+  colorScheme = ColorScheme.dark();
+  colorScheme = ColorScheme.highContrastLight();
+  colorScheme = ColorScheme.highContrastDark();
+  colorScheme = colorScheme.copyWith();
+  colorScheme.primaryContainer;
+  colorScheme.secondaryContainer;
 }


### PR DESCRIPTION
As part of the [migration to Material 3](https://github.com/flutter/flutter/issues/89852), this PR adds new colors to `ColorScheme` and deprecates two colors that are no longer being supported:

The added colors include a new ‘tertiary’ group and ‘container’ variants for several of the colors:

- primaryContainer
- secondaryContainer
- tertiary
- tertiaryContainer
- surfaceVariant
- errorContainer
- onPrimaryContainer
- onSecondaryContainer
- onTertiary
- onTertiaryContainer
- onSurfaceVariant
- onErrorContainer
- outline
- shadow
- inverseSurface
- onInverseSurface
- inversePrimary

The two colors being deprecated:

- primaryVariant
- secondaryVariant

Includes flutter fix data to automatically remove references to the two deprecated colors and rename references to them  with `primaryContainer` and `secondaryContainer`.

See the [design doc](http://flutter.dev/go/colorscheme-m3) for more discussion about this change.

Fixes: #89852

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
