### PR TITLE
Fuchsia text editing keybindings workaround

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -235,6 +235,8 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   static const LogicalKeyboardKey _kArrowDown = LogicalKeyboardKey(81 | _kFuchsiaKeyIdPlane);
   static const LogicalKeyboardKey _kArrowUp = LogicalKeyboardKey(82 | _kFuchsiaKeyIdPlane);
 
+  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/93450 .
+  // The keys should be normalized in the Fuchsia embedder.
   static const Map<ShortcutActivator, Intent> _fuchsiaShortcuts = <ShortcutActivator, Intent>{
     SingleActivator(_kBackspace): DeleteCharacterIntent(forward: false),
     SingleActivator(_kBackspace, control: true): DeleteToNextWordBoundaryIntent(forward: false),

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -264,45 +264,6 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     SingleActivator(_kArrowUp, shift: true): ExtendSelectionVerticallyToAdjacentLineIntent(forward: false, collapseSelection: false),
   };
 
-  static const Map<ShortcutActivator, Intent> defaultEditingShortcuts =
-      <ShortcutActivator, Intent>{
-    SingleActivator(kBackspace): DeleteTextIntent(),
-    SingleActivator(kBackspace, control: true): DeleteByWordTextIntent(),
-    SingleActivator(kBackspace, alt: true): DeleteByLineTextIntent(),
-    SingleActivator(kDelete): DeleteForwardTextIntent(),
-    SingleActivator(kDelete, control: true): DeleteForwardByWordTextIntent(),
-    SingleActivator(kDelete, alt: true): DeleteForwardByLineTextIntent(),
-    SingleActivator(kArrowDown, alt: true): MoveSelectionToEndTextIntent(),
-    SingleActivator(kArrowLeft, alt: true): MoveSelectionLeftByLineTextIntent(),
-    SingleActivator(kArrowRight, alt: true):
-        MoveSelectionRightByLineTextIntent(),
-    SingleActivator(kArrowUp, alt: true): MoveSelectionToStartTextIntent(),
-    SingleActivator(kArrowDown, shift: true, alt: true):
-        ExpandSelectionToEndTextIntent(),
-    SingleActivator(kArrowLeft, shift: true, alt: true):
-        ExpandSelectionLeftByLineTextIntent(),
-    SingleActivator(kArrowRight, shift: true, alt: true):
-        ExpandSelectionRightByLineTextIntent(),
-    SingleActivator(kArrowUp, shift: true, alt: true):
-        ExpandSelectionToStartTextIntent(),
-    SingleActivator(kArrowDown): MoveSelectionDownTextIntent(),
-    SingleActivator(kArrowLeft): MoveSelectionLeftTextIntent(),
-    SingleActivator(kArrowRight): MoveSelectionRightTextIntent(),
-    SingleActivator(kArrowUp): MoveSelectionUpTextIntent(),
-    SingleActivator(kArrowLeft, control: true):
-        MoveSelectionLeftByWordTextIntent(),
-    SingleActivator(kArrowRight, control: true):
-        MoveSelectionRightByWordTextIntent(),
-    SingleActivator(kArrowLeft, shift: true, control: true):
-        ExtendSelectionLeftByWordTextIntent(),
-    SingleActivator(kArrowRight, shift: true, control: true):
-        ExtendSelectionRightByWordTextIntent(),
-    SingleActivator(kArrowDown, shift: true): ExtendSelectionDownTextIntent(),
-    SingleActivator(kArrowLeft, shift: true): ExtendSelectionLeftTextIntent(),
-    SingleActivator(kArrowRight, shift: true): ExtendSelectionRightTextIntent(),
-    SingleActivator(kArrowUp, shift: true): ExtendSelectionUpTextIntent(),
-  };
-
   // The following key combinations have no effect on text editing on this
   // platform:
   //   * End

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -224,7 +224,84 @@ class DefaultTextEditingShortcuts extends Shortcuts {
   //   * Meta + backspace
   static const Map<ShortcutActivator, Intent> _androidShortcuts = _commonShortcuts;
 
-  static const Map<ShortcutActivator, Intent> _fuchsiaShortcuts = _androidShortcuts;
+  // Fuchsia keyboard HID usage values are defined in (page 53):
+  // https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf
+  static const int _kFuchsiaKeyIdPlane = LogicalKeyboardKey.fuchsiaPlane;
+
+  static const LogicalKeyboardKey _kBackspace = LogicalKeyboardKey(42 | _kFuchsiaKeyIdPlane);
+  static const LogicalKeyboardKey _kDelete = LogicalKeyboardKey(76 | _kFuchsiaKeyIdPlane);
+  static const LogicalKeyboardKey _kArrowLeft = LogicalKeyboardKey(80 | _kFuchsiaKeyIdPlane);
+  static const LogicalKeyboardKey _kArrowRight = LogicalKeyboardKey(79 | _kFuchsiaKeyIdPlane);
+  static const LogicalKeyboardKey _kArrowDown = LogicalKeyboardKey(81 | _kFuchsiaKeyIdPlane);
+  static const LogicalKeyboardKey _kArrowUp = LogicalKeyboardKey(82 | _kFuchsiaKeyIdPlane);
+
+  static const Map<ShortcutActivator, Intent> _fuchsiaShortcuts = <ShortcutActivator, Intent>{
+    SingleActivator(_kBackspace): DeleteCharacterIntent(forward: false),
+    SingleActivator(_kBackspace, control: true): DeleteToNextWordBoundaryIntent(forward: false),
+    SingleActivator(_kBackspace, alt: true): DeleteToLineBreakIntent(forward: false),
+    SingleActivator(_kDelete): DeleteCharacterIntent(forward: true),
+    SingleActivator(_kDelete, control: true): DeleteToNextWordBoundaryIntent(forward: true),
+    SingleActivator(_kDelete, alt: true): DeleteToLineBreakIntent(forward: true),
+    SingleActivator(_kArrowDown, alt: true): ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: true),
+    SingleActivator(_kArrowLeft, alt: true): ExtendSelectionToLineBreakIntent(forward: false, collapseSelection: true),
+    SingleActivator(_kArrowRight, alt: true): ExtendSelectionToLineBreakIntent(forward: true, collapseSelection: true),
+    SingleActivator(_kArrowUp, alt: true): ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: true),
+    SingleActivator(_kArrowDown, shift: true, alt: true): ExtendSelectionToDocumentBoundaryIntent(forward: true, collapseSelection: false),
+    SingleActivator(_kArrowLeft, shift: true, alt: true): ExtendSelectionToLineBreakIntent(forward: false, collapseSelection: false),
+    SingleActivator(_kArrowRight, shift: true, alt: true): ExtendSelectionToLineBreakIntent(forward: true, collapseSelection: false),
+    SingleActivator(_kArrowUp, shift: true, alt: true): ExtendSelectionToDocumentBoundaryIntent(forward: false, collapseSelection: false),
+    SingleActivator(_kArrowDown): ExtendSelectionVerticallyToAdjacentLineIntent(forward: true, collapseSelection: true),
+    SingleActivator(_kArrowLeft): ExtendSelectionByCharacterIntent(forward: false, collapseSelection: true),
+    SingleActivator(_kArrowRight): ExtendSelectionByCharacterIntent(forward: true, collapseSelection: true),
+    SingleActivator(_kArrowUp): ExtendSelectionVerticallyToAdjacentLineIntent(forward: false, collapseSelection: true),
+    SingleActivator(_kArrowLeft, control: true): ExtendSelectionToNextWordBoundaryIntent(forward: false, collapseSelection: true),
+    SingleActivator(_kArrowRight, control: true): ExtendSelectionToNextWordBoundaryIntent(forward: true, collapseSelection: true),
+    SingleActivator(_kArrowLeft, shift: true, control: true): ExtendSelectionToNextWordBoundaryIntent(forward: false, collapseSelection: false),
+    SingleActivator(_kArrowRight, shift: true, control: true): ExtendSelectionToNextWordBoundaryIntent(forward: true, collapseSelection: false),
+    SingleActivator(_kArrowDown, shift: true): ExtendSelectionVerticallyToAdjacentLineIntent(forward: true, collapseSelection: false),
+    SingleActivator(_kArrowLeft, shift: true): ExtendSelectionByCharacterIntent(forward: false, collapseSelection: false),
+    SingleActivator(_kArrowRight, shift: true): ExtendSelectionByCharacterIntent(forward: true, collapseSelection: false),
+    SingleActivator(_kArrowUp, shift: true): ExtendSelectionVerticallyToAdjacentLineIntent(forward: false, collapseSelection: false),
+  };
+
+  static const Map<ShortcutActivator, Intent> defaultEditingShortcuts =
+      <ShortcutActivator, Intent>{
+    SingleActivator(kBackspace): DeleteTextIntent(),
+    SingleActivator(kBackspace, control: true): DeleteByWordTextIntent(),
+    SingleActivator(kBackspace, alt: true): DeleteByLineTextIntent(),
+    SingleActivator(kDelete): DeleteForwardTextIntent(),
+    SingleActivator(kDelete, control: true): DeleteForwardByWordTextIntent(),
+    SingleActivator(kDelete, alt: true): DeleteForwardByLineTextIntent(),
+    SingleActivator(kArrowDown, alt: true): MoveSelectionToEndTextIntent(),
+    SingleActivator(kArrowLeft, alt: true): MoveSelectionLeftByLineTextIntent(),
+    SingleActivator(kArrowRight, alt: true):
+        MoveSelectionRightByLineTextIntent(),
+    SingleActivator(kArrowUp, alt: true): MoveSelectionToStartTextIntent(),
+    SingleActivator(kArrowDown, shift: true, alt: true):
+        ExpandSelectionToEndTextIntent(),
+    SingleActivator(kArrowLeft, shift: true, alt: true):
+        ExpandSelectionLeftByLineTextIntent(),
+    SingleActivator(kArrowRight, shift: true, alt: true):
+        ExpandSelectionRightByLineTextIntent(),
+    SingleActivator(kArrowUp, shift: true, alt: true):
+        ExpandSelectionToStartTextIntent(),
+    SingleActivator(kArrowDown): MoveSelectionDownTextIntent(),
+    SingleActivator(kArrowLeft): MoveSelectionLeftTextIntent(),
+    SingleActivator(kArrowRight): MoveSelectionRightTextIntent(),
+    SingleActivator(kArrowUp): MoveSelectionUpTextIntent(),
+    SingleActivator(kArrowLeft, control: true):
+        MoveSelectionLeftByWordTextIntent(),
+    SingleActivator(kArrowRight, control: true):
+        MoveSelectionRightByWordTextIntent(),
+    SingleActivator(kArrowLeft, shift: true, control: true):
+        ExtendSelectionLeftByWordTextIntent(),
+    SingleActivator(kArrowRight, shift: true, control: true):
+        ExtendSelectionRightByWordTextIntent(),
+    SingleActivator(kArrowDown, shift: true): ExtendSelectionDownTextIntent(),
+    SingleActivator(kArrowLeft, shift: true): ExtendSelectionLeftTextIntent(),
+    SingleActivator(kArrowRight, shift: true): ExtendSelectionRightTextIntent(),
+    SingleActivator(kArrowUp, shift: true): ExtendSelectionUpTextIntent(),
+  };
 
   // The following key combinations have no effect on text editing on this
   // platform:

--- a/packages/flutter/lib/src/widgets/text_editing_intents.dart
+++ b/packages/flutter/lib/src/widgets/text_editing_intents.dart
@@ -225,3 +225,216 @@ class UpdateSelectionIntent extends Intent {
   /// {@macro flutter.widgets.TextEditingIntents.cause}
   final SelectionChangedCause cause;
 }
+
+// These Intents are deprecated.
+
+/// An [Intent] to delete a character in the backwards direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteTextIntent extends Intent {
+  /// Creates an instance of DeleteTextIntent.
+  const DeleteTextIntent();
+}
+
+/// An [Intent] to delete a word in the backwards direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByWordTextIntent extends Intent {
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteByWordTextIntent();
+}
+
+/// An [Intent] to delete a line in the backwards direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteByLineTextIntent extends Intent {
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteByLineTextIntent();
+}
+
+/// An [Intent] to delete in the forward direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardTextIntent extends Intent {
+  /// Creates an instance of DeleteForwardTextIntent.
+  const DeleteForwardTextIntent();
+}
+
+/// An [Intent] to delete a word in the forward direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByWordTextIntent extends Intent {
+  /// Creates an instance of DeleteByWordTextIntent.
+  const DeleteForwardByWordTextIntent();
+}
+
+/// An [Intent] to delete a line in the forward direction.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class DeleteForwardByLineTextIntent extends Intent {
+  /// Creates an instance of DeleteByLineTextIntent.
+  const DeleteForwardByLineTextIntent();
+}
+
+/// An [Intent] to expand the selection left to the start/end of the current
+/// line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExpandSelectionLeftByLineTextIntent extends Intent {
+  /// Creates an instance of ExpandSelectionLeftByLineTextIntent.
+  const ExpandSelectionLeftByLineTextIntent();
+}
+
+/// An [Intent] to expand the selection right to the start/end of the current
+/// field.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExpandSelectionRightByLineTextIntent extends Intent {
+  /// Creates an instance of ExpandSelectionRightByLineTextIntent.
+  const ExpandSelectionRightByLineTextIntent();
+}
+
+/// An [Intent] to expand the selection to the end of the field.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExpandSelectionToEndTextIntent extends Intent {
+  /// Creates an instance of ExpandSelectionToEndTextIntent.
+  const ExpandSelectionToEndTextIntent();
+}
+
+/// An [Intent] to expand the selection to the start of the field.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExpandSelectionToStartTextIntent extends Intent {
+  /// Creates an instance of ExpandSelectionToStartTextIntent.
+  const ExpandSelectionToStartTextIntent();
+}
+
+/// An [Intent] to extend the selection down by one line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionDownTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionDownTextIntent.
+  const ExtendSelectionDownTextIntent();
+}
+
+/// An [Intent] to extend the selection left by one character.
+/// platform for the shift + arrow-left key event.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionLeftTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionLeftTextIntent.
+  const ExtendSelectionLeftTextIntent();
+}
+
+/// An [Intent] to extend the selection right by one character.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionRightTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionRightTextIntent.
+  const ExtendSelectionRightTextIntent();
+}
+
+/// An [Intent] to extend the selection up by one line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionUpTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionUpTextIntent.
+  const ExtendSelectionUpTextIntent();
+}
+
+/// An [Intent] to extend the selection left past the nearest word.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionLeftByWordTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionLeftByWordTextIntent.
+  const ExtendSelectionLeftByWordTextIntent();
+}
+
+/// An [Intent] to extend the selection right past the nearest word.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class ExtendSelectionRightByWordTextIntent extends Intent {
+  /// Creates an instance of ExtendSelectionRightByWordTextIntent.
+  const ExtendSelectionRightByWordTextIntent();
+}
+
+/// An [Intent] to move the selection down by one line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionDownTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionDownTextIntent.
+  const MoveSelectionDownTextIntent();
+}
+
+/// An [Intent] to move the selection left by one line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionLeftByLineTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionLeftByLineTextIntent.
+  const MoveSelectionLeftByLineTextIntent();
+}
+
+/// An [Intent] to move the selection left past the nearest word.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionLeftByWordTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionLeftByWordTextIntent.
+  const MoveSelectionLeftByWordTextIntent();
+}
+
+/// An [Intent] to move the selection left by one character.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionLeftTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionLeftTextIntent.
+  const MoveSelectionLeftTextIntent();
+}
+
+/// An [Intent] to move the selection to the start of the field.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionToStartTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionToStartTextIntent.
+  const MoveSelectionToStartTextIntent();
+}
+
+/// An [Intent] to move the selection right by one line.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionRightByLineTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionRightByLineTextIntent.
+  const MoveSelectionRightByLineTextIntent();
+}
+
+/// An [Intent] to move the selection right past the nearest word.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionRightByWordTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionRightByWordTextIntent.
+  const MoveSelectionRightByWordTextIntent();
+}
+
+/// An [Intent] to move the selection right by one character.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionRightTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionRightTextIntent.
+  const MoveSelectionRightTextIntent();
+}
+
+/// An [Intent] to move the selection to the end of the field.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionToEndTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionToEndTextIntent.
+  const MoveSelectionToEndTextIntent();
+}
+
+/// An [Intent] to move the selection up by one character.
+///
+/// {@macro flutter.widgets.TextEditingIntents.seeAlso}
+class MoveSelectionUpTextIntent extends Intent {
+  /// Creates an instance of MoveSelectionUpTextIntent.
+  const MoveSelectionUpTextIntent();
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -120,7 +120,7 @@ export 'src/widgets/spacer.dart';
 export 'src/widgets/status_transitions.dart';
 export 'src/widgets/table.dart';
 export 'src/widgets/text.dart';
-export 'src/widgets/text_editing_intents.dart';
+export 'src/widgets/text_editing_intents.dart' hide DeleteTextIntent, DeleteByWordTextIntent, DeleteByLineTextIntent, DeleteForwardTextIntent, DeleteForwardByWordTextIntent, DeleteForwardByLineTextIntent, ExpandSelectionLeftByLineTextIntent, ExpandSelectionRightByLineTextIntent, ExpandSelectionToEndTextIntent, ExpandSelectionToStartTextIntent, ExtendSelectionDownTextIntent, ExtendSelectionLeftTextIntent, ExtendSelectionRightTextIntent, ExtendSelectionUpTextIntent, ExtendSelectionLeftByWordTextIntent, ExtendSelectionRightByWordTextIntent, MoveSelectionDownTextIntent, MoveSelectionLeftByLineTextIntent, MoveSelectionLeftByWordTextIntent, MoveSelectionLeftTextIntent, MoveSelectionToStartTextIntent, MoveSelectionRightByLineTextIntent, MoveSelectionRightByWordTextIntent, MoveSelectionRightTextIntent, MoveSelectionToEndTextIntent, MoveSelectionUpTextIntent;
 export 'src/widgets/text_selection.dart';
 export 'src/widgets/text_selection_toolbar_layout_delegate.dart';
 export 'src/widgets/texture.dart';

--- a/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
@@ -1775,6 +1775,8 @@ void main() {
     }, variant: macOSOnly);
   });
 
+  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/93450 .
+  // Remove these tests once the above issue is resolved.
   final TargetPlatformVariant fuchsiaOnly = TargetPlatformVariant.only(TargetPlatform.fuchsia);
   group('fuchsia shortcuts', () {
     const int _kFuchsiaKeyIdPlane = LogicalKeyboardKey.fuchsiaPlane;
@@ -1910,6 +1912,44 @@ void main() {
       );
       expect(controller.selection, const TextSelection.collapsed(offset: 20));
     }, variant: fuchsiaOnly);
+
+    testWidgets('delete forward', (WidgetTester tester) async {
+      await tester.pumpWidget(buildEditableText());
+
+      // Character delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kDelete));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'all good peole\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 32));
+
+      // Word delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kDelete, control: true));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'all good peo\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 32));
+
+      // Line delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kDelete, alt: true));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'all good peo\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 32));
+    }, variant: fuchsiaOnly);
+
 
     testWidgets('arrow key navigation', (WidgetTester tester) async {
       await tester.pumpWidget(buildEditableText());

--- a/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -39,6 +41,10 @@ Iterable<SingleActivator> allModifierVariants(LogicalKeyboardKey trigger) {
     });
   });
 }
+
+final TargetPlatformVariant allExceptFuchsia = TargetPlatformVariant(
+  TargetPlatform.values.toSet()..remove(TargetPlatform.fuchsia),
+);
 
 void main() {
   const String testText =
@@ -114,12 +120,14 @@ void main() {
       }
     },
     skip: kIsWeb, // [intended]
-    variant: TargetPlatformVariant.all(),
+    variant: allExceptFuchsia,
   );
 
   group('Common text editing shortcuts: ',
     () {
-      final TargetPlatformVariant allExceptMacOS = TargetPlatformVariant(TargetPlatform.values.toSet()..remove(TargetPlatform.macOS));
+      final TargetPlatformVariant allExceptMacOSAndFuchsia = TargetPlatformVariant(
+        TargetPlatform.values.toSet()..remove(TargetPlatform.macOS)..remove(TargetPlatform.fuchsia),
+      );
 
       group('backspace', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.backspace;
@@ -147,7 +155,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 19),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('backspace readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -165,7 +173,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 20, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('backspace at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -188,7 +196,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('backspace at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -212,7 +220,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 71),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('backspace inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -233,7 +241,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('backspace at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -254,7 +262,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('delete: ', () {
@@ -284,7 +292,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 20),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('delete readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -302,7 +310,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 20, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('delete at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -325,7 +333,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('delete at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -349,7 +357,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 72, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('delete inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -370,7 +378,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('delete at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -391,7 +399,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 8),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('Non-collapsed delete', () {
@@ -417,7 +425,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 8),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at the boundaries of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -438,7 +446,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 8),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('cross-cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -459,7 +467,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('cross-cluster obscured text', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -480,7 +488,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 1),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('word modifier + backspace', () {
@@ -513,7 +521,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 24),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -531,7 +539,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 29, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -554,7 +562,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -578,7 +586,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 71),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -599,7 +607,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -620,7 +628,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('word modifier + delete', () {
@@ -653,7 +661,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 23),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -671,7 +679,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 23, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -694,7 +702,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -711,7 +719,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 72, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -732,7 +740,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -753,7 +761,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 8),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('line modifier + backspace', () {
@@ -786,7 +794,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 20),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('softwrap line boundary, upstream', (WidgetTester tester) async {
           controller.text = testSoftwrapText;
@@ -810,7 +818,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 20),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('softwrap line boundary, downstream', (WidgetTester tester) async {
           controller.text = testSoftwrapText;
@@ -828,7 +836,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 40),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -846,7 +854,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 29, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -869,7 +877,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -892,7 +900,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 55),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -913,7 +921,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -934,7 +942,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('line modifier + delete', () {
@@ -967,7 +975,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 23),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('softwrap line boundary, upstream', (WidgetTester tester) async {
           controller.text = testSoftwrapText;
@@ -986,7 +994,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 40, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('softwrap line boundary, downstream', (WidgetTester tester) async {
           controller.text = testSoftwrapText;
@@ -1009,7 +1017,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 40),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('readonly', (WidgetTester tester) async {
           controller.text = testText;
@@ -1027,7 +1035,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 23, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at start', (WidgetTester tester) async {
           controller.text = testText;
@@ -1050,7 +1058,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at end', (WidgetTester tester) async {
           controller.text = testText;
@@ -1067,7 +1075,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 72, affinity: TextAffinity.upstream),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('inside of a cluster', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -1088,7 +1096,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 0),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
 
         testWidgets('at cluster boundary', (WidgetTester tester) async {
           controller.text = testCluster;
@@ -1109,7 +1117,7 @@ void main() {
             controller.selection,
             const TextSelection.collapsed(offset: 8),
           );
-        }, variant: TargetPlatformVariant.all());
+        }, variant: allExceptFuchsia);
       });
 
       group('Arrow Movement', () {
@@ -1134,7 +1142,7 @@ void main() {
                 reason: activator.toString(),
               );
             }
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('base arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1148,7 +1156,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 19,
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1162,7 +1170,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 4,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
 
           testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1176,7 +1184,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 20,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
         });
 
         group('right', () {
@@ -1197,7 +1205,7 @@ void main() {
               expect(controller.selection.isCollapsed, isTrue, reason: activator.toString());
               expect(controller.selection.baseOffset, 72, reason: activator.toString());
             }
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('base arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1211,7 +1219,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 21,
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1225,7 +1233,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 10,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
 
          testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1240,7 +1248,7 @@ void main() {
               offset: 35, // Before the newline character.
               affinity: TextAffinity.upstream,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
         });
 
         group('With initial non-collapsed selection', () {
@@ -1294,7 +1302,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 23,
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1347,7 +1355,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 28, // After "good".
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
 
          testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1401,7 +1409,7 @@ void main() {
               offset: 35, // After "people".
               affinity: TextAffinity.upstream,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptMacOSAndFuchsia);
         });
 
         group('vertical movement', () {
@@ -1424,7 +1432,7 @@ void main() {
                 reason: activator.toString(),
               );
             }
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('at end', (WidgetTester tester) async {
             controller.text = testText;
@@ -1442,7 +1450,7 @@ void main() {
               expect(controller.selection.baseOffset, 72, reason: activator.toString());
               expect(controller.selection.extentOffset, 72, reason: activator.toString());
             }
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('run', (WidgetTester tester) async {
             controller.text =
@@ -1528,7 +1536,7 @@ void main() {
               offset: 4,
               affinity: TextAffinity.upstream,
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('run can be interrupted by layout changes', (WidgetTester tester) async {
             controller.text =
@@ -1557,7 +1565,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 3,
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
 
           testWidgets('run can be interrupted by selection changes', (WidgetTester tester) async {
             controller.text =
@@ -1592,7 +1600,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 3,   // Would have been 4 if the run wasn't interrupted.
             ));
-          }, variant: TargetPlatformVariant.all());
+          }, variant: allExceptFuchsia);
         });
       });
     },
@@ -1765,5 +1773,158 @@ void main() {
         affinity: TextAffinity.upstream,
       ));
     }, variant: macOSOnly);
+  });
+
+  final TargetPlatformVariant fuchsiaOnly = TargetPlatformVariant.only(TargetPlatform.fuchsia);
+  group('fuchsia shortcuts', () {
+    const int _kFuchsiaKeyIdPlane = LogicalKeyboardKey.fuchsiaPlane;
+    const LogicalKeyboardKey _kBackspace = LogicalKeyboardKey(42 | _kFuchsiaKeyIdPlane);
+    const LogicalKeyboardKey _kDelete = LogicalKeyboardKey(76 | _kFuchsiaKeyIdPlane);
+    const LogicalKeyboardKey _kArrowLeft = LogicalKeyboardKey(80 | _kFuchsiaKeyIdPlane);
+    const LogicalKeyboardKey _kArrowRight = LogicalKeyboardKey(79 | _kFuchsiaKeyIdPlane);
+    const LogicalKeyboardKey _kArrowDown = LogicalKeyboardKey(81 | _kFuchsiaKeyIdPlane);
+    const LogicalKeyboardKey _kArrowUp = LogicalKeyboardKey(82 | _kFuchsiaKeyIdPlane);
+
+    int _getFuchsiaModifierFlags(LogicalKeyboardKey newKey, bool isDown) {
+      int result = 0;
+      final Set<LogicalKeyboardKey> pressed = RawKeyboard.instance.keysPressed;
+      if (isDown) {
+        pressed.add(newKey);
+      } else {
+        pressed.remove(newKey);
+      }
+      if (pressed.contains(LogicalKeyboardKey.shiftLeft)) {
+        result |= RawKeyEventDataFuchsia.modifierLeftShift;
+      }
+      if (pressed.contains(LogicalKeyboardKey.shiftRight)) {
+        result |= RawKeyEventDataFuchsia.modifierRightShift;
+      }
+      if (pressed.contains(LogicalKeyboardKey.metaLeft)) {
+        result |= RawKeyEventDataFuchsia.modifierLeftMeta;
+      }
+      if (pressed.contains(LogicalKeyboardKey.metaRight)) {
+        result |= RawKeyEventDataFuchsia.modifierRightMeta;
+      }
+      if (pressed.contains(LogicalKeyboardKey.controlLeft)) {
+        result |= RawKeyEventDataFuchsia.modifierLeftControl;
+      }
+      if (pressed.contains(LogicalKeyboardKey.controlRight)) {
+        result |= RawKeyEventDataFuchsia.modifierRightControl;
+      }
+      if (pressed.contains(LogicalKeyboardKey.altLeft)) {
+        result |= RawKeyEventDataFuchsia.modifierLeftAlt;
+      }
+      if (pressed.contains(LogicalKeyboardKey.altRight)) {
+        result |= RawKeyEventDataFuchsia.modifierRightAlt;
+      }
+      if (pressed.contains(LogicalKeyboardKey.capsLock)) {
+        result |= RawKeyEventDataFuchsia.modifierCapsLock;
+      }
+      return result;
+    }
+
+    Future<bool> simulateFuchsiaKeyEvent(LogicalKeyboardKey logicalKey, bool isDown) async {
+      final Completer<bool> result = Completer<bool>();
+      final Map<String, dynamic> keyData = <String, dynamic>{
+        'type': isDown ? 'keydown' : 'keyup',
+        'keymap': 'fuchsia',
+        'hidUsage': logicalKey.keyId | LogicalKeyboardKey.unicodePlane,
+        'modifiers': _getFuchsiaModifierFlags(logicalKey, isDown),
+      };
+      await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
+        SystemChannels.keyEvent.name,
+        SystemChannels.keyEvent.codec.encodeMessage(keyData),
+        (ByteData? data) {
+          if (data == null) {
+            result.complete(false);
+            return;
+          }
+          final Map<String, dynamic> decoded = SystemChannels.keyEvent.codec.decodeMessage(data) as Map<String, dynamic>;
+          result.complete(decoded['handled'] as bool);
+        }
+      );
+      return result.future;
+    }
+
+    Future<void> sendFuchsiaKeyCombination(
+      WidgetTester tester,
+      SingleActivator activator,
+    ) async {
+      final List<LogicalKeyboardKey> modifiers = <LogicalKeyboardKey>[
+        if (activator.control) LogicalKeyboardKey.control,
+        if (activator.shift) LogicalKeyboardKey.shift,
+        if (activator.alt) LogicalKeyboardKey.alt,
+        if (activator.meta) LogicalKeyboardKey.meta,
+      ];
+      for (final LogicalKeyboardKey modifier in modifiers) {
+        await tester.sendKeyDownEvent(modifier, platform: 'fuchsia');
+      }
+      await simulateFuchsiaKeyEvent(activator.trigger, true);
+      await simulateFuchsiaKeyEvent(activator.trigger, false);
+      await tester.pump();
+      for (final LogicalKeyboardKey modifier in modifiers.reversed) {
+        await tester.sendKeyUpEvent(modifier, platform: 'fuchsia');
+      }
+    }
+
+    setUp(() {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(
+        offset: 32,   // all good peo|ple\n
+      );
+    });
+
+    testWidgets('delete', (WidgetTester tester) async {
+      await tester.pumpWidget(buildEditableText());
+
+      // Character delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kBackspace));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'all good peple\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 31));
+
+      // Word delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kBackspace, control: true));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'all good ple\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 29));
+
+      // Line delete.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kBackspace, alt: true));
+      expect(
+        controller.text,
+        'Now is the time for\n'
+        'ple\n'
+        'to come to the aid\n'
+        'of their country.',
+      );
+      expect(controller.selection, const TextSelection.collapsed(offset: 20));
+    }, variant: fuchsiaOnly);
+
+    testWidgets('arrow key navigation', (WidgetTester tester) async {
+      await tester.pumpWidget(buildEditableText());
+
+      // Verical movement.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kArrowUp));
+      expect(controller.selection, const TextSelection.collapsed(offset: 12));
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kArrowDown));
+      expect(controller.selection, const TextSelection.collapsed(offset: 32));
+
+      // Horizontal movement.
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kArrowLeft));
+      expect(controller.selection, const TextSelection.collapsed(offset: 31));
+      await sendFuchsiaKeyCombination(tester, const SingleActivator(_kArrowRight));
+      expect(controller.selection, const TextSelection.collapsed(offset: 32));
+    }, variant: fuchsiaOnly);
   });
 }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -15,6 +15,11 @@ import '../widgets/clipboard_utils.dart';
 import 'editable_text_utils.dart';
 import 'semantics_tester.dart';
 
+// TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/93450 .
+final TargetPlatformVariant allPlatformsExceptFuchsia = TargetPlatformVariant(
+  TargetPlatform.values.toSet()..remove(TargetPlatform.fuchsia),
+);
+
 Matcher matchesMethodCall(String method, { dynamic args }) => _MatchesMethodCall(method, arguments: args == null ? null : wrapMatcher(args));
 
 class _MatchesMethodCall extends Matcher {
@@ -5039,7 +5044,7 @@ void main() {
     debugKeyEventSimulatorTransitModeOverride = null;
 
     // On web, using keyboard for selection is handled by the browser.
-  }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+  }, variant: allPlatformsExceptFuchsia, skip: kIsWeb); // [intended]
 
   testWidgets('keyboard text selection works (ui.KeyData then RawKeyEvent)', (WidgetTester tester) async {
     debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
@@ -5049,7 +5054,7 @@ void main() {
     debugKeyEventSimulatorTransitModeOverride = null;
 
     // On web, using keyboard for selection is handled by the browser.
-  }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+  }, variant: allPlatformsExceptFuchsia, skip: kIsWeb); // [intended]
 
   testWidgets(
     'keyboard shortcuts respect read-only',
@@ -5227,7 +5232,7 @@ void main() {
     },
     // On web, using keyboard for selection is handled by the browser.
     skip: kIsWeb, // [intended]
-    variant: TargetPlatformVariant.all(),
+    variant: allPlatformsExceptFuchsia,
   );
 
   testWidgets('home/end keys', (WidgetTester tester) async {
@@ -5355,7 +5360,7 @@ void main() {
     expect(controller.text, equals(testText), reason: 'on $platform');
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
-    variant: TargetPlatformVariant.all(),
+    variant: allPlatformsExceptFuchsia,
   );
 
   testWidgets('shift + home/end keys', (WidgetTester tester) async {
@@ -5553,7 +5558,7 @@ void main() {
     }
   },
     skip: kIsWeb, // [intended] on web these keys are handled by the browser.
-    variant: TargetPlatformVariant.all(),
+    variant: allPlatformsExceptFuchsia,
   );
 
   // Regression test for https://github.com/flutter/flutter/issues/31287
@@ -8060,7 +8065,7 @@ void main() {
     expect(controller.selection.extentOffset, 9);
 
     // On web, using keyboard for selection is handled by the browser.
-  }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+  }, variant: allPlatformsExceptFuchsia, skip: kIsWeb); // [intended]
 
   testWidgets('navigating multiline text', (WidgetTester tester) async {
     const String multilineText = 'word word word\nword word\nword'; // 15 + 10 + 4;
@@ -8207,7 +8212,7 @@ void main() {
     expect(controller.selection.baseOffset, 15);
     expect(controller.selection.extentOffset, 24);
     // On web, using keyboard for selection is handled by the browser.
-  }, variant: TargetPlatformVariant.all(), skip: kIsWeb); // [intended]
+  }, variant: allPlatformsExceptFuchsia, skip: kIsWeb); // [intended]
 
   testWidgets('expanding selection to start/end', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(text: 'word word word');


### PR DESCRIPTION
On Fuchsia some keys are not mapped correctly so they end up being sent to the framework as "platform private" keys. This is a temporary fix to unblock the roll. /cc @dkwingsmt it seems the fuchsia embbeder needs to update some key mappings? Is there an existing issue?

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
