### PR TITLE
Add InputDecorator label color on error examples

### DIFF
--- a/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for InputDecorator
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const Center(
+          child: InputDecoratorExample(),
+        ),
+      ),
+    );
+  }
+}
+
+class InputDecoratorExample extends StatelessWidget {
+  const InputDecoratorExample({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: 'Name',
+        floatingLabelStyle: MaterialStateTextStyle.resolveWith(
+                (Set<MaterialState> states) {
+              final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
+              return TextStyle(color: color, letterSpacing: 1.3);
+            }
+        ),
+      ),
+      validator: (String? value) {
+        if (value == null || value == '') {
+          return 'Enter name';
+        }
+      },
+      autovalidateMode: AutovalidateMode.always,
+    );
+  }
+}

--- a/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
@@ -36,17 +36,21 @@ class InputDecoratorExample extends StatelessWidget {
       decoration: InputDecoration(
         border: const OutlineInputBorder(),
         labelText: 'Name',
+        // The MaterialStateProperty's value is a text style that is orange
+        // by default, but the theme's error color if the input decorator
+        // is in its error state.
         floatingLabelStyle: MaterialStateTextStyle.resolveWith(
-                (Set<MaterialState> states) {
-              final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
-              return TextStyle(color: color, letterSpacing: 1.3);
-            }
+          (Set<MaterialState> states) {
+            final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
+            return TextStyle(color: color, letterSpacing: 1.3);
+          }
         ),
       ),
       validator: (String? value) {
         if (value == null || value == '') {
           return 'Enter name';
         }
+        return null;
       },
       autovalidateMode: AutovalidateMode.always,
     );

--- a/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for InputDecorator
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const Center(
+          child: InputDecoratorExample(),
+        ),
+      ),
+    );
+  }
+}
+
+class InputDecoratorExample extends StatelessWidget {
+  const InputDecoratorExample({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: 'Name',
+        labelStyle: MaterialStateTextStyle.resolveWith(
+                (Set<MaterialState> states) {
+              final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
+              return TextStyle(color: color, letterSpacing: 1.3);
+            }
+        ),
+      ),
+      validator: (String? value) {
+        if (value == null || value == '') {
+          return 'Enter name';
+        }
+      },
+      autovalidateMode: AutovalidateMode.always,
+    );
+  }
+}

--- a/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
@@ -36,17 +36,21 @@ class InputDecoratorExample extends StatelessWidget {
       decoration: InputDecoration(
         border: const OutlineInputBorder(),
         labelText: 'Name',
+        // The MaterialStateProperty's value is a text style that is orange
+        // by default, but the theme's error color if the input decorator
+        // is in its error state.
         labelStyle: MaterialStateTextStyle.resolveWith(
-                (Set<MaterialState> states) {
-              final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
-              return TextStyle(color: color, letterSpacing: 1.3);
-            }
+          (Set<MaterialState> states) {
+            final Color color = states.contains(MaterialState.error) ? Theme.of(context).errorColor: Colors.orange;
+            return TextStyle(color: color, letterSpacing: 1.3);
+          }
         ),
       ),
       validator: (String? value) {
         if (value == null || value == '') {
           return 'Enter name';
         }
+        return null;
       },
       autovalidateMode: AutovalidateMode.always,
     );

--- a/examples/api/test/material/input_decorator/input_decoration.floating_label_style_error.0.test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.floating_label_style_error.0.test.dart
@@ -11,11 +11,12 @@ void main() {
     await tester.pumpWidget(
       const example.MyApp(),
     );
+    final Theme theme = tester.firstWidget(find.byType(Theme));
 
-    tester.tap(find.byType(TextFormField));
+    await tester.tap(find.byType(TextFormField));
     await tester.pumpAndSettle();
 
-    final AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
-    expect(label.style.color, Colors.red);
+    final AnimatedDefaultTextStyle label = tester.firstWidget(find.ancestor(of: find.text('Name'), matching: find.byType(AnimatedDefaultTextStyle)));
+    expect(label.style.color, theme.data.errorColor);
   });
 }

--- a/examples/api/test/material/input_decorator/input_decoration.floating_label_style_error.0.test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.floating_label_style_error.0.test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/input_decorator/input_decoration.floating_label_style_error.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('InputDecorator label uses errorColor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    tester.tap(find.byType(TextFormField));
+    await tester.pumpAndSettle();
+
+    final AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
+    expect(label.style.color, Colors.red);
+  });
+}

--- a/examples/api/test/material/input_decorator/input_decoration.label_style_error.0.test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.label_style_error.0.test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/input_decorator/input_decoration.label_style_error.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('InputDecorator label uses errorColor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    tester.tap(find.byType(TextFormField));
+    await tester.pumpAndSettle();
+
+    final AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
+    expect(label.style.color, Colors.red);
+  });
+}

--- a/examples/api/test/material/input_decorator/input_decoration.label_style_error.0.test.dart
+++ b/examples/api/test/material/input_decorator/input_decoration.label_style_error.0.test.dart
@@ -11,11 +11,9 @@ void main() {
     await tester.pumpWidget(
       const example.MyApp(),
     );
+    final Theme theme = tester.firstWidget(find.byType(Theme));
 
-    tester.tap(find.byType(TextFormField));
-    await tester.pumpAndSettle();
-
-    final AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
-    expect(label.style.color, Colors.red);
+    final AnimatedDefaultTextStyle label = tester.firstWidget(find.ancestor(of: find.text('Name'), matching: find.byType(AnimatedDefaultTextStyle)));
+    expect(label.style.color, theme.data.errorColor);
   });
 }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2617,8 +2617,8 @@ class InputDecoration {
   /// [InputDecoration.errorStyle] color or [ThemeData.errorColor].
   ///
   /// {@tool dartpad}
-  /// If it is not your intention to break the default behavior you can replicate
-  /// it by conditionally changing the color in this style.
+  /// It's possible to override the label style for just the error state, or
+  /// just the default state, or both.
   ///
   /// In this example the [labelStyle] is specified with a [MaterialStateProperty]
   /// which resolves to a text style whose color depends on the decorator's
@@ -2647,8 +2647,8 @@ class InputDecoration {
   /// [InputDecoration.errorStyle] color or [ThemeData.errorColor].
   ///
   /// {@tool dartpad}
-  /// If it is not your intention to break the default behavior you can replicate
-  /// it by conditionally changing the color in this style.
+  /// It's possible to override the label style for just the error state, or
+  /// just the default state, or both.
   ///
   /// In this example the [floatingLabelStyle] is specified with a
   /// [MaterialStateProperty] which resolves to a text style whose color depends

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2043,20 +2043,14 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
     }
 
-    final TextStyle? floatingLabelStyle = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
+    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
       ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.floatingLabelStyle, materialState);
 
-    TextStyle style =  themeData.textTheme.subtitle1!
+    return themeData.textTheme.subtitle1!
       .merge(widget.baseStyle)
       .copyWith(height: 1)
       .merge(getFallbackTextStyle())
-      .merge(floatingLabelStyle);
-
-    if (decoration!.errorText != null) {
-      style = style.copyWith(color: decoration!.errorStyle?.color ?? themeData.errorColor);
-    }
-
-    return style;
+      .merge(style);
   }
 
   TextStyle _getHelperStyle(ThemeData themeData) {

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2611,6 +2611,16 @@ class InputDecoration {
   ///
   /// If null, defaults to a value derived from the base [TextStyle] for the
   /// input field and the current [Theme].
+  ///
+  /// Note that if you specify this style it will override the default behavior
+  /// of [InputDecoration] that changes the color of the label to the
+  /// [InputDecoration.errorStyle] color or [Theme.errorColor].
+  ///
+  /// {@tool dartpad}
+  /// This can be resolved with a [MaterialStateProperty].
+  ///
+  /// ** See code in examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart **
+  /// {@end-tool}
   /// {@endtemplate}
   final TextStyle? labelStyle;
 
@@ -2626,6 +2636,16 @@ class InputDecoration {
   /// if the [TextField] is focused or not.
   ///
   /// If null, defaults to [labelStyle].
+  ///
+  /// Note that if you specify this style it will override the default behavior
+  /// of [InputDecoration] that changes the color of the label to the
+  /// [InputDecoration.errorStyle] color or [Theme.errorColor].
+  ///
+  /// {@tool dartpad}
+  /// This can be resolved with a [MaterialStateProperty].
+  ///
+  /// ** See code in examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart **
+  /// {@end-tool}
   /// {@endtemplate}
   final TextStyle? floatingLabelStyle;
 
@@ -2708,6 +2728,12 @@ class InputDecoration {
   ///
   /// If null, defaults of a value derived from the base [TextStyle] for the
   /// input field and the current [Theme].
+  ///
+  /// By default the color of style will be used by the label of
+  /// [InputDecoration] if [InputDecoration.errorText] is not null. See
+  /// [InputDecoration.labelStyle] or [InputDecoration.floatingLabelStyle] for
+  /// an example of how to replicate this behavior if you have specified either
+  /// style.
   /// {@endtemplate}
   final TextStyle? errorStyle;
 

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2050,8 +2050,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       .merge(widget.baseStyle)
       .copyWith(height: 1)
       .merge(getFallbackTextStyle())
-      .merge(floatingLabelStyle)
-      .copyWith(color: getFallbackTextStyle().color);
+      .merge(floatingLabelStyle);
 
     if (decoration!.errorText != null) {
       style = style.copyWith(color: decoration!.errorStyle?.color ?? themeData.errorColor);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2598,28 +2598,35 @@ class InputDecoration {
   /// Only one of [label] and [labelText] can be specified.
   final String? labelText;
 
-  /// The style to use for the [labelText] when the label is on top of the
-  /// input field.
+  /// {@template flutter.material.inputDecoration.labelStyle}
+  /// The style to use for [InputDecoration.labelText] when the label is on top
+  /// of the input field.
   ///
   /// If [labelStyle] is a [MaterialStateTextStyle], then the effective
   /// text style can depend on the [MaterialState.focused] state, i.e.
   /// if the [TextField] is focused or not.
   ///
-  /// When the [labelText] is above (i.e., vertically adjacent to) the input
-  /// field, the text uses the [floatingLabelStyle] instead.
+  /// When the [InputDecoration.labelText] is above (i.e., vertically adjacent to)
+  /// the input field, the text uses the [floatingLabelStyle] instead.
   ///
   /// If null, defaults to a value derived from the base [TextStyle] for the
   /// input field and the current [Theme].
+  /// {@endtemplate}
   final TextStyle? labelStyle;
 
-  /// The style to use for the [labelText] when the label is above (i.e.,
-  /// vertically adjacent to) the input field.
+  /// {@template flutter.material.inputDecoration.floatingLabelStyle}
+  /// The style to use for [InputDecoration.labelText] when the label is
+  /// above (i.e., vertically adjacent to) the input field.
+  ///
+  /// When the [InputDecoration.labelText] is on top of the input field, the
+  /// text uses the [labelStyle] instead.
   ///
   /// If [floatingLabelStyle] is a [MaterialStateTextStyle], then the effective
   /// text style can depend on the [MaterialState.focused] state, i.e.
   /// if the [TextField] is focused or not.
   ///
   /// If null, defaults to [labelStyle].
+  /// {@endtemplate}
   final TextStyle? floatingLabelStyle;
 
   /// Text that provides context about the [InputDecorator.child]'s value, such
@@ -2696,10 +2703,12 @@ class InputDecoration {
   /// [TextFormField.validator], if that is not null.
   final String? errorText;
 
-  /// The style to use for the [errorText].
+  /// {@template flutter.material.inputDecoration.errorStyle}
+  /// The style to use for the [InputDecoration.errorText].
   ///
   /// If null, defaults of a value derived from the base [TextStyle] for the
   /// input field and the current [Theme].
+  /// {@endtemplate}
   final TextStyle? errorStyle;
 
 
@@ -3680,31 +3689,10 @@ class InputDecorationTheme with Diagnosticable {
        assert(filled != null),
        assert(alignLabelWithHint != null);
 
-  /// The style to use for [InputDecoration.labelText] when the label is on top
-  /// of the input field.
-  ///
-  /// When the [InputDecoration.labelText] is floating above the input field,
-  /// the text uses the [floatingLabelStyle] instead.
-  ///
-  /// If [labelStyle] is a [MaterialStateTextStyle], then the effective
-  /// text style can depend on the [MaterialState.focused] state, i.e.
-  /// if the [TextField] is focused or not.
-  ///
-  /// If null, defaults to a value derived from the base [TextStyle] for the
-  /// input field and the current [Theme].
+  /// {@macro flutter.material.inputDecoration.labelStyle}
   final TextStyle? labelStyle;
 
-  /// The style to use for [InputDecoration.labelText] when the label is
-  /// above (i.e., vertically adjacent to) the input field.
-  ///
-  /// When the [InputDecoration.labelText] is on top of the input field, the
-  /// text uses the [labelStyle] instead.
-  ///
-  /// If [floatingLabelStyle] is a [MaterialStateTextStyle], then the effective
-  /// text style can depend on the [MaterialState.focused] state, i.e.
-  /// if the [TextField] is focused or not.
-  ///
-  /// If null, defaults to [labelStyle].
+  /// {@macro flutter.material.inputDecoration.floatingLabelStyle}
   final TextStyle? floatingLabelStyle;
 
   /// The style to use for [InputDecoration.helperText].
@@ -3742,10 +3730,7 @@ class InputDecorationTheme with Diagnosticable {
   /// input field and the current [Theme].
   final TextStyle? hintStyle;
 
-  /// The style to use for the [InputDecoration.errorText].
-  ///
-  /// If null, defaults of a value derived from the base [TextStyle] for the
-  /// input field and the current [Theme].
+  /// {@macro flutter.material.inputDecoration.errorStyle}
   final TextStyle? errorStyle;
 
   /// The maximum number of lines the [InputDecoration.errorText] can occupy.

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2617,7 +2617,12 @@ class InputDecoration {
   /// [InputDecoration.errorStyle] color or [Theme.errorColor].
   ///
   /// {@tool dartpad}
-  /// This can be resolved with a [MaterialStateProperty].
+  /// If it is not your intention to break the default behavior you can replicate
+  /// it by conditionally changing the color in this style.
+  ///
+  /// In this example the [labelStyle] is specified with a [MaterialStateProperty]
+  /// which resolves to a text style whose color depends on the decorator's
+  /// error state.
   ///
   /// ** See code in examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart **
   /// {@end-tool}
@@ -2642,7 +2647,12 @@ class InputDecoration {
   /// [InputDecoration.errorStyle] color or [Theme.errorColor].
   ///
   /// {@tool dartpad}
-  /// This can be resolved with a [MaterialStateProperty].
+  /// If it is not your intention to break the default behavior you can replicate
+  /// it by conditionally changing the color in this style.
+  ///
+  /// In this example the [floatingLabelStyle] is specified with a
+  /// [MaterialStateProperty] which resolves to a text style whose color depends
+  /// on the decorator's error state.
   ///
   /// ** See code in examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart **
   /// {@end-tool}

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2614,7 +2614,7 @@ class InputDecoration {
   ///
   /// Note that if you specify this style it will override the default behavior
   /// of [InputDecoration] that changes the color of the label to the
-  /// [InputDecoration.errorStyle] color or [Theme.errorColor].
+  /// [InputDecoration.errorStyle] color or [ThemeData.errorColor].
   ///
   /// {@tool dartpad}
   /// If it is not your intention to break the default behavior you can replicate
@@ -2644,7 +2644,7 @@ class InputDecoration {
   ///
   /// Note that if you specify this style it will override the default behavior
   /// of [InputDecoration] that changes the color of the label to the
-  /// [InputDecoration.errorStyle] color or [Theme.errorColor].
+  /// [InputDecoration.errorStyle] color or [ThemeData.errorColor].
   ///
   /// {@tool dartpad}
   /// If it is not your intention to break the default behavior you can replicate

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2043,14 +2043,21 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
     }
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
+    final TextStyle? floatingLabelStyle = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
       ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.floatingLabelStyle, materialState);
 
-    return themeData.textTheme.subtitle1!
+    TextStyle style =  themeData.textTheme.subtitle1!
       .merge(widget.baseStyle)
       .copyWith(height: 1)
       .merge(getFallbackTextStyle())
-      .merge(style);
+      .merge(floatingLabelStyle)
+      .copyWith(color: getFallbackTextStyle().color);
+
+    if (decoration!.errorText != null) {
+      style = style.copyWith(color: decoration!.errorStyle?.color ?? themeData.errorColor);
+    }
+
+    return style;
   }
 
   TextStyle _getHelperStyle(ThemeData themeData) {

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5715,4 +5715,45 @@ void main() {
     expect(tester.getTopLeft(find.text('label')).dy, -5.5);
 
   });
+
+  testWidgets('InputDecorator label uses errorStyle color when errorText is not null', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/74890
+    const TextStyle normalStyle = TextStyle(color: Colors.blue);
+    const TextStyle errorStyle = TextStyle(color: Colors.red);
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true,
+        isFocused: true,
+        decoration: const InputDecoration(
+          labelText: 'label',
+          filled: true,
+          labelStyle: normalStyle,
+          errorStyle: errorStyle,
+        ),
+      ),
+    );
+
+    AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
+    expect(label.style.color, normalStyle.color);
+
+    // If errorText is specified then label text should use errorStyle color
+    await tester.pumpWidget(
+      buildInputDecorator(
+        isEmpty: true,
+        isFocused: true,
+        decoration: const InputDecoration(
+          labelText: 'label',
+          errorText: 'error',
+          filled: true,
+          labelStyle: normalStyle,
+          errorStyle: errorStyle,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
+    expect(label.style.color, errorStyle.color);
+  });
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5715,45 +5715,4 @@ void main() {
     expect(tester.getTopLeft(find.text('label')).dy, -5.5);
 
   });
-
-  testWidgets('InputDecorator label uses errorStyle color when errorText is not null', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/74890
-    const TextStyle normalStyle = TextStyle(color: Colors.blue);
-    const TextStyle errorStyle = TextStyle(color: Colors.red);
-    await tester.pumpWidget(
-      buildInputDecorator(
-        isEmpty: true,
-        isFocused: true,
-        decoration: const InputDecoration(
-          labelText: 'label',
-          filled: true,
-          labelStyle: normalStyle,
-          errorStyle: errorStyle,
-        ),
-      ),
-    );
-
-    AnimatedDefaultTextStyle label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
-    expect(label.style.color, normalStyle.color);
-
-    // If errorText is specified then label text should use errorStyle color
-    await tester.pumpWidget(
-      buildInputDecorator(
-        isEmpty: true,
-        isFocused: true,
-        decoration: const InputDecoration(
-          labelText: 'label',
-          errorText: 'error',
-          filled: true,
-          labelStyle: normalStyle,
-          errorStyle: errorStyle,
-        ),
-      ),
-    );
-
-    await tester.pumpAndSettle();
-
-    label = tester.widget(find.byType(AnimatedDefaultTextStyle).last);
-    expect(label.style.color, errorStyle.color);
-  });
 }


### PR DESCRIPTION
Adds examples of how to use a `MaterialStateProperty` to replicate the default be havior of `InputDecorator` that changes the color of the label to the error color when `errorText` is not null.

Fixes https://github.com/flutter/flutter/issues/28075

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
