### PR TITLE
Marks Mac_android run_release_test to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2942,6 +2942,7 @@ targets:
     scheduler: luci
 
   - name: Mac_android run_release_test
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/91625
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac_android run_release_test"
}
-->

Issue link: https://github.com/flutter/flutter/issues/91625