### PR TITLE
Use navigator instead of overlay as TickerProvider for ModalBottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -508,7 +508,7 @@ class _ModalBottomSheetRoute<T> extends PopupRoute<T> {
       _animationController = transitionAnimationController;
       willDisposeAnimationController = false;
     } else {
-      _animationController = BottomSheet.createAnimationController(navigator!.overlay!);
+      _animationController = BottomSheet.createAnimationController(navigator!);
     }
     return _animationController!;
   }


### PR DESCRIPTION
The _ModalBottomSheetRoute is owned by the Navigator, which is in charge of disposing the route when it gets disposed. It also owns the Overlay as a child. When the whole tree is disposed, the Overlay is therefore disposed before the Navigator. This creates a problem when the _ModalBottomSheetRoute is deriving its Ticker from the Overlay: When the Overlay is disposed, the Route (and the Ticker it uses) is still active causing the TickerProvider built into the overlay to complain that some of its vended tickers are still in use. 

The problem can be avoided when the _ModalBottomSheetRoute derives its Ticker from the Navigator itself. Now the route gets disposed just before the Navigator's TickerProvider is disposed. This means the route can dispose its ticker before the Navigator's TickerProdvider is disposed and checking that there are no more active tickers.

That's also why the TransitionRoute derives its ticker from the Navigator.

Fixes b/205792918.