### PR TITLE
Restructure Windows plugin template

### DIFF
--- a/packages/flutter_tools/templates/plugin/windows.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/CMakeLists.txt.tmpl
@@ -12,12 +12,18 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # not be changed
 set(PLUGIN_NAME "{{projectName}}_plugin")
 
+# Any new source files that you add to the plugin should be added here.
+list(APPEND PLUGIN_SOURCES
+  "{{pluginClassSnakeCase}}.cpp"
+  "{{pluginClassSnakeCase}}.h"
+)
+
 # Define the plugin library target. Its name must not be changed (see comment
 # on PLUGIN_NAME above).
-#
-# Any new source files that you add to the plugin should be added here.
 add_library(${PLUGIN_NAME} SHARED
-  "{{pluginClassSnakeCase}}.cpp"
+  "include/{{projectName}}/{{pluginClassSnakeCase}}_c_api.h"
+  "{{pluginClassSnakeCase}}_c_api.cpp"
+  ${PLUGIN_SOURCES}
 )
 
 # Apply a standard set of build settings that are configured in the

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/include/projectName.tmpl/pluginClassSnakeCase_c_api.h.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/include/projectName.tmpl/pluginClassSnakeCase_c_api.h.tmpl
@@ -1,5 +1,5 @@
-#ifndef FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_
-#define FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_
+#ifndef FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_C_API_H_
+#define FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_C_API_H_
 
 #include <flutter_plugin_registrar.h>
 
@@ -13,11 +13,11 @@
 extern "C" {
 #endif
 
-FLUTTER_PLUGIN_EXPORT void {{pluginClass}}RegisterWithRegistrar(
+FLUTTER_PLUGIN_EXPORT void {{pluginClass}}CApiRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar);
 
 #if defined(__cplusplus)
 }  // extern "C"
 #endif
 
-#endif  // FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_
+#endif  // FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_C_API_H_

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase.cpp.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase.cpp.tmpl
@@ -1,4 +1,4 @@
-#include "include/{{projectName}}/{{pluginClassSnakeCase}}.h"
+#include "{{pluginClassSnakeCase}}.h"
 
 // This must be included before many other Windows headers.
 #include <windows.h>
@@ -10,26 +10,10 @@
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-#include <map>
 #include <memory>
 #include <sstream>
 
-namespace {
-
-class {{pluginClass}} : public flutter::Plugin {
- public:
-  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
-
-  {{pluginClass}}();
-
-  virtual ~{{pluginClass}}();
-
- private:
-  // Called when a method is called on this plugin's channel from Dart.
-  void HandleMethodCall(
-      const flutter::MethodCall<flutter::EncodableValue> &method_call,
-      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
-};
+namespace {{projectName}} {
 
 // static
 void {{pluginClass}}::RegisterWithRegistrar(
@@ -72,11 +56,4 @@ void {{pluginClass}}::HandleMethodCall(
   }
 }
 
-}  // namespace
-
-void {{pluginClass}}RegisterWithRegistrar(
-    FlutterDesktopPluginRegistrarRef registrar) {
-  {{pluginClass}}::RegisterWithRegistrar(
-      flutter::PluginRegistrarManager::GetInstance()
-          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
-}
+}  // namespace {{projectName}}

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase.h.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase.h.tmpl
@@ -1,0 +1,32 @@
+#ifndef FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_
+#define FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+
+#include <memory>
+
+namespace {{projectName}} {
+
+class {{pluginClass}} : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+
+  {{pluginClass}}();
+
+  virtual ~{{pluginClass}}();
+
+  // Disallow copy and assign.
+  {{pluginClass}}(const {{pluginClass}}&) = delete;
+  {{pluginClass}}& operator=(const {{pluginClass}}&) = delete;
+
+ private:
+  // Called when a method is called on this plugin's channel from Dart.
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+};
+
+}  // namespace {{projectName}}
+
+#endif  // FLUTTER_PLUGIN_{{pluginClassCapitalSnakeCase}}_H_

--- a/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase_c_api.cpp.tmpl
+++ b/packages/flutter_tools/templates/plugin/windows.tmpl/pluginClassSnakeCase_c_api.cpp.tmpl
@@ -1,0 +1,12 @@
+#include "include/{{projectName}}/{{pluginClassSnakeCase}}_c_api.h"
+
+#include <flutter/plugin_registrar_windows.h>
+
+#include "{{pluginClassSnakeCase}}.h"
+
+void {{pluginClass}}CApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  {{projectName}}::{{pluginClass}}::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -111,7 +111,7 @@ flutter:
 {{/macos}}
 {{#windows}}
       windows:
-        pluginClass: {{pluginClass}}
+        pluginClass: {{pluginClass}}CApi
 {{/windows}}
 {{#web}}
       web:

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -333,8 +333,10 @@
         "templates/plugin/README.md.tmpl",
         "templates/plugin/test/projectName_test.dart.tmpl",
         "templates/plugin/windows.tmpl/CMakeLists.txt.tmpl",
-        "templates/plugin/windows.tmpl/include/projectName.tmpl/pluginClassSnakeCase.h.tmpl",
+        "templates/plugin/windows.tmpl/include/projectName.tmpl/pluginClassSnakeCase_c_api.h.tmpl",
         "templates/plugin/windows.tmpl/pluginClassSnakeCase.cpp.tmpl",
+        "templates/plugin/windows.tmpl/pluginClassSnakeCase.h.tmpl",
+        "templates/plugin/windows.tmpl/pluginClassSnakeCase_c_api.cpp.tmpl",
         "templates/plugin/lib/projectName_web.dart.tmpl",
 
         "templates/plugin_ffi/android.tmpl/build.gradle.tmpl",


### PR DESCRIPTION
Changes the Windows plugin template from the single-file, file-scoped
C++ class structure to having separate files for the C++ class and the C
wrapper. This is the structure that flutter/plugins has standardized on
in order to allow for native unit testing (and to make code navigation
easier in non-trivial plugins).

This does not actually add native unit tests in the template, but that
will likely be done in the future. In the short term, though, this makes
applying the flutter/plugins unit test approach to a new plugin much
easier since it doesn't require a post-creation restructure of the code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
