### PR TITLE
imageCache: avoid pendingImage memleak

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -193,6 +193,11 @@ class ImageCache {
     for (final _CachedImage image in _cache.values) {
       image.dispose();
     }
+
+    for (final _PendingImage pendingImage in _pendingImages.values) {
+      pendingImage.removeListener();
+    }
+
     _cache.clear();
     _pendingImages.clear();
     _currentSizeBytes = 0;


### PR DESCRIPTION
It is possible that pendingImage listener was not removed from the pendingImage:
https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/painting/image_cache.dart#L431
because the pendingImages list was emptied in the meantime:
https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/painting/image_cache.dart#L197

This is a proposal to fix the issue:
#93535

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

