### PR TITLE
Use EditableText context for getting theme of material text selection handle

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -25,6 +25,7 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'focus_traversal.dart';
 import 'framework.dart';
+import 'inherited_theme.dart';
 import 'localizations.dart';
 import 'media_query.dart';
 import 'scroll_configuration.dart';
@@ -2530,7 +2531,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         _selectionOverlay!.update(_value);
       }
       _selectionOverlay!.handlesVisible = widget.showSelectionHandles;
-      _selectionOverlay!.showHandles();
+      final CapturedThemes themes = InheritedTheme.capture(from: context, to: null);
+      _selectionOverlay!.showHandles(themes);
     }
     // TODO(chunhtai): we should make sure selection actually changed before
     // we call the onSelectionChanged.

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -16,6 +16,7 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
+import 'inherited_theme.dart';
 import 'media_query.dart';
 import 'overlay.dart';
 import 'selection_container.dart';
@@ -558,8 +559,9 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
   /// Returns true if the handles are shown, false if the handles can't be
   /// shown.
   bool _showHandles() {
+    final CapturedThemes themes = InheritedTheme.capture(from: context, to: null);
     if (_selectionOverlay != null) {
-      _selectionOverlay!.showHandles();
+      _selectionOverlay!.showHandles(themes);
       return true;
     }
 
@@ -568,7 +570,7 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
     }
 
     _createSelectionOverlay();
-    _selectionOverlay!.showHandles();
+    _selectionOverlay!.showHandles(themes);
     return true;
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -19,6 +19,7 @@ import 'container.dart';
 import 'editable_text.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
+import 'inherited_theme.dart';
 import 'overlay.dart';
 import 'ticker_provider.dart';
 import 'transitions.dart';
@@ -326,9 +327,9 @@ class TextSelectionOverlay {
   }
 
   /// {@macro flutter.widgets.SelectionOverlay.showHandles}
-  void showHandles() {
+  void showHandles(CapturedThemes themes) {
     _updateSelectionOverlay();
-    _selectionOverlay.showHandles();
+    _selectionOverlay.showHandles(themes);
   }
 
   /// {@macro flutter.widgets.SelectionOverlay.hideHandles}
@@ -792,14 +793,14 @@ class SelectionOverlay {
   /// {@template flutter.widgets.SelectionOverlay.showHandles}
   /// Builds the handles by inserting them into the [context]'s overlay.
   /// {@endtemplate}
-  void showHandles() {
+  void showHandles(CapturedThemes themes) {
     if (_handles != null) {
       return;
     }
 
     _handles = <OverlayEntry>[
-      OverlayEntry(builder: _buildStartHandle),
-      OverlayEntry(builder: _buildEndHandle),
+      OverlayEntry(builder: (_) => _buildStartHandle(themes)),
+      OverlayEntry(builder: (_) => _buildEndHandle(themes)),
     ];
 
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
@@ -891,7 +892,7 @@ class SelectionOverlay {
     hide();
   }
 
-  Widget _buildStartHandle(BuildContext context) {
+  Widget _buildStartHandle(CapturedThemes themes) {
     final Widget handle;
     final TextSelectionControls? selectionControls = this.selectionControls;
     if (selectionControls == null) {
@@ -911,11 +912,11 @@ class SelectionOverlay {
       );
     }
     return ExcludeSemantics(
-      child: handle,
+      child: themes.wrap(handle),
     );
   }
 
-  Widget _buildEndHandle(BuildContext context) {
+  Widget _buildEndHandle(CapturedThemes themes) {
     final Widget handle;
     final TextSelectionControls? selectionControls = this.selectionControls;
     if (selectionControls == null || _startHandleType == TextSelectionHandleType.collapsed) {
@@ -936,7 +937,7 @@ class SelectionOverlay {
       );
     }
     return ExcludeSemantics(
-      child: handle,
+      child: themes.wrap(handle),
     );
   }
 

--- a/packages/flutter/test/material/text_selection_theme_test.dart
+++ b/packages/flutter/test/material/text_selection_theme_test.dart
@@ -62,11 +62,16 @@ void main() {
     addTearDown(() {
       EditableText.debugDeterministicCursor = false;
     });
+
     // Test TextField's cursor & selection color.
+    final TextEditingController editingController = TextEditingController(text: 'abc def ghi');
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Material(
-          child: TextField(autofocus: true),
+          child: TextField(
+            controller: editingController,
+            autofocus: true,
+          ),
         ),
       ),
     );
@@ -78,25 +83,16 @@ void main() {
     expect(renderEditable.cursorColor, defaultCursorColor);
     expect(renderEditable.selectionColor?.value, defaultSelectionColor.value);
 
+    // Select 'def'.
+    editingController.selection = const TextSelection(baseOffset: 4, extentOffset: 7);
+
     // Test the selection handle color.
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Builder(
-            builder: (BuildContext context) {
-              return materialTextSelectionControls.buildHandle(
-                context,
-                TextSelectionHandleType.left,
-                10.0,
-              );
-            },
-          ),
-        ),
-      ),
-    );
     await tester.pumpAndSettle();
-    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
-    expect(handle, paints..path(color: defaultSelectionHandleColor));
+    final Iterable<RenderBox> handles = tester.renderObjectList<RenderBox>(find.byType(CustomPaint));
+    final RenderBox leftHandle = handles.first;
+    final RenderBox rightHandle = handles.last;
+    expect(leftHandle, paints..path(color: defaultSelectionHandleColor));
+    expect(rightHandle, paints..path(color: defaultSelectionHandleColor));
   });
 
   testWidgets('ThemeData.textSelectionTheme will be used if provided', (WidgetTester tester) async {
@@ -115,11 +111,15 @@ void main() {
     });
 
     // Test TextField's cursor & selection color.
+    final TextEditingController editingController = TextEditingController(text: 'abc def ghi');
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
-          child: TextField(autofocus: true),
+        home: Material(
+          child: TextField(
+            controller: editingController,
+            autofocus: true,
+          ),
         ),
       ),
     );
@@ -130,29 +130,20 @@ void main() {
     expect(renderEditable.cursorColor, textSelectionTheme.cursorColor);
     expect(renderEditable.selectionColor, textSelectionTheme.selectionColor);
 
+    // Select 'def'.
+    editingController.selection = const TextSelection(baseOffset: 4, extentOffset: 7);
+
     // Test the selection handle color.
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: theme,
-        home: Material(
-          child: Builder(
-            builder: (BuildContext context) {
-              return materialTextSelectionControls.buildHandle(
-                context,
-                TextSelectionHandleType.left,
-                10.0,
-              );
-            },
-          ),
-        ),
-      ),
-    );
     await tester.pumpAndSettle();
-    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
-    expect(handle, paints..path(color: textSelectionTheme.selectionHandleColor));
+    final Iterable<RenderBox> handles = tester.renderObjectList<RenderBox>(find.byType(CustomPaint));
+    final RenderBox leftHandle = handles.first;
+    final RenderBox rightHandle = handles.last;
+    expect(leftHandle, paints..path(color: textSelectionTheme.selectionHandleColor));
+    expect(rightHandle, paints..path(color: textSelectionTheme.selectionHandleColor));
   });
 
   testWidgets('TextSelectionTheme widget will override ThemeData.textSelectionTheme', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/74890
     const TextSelectionThemeData defaultTextSelectionTheme = TextSelectionThemeData(
       cursorColor: Color(0xffaabbcc),
       selectionColor: Color(0x88888888),
@@ -171,14 +162,19 @@ void main() {
     addTearDown(() {
       EditableText.debugDeterministicCursor = false;
     });
+
     // Test TextField's cursor & selection color.
+    final TextEditingController editingController = TextEditingController(text: 'abc def ghi');
     await tester.pumpWidget(
       MaterialApp(
         theme: theme,
-        home: const Material(
+        home: Material(
           child: TextSelectionTheme(
             data: widgetTextSelectionTheme,
-            child: TextField(autofocus: true),
+            child: TextField(
+              controller: editingController,
+              autofocus: true,
+            ),
           ),
         ),
       ),
@@ -189,29 +185,16 @@ void main() {
     expect(renderEditable.cursorColor, widgetTextSelectionTheme.cursorColor);
     expect(renderEditable.selectionColor, widgetTextSelectionTheme.selectionColor);
 
+    // Select 'def'.
+    editingController.selection = const TextSelection(baseOffset: 4, extentOffset: 7);
+
     // Test the selection handle color.
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: theme,
-        home: Material(
-          child: TextSelectionTheme(
-            data: widgetTextSelectionTheme,
-            child: Builder(
-              builder: (BuildContext context) {
-                return materialTextSelectionControls.buildHandle(
-                  context,
-                  TextSelectionHandleType.left,
-                  10.0,
-                );
-              },
-            ),
-          ),
-        ),
-      ),
-    );
     await tester.pumpAndSettle();
-    final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
-    expect(handle, paints..path(color: widgetTextSelectionTheme.selectionHandleColor));
+    final Iterable<RenderBox> handles = tester.renderObjectList<RenderBox>(find.byType(CustomPaint));
+    final RenderBox leftHandle = handles.first;
+    final RenderBox rightHandle = handles.last;
+    expect(leftHandle, paints..path(color: widgetTextSelectionTheme.selectionHandleColor));
+    expect(rightHandle, paints..path(color: widgetTextSelectionTheme.selectionHandleColor));
   });
 
   testWidgets('TextField parameters will override theme settings', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1052,6 +1052,10 @@ void main() {
         tester,
         selectionControls: spy,
       );
+      final CapturedThemes themes = InheritedTheme.capture(
+          from: selectionOverlay.context,
+          to: null
+      );
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.left
         ..endHandleType = TextSelectionHandleType.right
@@ -1059,7 +1063,7 @@ void main() {
           TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
           TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
         ];
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       await tester.pump();
       expect(find.byKey(spy.leftHandleKey), findsOneWidget);
       expect(find.byKey(spy.rightHandleKey), findsOneWidget);
@@ -1077,7 +1081,7 @@ void main() {
       await tester.pump();
       expect(find.byKey(spy.toolBarKey), findsNothing);
 
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       selectionOverlay.showToolbar();
       await tester.pump();
       expect(find.byKey(spy.leftHandleKey), findsOneWidget);
@@ -1097,6 +1101,10 @@ void main() {
         tester,
         selectionControls: spy,
       );
+      final CapturedThemes themes = InheritedTheme.capture(
+          from: selectionOverlay.context,
+          to: null
+      );
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.collapsed
         ..endHandleType = TextSelectionHandleType.collapsed
@@ -1104,7 +1112,7 @@ void main() {
           TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
           TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
         ];
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       await tester.pump();
       expect(find.byKey(spy.leftHandleKey), findsNothing);
       expect(find.byKey(spy.rightHandleKey), findsNothing);
@@ -1117,6 +1125,10 @@ void main() {
         tester,
         selectionControls: spy,
       );
+      final CapturedThemes themes = InheritedTheme.capture(
+          from: selectionOverlay.context,
+          to: null
+      );
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.left
         ..lineHeightAtStart = 10.0
@@ -1126,7 +1138,7 @@ void main() {
           TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
           TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
         ];
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       await tester.pump();
       Text leftHandle = tester.widget(find.byKey(spy.leftHandleKey)) as Text;
       Text rightHandle = tester.widget(find.byKey(spy.rightHandleKey)) as Text;
@@ -1154,6 +1166,10 @@ void main() {
         onSelectionHandleTapped: handleTapped,
         selectionControls: spy,
       );
+      final CapturedThemes themes = InheritedTheme.capture(
+          from: selectionOverlay.context,
+          to: null
+      );
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.left
         ..lineHeightAtStart = 10.0
@@ -1163,7 +1179,7 @@ void main() {
           TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
           TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
         ];
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       await tester.pump();
       expect(find.byKey(spy.leftHandleKey), findsOneWidget);
       expect(find.byKey(spy.rightHandleKey), findsOneWidget);
@@ -1201,6 +1217,10 @@ void main() {
         onEndDragEnd: endDragEnd,
         selectionControls: spy,
       );
+      final CapturedThemes themes = InheritedTheme.capture(
+          from: selectionOverlay.context,
+          to: null
+      );
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.left
         ..lineHeightAtStart = 10.0
@@ -1210,7 +1230,7 @@ void main() {
           TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
           TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
         ];
-      selectionOverlay.showHandles();
+      selectionOverlay.showHandles(themes);
       await tester.pump();
       expect(find.byKey(spy.leftHandleKey), findsOneWidget);
       expect(find.byKey(spy.rightHandleKey), findsOneWidget);


### PR DESCRIPTION
The `buildHandle` method got the context of the overlay it will be built in as an argument, but should be getting the context of the `EditableText` it is meant for instead. This will get the correct inherited theme for the handle color.

The faulty behavior passed tests because they called the `buildHandle` method with the correct context directly (and only checked the left handle). This improves the tests so they select some text (building the handle through the proper callback chain) and then check the color of both handles.

Fixes https://github.com/flutter/flutter/issues/74890

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
