### PR TITLE
Ad-hoc codesign Flutter.framework when code signing is disabled

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -625,9 +625,9 @@ Future<void> _createStubAppFramework(File outputFile, Environment environment,
 }
 
 void _signFramework(Environment environment, String binaryPath, BuildMode buildMode) {
-  final String codesignIdentity = environment.defines[kCodesignIdentity];
+  String codesignIdentity = environment.defines[kCodesignIdentity];
   if (codesignIdentity == null || codesignIdentity.isEmpty) {
-    return;
+    codesignIdentity = '-';
   }
   final ProcessResult result = environment.processManager.runSync(<String>[
     'codesign',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -72,7 +72,8 @@ void main() {
   testUsingContext('DebugUniversalFramework creates simulator binary', () async {
     environment.defines[kIosArchs] = 'x86_64';
     environment.defines[kSdkRoot] = 'path/to/iPhoneSimulator.sdk';
-    processManager.addCommand(
+    final String appFrameworkPath = environment.buildDir.childDirectory('App.framework').childFile('App').path;
+    processManager.addCommands(<FakeCommand>[
       FakeCommand(command: <String>[
         'xcrun',
         'clang',
@@ -98,12 +99,17 @@ void main() {
         '-isysroot',
         'path/to/iPhoneSimulator.sdk',
         '-o',
-        environment.buildDir
-            .childDirectory('App.framework')
-            .childFile('App')
-            .path,
+        appFrameworkPath,
       ]),
-    );
+      FakeCommand(command: <String>[
+        'codesign',
+        '--force',
+        '--sign',
+        '-',
+        '--timestamp=none',
+        appFrameworkPath,
+      ]),
+    ]);
 
     await const DebugUniversalFramework().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);
@@ -116,7 +122,8 @@ void main() {
   testUsingContext('DebugUniversalFramework creates expected binary with arm64 only arch', () async {
     environment.defines[kIosArchs] = 'arm64';
     environment.defines[kSdkRoot] = 'path/to/iPhoneOS.sdk';
-    processManager.addCommand(
+    final String appFrameworkPath = environment.buildDir.childDirectory('App.framework').childFile('App').path;
+    processManager.addCommands(<FakeCommand>[
       FakeCommand(command: <String>[
         'xcrun',
         'clang',
@@ -129,12 +136,17 @@ void main() {
             '.tmp_rand0', 'flutter_tools_stub_source.rand0', 'debug_app.cc')),
         ..._kSharedConfig,
         '-o',
-        environment.buildDir
-            .childDirectory('App.framework')
-            .childFile('App')
-            .path,
+        appFrameworkPath,
       ]),
-    );
+      FakeCommand(command: <String>[
+        'codesign',
+        '--force',
+        '--sign',
+        '-',
+        '--timestamp=none',
+        appFrameworkPath,
+      ]),
+    ]);
 
     await const DebugUniversalFramework().build(environment);
     expect(processManager.hasRemainingExpectations, isFalse);
@@ -317,6 +329,7 @@ void main() {
     FakeCommand lipoCommandNonFatResult;
     FakeCommand lipoVerifyArm64Command;
     FakeCommand bitcodeStripCommand;
+    FakeCommand adHocCodesignCommand;
 
     setUp(() {
       final FileSystem fileSystem = MemoryFileSystem.test();
@@ -351,6 +364,15 @@ void main() {
         binary.path,
         '-m',
         '-o',
+        binary.path,
+      ]);
+
+      adHocCodesignCommand = FakeCommand(command: <String>[
+        'codesign',
+        '--force',
+        '--sign',
+        '-',
+        '--timestamp=none',
         binary.path,
       ]);
     });
@@ -389,6 +411,7 @@ void main() {
           '-verify_arch',
           'x86_64',
         ]),
+        adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
 
@@ -538,6 +561,7 @@ void main() {
         copyPhysicalFrameworkCommand,
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
+        adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
 
@@ -587,6 +611,7 @@ void main() {
           'armv7',
           binary.path,
         ]),
+        adHocCodesignCommand,
       ]);
 
       await const DebugUnpackIOS().build(environment);
@@ -658,6 +683,7 @@ void main() {
         lipoCommandNonFatResult,
         lipoVerifyArm64Command,
         bitcodeStripCommand,
+        adHocCodesignCommand,
       ]);
       await const DebugUnpackIOS().build(environment);
 


### PR DESCRIPTION
iOS apps can be ad-hoc codesigned (signed without a developer cert, and instead with identity `-`), which allows them to run on simulators, but not real devices.  We use ad-hoc codesigning for host-only simulator tests on machines where the developer cert is not set up: https://github.com/flutter/flutter/blob/0c81077582c8d22779ca6d01ab10b749cf294cae/dev/devicelab/bin/tasks/module_test_ios.dart#L258-L261

When the Flutter.framework is codesigned (every channel but master), the app will crash on launch because the framework is codesigned differently (not ad-hoc) than the app.  This manifests in dev/beta/release cherry-pick tests because the framework is codesigned, but not on master.
Instead of skipped codesigning the framework in this case, instead ad-hoc codesign with identity `-`.

Fixes https://github.com/flutter/flutter/issues/93517

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
