### PR TITLE
Reland "Exit on deprecated v1 embedding when trying to run or build" (#92901)

### DIFF
--- a/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/complex_layout/android/app/src/main/AndroidManifest.xml
@@ -7,8 +7,8 @@ found in the LICENSE file. -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:name="io.flutter.app.FlutterApplication" android:label="complex_layout" android:icon="@mipmap/ic_launcher">
-        <activity android:name="io.flutter.app.FlutterActivity"
+    <application android:name="${applicationName}" android:label="complex_layout" android:icon="@mipmap/ic_launcher">
+        <activity android:name="io.flutter.embedding.android.FlutterActivity"
                   android:exported="true"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
@@ -20,5 +20,8 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@ found in the LICENSE file. -->
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="macrobenchmarks"

--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="macrobenchmarks"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
@@ -19,5 +19,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/microbenchmarks/android/app/src/main/AndroidManifest.xml
@@ -7,8 +7,8 @@ found in the LICENSE file. -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:name="io.flutter.app.FlutterApplication" android:label="microbenchmarks" android:icon="@mipmap/ic_launcher">
-        <activity android:name="io.flutter.app.FlutterActivity"
+    <application android:name="${applicationName}" android:label="microbenchmarks" android:icon="@mipmap/ic_launcher">
+        <activity android:name="io.flutter.embedding.android.FlutterActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/dev/benchmarks/platform_views_layout/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/platform_views_layout/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@ found in the LICENSE file. -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:name="io.flutter.app.FlutterApplication" android:label="platform_view_layout">
+    <application android:name="${applicationName}" android:label="platform_view_layout">
         <activity android:name=".DummyPlatformViewActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@ found in the LICENSE file. -->
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:name="io.flutter.app.FlutterApplication" android:label="platform_view_layout">
+    <application android:name="${applicationName}" android:label="platform_view_layout">
         <activity android:name=".DummyPlatformViewActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="abstract_method_smoke_test">
         <activity
             android:name=".MainActivity"

--- a/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/abstract_method_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -6,11 +6,11 @@ found in the LICENSE file. -->
     package="com.example.abstract_method_smoke_test">
     <!-- TODO(https://github.com/flutter/flutter/issues/42349): Remove this permission once this issue is fixed. -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="abstract_method_smoke_test">

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,11 @@ found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android_embedding_v2_smoke_test">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="android_embedding_v2_smoke_test">

--- a/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="android_embedding_v2_smoke_test">
         <activity
             android:name=".MainActivity"

--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@ found in the LICENSE file. -->
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application android:name="${applicationName}" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
         <activity android:name="com.yourcompany.platforminteraction.MainActivity"
                   android:launchMode="singleTop"

--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@ found in the LICENSE file. -->
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
-    <application android:name="io.flutter.app.FlutterApplication" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
+    <application android:name="${applicationName}" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
         <activity android:name="com.yourcompany.platforminteraction.MainActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
@@ -28,5 +28,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -16,13 +16,16 @@ import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
 import android.content.Context;
+import androidx.annotation.NonNull;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterView;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugins.GeneratedPluginRegistrant;
-import io.flutter.view.FlutterView;
 
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
@@ -30,10 +33,10 @@ import android.view.accessibility.AccessibilityNodeInfo;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      GeneratedPluginRegistrant.registerWith(this);
-      new MethodChannel(getFlutterView(), "semantics").setMethodCallHandler(new SemanticsTesterMethodHandler());
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+      GeneratedPluginRegistrant.registerWith(flutterEngine);
+      new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), "semantics")
+              .setMethodCallHandler(new SemanticsTesterMethodHandler());
   }
 
   class SemanticsTesterMethodHandler implements MethodCallHandler {
@@ -41,7 +44,7 @@ public class MainActivity extends FlutterActivity {
 
     @Override
     public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
-        FlutterView flutterView = getFlutterView();
+        FlutterView flutterView = findViewById(FLUTTER_VIEW_ID);
         AccessibilityNodeProvider provider = flutterView.getAccessibilityNodeProvider();
         DisplayMetrics displayMetrics = new DisplayMetrics();
         WindowManager wm = (WindowManager) getApplicationContext().getSystemService(Context.WINDOW_SERVICE);

--- a/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/android_views/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="platform_views">
         <activity
             android:exported="true"

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@ found in the LICENSE file. -->
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
-    <application android:name="io.flutter.app.FlutterApplication" android:label="channels" android:icon="@mipmap/ic_launcher">
+    <application android:name="${applicationName}" android:label="channels" android:icon="@mipmap/ic_launcher">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"

--- a/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/channels/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@ found in the LICENSE file. -->
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application android:name="${applicationName}" android:label="channels" android:icon="@mipmap/ic_launcher">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTop"

--- a/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/deferred_components_test/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,11 @@ found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.flutter.integration.deferred_components_test">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="io.flutter.embedding.android.FlutterPlayStoreSplitApplication"
         android:label="deferred_components_test"

--- a/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@ found in the LICENSE file. -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="external_ui">
         <activity
             android:name=".MainActivity"
@@ -21,5 +21,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/external_ui/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@ found in the LICENSE file. -->
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">

--- a/dev/integration_tests/external_ui/android/app/src/main/java/io/flutter/externalui/MainActivity.java
+++ b/dev/integration_tests/external_ui/android/app/src/main/java/io/flutter/externalui/MainActivity.java
@@ -11,18 +11,24 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.Surface;
 import android.view.SurfaceHolder;
+import android.view.View;
+import androidx.annotation.NonNull;
 
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterSurfaceView;
+import io.flutter.embedding.android.FlutterView;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.view.TextureRegistry;
 import io.flutter.view.TextureRegistry.SurfaceTextureEntry;
+import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   private Surface surface;
@@ -35,10 +41,9 @@ public class MainActivity extends FlutterActivity {
   private AtomicInteger framesConsumed = new AtomicInteger(0);
 
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-
-    final MethodChannel channel = new MethodChannel(getFlutterView(), "texture");
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
+    final MethodChannel channel = new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), "texture");
     channel.setMethodCallHandler(new MethodCallHandler() {
       @Override
       public void onMethodCall(MethodCall methodCall, Result result) {
@@ -93,11 +98,14 @@ public class MainActivity extends FlutterActivity {
         }
       }
     });
+  }
 
-    getFlutterView().getHolder().addCallback(new SurfaceHolder.Callback() {
+  @Override
+  public void onFlutterSurfaceViewCreated(@NonNull FlutterSurfaceView flutterSurfaceView) {
+    flutterSurfaceView.getHolder().addCallback(new SurfaceHolder.Callback() {
       @Override
       public void surfaceCreated(SurfaceHolder holder) {
-        final SurfaceTextureEntry textureEntry = getFlutterView().createSurfaceTexture();
+        final SurfaceTextureEntry textureEntry = flutterSurfaceView.getAttachedRenderer().createSurfaceTexture();
         texture = textureEntry.surfaceTexture();
         texture.setDefaultBufferSize(300, 200);
         surface = new Surface(texture);

--- a/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/flavors/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@ found in the LICENSE file. -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="flavors">
         <activity
             android:name=".MainActivity"
@@ -21,5 +21,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
+++ b/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
@@ -6,9 +6,12 @@ package com.yourcompany.flavors;
 
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override

--- a/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
+++ b/dev/integration_tests/flavors/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
@@ -6,21 +6,19 @@ package com.yourcompany.flavors;
 
 import android.os.Bundle;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-    new MethodChannel(getFlutterView(), "flavor").setMethodCallHandler(new MethodChannel.MethodCallHandler() {
-      @Override
-      public void onMethodCall(MethodCall methodCall, MethodChannel.Result result) {
-        result.success(BuildConfig.FLAVOR);
-      }
-    });
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    GeneratedPluginRegistrant.registerWith(flutterEngine);
+    new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), "flavor")
+        .setMethodCallHandler(
+            (call, result) -> {
+                result.success(BuildConfig.FLAVOR);
+        }
+    );
   }
 }

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@ found in the LICENSE file. -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="flavors">
         <activity
             android:name=".MainActivity"
@@ -21,5 +21,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
+++ b/dev/integration_tests/gradle_deprecated_settings/android/app/src/main/java/com/yourcompany/flavors/MainActivity.java
@@ -4,15 +4,6 @@
 
 package com.yourcompany.flavors;
 
-import android.os.Bundle;
+import io.flutter.embedding.android.FlutterActivity;
 
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
-
-public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
-}
+public class MainActivity extends FlutterActivity {}

--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@ found in the LICENSE file. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="platform_views">
         <activity
             android:name=".MainActivity"

--- a/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,11 @@ found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.non_nullable">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="non_nullable"

--- a/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/non_nullable/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="non_nullable"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@ found in the LICENSE file. -->
     <application android:name="${applicationName}" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
         <activity android:name="com.yourcompany.platforminteraction.MainActivity"
                   android:launchMode="singleTop"
+                  android:exported="true"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
                   android:hardwareAccelerated="true"

--- a/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@ found in the LICENSE file. -->
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application android:name="${applicationName}" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
         <activity android:name="com.yourcompany.platforminteraction.MainActivity"
                   android:launchMode="singleTop"

--- a/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@ found in the LICENSE file. -->
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
-    <application android:name="io.flutter.app.FlutterApplication" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
+    <application android:name="${applicationName}" android:label="Platform Interaction" android:icon="@mipmap/ic_launcher">
         <activity android:name="com.yourcompany.platforminteraction.MainActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"
@@ -28,5 +28,10 @@ found in the LICENSE file. -->
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
 </manifest>

--- a/dev/integration_tests/platform_interaction/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -6,16 +6,10 @@ package com.yourcompany.platforminteraction;
 
 import android.os.Bundle;
 
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugin.common.*;
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
-  }
   public void finish() {
     BasicMessageChannel channel =
         new BasicMessageChannel<>(getFlutterView(), "navigation-test", StringCodec.INSTANCE);

--- a/dev/integration_tests/platform_interaction/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/platform_interaction/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -6,13 +6,22 @@ package com.yourcompany.platforminteraction;
 
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.plugin.common.*;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugin.common.BasicMessageChannel;
+import io.flutter.plugin.common.StringCodec;
 
 public class MainActivity extends FlutterActivity {
+  BasicMessageChannel channel;
+
+  @Override
+  public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    channel =
+        new BasicMessageChannel<>(flutterEngine.getDartExecutor().getBinaryMessenger(), "navigation-test", StringCodec.INSTANCE);
+  }
+
   public void finish() {
-    BasicMessageChannel channel =
-        new BasicMessageChannel<>(getFlutterView(), "navigation-test", StringCodec.INSTANCE);
     channel.send("ping");
   }
 }

--- a/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="release_smoke_test"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/release_smoke_test/android/app/src/main/AndroidManifest.xml
@@ -5,11 +5,11 @@ found in the LICENSE file. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.release_smoke_test">
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="release_smoke_test"

--- a/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@ found in the LICENSE file. -->
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application android:name="${applicationName}" android:label="IntegrationUI">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTop"

--- a/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/ui/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@ found in the LICENSE file. -->
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
-    <application android:name="io.flutter.app.FlutterApplication" android:label="IntegrationUI">
+    <application android:name="${applicationName}" android:label="IntegrationUI">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTop"
                   android:theme="@android:style/Theme.Black.NoTitleBar"

--- a/dev/manual_tests/android/app/src/main/AndroidManifest.xml
+++ b/dev/manual_tests/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,11 @@ found in the LICENSE file. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.manual_tests">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="manual_tests"

--- a/dev/manual_tests/android/app/src/main/AndroidManifest.xml
+++ b/dev/manual_tests/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="manual_tests"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -36,6 +36,7 @@ class BuildApkCommand extends BuildSubCommand {
     usesAnalyzeSizeFlag();
     addAndroidSpecificBuildOptions(hide: !verboseHelp);
     addMultidexOption();
+    addIgnoreDeprecationOption();
     argParser
       ..addFlag('split-per-abi',
         negatable: false,
@@ -53,6 +54,9 @@ class BuildApkCommand extends BuildSubCommand {
 
   @override
   final String name = 'apk';
+
+  @override
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -42,6 +42,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
     usesAnalyzeSizeFlag();
     addAndroidSpecificBuildOptions(hide: !verboseHelp);
     addMultidexOption();
+    addIgnoreDeprecationOption();
     argParser.addMultiOption('target-platform',
       splitCommas: true,
       defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
@@ -71,6 +72,9 @@ class BuildAppBundleCommand extends BuildSubCommand {
 
   @override
   final String name = 'appbundle';
+
+  @override
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -251,6 +251,7 @@ class RunCommand extends RunCommandBase {
     // without needing to know the port.
     addPublishPort(verboseHelp: verboseHelp);
     addMultidexOption();
+    addIgnoreDeprecationOption();
     argParser
       ..addFlag('enable-software-rendering',
         negatable: false,
@@ -341,6 +342,10 @@ class RunCommand extends RunCommandBase {
 
   @override
   final String name = 'run';
+
+  @override
+  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
+  DeprecationBehavior _deviceDeprecationBehavior = DeprecationBehavior.none;
 
   @override
   final String description = 'Run your Flutter app on an attached device.';
@@ -474,6 +479,10 @@ class RunCommand extends RunCommandBase {
       throwToolExit(
         '--${FlutterOptions.kDeviceUser} is only supported for Android. At least one Android device is required.'
       );
+    }
+
+    if (devices.any((Device device) => device is AndroidDevice)) {
+      _deviceDeprecationBehavior = DeprecationBehavior.exit;
     }
     // Only support "web mode" with a single web device due to resident runner
     // refactoring required otherwise.

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -181,6 +181,8 @@ abstract class FlutterCommand extends Command<void> {
 
   bool _usesFatalWarnings = false;
 
+  DeprecationBehavior get deprecationBehavior => DeprecationBehavior.none;
+
   bool get shouldRunPub => _usesPubOption && boolArg('pub');
 
   bool get shouldUpdateCache => true;
@@ -834,6 +836,15 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  void addIgnoreDeprecationOption({ bool hide = false }) {
+    argParser.addFlag('ignore-deprecation',
+      negatable: false,
+      help: 'Indicates that the app should ignore deprecation warnings and continue to build '
+            'using deprecated APIs. Use of this flag may cause your app to fail to build when '
+            'deprecated APIs are removed.',
+    );
+  }
+
   /// Adds build options common to all of the desktop build commands.
   void addCommonDesktopBuildOptions({ required bool verboseHelp }) {
     addBuildModeFlags(verboseHelp: verboseHelp);
@@ -1264,8 +1275,10 @@ abstract class FlutterCommand extends Command<void> {
 
     await validateCommand();
 
+    final FlutterProject project = FlutterProject.current();
+    project.checkForDeprecation(deprecationBehavior: deprecationBehavior);
+
     if (shouldRunPub) {
-      final FlutterProject project = FlutterProject.current();
       final Environment environment = Environment(
         artifacts: globals.artifacts!,
         logger: globals.logger,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -14,12 +14,15 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/android/android_device.dart';
+import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -209,6 +212,88 @@ void main() {
           '--device-user',
           '10',
         ]), throwsToolExit(message: '--device-user is only supported for Android. At least one Android device is required.'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => mockDeviceManager,
+        Stdio: () => FakeStdio(),
+        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      });
+
+      testUsingContext('fails when v1 FlutterApplication is detected', () async {
+        fs.file('pubspec.yaml').createSync();
+        fs.file('android/AndroidManifest.xml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+              package="com.example.v1">
+             <application
+                  android:name="io.flutter.app.FlutterApplication">
+              </application>
+          </manifest>
+        ''', flush: true);
+        fs.file('.packages').writeAsStringSync('\n');
+        fs.file('lib/main.dart').createSync(recursive: true);
+        final AndroidDevice device = AndroidDevice('1234',
+          modelID: 'TestModel',
+          logger: testLogger,
+          platform: FakePlatform(),
+          androidSdk: FakeAndroidSdk(),
+          fileSystem: fs,
+          processManager: FakeProcessManager.any(),
+        );
+
+        mockDeviceManager
+          ..devices = <Device>[device]
+          ..targetDevices = <Device>[device];
+
+        final RunCommand command = RunCommand();
+        await expectLater(createTestCommandRunner(command).run(<String>[
+          'run',
+          '--pub',
+        ]), throwsToolExit(message: 'Build failed due to use of deprecated Android v1 embedding.'));
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => mockDeviceManager,
+        Stdio: () => FakeStdio(),
+        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+      });
+
+      testUsingContext('fails when v1 metadata is detected', () async {
+        fs.file('pubspec.yaml').createSync();
+        fs.file('android/AndroidManifest.xml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+              package="com.example.v1">
+              <application >
+                <meta-data
+                    android:name="flutterEmbedding"
+                    android:value="1" />
+              </application>
+          </manifest>
+        ''', flush: true);
+        fs.file('.packages').writeAsStringSync('\n');
+        fs.file('lib/main.dart').createSync(recursive: true);
+        final AndroidDevice device = AndroidDevice('1234',
+          modelID: 'TestModel',
+          logger: testLogger,
+          platform: FakePlatform(),
+          androidSdk: FakeAndroidSdk(),
+          fileSystem: fs,
+          processManager: FakeProcessManager.any(),
+        );
+
+        mockDeviceManager
+          ..devices = <Device>[device]
+          ..targetDevices = <Device>[device];
+
+        final RunCommand command = RunCommand();
+        await expectLater(createTestCommandRunner(command).run(<String>[
+          'run',
+          '--pub',
+        ]), throwsToolExit(message: 'Build failed due to use of deprecated Android v1 embedding.'));
       }, overrides: <Type, Generator>{
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
@@ -535,6 +620,10 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   }
 }
 
+class FakeAndroidSdk extends Fake implements AndroidSdk {
+  @override
+  String get adbPath => 'adb';
+}
 
 class TestRunCommand extends RunCommand {
   @override

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -182,8 +182,29 @@ void main() {
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
 
-        await project.regeneratePlatformSpecificTooling();
-        expect(testLogger.warningText, contains('https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects'));
+        project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.none);
+        expect(testLogger.statusText, contains('https://flutter.dev/go/android-project-migration'));
+      });
+      _testInMemory('Android project not on v2 embedding exits', () async {
+        final FlutterProject project = await someProject();
+        // The default someProject with an empty <manifest> already indicates
+        // v1 embedding, as opposed to having <meta-data
+        // android:name="flutterEmbedding" android:value="2" />.
+
+        await expectToolExitLater(
+          Future<dynamic>.sync(() => project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.exit)),
+          contains('Build failed due to use of deprecated Android v1 embedding.')
+        );
+        expect(testLogger.statusText, contains('https://flutter.dev/go/android-project-migration'));
+      });
+      _testInMemory('Android project not on v2 embedding ignore continues', () async {
+        final FlutterProject project = await someProject();
+        // The default someProject with an empty <manifest> already indicates
+        // v1 embedding, as opposed to having <meta-data
+        // android:name="flutterEmbedding" android:value="2" />.
+
+        project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.ignore);
+        expect(testLogger.statusText, contains('https://flutter.dev/go/android-project-migration'));
       });
       _testInMemory('Android plugin without example app does not show a warning', () async {
         final FlutterProject project = await aPluginProject();

--- a/packages/integration_test/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/integration_test/example/android/app/src/main/AndroidManifest.xml
@@ -5,11 +5,11 @@ found in the LICENSE file. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.integration_test_example">
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
+    <!-- ${applicationName} is used by the Flutter tool to select the Application
+         class to use. For most apps, this is the default Android application.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
+         Application and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="integration_test_example"

--- a/packages/integration_test/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/integration_test/example/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@ found in the LICENSE file. -->
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="integration_test_example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
Post-submit-only tests were broken since it was not caught in presubmit. This fixes external_ui, platform_interaction, microbenchmarks, and flavors by fully migrates them to v2 embedding.

Relands #92901 and reverts https://github.com/flutter/flutter/pull/93518
