### PR TITLE
Handle empty text with no line metrics in RenderEditable._lineNumberFor

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2410,7 +2410,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
         return MapEntry<int, Offset>(lineMetrics.lineNumber, Offset(offset.dx, lineMetrics.baseline));
       }
     }
-    assert(false, 'unable to find the line for $startPosition');
+    assert(startPosition.offset == 0, 'unable to find the line for $startPosition');
     return MapEntry<int, Offset>(
       math.max(0, metrics.length - 1),
       Offset(offset.dx, metrics.isNotEmpty ? metrics.last.baseline + metrics.last.descent : 0.0),


### PR DESCRIPTION
SkParagraph will return an empty list of line metrics if the text
is empty.
