### PR TITLE
Add `CupertinoTimerPicker` Interactive Example

### DIFF
--- a/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
@@ -32,7 +32,7 @@ class MyStatelessWidget extends StatefulWidget {
 
 class _MyStatelessWidgetState extends State<MyStatelessWidget> {
   Duration duration = const Duration(hours: 1, minutes: 23, seconds: 59);
-  
+
   void _showDialog(Widget child) {
     showCupertinoModalPopup<void>(
       context: context,

--- a/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
@@ -5,7 +5,6 @@
 // Flutter code sample for CupertinoTimerPicker
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
 
@@ -31,7 +30,7 @@ class MyStatelessWidget extends StatefulWidget {
 }
 
 class _MyStatelessWidgetState extends State<MyStatelessWidget> {
-  Duration duration = const Duration(hours: 1, minutes: 23, seconds: 59);
+  Duration duration = const Duration(hours: 1, minutes: 23, seconds: 42);
 
   void _showDialog(Widget child) {
     showCupertinoModalPopup<void>(
@@ -72,8 +71,8 @@ class _MyStatelessWidgetState extends State<MyStatelessWidget> {
                         initialTimerDuration: duration,
                         onTimerDurationChanged: (Duration newDuration) {
                           setState(() => duration = newDuration);
-                          },
-                        ),
+                        },
+                      ),
                     ),
                     child: Text('$duration',
                       style: const TextStyle(

--- a/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
@@ -11,37 +11,41 @@ void main() => runApp(const MyApp());
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'CupertinoTimerPicker Sample';
 
   @override
   Widget build(BuildContext context) {
     return const CupertinoApp(
       title: _title,
-      home: MyStatelessWidget(),
+      home: CupertinoTimerPickerSample(),
     );
   }
 }
 
-class MyStatelessWidget extends StatefulWidget {
-  const MyStatelessWidget({Key? key}) : super(key: key);
+class CupertinoTimerPickerSample extends StatefulWidget {
+  const CupertinoTimerPickerSample({Key? key}) : super(key: key);
 
   @override
-  State<MyStatelessWidget> createState() => _MyStatelessWidgetState();
+  State<CupertinoTimerPickerSample> createState() => _CupertinoTimerPickerSampleState();
 }
 
-class _MyStatelessWidgetState extends State<MyStatelessWidget> {
-  Duration duration = const Duration(hours: 1, minutes: 23, seconds: 42);
+class _CupertinoTimerPickerSampleState extends State<CupertinoTimerPickerSample> {
+  Duration duration = const Duration(hours: 1, minutes: 23);
 
+  // This shows a CupertinoModalPopup with a reasonable fixed height which hosts CupertinoTimerPicker.
   void _showDialog(Widget child) {
     showCupertinoModalPopup<void>(
       context: context,
       builder: (BuildContext context) => Container(
         height: 216,
         padding: const EdgeInsets.only(top: 6.0),
+        // The Bottom margin is provided to align the popup above the system navigation bar.
         margin: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
         ),
+        // Provide a background color for the popup.
         color: CupertinoColors.systemBackground.resolveFrom(context),
+        // Use a SafeArea widget to avoid system overlaps.
         child: SafeArea(
           top: false,
           child: child,
@@ -66,14 +70,19 @@ class _MyStatelessWidgetState extends State<MyStatelessWidget> {
                 children: <Widget>[
                   const Text('Timer'),
                   CupertinoButton(
+                    // Display a CupertinoTimerPicker with hour/minute mode.
                     onPressed: () => _showDialog(
                       CupertinoTimerPicker(
+                        mode: CupertinoTimerPickerMode.hm,
                         initialTimerDuration: duration,
+                        // This is called when the user changes the timer duration.
                         onTimerDurationChanged: (Duration newDuration) {
                           setState(() => duration = newDuration);
                         },
                       ),
                     ),
+                    // In this example, the timer value is formatted manually. You can use intl package
+                    // to format the value based on user's locale settings.
                     child: Text('$duration',
                       style: const TextStyle(
                         fontSize: 22.0,
@@ -90,6 +99,7 @@ class _MyStatelessWidgetState extends State<MyStatelessWidget> {
   }
 }
 
+// This class simply decorates a row of widgets.
 class _TimerPickerItem extends StatelessWidget {
   const _TimerPickerItem({required this.children});
 

--- a/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
@@ -1,0 +1,123 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for CupertinoTimerPicker
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+class MyStatelessWidget extends StatefulWidget {
+  const MyStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  State<MyStatelessWidget> createState() => _MyStatelessWidgetState();
+}
+
+class _MyStatelessWidgetState extends State<MyStatelessWidget> {
+  Duration duration = const Duration(hours: 1, minutes: 23, seconds: 59);
+  
+  void _showDialog(Widget child) {
+    showCupertinoModalPopup<void>(
+      context: context,
+      builder: (BuildContext context) => Container(
+        height: 216,
+        padding: const EdgeInsets.only(top: 6.0),
+        margin: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        color: CupertinoColors.systemBackground.resolveFrom(context),
+        child: SafeArea(
+          top: false,
+          child: child,
+        ),
+      )
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      child: DefaultTextStyle(
+        style: TextStyle(
+          color: CupertinoColors.label.resolveFrom(context),
+          fontSize: 22.0,
+        ),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              _TimerPickerItem(
+                children: <Widget>[
+                  const Text('Timer'),
+                  CupertinoButton(
+                    onPressed: () => _showDialog(
+                      CupertinoTimerPicker(
+                        initialTimerDuration: duration,
+                        onTimerDurationChanged: (Duration newDuration) {
+                          setState(() => duration = newDuration);
+                          },
+                        ),
+                    ),
+                    child: Text('$duration',
+                      style: const TextStyle(
+                        fontSize: 22.0,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TimerPickerItem extends StatelessWidget {
+  const _TimerPickerItem({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: CupertinoColors.inactiveGray,
+            width: 0.0,
+          ),
+          bottom: BorderSide(
+            color: CupertinoColors.inactiveGray,
+            width: 0.0,
+          ),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: children,
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
+++ b/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_api_samples/cupertino/date_picker/cupertino_timer_picker.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+const Offset _kRowOffset = Offset(0.0, -50.0);
+
+void main() {
+  testWidgets('Can pick a duration from CupertinoTimerPicker', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    // Open the timer picker.
+    await tester.tap(find.text('1:23:42.000000'));
+    await tester.pumpAndSettle();
+
+    // Drag all three date wheels.
+    await tester.drag(find.text('1'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
+    await tester.drag(find.text('23'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
+    await tester.drag(find.text('42'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    //Close the date picker.
+    await tester.tapAt(const Offset(1.0, 1.0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('3:25:44.000000'), findsOneWidget);
+  });
+}

--- a/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
+++ b/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
@@ -13,14 +13,13 @@ void main() {
       const example.MyApp(),
     );
 
-    // Open the timer picker.
-    await tester.tap(find.text('1:23:42.000000'));
+    // Launch the timer picker.
+    await tester.tap(find.text('1:23:00.000000'));
     await tester.pumpAndSettle();
 
-    // Drag hour, minute, and second hand to change the time.
+    // Drag hour, minute to change the time.
     await tester.drag(find.text('1'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
     await tester.drag(find.text('23'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
-    await tester.drag(find.text('42'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -29,6 +28,6 @@ void main() {
     await tester.tapAt(const Offset(1.0, 1.0));
     await tester.pumpAndSettle();
 
-    expect(find.text('3:25:44.000000'), findsOneWidget);
+    expect(find.text('3:25:00.000000'), findsOneWidget);
   });
 }

--- a/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
+++ b/examples/api/test/cupertino/date_picker/cupertino_timer_picker.0_test.dart
@@ -17,7 +17,7 @@ void main() {
     await tester.tap(find.text('1:23:42.000000'));
     await tester.pumpAndSettle();
 
-    // Drag all three date wheels.
+    // Drag hour, minute, and second hand to change the time.
     await tester.drag(find.text('1'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
     await tester.drag(find.text('23'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
     await tester.drag(find.text('42'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
@@ -25,7 +25,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    //Close the date picker.
+    // Close the timer picker.
     await tester.tapAt(const Offset(1.0, 1.0));
     await tester.pumpAndSettle();
 

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1496,6 +1496,12 @@ enum CupertinoTimerPickerMode {
 /// provides more space than it needs, the picker will position itself according
 /// to its [alignment] property.
 ///
+/// {@tool dartpad}
+/// This example shows a [CupertinoTimerPicker] that returns a countdown duration.
+///
+/// ** See code in examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [CupertinoDatePicker], the class that implements different display modes


### PR DESCRIPTION
This adds an official `CupertinoTimerPicker` example, this makes it much easier to try timer picker without navigating to large Flutter Gallery source code or relying on third-party websites.

Note:
I couldn't format the duration without importing `intl`. 

Related https://github.com/flutter/flutter/issues/72926



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
