### PR TITLE
Add `CupertinoPicker` interactive example

### DIFF
--- a/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
+++ b/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
@@ -1,0 +1,117 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for CupertinoPicker
+
+import 'package:flutter/cupertino.dart';
+
+const double _kItemExtent = 32.0;
+const List<String> _fruitNames = <String>[
+  '🍎 Apple',
+  '🥭 Mango',
+  '🍌 Banana',
+  '🍊 Orange',
+  '🍍 Pineapple',
+  '🍓 Strawberry',
+];
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      title: _title,
+      home: CupertinoPickerSample(),
+    );
+  }
+}
+
+class CupertinoPickerSample extends StatefulWidget {
+  const CupertinoPickerSample({Key? key}) : super(key: key);
+
+  @override
+  State<CupertinoPickerSample> createState() => _CupertinoPickerSampleState();
+}
+
+class _CupertinoPickerSampleState extends State<CupertinoPickerSample> {
+  int _selectedFruit = 0;
+
+  // This shows a CupertinoModalPopup with a reasonable fixed height which hosts CupertinoPicker.
+  void _showDialog(Widget child) {
+    showCupertinoModalPopup<void>(
+      context: context,
+      builder: (BuildContext context) => Container(
+        height: 216,
+        padding: const EdgeInsets.only(top: 6.0),
+        // The Bottom margin is provided to align the popup above the system navigation bar.
+        margin: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        // Provide a background color for the popup.
+        color: CupertinoColors.systemBackground.resolveFrom(context),
+        // Use a SafeArea widget to avoid system overlaps.
+        child: SafeArea(
+          top: false,
+          child: child,
+        ),
+      )
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      child: DefaultTextStyle(
+        style: TextStyle(
+          color: CupertinoColors.label.resolveFrom(context),
+          fontSize: 22.0,
+        ),
+        child: Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              const Text('Selected fruit: '),
+              CupertinoButton(
+                padding: EdgeInsets.zero,
+                // Display a CupertinoPicker with list of fruits.
+                onPressed: () => _showDialog(
+                  CupertinoPicker(
+                    magnification: 1.22,
+                    squeeze: 1.2,
+                    useMagnifier: true,
+                    itemExtent: _kItemExtent,
+                    // This is called when selected item is changed.
+                    onSelectedItemChanged: (int selectedItem) {
+                      setState(() {
+                        _selectedFruit = selectedItem;
+                      });
+                    },
+                    children: List<Widget>.generate(_fruitNames.length, (int index) {
+                      return Center(
+                        child: Text(
+                          _fruitNames[index],
+                        ),
+                      );
+                    }),
+                  ),
+                ),
+                // This displays the selected fruit name.
+                child: Text(_fruitNames[_selectedFruit],
+                  style: const TextStyle(
+                    fontSize: 22.0,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/cupertino/picker/cupertino_picker.0_test.dart
+++ b/examples/api/test/cupertino/picker/cupertino_picker.0_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_api_samples/cupertino/picker/cupertino_picker.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+const Offset _kRowOffset = Offset(0.0, -50.0);
+
+void main() {
+  testWidgets('Change selected fruit using CupertinoPicker', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    // Open the Cupertino picker.
+    await tester.tap(find.text('🍎 Apple'));
+    await tester.pumpAndSettle();
+
+    // Drag the wheel to change fruit selection.
+    await tester.drag(find.text('🥭 Mango'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // Close the Cupertino picker.
+    await tester.tapAt(const Offset(1.0, 1.0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('🍌 Banana'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -38,6 +38,13 @@ const double _kOverAndUnderCenterOpacity = 0.447;
 ///
 /// By default, descendent texts are shown with [CupertinoTextThemeData.pickerTextStyle].
 ///
+/// {@tool dartpad}
+/// This example shows a [CupertinoPicker] that displays a list of fruits on a wheel for
+/// selection.
+///
+/// ** See code in examples/api/lib/cupertino/picker/cupertino_picker.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [ListWheelScrollView], the generic widget backing this picker without


### PR DESCRIPTION
This adds an official `CupertinoPicker` example, this makes it much easier to try Cupertino picker.

### Preview

https://user-images.githubusercontent.com/48603081/141693637-5409f340-d2c2-44b9-a671-8a24690d0bac.mov

Related https://github.com/flutter/flutter/issues/72926

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
