### PR TITLE
Add `CupertinoButton` interactive example

### DIFF
--- a/examples/api/lib/cupertino/button/cupertino_button.0.dart
+++ b/examples/api/lib/cupertino/button/cupertino_button.0.dart
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for CupertinoButton
+
+import 'package:flutter/cupertino.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+class MyStatelessWidget extends StatelessWidget {
+  const MyStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const CupertinoButton(
+            onPressed: null,
+            child: Text('Disabled'),
+          ),
+          const SizedBox(height: 30),
+          const CupertinoButton.filled(
+            onPressed: null,
+            child: Text('Disabled'),
+          ),
+          const SizedBox(height: 30),
+          CupertinoButton(
+            onPressed: () {},
+            child: const Text('Enabled'),
+          ),
+          const SizedBox(height: 30),
+          CupertinoButton.filled(
+            onPressed: () {},
+            child: const Text('Enabled'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/test/cupertino/button/cupertino_button.0_test.dart
+++ b/examples/api/test/cupertino/button/cupertino_button.0_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_api_samples/cupertino/button/cupertino_button.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Has 4 CupertinoButton variants', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    expect(find.byType(CupertinoButton), findsNWidgets(4));
+    expect(find.ancestor(of: find.text('Enabled'), matching: find.byType(CupertinoButton)), findsNWidgets(2));
+    expect(find.ancestor(of: find.text('Disabled'), matching: find.byType(CupertinoButton)), findsNWidgets(2));
+  });
+}

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -26,6 +26,14 @@ const EdgeInsets _kBackgroundButtonPadding = EdgeInsets.symmetric(
 /// [EdgeInsets.zero], should be used to prevent clipping larger [child]
 /// widgets.
 ///
+/// {@tool dartpad}
+/// This sample shows produces an enabled and disabled [CupertinoButton] and
+/// [CupertinoButton.filled].
+///
+/// ** See code in examples/api/lib/cupertino/button/cupertino_button.0.dart **
+/// {@end-tool}
+///
+/// See also:
 /// See also:
 ///
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/controls/buttons/>

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -34,7 +34,6 @@ const EdgeInsets _kBackgroundButtonPadding = EdgeInsets.symmetric(
 /// {@end-tool}
 ///
 /// See also:
-/// See also:
 ///
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/controls/buttons/>
 class CupertinoButton extends StatefulWidget {


### PR DESCRIPTION
This adds an official interactive example `CupertinoButton`. Similar to [ElevatedButton example](https://api.flutter.dev/flutter/material/ElevatedButton-class.html#material.ElevatedButton.1)

Related https://github.com/flutter/flutter/issues/72926

### Preview
https://user-images.githubusercontent.com/48603081/141705823-5591ece9-bc61-4c68-8819-8df04eb7dd9b.mov


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
