### PR TITLE
Fix CupertinoDatePicker width on wide screens

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1049,7 +1049,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 495.0),
+                  constraints: const BoxConstraints(maxWidth: 500.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,
@@ -1442,7 +1442,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 495.0),
+                  constraints: const BoxConstraints(maxWidth: 500.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1043,12 +1043,24 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: CustomMultiChildLayout(
-          delegate: _DatePickerLayoutDelegate(
-            columnWidths: columnWidths,
-            textDirectionFactor: textDirectionFactor,
-          ),
-          children: pickers,
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SizedBox(
+              width: constraints.maxWidth,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 500.0),
+                  child: CustomMultiChildLayout(
+                    delegate: _DatePickerLayoutDelegate(
+                      columnWidths: columnWidths,
+                      textDirectionFactor: textDirectionFactor,
+                    ),
+                    children: pickers,
+                  ),
+                ),
+              ),
+            );
+          }
         ),
       ),
     );
@@ -1424,12 +1436,24 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: CustomMultiChildLayout(
-          delegate: _DatePickerLayoutDelegate(
-            columnWidths: columnWidths,
-            textDirectionFactor: textDirectionFactor,
-          ),
-          children: pickers,
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SizedBox(
+              width: constraints.maxWidth,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 500.0),
+                  child: CustomMultiChildLayout(
+                    delegate: _DatePickerLayoutDelegate(
+                      columnWidths: columnWidths,
+                      textDirectionFactor: textDirectionFactor,
+                    ),
+                    children: pickers,
+                  ),
+                ),
+              ),
+            );
+          }
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1049,7 +1049,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 500.0),
+                  constraints: const BoxConstraints(maxWidth: 520.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,
@@ -1442,7 +1442,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 500.0),
+                  constraints: const BoxConstraints(maxWidth: 520.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1049,7 +1049,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 520.0),
+                  constraints: const BoxConstraints(maxWidth: 495.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,
@@ -1442,7 +1442,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
               width: constraints.maxWidth,
               child: Center(
                 child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 520.0),
+                  constraints: const BoxConstraints(maxWidth: 495.0),
                   child: CustomMultiChildLayout(
                     delegate: _DatePickerLayoutDelegate(
                       columnWidths: columnWidths,

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1220,6 +1220,31 @@ void main() {
       );
     });
 
+    testWidgets('DatePicker respects maxWidth constraint', (WidgetTester tester) async {
+      Widget _buildApp(CupertinoDatePickerMode mode) {
+        return CupertinoApp(
+          home: Center(
+            child: RepaintBoundary(
+              child: CupertinoDatePicker(
+                mode: mode,
+                initialDateTime: DateTime(2019, 1, 1, 4, 12, 30),
+                onDateTimeChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(_buildApp(CupertinoDatePickerMode.date));
+      expect(tester.getSize(find.byType(CustomMultiChildLayout)).width, 500.0);
+
+      await tester.pumpWidget(_buildApp(CupertinoDatePickerMode.dateAndTime));
+      expect(tester.getSize(find.byType(CustomMultiChildLayout)).width, 500.0);
+
+      await tester.pumpWidget(_buildApp(CupertinoDatePickerMode.time));
+      expect(tester.getSize(find.byType(CustomMultiChildLayout)).width, 500.0);
+    }, variant: TargetPlatformVariant.desktop());
+
     testWidgets('DatePicker displays the date in correct order', (WidgetTester tester) async {
       await tester.pumpWidget(
         CupertinoApp(


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/54241

Instead of providing all the width available, here we're limiting width after a certain size and it is not needed (this makes the wheels to be aligned properly instead of curving too much on a wide screen).



### Preview
#### Before

<img width="1552" alt="Screen Shot 2021-11-15 at 01 16 01" src="https://user-images.githubusercontent.com/48603081/141702588-057ec277-66ad-4a93-b2c9-38545c3dabff.png">


#### After

<img width="1552" alt="Screen Shot 2021-11-15 at 00 34 10" src="https://user-images.githubusercontent.com/48603081/141702610-9dbb1497-f6e3-45f9-aeaa-956d4823bf76.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
