### PR TITLE
Fix Draggable change TextStyle at dragging

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -7,6 +7,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
+import '../../widgets.dart';
 import 'basic.dart';
 import 'binding.dart';
 import 'framework.dart';
@@ -550,7 +551,10 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       axis: widget.axis,
       initialPosition: position,
       dragStartPoint: dragStartPoint,
-      feedback: widget.feedback,
+      feedback: DefaultTextStyle(
+        style: DefaultTextStyle.of(context).style,
+        child: widget.feedback,
+      ),
       feedbackOffset: widget.feedbackOffset,
       ignoringFeedbackSemantics: widget.ignoringFeedbackSemantics,
       onDragUpdate: (DragUpdateDetails details) {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2204,6 +2204,36 @@ void main() {
     expect(didTap, isFalse);
   });
 
+  testWidgets('Draggable not change TextStyle at dragging', (WidgetTester tester) async {
+    const TextStyle s1 = TextStyle(
+      height: 10,
+      color: Colors.blue,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: MaterialApp(
+          home: DefaultTextStyle(
+            style: s1,
+            child: Draggable<Object>(
+              feedback: Text('Dragging'),
+              child: Text('Source'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset firstLocation = tester.getCenter(find.text('Source'));
+    expect(find.text('Dragging'), findsNothing);
+    await tester.startGesture(firstLocation, pointer: 13);
+    await tester.pump();
+
+    final RichText text = tester.firstWidget(find.text('Dragging', findRichText: true));
+    expect(text, isNotNull);
+    expect(text.text.style, s1);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/6128.
   testWidgets('Draggable plays nice with onTap', (WidgetTester tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
This PR changes a text style of a widget under the pointer in the `Draggable` when a drag is underway. This is because the `feedback` widget loses its previous context when attached to the `MaterialApp`, and will not restore the previous `DefaultTextStyle`.

Fixes #85452

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
