### PR TITLE
[Web] Detect when running under Dart HHH Web and skip tests under investigation

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -220,17 +220,19 @@ Future<void> main(List<String> args) async {
   print('$clock ${bold}Test successful.$reset');
 }
 
+final String _luciBotId = Platform.environment['SWARMING_BOT_ID'] ?? '';
+final bool _runningInDartHHHBot = _luciBotId.startsWith('luci-dart-');
+
 /// Verify the Flutter Engine is the revision in
 /// bin/cache/internal/engine.version.
 Future<void> _validateEngineHash() async {
-  final String luciBotId = Platform.environment['SWARMING_BOT_ID'] ?? '';
-  if (luciBotId.startsWith('luci-dart-')) {
+  if (_runningInDartHHHBot) {
     // The Dart HHH bots intentionally modify the local artifact cache
     // and then use this script to run Flutter's test suites.
     // Because the artifacts have been changed, this particular test will return
     // a false positive and should be skipped.
     print('${yellow}Skipping Flutter Engine Version Validation for swarming '
-          'bot $luciBotId.');
+          'bot $_luciBotId.');
     return;
   }
   final String expectedVersion = File(engineVersionFile).readAsStringSync().trim();
@@ -1506,6 +1508,7 @@ Future<void> _runFlutterWebTest(String webRenderer, String workingDirectory, Lis
       '-v',
       '--platform=chrome',
       '--web-renderer=$webRenderer',
+      '--dart-define=DART_HHH_BOT=$_runningInDartHHHBot',
       '--sound-null-safety',
       ...flutterTestArgs,
       ...tests,

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -883,7 +883,9 @@ void main() {
 
     editable.layout(BoxConstraints.loose(const Size(1000.0, 1000.0)));
     expect(editable.maxScrollExtent, equals(10));
-  });
+    // TODO(yjbanov): This test is failing in the Dart HHH-web bot and
+    //                needs additional investigation before it can be reenabled.
+  }, skip: const bool.fromEnvironment('DART_HHH_BOT')); // https://github.com/flutter/flutter/issues/61021
 
   test('getEndpointsForSelection handles empty characters', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -885,8 +885,8 @@ void main() {
     expect(editable.maxScrollExtent, equals(10));
     // TODO(yjbanov): This test is failing in the Dart HHH-web bot and
     //                needs additional investigation before it can be reenabled.
-  }, skip: const bool.fromEnvironment('DART_HHH_BOT')); // https://github.com/flutter/flutter/issues/61021
-
+  }, skip: const bool.fromEnvironment('DART_HHH_BOT')); // https://github.com/flutter/flutter/issues/93691
+ 
   test('getEndpointsForSelection handles empty characters', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final RenderEditable editable = RenderEditable(

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -886,7 +886,7 @@ void main() {
     // TODO(yjbanov): This test is failing in the Dart HHH-web bot and
     //                needs additional investigation before it can be reenabled.
   }, skip: const bool.fromEnvironment('DART_HHH_BOT')); // https://github.com/flutter/flutter/issues/93691
- 
+
   test('getEndpointsForSelection handles empty characters', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final RenderEditable editable = RenderEditable(


### PR DESCRIPTION
Change the test launching script to detect when it is running under the Dart HHH bot and pass along that information to the underlying job running flutter web tests.

This change is then used to skip a single Flutter Web test that is failing in the Dart HHH bot while the underlying issue gets investigated (see https://github.com/flutter/flutter/issues/93691 for context)
