### PR TITLE
Fix CallbackShortcuts to only call shortcuts when triggered

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1005,9 +1005,11 @@ class CallbackShortcuts extends StatelessWidget {
   // throws, by providing the activator and event as arguments that will appear
   // in the stack trace.
   bool _applyKeyBinding(ShortcutActivator activator, RawKeyEvent event) {
-    if (activator.accepts(event, RawKeyboard.instance)) {
-      bindings[activator]!.call();
-      return true;
+    if (activator.triggers?.contains(event.logicalKey) ?? true) {
+      if (activator.accepts(event, RawKeyboard.instance)) {
+        bindings[activator]!.call();
+        return true;
+      }
     }
     return false;
   }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1126,12 +1126,16 @@ void main() {
 
   group('CallbackShortcuts', () {
     testWidgets('trigger on key events', (WidgetTester tester) async {
-      int invoked = 0;
+      int invokedA = 0;
+      int invokedB = 0;
       await tester.pumpWidget(
         CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
             const SingleActivator(LogicalKeyboardKey.keyA): () {
-              invoked += 1;
+              invokedA += 1;
+            },
+            const SingleActivator(LogicalKeyboardKey.keyB): () {
+              invokedB += 1;
             },
           },
           child: const Focus(
@@ -1143,9 +1147,20 @@ void main() {
       await tester.pump();
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
-      expect(invoked, equals(1));
+      await tester.pump();
+      expect(invokedA, equals(1));
+      expect(invokedB, equals(0));
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
-      expect(invoked, equals(1));
+      expect(invokedA, equals(1));
+      expect(invokedB, equals(0));
+      invokedA = 0;
+      invokedB = 0;
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyB);
+      expect(invokedA, equals(0));
+      expect(invokedB, equals(1));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyB);
+      expect(invokedA, equals(0));
+      expect(invokedB, equals(1));
     });
 
     testWidgets('nested CallbackShortcuts stop propagation', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This fixes the `CallbackShortcuts` class to only call callbacks when the shortcut is triggered by the appropriate event, instead of whenever the shortcut accepts the event.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/92717

## Tests
 - Added tests that make sure that only the shortcuts with the appropriate trigger keys are triggered.