### PR TITLE
The Draggable able change cursor on dragging

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -198,6 +198,7 @@ class Draggable<T extends Object> extends StatefulWidget {
     )
     this.dragAnchor = DragAnchor.child,
     this.dragAnchorStrategy,
+    this.feedbackCursor = MouseCursor.defer,
     this.affinity,
     this.maxSimultaneousDrags,
     this.onDragStarted,
@@ -216,6 +217,13 @@ class Draggable<T extends Object> extends StatefulWidget {
 
   /// The data that will be dropped by this draggable.
   final T? data;
+
+  /// The mouse cursor for mouse pointers that are over the [feedback].
+  ///
+  /// When a mouse is over the [feedback], its cursor will be changed to the [cursor].
+  ///
+  /// The [cursor] defaults to [MouseCursor.defer]
+  final MouseCursor feedbackCursor;
 
   /// The [Axis] to restrict this draggable's movement, if specified.
   ///
@@ -551,6 +559,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       initialPosition: position,
       dragStartPoint: dragStartPoint,
       feedback: widget.feedback,
+      feedbackCursor: widget.feedbackCursor,
       feedbackOffset: widget.feedbackOffset,
       ignoringFeedbackSemantics: widget.ignoringFeedbackSemantics,
       onDragUpdate: (DragUpdateDetails details) {
@@ -800,6 +809,7 @@ class _DragAvatar<T extends Object> extends Drag {
     required this.overlayState,
     this.data,
     this.axis,
+    this.feedbackCursor = MouseCursor.defer,
     required Offset initialPosition,
     this.dragStartPoint = Offset.zero,
     this.feedback,
@@ -818,6 +828,7 @@ class _DragAvatar<T extends Object> extends Drag {
   }
 
   final T? data;
+  final MouseCursor feedbackCursor;
   final Axis? axis;
   final Offset dragStartPoint;
   final Widget? feedback;
@@ -945,9 +956,13 @@ class _DragAvatar<T extends Object> extends Drag {
     return Positioned(
       left: _lastOffset!.dx - overlayTopLeft.dx,
       top: _lastOffset!.dy - overlayTopLeft.dy,
-      child: IgnorePointer(
-        ignoringSemantics: ignoringFeedbackSemantics,
-        child: feedback,
+      child: MouseRegion(
+        cursor: feedbackCursor,
+        opaque: false,
+        child: IgnorePointer(
+          ignoringSemantics: ignoringFeedbackSemantics,
+          child: feedback,
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -220,7 +220,7 @@ class Draggable<T extends Object> extends StatefulWidget {
 
   /// The cursor for a mouse pointer when the pointer is over the [feedback].
   ///
-  /// The [feedbackCursor] defaults to [MouseCursor.defer]
+  /// The [feedbackCursor] defaults to [MouseCursor.defer].
   final MouseCursor feedbackCursor;
 
   /// The [Axis] to restrict this draggable's movement, if specified.

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -218,11 +218,9 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// The data that will be dropped by this draggable.
   final T? data;
 
-  /// The mouse cursor for mouse pointers that are over the [feedback].
+  /// The cursor for a mouse pointer when the pointer is over the [feedback].
   ///
-  /// When a mouse is over the [feedback], its cursor will be changed to the [cursor].
-  ///
-  /// The [cursor] defaults to [MouseCursor.defer]
+  /// The [feedbackCursor] defaults to [MouseCursor.defer]
   final MouseCursor feedbackCursor;
 
   /// The [Axis] to restrict this draggable's movement, if specified.

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -2684,7 +2684,7 @@ void main() {
     await _testChildAnchorFeedbackPosition(tester: tester, left: 100.0, top: 100.0);
   });
 
-  testWidgets('Drag feedback change cursor correctly', (WidgetTester tester) async {
+  testWidgets('Drag feedback changes cursor correctly', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Column(
         children: const <Widget>[


### PR DESCRIPTION
This PR adds to the Draggable new parameter, the feedbackCursor, which changes a cursor when a pointer over the feedback widget. This is necessary because the feedback becomes invisible to the hit test, which means that the cursor cannot be redefined further down of the widget tree.

Fix #92083

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
