### PR TITLE
Show `RefreshIndicator` on top when scroll's axis direction is up (matching native behaviour)

### DIFF
--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -296,7 +296,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     // In this case, we don't want to trigger the refresh indicator.
     return ((notification is ScrollStartNotification && notification.dragDetails != null)
             || (notification is ScrollUpdateNotification && notification.dragDetails != null && widget.triggerMode == RefreshIndicatorTriggerMode.anywhere))
-      && notification.metrics.extentBefore == 0.0
+      && (( notification.metrics.axisDirection == AxisDirection.up && notification.metrics.extentAfter == 0.0)
+            || (notification.metrics.axisDirection == AxisDirection.down && notification.metrics.extentBefore == 0.0))
       && _mode == null
       && _start(notification.metrics.axisDirection);
   }
@@ -313,10 +314,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     bool? indicatorAtTopNow;
     switch (notification.metrics.axisDirection) {
       case AxisDirection.down:
-        indicatorAtTopNow = true;
-        break;
       case AxisDirection.up:
-        indicatorAtTopNow = false;
+        indicatorAtTopNow = true;
         break;
       case AxisDirection.left:
       case AxisDirection.right:
@@ -343,7 +342,11 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
       }
     } else if (notification is OverscrollNotification) {
       if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
-        _dragOffset = _dragOffset! - notification.overscroll;
+        if (notification.metrics.axisDirection == AxisDirection.down) {
+          _dragOffset = _dragOffset! - notification.overscroll;
+        } else if (notification.metrics.axisDirection == AxisDirection.up) {
+          _dragOffset = _dragOffset! + notification.overscroll;
+        }
         _checkDragOffset(notification.metrics.viewportDimension);
       }
     } else if (notification is ScrollEndNotification) {
@@ -382,10 +385,8 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     assert(_dragOffset == null);
     switch (direction) {
       case AxisDirection.down:
-        _isIndicatorAtTop = true;
-        break;
       case AxisDirection.up:
-        _isIndicatorAtTop = false;
+        _isIndicatorAtTop = true;
         break;
       case AxisDirection.left:
       case AxisDirection.right:

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -327,10 +327,15 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
         _dismiss(_RefreshIndicatorMode.canceled);
     } else if (notification is ScrollUpdateNotification) {
       if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
-        if (notification.metrics.extentBefore > 0.0) {
+        if ((notification.metrics.axisDirection  == AxisDirection.down && notification.metrics.extentBefore > 0.0)
+            || (notification.metrics.axisDirection  == AxisDirection.up && notification.metrics.extentAfter > 0.0)) {
           _dismiss(_RefreshIndicatorMode.canceled);
         } else {
-          _dragOffset = _dragOffset! - notification.scrollDelta!;
+          if (notification.metrics.axisDirection == AxisDirection.down) {
+            _dragOffset = _dragOffset! - notification.scrollDelta!;
+          } else if (notification.metrics.axisDirection == AxisDirection.up) {
+            _dragOffset = _dragOffset! + notification.scrollDelta!;
+          }
           _checkDragOffset(notification.metrics.viewportDimension);
         }
       }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -115,7 +115,7 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
@@ -169,11 +169,11 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     await tester.pump(const Duration(seconds: 1));
-    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, greaterThan(300.0));
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
   testWidgets('RefreshIndicator - no movement', (WidgetTester tester) async {
@@ -641,11 +641,11 @@ void main() {
 
     scrollController.jumpTo(50.0);
 
-    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
     await tester.pump();
     await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
     await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
-    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, greaterThan(300.0));
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/71936
@@ -817,7 +817,7 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
     await tester.pump();
     expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, primaryColor);
   });
@@ -857,7 +857,7 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('X'), const Offset(0.0, -300.0), 1000.0);
+    await tester.fling(find.text('X'), const Offset(0.0, 600.0), 1000.0);
     await tester.pump();
     expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, refreshIndicatorColor.withOpacity(1.0));
 

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -95,7 +95,7 @@ void main() {
     expect(refreshCalled, true);
   });
 
-  testWidgets('RefreshIndicator - bottom', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator - reverse', (WidgetTester tester) async {
     refreshCalled = false;
     await tester.pumpWidget(
       MaterialApp(
@@ -149,7 +149,7 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('RefreshIndicator - bottom - position', (WidgetTester tester) async {
+  testWidgets('RefreshIndicator - reverse - position', (WidgetTester tester) async {
     refreshCalled = false;
     await tester.pumpWidget(
       MaterialApp(
@@ -612,7 +612,7 @@ void main() {
     expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
   });
 
-  testWidgets('Bottom RefreshIndicator(anywhere mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Reverse RefreshIndicator(anywhere mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -719,7 +719,7 @@ void main() {
     expect(find.byType(RefreshProgressIndicator), findsNothing);
   });
 
-  testWidgets('Bottom RefreshIndicator(onEdge mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
+  testWidgets('Reverse RefreshIndicator(onEdge mode) should be shown when dragging from non-zero scroll position', (WidgetTester tester) async {
     refreshCalled = false;
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
@@ -867,5 +867,39 @@ void main() {
 
     await tester.pump();
     expect(tester.widget<RefreshProgressIndicator>(find.byType(RefreshProgressIndicator)).valueColor!.value, red.withOpacity(1.0));
+  });
+
+  testWidgets('RefreshIndicator - reverse - BouncingScrollPhysics', (WidgetTester tester) async {
+    refreshCalled = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RefreshIndicator(
+          onRefresh: refresh,
+          child: ListView(
+            reverse: true,
+            physics: const BouncingScrollPhysics(),
+            children: <Widget>[
+              for (int i = 0; i < 4; i++)
+                SizedBox(
+                  height: 200.0,
+                  child: Text('X - $i'),
+                ),
+            ],
+          )
+        ),
+      ),
+    );
+
+    // Scroll to top
+    await tester.fling(find.text('X - 0'), const Offset(0.0, 800.0), 1000.0);
+    await tester.pumpAndSettle();
+
+    // Fling down to show refresh indicator
+    await tester.fling(find.text('X - 3'), const Offset(0.0, 250.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // finish the scroll animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator settle animation
+    await tester.pump(const Duration(seconds: 1)); // finish the indicator hide animation
+    expect(refreshCalled, true);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26758

Created a repo for testing `RefreshIndicator` with `SwipeRefreshLayout`
https://github.com/TahaTesser/refresh_indicator_reverse_example
(Based on https://github.com/nt4f04uNd/tabs_overlay, thanks @nt4f04uNd)


### Showcase
This is commonly used in a chat app where new messages appear on top in a reversed list and when user want to load previous messages they scroll from top and indicator is shown for loading older messages (as new messages always at the bottom and these messages are usually loaded first).

Also looks like `SwipeRefreshLayout` doesn't support pull from bottom https://stackoverflow.com/questions/24867204/swiperefreshlayout-pull-from-bottom


This PR shows `RefreshIndicator` on top when scroll's axis direction is up (matching native behaviour)
### Current behaviour when `RefreshIndicator`is wrapped around reverse ListView.

| Pull from bottom  | Pull from top |
| --------------- | --------------- |
| Flutter triggers `RefreshIndicator` while Android doesn't. |  `SwipeRefreshLayout`triggered by Android. |
| <img src="https://user-images.githubusercontent.com/48603081/150970392-11fc7a70-c78c-4798-a175-6c285cb27787.gif" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/150970429-10c2e210-ad40-4a61-8a6b-85442639963c.gif" height="450" /> |

### With this PR, when `RefreshIndicator`is wrapped around reverse ListView

| Pull from bottom  | Pull from top |
| --------------- | --------------- |
|   Flutter doesn't triggers `RefreshIndicator` matching Android behaviour |  Both `RefreshIndicator` & `SwipeRefreshLayout` are triggered. |
| <img src="https://user-images.githubusercontent.com/48603081/150970666-07a4edd2-4dd3-47ec-aafe-34d2279d9b3d.gif" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/150970674-fa49c5e9-29fe-4e6e-a4eb-ad2cd92010be.gif" height="450" /> |




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
