### PR TITLE
implemented TapUp within InkResponse and InkWell

### DIFF
--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -295,6 +295,7 @@ class InkResponse extends StatelessWidget {
     this.child,
     this.onTap,
     this.onTapDown,
+    this.onTapUp,
     this.onTapCancel,
     this.onDoubleTap,
     this.onLongPress,
@@ -336,6 +337,9 @@ class InkResponse extends StatelessWidget {
 
   /// Called when the user taps down this part of the material.
   final GestureTapDownCallback? onTapDown;
+
+  /// Called when the user releases and before [onTap].
+  final GestureTapUpCallback? onTapUp;
 
   /// Called when the user cancels a tap that was started on this part of the
   /// material.
@@ -582,6 +586,7 @@ class InkResponse extends StatelessWidget {
     return _InkResponseStateWidget(
       onTap: onTap,
       onTapDown: onTapDown,
+      onTapUp: onTapUp,
       onTapCancel: onTapCancel,
       onDoubleTap: onDoubleTap,
       onLongPress: onLongPress,
@@ -632,6 +637,7 @@ class _InkResponseStateWidget extends StatefulWidget {
     this.child,
     this.onTap,
     this.onTapDown,
+    this.onTapUp,
     this.onTapCancel,
     this.onDoubleTap,
     this.onLongPress,
@@ -668,6 +674,7 @@ class _InkResponseStateWidget extends StatefulWidget {
   final Widget? child;
   final GestureTapCallback? onTap;
   final GestureTapDownCallback? onTapDown;
+  final GestureTapUpCallback? onTapUp;
   final GestureTapCallback? onTapCancel;
   final GestureTapCallback? onDoubleTap;
   final GestureLongPressCallback? onLongPress;
@@ -706,6 +713,7 @@ class _InkResponseStateWidget extends StatefulWidget {
       if (onDoubleTap != null) 'double tap',
       if (onLongPress != null) 'long press',
       if (onTapDown != null) 'tap down',
+      if (onTapUp != null) 'tap up',
       if (onTapCancel != null) 'tap cancel',
     ];
     properties.add(IterableProperty<String>('gestures', gestures, ifEmpty: '<none>'));
@@ -960,6 +968,10 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     widget.onTapDown?.call(details);
   }
 
+  void _handleTapUp(TapUpDetails details) {
+    widget.onTapUp?.call(details);
+  }
+
   void _startSplash({TapDownDetails? details, BuildContext? context}) {
     assert(details != null || context != null);
 
@@ -1102,6 +1114,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
               onLongPress: widget.excludeFromSemantics || widget.onLongPress == null ? null : _simulateLongPress,
               child: GestureDetector(
                 onTapDown: enabled ? _handleTapDown : null,
+                onTapUp: enabled ? _handleTapUp : null,
                 onTap: enabled ? _handleTap : null,
                 onTapCancel: enabled ? _handleTapCancel : null,
                 onDoubleTap: widget.onDoubleTap != null ? _handleDoubleTap : null,
@@ -1198,6 +1211,7 @@ class InkWell extends InkResponse {
     GestureTapCallback? onDoubleTap,
     GestureLongPressCallback? onLongPress,
     GestureTapDownCallback? onTapDown,
+    GestureTapUpCallback? onTapUp,
     GestureTapCancelCallback? onTapCancel,
     ValueChanged<bool>? onHighlightChanged,
     ValueChanged<bool>? onHover,
@@ -1224,6 +1238,7 @@ class InkWell extends InkResponse {
     onDoubleTap: onDoubleTap,
     onLongPress: onLongPress,
     onTapDown: onTapDown,
+    onTapUp: onTapUp,
     onTapCancel: onTapCancel,
     onHighlightChanged: onHighlightChanged,
     onHover: onHover,

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -338,7 +338,8 @@ class InkResponse extends StatelessWidget {
   /// Called when the user taps down this part of the material.
   final GestureTapDownCallback? onTapDown;
 
-  /// Called when the user releases and before [onTap].
+  /// Called when the user taps this part of the material and releases the tap,
+  /// invoked before [onTap].
   final GestureTapUpCallback? onTapUp;
 
   /// Called when the user cancels a tap that was started on this part of the

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -338,7 +338,7 @@ class InkResponse extends StatelessWidget {
   /// Called when the user taps down this part of the material.
   final GestureTapDownCallback? onTapDown;
 
-  /// Called when the user releases a tap that was started on this part of the 
+  /// Called when the user releases a tap that was started on this part of the
   /// material. [onTap] is called immediately after.
   final GestureTapUpCallback? onTapUp;
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -338,8 +338,8 @@ class InkResponse extends StatelessWidget {
   /// Called when the user taps down this part of the material.
   final GestureTapDownCallback? onTapDown;
 
-  /// Called when the user taps this part of the material and releases the tap,
-  /// invoked before [onTap].
+  /// Called when the user releases a tap that was started on this part of the 
+  /// material. [onTap] is called immediately after.
   final GestureTapUpCallback? onTapUp;
 
   /// Called when the user cancels a tap that was started on this part of the

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -33,6 +33,9 @@ void main() {
             onTapDown: (TapDownDetails details) {
               log.add('tap-down');
             },
+            onTapUp: (TapUpDetails details) {
+              log.add('tap-up');
+            },
             onTapCancel: () {
               log.add('tap-cancel');
             },
@@ -47,7 +50,7 @@ void main() {
 
     await tester.pump(const Duration(seconds: 1));
 
-    expect(log, equals(<String>['tap-down', 'tap']));
+    expect(log, equals(<String>['tap-down', 'tap-up', 'tap']));
     log.clear();
 
     await tester.tap(find.byType(InkWell), pointer: 2);
@@ -67,6 +70,7 @@ void main() {
     expect(log, equals(<String>['tap-down']));
     await gesture.up();
     await tester.pump(const Duration(seconds: 1));
+    expect(log, equals(<String>['tap-down', 'tap-up', 'tap']));
 
     log.clear();
     gesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);


### PR DESCRIPTION
implemented the missing TapUp event within InkResponse and InkWell

Issue #93683 identified this as missing 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
