### PR TITLE
Allow full locale in .arb files

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1270,7 +1270,7 @@ class LocalizationsGenerator {
     }).toList();
 
     for (final LocaleInfo locale in localesWithoutBaseClass) {
-        final File languageMessageFile = outputDirectory.childFile('${fileName}_$locale.$fileExtension');
+        final File languageMessageFile = outputDirectory.childFile('${fileName}_${locale.languageCode}.$fileExtension');
 
         // Generate the template for the base class file.
         final String languageBaseClassFile = _generateBaseClassFile(

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1275,7 +1275,7 @@ class LocalizationsGenerator {
         // Generate the template for the base class file.
         final String languageBaseClassFile = _generateBaseClassFile(
           className,
-          outputFileName, 
+          outputFileName,
           header,
           _allBundles.bundleFor(locale)!,
           _allBundles.bundleFor(_templateArbLocale)!,

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -466,20 +466,8 @@ class AppResourceBundle {
             // If @@locale was not defined, use the filename locale suffix.
             localeString = parserLocaleString;
           } else {
-            // If the localeString was defined in @@locale and in the filename, verify to
-            // see if the parsed locale matches, throw an error if it does not. This
-            // prevents developers from confusing issues when both @@locale and
-            // "_{locale}" is specified in the filename.
-            if (localeString != parserLocaleString) {
-              throw L10nException(
-                'The locale specified in @@locale and the arb filename do not match. \n'
-                'Please make sure that they match, since this prevents any confusion \n'
-                'with which locale to use. Otherwise, specify the locale in either the \n'
-                'filename of the @@locale key only.\n'
-                'Current @@locale value: $localeString\n'
-                'Current filename extension: $parserLocaleString'
-              );
-            }
+            final Locale? parseLocale = Locale.tryParse(localeString);
+            localeString = parseLocale.toString().replaceAll('-', '_');
           }
           break;
         }
@@ -538,23 +526,6 @@ class AppResourceBundleCollection {
         languageToLocales[bundle.locale.languageCode]!.add(bundle.locale);
       }
     }
-
-    languageToLocales.forEach((String language, List<LocaleInfo> listOfCorrespondingLocales) {
-      final List<String> localeStrings = listOfCorrespondingLocales.map((LocaleInfo locale) {
-        return locale.toString();
-      }).toList();
-      if (!localeStrings.contains(language)) {
-        throw L10nException(
-          'Arb file for a fallback, $language, does not exist, even though \n'
-          'the following locale(s) exist: $listOfCorrespondingLocales. \n'
-          'When locales specify a script code or country code, a \n'
-          'base locale (without the script code or country code) should \n'
-          'exist as the fallback. Please create a {fileName}_$language.arb \n'
-          'file.'
-        );
-      }
-    });
-
     return AppResourceBundleCollection._(directory, localeToBundle, languageToLocales);
   }
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1218,7 +1218,7 @@ flutter:
 
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart')), true);
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en_US.dart')), false);
-      expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_sr_Latn.dart')), true);
+      expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_sr.dart')), true);
 
       final String englishLocalizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart')


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/93401 with fixes added for library imports and fix for languages with script code not being generated

Also updated the test to include an arb file with script code.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
