### PR TITLE
[DAP] Add a custom event to pass flutter.serviceExtensionStateChanged…

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -66,4 +66,19 @@ Some custom requests are available for clients to call. Below are the Flutter-sp
 
 ## Custom Events
 
-The debug adapter may emit several custom events that are useful to clients. There are not currently any custom Flutter events, but the standard Dart DAP custom requests are [documented here](https://github.com/dart-lang/sdk/blob/main/pkg/dds/tool/dap/README.md#custom-events).
+The debug adapter may emit several custom events that are useful to clients. Below are the Flutter-specific custom events, and the standard Dart DAP custom events are [documented here](https://github.com/dart-lang/sdk/blob/main/pkg/dds/tool/dap/README.md#custom-events).
+
+### `flutter.serviceExtensionStateChanged`
+
+When the value of a Flutter service extension changes, this event is emitted and includes the new value. Values are always encoded as strings, even if numeric/boolean.
+
+```
+{
+	"type": "event",
+	"event": "flutter.serviceExtensionStateChanged",
+	"body": {
+		"extension": "ext.flutter.debugPaint",
+		"value": "true",
+	}
+}
+```

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -220,6 +220,54 @@ void main() {
 
     await dap.client.terminate();
   });
+
+  testWithoutContext('sends events for extension state updates', () async {
+    final BasicProject _project = BasicProject();
+    await _project.setUpIn(tempDir);
+    const String debugPaintRpc = 'ext.flutter.debugPaint';
+
+    // Create a future to capture the isolate ID when the debug paint service
+    // extension loads, as we'll need that to call it later.
+    final Future<String> isolateIdForDebugPaint = dap.client
+        .serviceExtensionAdded(debugPaintRpc)
+        .then((Map<String, Object/*?*/> body) => body['isolateId'] as String);
+
+    // Launch the app and wait for it to print "topLevelFunction" so we know
+    // it's up and running.
+    await Future.wait(<Future<Object>>[
+      dap.client.outputEvents.firstWhere((OutputEventBody output) =>
+          output.output.startsWith('topLevelFunction')),
+      dap.client.start(
+        launch: () => dap.client.launch(
+          cwd: _project.dir.path,
+          toolArgs: <String>['-d', 'flutter-tester'],
+        ),
+      ),
+    ], eagerError: true);
+
+    // Capture the next relevant state-change event (which should occur as a
+    // result of the call below).
+    final Future<Map<String, Object/*?*/>> stateChangeEventFuture =
+        dap.client.serviceExtensionStateChanged(debugPaintRpc);
+
+    // Enable debug paint to trigger the state change.
+    await dap.client.custom(
+      'callService',
+      <String, Object/*?*/>{
+        'method': debugPaintRpc,
+        'params': <String, Object/*?*/>{
+          'enabled': true,
+          'isolateId': await isolateIdForDebugPaint,
+        },
+      },
+    );
+
+    // Ensure the event occurred, and its value was as expected.
+    final Map<String, Object/*?*/> stateChangeEvent = await stateChangeEventFuture;
+    expect(stateChangeEvent['value'], 'true'); // extension state change values are always strings
+
+    await dap.client.terminate();
+  });
 }
 
 /// Extracts the output from a set of [OutputEventBody], removing any

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -78,6 +78,16 @@ class DapTestClient {
     return _eventController.stream.where((Event e) => e.event == event);
   }
 
+  /// Returns a stream of custom 'dart.serviceExtensionAdded' events.
+  Stream<Map<String, Object?>> get serviceExtensionAddedEvents =>
+      events('dart.serviceExtensionAdded')
+          .map((Event e) => e.body! as Map<String, Object?>);
+
+  /// Returns a stream of custom 'flutter.serviceExtensionStateChanged' events.
+  Stream<Map<String, Object?>> get serviceExtensionStateChangedEvents =>
+      events('flutter.serviceExtensionStateChanged')
+          .map((Event e) => e.body! as Map<String, Object?>);
+
   /// Returns a stream of 'dart.testNotification' custom events from the
   /// package:test JSON reporter.
   Stream<Map<String, Object?>> get testNotificationEvents =>
@@ -170,6 +180,18 @@ class DapTestClient {
     _channel.sendRequest(request);
     return completer.future;
   }
+
+  /// Returns a Future that completes with the next serviceExtensionAdded
+  /// event for [extension].
+  Future<Map<String, Object?>> serviceExtensionAdded(String extension) => serviceExtensionAddedEvents.firstWhere(
+      (Map<String, Object?> body) => body['extensionRPC'] == extension,
+      orElse: () => throw 'Did not recieve $extension extension added event before stream closed');
+
+  /// Returns a Future that completes with the next serviceExtensionStateChanged
+  /// event for [extension].
+  Future<Map<String, Object?>> serviceExtensionStateChanged(String extension) => serviceExtensionStateChangedEvents.firstWhere(
+      (Map<String, Object?> body) => body['extension'] == extension,
+      orElse: () => throw 'Did not recieve $extension extension state changed event before stream closed');
 
   /// Initializes the debug adapter and launches [program]/[cwd] or calls the
   /// custom [launch] method.


### PR DESCRIPTION
This exposes a custom event (`flutter.serviceExtensionStateChanged`) through DAP. This allows an editor to know when service extension state is changing (would could be as a result of another editor, or a DevTools instance changing it).

VS Code uses this to know know things like whether the app is in "select widget mode" so it can provide the correct toggle command.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
