### PR TITLE
[CupertinoTextField] Add missing focus listener

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -880,6 +880,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
       _createLocalController();
     }
     _effectiveFocusNode.canRequestFocus = widget.enabled ?? true;
+    _effectiveFocusNode.addListener(_handleFocusChanged);
   }
 
   @override

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -284,6 +284,40 @@ void main() {
     skip: kIsWeb, // [intended] the web handles this on its own.
   );
 
+  testWidgets('can get text selection color initially on desktop', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'blah1 blah2',
+    );
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: RepaintBoundary(
+            child: CupertinoTextField(
+              key: const ValueKey<int>(1),
+              controller: controller,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset endPos = textOffsetToPosition(tester, 5); // Index of 'blah1'.
+
+    final TestGesture gesture = await tester.startGesture(textFieldStart, kind: PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.moveTo(endPos);
+    await tester.pumpAndSettle();
+
+    await expectLater(
+      find.byKey(const ValueKey<int>(1)),
+      matchesGoldenFile('text_field_golden.InitialTextSelection.0.png'),
+    );
+  },
+    variant: TargetPlatformVariant.desktop(),
+  );
+
   testWidgets('Activates the text field when receives semantics focus on Mac', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     final SemanticsOwner semanticsOwner = tester.binding.pipelineOwner.semanticsOwner!;

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -310,10 +310,10 @@ void main() {
     await gesture.moveTo(endPos);
     await tester.pumpAndSettle();
 
-    await expectLater(
-      find.byKey(const ValueKey<int>(1)),
-      matchesGoldenFile('text_field_golden.InitialTextSelection.0.png'),
-    );
+    // await expectLater(
+    //   find.byKey(const ValueKey<int>(1)),
+    //   matchesGoldenFile('text_field_golden.InitialTextSelection.0.png'),
+    // );
   },
     variant: TargetPlatformVariant.desktop(),
   );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -285,6 +285,7 @@ void main() {
   );
 
   testWidgets('can get text selection color initially on desktop', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
     final TextEditingController controller = TextEditingController(
       text: 'blah1 blah2',
     );
@@ -295,25 +296,22 @@ void main() {
             child: CupertinoTextField(
               key: const ValueKey<int>(1),
               controller: controller,
+              focusNode: focusNode,
             ),
           ),
         ),
       ),
     );
-
-    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
-    final Offset endPos = textOffsetToPosition(tester, 5); // Index of 'blah1'.
-
-    final TestGesture gesture = await tester.startGesture(textFieldStart, kind: PointerDeviceKind.mouse);
-    addTearDown(gesture.removePointer);
+    
+    controller.selection = const TextSelection(baseOffset: 0, extentOffset: 11);
+    focusNode.requestFocus();
     await tester.pump();
-    await gesture.moveTo(endPos);
-    await tester.pumpAndSettle();
 
-    // await expectLater(
-    //   find.byKey(const ValueKey<int>(1)),
-    //   matchesGoldenFile('text_field_golden.InitialTextSelection.0.png'),
-    // );
+    expect(focusNode.hasFocus, true);
+    expect(
+      find.byKey(const ValueKey<int>(1)),
+      matchesGoldenFile('text_field_golden.text_selection_color.0.png'),
+    );
   },
     variant: TargetPlatformVariant.desktop(),
   );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -302,7 +302,7 @@ void main() {
         ),
       ),
     );
-    
+
     controller.selection = const TextSelection(baseOffset: 0, extentOffset: 11);
     focusNode.requestFocus();
     await tester.pump();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -308,7 +308,7 @@ void main() {
     await tester.pump();
 
     expect(focusNode.hasFocus, true);
-    expect(
+    expectLater(
       find.byKey(const ValueKey<int>(1)),
       matchesGoldenFile('text_field_golden.text_selection_color.0.png'),
     );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -312,9 +312,7 @@ void main() {
       find.byKey(const ValueKey<int>(1)),
       matchesGoldenFile('text_field_golden.text_selection_color.0.png'),
     );
-  },
-    variant: TargetPlatformVariant.desktop(),
-  );
+  });
 
   testWidgets('Activates the text field when receives semantics focus on Mac', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -308,7 +308,7 @@ void main() {
     await tester.pump();
 
     expect(focusNode.hasFocus, true);
-    expectLater(
+    await expectLater(
       find.byKey(const ValueKey<int>(1)),
       matchesGoldenFile('text_field_golden.text_selection_color.0.png'),
     );


### PR DESCRIPTION
This regression was introduced in https://github.com/flutter/flutter/pull/86796

Where listener for  `_effectiveFocusNode` was added for Material but missed for Cupertino text field.

This fixes https://github.com/flutter/flutter/issues/93169

The bug can be reproduced with `control + a` selection or drag to select the text. If the app is rebuilt either by setState or window resize or right to select, the listener is added to the focus node, and the bug is gone. 

### Golden test results

### Before
![text_field_golden text_selection_color 0](https://user-images.githubusercontent.com/48603081/142517554-55d4f2ea-6919-4d82-b076-44a1b448f420.png)

### After
![text_field_golden text_selection_color 0](https://user-images.githubusercontent.com/48603081/142517550-fb206a4a-6faf-4139-a55d-1eb69246ebf7.png)


<details> 
<summary>Integration Test</summary> 

## 
### Before
<img width="912" alt="bug" src="https://user-images.githubusercontent.com/48603081/142471768-9becfd9c-10b3-4d53-b118-511f4bbf8047.png">

### After
<img width="912" alt="fixed" src="https://user-images.githubusercontent.com/48603081/142471778-f867b631-e7b7-490f-b065-2bb898da125e.png">

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
