### PR TITLE
Force the a11y focus on textfield in android semantics integration test

### DIFF
--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -27,6 +27,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -64,6 +65,25 @@ public class MainActivity extends FlutterActivity {
             }
             AccessibilityNodeInfo node = provider.createAccessibilityNodeInfo(id);
             result.success(convertSemantics(node, id));
+            return;
+        }
+        if (methodCall.method.equals("sendSemanticsFocus")) {
+            Map<String, Object> data = methodCall.arguments();
+            @SuppressWarnings("unchecked")
+            Integer id = (Integer) data.get("id");
+            if (id == null) {
+                result.error("No ID provided", "", null);
+                return;
+            }
+            if (provider == null) {
+                result.error("Semantics not enabled", "", null);
+                return;
+            }
+            AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            event.setPackageName(flutterView.getContext().getPackageName());
+            event.setSource(flutterView, id);
+            flutterView.getParent().requestSendAccessibilityEvent(flutterView, event);
+            result.success(null);
             return;
         }
         result.notImplemented();

--- a/dev/integration_tests/android_semantics_testing/lib/main.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/main.dart
@@ -39,6 +39,21 @@ Future<String> dataHandler(String message) async {
       completeSemantics();
     return completer.future;
   }
+  if (message.contains('sendSemanticsFocus')) {
+    final Completer<String> completer = Completer<String>();
+    final int id = int.tryParse(message.split('#')[1]) ?? 0;
+    Future<void> completeSemantics([Object _]) async {
+      final dynamic result = await kSemanticsChannel.invokeMethod<dynamic>('sendSemanticsFocus', <String, dynamic>{
+        'id': id,
+      });
+      completer.complete(json.encode(result));
+    }
+    if (SchedulerBinding.instance.hasScheduledFrame)
+      SchedulerBinding.instance.addPostFrameCallback(completeSemantics);
+    else
+      completeSemantics();
+    return completer.future;
+  }
   throw UnimplementedError();
 }
 

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -29,6 +29,11 @@ void main() {
       return AndroidSemanticsNode.deserialize(data);
     }
 
+    Future<void> sendSemanticsFocus(SerializableFinder finder) async {
+      final int id = await driver.getSemanticsId(finder);
+      await driver.requestData('sendSemanticsFocus#$id');
+    }
+
     // The version of TalkBack running on the device.
     Version talkbackVersion;
 
@@ -148,6 +153,10 @@ void main() {
           matching: find.byType('Semantics'),
           firstMatchOnly: true,
         );
+        // Make sure the focus is on the back button.
+        await sendSemanticsFocus(find.byValueKey(backButtonKeyValue));
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+
         expect(
           await getSemantics(normalTextField),
           hasAndroidSemantics(
@@ -157,8 +166,7 @@ void main() {
             isFocused: false,
             isPassword: false,
             actions: <AndroidSemanticsAction>[
-              if (talkbackVersion < fixedTalkback) AndroidSemanticsAction.accessibilityFocus,
-              if (talkbackVersion >= fixedTalkback) AndroidSemanticsAction.clearAccessibilityFocus,
+              AndroidSemanticsAction.accessibilityFocus,
               AndroidSemanticsAction.click,
             ],
           ),


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/93253

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
