### PR TITLE
[conductor] Add global constants and startContext checkoutpath getter

### DIFF
--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -23,7 +23,7 @@ const String kReleaseDocumentationUrl = 'https://github.com/flutter/flutter/wiki
 
 const String kLuciPackagingConsoleLink = 'https://ci.chromium.org/p/flutter/g/packaging/console';
 
-const String kReleaseSDKURL = 'https://docs.flutter.dev/development/tools/sdk/releases';
+const String kWebsiteReleasesUrl = 'https://docs.flutter.dev/development/tools/sdk/releases';
 
 final RegExp releaseCandidateBranchRegex = RegExp(
   r'flutter-(\d+)\.(\d+)-candidate\.(\d+)',

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -23,6 +23,8 @@ const String kReleaseDocumentationUrl = 'https://github.com/flutter/flutter/wiki
 
 const String kLuciPackagingConsoleLink = 'https://ci.chromium.org/p/flutter/g/packaging/console';
 
+const String kReleaseSDKURL = 'https://docs.flutter.dev/development/tools/sdk/releases';
+
 final RegExp releaseCandidateBranchRegex = RegExp(
   r'flutter-(\d+)\.(\d+)-candidate\.(\d+)',
 );

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -312,12 +312,10 @@ class StartContext extends Context {
       cherrypicks: engineCherrypickRevisions,
       upstreamRef: EngineRepository.defaultBranch,
       releaseRef: candidateBranch,
-    ))
-        .map((String revision) => pb.Cherrypick(
-              trunkRevision: revision,
-              state: pb.CherrypickState.PENDING,
-            ))
-        .toList();
+    )).map((String revision) => pb.Cherrypick(
+      trunkRevision: revision,
+      state: pb.CherrypickState.PENDING,
+    )).toList();
 
     for (final pb.Cherrypick cherrypick in engineCherrypicks) {
       final String revision = cherrypick.trunkRevision;
@@ -362,12 +360,10 @@ class StartContext extends Context {
       cherrypicks: frameworkCherrypickRevisions,
       upstreamRef: FrameworkRepository.defaultBranch,
       releaseRef: candidateBranch,
-    ))
-        .map((String revision) => pb.Cherrypick(
-              trunkRevision: revision,
-              state: pb.CherrypickState.PENDING,
-            ))
-        .toList();
+    )).map((String revision) => pb.Cherrypick(
+      trunkRevision: revision,
+      state: pb.CherrypickState.PENDING,
+    )).toList();
 
     for (final pb.Cherrypick cherrypick in frameworkCherrypicks) {
       final String revision = cherrypick.trunkRevision;
@@ -517,9 +513,7 @@ class StartContext extends Context {
     final List<String> upstreamRevlist = (await repository.revList(<String>[
       '--ancestry-path',
       '$branchPoint..$upstreamRef',
-    ]))
-        .reversed
-        .toList();
+    ])).reversed.toList();
 
     stdio.printStatus('upstreamRevList:\n${upstreamRevlist.join('\n')}\n');
     stdio.printStatus('validatedCherrypicks:\n${validatedCherrypicks.join('\n')}\n');

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -345,7 +345,7 @@ class StartContext extends Context {
       upstream: pb.Remote(name: 'upstream', url: engine.upstreamRemote.url),
       mirror: pb.Remote(name: 'mirror', url: engine.mirrorRemote!.url),
     );
-    
+
     await framework.newBranch(workingBranchName);
     final List<pb.Cherrypick> frameworkCherrypicks = (await _sortCherrypicks(
       repository: framework,

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -822,12 +822,9 @@ void main() {
         ),
       ];
 
-      Map<String, String>? environment;
-      String? operatingSystem;
-
-      operatingSystem ??= const LocalPlatform().operatingSystem;
+      final String operatingSystem = const LocalPlatform().operatingSystem;
       final String pathSeparator = operatingSystem == 'windows' ? r'\' : '/';
-      environment ??= <String, String>{
+      final Map<String, String> environment = <String, String>{
         'HOME': '/path/to/user/home',
       };
       final Directory homeDir = fileSystem.directory(

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -681,7 +681,7 @@ void main() {
       expect(state.incrementLevel, incrementLevel);
     });
 
-    test('startContext can get engine and framework checkout directories after run', () async {
+    test('StartContext can get engine and framework checkout directories after run', () async {
       const String revision2 = 'def789';
       const String revision3 = '123abc';
       const String branchPointRevision = 'deadbeef';

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -681,7 +681,7 @@ void main() {
       expect(state.incrementLevel, incrementLevel);
     });
 
-    test('StartContext can get engine and framework checkout directories after run', () async {
+    test('StartContext gets engine and framework checkout directories after run', () async {
       stdio.stdin.add('y');
       const String revision2 = 'def789';
       const String revision3 = '123abc';

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -823,7 +823,6 @@ void main() {
       ];
 
       final String operatingSystem = const LocalPlatform().operatingSystem;
-      final String pathSeparator = operatingSystem == 'windows' ? r'\' : '/';
       final Map<String, String> environment = <String, String>{
         'HOME': '/path/to/user/home',
       };
@@ -835,7 +834,6 @@ void main() {
       platform = FakePlatform(
         environment: environment,
         operatingSystem: operatingSystem,
-        pathSeparator: pathSeparator,
       );
 
       final String stateFilePath = fileSystem.path.join(
@@ -875,8 +873,8 @@ void main() {
 
       await startContext.run();
 
-      expect((await startContext.engineCheckoutDirectory).path, equals(engine.path));
-      expect((await startContext.frameworkCheckoutDirectory).path, equals(framework.path));
+      expect((await startContext.engine.checkoutDirectory).path, equals(engine.path));
+      expect((await startContext.framework.checkoutDirectory).path, equals(framework.path));
     });
   }, onPlatform: <String, dynamic>{
     'windows': const Skip('Flutter Conductor only supported on macos/linux'),

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -682,6 +682,7 @@ void main() {
     });
 
     test('StartContext can get engine and framework checkout directories after run', () async {
+      stdio.stdin.add('y');
       const String revision2 = 'def789';
       const String revision3 = '123abc';
       const String branchPointRevision = 'deadbeef';
@@ -728,7 +729,7 @@ void main() {
           command: <String>['git', 'fetch', 'mirror'],
         ),
         const FakeCommand(
-          command: <String>['git', 'checkout', 'upstream/$candidateBranch'],
+          command: <String>['git', 'checkout', candidateBranch],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -781,7 +782,7 @@ void main() {
           command: <String>['git', 'fetch', 'mirror'],
         ),
         const FakeCommand(
-          command: <String>['git', 'checkout', 'upstream/$candidateBranch'],
+          command: <String>['git', 'checkout', candidateBranch],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -133,7 +133,8 @@ void main() {
       const String nextVersion = '1.2.0-1.1.pre';
       const String incrementLevel = 'n';
 
-      final Directory engine = fileSystem.directory(checkoutsParentDirectory)
+      final Directory engine = fileSystem
+          .directory(checkoutsParentDirectory)
           .childDirectory('flutter_conductor_checkouts')
           .childDirectory('engine');
 
@@ -141,21 +142,20 @@ void main() {
 
       final List<FakeCommand> engineCommands = <FakeCommand>[
         FakeCommand(
-          command: <String>[
-            'git',
-            'clone',
-            '--origin',
-            'upstream',
-            '--',
-            EngineRepository.defaultUpstream,
-            engine.path,
-          ],
-          onRun: () {
-            // Create the DEPS file which the tool will update
-            engine.createSync(recursive: true);
-            depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
-          }
-        ),
+            command: <String>[
+              'git',
+              'clone',
+              '--origin',
+              'upstream',
+              '--',
+              EngineRepository.defaultUpstream,
+              engine.path,
+            ],
+            onRun: () {
+              // Create the DEPS file which the tool will update
+              engine.createSync(recursive: true);
+              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+            }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
         ),
@@ -309,7 +309,7 @@ void main() {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String branchPointRevision='deadbeef';
+      const String branchPointRevision = 'deadbeef';
       const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
       const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
@@ -319,7 +319,8 @@ void main() {
       const String nextVersion = '1.2.0-3.1.pre';
       const String incrementLevel = 'm';
 
-      final Directory engine = fileSystem.directory(checkoutsParentDirectory)
+      final Directory engine = fileSystem
+          .directory(checkoutsParentDirectory)
           .childDirectory('flutter_conductor_checkouts')
           .childDirectory('engine');
 
@@ -327,21 +328,20 @@ void main() {
 
       final List<FakeCommand> engineCommands = <FakeCommand>[
         FakeCommand(
-          command: <String>[
-            'git',
-            'clone',
-            '--origin',
-            'upstream',
-            '--',
-            EngineRepository.defaultUpstream,
-            engine.path,
-          ],
-          onRun: () {
-            // Create the DEPS file which the tool will update
-            engine.createSync(recursive: true);
-            depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
-          }
-        ),
+            command: <String>[
+              'git',
+              'clone',
+              '--origin',
+              'upstream',
+              '--',
+              EngineRepository.defaultUpstream,
+              engine.path,
+            ],
+            onRun: () {
+              // Create the DEPS file which the tool will update
+              engine.createSync(recursive: true);
+              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+            }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
         ),
@@ -512,7 +512,8 @@ void main() {
       const String nextVersion = '1.2.0';
       const String incrementLevel = 'z';
 
-      final Directory engine = fileSystem.directory(checkoutsParentDirectory)
+      final Directory engine = fileSystem
+          .directory(checkoutsParentDirectory)
           .childDirectory('flutter_conductor_checkouts')
           .childDirectory('engine');
 
@@ -520,21 +521,20 @@ void main() {
 
       final List<FakeCommand> engineCommands = <FakeCommand>[
         FakeCommand(
-          command: <String>[
-            'git',
-            'clone',
-            '--origin',
-            'upstream',
-            '--',
-            EngineRepository.defaultUpstream,
-            engine.path,
-          ],
-          onRun: () {
-            // Create the DEPS file which the tool will update
-            engine.createSync(recursive: true);
-            depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
-          }
-        ),
+            command: <String>[
+              'git',
+              'clone',
+              '--origin',
+              'upstream',
+              '--',
+              EngineRepository.defaultUpstream,
+              engine.path,
+            ],
+            onRun: () {
+              // Create the DEPS file which the tool will update
+              engine.createSync(recursive: true);
+              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+            }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
         ),
@@ -868,7 +868,6 @@ void main() {
           incrementLetter: incrementLevel,
           processManager: processManager,
           conductorVersion: conductorVersion,
-          stdio: stdio,
           stateFile: stateFile);
 
       await startContext.run();


### PR DESCRIPTION
- Added global constants for both the release dashboard and CLI conductor to consume. 
- Added engine and framework checkout directory getters to startContext for the release dashboard to use and display to the users.

Main Issue:
- [x] https://github.com/flutter/flutter/issues/93816
- [x] https://github.com/flutter/flutter/issues/93878

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
