### PR TITLE
RawKeyboard synthesizes key pressing state for modifier

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -781,7 +781,7 @@ class RawKeyboard {
         thisKeyModifier = key;
       }
       if (modifiersPressed[key] == KeyboardSide.any) {
-        anySideKeys.addAll(thisModifierKeys!);
+        anySideKeys.addAll(thisModifierKeys);
         if (thisModifierKeys.any(keysPressedAfterEvent.contains)) {
           continue;
         }

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -818,13 +818,9 @@ class RawKeyboard {
     _keysPressed.addAll(modifierKeys);
     if (event is RawKeyDownEvent && thisKeyModifier != null
         && !_keysPressed.containsKey(event.physicalKey)) {
-      final Set<PhysicalKeyboardKey> physicalKeys = _modifierKeyMap[_ModifierSidePair(thisKeyModifier, KeyboardSide.any)]
-          ?? <PhysicalKeyboardKey>{};
-      for (final PhysicalKeyboardKey physicalKey in physicalKeys) {
-        final LogicalKeyboardKey? logicalKey = _allModifiersExceptFn[physicalKey];
-        if (logicalKey != null) {
-          _keysPressed[physicalKey] = logicalKey;
-        }
+      final LogicalKeyboardKey? logicalKey = _allModifiersExceptFn[event.physicalKey];
+      if (logicalKey != null) {
+        _keysPressed[event.physicalKey] = logicalKey;
       }
     }
   }

--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -816,11 +816,18 @@ class RawKeyboard {
       _keysPressed.remove(PhysicalKeyboardKey.fn);
     }
     _keysPressed.addAll(modifierKeys);
+    // In rare cases, the event presses a modifier key but the key does not
+    // exist in the modifier list. Enforce the pressing state.
     if (event is RawKeyDownEvent && thisKeyModifier != null
         && !_keysPressed.containsKey(event.physicalKey)) {
-      final LogicalKeyboardKey? logicalKey = _allModifiersExceptFn[event.physicalKey];
-      if (logicalKey != null) {
-        _keysPressed[event.physicalKey] = logicalKey;
+      // So far this inconsistancy is only found on Linux GTK for AltRight in a
+      // rare case. (See https://github.com/flutter/flutter/issues/93278 .) In
+      // other cases, this inconsistancy will be caught by an assertion later.
+      if (event.data is RawKeyEventDataLinux && event.physicalKey == PhysicalKeyboardKey.altRight) {
+        final LogicalKeyboardKey? logicalKey = _allModifiersExceptFn[event.physicalKey];
+        if (logicalKey != null) {
+          _keysPressed[event.physicalKey] = logicalKey;
+        }
       }
     }
   }

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -397,7 +397,7 @@ void main() {
           },
         ),
       );
-    }, skip: isBrowser); // [intended] This is a GLFW-specific test.
+    }, skip: isBrowser); // [intended] This is a GTK-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on web', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -382,10 +382,10 @@ void main() {
 
       RawKeyboard.instance.addListener(print);
 
-      await simulate(true, 0x6c, 0xffea, 0x2000000);
-      await simulate(true, 0x32, 0xfe08, 0x2000008);
-      await simulate(false, 0x6c, 0xfe03, 0x2002008);
-      await simulate(true, 0x6c, 0xfe03, 0x2002000);
+      await simulate(true,  0x6c/*AltRight*/,  0xffea/*AltRight*/,  0x2000000);
+      await simulate(true,  0x32/*ShiftLeft*/, 0xfe08/*NextGroup*/, 0x2000008/*MOD3*/);
+      await simulate(false, 0x6c/*AltRight*/,  0xfe03/*AltRight*/,  0x2002008/*MOD3|Reserve14*/);
+      await simulate(true,  0x6c/*AltRight*/,  0xfe03/*AltRight*/,  0x2002000/*Reserve14*/);
       // expect(
       //   RawKeyboard.instance.keysPressed,
       //   equals(

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -346,6 +348,56 @@ void main() {
           },
         ),
       );
+    }, skip: isBrowser); // [intended] This is a GLFW-specific test.
+
+    testWidgets('keysPressed modifiers are synchronized with key events on Linux GTK (down events)', (WidgetTester tester) async {
+      expect(RawKeyboard.instance.keysPressed, isEmpty);
+      Future<void> simulate(bool keyDown, int scancode, int keycode, int modifiers) async {
+        final Map<String, dynamic> data = <String, dynamic>{
+            'type': keyDown ? 'keydown' : 'keyup',
+            'keymap': 'linux',
+            'toolkit': 'gtk',
+            'scanCode': scancode,
+            'keyCode': keycode,
+            'modifiers': modifiers,
+          };
+        // Dispatch an empty key data to disable HardwareKeyboard sanity check,
+        // since we're only testing if the raw keyboard can handle the message.
+        // In real application the embedder responder will send correct key data
+        // (which is tested in the engine.)
+        TestDefaultBinaryMessengerBinding.instance!.keyEventManager.handleKeyData(const ui.KeyData(
+          type: ui.KeyEventType.down,
+          timeStamp: Duration.zero,
+          logical: 0,
+          physical: 0,
+          character: null,
+          synthesized: false,
+        ));
+        await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
+          SystemChannels.keyEvent.name,
+          SystemChannels.keyEvent.codec.encodeMessage(data),
+          (ByteData? data) {},
+        );
+      }
+
+      RawKeyboard.instance.addListener(print);
+
+      await simulate(true, 0x6c, 0xffea, 0x2000000);
+      await simulate(true, 0x32, 0xfe08, 0x2000008);
+      await simulate(false, 0x6c, 0xfe03, 0x2002008);
+      await simulate(true, 0x6c, 0xfe03, 0x2002000);
+      // expect(
+      //   RawKeyboard.instance.keysPressed,
+      //   equals(
+      //     <LogicalKeyboardKey>{
+      //       LogicalKeyboardKey.shiftLeft,
+      //       // Linux doesn't have a concept of left/right keys, so they're all
+      //       // shown as down when either is pressed.
+      //       LogicalKeyboardKey.shiftRight,
+      //       LogicalKeyboardKey.keyA,
+      //     },
+      //   ),
+      // );
     }, skip: isBrowser); // [intended] This is a GLFW-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on web', (WidgetTester tester) async {

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -350,6 +350,11 @@ void main() {
       );
     }, skip: isBrowser); // [intended] This is a GLFW-specific test.
 
+
+    // Regression test for https://github.com/flutter/flutter/issues/93278 .
+    //
+    // GTK has some weird behavior where the tested key event sequence will
+    // result in a AltRight down event without Alt bitmask.
     testWidgets('keysPressed modifiers are synchronized with key events on Linux GTK (down events)', (WidgetTester tester) async {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
       Future<void> simulate(bool keyDown, int scancode, int keycode, int modifiers) async {
@@ -380,24 +385,18 @@ void main() {
         );
       }
 
-      RawKeyboard.instance.addListener(print);
-
       await simulate(true,  0x6c/*AltRight*/,  0xffea/*AltRight*/,  0x2000000);
       await simulate(true,  0x32/*ShiftLeft*/, 0xfe08/*NextGroup*/, 0x2000008/*MOD3*/);
       await simulate(false, 0x6c/*AltRight*/,  0xfe03/*AltRight*/,  0x2002008/*MOD3|Reserve14*/);
       await simulate(true,  0x6c/*AltRight*/,  0xfe03/*AltRight*/,  0x2002000/*Reserve14*/);
-      // expect(
-      //   RawKeyboard.instance.keysPressed,
-      //   equals(
-      //     <LogicalKeyboardKey>{
-      //       LogicalKeyboardKey.shiftLeft,
-      //       // Linux doesn't have a concept of left/right keys, so they're all
-      //       // shown as down when either is pressed.
-      //       LogicalKeyboardKey.shiftRight,
-      //       LogicalKeyboardKey.keyA,
-      //     },
-      //   ),
-      // );
+      expect(
+        RawKeyboard.instance.keysPressed,
+        equals(
+          <LogicalKeyboardKey>{
+            LogicalKeyboardKey.altLeft,
+          },
+        ),
+      );
     }, skip: isBrowser); // [intended] This is a GLFW-specific test.
 
     testWidgets('keysPressed modifiers are synchronized with key events on web', (WidgetTester tester) async {

--- a/packages/flutter/test/services/raw_keyboard_test.dart
+++ b/packages/flutter/test/services/raw_keyboard_test.dart
@@ -393,7 +393,7 @@ void main() {
         RawKeyboard.instance.keysPressed,
         equals(
           <LogicalKeyboardKey>{
-            LogicalKeyboardKey.altLeft,
+            LogicalKeyboardKey.altRight,
           },
         ),
       );


### PR DESCRIPTION
This PR changes `RawKeyboard` so that, if the current key is being pressed but does not exist in the modifier bit mask, add this key to `keysPressed`. This change effectively disables the assertion check immediately after `_synchronizeModifiers` (but it is still kept there.)

This change fixes a case on Linux where a very peculiar sequence of key presses result in an AltRight key down event being sent without the Alt modifier bit, breaking our assumption where the key being pressed must exist in the modifier bit. The approach of this PR adapts the `keysPressed` state to the event. 

An alternative solution is to pretend this event didn't happen, adapting the event to the `keysPressed` state. I didn't choose this solution because it breaks `RawKeyboard`'s design of one-to-one mapping from the native events to the Flutter events. After all, the modifier bits are used to assist synthesization, not to change event output overall.

~~It's a sad choice to disable this check that helped us for so long.~~ Update: I've limited the check bypassing to Linux AltRight key.

This PR fixes one of the two symptoms of https://github.com/flutter/flutter/issues/93278.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
