### PR TITLE
Fix bottom sheet assertion on switching with multiple controllers

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2360,7 +2360,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     final LocalHistoryEntry? entry = isPersistent
       ? null
       : LocalHistoryEntry(onRemove: () {
-          if (!removedEntry) {
+          if (!removedEntry && _currentBottomSheet?._widget == bottomSheet) {
             _removeCurrentBottomSheet();
           }
         });

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1204,6 +1204,62 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('Bottom sheet onRemove LocalHistoryEntry only added for current bottom sheet', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/93717
+    PersistentBottomSheetController<void>? sheetController1;
+    PersistentBottomSheetController<void>? sheetController2;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (BuildContext context) {
+          return Center(
+            child: Column(
+              children: [
+                ElevatedButton(
+                  child: const Text('show 1'),
+                  onPressed: () {
+                    if (sheetController1 != null) {
+                      sheetController1!.close();
+                      sheetController1 = null;
+                    }
+                    sheetController1 = Scaffold.of(context).showBottomSheet<void>(
+                      (BuildContext context) => const Text('BottomSheet 1'),
+                    );
+                  },
+                ),
+                ElevatedButton(
+                  child: const Text('show 2'),
+                  onPressed: () {
+                    if (sheetController2 != null) {
+                      sheetController2!.close();
+                      sheetController2 = null;
+                    }
+                    sheetController2 = Scaffold.of(context).showBottomSheet<void>(
+                      (BuildContext context) => const Text('BottomSheet 2'),
+                    );
+                  },
+                ),
+              ],
+            ),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('show 1'));
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet 1'), findsOneWidget);
+
+
+    await tester.tap(find.text('show 2'));
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet 2'), findsOneWidget);
+
+    // This will throw an assertion if regressed.
+    await tester.tap(find.text('show 1'));
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet 1'), findsOneWidget);
+  });
+
   group('constraints', () {
 
     testWidgets('No constraints by default for bottomSheet property', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1253,7 +1253,7 @@ void main() {
     // This will throw an assertion if regressed
     await tester.tap(find.text('close 1'));
     await tester.pumpAndSettle();
-    expect(find.text('BottomSheet 1'), findsOneWidget);
+    expect(find.text('BottomSheet 2'), findsOneWidget);
   });
 
   group('constraints', () {

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1213,7 +1213,7 @@ void main() {
         body: Builder(builder: (BuildContext context) {
           return Center(
             child: Column(
-              children: [
+              children: <Widget>[
                 ElevatedButton(
                   child: const Text('show 1'),
                   onPressed: () {

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1205,7 +1205,7 @@ void main() {
   });
 
   testWidgets('Bottom sheet onRemove LocalHistoryEntry only added for current bottom sheet', (WidgetTester tester) async {
-    // This is a regression test for https://github.com/flutter/flutter/issues/93717
+    // Regression test for https://github.com/flutter/flutter/issues/93717
     PersistentBottomSheetController<void>? sheetController1;
     PersistentBottomSheetController<void>? sheetController2;
     await tester.pumpWidget(MaterialApp(
@@ -1254,7 +1254,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('BottomSheet 2'), findsOneWidget);
 
-    // This will throw an assertion if regressed.
+    // This will throw an assertion due to multiple onRemove entries if regressed.
     await tester.tap(find.text('show 1'));
     await tester.pumpAndSettle();
     expect(find.text('BottomSheet 1'), findsOneWidget);


### PR DESCRIPTION
Makes sure the bottom sheet matches the current bottom sheet when adding the `onRemove` `LocalHistoryEntry` in `_buildBottomSheet` so it isn't incorrectly called multiple times with multiple controllers.

Fixes https://github.com/flutter/flutter/issues/93717

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
