### PR TITLE
Skip flaky test `stateless_stateful_hot_reload_test.dart: Can switch between stateless and stateful`

### DIFF
--- a/packages/flutter_tools/test/integration.shard/stateless_stateful_hot_reload_test.dart
+++ b/packages/flutter_tools/test/integration.shard/stateless_stateful_hot_reload_test.dart
@@ -50,5 +50,5 @@ void main() {
     expect(logs, contains('STATELESS'));
     expect(logs, contains('STATEFUL'));
     await subscription.cancel();
-  });
+  }, skip: true); // test is flaky https://github.com/flutter/flutter/issues/93663
 }


### PR DESCRIPTION
This skips the flaky test while being investigated: https://github.com/flutter/flutter/issues/93663