### PR TITLE
De-flake web tool tests

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -198,18 +198,18 @@ class WebAssetServer implements AssetReader {
       address = (await InternetAddress.lookup(hostname)).first;
     }
     HttpServer httpServer;
-    dynamic lastError;
-    for (int i = 0; i < 5; i += 1) {
+    const int kMaxAttempts = 4;
+    for (int i = 0; i <= kMaxAttempts; i += 1) {
       try {
         httpServer = await HttpServer.bind(address, port ?? await globals.os.findFreePort());
         break;
-      } on SocketException catch (error) {
-        lastError = error;
+      } on SocketException catch (e, s) {
+        if (i == kMaxAttempts) {
+          globals.printError('Failed to bind web development server:\n$e', stackTrace: s);
+          throwToolExit('Failed to bind web development server:\n$e');
+        }
         await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-    }
-    if (httpServer == null) {
-      throwToolExit('Failed to bind web development server:\n$lastError');
     }
 
     // Allow rendering in a iframe.
@@ -240,7 +240,11 @@ class WebAssetServer implements AssetReader {
         webBuildDirectory: getWebBuildDirectory(),
         basePath: server.basePath,
       );
-      shelf.serveRequests(httpServer, releaseAssetServer.handle);
+      runZonedGuarded(() {
+        shelf.serveRequests(httpServer, releaseAssetServer.handle);
+      }, (Object e, StackTrace s) {
+        globals.printTrace('Release asset server: error serving requests: $e:$s');
+      });
       return server;
     }
 
@@ -266,8 +270,14 @@ class WebAssetServer implements AssetReader {
       };
     }
 
+    logging.Logger.root.level = logging.Level.ALL;
     logging.Logger.root.onRecord.listen((logging.LogRecord event) {
-      globals.printTrace('${event.loggerName}: ${event.message}');
+      if (event.level > logging.Level.INFO) {
+        final String error = event.error == null? ', ${event.error}':'';
+        globals.printError('${event.loggerName}: ${event.message}$error', stackTrace: event.stackTrace);
+      } else {
+        globals.printTrace('${event.loggerName}: ${event.message}');
+      }
     });
 
     // In debug builds, spin up DWDS and the full asset server.
@@ -302,7 +312,11 @@ class WebAssetServer implements AssetReader {
         pipeline.addHandler(server.handleRequest);
     final shelf.Cascade cascade =
         shelf.Cascade().add(dwds.handler).add(dwdsHandler);
-    shelf.serveRequests(httpServer, cascade.handler);
+    runZonedGuarded(() {
+      shelf.serveRequests(httpServer, cascade.handler);
+    }, (Object e, StackTrace s) {
+      globals.printTrace('Dwds server: error serving requests: $e:$s');
+    });
     server.dwds = dwds;
     return server;
   }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -270,7 +270,7 @@ class ChromiumLauncher {
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .map((String line) {
-          _logger.printTrace('[CHROME]:$line');
+          _logger.printError('[CHROME]:$line');
           if (line.contains(_kGlibcError)) {
             hitGlibcBug = true;
             shouldRetry = true;
@@ -287,7 +287,7 @@ class ChromiumLauncher {
             return '';
           }
           if (retry >= kMaxRetries) {
-            _logger.printTrace('Failed to launch browser after $kMaxRetries tries. Command used to launch it: ${args.join(' ')}');
+            _logger.printError('Failed to launch browser after $kMaxRetries tries. Command used to launch it: ${args.join(' ')}');
             throw ToolExit(
               'Failed to launch browser. Make sure you are using an up-to-date '
               'Chrome or Edge. Otherwise, consider using -d web-server instead '
@@ -395,7 +395,8 @@ class ChromiumLauncher {
     // connection is valid.
     if (!skipCheck) {
       try {
-        await chrome.chromeConnection.getTabs();
+        await chrome.chromeConnection.getTab(
+          (ChromeTab tab) => true, retryFor: const Duration(seconds: 2));
       } on Exception catch (error, stackTrace) {
         _logger.printError('$error', stackTrace: stackTrace);
         await chrome.close();

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -266,11 +266,13 @@ class ChromiumLauncher {
       // only required for flutter_test --platform=chrome and not flutter run.
       bool hitGlibcBug = false;
       bool shouldRetry = false;
+      final List<String> errors = <String>[];
       await process.stderr
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .map((String line) {
-          _logger.printError('[CHROME]:$line');
+          _logger.printTrace('[CHROME]: $line');
+          errors.add('[CHROME]:$line');
           if (line.contains(_kGlibcError)) {
             hitGlibcBug = true;
             shouldRetry = true;
@@ -287,6 +289,7 @@ class ChromiumLauncher {
             return '';
           }
           if (retry >= kMaxRetries) {
+            errors.forEach(_logger.printError);
             _logger.printError('Failed to launch browser after $kMaxRetries tries. Command used to launch it: ${args.join(' ')}');
             throw ToolExit(
               'Failed to launch browser. Make sure you are using an up-to-date '

--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
@@ -168,7 +168,7 @@ Future<void> evaluateComplexReturningExpressions(FlutterTestDriver flutter) asyn
   // Ensure we got a reasonable approximation. The more accurate we try to
   // make this, the more likely it'll fail due to differences in the time
   // in the remote VM and the local VM at the time the code runs.
-  final InstanceRef res = await flutter.evaluate(resp.id, r'"$year-$month-$day"');
+  final ObjRef res = await flutter.evaluate(resp.id, r'"$year-$month-$day"');
   expectValue(res, '${now.year}-${now.month}-${now.day}');
 }
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -58,6 +58,7 @@ abstract class FlutterTestDriver {
   VmService? _vmService;
   String get lastErrorInfo => _errorBuffer.toString();
   Stream<String> get stdout => _stdout.stream;
+  Stream<String> get stderr => _stderr.stream;
   int? get vmServicePort => _vmServiceWsUri?.port;
   bool get hasExited => _hasExited;
   Uri? get vmServiceWsUri => _vmServiceWsUri;
@@ -355,9 +356,9 @@ abstract class FlutterTestDriver {
     );
   }
 
-  Future<InstanceRef> evaluate(String targetId, String expression) async {
-    return _timeoutWithMessages<InstanceRef>(
-      () async => await _vmService!.evaluate(await _getFlutterIsolateId(), targetId, expression) as InstanceRef,
+  Future<ObjRef> evaluate(String targetId, String expression) async {
+    return _timeoutWithMessages<ObjRef>(
+      () async => await _vmService!.evaluate(await _getFlutterIsolateId(), targetId, expression) as ObjRef,
       task: 'Evaluating expression ($expression for $targetId)',
     );
   }

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -490,6 +490,15 @@ void main() {
   });
 
   testWithoutContext('gives up retrying when an error happens more than 3 times', () async {
+    final BufferLogger logger = BufferLogger.test();
+    final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
+      fileSystem: fileSystem,
+      platform: platform,
+      processManager: processManager,
+      operatingSystemUtils: operatingSystemUtils,
+      browserFinder: findChromeExecutable,
+      logger: logger,
+    );
     for (int i = 0; i < 4; i++) {
       processManager.addCommand(const FakeCommand(
         command: <String>[
@@ -508,13 +517,14 @@ void main() {
     }
 
     await expectToolExitLater(
-      chromeLauncher.launch(
+      chromiumLauncher.launch(
         'example_url',
         skipCheck: true,
         headless: true,
       ),
       contains('Failed to launch browser.'),
     );
+    expect(logger.errorText, contains('nothing in the std error indicating glibc error'));
   });
 
   testWithoutContext('Logs an error and exits if connection check fails.', () async {

--- a/packages/flutter_tools/test/web.shard/output_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/output_web_test.dart
@@ -35,17 +35,17 @@ void main() {
       // The non-test project has a loop around its breakpoints.
       // No need to start paused as all breakpoint would be eventually reached.
       await flutter.run(
-        withDebugger: true, 
+        withDebugger: true,
         chrome: true,
         expressionEvaluation: true,
         additionalCommandArgs: <String>[
-          if (verbose) '--verbose', 
-          '--web-renderer=html'
+          if (verbose) '--verbose',
+          '--web-renderer=html',
         ]);
   }
 
   Future<void> evaluate() async {
-    final ObjRef res = 
+    final ObjRef res =
       await flutter.evaluate('package:characters/characters.dart', 'true');
     expect(res, isA<InstanceRef>()
       .having((InstanceRef o) => o.kind, 'kind', 'Bool'));
@@ -55,13 +55,13 @@ void main() {
     final VmService client = await vmServiceConnectUri(
       '${flutter.vmServiceWsUri}');
     final Response result = await client.callServiceExtension(
-      'ext.dwds.sendEvent', 
+      'ext.dwds.sendEvent',
       args: event,
     );
     expect(result, isA<Success>());
     await client.dispose();
   }
-  
+
   testWithoutContext('flutter run outputs info messages from dwds in verbose mode', () async {
     final Future<dynamic> info = expectLater(
       flutter.stdout, emitsThrough(contains('Loaded debug metadata')));

--- a/packages/flutter_tools/test/web.shard/output_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/output_web_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service_io.dart';
+
+import '../integration.shard/test_data/basic_project.dart';
+import '../integration.shard/test_driver.dart';
+import '../integration.shard/test_utils.dart';
+import '../src/common.dart';
+
+void main() {
+  Directory tempDir;
+  final BasicProjectWithUnaryMain project = BasicProjectWithUnaryMain();
+  FlutterRunTestDriver flutter;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('run_test.');
+    await project.setUpIn(tempDir);
+    flutter = FlutterRunTestDriver(tempDir);
+    //flutter.stdout.listen(print);
+  });
+
+  tearDown(() async {
+    await flutter.stop();
+    tryToDelete(tempDir);
+  });
+
+  Future<void> start({bool verbose = false}) async {
+      // The non-test project has a loop around its breakpoints.
+      // No need to start paused as all breakpoint would be eventually reached.
+      await flutter.run(
+        withDebugger: true, 
+        chrome: true,
+        expressionEvaluation: true,
+        additionalCommandArgs: <String>[
+          if (verbose) '--verbose', 
+          '--web-renderer=html'
+        ]);
+  }
+
+  Future<void> evaluate() async {
+    final ObjRef res = 
+      await flutter.evaluate('package:characters/characters.dart', 'true');
+    expect(res, isA<InstanceRef>()
+      .having((InstanceRef o) => o.kind, 'kind', 'Bool'));
+  }
+
+  Future<void> sendEvent(Map<String, Object> event) async {
+    final VmService client = await vmServiceConnectUri(
+      '${flutter.vmServiceWsUri}');
+    final Response result = await client.callServiceExtension(
+      'ext.dwds.sendEvent', 
+      args: event,
+    );
+    expect(result, isA<Success>());
+    await client.dispose();
+  }
+  
+  testWithoutContext('flutter run outputs info messages from dwds in verbose mode', () async {
+    final Future<dynamic> info = expectLater(
+      flutter.stdout, emitsThrough(contains('Loaded debug metadata')));
+    await start(verbose: true);
+    await evaluate();
+    await flutter.stop();
+    await info;
+  });
+
+  testWithoutContext('flutter run outputs warning messages from dwds in non-verbose mode', () async {
+    final Future<dynamic> warning = expectLater(
+      flutter.stderr, emitsThrough(contains('Ignoring unknown event')));
+    await start();
+    await sendEvent(<String, Object>{'type': 'DevtoolsEvent'});
+    await warning;
+  });
+}

--- a/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
@@ -62,7 +62,7 @@ void main() {
         validateFlutterVersion(client1),
         validateFlutterVersion(client2)]
       );
-    }, skip: true); // DDS failure: https://github.com/dart-lang/sdk/issues/46696
+    });
   });
 
   group('Clients of flutter run on web with DDS disabled', () {


### PR DESCRIPTION
   Try to de-flake web tool tests
    
    - Run `shelf.serveRequests` in an error zone.
      This prevents errors that normally don't cause crashes to start
      crashing if a top-level run zone was added (ie in tests)
    - Report errors from chrome
    - Report errors from dwds
    - Report messages from dwds in verbose mode
    - Retry connecting to chrome tab on chrome launch
   
Closes:  https://github.com/flutter/flutter/issues/93889
Parent issue: https://github.com/flutter/flutter/issues/93256
    
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
