### PR TITLE
Added initial DatePickerTheme, DatePickerThemeData to customize showDatePicker appearance

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -64,6 +64,7 @@ export 'src/material/data_table_source.dart';
 export 'src/material/data_table_theme.dart';
 export 'src/material/date.dart';
 export 'src/material/date_picker.dart';
+export 'src/material/date_picker_theme.dart';
 export 'src/material/debug.dart';
 export 'src/material/desktop_text_selection.dart';
 export 'src/material/dialog.dart';

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -93,6 +93,9 @@ class CalendarDatePicker extends StatefulWidget {
     this.onDisplayedMonthChanged,
     this.initialCalendarMode = DatePickerMode.day,
     this.selectableDayPredicate,
+    this.selectedDayDecoration,
+    this.disabledDayDecoration,
+    this.todayDecoration,
   }) : assert(initialDate != null),
        assert(firstDate != null),
        assert(lastDate != null),
@@ -143,6 +146,15 @@ class CalendarDatePicker extends StatefulWidget {
 
   /// Function to provide full control over which dates in the calendar can be selected.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// The decoration of selected day; only applied when it is neither selected nor disabled.
+  final Decoration? selectedDayDecoration;
+
+  /// The decoration of disabled day.
+  final Decoration? disabledDayDecoration;
+
+  /// The decoration of today.
+  final Decoration? todayDecoration;
 
   @override
   State<CalendarDatePicker> createState() => _CalendarDatePickerState();
@@ -272,6 +284,9 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           onChanged: _handleDayChanged,
           onDisplayedMonthChanged: _handleMonthChanged,
           selectableDayPredicate: widget.selectableDayPredicate,
+          selectedDayDecoration: widget.selectedDayDecoration,
+          disabledDayDecoration: widget.disabledDayDecoration,
+          todayDecoration: widget.todayDecoration,
         );
       case DatePickerMode.year:
         return Padding(
@@ -440,6 +455,9 @@ class _MonthPicker extends StatefulWidget {
     required this.onChanged,
     required this.onDisplayedMonthChanged,
     this.selectableDayPredicate,
+    this.selectedDayDecoration,
+    this.disabledDayDecoration,
+    this.todayDecoration,
   }) : assert(selectedDate != null),
        assert(currentDate != null),
        assert(onChanged != null),
@@ -480,6 +498,15 @@ class _MonthPicker extends StatefulWidget {
 
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// The decoration of selected day; only applied when it is neither selected nor disabled.
+  final Decoration? selectedDayDecoration;
+
+  /// The decoration of disabled day.
+  final Decoration? disabledDayDecoration;
+
+  /// The decoration of today.
+  final Decoration? todayDecoration;
 
   @override
   _MonthPickerState createState() => _MonthPickerState();
@@ -734,6 +761,9 @@ class _MonthPickerState extends State<_MonthPicker> {
       lastDate: widget.lastDate,
       displayedMonth: month,
       selectableDayPredicate: widget.selectableDayPredicate,
+      selectedDayDecoration: widget.selectedDayDecoration,
+      disabledDayDecoration: widget.disabledDayDecoration,
+      todayDecoration: widget.todayDecoration,
     );
   }
 
@@ -827,6 +857,9 @@ class _DayPicker extends StatefulWidget {
     required this.selectedDate,
     required this.onChanged,
     this.selectableDayPredicate,
+    this.selectedDayDecoration,
+    this.disabledDayDecoration,
+    this.todayDecoration,
   }) : assert(currentDate != null),
        assert(displayedMonth != null),
        assert(firstDate != null),
@@ -863,6 +896,15 @@ class _DayPicker extends StatefulWidget {
 
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// The decoration of selected day; only applied when it is neither selected nor disabled.
+  final Decoration? selectedDayDecoration;
+
+  /// The decoration of disabled day.
+  final Decoration? disabledDayDecoration;
+
+  /// The decoration of today.
+  final Decoration? todayDecoration;
 
   @override
   _DayPickerState createState() => _DayPickerState();
@@ -970,23 +1012,24 @@ class _DayPickerState extends State<_DayPicker> {
         final bool isSelectedDay = DateUtils.isSameDay(widget.selectedDate, dayToBuild);
         final bool isToday = DateUtils.isSameDay(widget.currentDate, dayToBuild);
 
-        BoxDecoration? decoration;
+        Decoration? decoration;
         Color dayColor = enabledDayColor;
         if (isSelectedDay) {
           // The selected day gets a circle background highlight, and a
           // contrasting text color.
           dayColor = selectedDayColor;
-          decoration = BoxDecoration(
+          decoration = widget.selectedDayDecoration ?? BoxDecoration(
             color: selectedDayBackground,
             shape: BoxShape.circle,
           );
         } else if (isDisabled) {
+          decoration = widget.disabledDayDecoration;
           dayColor = disabledDayColor;
         } else if (isToday) {
           // The current day gets a different text color and a circle stroke
           // border.
           dayColor = todayColor;
-          decoration = BoxDecoration(
+          decoration = widget.todayDecoration ?? BoxDecoration(
             border: Border.all(color: todayColor),
             shape: BoxShape.circle,
           );

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -14,6 +14,7 @@ import 'back_button.dart';
 import 'calendar_date_picker.dart';
 import 'color_scheme.dart';
 import 'date.dart';
+import 'date_picker_theme.dart';
 import 'debug.dart';
 import 'dialog.dart';
 import 'dialog_theme.dart';
@@ -40,6 +41,9 @@ const Size _inputRangeLandscapeDialogSize = Size(496, 164.0);
 const Duration _dialogSizeAnimationDuration = Duration(milliseconds: 200);
 const double _inputFormPortraitHeight = 98.0;
 const double _inputFormLandscapeHeight = 108.0;
+
+const BorderRadius _kDefaultBorderRadius = BorderRadius.all(Radius.circular(4.0));
+const ShapeBorder _kDefaultShape = RoundedRectangleBorder(borderRadius: _kDefaultBorderRadius);
 
 /// Shows a dialog containing a Material Design date picker.
 ///
@@ -454,6 +458,8 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final DatePickerThemeData datePickerThemeData = DatePickerTheme.of(context);
+
     final ColorScheme colorScheme = theme.colorScheme;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final Orientation orientation = MediaQuery.of(context).orientation;
@@ -499,6 +505,9 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
         onDateChanged: _handleDateChanged,
         selectableDayPredicate: widget.selectableDayPredicate,
         initialCalendarMode: widget.initialCalendarMode,
+        selectedDayDecoration: datePickerThemeData.selectedDayDecoration,
+        disabledDayDecoration: datePickerThemeData.disabledDayDecoration,
+        todayDecoration: datePickerThemeData.todayDecoration,
       );
     }
 
@@ -543,7 +552,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
         picker = calendarDatePicker();
         entryModeButton = IconButton(
           icon: const Icon(Icons.edit),
-          color: onPrimarySurface,
+          color: datePickerThemeData.entryModeIconColor ?? onPrimarySurface,
           tooltip: localizations.inputDateModeButtonLabel,
           onPressed: _handleEntryModeToggle,
         );
@@ -558,7 +567,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
         picker = inputDatePicker();
         entryModeButton = IconButton(
           icon: const Icon(Icons.calendar_today),
-          color: onPrimarySurface,
+          color: datePickerThemeData.entryModeIconColor ?? onPrimarySurface,
           tooltip: localizations.calendarModeButtonLabel,
           onPressed: _handleEntryModeToggle,
         );
@@ -579,8 +588,12 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
       entryModeButton: entryModeButton,
     );
 
+    final DialogTheme dialogTheme = Theme.of(context).dialogTheme;
+
     final Size dialogSize = _dialogSize(context) * textScaleFactor;
     return Dialog(
+      shape: datePickerThemeData.shape ?? dialogTheme.shape ?? _kDefaultShape,
+      backgroundColor: datePickerThemeData.backgroundColor ?? theme.colorScheme.surface,
       insetPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
       clipBehavior: Clip.antiAlias,
       child: AnimatedContainer(
@@ -752,7 +765,7 @@ class _DatePickerHeader extends StatelessWidget {
     final Color primarySurfaceColor = isDark ? colorScheme.surface : colorScheme.primary;
     final Color onPrimarySurfaceColor = isDark ? colorScheme.onSurface : colorScheme.onPrimary;
 
-    final TextStyle? helpStyle = textTheme.overline?.copyWith(
+    final TextStyle? helpStyle = DatePickerTheme.of(context).helpTextStyle ?? textTheme.overline?.copyWith(
       color: onPrimarySurfaceColor,
     );
 

--- a/packages/flutter/lib/src/material/date_picker_theme.dart
+++ b/packages/flutter/lib/src/material/date_picker_theme.dart
@@ -1,0 +1,199 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'theme.dart';
+
+/// Defines the visual properties of the widget displayed with [showDatePicker].
+///
+/// Descendant widgets obtain the current [DatePickerThemeData] object using
+/// `DatePickerTheme.of(context)`. Instances of [DatePickerThemeData]
+/// can be customized with [DatePickerThemeData.copyWith].
+///
+/// Typically a [DatePickerThemeData] is specified as part of the overall
+/// [Theme] with [ThemeData.datePickerTheme].
+///
+/// All [DatePickerThemeData] properties are `null` by default. When null,
+/// [showDatePicker] will provide its own defaults.
+///
+/// See also:
+///
+///  * [ThemeData], which describes the overall theme information for the
+///    application.
+///  * [DatePickerTheme], which describes the actual configuration of a date
+///    picker theme.
+@immutable
+class DatePickerThemeData with Diagnosticable {
+  /// Creates a theme that can be used for [DatePickerTheme] or
+  /// [ThemeData.datePickerTheme].
+  const DatePickerThemeData({
+    this.backgroundColor,
+    this.entryModeIconColor,
+    this.helpTextStyle,
+    this.shape,
+    this.selectedDayDecoration,
+    this.disabledDayDecoration,
+    this.todayDecoration,
+  });
+
+  /// The background color of a date picker.
+  ///
+  /// If this is null, the date picker defaults to the overall theme's
+  /// [ColorScheme.background].
+  final Color? backgroundColor;
+
+  /// The color of the entry mode [IconButton].
+  ///
+  /// If this is null, the date picker defaults to:
+  /// ```
+  /// Theme.of(context).colorScheme.onSurface.withOpacity(
+  ///   Theme.of(context).colorScheme.brightness == Brightness.dark ? 1.0 : 0.6,
+  /// )
+  /// ```
+  final Color? entryModeIconColor;
+
+  /// Used to configure the [TextStyle]s for the helper text in the header.
+  ///
+  /// If this is null, the date picker defaults to the overall theme's
+  /// [TextTheme.overline].
+  final TextStyle? helpTextStyle;
+
+  /// The shape of the [Dialog] that the date picker is presented in.
+  ///
+  /// The default shape is a [RoundedRectangleBorder] with a radius of 4.0
+  final ShapeBorder? shape;
+
+  /// The decoration of selected day.
+  final Decoration? selectedDayDecoration;
+
+  /// The decoration of disabled day.
+  final Decoration? disabledDayDecoration;
+
+  /// The decoration of today; only applied when it is neither selected nor disabled.
+  final Decoration? todayDecoration;
+
+  /// Creates a copy of this object with the given fields replaced with the
+  /// new values.
+  DatePickerThemeData copyWith({
+    Color? backgroundColor,
+    Color? entryModeIconColor,
+    TextStyle? helpTextStyle,
+    ShapeBorder? shape,
+    Decoration? selectedDayDecoration,
+    Decoration? disabledDayDecoration,
+    Decoration? todayDecoration,
+  }) {
+    return DatePickerThemeData(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      entryModeIconColor: entryModeIconColor ?? this.entryModeIconColor,
+      helpTextStyle: helpTextStyle ?? this.helpTextStyle,
+      shape: shape ?? this.shape,
+      selectedDayDecoration: selectedDayDecoration ?? this.selectedDayDecoration,
+      disabledDayDecoration: disabledDayDecoration ?? this.disabledDayDecoration,
+      todayDecoration: todayDecoration ?? this.todayDecoration,
+    );
+  }
+
+  /// Linearly interpolate between two date picker themes.
+  ///
+  /// The argument `t` must not be null.
+  ///
+  static DatePickerThemeData lerp(DatePickerThemeData? a, DatePickerThemeData? b, double t) {
+    assert(t != null);
+    return DatePickerThemeData(
+      backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
+      entryModeIconColor: Color.lerp(a?.entryModeIconColor, b?.entryModeIconColor, t),
+      helpTextStyle: TextStyle.lerp(a?.helpTextStyle, b?.helpTextStyle, t),
+      shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
+      selectedDayDecoration: Decoration.lerp(a?.selectedDayDecoration, b?.selectedDayDecoration, t),
+      disabledDayDecoration: Decoration.lerp(a?.disabledDayDecoration, b?.disabledDayDecoration, t),
+      todayDecoration: Decoration.lerp(a?.todayDecoration, b?.todayDecoration, t),
+    );
+  }
+
+  @override
+  int get hashCode {
+    return hashValues(
+      backgroundColor,
+      entryModeIconColor,
+      helpTextStyle,
+      shape,
+      selectedDayDecoration,
+      disabledDayDecoration,
+      todayDecoration,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is DatePickerThemeData &&
+        other.backgroundColor == backgroundColor &&
+        other.entryModeIconColor == entryModeIconColor &&
+        other.helpTextStyle == helpTextStyle &&
+        other.shape == shape &&
+        other.selectedDayDecoration == selectedDayDecoration &&
+        other.disabledDayDecoration == disabledDayDecoration &&
+        other.todayDecoration == todayDecoration;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: null));
+    properties.add(ColorProperty('entryModeIconColor', entryModeIconColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<TextStyle>('helpTextStyle', helpTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('selectedDayDecoration', selectedDayDecoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('disabledDayDecoration', disabledDayDecoration, defaultValue: null));
+    properties.add(DiagnosticsProperty<Decoration>('todayDecoration', todayDecoration, defaultValue: null));
+  }
+}
+
+/// An inherited widget that defines the configuration for date pickers
+/// displayed using [showDatePicker] in this widget's subtree.
+///
+/// Values specified here are used for date picker properties that are not
+/// given an explicit non-null value.
+class DatePickerTheme extends InheritedTheme {
+  /// Creates a date picker theme that controls the configurations for
+  /// date pickers displayed in its widget subtree.
+  const DatePickerTheme({
+    Key? key,
+    required this.data,
+    required Widget child,
+  })  : assert(data != null),
+        super(key: key, child: child);
+
+  /// The properties for descendant date picker widgets.
+  final DatePickerThemeData data;
+
+  /// The [data] value of the closest [DatePickerTheme] ancestor.
+  ///
+  /// If there is no ancestor, it returns [ThemeData.datePickerTheme].
+  /// Applications can assume that the returned value will not be null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// DatePickerThemeData theme = DatePickerTheme.of(context);
+  /// ```
+  static DatePickerThemeData of(BuildContext context) {
+    final DatePickerTheme? datePickerTheme = context.dependOnInheritedWidgetOfExactType<DatePickerTheme>();
+    return datePickerTheme?.data ?? Theme.of(context).datePickerTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return DatePickerTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(DatePickerTheme oldWidget) => data != oldWidget.data;
+}

--- a/packages/flutter/lib/src/material/date_picker_theme.dart
+++ b/packages/flutter/lib/src/material/date_picker_theme.dart
@@ -116,7 +116,7 @@ class DatePickerThemeData with Diagnosticable {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
       backgroundColor,
       entryModeIconColor,
       helpTextStyle,
@@ -129,10 +129,12 @@ class DatePickerThemeData with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
+    if (identical(this, other)) {
       return true;
-    if (other.runtimeType != runtimeType)
+    }
+    if (other.runtimeType != runtimeType) {
       return false;
+    }
     return other is DatePickerThemeData &&
         other.backgroundColor == backgroundColor &&
         other.entryModeIconColor == entryModeIconColor &&
@@ -165,11 +167,10 @@ class DatePickerTheme extends InheritedTheme {
   /// Creates a date picker theme that controls the configurations for
   /// date pickers displayed in its widget subtree.
   const DatePickerTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  })  : assert(data != null),
-        super(key: key, child: child);
+    required super.child,
+  })  : assert(data != null);
 
   /// The properties for descendant date picker widgets.
   final DatePickerThemeData data;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -20,6 +20,7 @@ import 'chip_theme.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'data_table_theme.dart';
+import 'date_picker_theme.dart';
 import 'dialog_theme.dart';
 import 'divider_theme.dart';
 import 'drawer_theme.dart';
@@ -353,6 +354,7 @@ class ThemeData with Diagnosticable {
     TabBarTheme? tabBarTheme,
     TextButtonThemeData? textButtonTheme,
     TextSelectionThemeData? textSelectionTheme,
+    DatePickerThemeData? datePickerTheme,
     TimePickerThemeData? timePickerTheme,
     ToggleButtonsThemeData? toggleButtonsTheme,
     TooltipThemeData? tooltipTheme,
@@ -561,6 +563,7 @@ class ThemeData with Diagnosticable {
     tabBarTheme ??= const TabBarTheme();
     textButtonTheme ??= const TextButtonThemeData();
     textSelectionTheme ??= const TextSelectionThemeData();
+    datePickerTheme ??= const DatePickerThemeData();
     timePickerTheme ??= const TimePickerThemeData();
     toggleButtonsTheme ??= const ToggleButtonsThemeData();
     tooltipTheme ??= const TooltipThemeData();
@@ -653,6 +656,7 @@ class ThemeData with Diagnosticable {
       tabBarTheme: tabBarTheme,
       textButtonTheme: textButtonTheme,
       textSelectionTheme: textSelectionTheme,
+      datePickerTheme: datePickerTheme,
       timePickerTheme: timePickerTheme,
       toggleButtonsTheme: toggleButtonsTheme,
       tooltipTheme: tooltipTheme,
@@ -758,6 +762,7 @@ class ThemeData with Diagnosticable {
     required this.tabBarTheme,
     required this.textButtonTheme,
     required this.textSelectionTheme,
+    required this.datePickerTheme,
     required this.timePickerTheme,
     required this.toggleButtonsTheme,
     required this.tooltipTheme,
@@ -892,6 +897,7 @@ class ThemeData with Diagnosticable {
        assert(tabBarTheme != null),
        assert(textButtonTheme != null),
        assert(textSelectionTheme != null),
+       assert(datePickerTheme != null),
        assert(timePickerTheme != null),
        assert(toggleButtonsTheme != null),
        assert(tooltipTheme != null);
@@ -1465,6 +1471,9 @@ class ThemeData with Diagnosticable {
   /// A theme for customizing the appearance and layout of [TextField] widgets.
   final TextSelectionThemeData textSelectionTheme;
 
+  /// A theme for customizing the appearance and layout of date picker widgets.
+  final DatePickerThemeData datePickerTheme;
+
   /// A theme for customizing the appearance and layout of time picker widgets.
   final TimePickerThemeData timePickerTheme;
 
@@ -1701,6 +1710,7 @@ class ThemeData with Diagnosticable {
     TabBarTheme? tabBarTheme,
     TextButtonThemeData? textButtonTheme,
     TextSelectionThemeData? textSelectionTheme,
+    DatePickerThemeData? datePickerTheme,
     TimePickerThemeData? timePickerTheme,
     ToggleButtonsThemeData? toggleButtonsTheme,
     TooltipThemeData? tooltipTheme,
@@ -1835,6 +1845,7 @@ class ThemeData with Diagnosticable {
       tabBarTheme: tabBarTheme ?? this.tabBarTheme,
       textButtonTheme: textButtonTheme ?? this.textButtonTheme,
       textSelectionTheme: textSelectionTheme ?? this.textSelectionTheme,
+      datePickerTheme: datePickerTheme ?? this.datePickerTheme,
       timePickerTheme: timePickerTheme ?? this.timePickerTheme,
       toggleButtonsTheme: toggleButtonsTheme ?? this.toggleButtonsTheme,
       tooltipTheme: tooltipTheme ?? this.tooltipTheme,
@@ -2014,6 +2025,7 @@ class ThemeData with Diagnosticable {
       checkboxTheme: CheckboxThemeData.lerp(a.checkboxTheme, b.checkboxTheme, t),
       chipTheme: ChipThemeData.lerp(a.chipTheme, b.chipTheme, t)!,
       dataTableTheme: DataTableThemeData.lerp(a.dataTableTheme, b.dataTableTheme, t),
+      datePickerTheme: DatePickerThemeData.lerp(a.datePickerTheme, b.datePickerTheme, t),
       dialogTheme: DialogTheme.lerp(a.dialogTheme, b.dialogTheme, t),
       dividerTheme: DividerThemeData.lerp(a.dividerTheme, b.dividerTheme, t),
       drawerTheme: DrawerThemeData.lerp(a.drawerTheme, b.drawerTheme, t)!,
@@ -2211,6 +2223,7 @@ class ThemeData with Diagnosticable {
       checkboxTheme,
       chipTheme,
       dataTableTheme,
+      datePickerTheme,
       dialogTheme,
       dividerTheme,
       drawerTheme,
@@ -2310,6 +2323,7 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<CheckboxThemeData>('checkboxTheme', checkboxTheme, defaultValue: defaultData.checkboxTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<ChipThemeData>('chipTheme', chipTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<DataTableThemeData>('dataTableTheme', dataTableTheme, defaultValue: defaultData.dataTableTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<DatePickerThemeData>('datePickerTheme', datePickerTheme, defaultValue: defaultData.datePickerTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<DialogTheme>('dialogTheme', dialogTheme, defaultValue: defaultData.dialogTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<DividerThemeData>('dividerTheme', dividerTheme, defaultValue: defaultData.dividerTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<DrawerThemeData>('drawerTheme', drawerTheme, defaultValue: defaultData.drawerTheme, level: DiagnosticLevel.debug));

--- a/packages/flutter/test/material/date_picker_theme_test.dart
+++ b/packages/flutter/test/material/date_picker_theme_test.dart
@@ -1,0 +1,322 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('DatePickerThemeData copyWith, ==, hashCode basics', () {
+    expect(const DatePickerThemeData(), const DatePickerThemeData().copyWith());
+    expect(const DatePickerThemeData().hashCode, const DatePickerThemeData().copyWith().hashCode);
+  });
+
+  test('DatePickerThemeData null fields by default', () {
+    const DatePickerThemeData datePickerTheme = DatePickerThemeData();
+    expect(datePickerTheme.backgroundColor, null);
+    expect(datePickerTheme.entryModeIconColor, null);
+    expect(datePickerTheme.helpTextStyle, null);
+    expect(datePickerTheme.shape, null);
+    expect(datePickerTheme.selectedDayDecoration, null);
+    expect(datePickerTheme.disabledDayDecoration, null);
+    expect(datePickerTheme.todayDecoration, null);
+  });
+
+  testWidgets('Default DatePickerThemeData debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const DatePickerThemeData().debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
+
+    expect(description, <String>[]);
+  });
+
+  testWidgets('DatePickerThemeData implements debugFillProperties', (WidgetTester tester) async {
+    final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+    const DatePickerThemeData(
+      backgroundColor: Color(0xFFFFFFFF),
+      entryModeIconColor: Color(0xFFFFFFFF),
+      helpTextStyle: TextStyle(),
+      shape: RoundedRectangleBorder(),
+      selectedDayDecoration: BoxDecoration(),
+      disabledDayDecoration: BoxDecoration(),
+      todayDecoration: BoxDecoration(),
+    ).debugFillProperties(builder);
+
+    final List<String> description = builder.properties
+        .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((DiagnosticsNode node) => node.toString())
+        .toList();
+
+    expect(description, <String>[
+      'backgroundColor: Color(0xffffffff)',
+      'entryModeIconColor: Color(0xffffffff)',
+      'helpTextStyle: TextStyle(<all styles inherited>)',
+      'shape: RoundedRectangleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none), BorderRadius.zero)',
+      'selectedDayDecoration: BoxDecoration',
+      'disabledDayDecoration: BoxDecoration',
+      'todayDecoration: BoxDecoration'
+    ]);
+  });
+
+  testWidgets('Passing no DatePickerThemeData uses defaults', (WidgetTester tester) async {
+    final ThemeData defaultTheme = ThemeData.fallback();
+    await tester.pumpWidget(const _DatePickerLauncher());
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Material dialogMaterial = _dialogMaterial(tester);
+    expect(dialogMaterial.color, defaultTheme.colorScheme.surface);
+    expect(dialogMaterial.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+
+    final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT DATE');
+    expect(
+      helperText.text.style,
+      Typography.material2014().englishLike.overline!
+          .merge(Typography.material2014().white.overline),
+    );
+
+    final IconButton entryModeIconButton = _entryModeIconButton(tester);
+    expect(
+      entryModeIconButton.color,
+      defaultTheme.colorScheme.onPrimary,
+    );
+
+    final Color selectedDayBackground = defaultTheme.colorScheme.primary;
+    final Container selectedDayContainer = _textContainer(tester, '1');
+    expect(
+      selectedDayContainer.decoration,
+      BoxDecoration(
+        color: selectedDayBackground,
+        shape: BoxShape.circle,
+      ),
+    );
+
+    final Container disabledDayContainer = _textContainer(tester, '2');
+    expect(
+      disabledDayContainer.decoration,
+      null,
+    );
+  });
+
+  testWidgets('Passing no DatePickerThemeData uses defaults - today', (WidgetTester tester) async {
+    final DateTime today = DateTime.now();
+    final DateTime tomorrow = DateTime.now().add(const Duration(days: 1));
+    DateTime initialDate = tomorrow;
+    if(today.month != tomorrow.month){
+      final DateTime yesterday = DateTime.now().subtract(const Duration(days: 1));
+      initialDate = yesterday;
+    }
+
+
+    final ThemeData defaultTheme = ThemeData.fallback();
+    await tester.pumpWidget(_DatePickerLauncher(initialDate: initialDate));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Color todayColor = defaultTheme.colorScheme.primary;
+    final Container todayContainer = _textContainer(tester, today.day.toString());
+    expect(
+      todayContainer.decoration,
+      BoxDecoration(
+        border: Border.all(color: todayColor),
+        shape: BoxShape.circle,
+      ),
+    );
+  });
+
+  testWidgets('Passing no DatePickerThemeData uses defaults - input mode', (WidgetTester tester) async {
+    final ThemeData defaultTheme = ThemeData.fallback();
+    await tester.pumpWidget(const _DatePickerLauncher(entryMode: DatePickerEntryMode.input));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Material dialogMaterial = _dialogMaterial(tester);
+    expect(dialogMaterial.color, defaultTheme.colorScheme.surface);
+    expect(dialogMaterial.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+
+    final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT DATE');
+    expect(
+      helperText.text.style,
+      Typography.material2014().englishLike.overline!
+          .merge(Typography.material2014().white.overline),
+    );
+
+    final IconButton entryModeIconButton = _entryModeIconButton(tester);
+    expect(
+      entryModeIconButton.color,
+      defaultTheme.colorScheme.onPrimary,
+    );
+  });
+
+  testWidgets('Date picker uses values from DatePickerThemeData', (WidgetTester tester) async {
+    final DatePickerThemeData datePickerTheme = _datePickerTheme();
+    final ThemeData theme = ThemeData(datePickerTheme: datePickerTheme);
+    await tester.pumpWidget(_DatePickerLauncher(themeData: theme));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Material dialogMaterial = _dialogMaterial(tester);
+    expect(dialogMaterial.color, datePickerTheme.backgroundColor);
+    expect(dialogMaterial.shape, datePickerTheme.shape);
+
+    final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT DATE');
+    expect(
+      helperText.text.style,
+      Typography.material2014().englishLike.bodyText2!
+          .merge(Typography.material2014().black.bodyText2)
+          .merge(datePickerTheme.helpTextStyle),
+    );
+
+    final IconButton entryModeIconButton = _entryModeIconButton(tester);
+    expect(
+      entryModeIconButton.color,
+      datePickerTheme.entryModeIconColor,
+    );
+
+    final Container selectedDayContainer = _textContainer(tester, '1');
+    expect(
+      selectedDayContainer.decoration,
+      datePickerTheme.selectedDayDecoration,
+    );
+
+    final Container disabledDayContainer = _textContainer(tester, '2');
+    expect(
+      disabledDayContainer.decoration,
+      datePickerTheme.disabledDayDecoration,
+    );
+  });
+
+  testWidgets('Date picker uses values from DatePickerThemeData - today', (WidgetTester tester) async {
+    final DateTime today = DateTime.now();
+    final DateTime tomorrow = DateTime.now().add(const Duration(days: 1));
+    DateTime initialDate = tomorrow;
+    if(today.month != tomorrow.month){
+      final DateTime yesterday = DateTime.now().subtract(const Duration(days: 1));
+      initialDate = yesterday;
+    }
+
+
+    final DatePickerThemeData datePickerTheme = _datePickerTheme();
+    final ThemeData theme = ThemeData(datePickerTheme: datePickerTheme);
+    await tester.pumpWidget(_DatePickerLauncher(themeData: theme, initialDate: initialDate));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Container todayContainer = _textContainer(tester, today.day.toString());
+    expect(
+      todayContainer.decoration,
+      datePickerTheme.todayDecoration,
+    );
+  });
+
+  testWidgets('Date picker uses values from DatePickerThemeData - input mode', (WidgetTester tester) async {
+    final DatePickerThemeData datePickerTheme = _datePickerTheme();
+    final ThemeData theme = ThemeData(datePickerTheme: datePickerTheme);
+    await tester.pumpWidget(_DatePickerLauncher(themeData: theme, entryMode: DatePickerEntryMode.input));
+    await tester.tap(find.text('X'));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    final Material dialogMaterial = _dialogMaterial(tester);
+    expect(dialogMaterial.color, datePickerTheme.backgroundColor);
+    expect(dialogMaterial.shape, datePickerTheme.shape);
+
+    final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT DATE');
+    expect(
+      helperText.text.style,
+      Typography.material2014().englishLike.bodyText2!
+          .merge(Typography.material2014().black.bodyText2)
+          .merge(datePickerTheme.helpTextStyle),
+    );
+
+    final IconButton entryModeIconButton = _entryModeIconButton(tester);
+    expect(
+      entryModeIconButton.color,
+      datePickerTheme.entryModeIconColor,
+    );
+  });
+}
+
+DatePickerThemeData _datePickerTheme() {
+  return const DatePickerThemeData(
+    backgroundColor: Colors.orange,
+    entryModeIconColor: Colors.red,
+    helpTextStyle: TextStyle(fontSize: 8.0),
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0))),
+    selectedDayDecoration: BoxDecoration(
+      color: Colors.black,
+    ),
+    disabledDayDecoration: BoxDecoration(
+      color: Colors.black,
+    ),
+    todayDecoration: BoxDecoration(
+      color: Colors.black,
+    ),
+  );
+}
+
+class _DatePickerLauncher extends StatelessWidget {
+  const _DatePickerLauncher({
+    Key? key,
+    this.themeData,
+    this.entryMode = DatePickerEntryMode.calendar,
+    this.initialDate,
+  }) : super(key: key);
+
+  final ThemeData? themeData;
+  final DatePickerEntryMode entryMode;
+  final DateTime? initialDate;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: themeData,
+      home: Material(
+        child: Center(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                child: const Text('X'),
+                onPressed: () async {
+                  await showDatePicker(
+                    context: context,
+                    initialEntryMode: entryMode,
+                    initialDate: initialDate ?? DateTime(2000),
+                    firstDate: DateTime(1900),
+                    lastDate: DateTime(2100),
+                    selectableDayPredicate: (DateTime dateTime){
+                      if(dateTime == DateTime(2000, 1, 2)){
+                        return false;
+                      }
+                      return true;
+                    }
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Material _dialogMaterial(WidgetTester tester) {
+  return tester.widget<Material>(find.descendant(of: find.byType(Dialog), matching: find.byType(Material)).first);
+}
+
+IconButton _entryModeIconButton(WidgetTester tester) {
+  return tester.widget<IconButton>(find.descendant(of: find.byType(Dialog), matching: find.byType(IconButton)).first);
+}
+
+RenderParagraph _textRenderParagraph(WidgetTester tester, String text) {
+  return tester.element<StatelessElement>(find.text(text).first).renderObject! as RenderParagraph;
+}
+
+Container _textContainer(WidgetTester tester, String text) {
+  return tester.widget<Container>(find.ancestor(of: find.text(text), matching: find.byType(Container)).first);
+}

--- a/packages/flutter/test/material/date_picker_theme_test.dart
+++ b/packages/flutter/test/material/date_picker_theme_test.dart
@@ -261,11 +261,10 @@ DatePickerThemeData _datePickerTheme() {
 
 class _DatePickerLauncher extends StatelessWidget {
   const _DatePickerLauncher({
-    Key? key,
     this.themeData,
     this.entryMode = DatePickerEntryMode.calendar,
     this.initialDate,
-  }) : super(key: key);
+  });
 
   final ThemeData? themeData;
   final DatePickerEntryMode entryMode;

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -697,6 +697,7 @@ void main() {
       tabBarTheme: const TabBarTheme(labelColor: Colors.black),
       textButtonTheme: TextButtonThemeData(style: TextButton.styleFrom(primary: Colors.red)),
       textSelectionTheme: const TextSelectionThemeData(cursorColor: Colors.black),
+      datePickerTheme: const DatePickerThemeData(backgroundColor: Colors.black),
       timePickerTheme: const TimePickerThemeData(backgroundColor: Colors.black),
       toggleButtonsTheme: const ToggleButtonsThemeData(textStyle: TextStyle(color: Colors.black)),
       tooltipTheme: const TooltipThemeData(height: 100),
@@ -809,6 +810,7 @@ void main() {
       tabBarTheme: const TabBarTheme(labelColor: Colors.white),
       textButtonTheme: const TextButtonThemeData(),
       textSelectionTheme: const TextSelectionThemeData(cursorColor: Colors.white),
+      datePickerTheme: const DatePickerThemeData(backgroundColor: Colors.white),
       timePickerTheme: const TimePickerThemeData(backgroundColor: Colors.white),
       toggleButtonsTheme: const ToggleButtonsThemeData(textStyle: TextStyle(color: Colors.white)),
       tooltipTheme: const TooltipThemeData(height: 100),
@@ -907,6 +909,7 @@ void main() {
       tabBarTheme: otherTheme.tabBarTheme,
       textButtonTheme: otherTheme.textButtonTheme,
       textSelectionTheme: otherTheme.textSelectionTheme,
+      datePickerTheme: otherTheme.datePickerTheme,
       timePickerTheme: otherTheme.timePickerTheme,
       toggleButtonsTheme: otherTheme.toggleButtonsTheme,
       tooltipTheme: otherTheme.tooltipTheme,
@@ -994,6 +997,7 @@ void main() {
     expect(themeDataCopy.listTileTheme, equals(otherTheme.listTileTheme));
     expect(themeDataCopy.navigationBarTheme, equals(otherTheme.navigationBarTheme));
     expect(themeDataCopy.navigationRailTheme, equals(otherTheme.navigationRailTheme));
+    expect(themeDataCopy.datePickerTheme, equals(otherTheme.datePickerTheme));
     expect(themeDataCopy.outlinedButtonTheme, equals(otherTheme.outlinedButtonTheme));
     expect(themeDataCopy.popupMenuTheme, equals(otherTheme.popupMenuTheme));
     expect(themeDataCopy.progressIndicatorTheme, equals(otherTheme.progressIndicatorTheme));
@@ -1138,6 +1142,7 @@ void main() {
       'tabBarTheme',
       'textButtonTheme',
       'textSelectionTheme',
+      'datePickerTheme',
       'timePickerTheme',
       'toggleButtonsTheme',
       'tooltipTheme',


### PR DESCRIPTION
Added initial DatePickerTheme to customize showDatePicker appearance for now it only has:
- backgroundColor
- entryModeIconColor
- helpTextStyle
- shape
- selectedDayDecoration
- disabledDayDecoration
- todayDecoration

Partially fixes #93707

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

