### PR TITLE
Add parameter for calling `onPageChanged` once at the end of the scroll

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -150,11 +150,7 @@ class PageController extends ScrollController {
   /// direction.
   final double viewportFraction;
 
-  /// This sets a condition if the [PageView] onPageChanged should be called only
-  /// when scrolling reaches the end.
-  ///
-  /// Default vakue is false.
-  bool callPageChangeAtEnd = false;
+  bool _callPageChangeAtEnd = false;
 
   /// The current page displayed in the controlled [PageView].
   ///
@@ -193,6 +189,11 @@ class PageController extends ScrollController {
   /// The returned [Future] resolves when the animation completes.
   ///
   /// The `duration` and `curve` arguments must not be null.
+  ///
+  /// The `callPageChangeAtEnd` sets a condition if the [PageView] onPageChanged 
+  /// should be called only when scrolling reaches the end.
+  ///
+  /// Default value is false.
   Future<void> animateToPage(
     int page, {
     required Duration duration,
@@ -205,7 +206,7 @@ class PageController extends ScrollController {
       return Future<void>.value();
     }
 
-    this.callPageChangeAtEnd = callPageChangeAtEnd;
+    _callPageChangeAtEnd = callPageChangeAtEnd;
 
     return position.animateTo(
       position.getPixelsFromPage(page.toDouble()),
@@ -948,10 +949,10 @@ class _PageViewState extends State<PageView> {
           final PageMetrics metrics = notification.metrics as PageMetrics;
           final int currentPage = metrics.page!.round();
           if (currentPage != _lastReportedPage) {
-            if (!widget.controller.callPageChangeAtEnd  && notification is ScrollUpdateNotification) {
+            if (!widget.controller._callPageChangeAtEnd  && notification is ScrollUpdateNotification) {
               _lastReportedPage = currentPage;
               widget.onPageChanged!(currentPage);
-            } else if (widget.controller.callPageChangeAtEnd  && notification is ScrollEndNotification) {
+            } else if (widget.controller._callPageChangeAtEnd  && notification is ScrollEndNotification) {
               _lastReportedPage = currentPage;
               widget.onPageChanged!(currentPage);
             }

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -190,7 +190,7 @@ class PageController extends ScrollController {
   ///
   /// The `duration` and `curve` arguments must not be null.
   ///
-  /// The `callPageChangeAtEnd` sets a condition if the [PageView] onPageChanged 
+  /// The `callPageChangeAtEnd` sets a condition if the [PageView] onPageChanged
   /// should be called only when scrolling reaches the end.
   ///
   /// Default value is false.

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -437,22 +437,22 @@ void main() {
                 TextButton(
                   key: firstPageButton,
                   onPressed: () {
-                    controller.animateToPage(kStates.indexOf(kStates.first), 
+                    controller.animateToPage(kStates.indexOf(kStates.first),
                       duration: const Duration(milliseconds: 800),
                       curve: Curves.easeOutQuart,
                       callPageChangeAtEnd: true,
                     );
-                  }, 
+                  },
                   child: const Text('Animate to first page'),
                 ),
                 TextButton(
                   key: lastPageButton,
                   onPressed: () {
-                    controller.animateToPage(kStates.indexOf(kStates.last), 
+                    controller.animateToPage(kStates.indexOf(kStates.last),
                       duration: const Duration(milliseconds: 800),
                       curve: Curves.easeOutQuart,
                     );
-                  }, 
+                  },
                   child: const Text('Animate to last page'),
                 ),
               ],

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -415,6 +415,63 @@ void main() {
     expect(find.text('Alaska'), findsOneWidget);
   });
 
+  testWidgets('callPageChangeAtEnd parameter calls onPageChanged once', (WidgetTester tester) async {
+    const Key firstPageButton = Key('firstPageButton');
+    const Key lastPageButton = Key('lastPageButton');
+    final PageController controller = PageController();
+    int onPageChangedCalled = 0;
+
+    await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: <Widget>[
+            PageView(
+              controller: controller,
+              onPageChanged: (int value) {
+                onPageChangedCalled = onPageChangedCalled + 1;
+              },
+              children: kStates.map<Widget>((String state) => Text(state)).toList(),
+            ),
+            Column(
+              children: <Widget>[
+                TextButton(
+                  key: firstPageButton,
+                  onPressed: () {
+                    controller.animateToPage(kStates.indexOf(kStates.first), 
+                      duration: const Duration(milliseconds: 800),
+                      curve: Curves.easeOutQuart,
+                      callPageChangeAtEnd: true,
+                    );
+                  }, 
+                  child: const Text('Animate to first page'),
+                ),
+                TextButton(
+                  key: lastPageButton,
+                  onPressed: () {
+                    controller.animateToPage(kStates.indexOf(kStates.last), 
+                      duration: const Duration(milliseconds: 800),
+                      curve: Curves.easeOutQuart,
+                    );
+                  }, 
+                  child: const Text('Animate to last page'),
+                ),
+              ],
+            ),
+          ],
+        ),
+    ));
+
+    await tester.tap(find.byKey(lastPageButton));
+    await tester.pumpAndSettle();
+    expect(onPageChangedCalled, 7);
+
+    onPageChangedCalled = 0;
+
+    await tester.tap(find.byKey(firstPageButton));
+    await tester.pumpAndSettle();
+    expect(onPageChangedCalled, 1);
+  });
+
   testWidgets('Bouncing scroll physics ballistics does not overshoot', (WidgetTester tester) async {
     final List<int> log = <int>[];
     final PageController controller = PageController(viewportFraction: 0.9);


### PR DESCRIPTION
This adds a parameter to call onPageChanged once, at the end of the scroll, this is added to `animateToPage` in`PageController`.

Fixes https://github.com/flutter/flutter/issues/43813

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
