### PR TITLE
Modified TextField docs - Replaced 'labelText' to 'hintText' in code snippet

### DIFF
--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -32,11 +32,11 @@ class MyStatelessWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       body: Center(
         child: SizedBox(
           width: 250,
-          child: const TextField(
+          child: TextField(
             obscureText: true,
             decoration: InputDecoration(
               border: OutlineInputBorder(),

--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -6,45 +6,37 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+class ObscuredTextFieldSample extends StatelessWidget {
+  const ObscuredTextFieldSample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: 250,
+      child: TextField(
+        obscureText: true,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: 'Password',
+        ),
+      ),
+    );
+  }
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
-
-  static const String _title = 'Flutter Code Sample';
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
+        appBar: AppBar(title: const Text('Obscured Textfield')),
         body: const Center(
-          child: MyStatelessWidget(),
+          child: ObscuredTextFieldSample(),
         ),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: SizedBox(
-          width: 250,
-          child: TextField(
-            obscureText: true,
-            decoration: InputDecoration(
-              border: OutlineInputBorder(),
-              labelText: 'Password',
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
+void main() => runApp(const MyApp());

--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   static const String _title = 'Flutter Code Sample';
 
@@ -28,13 +28,13 @@ class MyApp extends StatelessWidget {
 }
 
 class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({Key? key}) : super(key: key);
+  const MyStatelessWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: Container(
+        child: SizedBox(
           width: 250,
           child: const TextField(
             obscureText: true,

--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -33,18 +33,18 @@ class MyStatelessWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Center(
-          child: Container(
-            width: 250,
-            child: const TextField(
-              obscureText: true,
-              decoration: InputDecoration(
-                border: OutlineInputBorder(),
-                labelText: 'Password',
-              ),
+      body: Center(
+        child: Container(
+          width: 250,
+          child: const TextField(
+            obscureText: true,
+            decoration: InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: 'Password',
             ),
           ),
         ),
+      ),
     );
   }
 }

--- a/examples/api/lib/material/text_field/text_field.0.dart
+++ b/examples/api/lib/material/text_field/text_field.0.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for TextField
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const Center(
+          child: MyStatelessWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+class MyStatelessWidget extends StatelessWidget {
+  const MyStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Center(
+          child: Container(
+            width: 250,
+            child: const TextField(
+              obscureText: true,
+              decoration: InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Password',
+              ),
+            ),
+          ),
+        ),
+    );
+  }
+}

--- a/examples/api/test/material/text_field/text_field.0_test.dart
+++ b/examples/api/test/material/text_field/text_field.0_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/text_field/text_field.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('TextField is obscured and has "Password" as labelText', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.MyApp());
+
+    expect(find.byType(TextField), findsOneWidget);
+
+    final TextField textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.obscureText, isTrue);
+    expect(textField.decoration!.labelText, 'Password');
+  });
+}

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -132,7 +132,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// ## Obscured Input
 ///
 /// {@tool dartpad}
-/// This example shows how to create a [TextField] that will obscured input. The
+/// This example shows how to create a [TextField] that will obscure input. The
 /// [InputDecoration] surrounds the field in a border using [OutlineInputBorder]
 /// and adds a label.
 ///

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -129,22 +129,14 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 /// when it is no longer needed. This will ensure we discard any resources used
 /// by the object.
 ///
-/// {@tool snippet}
-/// This example shows how to create a [TextField] that will obscure input. The
+/// ## Obscured Input
+///
+/// {@tool dartpad}
+/// This example shows how to create a [TextField] that will obscured input. The
 /// [InputDecoration] surrounds the field in a border using [OutlineInputBorder]
 /// and adds a label.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/text_field.png)
-///
-/// ```dart
-/// const TextField(
-///   obscureText: true,
-///   decoration: InputDecoration(
-///     border: OutlineInputBorder(),
-///     labelText: 'Password',
-///   ),
-/// )
-/// ```
+/// ** See code in examples/api/lib/material/text_field/text_field.0.dart **
 /// {@end-tool}
 ///
 /// ## Reading values


### PR DESCRIPTION
Below is a screenshot of the current state of the [TextField ](https://api.flutter.dev/flutter/material/TextField-class.html) docs. As you can see, the code snippet shows `labelText`, but the image that is attached shows `hintText`. This PR corrects that change so that the code snippet matches the image.


![image](https://user-images.githubusercontent.com/19626901/143135989-8105a9b0-9ffe-4cde-964b-812b2a1f4e23.png)

