### PR TITLE
make CIPD url customizable using FLUTTER_STORAGE_BASE_URL

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -446,6 +446,29 @@ class Cache {
     return overrideUrl;
   }
 
+  String get cipdBaseUrl {
+    final String? overrideUrl = _platform.environment['FLUTTER_STORAGE_BASE_URL'];
+    if (overrideUrl == null) {
+      return 'https://chrome-infra-packages.appspot.com/dl';
+    }
+
+    final Uri original;
+    try {
+      original = Uri.parse(overrideUrl);
+    } on FormatException catch (err) {
+      throwToolExit('"FLUTTER_STORAGE_BASE_URL" contains an invalid URI:\n$err');
+    }
+
+    final String cipdOverride = original.replace(
+      pathSegments: <String>[
+        ...original.pathSegments,
+        'flutter_infra_release',
+        'cipd',
+      ],
+    ).toString();
+    return cipdOverride;
+  }
+
   bool _hasWarnedAboutStorageOverride = false;
 
   void _maybeWarnAboutStorageOverride(String overrideUrl) {

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -198,7 +198,7 @@ class FlutterWebSdk extends CachedArtifact {
     }
 
     final String canvasKitVersion = cache.getVersionFor('canvaskit')!;
-    final String canvasKitUrl = '$_cipdBaseUrl/flutter/web/canvaskit_bundle/+/$canvasKitVersion';
+    final String canvasKitUrl = '${cache.cipdBaseUrl}/flutter/web/canvaskit_bundle/+/$canvasKitVersion';
     return artifactUpdater.downloadZipArchive(
       'Downloading CanvasKit...',
       Uri.parse(canvasKitUrl),
@@ -575,8 +575,6 @@ class GradleWrapper extends CachedArtifact {
   }
 }
 
-const String _cipdBaseUrl = 'https://chrome-infra-packages.appspot.com/dl';
-
 /// Common functionality for pulling Fuchsia SDKs.
 abstract class _FuchsiaSDKArtifacts extends CachedArtifact {
   _FuchsiaSDKArtifacts(Cache cache, String platform) :
@@ -593,7 +591,7 @@ abstract class _FuchsiaSDKArtifacts extends CachedArtifact {
   Directory get location => cache.getArtifactDirectory('fuchsia');
 
   Future<void> _doUpdate(ArtifactUpdater artifactUpdater) {
-    final String url = '$_cipdBaseUrl/$_path/+/$version';
+    final String url = '${cache.cipdBaseUrl}/$_path/+/$version';
     return artifactUpdater.downloadZipArchive('Downloading package fuchsia SDK...',
                                Uri.parse(url), location);
   }
@@ -627,7 +625,7 @@ class FlutterRunnerSDKArtifacts extends CachedArtifact {
     if (!_platform.isLinux && !_platform.isMacOS) {
       return;
     }
-    final String url = '$_cipdBaseUrl/flutter/fuchsia/+/git_revision:$version';
+    final String url = '${cache.cipdBaseUrl}/flutter/fuchsia/+/git_revision:$version';
     await artifactUpdater.downloadZipArchive('Downloading package flutter runner...', Uri.parse(url), location);
   }
 }
@@ -644,11 +642,13 @@ abstract class VersionedPackageResolver {
 
 /// Resolves the CIPD archive URL for a given package and version.
 class CipdArchiveResolver extends VersionedPackageResolver {
-  const CipdArchiveResolver();
+  const CipdArchiveResolver(this.cache);
+
+  final Cache cache;
 
   @override
   String resolveUrl(String packageName, String version) {
-    return '$_cipdBaseUrl/flutter/$packageName/+/git_revision:$version';
+    return '${cache.cipdBaseUrl}/flutter/$packageName/+/git_revision:$version';
   }
 }
 
@@ -656,9 +656,10 @@ class CipdArchiveResolver extends VersionedPackageResolver {
 class FlutterRunnerDebugSymbols extends CachedArtifact {
   FlutterRunnerDebugSymbols(Cache cache, {
     required Platform platform,
-    this.packageResolver = const CipdArchiveResolver(),
+    VersionedPackageResolver? packageResolver,
   }) : _platform = platform,
-      super('flutter_runner_debug_symbols', cache, DevelopmentArtifact.flutterRunner);
+       packageResolver = packageResolver ?? CipdArchiveResolver(cache),
+       super('flutter_runner_debug_symbols', cache, DevelopmentArtifact.flutterRunner);
 
   final VersionedPackageResolver packageResolver;
   final Platform _platform;


### PR DESCRIPTION
Allow customizing the base CIPD URL via `FLUTTER_STORAGE_BASE_URL` as follows:

- If `FLUTTER_STORAGE_BASE_URL` is not specified, use https://chrome-infra-packages.appspot.com/dl as the base CIPD URL.
- Otherwise, make the base CIPD URL `FLUTTER_STORAGE_BASE_URL/flutter_infra_release/cipd`

This way maintainers of Flutter SDK artifact mirrors can include some of the CIPD packages that are needed to build for some platforms. For example, this can be used to mirror the build of CanvasKit.

Fixes https://github.com/flutter/flutter/issues/92357