### PR TITLE
Mark fixed Mac_android tests unflaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2561,7 +2561,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_android android_semantics_integration_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/93253
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
@@ -2946,7 +2945,6 @@ targets:
     scheduler: luci
 
   - name: Mac_android run_release_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/91625
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
These tests are currently failing on the dashboard due to a mismatch of dimensions from .ci.yaml and tests running on staging (where flaky tests run): https://github.com/flutter/flutter/issues/94175

These tests have already been fixed and have not flaked in the last 50 runs.  Mark them as unflaky to work around the issue.
https://github.com/flutter/flutter/issues/93253
https://github.com/flutter/flutter/issues/91625
