### PR TITLE
[conductor] channel constants refactor

### DIFF
--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -12,12 +12,9 @@ const String gsutilBinary = 'gsutil.py';
 const String kFrameworkDefaultBranch = 'master';
 const String kForceFlag = 'force';
 
-const List<String> kReleaseChannels = <String>[
-  'stable',
-  'beta',
-  'dev',
-  FrameworkRepository.defaultBranch,
-];
+const List<String> kBaseReleaseChannels = <String>['stable', 'beta', 'dev'];
+
+List<String> kReleaseChannels = List<String>.from(kBaseReleaseChannels)..add(FrameworkRepository.defaultBranch);
 
 const String kReleaseDocumentationUrl = 'https://github.com/flutter/flutter/wiki/Flutter-Cherrypick-Process';
 

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -14,7 +14,7 @@ const String kForceFlag = 'force';
 
 const List<String> kBaseReleaseChannels = <String>['stable', 'beta', 'dev'];
 
-List<String> kReleaseChannels = List<String>.from(kBaseReleaseChannels)..add(FrameworkRepository.defaultBranch);
+const List<String> kReleaseChannels = <String>[...kBaseReleaseChannels, FrameworkRepository.defaultBranch];
 
 const List<String> KReleaseIncrements = <String>['y', 'z', 'm', 'n'];
 

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -16,6 +16,8 @@ const List<String> kBaseReleaseChannels = <String>['stable', 'beta', 'dev'];
 
 List<String> kReleaseChannels = List<String>.from(kBaseReleaseChannels)..add(FrameworkRepository.defaultBranch);
 
+const List<String> KReleaseIncrements = <String>['y', 'z', 'm', 'n'];
+
 const String kReleaseDocumentationUrl = 'https://github.com/flutter/flutter/wiki/Flutter-Cherrypick-Process';
 
 const String kLuciPackagingConsoleLink = 'https://ci.chromium.org/p/flutter/g/packaging/console';
@@ -77,9 +79,8 @@ String? getValueFromEnvOrArgs(
   if (allowNull) {
     return null;
   }
-  throw ConductorException(
-    'Expected either the CLI arg --$name or the environment variable $envName '
-    'to be provided!');
+  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
+      'to be provided!');
 }
 
 bool getBoolFromEnvOrArgs(
@@ -117,9 +118,8 @@ List<String> getValuesFromEnvOrArgs(
     return argValues;
   }
 
-  throw ConductorException(
-    'Expected either the CLI arg --$name or the environment variable $envName '
-    'to be provided!');
+  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
+      'to be provided!');
 }
 
 /// Translate CLI arg names to env variable names.

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -93,7 +93,7 @@ class StartCommand extends Command<void> {
       kIncrementOption,
       help: 'Specifies which part of the x.y.z version number to increment. Required.',
       valueHelp: 'level',
-      allowed: <String>['y', 'z', 'm', 'n'],
+      allowed: KReleaseIncrements,
       allowedHelp: <String, String>{
         'y': 'Indicates the first dev release after a beta release.',
         'z': 'Indicates a hotfix to a stable release.',

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -48,7 +48,7 @@ class StartCommand extends Command<void> {
     argParser.addOption(
       kReleaseOption,
       help: 'The target release channel for the release.',
-      allowed: <String>['stable', 'beta', 'dev'],
+      allowed: kBaseReleaseChannels,
     );
     argParser.addOption(
       kFrameworkUpstreamOption,

--- a/dev/conductor/core/lib/src/state.dart
+++ b/dev/conductor/core/lib/src/state.dart
@@ -15,7 +15,7 @@ const String kStateFileName = '.flutter_conductor_state.json';
 
 String luciConsoleLink(String channel, String groupName) {
   assert(
-    <String>['stable', 'beta', 'dev', 'master'].contains(channel),
+    kReleaseChannels.contains(channel),
     'channel $channel not recognized',
   );
   assert(

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import './globals.dart' show releaseCandidateBranchRegex, ConductorException;
+import './globals.dart' show ConductorException, KReleaseIncrements, releaseCandidateBranchRegex;
 
 /// Possible string formats that `flutter --version` can return.
 enum VersionType {
@@ -262,7 +262,7 @@ class Version {
   /// Will throw a [ConductorException] if the version is not possible given the
   /// [candidateBranch] and [incrementLetter].
   void ensureValid(String candidateBranch, String incrementLetter) {
-    if (!const <String>{'y', 'z', 'm', 'n'}.contains(incrementLetter)) {
+    if (!KReleaseIncrements.contains(incrementLetter)) {
       throw ConductorException('Invalid incrementLetter: $incrementLetter');
     }
     final RegExpMatch? branchMatch = releaseCandidateBranchRegex.firstMatch(candidateBranch);


### PR DESCRIPTION
Added a constant in globals for the release channels and release increments, and refactored the core to use the constants. In that case, the release dashboard and the core both use the same constants as the source of truth. In the future, when we decide to remove the `dev` channels, only that constant needs to be modified.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
