### PR TITLE
Ensure the engineLayer is disposed when an OpacityLayer is disabled

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1764,11 +1764,16 @@ class OpacityLayer extends OffsetLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(alpha != null);
-    bool enabled = firstChild != null;  // don't add this layer if there's no child
+
+    // Don't add this layer if there's no child.
+    bool enabled = firstChild != null;
     if (!enabled) {
+      // Ensure the engineLayer is disposed.
+      engineLayer = null;
       // TODO(dnfield): Remove this if/when we can fix https://github.com/flutter/flutter/issues/90004
       return;
     }
+
     assert(() {
       enabled = enabled && !debugDisableOpacityLayers;
       return true;

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -637,6 +637,21 @@ void main() {
     expect(builder.addedPicture, true);
     expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
   });
+
+  test('OpacityLayer dispose its engineLayer if there are no children', () {
+    final OpacityLayer layer = OpacityLayer(alpha: 128);
+    final FakeSceneBuilder builder = FakeSceneBuilder();
+    layer.addToScene(builder);
+    expect(layer.engineLayer, null);
+
+    layer.append(PictureLayer(Rect.largest)..picture = FakePicture());
+    layer.addToScene(builder);
+    expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
+
+    layer.removeAllChildren();
+    layer.addToScene(builder);
+    expect(layer.engineLayer, null);
+  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {


### PR DESCRIPTION
After #90017 the `addToScene` in `OpacityLayer` returns directly when there is no child in current layer. The corresponding `engineLayer` may not be disposed correctly, which causes an assertion failed in web engine (#92830).

This PR fixes issue #92830.

No tests are changed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.