### PR TITLE
Don't treat stderr output as failures during DAP test teardown

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
@@ -73,13 +73,16 @@ class OutOfProcessDapTestServer extends DapTestServer {
     Logger? logger,
   ) {
     // Treat anything written to stderr as the DAP crashing and fail the test
-    // unless it's "Waiting for another flutter command to release the startup lock".
+    // unless it's "Waiting for another flutter command to release the startup
+    // lock" or we're tearing down.
     _process.stderr
         .transform(utf8.decoder)
         .where((String error) => !error.contains('Waiting for another flutter command to release the startup lock'))
         .listen((String error) {
       logger?.call(error);
-      throw error;
+      if (!_isShuttingDown) {
+        throw error;
+      }
     });
     unawaited(_process.exitCode.then((int code) {
       final String message = 'Out-of-process DAP server terminated with code $code';


### PR DESCRIPTION
I think this should fix #94030.

We usually throw (to fail tests) if there is output to stderr process or a non-zero exit code during a test run. However when we're running teardown code we generally don't want this (tests aren't guaranteed to leave things cleanly, they just finish when their expectations are met and allow the teardown code to terminate the process). There was code to allow non-zero exit codes during shutdown, but not stderr output.