### PR TITLE
Revert "Marks Linux_android image_list_jit_reported_duration to be flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1714,7 +1714,6 @@ targets:
     scheduler: luci
 
   - name: Linux_android image_list_jit_reported_duration
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/93804
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Reverts flutter/flutter#93805. Based on [how flaky this has been recently](https://github.com/flutter/flutter/issues/93804#issuecomment-981772318).

Fixes https://github.com/flutter/flutter/issues/93804