### PR TITLE
Newly constructed tweens should have same begin and end

### DIFF
--- a/packages/flutter/lib/src/widgets/implicit_animations.dart
+++ b/packages/flutter/lib/src/widgets/implicit_animations.dart
@@ -430,6 +430,8 @@ abstract class ImplicitlyAnimatedWidgetState<T extends ImplicitlyAnimatedWidget>
         tween ??= constructor(targetValue);
         if (_shouldAnimateTween(tween, targetValue))
           shouldStartAnimation = true;
+        else
+          tween.end ??= tween.begin;
       } else {
         tween = null;
       }

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -85,7 +85,7 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
-    
+
     await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
@@ -627,7 +627,7 @@ void main() {
   });
 }
 
-Future<void> tapTest2and3(WidgetTester tester, Finder widgetFinder, 
+Future<void> tapTest2and3(WidgetTester tester, Finder widgetFinder,
     MockOnEndFunction mockOnEndFunction) async {
   await tester.tap(widgetFinder);
 

--- a/packages/flutter/test/widgets/implicit_animations_test.dart
+++ b/packages/flutter/test/widgets/implicit_animations_test.dart
@@ -85,6 +85,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+    
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedPadding onEnd callback test', (WidgetTester tester) async {
@@ -106,6 +108,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedAlign onEnd callback test', (WidgetTester tester) async {
@@ -127,6 +131,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedPositioned onEnd callback test', (WidgetTester tester) async {
@@ -148,6 +154,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedPositionedDirectional onEnd callback test', (WidgetTester tester) async {
@@ -169,6 +177,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
    testWidgets('AnimatedSlide onEnd callback test', (WidgetTester tester) async {
@@ -189,6 +199,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedSlide transition test', (WidgetTester tester) async {
@@ -247,6 +259,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedScale transition test', (WidgetTester tester) async {
@@ -305,6 +319,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedRotation transition test', (WidgetTester tester) async {
@@ -363,6 +379,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedOpacity transition test', (WidgetTester tester) async {
@@ -421,6 +439,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('SliverAnimatedOpacity transition test', (WidgetTester tester) async {
@@ -480,6 +500,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedPhysicalModel onEnd callback test', (WidgetTester tester) async {
@@ -501,6 +523,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('TweenAnimationBuilder onEnd callback test', (WidgetTester tester) async {
@@ -522,6 +546,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('AnimatedTheme onEnd callback test', (WidgetTester tester) async {
@@ -543,6 +569,8 @@ void main() {
     expect(mockOnEndFunction.called, 0);
     await tester.pump(additionalDelay);
     expect(mockOnEndFunction.called, 1);
+
+    await tapTest2and3(tester, widgetFinder, mockOnEndFunction);
   });
 
   testWidgets('Ensure CurvedAnimations are disposed on widget change',
@@ -597,6 +625,21 @@ void main() {
 
     expect(secondCurvedAnimation.isDisposed, isTrue);
   });
+}
+
+Future<void> tapTest2and3(WidgetTester tester, Finder widgetFinder, 
+    MockOnEndFunction mockOnEndFunction) async {
+  await tester.tap(widgetFinder);
+
+  await tester.pump();
+  await tester.pump(animationDuration + additionalDelay);
+  expect(mockOnEndFunction.called, 2);
+
+  await tester.tap(widgetFinder);
+
+  await tester.pump();
+  await tester.pump(animationDuration + additionalDelay);
+  expect(mockOnEndFunction.called, 3);
 }
 
 Widget wrap({required Widget child}) {
@@ -664,6 +707,7 @@ class _TestAnimatedContainerWidgetState extends _TestAnimatedWidgetState {
       duration: duration,
       onEnd: widget.callback,
       width: toggle ? 10 : 20,
+      foregroundDecoration: toggle ? const BoxDecoration() : null,
       child: child,
     );
   }
@@ -835,7 +879,7 @@ class _TestTweenAnimationBuilderWidgetState extends _TestAnimatedWidgetState {
   @override
   Widget getAnimatedWidget() {
     return TweenAnimationBuilder<double>(
-      tween: Tween<double>(begin: 1, end: 2),
+      tween: toggle ? Tween<double>(begin: 1, end: 2) : Tween<double>(begin: 2, end: 1),
       duration: duration,
       onEnd: widget.callback,
       child: child,


### PR DESCRIPTION
FIxes a bug where when a tween is constructed (was null before), after the implicit animated widget has animated at least once, the newly constructed tween has `end = null`. The widget is not animated, as the tween has just been constructed  ([`shouldAnimate = targetValue != (tween.end ?? tween.begin)`](https://github.com/flutter/flutter/blob/c701126481dcbe62eb06b558f5b1951ae8e8e89c/packages/flutter/lib/src/widgets/implicit_animations.dart#L414)) and hence not updated. But the `animation.value` is 1.0 (as it has been animated once before). So, when this tween is evaluated against `animation.value`, it throws an error.

The fix is to set the `tween.end` of every newly constructed tween to `tween.begin`.

fixes #84258

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
