### PR TITLE
Add failing test to close the tree for #94356

### DIFF
--- a/packages/flutter_tools/test/general.shard/failing_test.dart
+++ b/packages/flutter_tools/test/general.shard/failing_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../src/common.dart';
+
+// This is a test that we can use to close the tree until
+// https://github.com/flutter/flutter/issues/74529 is addressed.
+
+void main() {
+  test('Fail unconditionally', () { // ignore: void_checks
+    fail('Failing to close the tree for https://github.com/flutter/flutter/issues/94356');
+  }); // Skip this test to re-open the tree.
+}


### PR DESCRIPTION
Closes the tree for https://github.com/flutter/flutter/issues/94356

Instead of closing the tree by failing a devicelab test, which breaks Dart benchmarks (https://github.com/flutter/flutter/pull/88532#issuecomment-902797273), this PR adds a tool unit test that fails unconditionally. To re-open the tree, we can skip the test. When https://github.com/flutter/flutter/issues/74529 is resolved, we can delete this.