### PR TITLE
[ci.yaml] Update ios_32 host to monterey

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -130,7 +130,7 @@ platform_properties:
           {"dependency": "gems"},
           {"dependency": "ios_signing"}
         ]
-      os: Mac-10.15
+      os: Mac-12.0
       device_os: iOS-9.3.6
       xcode: 12c33
   windows:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94351

[Example failing task](https://chromium-swarm.appspot.com/task?d=true&id=57865a66673cc110&w=true) - Looks for host Mac OS 10.15

Whereas the [bot page](https://chromium-swarm.appspot.com/bot?id=flutter-devicelab-mac-11) shows it is on MacOS 12

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

