### PR TITLE
Detect additional ARM ffi CocoaPods error

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -360,8 +360,7 @@ class CocoaPods {
         '  pod repo update\n',
         emphasis: true,
       );
-    } else if (stdout.contains('Init_ffi_c') &&
-        stdout.contains('symbol not found') &&
+    } else if (stdout.contains('ffi_c.bundle') && stdout.contains('LoadError') &&
         _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
       // https://github.com/flutter/flutter/issues/70796
       UsageEvent(

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -491,46 +491,52 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       );
     });
 
-    testUsingContext('ffi failure on ARM macOS prompts gem install', () async {
-      final FlutterProject projectUnderTest = setupProjectUnderTest();
-      pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
-      fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
-        ..createSync()
-        ..writeAsStringSync('Existing Podfile');
+    final Map<String, String> possibleErrors = <String, String>{
+      'symbol not found': 'LoadError - dlsym(0x7fbbeb6837d0, Init_ffi_c): symbol not found - /Library/Ruby/Gems/2.6.0/gems/ffi-1.13.1/lib/ffi_c.bundle',
+      'incompatible architecture': "LoadError - (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/usr/lib/ffi_c.bundle' (no such file) - /Library/Ruby/Gems/2.6.0/gems/ffi-1.15.4/lib/ffi_c.bundle",
+    };
+    possibleErrors.forEach((String errorName, String cocoaPodsError) {
+      testUsingContext('ffi $errorName failure on ARM macOS prompts gem install', () async {
+        final FlutterProject projectUnderTest = setupProjectUnderTest();
+        pretendPodIsInstalled();
+        pretendPodVersionIs('1.10.0');
+        fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
+          ..createSync()
+          ..writeAsStringSync('Existing Podfile');
 
-      fakeProcessManager.addCommands(<FakeCommand>[
-        const FakeCommand(
-          command: <String>['pod', 'install', '--verbose'],
-          workingDirectory: 'project/ios',
-          environment: <String, String>{
-            'COCOAPODS_DISABLE_STATS': 'true',
-            'LANG': 'en_US.UTF-8',
-          },
-          exitCode: 1,
-          stdout: 'LoadError - dlsym(0x7fbbeb6837d0, Init_ffi_c): symbol not found - /Library/Ruby/Gems/2.6.0/gems/ffi-1.13.1/lib/ffi_c.bundle',
-        ),
-        const FakeCommand(
-          command: <String>['which', 'sysctl'],
-        ),
-        const FakeCommand(
-          command: <String>['sysctl', 'hw.optional.arm64'],
-          stdout: 'hw.optional.arm64: 1',
-        ),
-      ]);
+        fakeProcessManager.addCommands(<FakeCommand>[
+          FakeCommand(
+            command: const <String>['pod', 'install', '--verbose'],
+            workingDirectory: 'project/ios',
+            environment: const <String, String>{
+              'COCOAPODS_DISABLE_STATS': 'true',
+              'LANG': 'en_US.UTF-8',
+            },
+            exitCode: 1,
+            stdout: cocoaPodsError,
+          ),
+          const FakeCommand(
+            command: <String>['which', 'sysctl'],
+          ),
+          const FakeCommand(
+            command: <String>['sysctl', 'hw.optional.arm64'],
+            stdout: 'hw.optional.arm64: 1',
+          ),
+        ]);
 
-      await expectToolExitLater(
-        cocoaPodsUnderTest.processPods(
-          xcodeProject: projectUnderTest.ios,
-          buildMode: BuildMode.debug,
-        ),
-        equals('Error running pod install'),
-      );
-      expect(
-        logger.errorText,
-        contains('set up CocoaPods for ARM macOS'),
-      );
-      expect(usage.events, contains(const TestUsageEvent('pod-install-failure', 'arm-ffi')));
+        await expectToolExitLater(
+          cocoaPodsUnderTest.processPods(
+            xcodeProject: projectUnderTest.ios,
+            buildMode: BuildMode.debug,
+          ),
+          equals('Error running pod install'),
+        );
+        expect(
+          logger.errorText,
+          contains('set up CocoaPods for ARM macOS'),
+        );
+        expect(usage.events, contains(const TestUsageEvent('pod-install-failure', 'arm-ffi')));
+      });
     });
 
     testUsingContext('ffi failure on x86 macOS does not prompt gem install', () async {


### PR DESCRIPTION
CocoaPods crashes on ARM Macs if the x86 version of the `ffi` gem isn't installed.

https://github.com/flutter/flutter/pull/70801 detected one crash, but there have been additional crash messages reported.  Parse `LoadError` and the file in question `ffi_c.bundle` so users get a prompt in both cases about how to fix it (with `sudo` so we can't just do it ourselves)

Fixes https://github.com/flutter/flutter/issues/93908.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
