### PR TITLE
Add estimateChildHeight for calculate  maxScrollExtent when sliver_list not in viewport at first.

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_list.dart
@@ -45,6 +45,21 @@ class RenderSliverList extends RenderSliverMultiBoxAdaptor {
   @override
   void performLayout() {
     final SliverConstraints constraints = this.constraints;
+    if ((constraints.remainingCacheExtent + constraints.remainingPaintExtent) <= 0.01 && childManager.estimateChildHeight != null) {
+      childManager.didStartLayout();
+      childManager.setDidUnderflow(false);
+      geometry = SliverGeometry(
+        maxPaintExtent: childManager.estimateMaxScrollOffset(
+          this.constraints,
+          firstIndex: 0,
+          lastIndex: 0,
+          trailingScrollOffset: childManager.estimateChildHeight,
+          leadingScrollOffset: 0,
+        ),
+      );
+      childManager.didFinishLayout();
+      return;
+    }
     childManager.didStartLayout();
     childManager.setDidUnderflow(false);
 

--- a/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
+++ b/packages/flutter/lib/src/rendering/sliver_multi_box_adaptor.dart
@@ -79,6 +79,9 @@ abstract class RenderSliverBoxChildManager {
   /// list).
   int get childCount;
 
+  /// Called to a estimate hight of the child.
+  double? get estimateChildHeight => null;
+  
   /// Called during [RenderSliverMultiBoxAdaptor.adoptChild] or
   /// [RenderSliverMultiBoxAdaptor.move].
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -146,6 +146,12 @@ abstract class SliverChildDelegate {
   /// used to implement [RenderSliverBoxChildManager.childCount].
   int? get estimatedChildCount => null;
 
+  /// Returns an estimate of the height extent for single child
+  /// 
+  /// The default implementation returns null, not use estimateChildHeight for 
+  /// their max scroll extent.
+  double? get estimateChildHeight => null;
+
   /// Returns an estimate of the max scroll extent for all the children.
   ///
   /// Subclasses should override this function if they have additional
@@ -347,11 +353,13 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
     this.addSemanticIndexes = true,
     this.semanticIndexCallback = _kDefaultSemanticIndexCallback,
     this.semanticIndexOffset = 0,
+    double? estimateChildHeight,
   }) : assert(builder != null),
        assert(addAutomaticKeepAlives != null),
        assert(addRepaintBoundaries != null),
        assert(addSemanticIndexes != null),
-       assert(semanticIndexCallback != null);
+       assert(semanticIndexCallback != null),
+       _estimateChildHeight = estimateChildHeight;
 
   /// Called to build children for the sliver.
   ///
@@ -370,6 +378,12 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
   /// If null, the number of children is determined by the least index for which
   /// [builder] returns null.
   final int? childCount;
+
+  /// The estimate height of child.
+  final double? _estimateChildHeight;
+
+  @override
+  double? get estimateChildHeight => _estimateChildHeight;
 
   /// Whether to wrap each child in an [AutomaticKeepAlive].
   ///
@@ -1329,6 +1343,10 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   ///
   ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
   int? get estimatedChildCount => widget.delegate.estimatedChildCount;
+
+  /// use [estimateChildHeight] if sliver not in paint offset for child height .
+  @override
+  double? get estimateChildHeight => widget.delegate.estimateChildHeight;
 
   @override
   int get childCount {


### PR DESCRIPTION
Partial fix 
https://github.com/flutter/flutter/issues/92276

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
