### PR TITLE
Opacity Peephole optimization benchmarks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1865,7 +1865,7 @@ targets:
 
   - name: Linux_android opacity_peephole_one_rect_perf__e2e_summary
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    presubmit: false
     timeout: 60
     properties:
       tags: >
@@ -1875,7 +1875,7 @@ targets:
 
   - name: Linux_android opacity_peephole_col_of_rows_perf__e2e_summary
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    presubmit: false
     timeout: 60
     properties:
       tags: >
@@ -1885,7 +1885,7 @@ targets:
 
   - name: Linux_android opacity_peephole_opacity_of_grid_perf__e2e_summary
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    presubmit: false
     timeout: 60
     properties:
       tags: >
@@ -1895,7 +1895,7 @@ targets:
 
   - name: Linux_android opacity_peephole_grid_of_opacity_perf__e2e_summary
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    presubmit: false
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1863,6 +1863,46 @@ targets:
     timeout: 60
     scheduler: luci
 
+  - name: Linux_android opacity_peephole_one_rect_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: opacity_peephole_one_rect_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android opacity_peephole_col_of_rows_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: opacity_peephole_col_of_rows_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android opacity_peephole_opacity_of_grid_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: opacity_peephole_opacity_of_grid_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android opacity_peephole_grid_of_opacity_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: opacity_peephole_grid_of_opacity_perf__e2e_summary
+    scheduler: luci
+
   - name: Mac build_aar_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1903,6 +1903,16 @@ targets:
       task_name: opacity_peephole_grid_of_opacity_perf__e2e_summary
     scheduler: luci
 
+  - name: Linux_android opacity_peephole_fade_transition_text_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: opacity_peephole_fade_transition_text_perf__e2e_summary
+    scheduler: luci
+
   - name: Mac build_aar_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -65,6 +65,7 @@
 /dev/devicelab/bin/tasks/opacity_peephole_grid_of_opacity_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/opacity_peephole_one_rect_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/opacity_peephole_opacity_of_grid_perf__e2e_summary.dart @flar @flutter/engine
+/dev/devicelab/bin/tasks/opacity_peephole_fade_transition_text_perf__e2e_summary.dart @flar @flutter/engine
 
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -61,6 +61,10 @@
 /dev/devicelab/bin/tasks/routing_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/web_size__compile_test.dart @yjbanov @flutter/web
+/dev/devicelab/bin/tasks/opacity_peephole_col_of_rows_perf__e2e_summary.dart @flar @flutter/engine
+/dev/devicelab/bin/tasks/opacity_peephole_grid_of_opacity_perf__e2e_summary.dart @flar @flutter/engine
+/dev/devicelab/bin/tasks/opacity_peephole_one_rect_perf__e2e_summary.dart @flar @flutter/engine
+/dev/devicelab/bin/tasks/opacity_peephole_opacity_of_grid_perf__e2e_summary.dart @flar @flutter/engine
 
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -31,6 +31,7 @@ const String kOpacityPeepholeOpacityOfColumnRouteName = '$kOpacityPeepholeRouteN
 const String kOpacityPeepholeGridOfOpacityRouteName = '$kOpacityPeepholeRouteName/grid_of_opacity';
 const String kOpacityPeepholeOpacityOfGridRouteName = '$kOpacityPeepholeRouteName/opacity_of_grid';
 const String kOpacityPeepholeOpacityOfColOfRowsRouteName = '$kOpacityPeepholeRouteName/opacity_of_col_of_rows';
+const String kOpacityPeepholeFadeTransitionTextRouteName = '$kOpacityPeepholeRouteName/fade_transition_text';
 
 const String kScrollableName = '/macrobenchmark_listview';
 

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -22,6 +22,15 @@ const String kSimpleScrollRouteName = '/simple_scroll';
 const String kStackSizeRouteName = '/stack_size';
 const String kAnimationWithMicrotasksRouteName = '/animation_with_microtasks';
 const String kAnimatedImageRouteName = '/animated_image';
+const String kOpacityPeepholeRouteName = '/opacity_peephole';
+
+const String kOpacityPeepholeOneRectRouteName = '$kOpacityPeepholeRouteName/one_big_rect';
+const String kOpacityPeepholeColumnOfOpacityRouteName = '$kOpacityPeepholeRouteName/column_of_opacity';
+const String kOpacityPeepholeOpacityOfCachedChildRouteName = '$kOpacityPeepholeRouteName/opacity_of_cached_child';
+const String kOpacityPeepholeOpacityOfColumnRouteName = '$kOpacityPeepholeRouteName/opacity_of_column';
+const String kOpacityPeepholeGridOfOpacityRouteName = '$kOpacityPeepholeRouteName/grid_of_opacity';
+const String kOpacityPeepholeOpacityOfGridRouteName = '$kOpacityPeepholeRouteName/opacity_of_grid';
+const String kOpacityPeepholeOpacityOfColOfRowsRouteName = '$kOpacityPeepholeRouteName/opacity_of_col_of_rows';
 
 const String kScrollableName = '/macrobenchmark_listview';
 

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -19,6 +19,7 @@ import 'src/heavy_grid_view.dart';
 import 'src/large_image_changer.dart';
 import 'src/large_images.dart';
 import 'src/multi_widget_construction.dart';
+import 'src/opacity_peephole.dart';
 import 'src/picture_cache.dart';
 import 'src/post_backdrop_filter.dart';
 import 'src/simple_animation.dart';
@@ -60,6 +61,8 @@ class MacrobenchmarksApp extends StatelessWidget {
         kStackSizeRouteName: (BuildContext context) => const StackSizePage(),
         kAnimationWithMicrotasksRouteName: (BuildContext context) => const AnimationWithMicrotasks(),
         kAnimatedImageRouteName: (BuildContext context) => const AnimatedImagePage(),
+        kOpacityPeepholeRouteName: (BuildContext context) => const OpacityPeepholePage(),
+        ...opacityPeepholeRoutes,
       },
     );
   }
@@ -208,6 +211,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Animated Image'),
             onPressed: () {
               Navigator.pushNamed(context, kAnimatedImageRouteName);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kOpacityPeepholeRouteName),
+            child: const Text('Opacity Peephole tests'),
+            onPressed: () {
+              Navigator.pushNamed(context, kOpacityPeepholeRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/opacity_peephole.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/opacity_peephole.dart
@@ -1,0 +1,303 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '../common.dart';
+
+// Various tests to verify that the Opacity layer propagates the opacity to various
+// combinations of children that can apply it themselves.
+// See https://github.com/flutter/flutter/issues/75697
+class OpacityPeepholePage extends StatelessWidget {
+  const OpacityPeepholePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Opacity Peephole tests')),
+      body: ListView(
+        key: const Key('${kOpacityPeepholeRouteName}_listview'),
+        children: <Widget>[
+          for (OpacityPeepholeCase variant in allOpacityPeepholeCases)
+            ElevatedButton(
+              key: Key(variant.route),
+              child: Text(variant.name),
+              onPressed: () {
+                Navigator.pushNamed(context, variant.route);
+              },
+            )
+        ],
+      ),
+    );
+  }
+}
+
+typedef TestBuilder = Widget Function(double v);
+
+double _opacity(double v) => v * 0.5 + 0.25;
+int _red(double v) => (v * 255).round();
+int _green(double v) => _red(1 - v);
+int _blue(double v) => 0;
+
+class OpacityPeepholeCase {
+  OpacityPeepholeCase({required this.route, required this.name, required this.builder});
+
+  final String route;
+  final String name;
+  final TestBuilder builder;
+
+  Widget build(BuildContext context) {
+    return VariantPage(variant: this);
+  }
+}
+
+List<OpacityPeepholeCase> allOpacityPeepholeCases = <OpacityPeepholeCase>[
+  // Tests that Opacity can hand down value to a simple child
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeOneRectRouteName,
+    name: 'One Big Rectangle',
+    builder: (double v) => Opacity(
+      opacity: _opacity(v),
+      child: Container(
+        width: 300,
+        height: 400,
+        color: Color.fromARGB(255, _red(v), _green(v), _blue(v)),
+      ),
+    ),
+  ),
+  // Tests that a column of Opacity widgets can individually hand their values down to simple children
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeColumnOfOpacityRouteName,
+    name: 'Column of Opacity',
+    builder: (double v) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          for (int i = 0; i < 10; i++, v = 1 - v)
+            Opacity(
+              opacity: _opacity(v),
+              child: Padding(
+                padding: const EdgeInsets.all(5),
+                child: Container(
+                  width: 300,
+                  height: 30,
+                  color: Color.fromARGB(255, _red(v), _green(v), _blue(v)),
+                ),
+              ),
+            ),
+        ],
+      );
+    },
+  ),
+  // Tests that an Opacity can hand value down to a cached child
+  OpacityPeepholeCase(
+      route: kOpacityPeepholeOpacityOfCachedChildRouteName,
+      name: 'Opacity of Cached Child',
+      builder: (double v) {
+        // ChildV starts as a constant so the same color pattern always appears and the child will be cached
+        double childV = 0;
+        return Opacity(
+          opacity: _opacity(v),
+          child: RepaintBoundary(
+            child: SizedBox(
+              width: 300,
+              height: 400,
+              child: Stack(
+                children: <Widget>[
+                  for (double i = 0; i < 100; i += 10, childV = 1 - childV)
+                    Positioned.fromRelativeRect(
+                      rect: RelativeRect.fromLTRB(i, i, i, i),
+                      child: Container(
+                        color: Color.fromARGB(255, _red(childV), _green(childV), _blue(childV)),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        );
+      }
+  ),
+  // Tests that an Opacity can hand a value down to a Column of simple non-overlapping children
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeOpacityOfColumnRouteName,
+    name: 'Opacity of Column',
+    builder: (double v) {
+      return Opacity(
+        opacity: _opacity(v),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            for (int i = 0; i < 10; i++, v = 1 - v)
+              Padding(
+                padding: const EdgeInsets.all(5),
+                // RepaintBoundary here to avoid combining children into 1 big Picture
+                child: RepaintBoundary(
+                  child: Container(
+                    width: 300,
+                    height: 30,
+                    color: Color.fromARGB(255, _red(v), _green(v), _blue(v)),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      );
+    },
+  ),
+  // Tests that an entire grid of Opacity objects can hand their values down to their simple children
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeGridOfOpacityRouteName,
+    name: 'Grid of Opacity',
+    builder: (double v) {
+      double rowV = v;
+      double colV = v;
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          for (int i = 0; i < 10; i++, rowV = 1 - rowV, colV = rowV)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                for (int j = 0; j < 7; j++, colV = 1 - colV)
+                  Opacity(
+                    opacity: _opacity(colV),
+                    child: Padding(
+                      padding: const EdgeInsets.all(5),
+                      child: Container(
+                        width: 30,
+                        height: 30,
+                        color: Color.fromARGB(255, _red(colV), _green(colV), _blue(colV)),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+        ],
+      );
+    },
+  ),
+  // tests if an Opacity can hand its value down to a 2D grid of simple non-overlapping children.
+  // The success of this case would depend on the sophistication of the non-overlapping tests.
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeOpacityOfGridRouteName,
+    name: 'Opacity of Grid',
+    builder: (double v) {
+      double rowV = v;
+      double colV = v;
+      return Opacity(
+        opacity: _opacity(v),
+        child: SizedBox(
+          width: 300,
+          height: 400,
+          child: Stack(
+            children: <Widget>[
+              for (int i = 0; i < 10; i++, rowV = 1 - rowV, colV = rowV)
+                for (int j = 0; j < 7; j++, colV = 1 - colV)
+                  Positioned.fromRect(
+                    rect: Rect.fromLTWH(j * 40 + 5, i * 40 + 5, 30, 30),
+                    // RepaintBoundary here to avoid combining the 70 children into a single Picture
+                    child: RepaintBoundary(
+                      child: Container(
+                        color: Color.fromARGB(255, _red(colV), _green(colV), _blue(colV)),
+                      ),
+                    ),
+                  ),
+            ],
+          ),
+        ),
+      );
+    },
+  ),
+  // tests if an Opacity can hand its value down to a Column of non-overlapping rows of non-overlapping simple children.
+  // This test only requires linear non-overlapping tests to succeed.
+  OpacityPeepholeCase(
+    route: kOpacityPeepholeOpacityOfColOfRowsRouteName,
+    name: 'Opacity of Column of Rows',
+    builder: (double v) {
+      double rowV = v;
+      double colV = v;
+      return Opacity(
+        opacity: _opacity(v),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            for (int i = 0; i < 10; i++, rowV = 1 - rowV, colV = rowV)
+              Padding(
+                padding: const EdgeInsets.only(top: 5, bottom: 5),
+                // RepaintBoundary here to separate each row into a separate layer child
+                child: RepaintBoundary(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      for (int j = 0; j < 7; j++, colV = 1 - colV)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 5, right: 5),
+                          // RepaintBoundary here to prevent the row children combining into a single Picture
+                          child: RepaintBoundary(
+                            child: Container(
+                              width: 30,
+                              height: 30,
+                              color: Color.fromARGB(255, _red(colV), _green(colV), _blue(colV)),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ),
+      );
+    },
+  ),
+];
+
+Map<String, WidgetBuilder> opacityPeepholeRoutes = <String, WidgetBuilder>{
+  for (OpacityPeepholeCase variant in allOpacityPeepholeCases)
+    variant.route: variant.build,
+};
+
+class VariantPage extends StatefulWidget {
+  const VariantPage({Key? key, required this.variant}) : super(key: key);
+
+  final OpacityPeepholeCase variant;
+
+  @override
+  State<VariantPage> createState() => VariantPageState();
+}
+
+class VariantPageState extends State<VariantPage> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 4));
+    _controller.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.variant.name),
+      ),
+      body: Center(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (BuildContext context, Widget? child) => widget.variant.builder(_controller.value),
+        ),
+      ),
+    );
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_col_of_rows_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_col_of_rows_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'opacity_peephole_col_of_rows_perf',
+    kOpacityPeepholeOpacityOfColOfRowsRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_fade_transition_text_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_fade_transition_text_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'opacity_peephole_fade_transition_text_perf',
+    kOpacityPeepholeFadeTransitionTextRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_grid_of_opacity_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_grid_of_opacity_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'opacity_peephole_grid_of_opacity_perf',
+    kOpacityPeepholeGridOfOpacityRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_one_rect_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_one_rect_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'opacity_peephole_one_rect_perf',
+    kOpacityPeepholeOneRectRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_opacity_of_grid_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_opacity_of_grid_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'opacity_peephole_opacity_of_grid_perf',
+    kOpacityPeepholeOpacityOfGridRouteName,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:macrobenchmarks/common.dart';
 import 'package:macrobenchmarks/main.dart' as app;
 
 typedef ControlCallback = Future<void> Function(WidgetController controller);
@@ -34,17 +33,21 @@ void macroPerfTestE2E(
     // See: https://github.com/flutter/flutter/issues/19434
     await tester.binding.delayed(const Duration(microseconds: 250));
 
-    final Finder scrollable =
-        find.byKey(const ValueKey<String>(kScrollableName));
-    expect(scrollable, findsOneWidget);
-    final Finder button =
-        find.byKey(ValueKey<String>(routeName), skipOffstage: false);
-    await tester.scrollUntilVisible(button, 50);
-    expect(button, findsOneWidget);
-    await tester.pumpAndSettle();
-    await tester.tap(button);
-    // Cannot be pumpAndSettle because some tests have infinite animation.
-    await tester.pump(const Duration(milliseconds: 20));
+    expect(routeName, startsWith('/'));
+    int i = 0;
+    while (i < routeName.length) {
+      i = routeName.indexOf('/', i + 1);
+      if (i < 0) {
+        i = routeName.length;
+      }
+      final Finder button = find.byKey(ValueKey<String>(routeName.substring(0, i)), skipOffstage: false);
+      await tester.scrollUntilVisible(button, 50);
+      expect(button, findsOneWidget);
+      await tester.pumpAndSettle();
+      await tester.tap(button);
+      // Cannot be pumpAndSettle because some tests have infinite animation.
+      await tester.pump(const Duration(milliseconds: 20));
+    }
 
     if (pageDelay != null) {
       // Wait for the page to load

--- a/dev/devicelab/bin/tasks/opacity_peephole_col_of_rows_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/opacity_peephole_col_of_rows_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createOpacityPeepholeColOfRowsPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/opacity_peephole_fade_transition_text_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/opacity_peephole_fade_transition_text_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createOpacityPeepholeFadeTransitionTextPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/opacity_peephole_grid_of_opacity_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/opacity_peephole_grid_of_opacity_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createOpacityPeepholeGridOfOpacityPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/opacity_peephole_one_rect_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/opacity_peephole_one_rect_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createOpacityPeepholeOneRectPerfE2ETest());
+}

--- a/dev/devicelab/bin/tasks/opacity_peephole_opacity_of_grid_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/opacity_peephole_opacity_of_grid_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createOpacityPeepholeOpacityOfGridPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -512,6 +512,13 @@ TaskFunction createOpacityPeepholeGridOfOpacityPerfE2ETest() {
   ).run;
 }
 
+TaskFunction createOpacityPeepholeFadeTransitionTextPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/opacity_peephole_fade_transition_text_perf_e2e.dart',
+  ).run;
+}
+
 Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations) {
   final Map<String, dynamic> tally = <String, dynamic>{};
   for (final Map<String, dynamic> item in results) {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -484,6 +484,34 @@ TaskFunction createFramePolicyIntegrationTest() {
   };
 }
 
+TaskFunction createOpacityPeepholeOneRectPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/opacity_peephole_one_rect_perf_e2e.dart',
+  ).run;
+}
+
+TaskFunction createOpacityPeepholeColOfRowsPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/opacity_peephole_col_of_rows_perf_e2e.dart',
+  ).run;
+}
+
+TaskFunction createOpacityPeepholeOpacityOfGridPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/opacity_peephole_opacity_of_grid_perf_e2e.dart',
+  ).run;
+}
+
+TaskFunction createOpacityPeepholeGridOfOpacityPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/opacity_peephole_grid_of_opacity_perf_e2e.dart',
+  ).run;
+}
+
 Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations) {
   final Map<String, dynamic> tally = <String, dynamic>{};
   for (final Map<String, dynamic> item in results) {


### PR DESCRIPTION
This PR enables 5 of the benchmarks I wrote to test various combinations of layers and the new peephole optimizations being enabled in the engine. The goal is to get these benchmarks running in the post-submit stages before the engine commits are merged so that we have a baseline to see the effect of the optimization.

Please look at the `List<>` of benchmarks mentioned in https://github.com/flutter/flutter/pull/94447#discussion_r759850604 to see which benchmarks are available and to suggest more benchmarks or a change in the variants that were chosen to be run as post-submit tasks.

Here is a chart comparing the performance with and without the current optimizations in https://github.com/flutter/engine/pull/29775. The differences are mainly in the memory saved, though one of the tests does show a large improvement in the raster time (this is the test with 70 opacity layers each with a simple child to optimize so it represents 70x the savings of one opacity layer).

Note that on one of the benchmarks "opacity of grid" the numbers are essentially the same with and without the optimization because we don't yet have a sophisticated RTree implementation that can detect the non-overlapping status of a grid of layers. Also, the one bar that goes all the way to 30 is actually representing the number "140", but I cut off the range so that the rest of the bars in the graph wouldn't be too tiny to gauge. Just suffice it to say that that bar should extend off the graph and a few feet to the right...

![Opacity Peephole optimization impact (1)](https://user-images.githubusercontent.com/50503328/144195965-f35dc5b7-d07c-423e-8be6-e14758560635.png)
