### PR TITLE
Fix `DataTable` `_SortArrow` changing orientation when state is updated

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1142,6 +1142,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
   @override
   void initState() {
     super.initState();
+    _up = widget.up;
     _opacityAnimation = CurvedAnimation(
       parent: _opacityController = AnimationController(
         duration: widget.duration,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1194,7 +1194,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
         _opacityController.reverse();
       }
     }
-    if ((_up != newUp) && !skipArrow) {
+    if ((_up != null) && (_up != newUp) && !skipArrow) {
       if (_orientationController.status == AnimationStatus.dismissed) {
         _orientationController.forward();
       } else {

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1195,7 +1195,7 @@ class _SortArrowState extends State<_SortArrow> with TickerProviderStateMixin {
         _opacityController.reverse();
       }
     }
-    if ((_up != null) && (_up != newUp) && !skipArrow) {
+    if ((_up != newUp) && !skipArrow) {
       if (_orientationController.status == AnimationStatus.dismissed) {
         _orientationController.forward();
       } else {

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -486,6 +486,55 @@ void main() {
     );
   });
 
+  testWidgets('DataTable sort indicator orientation - does not change on state update', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/43724
+    Widget buildTable({String title = 'Name1'}) {
+      return DataTable(
+        sortColumnIndex: 0,
+        sortAscending: true,
+        columns: <DataColumn>[
+          DataColumn(
+            label: Text(title),
+            tooltip: 'Name',
+            onSort: (int columnIndex, bool ascending) {},
+          ),
+        ],
+        rows: kDesserts.map<DataRow>((Dessert dessert) {
+          return DataRow(
+            cells: <DataCell>[
+              DataCell(
+                Text(dessert.name),
+              ),
+            ],
+          );
+        }).toList(),
+      );
+    }
+
+    // Check for ascending list
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable()),
+    ));
+    // The `tester.widget` ensures that there is exactly one upward arrow.
+    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    expect(
+      transformOfArrow.transform.getRotation(),
+      equals(Matrix3.identity()),
+    );
+
+    // Cause a rebuild by updating the widget
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable(title: 'Name2')),
+    ));
+    await tester.pumpAndSettle();
+    // The `tester.widget` ensures that there is exactly one upward arrow.
+    transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    expect(
+      transformOfArrow.transform.getRotation(),
+      equals(Matrix3.identity()), // Should not have changed
+    );
+  });
+
   testWidgets('DataTable row onSelectChanged test', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -491,7 +491,6 @@ void main() {
     Widget buildTable({String title = 'Name1'}) {
       return DataTable(
         sortColumnIndex: 0,
-        sortAscending: true,
         columns: <DataColumn>[
           DataColumn(
             label: Text(title),

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -486,7 +486,7 @@ void main() {
     );
   });
 
-  testWidgets('DataTable sort indicator orientation - does not change on state update', (WidgetTester tester) async {
+  testWidgets('DataTable sort indicator orientation does not change on state update', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/43724
     Widget buildTable({String title = 'Name1'}) {
       return DataTable(
@@ -531,6 +531,55 @@ void main() {
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.identity()), // Should not have changed
+    );
+  });
+
+  testWidgets('DataTable sort indicator orientation does not change on state update - reverse', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/43724
+    Widget buildTable({String title = 'Name1'}) {
+      return DataTable(
+        sortColumnIndex: 0,
+        sortAscending: false,
+        columns: <DataColumn>[
+          DataColumn(
+            label: Text(title),
+            tooltip: 'Name',
+            onSort: (int columnIndex, bool ascending) {},
+          ),
+        ],
+        rows: kDesserts.map<DataRow>((Dessert dessert) {
+          return DataRow(
+            cells: <DataCell>[
+              DataCell(
+                Text(dessert.name),
+              ),
+            ],
+          );
+        }).toList(),
+      );
+    }
+
+    // Check for ascending list
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable()),
+    ));
+    // The `tester.widget` ensures that there is exactly one upward arrow.
+    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    expect(
+      transformOfArrow.transform.getRotation(),
+      equals(Matrix3.rotationZ(math.pi)),
+    );
+
+    // Cause a rebuild by updating the widget
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable(title: 'Name2')),
+    ));
+    await tester.pumpAndSettle();
+    // The `tester.widget` ensures that there is exactly one upward arrow.
+    transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    expect(
+      transformOfArrow.transform.getRotation(),
+      equals(Matrix3.rotationZ(math.pi)), // Should not have changed
     );
   });
 

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -515,7 +515,8 @@ void main() {
       home: Material(child: buildTable()),
     ));
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    final Finder iconFinder = find.widgetWithIcon(Transform, Icons.arrow_upward);
+    Transform transformOfArrow = tester.widget<Transform>(iconFinder);
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.identity()),
@@ -527,7 +528,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    transformOfArrow = tester.widget<Transform>(iconFinder);
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.identity()), // Should not have changed
@@ -564,7 +565,8 @@ void main() {
       home: Material(child: buildTable()),
     ));
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    Transform transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    final Finder iconFinder = find.widgetWithIcon(Transform, Icons.arrow_upward);
+    Transform transformOfArrow = tester.widget<Transform>(iconFinder);
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.rotationZ(math.pi)),
@@ -576,7 +578,7 @@ void main() {
     ));
     await tester.pumpAndSettle();
     // The `tester.widget` ensures that there is exactly one upward arrow.
-    transformOfArrow = tester.widget<Transform>(find.widgetWithIcon(Transform, Icons.arrow_upward));
+    transformOfArrow = tester.widget<Transform>(iconFinder);
     expect(
       transformOfArrow.transform.getRotation(),
       equals(Matrix3.rotationZ(math.pi)), // Should not have changed


### PR DESCRIPTION
The SortArrow should not change orientation when `_up` is null. This led to the arrow changing orientation just because the state was updated (but not the sorting direction). The test shows this in action.

Fixes https://github.com/flutter/flutter/issues/43724

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
