### PR TITLE
Unfocus when pressing `done` in Input mode

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1775,7 +1775,10 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
             controller: controller.value,
             decoration: inputDecoration,
             validator: widget.validator,
-            onEditingComplete: () => widget.onSavedSubmitted(controller.value.text),
+            onEditingComplete: () {
+              widget.onSavedSubmitted(controller.value.text);
+              focusNode.unfocus();
+            },
             onSaved: widget.onSavedSubmitted,
             onFieldSubmitted: widget.onSavedSubmitted,
             onChanged: widget.onChanged,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -1023,6 +1023,21 @@ void _testsInput() {
     expect(result, equals(const TimeOfDay(hour: 9, minute: 12)));
   });
 
+    testWidgets('Does lose focus when pressing "done" in the input mode', (WidgetTester tester) async {
+    await startPicker(tester, (TimeOfDay? time) {}, entryMode: TimePickerEntryMode.input);
+    await tester.enterText(find.byType(TextField).first, '9');
+    await tester.enterText(find.byType(TextField).last, '12');
+    expect(tester.testTextInput.isVisible, true);
+    await finishPicker(tester);
+
+    await startPicker(tester, (TimeOfDay? time) {}, entryMode: TimePickerEntryMode.input);
+    await tester.enterText(find.byType(TextField).first, '9');
+    await tester.enterText(find.byType(TextField).last, '12');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    expect(tester.testTextInput.isVisible, false);
+    await finishPicker(tester);
+  });
+
   testWidgets('Toggle to dial mode keeps selected time', (WidgetTester tester) async {
     late TimeOfDay result;
     await startPicker(tester, (TimeOfDay? time) { result = time!; }, entryMode: TimePickerEntryMode.input);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/68249

This is caused by `onEditingComplete` on `_HourMinuteTextField`
https://github.com/flutter/flutter/blob/ee204880a5f28465f1f682868b6cba4d4bd41909/packages/flutter/lib/src/material/time_picker.dart#L1778

[onEditingComplete](https://master-api.flutter.dev/flutter/widgets/EditableText/onEditingComplete.html) callback override the default behavior of such action

> Providing onEditingComplete prevents the aforementioned default behavior.



For `TimePicker`, based on this issue, we don't want this behavior but wanna keep `onEditingComplete`, I've filed this PR which will unfocus the `_HourMinuteTextField` when pressing `done`.





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
