### PR TITLE
When used in a Navigator, RenderUiKitView tried to access its size without having a size

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -383,6 +383,9 @@ class RenderUiKitView extends RenderBox {
     if (event is! PointerDownEvent) {
       return;
     }
+    if (!hasSize) {
+      return;
+    }
     if (!(Offset.zero & size).contains(globalToLocal(event.position))) {
       return;
     }


### PR DESCRIPTION
Fixes: 
* https://github.com/flutter/flutter/issues/94528
* https://github.com/flutter/flutter/issues/83481

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ x] I signed the [CLA].
- [ x] I listed at least one issue that this PR fixes in the description above.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ x] All existing and new tests are passing.
