### PR TITLE
Mark Mac_android run_release_test flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2994,6 +2994,7 @@ targets:
 
   - name: Mac_android run_release_test
     recipe: devicelab/devicelab_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/91625
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/91625

@blasten @GaryQian

