### PR TITLE
Improve the error message when calling `Image.file` on web

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -466,7 +466,10 @@ class Image extends StatefulWidget {
     int? cacheHeight,
   }) :
        // FileImage is not supported on Flutter Web therefore neither this method.
-       assert(!kIsWeb, 'Image.file is not supported on Flutter Web.'),
+       assert(
+          !kIsWeb,
+          'Image.file is not supported on Flutter Web. '
+          'Consider using either Image.asset or Image.network instead.'),
        image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
        loadingBuilder = null,
        assert(alignment != null),

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -464,7 +464,10 @@ class Image extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     int? cacheWidth,
     int? cacheHeight,
-  }) : image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
+  }) :
+       // FileImage is not supported on Flutter Web therefore neither this method.
+       assert(!kIsWeb, 'Image.file is not supported on Flutter Web.'),
+       image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
        loadingBuilder = null,
        assert(alignment != null),
        assert(repeat != null),

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -467,9 +467,10 @@ class Image extends StatefulWidget {
   }) :
        // FileImage is not supported on Flutter Web therefore neither this method.
        assert(
-          !kIsWeb,
-          'Image.file is not supported on Flutter Web. '
-          'Consider using either Image.asset or Image.network instead.'),
+         !kIsWeb,
+         'Image.file is not supported on Flutter Web. '
+         'Consider using either Image.asset or Image.network instead.',
+        ),
        image = ResizeImage.resizeIfNeeded(cacheWidth, cacheHeight, FileImage(file, scale: scale)),
        loadingBuilder = null,
        assert(alignment != null),

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1958,7 +1958,7 @@ void main() {
     );
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/74935 (broken assets not being reported on web)
 
-   testWidgets('Image.file throws a non-implemented error on web', (WidgetTester tester) async {
+  testWidgets('Image.file throws a non-implemented error on web', (WidgetTester tester) async {
     const String expectedError =
       'Image.file is not supported on Flutter Web. '
       'Consider using either Image.asset or Image.network instead.';

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1966,9 +1966,13 @@ void main() {
     final File file = File.fromUri(uri);
     expect(
       () => Image.file(file),
-      throwsA(predicate((AssertionError e) => e.message == expectedError)),
+      kIsWeb
+        // Web does not support file access, expect AssertionError
+        ? throwsA(predicate((AssertionError e) => e.message == expectedError))
+        // AOT supports file access, expect constructor to succeed
+        : isNot(throwsA(anything)),
     );
-  }, skip: !kIsWeb); // https://github.com/flutter/flutter/issues/88772 (Improve the error message when calling Image.file on web)
+  });
 }
 
 @immutable

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -7,6 +7,7 @@
 @Tags(<String>['reduced-test-set'])
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -1956,6 +1957,18 @@ void main() {
       matchesGoldenFile('image_test.missing.2.png'),
     );
   }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/74935 (broken assets not being reported on web)
+
+   testWidgets('Image.file throws a non-implemented error on web', (WidgetTester tester) async {
+    const String expectedError =
+      'Image.file is not supported on Flutter Web. '
+      'Consider using either Image.asset or Image.network instead.';
+    final Uri uri = Uri.parse('/home/flutter/dash.png');
+    final File file = File.fromUri(uri);
+    expect(
+      () => Image.file(file),
+      throwsA(predicate((AssertionError e) => e.message == expectedError)),
+    );
+  }, skip: !kIsWeb);
 }
 
 @immutable

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1968,7 +1968,7 @@ void main() {
       () => Image.file(file),
       throwsA(predicate((AssertionError e) => e.message == expectedError)),
     );
-  }, skip: !kIsWeb);
+  }, skip: !kIsWeb); // https://github.com/flutter/flutter/issues/88772 (Improve the error message when calling Image.file on web)
 }
 
 @immutable


### PR DESCRIPTION
# Improve the error message when calling `Image.file` on web

Fixes https://github.com/flutter/flutter/issues/88772

### Before:
![image](https://user-images.githubusercontent.com/7821057/144509057-a85f98d1-bbcd-4bca-b356-0c6743d6b518.png)

### After: 
![image](https://user-images.githubusercontent.com/7821057/144509032-d9b7a5ad-9bdb-4786-b2c7-1f569b122721.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
