### PR TITLE
[FlutterDriver] minor nullability fixes

### DIFF
--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -366,11 +366,12 @@ class FlutterDriverExtension with DeserializeFinderFactory, CreateFinderFactory,
       final Command command = deserializeCommand(params, this);
       assert(WidgetsBinding.instance!.isRootWidgetAttached || !command.requiresRootWidgetAttached,
           'No root widget is attached; have you remembered to call runApp()?');
-      Future<Result?> responseFuture = handleCommand(command, _prober, this);
-      if (command.timeout != null)
-        responseFuture = responseFuture.timeout(command.timeout ?? Duration.zero);
-      final Result? response = await responseFuture;
-      return _makeResponse(response?.toJson());
+      Future<Result> responseFuture = handleCommand(command, _prober, this);
+      if (command.timeout != null) {
+        responseFuture = responseFuture.timeout(command.timeout!);
+      }
+      final Result response = await responseFuture;
+      return _makeResponse(response.toJson());
     } on TimeoutException catch (error, stackTrace) {
       final String message = 'Timeout while executing $commandKind: $error\n$stackTrace';
       _log(message);


### PR DESCRIPTION
A small null safety clean-up in `FlutterDriverExtension`:

- `handleCommand` returns `Future<Result>`; no need to make the result nullable
- `command.timeout` was checked for null twice; the second check is unnecessary

This code confused me as I was looking into https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20web_long_running_tests_5_5/2301/overview