### PR TITLE
Fixes `FadeInImage` to follow gapless playback

### DIFF
--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -467,6 +467,7 @@ class _AnimatedFadeOutFadeIn extends ImplicitlyAnimatedWidget {
        assert(fadeOutCurve != null),
        assert(fadeInDuration != null),
        assert(fadeInCurve != null),
+       assert(!wasSynchronouslyLoaded || isTargetLoaded),
        super(key: key, duration: fadeInDuration + fadeOutDuration);
 
   final Widget target;

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -160,6 +160,7 @@ Future<void> main() async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
       final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
+      late FadeInImageParts parts;
 
       await tester.pumpWidget(FadeInImage(
         placeholder: placeholderProvider,
@@ -186,11 +187,15 @@ Future<void> main() async {
         excludeFromSemantics: true,
       ));
 
+      parts = findFadeInImage(tester);
+      expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
+      expect(parts.placeholder!.opacity, moreOrLessEquals(1.0));
+
       secondImageProvider.complete();
       await tester.pump();
 
       for (int i = 0; i < 5; i += 1) {
-        final FadeInImageParts parts = findFadeInImage(tester);
+        parts = findFadeInImage(tester);
         expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
         expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
         expect(parts.placeholder!.opacity, moreOrLessEquals(1 - i / 5));
@@ -199,7 +204,7 @@ Future<void> main() async {
       }
 
       for (int i = 0; i < 5; i += 1) {
-        final FadeInImageParts parts = findFadeInImage(tester);
+        parts = findFadeInImage(tester);
         expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
         expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
         expect(parts.placeholder!.opacity, 0);
@@ -211,6 +216,7 @@ Future<void> main() async {
         placeholder: placeholderProvider,
         image: secondImageProvider,
       ));
+      parts = findFadeInImage(tester);
       expect(findFadeInImage(tester).target.rawImage.image!.isCloneOf(replacementImage), true);
       expect(findFadeInImage(tester).target.opacity, 1);
     });
@@ -227,30 +233,6 @@ Future<void> main() async {
       ));
 
       expect(findFadeInImage(tester).target.rawImage.image!.isCloneOf(targetImage), true);
-      expect(findFadeInImage(tester).placeholder, isNull);
-      expect(findFadeInImage(tester).target.opacity, 1);
-    });
-
-    testWidgets('shows second cached image immediately', (WidgetTester tester) async {
-      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
-      final TestImageProvider imageProvider = TestImageProvider(targetImage);
-      final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
-      imageProvider.resolve(ImageConfiguration.empty);
-      secondImageProvider.resolve(ImageConfiguration.empty);
-      imageProvider.complete();
-      secondImageProvider.complete();
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: imageProvider,
-      ));
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: secondImageProvider,
-      ));
-
-      expect(findFadeInImage(tester).target.rawImage.image!.isCloneOf(replacementImage), true);
       expect(findFadeInImage(tester).placeholder, isNull);
       expect(findFadeInImage(tester).target.opacity, 1);
     });

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -156,6 +156,82 @@ Future<void> main() async {
       expect(findFadeInImage(tester).target.opacity, 1);
     });
 
+    testWidgets('image gapless playback', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+      final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
+
+      await tester.pumpWidget(FadeInImage(
+        placeholder: placeholderProvider,
+        image: imageProvider,
+        fadeOutDuration: animationDuration,
+        fadeInDuration: animationDuration,
+      ));
+
+      imageProvider.complete();
+      placeholderProvider.complete();
+      await tester.pump();
+      await tester.pump(animationDuration * 2);
+      // call setState after the animation, which removes the placeholder image.
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.pumpWidget(FadeInImage(
+        placeholder: placeholderProvider,
+        image: secondImageProvider,
+      ));
+      await tester.pump();
+
+      FadeInImageParts parts = findFadeInImage(tester);
+      // continually shows previously loaded image.
+      expect(parts.placeholder, isNull);
+      expect(parts.target.rawImage.image!.isCloneOf(targetImage), true);
+      expect(parts.target.opacity, 1);
+
+      // Until the new image provider provides the image.
+      secondImageProvider.complete();
+      await tester.pump();
+
+      parts = findFadeInImage(tester);
+      expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
+      expect(parts.target.opacity, 1);
+    });
+
+    testWidgets('placeholder gapless playback', (WidgetTester tester) async {
+      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+      final TestImageProvider secondPlaceholderProvider = TestImageProvider(replacementImage);
+      final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+      await tester.pumpWidget(FadeInImage(
+        placeholder: placeholderProvider,
+        image: imageProvider,
+      ));
+
+      placeholderProvider.complete();
+      await tester.pump();
+
+      FadeInImageParts parts = findFadeInImage(tester);
+      expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
+      expect(parts.placeholder!.opacity, 1);
+
+      await tester.pumpWidget(FadeInImage(
+        placeholder: secondPlaceholderProvider,
+        image: imageProvider,
+      ));
+
+      parts = findFadeInImage(tester);
+      // continually shows previously loaded image.
+      expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
+      expect(parts.placeholder!.opacity, 1);
+
+      // Until the new image provider provides the image.
+      secondPlaceholderProvider.complete();
+      await tester.pump();
+
+      parts = findFadeInImage(tester);
+      expect(parts.placeholder!.rawImage.image!.isCloneOf(replacementImage), true);
+      expect(parts.placeholder!.opacity, 1);
+    });
+
     testWidgets('shows a cached image immediately when skipFadeOnSynchronousLoad=true', (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
@@ -224,48 +300,6 @@ Future<void> main() async {
       imageProvider.complete();
       await tester.pumpAndSettle();
       expect(find.byType(Image), findsOneWidget);
-    });
-
-    testWidgets('re-fades in the image when the target image is updated', (WidgetTester tester) async {
-      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
-      final TestImageProvider imageProvider = TestImageProvider(targetImage);
-      final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: imageProvider,
-        fadeOutDuration: animationDuration,
-        fadeInDuration: animationDuration,
-        excludeFromSemantics: true,
-      ));
-
-      final State? state = findFadeInImage(tester).state;
-      placeholderProvider.complete();
-      imageProvider.complete();
-      await tester.pump();
-      await tester.pump(animationDuration * 2);
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: secondImageProvider,
-        fadeOutDuration: animationDuration,
-        fadeInDuration: animationDuration,
-        excludeFromSemantics: true,
-      ));
-
-      secondImageProvider.complete();
-      await tester.pump();
-
-      expect(findFadeInImage(tester).target.rawImage.image!.isCloneOf(replacementImage), true);
-      expect(findFadeInImage(tester).state, same(state));
-      expect(findFadeInImage(tester).placeholder!.opacity, moreOrLessEquals(1));
-      expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(0));
-      await tester.pump(animationDuration);
-      expect(findFadeInImage(tester).placeholder!.opacity, moreOrLessEquals(0));
-      expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(0));
-      await tester.pump(animationDuration);
-      expect(findFadeInImage(tester).placeholder!.opacity, moreOrLessEquals(0));
-      expect(findFadeInImage(tester).target.opacity, moreOrLessEquals(1));
     });
 
     testWidgets("doesn't interrupt in-progress animation when animation values are updated", (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -156,7 +156,7 @@ Future<void> main() async {
       expect(findFadeInImage(tester).target.opacity, 1);
     });
 
-    testWidgets('image gapless playback', (WidgetTester tester) async {
+    testWidgets("FadeInImage's image obeys gapless playback", (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
       final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
@@ -172,7 +172,7 @@ Future<void> main() async {
       placeholderProvider.complete();
       await tester.pump();
       await tester.pump(animationDuration * 2);
-      // call setState after the animation, which removes the placeholder image.
+      // Calls setState after the animation, which removes the placeholder image.
       await tester.pump(const Duration(milliseconds: 100));
 
       await tester.pumpWidget(FadeInImage(
@@ -182,9 +182,9 @@ Future<void> main() async {
       await tester.pump();
 
       FadeInImageParts parts = findFadeInImage(tester);
-      // continually shows previously loaded image.
+      // Continually shows previously loaded image,
       expect(parts.placeholder, isNull);
-      expect(parts.target.rawImage.image!.isCloneOf(targetImage), true);
+      expect(parts.target.rawImage.image!.isCloneOf(targetImage), isTrue);
       expect(parts.target.opacity, 1);
 
       // Until the new image provider provides the image.
@@ -192,11 +192,11 @@ Future<void> main() async {
       await tester.pump();
 
       parts = findFadeInImage(tester);
-      expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
+      expect(parts.target.rawImage.image!.isCloneOf(replacementImage), isTrue);
       expect(parts.target.opacity, 1);
     });
 
-    testWidgets('placeholder gapless playback', (WidgetTester tester) async {
+    testWidgets("FadeInImage's placeholder obeys gapless playback", (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider secondPlaceholderProvider = TestImageProvider(replacementImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -156,72 +156,7 @@ Future<void> main() async {
       expect(findFadeInImage(tester).target.opacity, 1);
     });
 
-    testWidgets('re-animates updated uncached image', (WidgetTester tester) async {
-      final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
-      final TestImageProvider imageProvider = TestImageProvider(targetImage);
-      final TestImageProvider secondImageProvider = TestImageProvider(replacementImage);
-      late FadeInImageParts parts;
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: imageProvider,
-        fadeOutDuration: animationDuration,
-        fadeInDuration: animationDuration,
-        fadeOutCurve: Curves.linear,
-        fadeInCurve: Curves.linear,
-        excludeFromSemantics: true,
-      ));
-
-      imageProvider.complete();
-      placeholderProvider.complete();
-      await tester.pump();
-      await tester.pump(animationDuration * 2);
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: secondImageProvider,
-        fadeOutDuration: animationDuration,
-        fadeInDuration: animationDuration,
-        fadeOutCurve: Curves.linear,
-        fadeInCurve: Curves.linear,
-        excludeFromSemantics: true,
-      ));
-
-      parts = findFadeInImage(tester);
-      expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
-      expect(parts.placeholder!.opacity, moreOrLessEquals(1.0));
-
-      secondImageProvider.complete();
-      await tester.pump();
-
-      for (int i = 0; i < 5; i += 1) {
-        parts = findFadeInImage(tester);
-        expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
-        expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
-        expect(parts.placeholder!.opacity, moreOrLessEquals(1 - i / 5));
-        expect(parts.target.opacity, 0);
-        await tester.pump(const Duration(milliseconds: 10));
-      }
-
-      for (int i = 0; i < 5; i += 1) {
-        parts = findFadeInImage(tester);
-        expect(parts.placeholder!.rawImage.image!.isCloneOf(placeholderImage), true);
-        expect(parts.target.rawImage.image!.isCloneOf(replacementImage), true);
-        expect(parts.placeholder!.opacity, 0);
-        expect(parts.target.opacity, moreOrLessEquals(i / 5));
-        await tester.pump(const Duration(milliseconds: 10));
-      }
-
-      await tester.pumpWidget(FadeInImage(
-        placeholder: placeholderProvider,
-        image: secondImageProvider,
-      ));
-      parts = findFadeInImage(tester);
-      expect(findFadeInImage(tester).target.rawImage.image!.isCloneOf(replacementImage), true);
-      expect(findFadeInImage(tester).target.opacity, 1);
-    });
-
-    testWidgets('shows a cached image immediately', (WidgetTester tester) async {
+    testWidgets('shows a cached image immediately when skipFadeOnSynchronousLoad=true', (WidgetTester tester) async {
       final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
       final TestImageProvider imageProvider = TestImageProvider(targetImage);
       imageProvider.resolve(ImageConfiguration.empty);


### PR DESCRIPTION
`FadeInImage` does not follow [gapless playback](https://api.flutter.dev/flutter/widgets/Image/gaplessPlayback.html), even though it is documented in the last line of [its documentation](https://api.flutter.dev/flutter/widgets/FadeInImage-class.html).

This is a regression, caused in #33370.

Fixes #94540 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

## Bugs needed to be fixed:

- [ ] When using two images, as in the issue's code sample, one of them is not cached (the first one to be specific), while the other is.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
