### PR TITLE
update scrollbar to support the leading and trailing buttons

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -213,8 +213,8 @@ class _MaterialScrollbar extends RawScrollbar {
     ScrollController? controller,
     bool? isAlwaysShown,
     this.trackVisibility,
-    this.buttonVisibility,
-    this.buttonStyles,
+    bool? buttonVisibility,
+    ScrollbarButtonStyles? buttonStyles,
     this.showTrackOnHover,
     this.hoverThickness,
     double? thickness,
@@ -222,24 +222,26 @@ class _MaterialScrollbar extends RawScrollbar {
     ScrollNotificationPredicate? notificationPredicate,
     bool? interactive,
     ScrollbarOrientation? scrollbarOrientation,
-  }) : super(
-         key: key,
-         child: child,
-         controller: controller,
-         isAlwaysShown: isAlwaysShown,
-         thickness: thickness,
-         radius: radius,
-         fadeDuration: _kScrollbarFadeDuration,
-         timeToFade: _kScrollbarTimeToFade,
-         pressDuration: Duration.zero,
-         notificationPredicate: notificationPredicate ?? defaultScrollNotificationPredicate,
-         interactive: interactive,
-         scrollbarOrientation: scrollbarOrientation,
-       );
+  }) : _buttonVisibility = buttonVisibility,
+    _buttonStyles = buttonStyles,
+    super(
+      key: key,
+      child: child,
+      controller: controller,
+      isAlwaysShown: isAlwaysShown,
+      thickness: thickness,
+      radius: radius,
+      fadeDuration: _kScrollbarFadeDuration,
+      timeToFade: _kScrollbarTimeToFade,
+      pressDuration: Duration.zero,
+      notificationPredicate: notificationPredicate ?? defaultScrollNotificationPredicate,
+      interactive: interactive,
+      scrollbarOrientation: scrollbarOrientation,
+    );
 
   final bool? trackVisibility;
-  final bool? buttonVisibility;
-  final ScrollbarButtonStyles? buttonStyles;
+  final bool? _buttonVisibility;
+  final ScrollbarButtonStyles? _buttonStyles;
   final bool? showTrackOnHover;
   final double? hoverThickness;
 
@@ -276,12 +278,12 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   });
 
   MaterialStateProperty<bool> get _buttonVisibility => MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-    return widget.buttonVisibility ?? _scrollbarTheme.buttonVisibility?.resolve(states) ?? false;
+    return widget._buttonVisibility ?? _scrollbarTheme.buttonVisibility?.resolve(states) ?? false;
   });
 
   ScrollbarButtonStyles get _buttonStyles {
     final ScrollbarButtonStyles styles =
-        widget.buttonStyles ?? _scrollbarTheme.buttonStyles ?? const ScrollbarButtonStateStyles();
+        widget._buttonStyles ?? _scrollbarTheme.buttonStyles ?? const ScrollbarButtonStateStyles();
     final ScrollbarButtonColors leadingButtonColors = styles.leadingButtonColors;
     final ScrollbarButtonColors trailingButtonColors = styles.trailingButtonColors;
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -282,8 +282,8 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   ScrollbarButtonStyles get _buttonStyles {
     final ScrollbarButtonStyles styles =
         widget.buttonStyles ?? _scrollbarTheme.buttonStyles ?? const ScrollbarButtonStateStyles();
-    ScrollbarButtonColors leadingButtonColors = styles.leadingButtonColors;
-    ScrollbarButtonColors trailingButtonColors = styles.trailingButtonColors;
+    final ScrollbarButtonColors leadingButtonColors = styles.leadingButtonColors;
+    final ScrollbarButtonColors trailingButtonColors = styles.trailingButtonColors;
 
     Color leadingIndicatorColor = leadingButtonColors.indicatorColor;
     Color leadingBackgroundColor = leadingButtonColors.backgroundColor ?? _trackColor.resolve(_states);

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -111,10 +111,24 @@ class Scrollbar extends StatelessWidget {
   /// [showTrackOnHover] can be replaced by this and will be deprecated.
   final bool? trackVisibility;
 
-  /// todo
+  /// Controls the button visibility.
+  ///
+  /// If this property is null, then [ScrollbarThemeData.buttonVisibility] of
+  /// [ThemeData.scrollbarTheme] is used. If that is also null, the default value
+  /// is false.
   final bool? buttonVisibility;
 
-  /// todo
+  /// Controls the presentation style of the scrollbar button.
+  ///
+  /// If this property is null, then [ScrollbarThemeData.buttonStyles] of
+  /// [ThemeData.scrollbarTheme] is used. If that is also null, the default value
+  /// is [ScrollbarButtonStateStyles].
+  ///
+  /// See also:
+  ///
+  ///  * [ScrollbarButtonStateStyles], a scrollbar button style that use
+  ///  [ScrollbarButtonStateColors] which the default value follows the
+  ///  Windows platform style.
   final ScrollbarButtonStyles? buttonStyles;
 
   /// Controls if the track will show on hover and remain, including during drag.
@@ -266,7 +280,8 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
   });
 
   ScrollbarButtonStyles get _buttonStyles {
-    final ScrollbarButtonStyles styles = widget.buttonStyles ?? const ScrollbarButtonStateStyles();
+    final ScrollbarButtonStyles styles =
+        widget.buttonStyles ?? _scrollbarTheme.buttonStyles ?? const ScrollbarButtonStateStyles();
     ScrollbarButtonColors leadingButtonColors = styles.leadingButtonColors;
     ScrollbarButtonColors trailingButtonColors = styles.trailingButtonColors;
 

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -371,7 +371,12 @@ class ScrollbarButtonStateColors extends ScrollbarButtonColors {
     indicatorColor: indicatorColor,
   );
 
+  /// The color of the button background when hovered.
   final Color? hoveredBackgroundColor;
+
+  /// The color of the button background when pressed.
   final Color? pressedBackgroundColor;
+
+  /// The color of the button indicator when the thumb reaches the corresponding edge.
   final Color? inactiveIndicatorColor;
 }

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -33,6 +33,7 @@ class ScrollbarThemeData with Diagnosticable {
   const ScrollbarThemeData({
     this.thickness,
     this.trackVisibility,
+    this.buttonVisibility,
     this.showTrackOnHover,
     this.isAlwaysShown,
     this.radius,
@@ -55,6 +56,10 @@ class ScrollbarThemeData with Diagnosticable {
   /// Overrides the default value of [Scrollbar.trackVisibility] in all
   /// descendant [Scrollbar] widgets.
   final MaterialStateProperty<bool?>? trackVisibility;
+
+  /// Overrides the default value of [Scrollbar.buttonVisibility] in all
+  /// descendant [Scrollbar] widgets.
+  final MaterialStateProperty<bool?>? buttonVisibility;
 
   /// Overrides the default value of [Scrollbar.showTrackOnHover] in all
   /// descendant [Scrollbar] widgets.
@@ -128,6 +133,7 @@ class ScrollbarThemeData with Diagnosticable {
   ScrollbarThemeData copyWith({
     MaterialStateProperty<double?>? thickness,
     MaterialStateProperty<bool?>? trackVisibility,
+    MaterialStateProperty<bool?>? buttonVisibility,
     bool? showTrackOnHover,
     bool? isAlwaysShown,
     bool? interactive,
@@ -142,6 +148,7 @@ class ScrollbarThemeData with Diagnosticable {
     return ScrollbarThemeData(
       thickness: thickness ?? this.thickness,
       trackVisibility: trackVisibility ?? this.trackVisibility,
+      buttonVisibility: buttonVisibility ?? this.buttonVisibility,
       showTrackOnHover: showTrackOnHover ?? this.showTrackOnHover,
       isAlwaysShown: isAlwaysShown ?? this.isAlwaysShown,
       interactive: interactive ?? this.interactive,
@@ -165,6 +172,7 @@ class ScrollbarThemeData with Diagnosticable {
     return ScrollbarThemeData(
       thickness: _lerpProperties<double?>(a?.thickness, b?.thickness, t, lerpDouble),
       trackVisibility: _lerpProperties<bool?>(a?.trackVisibility, b?.trackVisibility, t, _lerpBool),
+      buttonVisibility: _lerpProperties<bool?>(a?.buttonVisibility, b?.buttonVisibility, t, _lerpBool),
       showTrackOnHover: _lerpBool(a?.showTrackOnHover, b?.showTrackOnHover, t),
       isAlwaysShown: _lerpBool(a?.isAlwaysShown, b?.isAlwaysShown, t),
       interactive: _lerpBool(a?.interactive, b?.interactive, t),
@@ -183,6 +191,7 @@ class ScrollbarThemeData with Diagnosticable {
     return hashValues(
       thickness,
       trackVisibility,
+      buttonVisibility,
       showTrackOnHover,
       isAlwaysShown,
       interactive,
@@ -205,6 +214,7 @@ class ScrollbarThemeData with Diagnosticable {
     return other is ScrollbarThemeData
       && other.thickness == thickness
       && other.trackVisibility == trackVisibility
+      && other.buttonVisibility == buttonVisibility
       && other.showTrackOnHover == showTrackOnHover
       && other.isAlwaysShown == isAlwaysShown
       && other.interactive == interactive
@@ -222,6 +232,7 @@ class ScrollbarThemeData with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('thickness', thickness, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('trackVisibility', trackVisibility, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('buttonVisibility', buttonVisibility, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('showTrackOnHover', showTrackOnHover, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('isAlwaysShown', isAlwaysShown, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('interactive', interactive, defaultValue: null));
@@ -305,4 +316,46 @@ class ScrollbarTheme extends InheritedWidget {
 
   @override
   bool updateShouldNotify(ScrollbarTheme oldWidget) => data != oldWidget.data;
+}
+
+/// A scrollbar button style that use [ScrollbarButtonStateColors].
+class ScrollbarButtonStateStyles extends ScrollbarButtonStyles {
+  const ScrollbarButtonStateStyles({
+    ScrollbarButtonLocation location = ScrollbarButtonLocation.split,
+    double extent = 18.0,
+    double indicatorWidth = 8.0,
+    PaintingStyle indicatorPaintingStyle = PaintingStyle.stroke,
+    ScrollbarButtonStateColors leadingButtonColors = const ScrollbarButtonStateColors(),
+    ScrollbarButtonStateColors trailingButtonColors = const ScrollbarButtonStateColors(),
+  }) : super(
+    location: location,
+    extent: extent,
+    indicatorWidth: indicatorWidth,
+    indicatorPaintingStyle: indicatorPaintingStyle,
+    leadingButtonColors: leadingButtonColors,
+    trailingButtonColors: trailingButtonColors,
+  );
+}
+
+/// A scrollbar button colors style that supports customized colors with
+/// different states.
+///
+/// Only the [ScrollBar] widget responds to this.
+///
+/// The default value follows the Windows platform style.
+class ScrollbarButtonStateColors extends ScrollbarButtonColors {
+  const ScrollbarButtonStateColors({
+    Color? backgroundColor,
+    this.hoveredBackgroundColor = const Color(0xFFD2D2D2),
+    this.pressedBackgroundColor = const Color(0xFF787878),
+    Color indicatorColor = const Color(0xFF505050),
+    this.inactiveIndicatorColor = const Color(0xFFA3A3A3),
+  }) : super(
+    backgroundColor: backgroundColor,
+    indicatorColor: indicatorColor,
+  );
+
+  final Color? hoveredBackgroundColor;
+  final Color? pressedBackgroundColor;
+  final Color? inactiveIndicatorColor;
 }

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -34,6 +34,7 @@ class ScrollbarThemeData with Diagnosticable {
     this.thickness,
     this.trackVisibility,
     this.buttonVisibility,
+    this.buttonStyles,
     this.showTrackOnHover,
     this.isAlwaysShown,
     this.radius,
@@ -56,6 +57,13 @@ class ScrollbarThemeData with Diagnosticable {
   /// Overrides the default value of [Scrollbar.trackVisibility] in all
   /// descendant [Scrollbar] widgets.
   final MaterialStateProperty<bool?>? trackVisibility;
+
+  /// Overrides the default value of [Scrollbar.buttonStyles] in all
+  /// descendant [Scrollbar] widgets.
+  ///
+  /// [ScrollbarButtonStateStyles] is recommended, which can customize styles
+  /// with different states.
+  final ScrollbarButtonStyles? buttonStyles;
 
   /// Overrides the default value of [Scrollbar.buttonVisibility] in all
   /// descendant [Scrollbar] widgets.
@@ -134,6 +142,7 @@ class ScrollbarThemeData with Diagnosticable {
     MaterialStateProperty<double?>? thickness,
     MaterialStateProperty<bool?>? trackVisibility,
     MaterialStateProperty<bool?>? buttonVisibility,
+    ScrollbarButtonStyles? buttonStyles,
     bool? showTrackOnHover,
     bool? isAlwaysShown,
     bool? interactive,
@@ -149,6 +158,7 @@ class ScrollbarThemeData with Diagnosticable {
       thickness: thickness ?? this.thickness,
       trackVisibility: trackVisibility ?? this.trackVisibility,
       buttonVisibility: buttonVisibility ?? this.buttonVisibility,
+      buttonStyles: buttonStyles ?? this.buttonStyles,
       showTrackOnHover: showTrackOnHover ?? this.showTrackOnHover,
       isAlwaysShown: isAlwaysShown ?? this.isAlwaysShown,
       interactive: interactive ?? this.interactive,
@@ -173,6 +183,7 @@ class ScrollbarThemeData with Diagnosticable {
       thickness: _lerpProperties<double?>(a?.thickness, b?.thickness, t, lerpDouble),
       trackVisibility: _lerpProperties<bool?>(a?.trackVisibility, b?.trackVisibility, t, _lerpBool),
       buttonVisibility: _lerpProperties<bool?>(a?.buttonVisibility, b?.buttonVisibility, t, _lerpBool),
+      buttonStyles: t < 0.5 ? a?.buttonStyles : b?.buttonStyles ,
       showTrackOnHover: _lerpBool(a?.showTrackOnHover, b?.showTrackOnHover, t),
       isAlwaysShown: _lerpBool(a?.isAlwaysShown, b?.isAlwaysShown, t),
       interactive: _lerpBool(a?.interactive, b?.interactive, t),
@@ -192,6 +203,7 @@ class ScrollbarThemeData with Diagnosticable {
       thickness,
       trackVisibility,
       buttonVisibility,
+      buttonStyles,
       showTrackOnHover,
       isAlwaysShown,
       interactive,
@@ -215,6 +227,7 @@ class ScrollbarThemeData with Diagnosticable {
       && other.thickness == thickness
       && other.trackVisibility == trackVisibility
       && other.buttonVisibility == buttonVisibility
+      && other.buttonStyles == buttonStyles
       && other.showTrackOnHover == showTrackOnHover
       && other.isAlwaysShown == isAlwaysShown
       && other.interactive == interactive
@@ -233,6 +246,7 @@ class ScrollbarThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('thickness', thickness, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('trackVisibility', trackVisibility, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<bool?>>('buttonVisibility', buttonVisibility, defaultValue: null));
+    properties.add(DiagnosticsProperty<ScrollbarButtonStyles?>('buttonStyles', buttonStyles, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('showTrackOnHover', showTrackOnHover, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('isAlwaysShown', isAlwaysShown, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('interactive', interactive, defaultValue: null));
@@ -319,6 +333,8 @@ class ScrollbarTheme extends InheritedWidget {
 }
 
 /// A scrollbar button style that use [ScrollbarButtonStateColors].
+///
+/// The default value follows the Windows platform style.
 class ScrollbarButtonStateStyles extends ScrollbarButtonStyles {
   const ScrollbarButtonStateStyles({
     ScrollbarButtonLocation location = ScrollbarButtonLocation.split,

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -336,6 +336,8 @@ class ScrollbarTheme extends InheritedWidget {
 ///
 /// The default value follows the Windows platform style.
 class ScrollbarButtonStateStyles extends ScrollbarButtonStyles {
+  /// Creates a scrollbar button styles that can be used for
+  /// [ScrollbarThemeData.buttonStyles] or [Scrollbar.buttonStyles].
   const ScrollbarButtonStateStyles({
     ScrollbarButtonLocation location = ScrollbarButtonLocation.split,
     double extent = 18.0,
@@ -356,10 +358,12 @@ class ScrollbarButtonStateStyles extends ScrollbarButtonStyles {
 /// A scrollbar button colors style that supports customized colors with
 /// different states.
 ///
-/// Only the [ScrollBar] widget responds to this.
+/// Only the [Scrollbar] widget responds to this.
 ///
 /// The default value follows the Windows platform style.
 class ScrollbarButtonStateColors extends ScrollbarButtonColors {
+  /// Creates a scrollbar button color styles that can be used for
+  /// [ScrollbarButtonStateStyles].
   const ScrollbarButtonStateColors({
     Color? backgroundColor,
     this.hoveredBackgroundColor = const Color(0xFFD2D2D2),
@@ -377,6 +381,7 @@ class ScrollbarButtonStateColors extends ScrollbarButtonColors {
   /// The color of the button background when pressed.
   final Color? pressedBackgroundColor;
 
-  /// The color of the button indicator when the thumb reaches the corresponding edge.
+  /// The color of the button indicator when the thumb reaches the
+  /// corresponding edge.
   final Color? inactiveIndicatorColor;
 }

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1895,9 +1895,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     if (_shouldUpdatePainter(metrics.axis)) {
       scrollbarPainter.update(metrics, metrics.axisDirection);
       _lastMetrics = metrics;
-      if (_lastMetrics!.atEdge) {
-        updateScrollbarPainter();
-      }
+      updateScrollbarPainter();
     }
     return false;
   }
@@ -1916,9 +1914,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       if (_shouldUpdatePainter(metrics.axis)) {
         scrollbarPainter.update(metrics, metrics.axisDirection);
         _lastMetrics = metrics;
-        if (_lastMetrics!.atEdge) {
-          updateScrollbarPainter();
-        }
+        updateScrollbarPainter();
       }
       return false;
     }
@@ -1935,9 +1931,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       if (_shouldUpdatePainter(metrics.axis)) {
         scrollbarPainter.update(metrics, metrics.axisDirection);
         _lastMetrics = metrics;
-        if (_lastMetrics!.atEdge) {
-          updateScrollbarPainter();
-        }
+        updateScrollbarPainter();
       }
     } else if (notification is ScrollEndNotification) {
       if (_dragScrollbarAxisOffset == null)

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1030,7 +1030,7 @@ class RawScrollbar extends StatefulWidget {
     this.shape,
     this.radius,
     this.thickness,
-    this.buttonVisibility = false,
+    this.buttonVisibility,
     this.buttonStyles,
     this.thumbColor,
     this.minThumbLength = _kMinThumbExtent,
@@ -1054,7 +1054,6 @@ class RawScrollbar extends StatefulWidget {
        assert(pressDuration != null),
        assert(mainAxisMargin != null),
        assert(crossAxisMargin != null),
-       assert(buttonVisibility == null || !buttonVisibility || buttonStyles != null),
        super(key: key);
 
   /// {@template flutter.widgets.Scrollbar.child}
@@ -1229,10 +1228,16 @@ class RawScrollbar extends StatefulWidget {
   /// If null, will default to 6.0 pixels.
   final double? thickness;
 
-  /// todo
+  /// Controls the button visibility.
+  ///
+  /// If null, will default to false.
   final bool? buttonVisibility;
 
-  /// todo
+  /// Controls the presentation style of the scrollbar button.
+  ///
+  /// If null, the default value is [ScrollbarButtonStyles].
+  ///
+  /// [RawScrollbar]'s button does not respond to the change of button state.
   final ScrollbarButtonStyles? buttonStyles;
 
   /// The color of the scrollbar thumb.
@@ -1549,7 +1554,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..minOverscrollLength = widget.minOverscrollLength ?? widget.minThumbLength
       ..ignorePointer = !enableGestures
       ..buttonVisibility = widget.buttonVisibility ?? false
-      ..buttonStyles = widget.buttonStyles;
+      ..buttonStyles = widget.buttonStyles ?? const ScrollbarButtonStyles();
   }
 
   @override
@@ -2103,7 +2108,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     _maybeStartFadeoutTimer();
   }
 
-  /// Whether the scrollbar at the leading or trailing edge.
+  /// Whether the scrollbar thumb arrive at the leading or trailing edge
+  /// of the track.
   bool atEdge({ required bool isLeading}) {
     if (_lastMetrics == null) {
       return false;
@@ -2337,6 +2343,9 @@ Offset _getLocalOffset(GlobalKey scrollbarPainterKey, Offset position) {
   return renderBox.globalToLocal(position);
 }
 
+/// Define the presentation style of the scrollbar button.
+///
+/// The default value follows the Windows platform style.
 class ScrollbarButtonStyles {
   const ScrollbarButtonStyles({
     this.location = ScrollbarButtonLocation.split,
@@ -2347,13 +2356,25 @@ class ScrollbarButtonStyles {
     this.trailingButtonColors = const ScrollbarButtonColors(),
   });
 
+  /// The location of the scrollbar button.
   final ScrollbarButtonLocation location;
+
+  /// The extent of the scrollbar button.
   final double extent;
+
+  /// The width of the button indicator paint area.
   final double indicatorWidth;
+
+  /// The painting style of the button indicator
   final PaintingStyle indicatorPaintingStyle;
+
+  /// The color style of the leading button.
   final ScrollbarButtonColors leadingButtonColors;
+
+  /// The color style of the trailing button.
   final ScrollbarButtonColors trailingButtonColors;
 
+  /// Get the leading or trailing button indicator's path.
   Path getIndicatorPath({
     required Rect buttonRect,
     required bool isLeading,
@@ -2403,6 +2424,7 @@ class ScrollbarButtonStyles {
   }
 }
 
+/// The color styles of the button.
 class ScrollbarButtonColors {
   const ScrollbarButtonColors({
     this.backgroundColor,
@@ -2413,8 +2435,10 @@ class ScrollbarButtonColors {
   /// 
   /// If this is null, the track color used.
   final Color? backgroundColor;
-  
-  /// todo
+
+  /// The color of the button indicator.
+  ///
+  /// Defaults to Color(0xFF505050).
   final Color indicatorColor;
 }
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -373,7 +373,7 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
     notifyListeners();
   }
 
-  /// todo
+  /// The presentation style of the scrollbar button.
   ScrollbarButtonStyles? get buttonStyles => _buttonStyles;
   ScrollbarButtonStyles? _buttonStyles;
   set buttonStyles(ScrollbarButtonStyles? value) {
@@ -2347,9 +2347,9 @@ Offset _getLocalOffset(GlobalKey scrollbarPainterKey, Offset position) {
 }
 
 /// Define the presentation style of the scrollbar button.
-///
-/// The default value follows the Windows platform style.
 class ScrollbarButtonStyles {
+  /// Creates a scrollbar button styles that can be used for
+  /// [RawScrollbar.buttonStyles].
   const ScrollbarButtonStyles({
     this.location = ScrollbarButtonLocation.split,
     this.extent = 48.0,
@@ -2378,6 +2378,8 @@ class ScrollbarButtonStyles {
   final ScrollbarButtonColors trailingButtonColors;
 
   /// Get the leading or trailing button indicator's path.
+  ///
+  /// By default, a simple arrow path is returned.
   Path getIndicatorPath({
     required Rect buttonRect,
     required bool isLeading,
@@ -2427,6 +2429,8 @@ class ScrollbarButtonStyles {
 
 /// The color styles of the button.
 class ScrollbarButtonColors {
+  /// Creates a scrollbar button colors style that can be used for
+  /// [ScrollbarButtonStyles].
   const ScrollbarButtonColors({
     this.backgroundColor,
     this.indicatorColor = const Color(0xFF505050),

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -2432,7 +2432,7 @@ class ScrollbarButtonColors {
   });
 
   /// The color of the button background.
-  /// 
+  ///
   /// If this is null, the track color used.
   final Color? backgroundColor;
 

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -495,12 +495,12 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
           trackOffset = trailingButtonOffset + Offset(0.0, _buttonExtent);
         } else {
           assert(buttonStyles!.location == ScrollbarButtonLocation.groupedTrailing);
-          trackOffset = Offset(x - crossAxisMargin, padding.top + mainAxisMargin);
+          trackOffset = Offset(x - crossAxisMargin, mainAxisMargin + padding.top);
           leadingButtonOffset = trackOffset + Offset(0.0, _trackExtent);
           trailingButtonOffset = leadingButtonOffset + Offset(0.0, _buttonExtent);
         }
-        borderStart = leadingButtonOffset + Offset(trackSize.width, 0.0);
-        borderEnd = Offset(leadingButtonOffset.dx + trackSize.width, leadingButtonOffset.dy + _trackExtent + _buttonExtent * 2.0);
+        borderStart = Offset(x - crossAxisMargin, mainAxisMargin + padding.top) + Offset(trackSize.width, 0.0);
+        borderEnd = Offset(borderStart.dx, borderStart.dy + _trackExtent + _buttonExtent * 2.0);
         break;
       case ScrollbarOrientation.right:
         thumbSize = Size(thickness, thumbExtent);
@@ -515,15 +515,15 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
         } else if (buttonStyles!.location == ScrollbarButtonLocation.groupedLeading) {
           leadingButtonOffset = Offset(x - crossAxisMargin, mainAxisMargin + padding.top);
           trailingButtonOffset = leadingButtonOffset + Offset(0.0, _buttonExtent);
-          trackOffset = trailingButtonOffset + Offset(0.0, _trackExtent);
+          trackOffset = trailingButtonOffset + Offset(0.0, _buttonExtent);
         } else {
           assert(buttonStyles!.location == ScrollbarButtonLocation.groupedTrailing);
-          trackOffset = Offset(x - crossAxisMargin, padding.top + mainAxisMargin);
+          trackOffset = Offset(x - crossAxisMargin, mainAxisMargin + padding.top);
           leadingButtonOffset = trackOffset + Offset(0.0, _trackExtent);
           trailingButtonOffset = leadingButtonOffset + Offset(0.0, _buttonExtent);
         }
-        borderStart = leadingButtonOffset;
-        borderEnd = Offset(leadingButtonOffset.dx, leadingButtonOffset.dy + _trackExtent + _buttonExtent * 2.0);
+        borderStart = Offset(x - crossAxisMargin, mainAxisMargin + padding.top);
+        borderEnd = Offset(borderStart.dx, borderStart.dy + _trackExtent + _buttonExtent * 2.0);
         break;
       case ScrollbarOrientation.top:
         thumbSize = Size(thumbExtent, thickness);
@@ -545,8 +545,8 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
           leadingButtonOffset = trackOffset + Offset(_trackExtent, 0.0);
           trailingButtonOffset = leadingButtonOffset + Offset(_buttonExtent, 0.0);
         }
-        borderStart = leadingButtonOffset + Offset(0.0, trackSize.height);
-        borderEnd = Offset(leadingButtonOffset.dx + _trackExtent + _buttonExtent * 2.0, leadingButtonOffset.dy + trackSize.height);
+        borderStart = Offset(mainAxisMargin + padding.left, y - crossAxisMargin) + Offset(0.0, trackSize.height);
+        borderEnd = Offset(borderStart.dx + _trackExtent + _buttonExtent * 2.0, borderStart.dy);
         break;
       case ScrollbarOrientation.bottom:
         thumbSize = Size(thumbExtent, thickness);
@@ -568,8 +568,8 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
           leadingButtonOffset = trackOffset + Offset(_trackExtent, 0.0);
           trailingButtonOffset = leadingButtonOffset + Offset(_buttonExtent, 0.0);
         }
-        borderStart = leadingButtonOffset;
-        borderEnd = Offset(leadingButtonOffset.dx + _trackExtent + _buttonExtent * 2.0, leadingButtonOffset.dy);
+        borderStart = Offset(mainAxisMargin + padding.left, y - crossAxisMargin);
+        borderEnd = Offset(borderStart.dx + _trackExtent + _buttonExtent * 2.0, borderStart.dy);
         break;
     }
 
@@ -885,7 +885,10 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
       return false;
     }
 
-    return _thumbRect!.contains(position!);
+    return _thumbRect!.contains(position!)
+      || _trackRect!.contains(position)
+      || _leadingButtonRect.contains(position)
+      || _trailingButtonRect.contains(position);
   }
 
   @override
@@ -2400,7 +2403,6 @@ class ScrollbarButtonStyles {
             ..lineTo(indicatorRect.bottomCenter.dx, indicatorRect.bottomCenter.dy)
             ..lineTo(indicatorRect.topRight.dx, indicatorRect.topRight.dy);
         }
-        break;
       case ScrollbarOrientation.top:
       case ScrollbarOrientation.bottom:
         indicatorRect = Rect.fromCenter(
@@ -2419,7 +2421,6 @@ class ScrollbarButtonStyles {
             ..lineTo(indicatorRect.centerRight.dx, indicatorRect.centerRight.dy)
             ..lineTo(indicatorRect.bottomLeft.dx, indicatorRect.bottomLeft.dy);
         }
-        break;
     }
   }
 }

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1774,13 +1774,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
   /// Handler called when the pointer stops contacting the buttons.
   @protected
   @mustCallSuper
-  void handleButtonsPressUp({ required bool isLeadingButton }) {
-    // if (isLeadingButton) {
-    //   setState(() { _leadingButtonPressed = false; });
-    // } else {
-    //   setState(() { _trailingButtonPressed = false; });
-    // }
-  }
+  void handleButtonsPressUp({ required bool isLeadingButton }) {}
 
   /// Handler called when a press on the leading or trailing scrollbar's buttons
   /// has been recognized.


### PR DESCRIPTION
Another implementation of #91877, which decouples the state information from the RawScrollbar widget.

CC @Piinks 