### PR TITLE
fix small typo in doc of SingleChildScrollView

### DIFF
--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -34,7 +34,7 @@ import 'scrollable.dart';
 /// When you have a list of children and do not require cross-axis
 /// shrink-wrapping behavior, for example a scrolling list that is always the
 /// width of the screen, consider [ListView], which is vastly more efficient
-/// that a [SingleChildScrollView] containing a [ListBody] or [Column] with
+/// than a [SingleChildScrollView] containing a [ListBody] or [Column] with
 /// many children.
 ///
 /// ## Sample code: Using [SingleChildScrollView] with a [Column]


### PR DESCRIPTION
Just the smallest of typo fixes ("that" becomes "than") in the documentation for SingleChildScrollView.

Issues fixed: I didn't create an issue because this is just a typo fix, let me know if you'd like me to.