### PR TITLE
Fixes `RangeError` bug when length of `TabBar.tabs` is changed

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -982,11 +982,11 @@ class _TabBarState extends State<TabBar> {
       _initIndicatorPainter();
     }
 
-    if (widget.tabs.length > oldWidget.tabs.length) {
-      final int delta = widget.tabs.length - oldWidget.tabs.length;
+    if (widget.tabs.length > _tabKeys.length) {
+      final int delta = widget.tabs.length - _tabKeys.length;
       _tabKeys.addAll(List<GlobalKey>.generate(delta, (int n) => GlobalKey()));
-    } else if (widget.tabs.length < oldWidget.tabs.length) {
-      _tabKeys.removeRange(widget.tabs.length, oldWidget.tabs.length);
+    } else if (widget.tabs.length < _tabKeys.length) {
+      _tabKeys.removeRange(widget.tabs.length, _tabKeys.length);
     }
   }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3301,6 +3301,52 @@ void main() {
     expect(await tester.pumpAndSettle(), 1); // no more frames are scheduled.
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/20292.
+  testWidgets('Number of tabs can be updated dynamically', (WidgetTester tester) async {
+    final List<String> threeTabs = <String>['A', 'B', 'C'];
+    final List<String> twoTabs = <String>['A', 'B'];
+    final List<String> oneTab = <String>['A'];
+    final Key key = UniqueKey();
+    Widget buildTabs(List<String> tabs) {
+      return boilerplate(
+        child: DefaultTabController(
+          key: key,
+          length: tabs.length,
+          child: TabBar(
+            tabs: tabs.map<Widget>((String tab) => Tab(text: tab)).toList(),
+          ),
+        ),
+      );
+    }
+    TabController getController() => DefaultTabController.of(tester.element(find.text('A')))!;
+
+    await tester.pumpWidget(buildTabs(threeTabs));
+    await tester.tap(find.text('B'));
+    await tester.pump();
+    TabController controller = getController();
+    expect(controller.previousIndex, 0);
+    expect(controller.index, 1);
+    expect(controller.length, 3);
+
+    await tester.pumpWidget(buildTabs(twoTabs));
+    controller = getController();
+    expect(controller.previousIndex, 0);
+    expect(controller.index, 1);
+    expect(controller.length, 2);
+
+    await tester.pumpWidget(buildTabs(oneTab));
+    controller = getController();
+    expect(controller.previousIndex, 1);
+    expect(controller.index, 0);
+    expect(controller.length, 1);
+
+    await tester.pumpWidget(buildTabs(twoTabs));
+    controller = getController();
+    expect(controller.previousIndex, 1);
+    expect(controller.index, 0);
+    expect(controller.length, 2);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/15008.
   testWidgets('TabBar with one tab has correct color', (WidgetTester tester) async {
     const Tab tab = Tab(text: 'A');

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -3419,8 +3419,79 @@ void main() {
     expect(find.text('Tab2'), findsOneWidget);
   });
 
-  testWidgets('DefaultTabController should allow dynamic length of tabs', (WidgetTester tester) async {
+  testWidgets('DefaultTabController should allow for a length of zero', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/20292.
+    List<String> tabTextContent = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return DefaultTabController(
+              length: tabTextContent.length,
+              child: Scaffold(
+                appBar: AppBar(
+                  title: const Text('Default TabBar Preview'),
+                  bottom: tabTextContent.isNotEmpty
+                    ? TabBar(
+                        isScrollable: true,
+                        tabs: tabTextContent.map((String textContent) => Tab(text: textContent)).toList(),
+                      )
+                    : null,
+                ),
+                body: tabTextContent.isNotEmpty
+                  ? TabBarView(
+                      children: tabTextContent.map((String textContent) => Tab(text: "$textContent's view")).toList(),
+                    )
+                  : const Center(child: Text('No tabs')),
+                bottomNavigationBar: BottomAppBar(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      IconButton(
+                        key: const Key('Add tab'),
+                        icon: const Icon(Icons.add),
+                        onPressed: () {
+                          setState(() {
+                            tabTextContent = List<String>.from(tabTextContent)
+                              ..add('Tab ${tabTextContent.length + 1}');
+                          });
+                        },
+                      ),
+                      IconButton(
+                        key: const Key('Delete tab'),
+                        icon: const Icon(Icons.delete),
+                        onPressed: () {
+                          setState(() {
+                            tabTextContent = List<String>.from(tabTextContent)
+                              ..removeLast();
+                          });
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Initializes with zero tabs properly
+    expect(find.text('No tabs'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('Add tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('Tab 1'), findsOneWidget);
+    expect(find.text("Tab 1's view"), findsOneWidget);
+
+    // Dynamically updates to zero tabs properly
+    await tester.tap(find.byKey(const Key('Delete tab')));
+    await tester.pumpAndSettle();
+    expect(find.text('No tabs'), findsOneWidget);
+  });
+
+  testWidgets('DefaultTabController should allow dynamic length of tabs', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/94504.
     final List<String> tabTitles = <String>[];
 


### PR DESCRIPTION
When `TabBar.tabs` is passed a `List`'s reference, and when the reference is updated, `TabBar` throws a RangeError because when widget is updated, `TabBar.didUpdateWidget` compares `widget.tabs.length` with `oldWidget.tabs.length`. Since they are referencing the same list, their lengths are also same and `TabBar._tabKeys` is not updated.

~This PR also removes a test, which was a regression test for #20292. This is because the test changes the list's reference by attaching a new list when pumping a new state, but the issue used the same list reference.~

Fixes #94504 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
