### PR TITLE
let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}

### DIFF
--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -40,17 +40,13 @@ String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolute
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->
-            //only flutter submodules.
             if (androidPlugins != null) {
                 String sanitizedPluginName = sp.name.replace(":", "");
-                //matching submodule, which one's name on the `pluginsFile`.
                 if (androidPlugins.name.contains(sanitizedPluginName)){
                     File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator + "plugins_build_output" + File.separator + sanitizedPluginName);
                     if (!androidPluginBuildOutputDir.exists()){
-                        //make dir if not exist.
                         androidPluginBuildOutputDir.mkdirs()
                     }
-                    //let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}.
                     sp.buildDir = androidPluginBuildOutputDir
                 }
             }

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -35,7 +35,6 @@ if (pluginsFile.exists()) {
     }
 }
 
-String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -9,16 +9,15 @@ import groovy.json.JsonSlurper
 
 def moduleProjectRoot = project(':flutter').projectDir.parentFile.parentFile
 
-def androidPlugins = null;
+def object = null;
 String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 // Note: if this logic is changed, also change the logic in app_plugin_loader.gradle.
 def pluginsFile = new File(moduleProjectRoot, '.flutter-plugins-dependencies')
 if (pluginsFile.exists()) {
-    def object = new JsonSlurper().parseText(pluginsFile.text)
+    object = new JsonSlurper().parseText(pluginsFile.text)
     assert object instanceof Map
     assert object.plugins instanceof Map
     assert object.plugins.android instanceof List
-    androidPlugins = object.plugins.android
     // Includes the Flutter plugins that support the Android platform.
     object.plugins.android.each { androidPlugin ->
         assert androidPlugin.name instanceof String
@@ -40,15 +39,14 @@ String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolute
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->
-            if (androidPlugins != null) {
+            if (object != null && object.plugins.android.name.contains(sanitizedPluginName)) {
                 String sanitizedPluginName = sp.name.replace(":", "");
-                if (androidPlugins.name.contains(sanitizedPluginName)){
-                    File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator + "plugins_build_output" + File.separator + sanitizedPluginName);
-                    if (!androidPluginBuildOutputDir.exists()){
-                        androidPluginBuildOutputDir.mkdirs()
-                    }
-                    sp.buildDir = androidPluginBuildOutputDir
+                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator
+                        + "plugins_build_output" + File.separator + sanitizedPluginName);
+                if (!androidPluginBuildOutputDir.exists()){
+                    androidPluginBuildOutputDir.mkdirs()
                 }
+                sp.buildDir = androidPluginBuildOutputDir
             }
         }
         def _mainModuleName = binding.variables['mainModuleName']

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -38,9 +38,9 @@ if (pluginsFile.exists()) {
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->
+            String sanitizedPluginName = sp.name.replace(":", "");
             if (object != null && object.plugins != null && object.plugins.android != null
                     && object.plugins.android.name.contains(sanitizedPluginName)) {
-                String sanitizedPluginName = sp.name.replace(":", "");
                 File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator
                         + "plugins_build_output" + File.separator + sanitizedPluginName);
                 if (!androidPluginBuildOutputDir.exists()) {

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -11,6 +11,7 @@ def moduleProjectRoot = project(':flutter').projectDir.parentFile.parentFile
 
 // Note: if this logic is changed, also change the logic in app_plugin_loader.gradle.
 def pluginsFile = new File(moduleProjectRoot, '.flutter-plugins-dependencies')
+List<String> pluginsNames = new ArrayList<>()
 if (pluginsFile.exists()) {
     def object = new JsonSlurper().parseText(pluginsFile.text)
     assert object instanceof Map
@@ -20,6 +21,7 @@ if (pluginsFile.exists()) {
     object.plugins.android.each { androidPlugin ->
         assert androidPlugin.name instanceof String
         assert androidPlugin.path instanceof String
+        pluginsNames.add(androidPlugin.name)
         // Skip plugins that have no native build (such as a Dart-only
         // implementation of a federated plugin).
         def needsBuild = androidPlugin.containsKey('native_build') ? androidPlugin['native_build'] : true
@@ -33,8 +35,20 @@ if (pluginsFile.exists()) {
     }
 }
 
+String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
+        //let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}.
+        p.subprojects { sp ->
+            if (pluginsNames.contains(sp.name.replace(":", ""))){
+                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator + "plugins_build_output" + File.separator + sp.name.replace(":", ""));
+                if (!androidPluginBuildOutputDir.exists()){
+                    //make dir if not exist.
+                    androidPluginBuildOutputDir.mkdirs()
+                }
+                sp.buildDir = androidPluginBuildOutputDir
+            }
+        }
         def _mainModuleName = binding.variables['mainModuleName']
         if (_mainModuleName != null && !_mainModuleName.empty) {
             p.ext.mainModuleName = _mainModuleName

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -35,18 +35,12 @@ if (pluginsFile.exists()) {
     }
 }
 
-String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
-        //let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}.
+        //let the plugin's output generated in "${rootProject.buildDir}/${androidPlugin.name}".
         p.subprojects { sp ->
             if (pluginsNames.contains(sp.name.replace(":", ""))){
-                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator + "plugins_build_output" + File.separator + sp.name.replace(":", ""));
-                if (!androidPluginBuildOutputDir.exists()){
-                    //make dir if not exist.
-                    androidPluginBuildOutputDir.mkdirs()
-                }
-                sp.buildDir = androidPluginBuildOutputDir
+                sp.buildDir = "${rootProject.buildDir}/${sp.name.replace(":", "")}"
             }
         }
         def _mainModuleName = binding.variables['mainModuleName']

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -21,6 +21,7 @@ if (pluginsFile.exists()) {
     object.plugins.android.each { androidPlugin ->
         assert androidPlugin.name instanceof String
         assert androidPlugin.path instanceof String
+        // save plugin's name for modifying it's buildDir location. see issue #92252 for detail.
         pluginsNames.add(androidPlugin.name)
         // Skip plugins that have no native build (such as a Dart-only
         // implementation of a federated plugin).
@@ -45,6 +46,8 @@ gradle.getGradle().projectsLoaded { g ->
                     //make dir if not exist.
                     androidPluginBuildOutputDir.mkdirs()
                 }
+                // only the project object here can modify the `buildDir`.
+                // {@see https://github.com/flutter/flutter/pull/94645/files/7c77d3653709ccd1e2b45268b209f00f36d8470d#r819224682}
                 sp.buildDir = androidPluginBuildOutputDir
             }
         }

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -42,9 +42,9 @@ gradle.getGradle().projectsLoaded { g ->
             if (object != null && object.plugins != null && object.plugins.android != null
                     && object.plugins.android.name.contains(sanitizedPluginName)) {
                 String sanitizedPluginName = sp.name.replace(":", "");
-                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator
+                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator
                         + "plugins_build_output" + File.separator + sanitizedPluginName);
-                if (!androidPluginBuildOutputDir.exists()){
+                if (!androidPluginBuildOutputDir.exists()) {
                     androidPluginBuildOutputDir.mkdirs()
                 }
                 sp.buildDir = androidPluginBuildOutputDir

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -40,7 +40,7 @@ String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolute
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->
-            //only flutter 'add-to-app' project.
+            //only flutter submodules.
             if (androidPlugins != null) {
                 String sanitizedPluginName = sp.name.replace(":", "");
                 //matching submodule, which one's name on the `pluginsFile`.

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -37,16 +37,16 @@ if (pluginsFile.exists()) {
 
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
-        p.subprojects { sp ->
-            String sanitizedPluginName = sp.name.replace(":", "");
+        p.subprojects { subproject ->
+            String pluginName = subproject.name.replace(":", "");
             if (object != null && object.plugins != null && object.plugins.android != null
-                    && object.plugins.android.name.contains(sanitizedPluginName)) {
+                    && object.plugins.android.name.contains(pluginName)) {
                 File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator
-                        + "plugins_build_output" + File.separator + sanitizedPluginName);
+                        + "plugins_build_output" + File.separator + pluginName);
                 if (!androidPluginBuildOutputDir.exists()) {
                     androidPluginBuildOutputDir.mkdirs()
                 }
-                sp.buildDir = androidPluginBuildOutputDir
+                subproject.buildDir = androidPluginBuildOutputDir
             }
         }
         def _mainModuleName = binding.variables['mainModuleName']

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -9,20 +9,20 @@ import groovy.json.JsonSlurper
 
 def moduleProjectRoot = project(':flutter').projectDir.parentFile.parentFile
 
+def androidPlugins = null;
+String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 // Note: if this logic is changed, also change the logic in app_plugin_loader.gradle.
 def pluginsFile = new File(moduleProjectRoot, '.flutter-plugins-dependencies')
-List<String> pluginsNames = new ArrayList<>()
 if (pluginsFile.exists()) {
     def object = new JsonSlurper().parseText(pluginsFile.text)
     assert object instanceof Map
     assert object.plugins instanceof Map
     assert object.plugins.android instanceof List
+    androidPlugins = object.plugins.android
     // Includes the Flutter plugins that support the Android platform.
     object.plugins.android.each { androidPlugin ->
         assert androidPlugin.name instanceof String
         assert androidPlugin.path instanceof String
-        // save plugin's name for modifying it's buildDir location. see issue #92252 for detail.
-        pluginsNames.add(androidPlugin.name)
         // Skip plugins that have no native build (such as a Dart-only
         // implementation of a federated plugin).
         def needsBuild = androidPlugin.containsKey('native_build') ? androidPlugin['native_build'] : true
@@ -36,19 +36,23 @@ if (pluginsFile.exists()) {
     }
 }
 
+String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
-        //let the plugin's output generated in flutterModule/build/host/${androidPlugin.name}.
         p.subprojects { sp ->
-            if (pluginsNames.contains(sp.name.replace(":", ""))){
-                File androidPluginBuildOutputDir = new File(moduleProjectRoot.getAbsolutePath() + File.separator + "build" + File.separator + "host" + File.separator + sp.name.replace(":", ""));
-                if (!androidPluginBuildOutputDir.exists()){
-                    //make dir if not exist.
-                    androidPluginBuildOutputDir.mkdirs()
+            //only flutter 'add-to-app' project.
+            if (androidPlugins != null) {
+                String sanitizedPluginName = sp.name.replace(":", "");
+                //matching submodule, which one's name on the `pluginsFile`.
+                if (androidPlugins.name.contains(sanitizedPluginName)){
+                    File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator + "plugins_build_output" + File.separator + sanitizedPluginName);
+                    if (!androidPluginBuildOutputDir.exists()){
+                        //make dir if not exist.
+                        androidPluginBuildOutputDir.mkdirs()
+                    }
+                    //let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}.
+                    sp.buildDir = androidPluginBuildOutputDir
                 }
-                // only the project object here can modify the `buildDir`.
-                // {@see https://github.com/flutter/flutter/pull/94645/files/7c77d3653709ccd1e2b45268b209f00f36d8470d#r819224682}
-                sp.buildDir = androidPluginBuildOutputDir
             }
         }
         def _mainModuleName = binding.variables['mainModuleName']

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -35,13 +35,12 @@ if (pluginsFile.exists()) {
     }
 }
 
-String flutterModulePath = project(':flutter').projectDir.parentFile.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         //let the plugin's output generated in flutterModule/build/host/${androidPlugin.name}.
         p.subprojects { sp ->
             if (pluginsNames.contains(sp.name.replace(":", ""))){
-                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + "build" + File.separator + "host" + File.separator + sp.name.replace(":", ""));
+                File androidPluginBuildOutputDir = new File(moduleProjectRoot.getAbsolutePath() + File.separator + "build" + File.separator + "host" + File.separator + sp.name.replace(":", ""));
                 if (!androidPluginBuildOutputDir.exists()){
                     //make dir if not exist.
                     androidPluginBuildOutputDir.mkdirs()

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -39,7 +39,8 @@ String flutterModulePath = project(':flutter').projectDir.parentFile.getAbsolute
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { sp ->
-            if (object != null && object.plugins.android.name.contains(sanitizedPluginName)) {
+            if (object != null && object.plugins != null && object.plugins.android != null
+                    && object.plugins.android.name.contains(sanitizedPluginName)) {
                 String sanitizedPluginName = sp.name.replace(":", "");
                 File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + File.separator
                         + "plugins_build_output" + File.separator + sanitizedPluginName);

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -38,11 +38,10 @@ if (pluginsFile.exists()) {
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
         p.subprojects { subproject ->
-            String pluginName = subproject.name.replace(":", "");
             if (object != null && object.plugins != null && object.plugins.android != null
-                    && object.plugins.android.name.contains(pluginName)) {
+                    && object.plugins.android.name.contains(subproject.name)) {
                 File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator
-                        + "plugins_build_output" + File.separator + pluginName);
+                        + "plugins_build_output" + File.separator + subproject.name);
                 if (!androidPluginBuildOutputDir.exists()) {
                     androidPluginBuildOutputDir.mkdirs()
                 }

--- a/packages/flutter_tools/gradle/module_plugin_loader.gradle
+++ b/packages/flutter_tools/gradle/module_plugin_loader.gradle
@@ -35,12 +35,18 @@ if (pluginsFile.exists()) {
     }
 }
 
+String flutterModulePath = project(':flutter').projectDir.parentFile.parentFile.getAbsolutePath()
 gradle.getGradle().projectsLoaded { g ->
     g.rootProject.beforeEvaluate { p ->
-        //let the plugin's output generated in "${rootProject.buildDir}/${androidPlugin.name}".
+        //let the plugin's output generated in flutterModule/build/host/${androidPlugin.name}.
         p.subprojects { sp ->
             if (pluginsNames.contains(sp.name.replace(":", ""))){
-                sp.buildDir = "${rootProject.buildDir}/${sp.name.replace(":", "")}"
+                File androidPluginBuildOutputDir = new File(flutterModulePath + File.separator + "build" + File.separator + "host" + File.separator + sp.name.replace(":", ""));
+                if (!androidPluginBuildOutputDir.exists()){
+                    //make dir if not exist.
+                    androidPluginBuildOutputDir.mkdirs()
+                }
+                sp.buildDir = androidPluginBuildOutputDir
             }
         }
         def _mainModuleName = binding.variables['mainModuleName']

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     final String projectPath = fileSystem.path.join(tempDir.path, 'flutter_project');
 
-    File modulePubspec = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.yaml'));
+    final File modulePubspec = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.yaml'));
     String pubspecContent = modulePubspec.readAsStringSync();
     pubspecContent = pubspecContent.replaceFirst(
       'dependencies:',

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -25,7 +25,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test("error logged when plugin's output dir was flutter_project/", () async {
+  test("error logged when plugin's build output dir was not private.", () async {
     final String flutterBin = fileSystem.path.join(
       getFlutterRoot(),
       'bin',

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -13,7 +15,6 @@ import 'test_utils.dart';
 void main() {
 
   late Directory tempDir;
-  late String projectPath;
 
   setUp(()  {
     Cache.flutterRoot = getFlutterRoot();
@@ -39,13 +40,14 @@ void main() {
       'flutter_project'
     ], workingDirectory: tempDir.path);
 
-    projectPath = fileSystem.path.join(tempDir.path, 'flutter_project');
+    final String projectPath = fileSystem.path.join(tempDir.path, 'flutter_project');
 
     File modulePubspec = fileSystem.file(fileSystem.path.join(projectPath, 'pubspec.yaml'));
     String pubspecContent = modulePubspec.readAsStringSync();
     pubspecContent = pubspecContent.replaceFirst(
       'dependencies:',
-      '''dependencies:
+      '''
+dependencies:
   image_picker: any''',
     );
     modulePubspec.writeAsStringSync(pubspecContent);
@@ -58,6 +60,8 @@ void main() {
       'aar',
       '--target-platform=android-arm',
     ], workingDirectory: projectPath);
+
+    log(result.exitCode);
 
     // Check outputDir existed
     final Directory outputDir = fileSystem.directory(fileSystem.path.join(

--- a/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_new_output_dir_test.dart
@@ -48,7 +48,7 @@ void main() {
       'dependencies:',
       '''
 dependencies:
-  image_picker: any''',
+  image_picker: 0.8.5+3''',
     );
     modulePubspec.writeAsStringSync(pubspecContent);
 


### PR DESCRIPTION
let the plugin's output generated in flutter/.android/plugins_build_output/${androidPlugin.name}. will close #92252

*change the output directory of native plugin's from `$HOME/.pub-cache/${plugin_path}` to `${flutter_module_path}/.android/plugins_build_output/${androidPlugin.name}`. Because the directory userd before was a shared directory,it will cause issue #92252 when run multiple task simultaneously.*

*List which issues are fixed by this PR. You must list at least one issue.*
#92252

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
