### PR TITLE
Make BottomNavigationBarItem label required to avoid getting an error

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -184,10 +184,6 @@ class BottomNavigationBar extends StatefulWidget {
     this.landscapeLayout,
   }) : assert(items != null),
        assert(items.length >= 2),
-       assert(
-        items.every((BottomNavigationBarItem item) => item.label != null),
-        'Every item must have a non-null label',
-       ),
        assert(0 <= currentIndex && currentIndex < items.length),
        assert(elevation == null || elevation >= 0.0),
        assert(iconSize != null && iconSize >= 0.0),

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -24,7 +24,7 @@ class BottomNavigationBarItem {
   /// The argument [icon] should not be null and the argument [label] should not be null when used in a Material Design's [BottomNavigationBar].
   const BottomNavigationBarItem({
     required this.icon,
-    this.label,
+    required this.label,
     Widget? activeIcon,
     this.backgroundColor,
     this.tooltip,

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -429,43 +429,6 @@ Future<void> main() async {
     semantics.dispose();
   });
 
-  testWidgets('Label of items should be nullable', (WidgetTester tester) async {
-    final MemoryImage iconProvider = MemoryImage(Uint8List.fromList(kTransparentImage));
-    final List<int> itemsTapped = <int>[];
-
-    await pumpWidgetWithBoilerplate(
-      tester,
-      MediaQuery(
-        data: const MediaQueryData(),
-        child: CupertinoTabBar(
-          items: <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-              icon: ImageIcon(
-                MemoryImage(Uint8List.fromList(kTransparentImage)),
-              ),
-              label: 'Tab 1',
-            ),
-            BottomNavigationBarItem(
-              icon: ImageIcon(
-                iconProvider,
-              ),
-            ),
-          ],
-          onTap: (int index) => itemsTapped.add(index),
-        ),
-      ),
-    );
-
-    expect(find.text('Tab 1'), findsOneWidget);
-
-    final Finder finder = find.byWidgetPredicate(
-      (Widget widget) => widget is Image && widget.image == iconProvider,
-    );
-
-    await tester.tap(finder);
-    expect(itemsTapped, <int>[1]);
-  });
-
   testWidgets('Hide border hides the top border of the tabBar', (WidgetTester tester) async {
     await pumpWidgetWithBoilerplate(
       tester,

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1626,27 +1626,6 @@ void main() {
     }
   });
 
-  testWidgets('BottomNavigationBar item label should not be nullable', (WidgetTester tester) async {
-    expect(() {
-      MaterialApp(
-        home: Scaffold(
-          bottomNavigationBar: BottomNavigationBar(
-            type: BottomNavigationBarType.shifting,
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
-                icon: Icon(Icons.ac_unit),
-                label: 'AC',
-              ),
-              BottomNavigationBarItem(
-                icon: Icon(Icons.access_alarm),
-              ),
-            ],
-          ),
-        ),
-      );
-    }, throwsAssertionError);
-  });
-
   testWidgets(
     'BottomNavigationBar [showSelectedLabels]=false and [showUnselectedLabels]=false '
     'for shifting navbar, expect that there is no rendered text',

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -2117,8 +2117,8 @@ Future<void> main() async {
         home: CupertinoTabScaffold(
           tabBar: CupertinoTabBar(
             items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(icon: Icon(Icons.home)),
-              BottomNavigationBarItem(icon: Icon(Icons.favorite)),
+              BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+              BottomNavigationBarItem(icon: Icon(Icons.favorite), label: 'Favorite'),
             ],
           ),
           tabBuilder: (BuildContext context, int index) {


### PR DESCRIPTION
Make BottomNavigationBarItem label required to avoid getting an error.

Remove assert of item.label != null because now are required

Remove test "BottomNavigationBar item label should not be nullable" because now is required

I'm not sure if there is a way to create tests to a required field...
