### PR TITLE
Fixed order dependency and removed no-shuffle-tag in build_ios_framew…

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -56,7 +56,6 @@ void main() {
           fileSystem: memoryFileSystem,
           processManager: FakeProcessManager.any(),
         );
-
         rootOverride.childDirectory('bin').childDirectory('internal').childFile('engine.version')
           ..createSync(recursive: true)
           ..writeAsStringSync(engineRevision);

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -55,7 +55,7 @@ void main() {
           platform: fakePlatform,
           fileSystem: memoryFileSystem,
           processManager: FakeProcessManager.any(),
-        ); 
+        );
 
         rootOverride.childDirectory('bin').childDirectory('internal').childFile('engine.version')
           ..createSync(recursive: true)
@@ -142,7 +142,7 @@ void main() {
 
         setUp(() {
           // cache.getLicenseFile() relies on the flutter root being set.
-          Cache.flutterRoot ??= getFlutterRoot(); 
+          Cache.flutterRoot ??= getFlutterRoot();
           cache.getLicenseFile()
             ..createSync(recursive: true)
             ..writeAsStringSync(licenseText);

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_framework_test.dart
@@ -4,12 +4,6 @@
 
 // @dart = 2.8
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -61,7 +55,8 @@ void main() {
           platform: fakePlatform,
           fileSystem: memoryFileSystem,
           processManager: FakeProcessManager.any(),
-        );
+        ); 
+
         rootOverride.childDirectory('bin').childDirectory('internal').childFile('engine.version')
           ..createSync(recursive: true)
           ..writeAsStringSync(engineRevision);
@@ -146,6 +141,8 @@ void main() {
         const String licenseText = 'This is the license!';
 
         setUp(() {
+          // cache.getLicenseFile() relies on the flutter root being set.
+          Cache.flutterRoot ??= getFlutterRoot(); 
           cache.getLicenseFile()
             ..createSync(recursive: true)
             ..writeAsStringSync(licenseText);


### PR DESCRIPTION
Fixed order dependency and removed no-shuffle-tag in build_ios_framework_test.dart. Part of #85160.

Another one of these down. This one was a tad more tricky.

## The Problem
The tests were failing when using --test-randomize-ordering-seed=1000, and most other seeds as well.

The first three tests in this file set the Cache.flutterRoot variable. This is done by default by the testUsingContext method.
When randomizing the test order the method setUp on line 143 runs cache.getLicenseFile() without Cache.flutterRoot being set. The method getLicenseFile is dependent on flutterRoot being set, so this makes all test in that group fail.

## The Solution
Set the Cache.flutterRoot variable, if not set, before calling the method cache.getLicenseFile().


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
