### PR TITLE
[web] Stop using web experiments in benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/web_benchmarks.dart
@@ -72,11 +72,8 @@ final Map<String, RecorderFactory> benchmarks = <String, RecorderFactory>{
 
   // HTML-only benchmarks
   if (!isCanvasKit) ...<String, RecorderFactory>{
-    BenchTextLayout.domBenchmarkName: () => BenchTextLayout.dom(),
     BenchTextLayout.canvasBenchmarkName: () => BenchTextLayout.canvas(),
-    BenchTextCachedLayout.domBenchmarkName: () => BenchTextCachedLayout.dom(),
     BenchTextCachedLayout.canvasBenchmarkName: () => BenchTextCachedLayout.canvas(),
-    BenchBuildColorsGrid.domBenchmarkName: () => BenchBuildColorsGrid.dom(),
     BenchBuildColorsGrid.canvasBenchmarkName: () => BenchBuildColorsGrid.canvas(),
   },
 };


### PR DESCRIPTION
The web experiments API was removed in https://github.com/flutter/engine/pull/30007. It caused benchmarks to fail because they use this API.

The PR was reverted here: https://github.com/flutter/engine/pull/30137

This PR removes the usage of web experiments in benchmarks so we can safely reland https://github.com/flutter/engine/pull/30007