### PR TITLE
Revert "Ensure the engineLayer is disposed when an OpacityLayer is disabled"

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1764,16 +1764,11 @@ class OpacityLayer extends OffsetLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(alpha != null);
-
-    // Don't add this layer if there's no child.
-    bool enabled = firstChild != null;
+    bool enabled = firstChild != null;  // don't add this layer if there's no child
     if (!enabled) {
-      // Ensure the engineLayer is disposed.
-      engineLayer = null;
       // TODO(dnfield): Remove this if/when we can fix https://github.com/flutter/flutter/issues/90004
       return;
     }
-
     assert(() {
       enabled = enabled && !debugDisableOpacityLayers;
       return true;

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -637,21 +637,6 @@ void main() {
     expect(builder.addedPicture, true);
     expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
   });
-
-  test('OpacityLayer dispose its engineLayer if there are no children', () {
-    final OpacityLayer layer = OpacityLayer(alpha: 128);
-    final FakeSceneBuilder builder = FakeSceneBuilder();
-    layer.addToScene(builder);
-    expect(layer.engineLayer, null);
-
-    layer.append(PictureLayer(Rect.largest)..picture = FakePicture());
-    layer.addToScene(builder);
-    expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
-
-    layer.removeAllChildren();
-    layer.addToScene(builder);
-    expect(layer.engineLayer, null);
-  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {


### PR DESCRIPTION
Reverts flutter/flutter#94280

This causes some internal test failure: b/209109682
