### PR TITLE
Xcode error message

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -32,6 +32,7 @@ import 'migrations/remove_framework_link_and_embedding_migration.dart';
 import 'migrations/xcode_build_system_migration.dart';
 import 'xcode_build_settings.dart';
 import 'xcodeproj.dart';
+import 'xcresult.dart';
 
 class IMobileDevice {
   IMobileDevice({
@@ -315,74 +316,97 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   Status? buildSubStatus;
   Status? initialBuildStatus;
-  Directory? tempDir;
-
   File? scriptOutputPipeFile;
-  if (globals.logger.hasTerminal) {
-    tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_build_log_pipe.');
-    scriptOutputPipeFile = tempDir.childFile('pipe_to_stdout');
-    globals.os.makePipe(scriptOutputPipeFile.path);
+  RunResult? buildResult;
+  XCResult? xcResult;
 
-    Future<void> listenToScriptOutputLine() async {
-      final List<String> lines = await scriptOutputPipeFile!.readAsLines();
-      for (final String line in lines) {
-        if (line == 'done' || line == 'all done') {
-          buildSubStatus?.stop();
-          buildSubStatus = null;
-          if (line == 'all done') {
-            // Free pipe file.
-            tempDir?.deleteSync(recursive: true);
-            return;
+  final Directory tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_ios_build_temp_dir');
+  try {
+    if (globals.logger.hasTerminal) {
+      scriptOutputPipeFile = tempDir.childFile('pipe_to_stdout');
+      globals.os.makePipe(scriptOutputPipeFile.path);
+
+      Future<void> listenToScriptOutputLine() async {
+        final List<String> lines = await scriptOutputPipeFile!.readAsLines();
+        for (final String line in lines) {
+          if (line == 'done' || line == 'all done') {
+            buildSubStatus?.stop();
+            buildSubStatus = null;
+            if (line == 'all done') {
+              return;
+            }
+          } else {
+            initialBuildStatus?.cancel();
+            initialBuildStatus = null;
+            buildSubStatus = globals.logger.startProgress(
+              line,
+              progressIndicatorPadding: kDefaultStatusPadding - 7,
+            );
           }
-        } else {
-          initialBuildStatus?.cancel();
-          initialBuildStatus = null;
-          buildSubStatus = globals.logger.startProgress(
-            line,
-            progressIndicatorPadding: kDefaultStatusPadding - 7,
-          );
         }
+        await listenToScriptOutputLine();
       }
-      await listenToScriptOutputLine();
+
+      // Trigger the start of the pipe -> stdout loop. Ignore exceptions.
+      unawaited(listenToScriptOutputLine());
+
+      buildCommands.add('SCRIPT_OUTPUT_STREAM_FILE=${scriptOutputPipeFile.absolute.path}');
     }
 
-    // Trigger the start of the pipe -> stdout loop. Ignore exceptions.
-    unawaited(listenToScriptOutputLine());
-
-    buildCommands.add('SCRIPT_OUTPUT_STREAM_FILE=${scriptOutputPipeFile.absolute.path}');
-  }
-
-  // Don't log analytics for downstream Flutter commands.
-  // e.g. `flutter build bundle`.
-  buildCommands.add('FLUTTER_SUPPRESS_ANALYTICS=true');
-  buildCommands.add('COMPILER_INDEX_STORE_ENABLE=NO');
-  buildCommands.addAll(environmentVariablesAsXcodeBuildSettings(globals.platform));
-
-  if (buildAction == XcodeBuildAction.archive) {
     buildCommands.addAll(<String>[
-      '-archivePath',
-      globals.fs.path.absolute(app.archiveBundlePath),
-      'archive',
+      '-resultBundlePath',
+      tempDir.childFile(_kResultBundlePath).absolute.path,
+      '-resultBundleVersion',
+      _kResultBundleVersion
     ]);
+
+    // Don't log analytics for downstream Flutter commands.
+    // e.g. `flutter build bundle`.
+    buildCommands.add('FLUTTER_SUPPRESS_ANALYTICS=true');
+    buildCommands.add('COMPILER_INDEX_STORE_ENABLE=NO');
+    buildCommands.addAll(environmentVariablesAsXcodeBuildSettings(globals.platform));
+
+    if (buildAction == XcodeBuildAction.archive) {
+      buildCommands.addAll(<String>[
+        '-archivePath',
+        globals.fs.path.absolute(app.archiveBundlePath),
+        'archive',
+      ]);
+    }
+
+    final Stopwatch sw = Stopwatch()..start();
+    initialBuildStatus = globals.logger.startProgress('Running Xcode build...');
+
+    buildResult = await _runBuildWithRetries(buildCommands, app);
+
+    // Notifies listener that no more output is coming.
+    scriptOutputPipeFile?.writeAsStringSync('all done');
+    buildSubStatus?.stop();
+    buildSubStatus = null;
+    initialBuildStatus?.cancel();
+    initialBuildStatus = null;
+    globals.printStatus(
+      'Xcode ${xcodeBuildActionToString(buildAction)} done.'.padRight(kDefaultStatusPadding + 1)
+          + getElapsedAsSeconds(sw.elapsed).padLeft(5),
+    );
+    globals.flutterUsage.sendTiming(xcodeBuildActionToString(buildAction), 'xcode-ios', Duration(milliseconds: sw.elapsedMilliseconds));
+
+    if (tempDir.existsSync()) {
+      // Display additional warning and error message from xcresult bundle.
+      final Directory resultBundle = tempDir.childDirectory(_kResultBundlePath);
+      if (!resultBundle.existsSync()) {
+        globals.printTrace('The xcresult bundle are not generated. Displaying xcresult is disabled.');
+      } else {
+        // Discard unwanted errors. See: https://github.com/flutter/flutter/issues/95354
+        final XCResultIssueDiscarder warningDiscarder = XCResultIssueDiscarder(typeMatcher: XCResultIssueType.warning);
+        final XCResultIssueDiscarder dartBuildErrorDiscarder = XCResultIssueDiscarder(messageMatcher: RegExp(r'Command PhaseScriptExecution failed with a nonzero exit code'));
+        final XCResultGenerator xcResultGenerator = XCResultGenerator(resultPath: resultBundle.absolute.path, xcode: globals.xcode!, processUtils: globals.processUtils);
+        xcResult = await xcResultGenerator.generate(issueDiscarders: <XCResultIssueDiscarder>[warningDiscarder, dartBuildErrorDiscarder]);
+      }
+    }
+  } finally {
+    tempDir.deleteSync(recursive: true);
   }
-
-  final Stopwatch sw = Stopwatch()..start();
-  initialBuildStatus = globals.logger.startProgress('Running Xcode build...');
-
-  final RunResult? buildResult = await _runBuildWithRetries(buildCommands, app);
-
-  // Notifies listener that no more output is coming.
-  scriptOutputPipeFile?.writeAsStringSync('all done');
-  buildSubStatus?.stop();
-  buildSubStatus = null;
-  initialBuildStatus?.cancel();
-  initialBuildStatus = null;
-  globals.printStatus(
-    'Xcode ${xcodeBuildActionToString(buildAction)} done.'.padRight(kDefaultStatusPadding + 1)
-        + getElapsedAsSeconds(sw.elapsed).padLeft(5),
-  );
-  globals.flutterUsage.sendTiming(xcodeBuildActionToString(buildAction), 'xcode-ios', Duration(milliseconds: sw.elapsedMilliseconds));
-
   if (buildResult != null && buildResult.exitCode != 0) {
     globals.printStatus('Failed to build iOS app');
     if (buildResult.stderr.isNotEmpty) {
@@ -403,6 +427,7 @@ Future<XcodeBuildResult> buildXcodeProject({
         environmentType: environmentType,
         buildSettings: buildSettings,
       ),
+      xcResult: xcResult,
     );
   } else {
     String? outputDir;
@@ -466,6 +491,7 @@ Future<XcodeBuildResult> buildXcodeProject({
           environmentType: environmentType,
           buildSettings: buildSettings,
       ),
+      xcResult: xcResult,
     );
   }
 }
@@ -585,15 +611,18 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
     logger.printError('  open ios/Runner.xcworkspace');
     return;
   }
-  if (result.stdout?.contains('Code Sign error') == true) {
-    logger.printError('');
-    logger.printError('It appears that there was a problem signing your application prior to installation on the device.');
-    logger.printError('');
-    logger.printError('Verify that the Bundle Identifier in your project is your signing id in Xcode');
-    logger.printError('  open ios/Runner.xcworkspace');
-    logger.printError('');
-    logger.printError("Also try selecting 'Product > Build' to fix the problem:");
+
+  // Handle xcresult errors.
+  final XCResult? xcResult = result.xcResult;
+  if (xcResult == null) {
     return;
+  }
+  if (!xcResult.parseSuccess) {
+    globals.printTrace('XCResult parsing error: ${xcResult.parsingErrorMessage}');
+    return;
+  }
+  for (final XCResultIssue issue in xcResult.issues) {
+    _handleXCResultIssue(issue: issue, logger: logger);
   }
 }
 
@@ -618,6 +647,7 @@ class XcodeBuildResult {
     this.stdout,
     this.stderr,
     this.xcodeBuildExecution,
+    this.xcResult
   });
 
   final bool success;
@@ -626,6 +656,10 @@ class XcodeBuildResult {
   final String? stderr;
   /// The invocation of the build that resulted in this result instance.
   final XcodeBuildExecution? xcodeBuildExecution;
+  /// Parsed information in xcresult bundle.
+  ///
+  /// Can be null if the bundle is not created during build.
+  final XCResult? xcResult;
 }
 
 /// Describes an invocation of a Xcode build command.
@@ -686,3 +720,38 @@ bool upgradePbxProjWithFlutterAssets(IosProject project, Logger logger) {
   xcodeProjectFile.writeAsStringSync(buffer.toString());
   return true;
 }
+
+void _handleXCResultIssue({required XCResultIssue issue, required Logger logger}) {
+  // Issue summary from xcresult.
+  final StringBuffer issueSummaryBuffer = StringBuffer();
+  issueSummaryBuffer.write(issue.subType ?? 'Unknown');
+  issueSummaryBuffer.write(' (Xcode): ');
+  issueSummaryBuffer.writeln(issue.message ?? '');
+  if (issue.location != null ) {
+    issueSummaryBuffer.writeln(issue.location);
+  }
+  final String issueSummary = issueSummaryBuffer.toString();
+
+  switch (issue.type) {
+    case XCResultIssueType.error:
+      logger.printError(issueSummary);
+      break;
+    case XCResultIssueType.warning:
+      logger.printWarning(issueSummary);
+      break;
+  }
+
+  // Add more custom output for flutter users.
+  if (issue.message != null && issue.message!.toLowerCase().contains('provisioning profile')) {
+    logger.printError('');
+    logger.printError('It appears that there was a problem signing your application prior to installation on the device.');
+    logger.printError('');
+    logger.printError('Verify that the Bundle Identifier in your project is your signing id in Xcode');
+    logger.printError('  open ios/Runner.xcworkspace');
+    logger.printError('');
+    logger.printError("Also try selecting 'Product > Build' to fix the problem:");
+  }
+}
+
+const String _kResultBundlePath = 'temporary_xcresult_bundle';
+const String _kResultBundleVersion = '3';

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -545,6 +545,7 @@ class IOSSimulator extends Device {
       deviceID: id,
     );
     if (!buildResult.success) {
+      await diagnoseXcodeBuildFailure(buildResult, globals.flutterUsage, globals.logger);
       throwToolExit('Could not build the application for the simulator.');
     }
 

--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -78,31 +78,8 @@ class XCResult {
   /// Parse the `resultJson` and stores useful informations in the returned `XCResult`.
   factory XCResult({required Map<String, Object?> resultJson, List<XCResultIssueDiscarder> issueDiscarders = const <XCResultIssueDiscarder>[]}) {
     final List<XCResultIssue> issues = <XCResultIssue>[];
-    final Object? actionsMap = resultJson['actions'];
-    if (actionsMap == null || actionsMap is! Map<String, Object?>) {
-      return XCResult.failed(
-          errorMessage: 'xcresult parser: Failed to parse the actions map.');
-    }
-    final Object? actionValueList = actionsMap['_values'];
-    if (actionValueList == null ||
-        actionValueList is! List<Object?> ||
-        actionValueList.isEmpty) {
-      return XCResult.failed(
-          errorMessage: 'xcresult parser: Failed to parse the actions map.');
-    }
-    final Object? actionMap = actionValueList.first;
-    if (actionMap == null || actionMap is! Map<String, Object?>) {
-      return XCResult.failed(
-          errorMessage:
-              'xcresult parser: Failed to parse the first action map.');
-    }
-    final Object? buildResultMap = actionMap['buildResult'];
-    if (buildResultMap == null || buildResultMap is! Map<String, Object?>) {
-      return XCResult.failed(
-          errorMessage:
-              'xcresult parser: Failed to parse the buildResult map.');
-    }
-    final Object? issuesMap = buildResultMap['issues'];
+
+    final Object? issuesMap = resultJson['issues'];
     if (issuesMap == null || issuesMap is! Map<String, Object?>) {
       return XCResult.failed(
           errorMessage: 'xcresult parser: Failed to parse the issues map.');

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -58,6 +58,8 @@ const List<String> kRunReleaseArgs = <String>[
   'id=123',
   'ONLY_ACTIVE_ARCH=YES',
   'ARCHS=arm64',
+  '-resultBundlePath', '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle',
+  '-resultBundleVersion', '3',
   'FLUTTER_SUPPRESS_ANALYTICS=true',
   'COMPILER_INDEX_STORE_ENABLE=NO',
 ];

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
@@ -240,58 +240,17 @@ void main() {
         'xcresult parser: Unrecognized top level json format.');
   });
 
-  testWithoutContext('error: fail to parse actions map', () async {
+  testWithoutContext('error: fail to parse issue map', () async {
     final XCResultGenerator generator = _setupGenerator(resultJson: '{}');
 
     final XCResult result = await generator.generate();
     expect(result.issues.length, 0);
     expect(result.parseSuccess, false);
     expect(result.parsingErrorMessage,
-        'xcresult parser: Failed to parse the actions map.');
+        'xcresult parser: Failed to parse the issues map.');
   });
 
-  testWithoutContext('error: empty actions map', () async {
-    final XCResultGenerator generator =
-        _setupGenerator(resultJson: kSampleResultJsonEmptyActionsMap);
-
-    final XCResult result = await generator.generate();
-    expect(result.issues.length, 0);
-    expect(result.parseSuccess, false);
-    expect(result.parsingErrorMessage,
-        'xcresult parser: Failed to parse the actions map.');
-  });
-
-  testWithoutContext('error: empty actions map', () async {
-    final XCResultGenerator generator = _setupGenerator(resultJson: kSampleResultJsonEmptyActionsMap);
-
-    final XCResult result = await generator.generate();
-    expect(result.issues.length, 0);
-    expect(result.parseSuccess, false);
-    expect(result.parsingErrorMessage,
-        'xcresult parser: Failed to parse the actions map.');
-  });
-
-  testWithoutContext('error: empty actions map', () async {
-    final XCResultGenerator generator = _setupGenerator(resultJson: kSampleResultJsonInvalidActionMap);
-
-    final XCResult result = await generator.generate();
-    expect(result.issues.length, 0);
-    expect(result.parseSuccess, false);
-    expect(result.parsingErrorMessage,
-        'xcresult parser: Failed to parse the first action map.');
-  });
-
-  testWithoutContext('error: empty actions map', () async {
-    final XCResultGenerator generator = _setupGenerator(resultJson: kSampleResultJsonInvalidBuildResultMap);
-
-    final XCResult result = await generator.generate();
-    expect(result.issues.length, 0);
-    expect(result.parseSuccess, false);
-    expect(result.parsingErrorMessage,
-        'xcresult parser: Failed to parse the buildResult map.');
-  });
-
-  testWithoutContext('error: empty actions map', () async {
+  testWithoutContext('error: invalid issue map', () async {
     final XCResultGenerator generator = _setupGenerator(resultJson: kSampleResultJsonInvalidIssuesMap);
 
     final XCResult result = await generator.generate();

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
@@ -8,67 +8,99 @@ const String kSampleResultJsonInvalidIssuesMap = r'''
   "_type" : {
     "_name" : "ActionsInvocationRecord"
   },
-  "actions" : {
+  "issues": []
+}
+''';
+
+/// An example xcresult bundle json that contains warnings and errors that needs to be discarded per https://github.com/flutter/flutter/issues/95354.
+const String kSampleResultJsonWithIssuesToBeDiscarded = r'''
+{
+  "issues" : {
     "_type" : {
-      "_name" : "Array"
+      "_name" : "ResultIssueSummaries"
     },
-    "_values" : [
-      {
-        "buildResult": {
+    "errorSummaries" : {
+      "_type" : {
+        "_name" : "Array"
+      },
+      "_values" : [
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "documentLocationInCreatingWorkspace" : {
+            "_type" : {
+              "_name" : "DocumentLocation"
+            },
+            "concreteTypeName" : {
+              "_type" : {
+                "_name" : "String"
+              },
+              "_value" : "DVTTextDocumentLocation"
+            },
+            "url" : {
+              "_type" : {
+                "_name" : "String"
+              },
+              "_value" : "file:\/\/\/Users\/m\/Projects\/test_create\/ios\/Runner\/AppDelegate.m#CharacterRangeLen=0&CharacterRangeLoc=263&EndingColumnNumber=56&EndingLineNumber=7&LocationEncoding=1&StartingColumnNumber=56&StartingLineNumber=7"
+            }
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Semantic Issue"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Use of undeclared identifier 'asdas'"
+          }
+        },
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Uncategorized"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Command PhaseScriptExecution failed with a nonzero exit code"
+          }
         }
-      }
-    ]
-  }
-}
-''';
-
-/// An example xcresult bundle json with invalid build result map.
-const String kSampleResultJsonInvalidBuildResultMap = r'''
-{
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
+      ]
     },
-    "_values" : [
-      {}
-    ]
-  }
-}
-''';
-
-
-/// An example xcresult bundle json with invalid action map.
-const String kSampleResultJsonInvalidActionMap = r'''
-{
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
-    },
-    "_values" : [
-      []
-    ]
-  }
-}
-''';
-
-/// An example xcresult bundle json that contains empty actions map.
-const String kSampleResultJsonEmptyActionsMap = r'''
-{
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
-    },
-    "_values" : [
-    ]
+    "warningSummaries" : {
+      "_type" : {
+        "_name" : "Array"
+      },
+      "_values" : [
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Warning"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."
+          }
+        }
+      ]
+    }
   }
 }
 ''';
@@ -76,430 +108,6 @@ const String kSampleResultJsonEmptyActionsMap = r'''
 /// An example xcresult bundle json that contains some warning and some errors.
 const String kSampleResultJsonWithIssues = r'''
 {
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
-    },
-    "_values" : [
-      {
-        "_type" : {
-          "_name" : "ActionRecord"
-        },
-        "actionResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "action"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "notRequested"
-          }
-        },
-        "buildResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            },
-            "errorSummaries" : {
-              "_type" : {
-                "_name" : "Array"
-              },
-              "_values" : [
-                {
-                  "_type" : {
-                    "_name" : "IssueSummary"
-                  },
-                  "documentLocationInCreatingWorkspace" : {
-                    "_type" : {
-                      "_name" : "DocumentLocation"
-                    },
-                    "concreteTypeName" : {
-                      "_type" : {
-                        "_name" : "String"
-                      },
-                      "_value" : "DVTTextDocumentLocation"
-                    },
-                    "url" : {
-                      "_type" : {
-                        "_name" : "String"
-                      },
-                      "_value" : "file:\/\/\/Users\/m\/Projects\/test_create\/ios\/Runner\/AppDelegate.m#CharacterRangeLen=0&CharacterRangeLoc=263&EndingColumnNumber=56&EndingLineNumber=7&LocationEncoding=1&StartingColumnNumber=56&StartingLineNumber=7"
-                    }
-                  },
-                  "issueType" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Semantic Issue"
-                  },
-                  "message" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Use of undeclared identifier 'asdas'"
-                  }
-                }
-              ]
-            },
-            "warningSummaries" : {
-              "_type" : {
-                "_name" : "Array"
-              },
-              "_values" : [
-                {
-                  "_type" : {
-                    "_name" : "IssueSummary"
-                  },
-                  "issueType" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Warning"
-                  },
-                  "message" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."
-                  }
-                }
-              ]
-            }
-          },
-          "logRef" : {
-            "_type" : {
-              "_name" : "Reference"
-            },
-            "id" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "0~bjiFq9EH53z6VfWSr47dakT0w_aGcY_GFqgPuexHq1JsoKMmvf_6GLglMcWBYRCSNufKEX6l1YgbFmnuobsw5w=="
-            },
-            "targetType" : {
-              "_type" : {
-                "_name" : "TypeDefinition"
-              },
-              "name" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "ActivityLogSection"
-              }
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            },
-            "errorCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            },
-            "warningCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "build"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "failed"
-          }
-        },
-        "endedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2020-09-28T14:31:16.931-0700"
-        },
-        "runDestination" : {
-          "_type" : {
-            "_name" : "ActionRunDestinationRecord"
-          },
-          "displayName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "Any iOS Device"
-          },
-          "localComputerRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "busSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "100"
-            },
-            "cpuCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            },
-            "cpuKind" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "8-Core Intel Xeon W"
-            },
-            "cpuSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "3200"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "87BE7059-56E3-5470-B52D-31A0F76402B3"
-            },
-            "isConcreteDevice" : {
-              "_type" : {
-                "_name" : "Bool"
-              },
-              "_value" : "true"
-            },
-            "logicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "16"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iMacPro1,1"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iMac Pro"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.imacpro-2017"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "My Mac"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "x86_64h"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "10.15.5"
-            },
-            "operatingSystemVersionWithBuildNumber" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "10.15.5 (19F101)"
-            },
-            "physicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "8"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.macosx"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "macOS"
-              }
-            },
-            "ramSizeInMegabytes" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "65536"
-            }
-          },
-          "targetArchitecture" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "arm64e"
-          },
-          "targetDeviceRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.dt.Xcode.device.GenericiOS"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "Any iOS Device"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "arm64e"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.iphoneos"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "iOS"
-              }
-            }
-          },
-          "targetSDKRecord" : {
-            "_type" : {
-              "_name" : "ActionSDKRecord"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iphoneos14.0"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iOS 14.0"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "14.0"
-            }
-          }
-        },
-        "schemeCommandName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Run"
-        },
-        "schemeTaskName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build"
-        },
-        "startedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2020-09-28T14:31:13.125-0700"
-        },
-        "title" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build \"Runner\""
-        }
-      }
-    ]
-  },
   "issues" : {
     "_type" : {
       "_name" : "ResultIssueSummaries"
@@ -568,45 +176,6 @@ const String kSampleResultJsonWithIssues = r'''
           }
         }
       ]
-    }
-  },
-  "metadataRef" : {
-    "_type" : {
-      "_name" : "Reference"
-    },
-    "id" : {
-      "_type" : {
-        "_name" : "String"
-      },
-      "_value" : "0~hrKQOFMo2Ri-TrlvSpVK8vTHcYQxwuWYJuRHCjoxIleliOdh5fHOdfIALZV0S0FtjVmUB83FpKkPbWajga4wxA=="
-    },
-    "targetType" : {
-      "_type" : {
-        "_name" : "TypeDefinition"
-      },
-      "name" : {
-        "_type" : {
-          "_name" : "String"
-        },
-        "_value" : "ActionsInvocationMetadata"
-      }
-    }
-  },
-  "metrics" : {
-    "_type" : {
-      "_name" : "ResultMetrics"
-    },
-    "errorCount" : {
-      "_type" : {
-        "_name" : "Int"
-      },
-      "_value" : "1"
-    },
-    "warningCount" : {
-      "_type" : {
-        "_name" : "Int"
-      },
-      "_value" : "1"
     }
   }
 }
@@ -615,430 +184,6 @@ const String kSampleResultJsonWithIssues = r'''
 /// An example xcresult bundle json that contains some warning and some errors.
 const String kSampleResultJsonWithIssuesAndInvalidUrl = r'''
 {
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
-    },
-    "_values" : [
-      {
-        "_type" : {
-          "_name" : "ActionRecord"
-        },
-        "actionResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "action"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "notRequested"
-          }
-        },
-        "buildResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            },
-            "errorSummaries" : {
-              "_type" : {
-                "_name" : "Array"
-              },
-              "_values" : [
-                {
-                  "_type" : {
-                    "_name" : "IssueSummary"
-                  },
-                  "documentLocationInCreatingWorkspace" : {
-                    "_type" : {
-                      "_name" : "DocumentLocation"
-                    },
-                    "concreteTypeName" : {
-                      "_type" : {
-                        "_name" : "String"
-                      },
-                      "_value" : "DVTTextDocumentLocation"
-                    },
-                    "url" : {
-                      "_type" : {
-                        "_name" : "String"
-                      },
-                      "_value" : "3:00"
-                    }
-                  },
-                  "issueType" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Semantic Issue"
-                  },
-                  "message" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Use of undeclared identifier 'asdas'"
-                  }
-                }
-              ]
-            },
-            "warningSummaries" : {
-              "_type" : {
-                "_name" : "Array"
-              },
-              "_values" : [
-                {
-                  "_type" : {
-                    "_name" : "IssueSummary"
-                  },
-                  "issueType" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "Warning"
-                  },
-                  "message" : {
-                    "_type" : {
-                      "_name" : "String"
-                    },
-                    "_value" : "The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."
-                  }
-                }
-              ]
-            }
-          },
-          "logRef" : {
-            "_type" : {
-              "_name" : "Reference"
-            },
-            "id" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "0~bjiFq9EH53z6VfWSr47dakT0w_aGcY_GFqgPuexHq1JsoKMmvf_6GLglMcWBYRCSNufKEX6l1YgbFmnuobsw5w=="
-            },
-            "targetType" : {
-              "_type" : {
-                "_name" : "TypeDefinition"
-              },
-              "name" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "ActivityLogSection"
-              }
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            },
-            "errorCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            },
-            "warningCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "build"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "failed"
-          }
-        },
-        "endedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2020-09-28T14:31:16.931-0700"
-        },
-        "runDestination" : {
-          "_type" : {
-            "_name" : "ActionRunDestinationRecord"
-          },
-          "displayName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "Any iOS Device"
-          },
-          "localComputerRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "busSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "100"
-            },
-            "cpuCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            },
-            "cpuKind" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "8-Core Intel Xeon W"
-            },
-            "cpuSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "3200"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "87BE7059-56E3-5470-B52D-31A0F76402B3"
-            },
-            "isConcreteDevice" : {
-              "_type" : {
-                "_name" : "Bool"
-              },
-              "_value" : "true"
-            },
-            "logicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "16"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iMacPro1,1"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iMac Pro"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.imacpro-2017"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "My Mac"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "x86_64h"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "10.15.5"
-            },
-            "operatingSystemVersionWithBuildNumber" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "10.15.5 (19F101)"
-            },
-            "physicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "8"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.macosx"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "macOS"
-              }
-            },
-            "ramSizeInMegabytes" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "65536"
-            }
-          },
-          "targetArchitecture" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "arm64e"
-          },
-          "targetDeviceRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.dt.Xcode.device.GenericiOS"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "Any iOS Device"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "arm64e"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.iphoneos"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "iOS"
-              }
-            }
-          },
-          "targetSDKRecord" : {
-            "_type" : {
-              "_name" : "ActionSDKRecord"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iphoneos14.0"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iOS 14.0"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "14.0"
-            }
-          }
-        },
-        "schemeCommandName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Run"
-        },
-        "schemeTaskName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build"
-        },
-        "startedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2020-09-28T14:31:13.125-0700"
-        },
-        "title" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build \"Runner\""
-        }
-      }
-    ]
-  },
   "issues" : {
     "_type" : {
       "_name" : "ResultIssueSummaries"
@@ -1066,7 +211,7 @@ const String kSampleResultJsonWithIssuesAndInvalidUrl = r'''
               "_type" : {
                 "_name" : "String"
               },
-              "_value" : "file:\/\/\/Users\/m\/Projects\/test_create\/ios\/Runner\/AppDelegate.m#CharacterRangeLen=0&CharacterRangeLoc=263&EndingColumnNumber=56&EndingLineNumber=7&LocationEncoding=1&StartingColumnNumber=56&StartingLineNumber=7"
+              "_value" : "3:00"
             }
           },
           "issueType" : {
@@ -1108,45 +253,6 @@ const String kSampleResultJsonWithIssuesAndInvalidUrl = r'''
         }
       ]
     }
-  },
-  "metadataRef" : {
-    "_type" : {
-      "_name" : "Reference"
-    },
-    "id" : {
-      "_type" : {
-        "_name" : "String"
-      },
-      "_value" : "0~hrKQOFMo2Ri-TrlvSpVK8vTHcYQxwuWYJuRHCjoxIleliOdh5fHOdfIALZV0S0FtjVmUB83FpKkPbWajga4wxA=="
-    },
-    "targetType" : {
-      "_type" : {
-        "_name" : "TypeDefinition"
-      },
-      "name" : {
-        "_type" : {
-          "_name" : "String"
-        },
-        "_value" : "ActionsInvocationMetadata"
-      }
-    }
-  },
-  "metrics" : {
-    "_type" : {
-      "_name" : "ResultMetrics"
-    },
-    "errorCount" : {
-      "_type" : {
-        "_name" : "Int"
-      },
-      "_value" : "1"
-    },
-    "warningCount" : {
-      "_type" : {
-        "_name" : "Int"
-      },
-      "_value" : "1"
-    }
   }
 }
 ''';
@@ -1154,419 +260,44 @@ const String kSampleResultJsonWithIssuesAndInvalidUrl = r'''
 /// An example xcresult bundle json that contains no issues.
 const String kSampleResultJsonNoIssues = r'''
 {
-  "_type" : {
-    "_name" : "ActionsInvocationRecord"
-  },
-  "actions" : {
-    "_type" : {
-      "_name" : "Array"
-    },
-    "_values" : [
-      {
-        "_type" : {
-          "_name" : "ActionRecord"
-        },
-        "actionResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "action"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "notRequested"
-          }
-        },
-        "buildResult" : {
-          "_type" : {
-            "_name" : "ActionResult"
-          },
-          "coverage" : {
-            "_type" : {
-              "_name" : "CodeCoverageInfo"
-            }
-          },
-          "issues" : {
-            "_type" : {
-              "_name" : "ResultIssueSummaries"
-            }
-          },
-          "logRef" : {
-            "_type" : {
-              "_name" : "Reference"
-            },
-            "id" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "0~XBP6QfgBACcao7crWD8_8W18SPIqMzlK0U0oBhSvElOM8k-vQKO4ZmCtUhL-BfTDFSylC3qEPStUI3jNsBPTXA=="
-            },
-            "targetType" : {
-              "_type" : {
-                "_name" : "TypeDefinition"
-              },
-              "name" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "ActivityLogSection"
-              }
-            }
-          },
-          "metrics" : {
-            "_type" : {
-              "_name" : "ResultMetrics"
-            }
-          },
-          "resultName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "build"
-          },
-          "status" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "succeeded"
-          }
-        },
-        "endedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2021-10-27T13:13:38.875-0700"
-        },
-        "runDestination" : {
-          "_type" : {
-            "_name" : "ActionRunDestinationRecord"
-          },
-          "displayName" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "Any iOS Device"
-          },
-          "localComputerRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "busSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "100"
-            },
-            "cpuCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "1"
-            },
-            "cpuKind" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "12-Core Intel Xeon E5"
-            },
-            "cpuSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "2700"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "2BE58010-D352-540B-92E6-9A945BA6D36D"
-            },
-            "isConcreteDevice" : {
-              "_type" : {
-                "_name" : "Bool"
-              },
-              "_value" : "true"
-            },
-            "logicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "24"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "MacPro6,1"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "Mac Pro"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.macpro-cylinder"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "My Mac"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "x86_64"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "11.6"
-            },
-            "operatingSystemVersionWithBuildNumber" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "11.6 (20G165)"
-            },
-            "physicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "12"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.macosx"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "macOS"
-              }
-            },
-            "ramSizeInMegabytes" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "65536"
-            }
-          },
-          "targetArchitecture" : {
-            "_type" : {
-              "_name" : "String"
-            },
-            "_value" : "arm64e"
-          },
-          "targetDeviceRecord" : {
-            "_type" : {
-              "_name" : "ActionDeviceRecord"
-            },
-            "busSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            },
-            "cpuCount" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            },
-            "cpuSpeedInMHz" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder"
-            },
-            "logicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            },
-            "modelCode" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelName" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "GenericiOS"
-            },
-            "modelUTI" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "com.apple.dt.Xcode.device.GenericiOS"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "Any iOS Device"
-            },
-            "nativeArchitecture" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "arm64e"
-            },
-            "physicalCPUCoresPerPackage" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            },
-            "platformRecord" : {
-              "_type" : {
-                "_name" : "ActionPlatformRecord"
-              },
-              "identifier" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "com.apple.platform.iphoneos"
-              },
-              "userDescription" : {
-                "_type" : {
-                  "_name" : "String"
-                },
-                "_value" : "iOS"
-              }
-            },
-            "ramSizeInMegabytes" : {
-              "_type" : {
-                "_name" : "Int"
-              },
-              "_value" : "0"
-            }
-          },
-          "targetSDKRecord" : {
-            "_type" : {
-              "_name" : "ActionSDKRecord"
-            },
-            "identifier" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iphoneos15.0"
-            },
-            "name" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "iOS 15.0"
-            },
-            "operatingSystemVersion" : {
-              "_type" : {
-                "_name" : "String"
-              },
-              "_value" : "15.0"
-            }
-          }
-        },
-        "schemeCommandName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Run"
-        },
-        "schemeTaskName" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build"
-        },
-        "startedTime" : {
-          "_type" : {
-            "_name" : "Date"
-          },
-          "_value" : "2021-10-27T13:13:02.396-0700"
-        },
-        "title" : {
-          "_type" : {
-            "_name" : "String"
-          },
-          "_value" : "Build \"XCResultTestApp\""
-        }
-      }
-    ]
-  },
   "issues" : {
     "_type" : {
       "_name" : "ResultIssueSummaries"
     }
-  },
-  "metadataRef" : {
+  }
+}
+''';
+
+/// An example xcresult bundle json with some provision profile issue.
+const String kSampleResultJsonWithProvisionIssue = r'''
+{
+  "issues" : {
     "_type" : {
-      "_name" : "Reference"
+      "_name" : "ResultIssueSummaries"
     },
-    "id" : {
+    "errorSummaries" : {
       "_type" : {
-        "_name" : "String"
+        "_name" : "Array"
       },
-      "_value" : "0~4PY3oMxYEC19JHgIcIfOFnFe-ngUSzJD4NzcBevC8Y2-5y41lCyXxYXhi9eObvKdlU14arnDn8ilaTw6B_bbQQ=="
-    },
-    "targetType" : {
-      "_type" : {
-        "_name" : "TypeDefinition"
-      },
-      "name" : {
-        "_type" : {
-          "_name" : "String"
-        },
-        "_value" : "ActionsInvocationMetadata"
-      }
-    }
-  },
-  "metrics" : {
-    "_type" : {
-      "_name" : "ResultMetrics"
+      "_values" : [
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Semantic Issue"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Some Provisioning profile issue."
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Parse issues in xcresult and display them in console.

Fixes https://github.com/flutter/flutter/issues/22536

Sample output:
```
Semantic Issue (Xcode): Use of undeclared identifier 'ss'
/path/ios/Runner/AppDelegate.m:11:56
```

Also in this PR:
1. Updated XCResultGenerator uses a simpler "issuesMap" when parsing issues.
2. Make simulator build to diagnose failure when build fails.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
