### PR TITLE
Mark Linux android views as non-flaky and run deferred components in presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1834,7 +1834,6 @@ targets:
 
   - name: Linux android views
     recipe: flutter/android_views
-    presubmit: true
     properties:
       dependencies: >-
         [
@@ -1848,7 +1847,6 @@ targets:
 
   - name: Linux deferred components
     recipe: flutter/deferred_components
-    presubmit: true
     properties:
       dependencies: >-
         [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1833,7 +1833,6 @@ targets:
     scheduler: luci
 
   - name: Linux android views
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/94032
     recipe: flutter/android_views
     presubmit: true
     properties:
@@ -1849,6 +1848,7 @@ targets:
 
   - name: Linux deferred components
     recipe: flutter/deferred_components
+    presubmit: true
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
Linux android views is not flaky. Failures were due to infra.

Also run Linux deferred components in presubmit.

Fixes https://github.com/flutter/flutter/issues/94032