### PR TITLE
Remove `ClipRect` from Snackbar

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -612,7 +612,7 @@ class _SnackBarState extends State<SnackBar> {
 
     return Hero(
       tag: '<SnackBar Hero tag - ${widget.content}>',
-      child: ClipRect(child: snackBarTransition),
+      child: Container(child: snackBarTransition),
     );
   }
 }

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -612,7 +612,7 @@ class _SnackBarState extends State<SnackBar> {
 
     return Hero(
       tag: '<SnackBar Hero tag - ${widget.content}>',
-      child: Container(child: snackBarTransition),
+      child: snackBarTransition,
     );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94701

Complete details https://github.com/flutter/flutter/issues/94701#issuecomment-987885279

Based on this feedback, I notice a lot of inner `snackbar` widget instances already have `clip.none` as default, and I also tried the material widget with a container for `clip.none` yet the clipping was not going away then I realized, `ClipRect` is actually the widget that is doing this clipping here. Replacing this widget with a simple container solves the clipping but it does affect a few golden tests as expected.

`Golden "material.snack_bar.goldenTest.workWithBottomSheet.png": Pixel test failed, 0.16% diff
detected.`

| Before | After |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/145069054-76ee2aec-78b5-49f0-a4f1-f50a811895fe.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/145069040-6d917b08-2f8f-47e0-a581-128cfbe91a12.png" height="450" /> |


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
