### PR TITLE
Use XML format in PlistParser

### DIFF
--- a/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
@@ -500,7 +500,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
 
   @override
   String get version {
-    return _version ??= _plistParser.getValueFromFile(
+    return _version ??= _plistParser.getStringValueFromFile(
         plistFile,
         PlistParser.kCFBundleShortVersionStringKey,
       ) ?? 'unknown';
@@ -514,7 +514,7 @@ class IntelliJValidatorOnMac extends IntelliJValidator {
     }
 
     final String? altLocation = _plistParser
-      .getValueFromFile(plistFile, 'JetBrainsToolboxApp');
+      .getStringValueFromFile(plistFile, 'JetBrainsToolboxApp');
 
     if (altLocation != null) {
       _pluginsPath = '$altLocation.plugins';

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -56,7 +56,7 @@ abstract class IOSApp extends ApplicationPackage {
       globals.printError('Invalid prebuilt iOS app. Does not contain Info.plist.');
       return null;
     }
-    final String? id = globals.plistParser.getValueFromFile(
+    final String? id = globals.plistParser.getStringValueFromFile(
       plistPath,
       PlistParser.kCFBundleIdentifierKey,
     );

--- a/packages/flutter_tools/lib/src/ios/bitcode.dart
+++ b/packages/flutter_tools/lib/src/ios/bitcode.dart
@@ -27,7 +27,7 @@ Future<void> validateBitcode(BuildMode buildMode, TargetPlatform targetPlatform,
   final String? clangVersion = clangResult?.stdout.split('\n').first;
   final String? engineClangVersion = flutterFrameworkPath == null
       ? null
-      : globals.plistParser.getValueFromFile(
+      : globals.plistParser.getStringValueFromFile(
           globals.fs.path.join(flutterFrameworkPath, 'Info.plist'),
           'ClangVersion',
         );

--- a/packages/flutter_tools/lib/src/ios/plist_parser.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_parser.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:process/process.dart';
+import 'package:xml/xml.dart';
 
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
-import '../base/utils.dart';
 import '../convert.dart';
 
 class PlistParser {
@@ -28,6 +28,33 @@ class PlistParser {
   static const String kCFBundleShortVersionStringKey = 'CFBundleShortVersionString';
   static const String kCFBundleExecutable = 'CFBundleExecutable';
 
+  /// Returns the content, converted to XML, of the plist file located at
+  /// [plistFilePath].
+  ///
+  /// If [plistFilePath] points to a non-existent file or a file that's not a
+  /// valid property list file, this will return null.
+  ///
+  /// The [plistFilePath] argument must not be null.
+  String? plistXmlContent(String plistFilePath) {
+    const String executable = '/usr/bin/plutil';
+    if (!_fileSystem.isFileSync(executable)) {
+      throw const FileNotFoundException(executable);
+    }
+    final List<String> args = <String>[
+      executable, '-convert', 'xml1', '-o', '-', plistFilePath,
+    ];
+    try {
+      final String xmlContent = _processUtils.runSync(
+        args,
+        throwOnError: true,
+      ).stdout.trim();
+      return xmlContent;
+    } on ProcessException catch (error) {
+      _logger.printTrace('$error');
+      return null;
+    }
+  }
+
   /// Parses the plist file located at [plistFilePath] and returns the
   /// associated map of key/value property list pairs.
   ///
@@ -37,29 +64,82 @@ class PlistParser {
   /// The [plistFilePath] argument must not be null.
   Map<String, dynamic> parseFile(String plistFilePath) {
     assert(plistFilePath != null);
-    const String executable = '/usr/bin/plutil';
-    if (!_fileSystem.isFileSync(executable)) {
-      throw const FileNotFoundException(executable);
-    }
     if (!_fileSystem.isFileSync(plistFilePath)) {
       return const <String, dynamic>{};
     }
 
     final String normalizedPlistPath = _fileSystem.path.absolute(plistFilePath);
 
-    try {
-      final List<String> args = <String>[
-        executable, '-convert', 'json', '-o', '-', normalizedPlistPath,
-      ];
-      final String jsonContent = _processUtils.runSync(
-        args,
-        throwOnError: true,
-      ).stdout.trim();
-      return castStringKeyedMap(json.decode(jsonContent)) ?? const <String, dynamic>{};
-    } on ProcessException catch (error) {
-      _logger.printTrace('$error');
+    final String? xmlContent = plistXmlContent(normalizedPlistPath);
+    if (xmlContent == null) {
       return const <String, dynamic>{};
     }
+
+    return _parseXml(xmlContent);
+  }
+
+  Map<String, dynamic> _parseXml(String xmlContent) {
+    final XmlDocument document = XmlDocument.parse(xmlContent);
+    // First element child is <plist>. The first element child of plist is <dict>.
+    final XmlElement dictObject = document.firstElementChild!.firstElementChild!;
+    return _parseXmlDict(dictObject);
+  }
+
+  Map<String, dynamic> _parseXmlDict(XmlElement node) {
+    String? lastKey;
+    final Map<String, dynamic> result = <String, dynamic>{};
+    for (final XmlNode child in node.children) {
+      if (child is XmlElement) {
+        if (child.name.local == 'key') {
+          lastKey = child.text;
+        } else {
+          assert(lastKey != null);
+          result[lastKey!] = _parseXmlNode(child);
+          lastKey = null;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  static final RegExp _nonBase64Pattern = RegExp('[^a-zA-Z0-9+/=]+');
+
+  dynamic _parseXmlNode(XmlElement node) {
+    switch (node.name.local){
+      case 'string':
+        return node.text;
+      case 'real':
+        return double.parse(node.text);
+      case 'integer':
+        return int.parse(node.text);
+      case 'true':
+        return true;
+      case 'false':
+        return false;
+      case 'date':
+        return DateTime.parse(node.text);
+      case 'data':
+        return base64.decode(node.text.replaceAll(_nonBase64Pattern, ''));
+      case 'array':
+        return node.children.whereType<XmlElement>().map<dynamic>(_parseXmlNode).toList();
+      case 'dict':
+        return _parseXmlDict(node);
+    }
+    return null;
+  }
+
+  /// Parses the Plist file located at [plistFilePath] and returns the string
+  /// value that's associated with the specified [key] within the property list.
+  ///
+  /// If [plistFilePath] points to a non-existent file or a file that's not a
+  /// valid property list file, this will return null.
+  ///
+  /// If [key] is not found in the property list, this will return null.
+  ///
+  /// The [plistFilePath] and [key] arguments must not be null.
+  String? getStringValueFromFile(String plistFilePath, String key) {
+    return getValueFromFile(plistFilePath, key) as String?;
   }
 
   /// Parses the Plist file located at [plistFilePath] and returns the value
@@ -71,9 +151,9 @@ class PlistParser {
   /// If [key] is not found in the property list, this will return null.
   ///
   /// The [plistFilePath] and [key] arguments must not be null.
-  String? getValueFromFile(String plistFilePath, String key) {
+  dynamic getValueFromFile(String plistFilePath, String key) {
     assert(key != null);
     final Map<String, dynamic> parsed = parseFile(plistFilePath);
-    return parsed[key] as String;
+    return parsed[key];
   }
 }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -495,7 +495,7 @@ class IOSSimulator extends Device {
       // parsing the xcodeproj or configuration files.
       // See https://github.com/flutter/flutter/issues/31037 for more information.
       final String plistPath = globals.fs.path.join(package.simulatorBundlePath, 'Info.plist');
-      final String? bundleIdentifier = globals.plistParser.getValueFromFile(plistPath, PlistParser.kCFBundleIdentifierKey);
+      final String? bundleIdentifier = globals.plistParser.getStringValueFromFile(plistPath, PlistParser.kCFBundleIdentifierKey);
       if (bundleIdentifier == null) {
         globals.printError('Invalid prebuilt iOS app. Info.plist does not contain bundle identifier');
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -180,7 +180,7 @@ class IosProject extends XcodeBasedProject {
     // Try parsing the default, first.
     if (defaultInfoPlist.existsSync()) {
       try {
-        fromPlist = globals.plistParser.getValueFromFile(
+        fromPlist = globals.plistParser.getStringValueFromFile(
           defaultHostInfoPlist.path,
           PlistParser.kCFBundleIdentifierKey,
         );
@@ -332,7 +332,7 @@ class IosProject extends XcodeBasedProject {
       // The Info.plist file of a target contains the key WKCompanionAppBundleIdentifier,
       // if it is a watchOS companion app.
       if (infoFile.existsSync()) {
-        final String? fromPlist = globals.plistParser.getValueFromFile(infoFile.path, 'WKCompanionAppBundleIdentifier');
+        final String? fromPlist = globals.plistParser.getStringValueFromFile(infoFile.path, 'WKCompanionAppBundleIdentifier');
         if (bundleIdentifier == fromPlist) {
           return true;
         }

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -11,10 +11,10 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/intellij/intellij_validator.dart';
 import 'package:flutter_tools/src/ios/plist_parser.dart';
-import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
+import '../../src/fakes.dart';
 
 final Platform macPlatform = FakePlatform(
   operatingSystem: 'macos',
@@ -371,17 +371,6 @@ void main() {
 
     expect(validator.pluginsPath, '/path/to/JetBrainsToolboxApp.plugins');
   });
-}
-
-class FakePlistParser extends Fake implements PlistParser {
-  FakePlistParser(this.values);
-
-  final Map<String, String> values;
-
-  @override
-  String? getValueFromFile(String plistFilePath, String key) {
-    return values[key];
-  }
 }
 
 class IntelliJValidatorTestTarget extends IntelliJValidator {

--- a/packages/flutter_tools/test/integration.shard/plist_parser_test.dart
+++ b/packages/flutter_tools/test/integration.shard/plist_parser_test.dart
@@ -33,6 +33,20 @@ const String base64PlistJson =
     'eyJDRkJ1bmRsZUV4ZWN1dGFibGUiOiJBcHAiLCJDRkJ1bmRsZUlkZW50aWZpZXIiOiJpby5mb'
     'HV0dGVyLmZsdXR0ZXIuYXBwIn0=';
 
+const String base64PlistXmlWithComplexDatatypes =
+    'PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPCFET0NUWVBFIHBsaXN0I'
+    'FBVQkxJQyAiLS8vQXBwbGUvL0RURCBQTElTVCAxLjAvL0VOIiAiaHR0cDovL3d3dy5hcHBsZS'
+    '5jb20vRFREcy9Qcm9wZXJ0eUxpc3QtMS4wLmR0ZCI+CjxwbGlzdCB2ZXJzaW9uPSIxLjAiPgo'
+    '8ZGljdD4KICA8a2V5PkNGQnVuZGxlRXhlY3V0YWJsZTwva2V5PgogIDxzdHJpbmc+QXBwPC9z'
+    'dHJpbmc+CiAgPGtleT5DRkJ1bmRsZUlkZW50aWZpZXI8L2tleT4KICA8c3RyaW5nPmlvLmZsd'
+    'XR0ZXIuZmx1dHRlci5hcHA8L3N0cmluZz4KICA8a2V5PmludFZhbHVlPC9rZXk+CiAgPGludG'
+    'VnZXI+MjwvaW50ZWdlcj4KICA8a2V5PmRvdWJsZVZhbHVlPC9rZXk+CiAgPHJlYWw+MS41PC9'
+    'yZWFsPgogIDxrZXk+YmluYXJ5VmFsdWU8L2tleT4KICA8ZGF0YT5ZV0pqWkE9PTwvZGF0YT4K'
+    'ICA8a2V5PmFycmF5VmFsdWU8L2tleT4KICA8YXJyYXk+CiAgICA8dHJ1ZSAvPgogICAgPGZhb'
+    'HNlIC8+CiAgICA8aW50ZWdlcj4zPC9pbnRlZ2VyPgogIDwvYXJyYXk+CiAgPGtleT5kYXRlVm'
+    'FsdWU8L2tleT4KICA8ZGF0ZT4yMDIxLTEyLTAxVDEyOjM0OjU2WjwvZGF0ZT4KPC9kaWN0Pgo'
+    '8L3BsaXN0Pg==';
+
 void main() {
   // The tests herein explicitly don't use `MemoryFileSystem` or a mocked
   // `ProcessManager` because doing so wouldn't actually test what we want to
@@ -62,62 +76,78 @@ void main() {
     file.deleteSync();
   });
 
-  testWithoutContext('PlistParser.getValueFromFile works with xml file', () {
+  testWithoutContext('PlistParser.getStringValueFromFile works with xml file', () {
     file.writeAsBytesSync(base64.decode(base64PlistXml));
 
-    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
-    expect(parser.getValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile works with binary file', () {
+  testWithoutContext('PlistParser.getStringValueFromFile works with binary file', () {
     file.writeAsBytesSync(base64.decode(base64PlistBinary));
 
-    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
-    expect(parser.getValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile works with json file', () {
+  testWithoutContext('PlistParser.getStringValueFromFile works with json file', () {
     file.writeAsBytesSync(base64.decode(base64PlistJson));
 
-    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
-    expect(parser.getValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getStringValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile returns null for non-existent plist file', () {
-    expect(parser.getValueFromFile('missing.plist', 'CFBundleIdentifier'), null);
+  testWithoutContext('PlistParser.getStringValueFromFile returns null for non-existent plist file', () {
+    expect(parser.getStringValueFromFile('missing.plist', 'CFBundleIdentifier'), null);
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile returns null for non-existent key within plist', () {
+  testWithoutContext('PlistParser.getStringValueFromFile returns null for non-existent key within plist', () {
     file.writeAsBytesSync(base64.decode(base64PlistXml));
 
-    expect(parser.getValueFromFile(file.path, 'BadKey'), null);
-    expect(parser.getValueFromFile(file.absolute.path, 'BadKey'), null);
+    expect(parser.getStringValueFromFile(file.path, 'BadKey'), null);
+    expect(parser.getStringValueFromFile(file.absolute.path, 'BadKey'), null);
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile returns null for malformed plist file', () {
+  testWithoutContext('PlistParser.getStringValueFromFile returns null for malformed plist file', () {
     file.writeAsBytesSync(const <int>[1, 2, 3, 4, 5, 6]);
 
-    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), null);
+    expect(parser.getStringValueFromFile(file.path, 'CFBundleIdentifier'), null);
     expect(logger.statusText, isNotEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile throws when /usr/bin/plutil is not found', () async {
+  testWithoutContext('PlistParser.getStringValueFromFile throws when /usr/bin/plutil is not found', () async {
+    file.writeAsBytesSync(base64.decode(base64PlistXml));
+
     expect(
-      () => parser.getValueFromFile('irrelevant.plist', 'ununsed'),
+      () => parser.getStringValueFromFile(file.path, 'unused'),
       throwsA(isA<FileNotFoundException>()),
     );
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: platform.isMacOS); // [intended] requires macos tool chain.
+
+  testWithoutContext('PlistParser.getValueFromFile can handle different datatypes', () async {
+    file.writeAsBytesSync(base64.decode(base64PlistXmlWithComplexDatatypes));
+
+    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
+    expect(parser.getValueFromFile(file.absolute.path, 'intValue'), 2);
+    expect(parser.getValueFromFile(file.absolute.path, 'doubleValue'), 1.5);
+    expect(parser.getValueFromFile(file.absolute.path, 'binaryValue'), base64.decode('YWJjZA=='));
+    expect(parser.getValueFromFile(file.absolute.path, 'arrayValue'), <dynamic>[true, false, 3]);
+    expect(parser.getValueFromFile(file.absolute.path, 'dateValue'), DateTime.utc(2021, 12, 1, 12, 34, 56));
+    expect(logger.statusText, isEmpty);
+    expect(logger.errorText, isEmpty);
+  }, skip: !platform.isMacOS); // [intended] requires macos tool chain.
 }

--- a/packages/flutter_tools/test/integration.shard/plist_parser_test.dart
+++ b/packages/flutter_tools/test/integration.shard/plist_parser_test.dart
@@ -137,16 +137,17 @@ void main() {
     expect(logger.errorText, isEmpty);
   }, skip: platform.isMacOS); // [intended] requires macos tool chain.
 
-  testWithoutContext('PlistParser.getValueFromFile can handle different datatypes', () async {
+  testWithoutContext('PlistParser.parseFile can handle different datatypes', () async {
     file.writeAsBytesSync(base64.decode(base64PlistXmlWithComplexDatatypes));
+    final Map<String, Object> values = parser.parseFile(file.path);
 
-    expect(parser.getValueFromFile(file.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
-    expect(parser.getValueFromFile(file.absolute.path, 'CFBundleIdentifier'), 'io.flutter.flutter.app');
-    expect(parser.getValueFromFile(file.absolute.path, 'intValue'), 2);
-    expect(parser.getValueFromFile(file.absolute.path, 'doubleValue'), 1.5);
-    expect(parser.getValueFromFile(file.absolute.path, 'binaryValue'), base64.decode('YWJjZA=='));
-    expect(parser.getValueFromFile(file.absolute.path, 'arrayValue'), <dynamic>[true, false, 3]);
-    expect(parser.getValueFromFile(file.absolute.path, 'dateValue'), DateTime.utc(2021, 12, 1, 12, 34, 56));
+    expect(values['CFBundleIdentifier'], 'io.flutter.flutter.app');
+    expect(values['CFBundleIdentifier'], 'io.flutter.flutter.app');
+    expect(values['intValue'], 2);
+    expect(values['doubleValue'], 1.5);
+    expect(values['binaryValue'], base64.decode('YWJjZA=='));
+    expect(values['arrayValue'], <dynamic>[true, false, 3]);
+    expect(values['dateValue'], DateTime.utc(2021, 12, 1, 12, 34, 56));
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, isEmpty);
   }, skip: !platform.isMacOS); // [intended] requires macos tool chain.

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -289,12 +289,12 @@ class FakeStdio extends Stdio {
 }
 
 class FakePlistParser implements PlistParser {
-  FakePlistParser([Map<String, dynamic>? underlyingValues]):
-    _underlyingValues = underlyingValues ?? <String, dynamic>{};
+  FakePlistParser([Map<String, Object>? underlyingValues]):
+    _underlyingValues = underlyingValues ?? <String, Object>{};
 
-  final Map<String, dynamic> _underlyingValues;
+  final Map<String, Object> _underlyingValues;
 
-  void setProperty(String key, dynamic value) {
+  void setProperty(String key, Object value) {
     _underlyingValues[key] = value;
   }
 
@@ -302,18 +302,13 @@ class FakePlistParser implements PlistParser {
   String? plistXmlContent(String plistFilePath) => throw UnimplementedError();
 
   @override
-  Map<String, dynamic> parseFile(String plistFilePath) {
+  Map<String, Object> parseFile(String plistFilePath) {
     return _underlyingValues;
   }
 
   @override
   String? getStringValueFromFile(String plistFilePath, String key) {
     return _underlyingValues[key] as String?;
-  }
-
-  @override
-  dynamic getValueFromFile(String plistFilePath, String key) {
-    return _underlyingValues[key];
   }
 }
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -289,11 +289,17 @@ class FakeStdio extends Stdio {
 }
 
 class FakePlistParser implements PlistParser {
-  final Map<String, dynamic> _underlyingValues = <String, String>{};
+  FakePlistParser([Map<String, dynamic>? underlyingValues]):
+    _underlyingValues = underlyingValues ?? <String, dynamic>{};
+
+  final Map<String, dynamic> _underlyingValues;
 
   void setProperty(String key, dynamic value) {
     _underlyingValues[key] = value;
   }
+
+  @override
+  String? plistXmlContent(String plistFilePath) => throw UnimplementedError();
 
   @override
   Map<String, dynamic> parseFile(String plistFilePath) {
@@ -301,8 +307,13 @@ class FakePlistParser implements PlistParser {
   }
 
   @override
-  String getValueFromFile(String plistFilePath, String key) {
-    return _underlyingValues[key] as String;
+  String? getStringValueFromFile(String plistFilePath, String key) {
+    return _underlyingValues[key] as String?;
+  }
+
+  @override
+  dynamic getValueFromFile(String plistFilePath, String key) {
+    return _underlyingValues[key];
   }
 }
 


### PR DESCRIPTION
Parse the Plist in XML format instead of JSON so that it can accept data that is not representable in JSON.

Move the part that reads the plist file content to a separate method so that it can be overridden to use a different tool other than plutil (which is Mac only).

Rename `getValueFromFile` to `getStringValueFromFile` now that we have the ability to read value of any type from the plist file.

Fixes #62160

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
