### PR TITLE
Fix android semantics integration test flakiness

### DIFF
--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -27,7 +27,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -65,25 +64,6 @@ public class MainActivity extends FlutterActivity {
             }
             AccessibilityNodeInfo node = provider.createAccessibilityNodeInfo(id);
             result.success(convertSemantics(node, id));
-            return;
-        }
-        if (methodCall.method.equals("sendSemanticsFocus")) {
-            Map<String, Object> data = methodCall.arguments();
-            @SuppressWarnings("unchecked")
-            Integer id = (Integer) data.get("id");
-            if (id == null) {
-                result.error("No ID provided", "", null);
-                return;
-            }
-            if (provider == null) {
-                result.error("Semantics not enabled", "", null);
-                return;
-            }
-            AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
-            event.setPackageName(flutterView.getContext().getPackageName());
-            event.setSource(flutterView, id);
-            flutterView.getParent().requestSendAccessibilityEvent(flutterView, event);
-            result.success(null);
             return;
         }
         result.notImplemented();

--- a/dev/integration_tests/android_semantics_testing/lib/main.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/main.dart
@@ -39,21 +39,6 @@ Future<String> dataHandler(String message) async {
       completeSemantics();
     return completer.future;
   }
-  if (message.contains('sendSemanticsFocus')) {
-    final Completer<String> completer = Completer<String>();
-    final int id = int.tryParse(message.split('#')[1]) ?? 0;
-    Future<void> completeSemantics([Object _]) async {
-      final dynamic result = await kSemanticsChannel.invokeMethod<dynamic>('sendSemanticsFocus', <String, dynamic>{
-        'id': id,
-      });
-      completer.complete(json.encode(result));
-    }
-    if (SchedulerBinding.instance.hasScheduledFrame)
-      SchedulerBinding.instance.addPostFrameCallback(completeSemantics);
-    else
-      completeSemantics();
-    return completer.future;
-  }
   throw UnimplementedError();
 }
 

--- a/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
@@ -25,6 +25,7 @@ Matcher hasAndroidSemantics({
   Rect rect,
   Size size,
   List<AndroidSemanticsAction> actions,
+  List<AndroidSemanticsAction> ignoredActions,
   List<AndroidSemanticsNode> children,
   bool isChecked,
   bool isCheckable,
@@ -44,6 +45,7 @@ Matcher hasAndroidSemantics({
     size: size,
     id: id,
     actions: actions,
+    ignoredActions: ignoredActions,
     isChecked: isChecked,
     isCheckable: isCheckable,
     isEditable: isEditable,
@@ -63,6 +65,7 @@ class _AndroidSemanticsMatcher extends Matcher {
     this.className,
     this.id,
     this.actions,
+    this.ignoredActions,
     this.rect,
     this.size,
     this.isChecked,
@@ -81,6 +84,7 @@ class _AndroidSemanticsMatcher extends Matcher {
   final String contentDescription;
   final int id;
   final List<AndroidSemanticsAction> actions;
+  final List<AndroidSemanticsAction> ignoredActions;
   final Rect rect;
   final Size size;
   final bool isChecked;
@@ -148,9 +152,13 @@ class _AndroidSemanticsMatcher extends Matcher {
       if (!unorderedEquals(actions).matches(itemActions, matchState)) {
         final List<String> actionsString = actions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
         final List<String> itemActionsString = itemActions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
-        final Set<String> unexpected = itemActionsString.toSet().difference(actionsString.toSet());
-        final Set<String> missing = actionsString.toSet().difference(itemActionsString.toSet());
-        return _failWithMessage('Expected actions: $actionsString\nActual actions: $itemActionsString\nUnexpected: $unexpected\nMissing: $missing', matchState);
+        final Set<AndroidSemanticsAction> unexpected = itemActions.toSet().difference(actions.toSet());
+        final Set<String> unexpectedInString = itemActionsString.toSet().difference(actionsString.toSet());
+        final Set<String> missingInString = actionsString.toSet().difference(itemActionsString.toSet());
+        if (missingInString.isEmpty && ignoredActions != null && unexpected.every(ignoredActions.contains)) {
+          return true;
+        }
+        return _failWithMessage('Expected actions: $actionsString\nActual actions: $itemActionsString\nUnexpected: $unexpectedInString\nMissing: $missingInString', matchState);
       }
     }
     if (isChecked != null && isChecked != item.isChecked)

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -686,6 +686,11 @@ void main() {
                   isCheckable: false,
                   isEnabled: true,
                   isFocusable: true,
+                  actions: <AndroidSemanticsAction>[
+                    if (talkbackVersion < fixedTalkback && item == 'Title') AndroidSemanticsAction.accessibilityFocus,
+                    if (talkbackVersion >= fixedTalkback && item == 'Title') AndroidSemanticsAction.clearAccessibilityFocus,
+                    if (item != 'Title') AndroidSemanticsAction.accessibilityFocus,
+                  ],
                 ),
                 reason: "Alert $item button doesn't have the right semantics");
           }

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -11,6 +11,9 @@ import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart' hide isInstanceOf;
 
+// The accessibility focus actions are added when a semantics node receives or
+// lose accessibility focus. This test ignores these actions since it is hard to
+// predict which node has the accessibility focus after a screen changes.
 const List<AndroidSemanticsAction> ignoredAccessibilityFocusActions = <AndroidSemanticsAction>[
   AndroidSemanticsAction.accessibilityFocus,
   AndroidSemanticsAction.clearAccessibilityFocus,


### PR DESCRIPTION
reverted previous patch and added ignored actions to ignore accessibility focus action.

fixes https://github.com/flutter/flutter/issues/94730

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
