### PR TITLE
Attempt to mitigate flakiness around devtools

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -768,19 +768,7 @@ Future<void> _runFrameworkTests() async {
     if (Directory(pubCache).existsSync()) {
       pubEnvironment['PUB_CACHE'] = pubCache;
     }
-
-    // If an existing env variable exists append to it, but only if
-    // it doesn't appear to already include enable-asserts.
-    String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
-    if (!toolsArgs.contains('--enable-asserts')) {
-      toolsArgs += ' --enable-asserts';
-    }
-    pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
-    // The flutter_tool will originally have been snapshotted without asserts.
-    // We need to force it to be regenerated with them enabled.
-    deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.snapshot'));
-    deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.stamp'));
-
+    recompileFlutterToolWithAsserts(pubEnvironment);
     await runCommand(
       pub,
       args,
@@ -1454,6 +1442,10 @@ Future<void> _runWebDebugTest(String target, {
 }) async {
   final String testAppDirectory = path.join(flutterRoot, 'dev', 'integration_tests', 'web');
   bool success = false;
+  final Map<String, String> environment = <String, String>{
+    'FLUTTER_WEB': 'true',
+  };
+  recompileFlutterToolWithAsserts(environment);
   final CommandResult result = await runCommand(
     flutter,
     <String>[
@@ -1483,9 +1475,7 @@ Future<void> _runWebDebugTest(String target, {
       }
     },
     workingDirectory: testAppDirectory,
-    environment: <String, String>{
-      'FLUTTER_WEB': 'true',
-    },
+    environment: environment,
   );
 
   if (success) {
@@ -1581,16 +1571,7 @@ Future<void> _pubRunTest(String workingDirectory, {
     pubEnvironment['PUB_CACHE'] = pubCache;
   }
   if (enableFlutterToolAsserts) {
-    // If an existing env variable exists append to it, but only if
-    // it doesn't appear to already include enable-asserts.
-    String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
-    if (!toolsArgs.contains('--enable-asserts'))
-      toolsArgs += ' --enable-asserts';
-    pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
-    // The flutter_tool will originally have been snapshotted without asserts.
-    // We need to force it to be regenerated with them enabled.
-    deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.snapshot'));
-    deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.stamp'));
+    recompileFlutterToolWithAsserts(pubEnvironment);
   }
   if (ensurePrecompiledTool) {
     // We rerun the `flutter` tool here just to make sure that it is compiled
@@ -1716,6 +1697,22 @@ Future<void> _runFlutterTest(String workingDirectory, {
       expectNonZeroExit: expectFailure,
     );
   }
+}
+
+/// This will force the next run of the Flutter tool (if it uses the provided environment) to
+/// have asserts enabled, by setting an environment variable and deleting the cache.
+void recompileFlutterToolWithAsserts(Map<String, String> pubEnvironment) {
+  // If an existing env variable exists append to it, but only if
+  // it doesn't appear to already include enable-asserts.
+  String toolsArgs = Platform.environment['FLUTTER_TOOL_ARGS'] ?? '';
+  if (!toolsArgs.contains('--enable-asserts')) {
+    toolsArgs += ' --enable-asserts';
+  }
+  pubEnvironment['FLUTTER_TOOL_ARGS'] = toolsArgs.trim();
+  // The flutter_tool will originally have been snapshotted without asserts.
+  // We need to force it to be regenerated with them enabled.
+  deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.snapshot'));
+  deleteFile(path.join(flutterRoot, 'bin', 'cache', 'flutter_tools.stamp'));
 }
 
 Map<String, String> _initGradleEnvironment() {


### PR DESCRIPTION
This does three things:

 * Add more asserts around the devtools launching
 * Add more defensive checks around the devtools launching in case we're seeing shutdown races
 * Enable the asserts for the web tests.

The idea is to either avoid a flake like this, or make the logs more useful:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8828452555087042433/+/u/run_test.dart_for_web_long_running_tests_shard_and_subshard_1_5/test_stdout

See also https://github.com/flutter/flutter/issues/60239
