### PR TITLE
Remove chunk event subscription when disposing a MultiFrameImageStreamCompleter

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -571,6 +571,8 @@ abstract class ImageStreamCompleter with Diagnosticable {
   }
 
   bool _disposed = false;
+
+  @mustCallSuper
   void _maybeDispose() {
     if (!_hadAtLeastOneListener || _disposed || _listeners.isNotEmpty || _keepAliveHandles != 0) {
       return;
@@ -722,6 +724,8 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// [ImageChunkEvent].
   @protected
   void reportImageChunkEvent(ImageChunkEvent event) {
+    print(event);
+    print(_disposed);
     _checkDisposed();
     if (hasListeners) {
       // Make a copy to allow for concurrent modification.
@@ -851,7 +855,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
       );
     });
     if (chunkEvents != null) {
-      chunkEvents.listen(reportImageChunkEvent,
+      _chunkSubscription = chunkEvents.listen(reportImageChunkEvent,
         onError: (Object error, StackTrace stack) {
           reportError(
             context: ErrorDescription('loading an image'),
@@ -865,6 +869,7 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
     }
   }
 
+  StreamSubscription<ImageChunkEvent>? _chunkSubscription;
   ui.Codec? _codec;
   final double _scale;
   final InformationCollector? _informationCollector;
@@ -988,6 +993,16 @@ class MultiFrameImageStreamCompleter extends ImageStreamCompleter {
     if (!hasListeners) {
       _timer?.cancel();
       _timer = null;
+    }
+  }
+
+  @override
+  void _maybeDispose() {
+    super._maybeDispose();
+    if (_disposed) {
+      _chunkSubscription?.onData(null);
+      _chunkSubscription?.cancel();
+      _chunkSubscription = null;
     }
   }
 }

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -724,8 +724,6 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// [ImageChunkEvent].
   @protected
   void reportImageChunkEvent(ImageChunkEvent event) {
-    print(event);
-    print(_disposed);
     _checkDisposed();
     if (hasListeners) {
       // Make a copy to allow for concurrent modification.


### PR DESCRIPTION
Otherwise, when data comes in from the network, we might hit a code path we expect not to hit when we're disposed.

Also deletes a commented out test.

Fixes https://github.com/flutter/flutter/issues/77576