### PR TITLE
RefreshIndicator fidelity and improvements

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -15,6 +15,7 @@ import 'theme.dart';
 const double _kMinCircularProgressIndicatorSize = 36.0;
 const int _kIndeterminateLinearDuration = 1800;
 const int _kIndeterminateCircularDuration = 1333 * 2222;
+const double _kMaxArcLength = 3 / 2;
 
 enum _ActivityIndicatorType { material, adaptive }
 
@@ -383,7 +384,7 @@ class _LinearProgressIndicatorState extends State<LinearProgressIndicator> with 
 class _CircularProgressIndicatorPainter extends CustomPainter {
   _CircularProgressIndicatorPainter({
     this.backgroundColor,
-    double maxArcLength = 3 / 2,
+    double maxArcLength = _kMaxArcLength,
     required this.valueColor,
     required this.value,
     required this.headValue,
@@ -678,7 +679,7 @@ class _RefreshProgressIndicatorPainter extends _CircularProgressIndicatorPainter
     required this.arrowheadScale,
   }) : super(
     // Lengthen the arc a little
-    maxArcLength: 3 / 2 * 1.05, // = 1.575
+    maxArcLength: _kMaxArcLength * 1.05,
     valueColor: valueColor,
     value: value,
     headValue: headValue,

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -239,7 +239,12 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   bool? _isIndicatorAtTop;
   double? _dragOffset;
 
-  static final Animatable<double> _valueTween = Tween<double>(begin: 0.0, end: 0.78);
+  static final Animatable<double> _valueTween = Tween<double>(
+    begin: 0.0,
+    end: 0.8,
+  ).chain(CurveTween(
+    curve: const Cubic(0.5, 0.35, 0.4, 0.8),
+  ));
   static final Animatable<double> _kDragSizeFactorLimitTween = Tween<double>(
     begin: 0.0,
     end: _kDragSizeFactorLimit,
@@ -254,11 +259,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
     _positionController = AnimationController(vsync: this);
     _positionFactor = _positionController.drive(_kDragSizeFactorLimitTween);
     // The "value" of the circular progress indicator during a drag.
-    _value = _positionController.drive(
-      _valueTween
-        .chain(CurveTween(curve: _kDragCurve))
-        .chain(CurveTween(curve: const Interval(0.1, 1.0))),
-    );
+    _value = _positionController.drive(_valueTween);
 
     _scaleController = AnimationController(vsync: this);
     _scaleFactor = _scaleController.drive(_oneToZeroTween);

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -392,7 +392,7 @@ class RefreshIndicatorState extends State<RefreshIndicator> with TickerProviderS
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
     if (notification.depth != 0 || !notification.leading)
       return false;
-    if (_mode == _RefreshIndicatorMode.drag) {
+    if (_mode == _RefreshIndicatorMode.drag || _mode == _RefreshIndicatorMode.armed) {
       notification.disallowGlow();
       return true;
     }

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -972,19 +972,11 @@ void main() {
             localRefreshCalled = true;
             return Future<void>.delayed(indeterminateDuration);
           },
-          child: NotificationListener<OverscrollIndicatorNotification>(
-            onNotification: (OverscrollIndicatorNotification overscroll) {
-              // Remove glow from the golden
-              // TODO(Piinks): remove this when https://github.com/flutter/flutter/issues/94933 is fixed
-              overscroll.disallowGlow();
-              return false;
-            },
-            child: SingleChildScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              child: Container(
-                height: sheetHeight,
-                color: backgroundColor,
-              ),
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: Container(
+              height: sheetHeight,
+              color: backgroundColor,
             ),
           ),
         ),
@@ -1011,7 +1003,7 @@ void main() {
 
     // 12 frames of hide animation
     await tester.pumpFrames(animationSheet.record(
-      buildApp(Colors.white),
+      buildApp(Colors.yellow),
     ), const Duration(milliseconds: 12 * frameTime));
 
     expect(localRefreshCalled, false);
@@ -1032,11 +1024,11 @@ void main() {
       ), const Duration(milliseconds: frameTime));
     }
 
-    // 6 frames after expand
-    for (num i = 0; i < 10; i++) {
+    // 20 frames after expand - make sure there's no glow
+    for (num i = 0; i < 20; i++) {
       await drag2.moveBy(const Offset(0.0, dragInterval));
       await tester.pumpFrames(animationSheet.record(
-        buildApp(Colors.green),
+        buildApp(Colors.white),
       ), const Duration(milliseconds: frameTime));
     }
 
@@ -1051,7 +1043,7 @@ void main() {
 
     // 20 frames of indeterminate animation
     await tester.pumpFrames(animationSheet.record(
-      buildApp(Colors.yellow),
+      buildApp(Colors.green),
     ), const Duration(milliseconds: indeterminateFrames * frameTime));
 
     // 12 frames of hide animation


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6052
Fixes https://github.com/flutter/flutter/issues/9602
Fixes https://github.com/flutter/flutter/issues/36158
Fixes https://github.com/flutter/flutter/issues/94933
Related (partial fix) https://github.com/flutter/flutter/issues/71075

To make this patch I made an app similar to [scroll_overlay](https://github.com/flutter/platform_tests/tree/master/scroll_overlay) - [refresh_indicator_overlay](https://github.com/nt4f04uNd/refresh_indicator_overlay)

Here's a quick summary of the changes:

* allow cancellation of RefreshIndicator with `position.correctBy`
* `_kDragContainerExtentPercentage` 0.25 -> 0.5
* mitigate an extra friction on iOS which became obvious from changing `_kDragContainerExtentPercentage`
* declare a clear `_kArmedThreshold`
* various curves to try to match Android
* keep last value before going indeterminate
* add arrowhead hide animation before going indeterminate as there's one in Android
* dedup code with `_updateValueColor`
* fix and refactor some tests to be more reliable

Also:

* fixed a bug in RefreshProgressIndicator when arc length wast jumping after 1 full circle (introduced in https://github.com/flutter/flutter/pull/88301 because of trying to lengthen the arc not in proper way)
* more fidelity for RefreshProgressIndicator rotation

<details>
<summary>Video after PR</summary>

https://user-images.githubusercontent.com/39104740/145752860-e2aac3e9-8955-4210-a603-2541d85f2094.mp4
</details>

<details>
<summary>Video after PR with overlay</summary>

https://user-images.githubusercontent.com/39104740/145752888-a72ed0dd-0fc1-4e8e-8890-5da4fd726fb3.mp4
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

