### PR TITLE
fix flutter_assets not found

### DIFF
--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -121,7 +121,7 @@ def install_flutter_application_pod(flutter_application_path)
 
   flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
   script_phase :name => 'Run Flutter Build {{projectName}} Script',
-    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
+    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh embed",
     :execution_position => :before_compile
 end
 


### PR DESCRIPTION

Fix failed to find assets path for "Frameworks/App.framework/flutter_assets" on iOS 15 (Maybe Under 15 also) with macOS Monterey, and white screen after launched app.

macOS 12.0.1
Xcode 13.1
iOS 15
pod 1.11.2
flutter 2.2.1 ~ 2.8.0

Issue: https://github.com/flutter/flutter/issues/94481
