### PR TITLE
feat: support configure a custom launch url for flutter web

### DIFF
--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -227,7 +227,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: browserDebugPort,
         webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
-        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : '',
+        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : null,
         vmserviceOutFile: stringArg('vmservice-out-file'),
         fastStart: argParser.options.containsKey('fast-start')
           && boolArg('fast-start')

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -227,6 +227,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: browserDebugPort,
         webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
+        webLaunchUrl: featureFlags.isWebEnabled ? stringArg('web-launch-url') : '',
         vmserviceOutFile: stringArg('vmservice-out-file'),
         fastStart: argParser.options.containsKey('fast-start')
           && boolArg('fast-start')

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -762,6 +762,7 @@ class DebuggingOptions {
     this.webRunHeadless = false,
     this.webBrowserDebugPort,
     this.webEnableExpressionEvaluation = false,
+    this.webLaunchUrl,
     this.vmserviceOutFile,
     this.fastStart = false,
     this.nullAssertions = false,
@@ -778,6 +779,7 @@ class DebuggingOptions {
       this.webUseSseForInjectedClient = true,
       this.webRunHeadless = false,
       this.webBrowserDebugPort,
+      this.webLaunchUrl,
       this.cacheSkSL = false,
       this.traceAllowlist,
     }) : debuggingEnabled = false,
@@ -850,6 +852,9 @@ class DebuggingOptions {
 
   /// Enable expression evaluation for web target.
   final bool webEnableExpressionEvaluation;
+
+  /// Allow developers to customize the browser's launch URL
+  final String? webLaunchUrl;
 
   /// A file where the VM Service URL should be written after the application is started.
   final String? vmserviceOutFile;

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -264,9 +264,8 @@ abstract class FlutterCommand extends Command<void> {
       hide: !verboseHelp,
     );
     argParser.addOption('web-launch-url',
-      help: 'The launch URL the browser should use preferentially. If not provided, '
-          'the default launch URL depends on "--web-hostname" and "--web-port".',
-      hide: !verboseHelp,
+      help: 'The URL to provide to the browser. Defaults to an HTTP URL with the host '
+          'name of "--web-hostname", the port of "--web-port", and the path set to "/".',
     );
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -264,9 +264,8 @@ abstract class FlutterCommand extends Command<void> {
       hide: !verboseHelp,
     );
     argParser.addOption('web-launch-url',
-      defaultsTo: null,
       help: 'The launch URL the browser should use preferentially. If not provided, '
-          'the default depends on the web-hostname and web-port',
+          'the default launch URL depends on "--web-hostname" and "--web-port".',
       hide: !verboseHelp,
     );
   }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -263,6 +263,12 @@ abstract class FlutterCommand extends Command<void> {
       help: 'Enables expression evaluation in the debugger.',
       hide: !verboseHelp,
     );
+    argParser.addOption('web-launch-url',
+      defaultsTo: null,
+      help: 'The launch URL the browser should use preferentially. If not provided, '
+          'the default depends on the web-hostname and web-port',
+      hide: !verboseHelp,
+    );
   }
 
   void usesTargetOption() {

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
@@ -134,8 +135,7 @@ abstract class ChromiumDevice extends Device {
       if (pattern.hasMatch(debuggingOptions.webLaunchUrl!)) {
         url = debuggingOptions.webLaunchUrl!;
       } else {
-        url = platformArgs['uri']! as String;
-        _logger.printStatus('"${debuggingOptions.webLaunchUrl}" is not a vaild HTTP URL,"$url" will be used.');
+        throwToolExit('"${debuggingOptions.webLaunchUrl}" is not a vaild HTTP URL.');
       }
     } else {
       url = platformArgs['uri']! as String;

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -128,7 +128,7 @@ abstract class ChromiumDevice extends Device {
   }) async {
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
     // for the web initialization and server logic.
-    final String url = debuggingOptions.webLaunchUrl ?? platformArgs['uri'] as String;
+    final String url = debuggingOptions.webLaunchUrl ?? platformArgs['uri']! as String;
     final bool launchChrome = platformArgs['no-launch-chrome'] != true;
     if (launchChrome) {
       _chrome = await chromeLauncher.launch(

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -128,7 +128,7 @@ abstract class ChromiumDevice extends Device {
   }) async {
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
     // for the web initialization and server logic.
-    final String url = platformArgs['uri']! as String;
+    final String url = debuggingOptions.webLaunchUrl ?? platformArgs['uri'] as String;
     final bool launchChrome = platformArgs['no-launch-chrome'] != true;
     if (launchChrome) {
       _chrome = await chromeLauncher.launch(

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -128,7 +128,18 @@ abstract class ChromiumDevice extends Device {
   }) async {
     // See [ResidentWebRunner.run] in flutter_tools/lib/src/resident_web_runner.dart
     // for the web initialization and server logic.
-    final String url = debuggingOptions.webLaunchUrl ?? platformArgs['uri']! as String;
+    String url;
+    if (debuggingOptions.webLaunchUrl != null) {
+      final RegExp pattern = RegExp(r'^((http)?:\/\/)[^\s]+');
+      if (pattern.hasMatch(debuggingOptions.webLaunchUrl!)) {
+        url = debuggingOptions.webLaunchUrl!;
+      } else {
+        url = platformArgs['uri']! as String;
+        _logger.printStatus('"${debuggingOptions.webLaunchUrl}" is not a vaild HTTP URL,"$url" will be used.');
+      }
+    } else {
+      url = platformArgs['uri']! as String;
+    }
     final bool launchChrome = platformArgs['no-launch-chrome'] != true;
     if (launchChrome) {
       _chrome = await chromeLauncher.launch(

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import '../application_package.dart';
+import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -595,12 +595,12 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('Does not support "--web-launch-url"', () async {
+  testUsingContext('fails when "--web-launch-url" is not supported', () async {
     final RunCommand command = RunCommand();
     await expectLater(
           () => createTestCommandRunner(command).run(<String>[
         'run',
-        '--web-launch-url=example_url',
+        '--web-launch-url=http://flutter.dev',
       ]),
       throwsA(isException.having(
             (Exception exception) => exception.toString(),
@@ -608,8 +608,12 @@ void main() {
         isNot(contains('web-launch-url')),
       )),
     );
+
     final DebuggingOptions options = await command.createDebuggingOptions(true);
-    expect(options.webLaunchUrl, 'example_url');
+    expect(options.webLaunchUrl, 'http://flutter.dev');
+
+    final RegExp pattern = RegExp(r'^((http)?:\/\/)[^\s]+');
+    expect(pattern.hasMatch(options.webLaunchUrl), true);
   }, overrides: <Type, Generator>{
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -594,6 +594,26 @@ void main() {
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),
   });
+
+  testUsingContext('Does not support "--web-launch-url"', () async {
+    final RunCommand command = RunCommand();
+    await expectLater(
+          () => createTestCommandRunner(command).run(<String>[
+        'run',
+        '--web-launch-url=example_url',
+      ]),
+      throwsA(isException.having(
+            (Exception exception) => exception.toString(),
+        'toString',
+        isNot(contains('web-launch-url')),
+      )),
+    );
+    final DebuggingOptions options = await command.createDebuggingOptions(true);
+    expect(options.webLaunchUrl, 'example_url');
+  }, overrides: <Type, Generator>{
+    ProcessManager: () => FakeProcessManager.any(),
+    Logger: () => BufferLogger.test(),
+  });
 }
 
 class FakeDeviceManager extends Fake implements DeviceManager {


### PR DESCRIPTION
When we develop with flutter for web, the default launch url is http://${web-hostname}:${web-port}. But when the page must use cookie with a specific domain, such as login information, a cross-domain error will occur.

In order to solve the cross-domain problem to share cookie, a launch url that match the same-origin policy should be used when the browser is first opened, so we need to support configure a custom launch url for flutter web.

For more information see #95001 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
