### PR TITLE
Fix some issues with samples

### DIFF
--- a/dev/snippets/config/templates/README.md
+++ b/dev/snippets/config/templates/README.md
@@ -1,10 +1,21 @@
+## Templates are only used for Engine code samples.
+
+They should not be used in the Framework, since the code samples should reside
+in the [`examples/api`](../../../../examples/api) directory.
+
+If you are creating engine code samples, the following document may be of
+interest.
+
+Eventually, Engine code samples will also be converted to point to separate
+files as the framework does.
+
 ## Creating Code Snippets
 
 In general, creating application snippets can be accomplished with the following
-syntax inside of the dartdoc comment for a Flutter class/variable/enum/etc.:
+syntax inside the dartdoc comment for a Flutter class/variable/enum/etc.:
 
 ```dart
-/// {@tool snippet --template=stateful_widget}
+/// {@tool snippet}
 /// Any text outside of the code blocks will be accumulated and placed at the
 /// top of the snippet box as a description. Don't try and say "see the code
 /// above" or "see the code below", since the location of the description may

--- a/examples/api/lib/services/mouse_cursor/mouse_cursor.0.dart
+++ b/examples/api/lib/services/mouse_cursor/mouse_cursor.0.dart
@@ -1,0 +1,48 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for MouseCursor
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'MouseCursor Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const MyStatelessWidget(),
+      ),
+    );
+  }
+}
+
+class MyStatelessWidget extends StatelessWidget {
+  const MyStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: MouseRegion(
+        cursor: SystemMouseCursors.text,
+        child: Container(
+          width: 200,
+          height: 100,
+          decoration: BoxDecoration(
+            color: Colors.blue,
+            border: Border.all(color: Colors.yellow),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/widgets/will_pop_scope/will_pop_scope.0.dart
+++ b/examples/api/lib/widgets/will_pop_scope/will_pop_scope.0.dart
@@ -69,7 +69,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
               ),
               const Text('Push to a new screen, then tap on shouldPop '
                   'button to toggle its value. Press the back '
-                  'button in the appBar to check its behaviour '
+                  'button in the appBar to check its behavior '
                   'for different values of shouldPop'),
             ],
           ),

--- a/examples/api/test/services/mouse_cursor/mouse_cursor.0_test.dart
+++ b/examples/api/test/services/mouse_cursor/mouse_cursor.0_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/services/mouse_cursor/mouse_cursor.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Uses Text Cursor', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    expect(find.byType(MouseRegion), findsNWidgets(2)); // There's one in the MaterialApp
+    final Finder mouseRegionFinder = find.ancestor(of: find.byType(Container), matching: find.byType(MouseRegion));
+    expect(mouseRegionFinder, findsOneWidget);
+    expect((tester.widget(mouseRegionFinder) as MouseRegion).cursor, equals(SystemMouseCursors.text));
+  });
+}

--- a/examples/api/test/widgets/will_pop_scope/will_pop_scope.0_test.dart
+++ b/examples/api/test/widgets/will_pop_scope/will_pop_scope.0_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_api_samples/widgets/will_pop_scope/will_pop_scope.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('pressing shouldPop button changes shouldPop', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    final Finder buttonFinder = find.text('shouldPop: true');
+    expect(buttonFinder, findsOneWidget);
+    await tester.tap(buttonFinder);
+    await tester.pump();
+    expect(find.text('shouldPop: false'), findsOneWidget);
+  });
+  testWidgets('pressing Push button pushes route', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    final Finder buttonFinder = find.text('Push');
+    expect(buttonFinder, findsOneWidget);
+    expect(find.byType(example.MyStatefulWidget), findsOneWidget);
+    await tester.tap(buttonFinder);
+    await tester.pumpAndSettle();
+    expect(find.byType(example.MyStatefulWidget, skipOffstage: false), findsNWidgets(2));
+  });
+}

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2395,7 +2395,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ** See code in examples/api/lib/material/input_decorator/input_decoration.3.dart **
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad}
 /// This sample shows how to style a `TextField` with a prefixIcon that changes color
 /// based on the `MaterialState`. The color defaults to gray, be blue while focused
 /// and red if in an error state.
@@ -2403,7 +2403,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 /// ** See code in examples/api/lib/material/input_decorator/input_decoration.material_state.0.dart **
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateless_widget_scaffold}
+/// {@tool dartpad}
 /// This sample shows how to style a `TextField` with a prefixIcon that changes color
 /// based on the `MaterialState` through the use of `ThemeData`. The color defaults
 /// to gray, be blue while focused and red if in an error state.

--- a/packages/flutter/lib/src/services/mouse_cursor.dart
+++ b/packages/flutter/lib/src/services/mouse_cursor.dart
@@ -160,28 +160,12 @@ abstract class MouseCursorSession {
 /// another widget that exposes the [MouseRegion] API, such as
 /// [InkResponse.mouseCursor].
 ///
-/// {@tool snippet --template=stateless_widget_material}
+/// {@tool dartpad}
 /// This sample creates a rectangular region that is wrapped by a [MouseRegion]
 /// with a system mouse cursor. The mouse pointer becomes an I-beam when
 /// hovering over the region.
 ///
-/// ```dart
-/// Widget build(BuildContext context) {
-///   return Center(
-///     child: MouseRegion(
-///       cursor: SystemMouseCursors.text,
-///       child: Container(
-///         width: 200,
-///         height: 100,
-///         decoration: BoxDecoration(
-///           color: Colors.blue,
-///           border: Border.all(color: Colors.yellow),
-///         ),
-///       ),
-///     ),
-///   );
-/// }
-/// ```
+/// ** See code in examples/api/lib/services/mouse_cursor/mouse_cursor.0.dart **
 /// {@end-tool}
 ///
 /// Assigning regions with mouse cursors on platforms that do not support mouse

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -55,7 +55,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// (those inside the [TabBarView], hooking them together so that they appear,
 /// to the user, as one coherent scroll view.
 ///
-/// {@tool sample}
+/// {@tool dartpad}
 /// This example shows a [NestedScrollView] whose header is the combination of a
 /// [TabBar] in a [SliverAppBar] and whose body is a [TabBarView]. It uses a
 /// [SliverOverlapAbsorber]/[SliverOverlapInjector] pair to make the inner lists
@@ -110,7 +110,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// configuration, the flexible space of the app bar will open and collapse,
 /// while the primary portion of the app bar remains pinned.
 ///
-/// {@tool sample}
+/// {@tool dartpad}
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// floating [SliverAppBar]. By using the [floatHeaderSlivers] property, the
 /// floating behavior is coordinated between the outer and inner [Scrollable]s,
@@ -140,7 +140,7 @@ typedef NestedScrollViewHeaderSliversBuilder = List<Widget> Function(BuildContex
 /// for the nested "inner" scroll view below to end up under the [SliverAppBar]
 /// even when the inner scroll view thinks it has not been scrolled.
 ///
-/// {@tool sample}
+/// {@tool dartpad}
 /// This simple example shows a [NestedScrollView] whose header contains a
 /// snapping, floating [SliverAppBar]. _Without_ setting any additional flags,
 /// e.g [NestedScrollView.floatHeaderSlivers], the [SliverAppBar] will animate

--- a/packages/flutter/lib/src/widgets/sliver_fill.dart
+++ b/packages/flutter/lib/src/widgets/sliver_fill.dart
@@ -239,7 +239,7 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
 ///
 /// {@animation 250 500 https://flutter.github.io/assets-for-api-docs/assets/widgets/sliver_fill_remaining_fill_overscroll.mp4}
 ///
-/// {@tool sample}
+/// {@tool dartpad}
 /// In this sample the [SliverFillRemaining]'s child stretches to fill the
 /// overscroll area when [fillOverscroll] is true. This sample also features a
 /// button that is pinned to the bottom of the sliver, regardless of size or

--- a/packages/flutter/lib/src/widgets/will_pop_scope.dart
+++ b/packages/flutter/lib/src/widgets/will_pop_scope.dart
@@ -9,30 +9,12 @@ import 'routes.dart';
 /// Registers a callback to veto attempts by the user to dismiss the enclosing
 /// [ModalRoute].
 ///
-/// {@tool snippet --template=stateful_widget}
-///
+/// {@tool dartpad}
 /// Whenever the back button is pressed, you will get a callback at [onWillPop],
 /// which returns a [Future]. If the [Future] returns true, the screen is
 /// popped.
 ///
-/// ```dart
-/// bool shouldPop = true;
-/// @override
-/// Widget build(BuildContext context) {
-///   return WillPopScope (
-///     onWillPop: () async {
-///       return shouldPop;
-///     },
-///     child: const Text('WillPopScope sample'),
-///   );
-/// }
-/// ```
-/// {@end-tool}
-///
-/// {@tool dartpad}
-///
-///
-/// ** See code in examples/api/lib/widgets/will_pop_scope/will_pop_scope.1.dart **
+/// ** See code in examples/api/lib/widgets/will_pop_scope/will_pop_scope.0.dart **
 /// {@end-tool}
 ///
 /// See also:


### PR DESCRIPTION
## Description

This fixes various problems with some API examples. There were several places where people had used `{@tool sample}` when they meant `{@tool dartpad}`, and some issues with still using templates, which shouldn't be used except on Engine code at this point (and soon not there either).

## Related Issues
 - Fixes #94978

## Tests
 - Added tests for the two examples I extracted.