### PR TITLE
Make `FocusNode.traversalChildren` not be affected by parent's `canRequestFocus`

### DIFF
--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -151,6 +151,37 @@ void main() {
       expect(scope.traversalDescendants.contains(child2), isFalse);
     });
 
+    testWidgets("canRequestFocus doesn't affect traversalChildren", (WidgetTester tester) async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode scope = FocusScopeNode(debugLabel: 'Scope');
+      final FocusAttachment scopeAttachment = scope.attach(context);
+      final FocusNode parent1 = FocusNode(debugLabel: 'Parent 1');
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode parent2 = FocusNode(debugLabel: 'Parent 2');
+      final FocusAttachment parent2Attachment = parent2.attach(context);
+      final FocusNode child1 = FocusNode(debugLabel: 'Child 1');
+      final FocusAttachment child1Attachment = child1.attach(context);
+      final FocusNode child2 = FocusNode(debugLabel: 'Child 2');
+      final FocusAttachment child2Attachment = child2.attach(context);
+      scopeAttachment.reparent(parent: tester.binding.focusManager.rootScope);
+      parent1Attachment.reparent(parent: scope);
+      parent2Attachment.reparent(parent: scope);
+      child1Attachment.reparent(parent: parent1);
+      child2Attachment.reparent(parent: parent2);
+      child1.requestFocus();
+      await tester.pump();
+
+      expect(tester.binding.focusManager.primaryFocus, equals(child1));
+      expect(scope.focusedChild, equals(child1));
+      expect(parent2.traversalChildren.contains(child2), isTrue);
+      expect(scope.traversalChildren.contains(parent2), isTrue);
+
+      parent2.canRequestFocus = false;
+      await tester.pump();
+      expect(parent2.traversalChildren.contains(child2), isTrue);
+      expect(scope.traversalChildren.contains(parent2), isFalse);
+    });
+
     testWidgets('implements debugFillProperties', (WidgetTester tester) async {
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
       FocusNode(
@@ -502,6 +533,8 @@ void main() {
       expect(scope.focusedChild, equals(child1));
       expect(scope.traversalDescendants.contains(child1), isTrue);
       expect(scope.traversalDescendants.contains(child2), isTrue);
+      expect(scope.traversalChildren.contains(parent1), isTrue);
+      expect(parent1.traversalChildren.contains(child2), isTrue);
 
       scope.canRequestFocus = false;
       await tester.pump();
@@ -512,6 +545,8 @@ void main() {
       expect(scope.focusedChild, equals(child1));
       expect(scope.traversalDescendants.contains(child1), isFalse);
       expect(scope.traversalDescendants.contains(child2), isFalse);
+      expect(scope.traversalChildren.contains(parent1), isFalse);
+      expect(parent1.traversalChildren.contains(child2), isFalse);
     });
 
     testWidgets("skipTraversal doesn't affect children.", (WidgetTester tester) async {


### PR DESCRIPTION
## Description

In this [Discord conversation](https://discord.com/channels/608014603317936148/608021635370582020/918967376370864208), it was pointed out that the docs and the behavior of `FocusNode.traversalChildren` were out of sync. This PR brings them into sync. This was a case of not having test coverage for a function that we don't actually call anymore in the framework.

I also optimized the call to `FocusNode.traversalDescendants` to just return an empty `Iterable` if `descendantsAreFocusable` is false.

## Tests
 - Updated/added tests for `traversalChildren` for both `FocusNode` and `FocusScopeNode`.