### PR TITLE
Adds a home method to device classes.

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -25,17 +25,19 @@ class DeviceException implements Exception {
 
 /// Gets the artifact path relative to the current directory.
 String getArtifactPath() {
-  return path.normalize(path.join(
-    path.current,
-    '../../bin/cache/artifacts',
-  ));
+  return path.normalize(
+      path.join(
+        path.current,
+        '../../bin/cache/artifacts',
+      )
+    );
 }
 
 /// Return the item is in idList if find a match, otherwise return null
 String? _findMatchId(List<String> idList, String idPattern) {
   String? candidate;
   idPattern = idPattern.toLowerCase();
-  for (final String id in idList) {
+  for(final String id in idList) {
     if (id.toLowerCase() == idPattern) {
       return id;
     }
@@ -50,8 +52,7 @@ String? _findMatchId(List<String> idList, String idPattern) {
 DeviceDiscovery get devices => DeviceDiscovery();
 
 /// Device operating system the test is configured to test.
-
-enum DeviceOperatingSystem { android, androidArm, androidArm64, ios, fuchsia, fake }
+enum DeviceOperatingSystem { android, androidArm, androidArm64 ,ios, fuchsia, fake }
 
 /// Device OS to test on.
 DeviceOperatingSystem deviceOperatingSystem = DeviceOperatingSystem.android;
@@ -123,11 +124,11 @@ abstract class Device {
   /// Send the device to sleep mode.
   Future<void> sendToSleep();
 
-  /// Emulates pressing the power button, toggling the device's on/off state.
-  Future<void> togglePower();
-
   /// Emulates pressing the home button.
   Future<void> home();
+
+  /// Emulates pressing the power button, toggling the device's on/off state.
+  Future<void> togglePower();
 
   /// Unlocks the device.
   ///
@@ -227,12 +228,12 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   /// [workingDevice].
   @override
   Future<void> chooseWorkingDevice() async {
-    final List<AndroidDevice> allDevices =
-        (await discoverDevices()).map<AndroidDevice>((String id) => AndroidDevice(deviceId: id)).toList();
+    final List<AndroidDevice> allDevices = (await discoverDevices())
+      .map<AndroidDevice>((String id) => AndroidDevice(deviceId: id))
+      .toList();
 
-    if (allDevices.isEmpty) {
+    if (allDevices.isEmpty)
       throw const DeviceException('No Android devices detected');
-    }
 
     if (cpu != null) {
       for (final AndroidDevice device in allDevices) {
@@ -241,14 +242,14 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
           break;
         }
       }
+
     } else {
       // TODO(yjbanov): filter out and warn about those with low battery level
       _workingDevice = allDevices[math.Random().nextInt(allDevices.length)];
     }
 
-    if (_workingDevice == null) {
+    if (_workingDevice == null)
       throw const DeviceException('Cannot find a suitable Android device');
-    }
 
     print('Device chosen: $_workingDevice');
   }
@@ -266,23 +267,24 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       print('Choose device by ID: $matchedId');
       return;
     }
-    throw DeviceException('Device with ID $deviceId is not found for operating system: '
-        '$deviceOperatingSystem');
+    throw DeviceException(
+      'Device with ID $deviceId is not found for operating system: '
+      '$deviceOperatingSystem'
+      );
   }
 
   @override
   Future<List<String>> discoverDevices() async {
-    final List<String> output = (await eval(adbPath, <String>['devices', '-l'])).trim().split('\n');
+    final List<String> output = (await eval(adbPath, <String>['devices', '-l']))
+        .trim().split('\n');
     final List<String> results = <String>[];
     for (final String line in output) {
       // Skip lines like: * daemon started successfully *
-      if (line.startsWith('* daemon ')) {
+      if (line.startsWith('* daemon '))
         continue;
-      }
 
-      if (line.startsWith('List of devices')) {
+      if (line.startsWith('List of devices'))
         continue;
-      }
 
       if (_kDeviceRegex.hasMatch(line)) {
         final Match match = _kDeviceRegex.firstMatch(line)!;
@@ -342,7 +344,7 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
   FuchsiaDevice? _workingDevice;
 
   String get _ffx {
-    final String ffx = path.join(getArtifactPath(), 'fuchsia', 'tools', 'x64', 'ffx');
+    final String ffx = path.join(getArtifactPath(), 'fuchsia', 'tools','x64', 'ffx');
     if (!File(ffx).existsSync()) {
       throw FileSystemException("Couldn't find ffx at location $ffx");
     }
@@ -365,8 +367,9 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
   /// Picks the first connected Fuchsia device.
   @override
   Future<void> chooseWorkingDevice() async {
-    final List<FuchsiaDevice> allDevices =
-        (await discoverDevices()).map<FuchsiaDevice>((String id) => FuchsiaDevice(deviceId: id)).toList();
+    final List<FuchsiaDevice> allDevices = (await discoverDevices())
+      .map<FuchsiaDevice>((String id) => FuchsiaDevice(deviceId: id))
+      .toList();
 
     if (allDevices.isEmpty) {
       throw const DeviceException('No Fuchsia devices detected');
@@ -383,13 +386,17 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
       print('Choose device by ID: $matchedId');
       return;
     }
-    throw DeviceException('Device with ID $deviceId is not found for operating system: '
-        '$deviceOperatingSystem');
+    throw DeviceException(
+      'Device with ID $deviceId is not found for operating system: '
+      '$deviceOperatingSystem'
+      );
   }
 
   @override
   Future<List<String>> discoverDevices() async {
-    final List<String> output = (await eval(_ffx, <String>['target', 'list', '--format', 's'])).trim().split('\n');
+    final List<String> output = (await eval(_ffx, <String>['target', 'list', '--format', 's']))
+      .trim()
+      .split('\n');
 
     final List<String> devices = <String>[];
     for (final String line in output) {
@@ -405,13 +412,16 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
     final Map<String, HealthCheckResult> results = <String, HealthCheckResult>{};
     for (final String deviceId in await discoverDevices()) {
       try {
-        final int resolveResult = await exec(_ffx, <String>[
-          'target',
-          'list',
-          '--format',
-          'a',
-          deviceId,
-        ]);
+        final int resolveResult = await exec(
+          _ffx,
+          <String>[
+            'target',
+            'list',
+            '--format',
+            'a',
+            deviceId,
+          ]
+        );
         if (resolveResult == 0) {
           results['fuchsia-device-$deviceId'] = HealthCheckResult.success();
         } else {
@@ -452,17 +462,21 @@ class AndroidDevice extends Device {
   /// Wake up the device if it is not awake using [togglePower].
   @override
   Future<void> wakeUp() async {
-    if (!(await isAwake())) {
+    if (!(await isAwake()))
       await togglePower();
-    }
   }
 
   /// Send the device to sleep mode if it is not asleep using [togglePower].
   @override
   Future<void> sendToSleep() async {
-    if (!(await isAsleep())) {
+    if (!(await isAsleep()))
       await togglePower();
-    }
+  }
+
+  /// Sends `KEYCODE_HOME` (3), which causes the device to go to the home screen.
+  @override
+  Future<void> home() async {
+    await shellExec('input', const <String>['keyevent', '3']);
   }
 
   /// Sends `KEYCODE_POWER` (26), which causes the device to toggle its mode
@@ -511,13 +525,9 @@ class AndroidDevice extends Device {
       info = await shellEval(
         'getprop',
         <String>[
-          'ro.bootimage.build.fingerprint',
-          ';',
-          'getprop',
-          'ro.build.version.release',
-          ';',
-          'getprop',
-          'ro.build.version.sdk',
+          'ro.bootimage.build.fingerprint', ';',
+          'getprop', 'ro.build.version.release', ';',
+          'getprop', 'ro.build.version.sdk',
         ],
         silent: true,
       );
@@ -533,23 +543,21 @@ class AndroidDevice extends Device {
   }
 
   /// Executes [command] on `adb shell` and returns its exit code.
-  Future<void> shellExec(String command, List<String> arguments,
-      {Map<String, String>? environment, bool silent = false}) async {
+  Future<void> shellExec(String command, List<String> arguments, { Map<String, String>? environment, bool silent = false }) async {
     await adb(<String>['shell', command, ...arguments], environment: environment, silent: silent);
   }
 
   /// Executes [command] on `adb shell` and returns its standard output as a [String].
-  Future<String> shellEval(String command, List<String> arguments,
-      {Map<String, String>? environment, bool silent = false}) {
+  Future<String> shellEval(String command, List<String> arguments, { Map<String, String>? environment, bool silent = false }) {
     return adb(<String>['shell', command, ...arguments], environment: environment, silent: silent);
   }
 
   /// Runs `adb` with the given [arguments], selecting this device.
   Future<String> adb(
-    List<String> arguments, {
-    Map<String, String>? environment,
-    bool silent = false,
-  }) {
+      List<String> arguments, {
+      Map<String, String>? environment,
+      bool silent = false,
+    }) {
     return eval(
       adbPath,
       <String>['-s', deviceId, ...arguments],
@@ -590,12 +598,16 @@ class AndroidDevice extends Device {
       // to view the whole log, or just run logcat alongside this.
       <String>['-s', deviceId, 'logcat', 'ActivityManager:I', 'flutter:V', '*:F'],
     );
-    _loggingProcess!.stdout.transform<String>(const Utf8Decoder(allowMalformed: true)).listen((String line) {
-      sink.write(line);
-    });
-    _loggingProcess!.stderr.transform<String>(const Utf8Decoder(allowMalformed: true)).listen((String line) {
-      sink.write(line);
-    });
+    _loggingProcess!.stdout
+      .transform<String>(const Utf8Decoder(allowMalformed: true))
+      .listen((String line) {
+        sink.write(line);
+      });
+    _loggingProcess!.stderr
+      .transform<String>(const Utf8Decoder(allowMalformed: true))
+      .listen((String line) {
+        sink.write(line);
+      });
     unawaited(_loggingProcess!.exitCode.then<void>((int exitCode) {
       if (!_abortedLogging) {
         sink.writeln('adb logcat failed with exit code $exitCode.\n');
@@ -633,19 +645,21 @@ class AndroidDevice extends Device {
           // to view the whole log, or just run logcat alongside this.
           <String>['-s', deviceId, 'logcat', 'ActivityManager:I', 'flutter:V', '*:F'],
         );
-        process.stdout.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen((String line) {
-          print('adb logcat: $line');
-          if (!stream.isClosed) {
-            stream.sink.add(line);
-          }
-        }, onDone: () {
-          stdoutDone.complete();
-        });
-        process.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).listen((String line) {
-          print('adb logcat stderr: $line');
-        }, onDone: () {
-          stderrDone.complete();
-        });
+        process.stdout
+          .transform<String>(utf8.decoder)
+          .transform<String>(const LineSplitter())
+          .listen((String line) {
+            print('adb logcat: $line');
+            if (!stream.isClosed) {
+              stream.sink.add(line);
+            }
+          }, onDone: () { stdoutDone.complete(); });
+        process.stderr
+          .transform<String>(utf8.decoder)
+          .transform<String>(const LineSplitter())
+          .listen((String line) {
+            print('adb logcat stderr: $line');
+          }, onDone: () { stderrDone.complete(); });
         unawaited(process.exitCode.then<void>((int exitCode) {
           print('adb logcat process terminated with exit code $exitCode');
           if (!aborted) {
@@ -692,11 +706,6 @@ class AndroidDevice extends Device {
   Future<void> reboot() {
     return adb(<String>['reboot']);
   }
-
-  @override
-  Future<void> home() async {
-    await shellExec('input', const <String>['keyevent', '3']);
-  }
 }
 
 class IosDeviceDiscovery implements DeviceDiscovery {
@@ -728,12 +737,12 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   /// [workingDevice].
   @override
   Future<void> chooseWorkingDevice() async {
-    final List<IosDevice> allDevices =
-        (await discoverDevices()).map<IosDevice>((String id) => IosDevice(deviceId: id)).toList();
+    final List<IosDevice> allDevices = (await discoverDevices())
+      .map<IosDevice>((String id) => IosDevice(deviceId: id))
+      .toList();
 
-    if (allDevices.isEmpty) {
+    if (allDevices.isEmpty)
       throw const DeviceException('No iOS devices detected');
-    }
 
     // TODO(yjbanov): filter out and warn about those with low battery level
     _workingDevice = allDevices[math.Random().nextInt(allDevices.length)];
@@ -748,8 +757,10 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       print('Choose device by ID: $matchedId');
       return;
     }
-    throw DeviceException('Device with ID $deviceId is not found for operating system: '
-        '$deviceOperatingSystem');
+    throw DeviceException(
+      'Device with ID $deviceId is not found for operating system: '
+      '$deviceOperatingSystem'
+      );
   }
 
   @override
@@ -815,7 +826,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 
 /// iOS device.
 class IosDevice extends Device {
-  IosDevice({required this.deviceId});
+  IosDevice({ required this.deviceId });
 
   @override
   final String deviceId;
@@ -850,12 +861,16 @@ class IosDevice extends Device {
         'DYLD_LIBRARY_PATH': dyldLibraryPath,
       },
     );
-    _loggingProcess!.stdout.transform<String>(const Utf8Decoder(allowMalformed: true)).listen((String line) {
-      sink.write(line);
-    });
-    _loggingProcess!.stderr.transform<String>(const Utf8Decoder(allowMalformed: true)).listen((String line) {
-      sink.write(line);
-    });
+    _loggingProcess!.stdout
+      .transform<String>(const Utf8Decoder(allowMalformed: true))
+      .listen((String line) {
+        sink.write(line);
+      });
+    _loggingProcess!.stderr
+      .transform<String>(const Utf8Decoder(allowMalformed: true))
+      .listen((String line) {
+        sink.write(line);
+      });
     unawaited(_loggingProcess!.exitCode.then<void>((int exitCode) {
       if (!_abortedLogging) {
         sink.writeln('idevicesyslog failed with exit code $exitCode.\n');
@@ -890,6 +905,9 @@ class IosDevice extends Device {
   Future<void> sendToSleep() async {}
 
   @override
+  Future<void> home() async {}
+
+  @override
   Future<void> togglePower() async {}
 
   @override
@@ -917,16 +935,11 @@ class IosDevice extends Device {
   Future<void> reboot() {
     return Process.run('idevicediagnostics', <String>['restart', '-u', deviceId]);
   }
-
-  @override
-  Future<void> home() async {
-    // It does nothing for ios devices.
-  }
 }
 
 /// Fuchsia device.
 class FuchsiaDevice extends Device {
-  const FuchsiaDevice({required this.deviceId});
+  const FuchsiaDevice({ required this.deviceId });
 
   @override
   final String deviceId;
@@ -943,6 +956,9 @@ class FuchsiaDevice extends Device {
 
   @override
   Future<void> sendToSleep() async {}
+
+  @override
+  Future<void> home() async {}
 
   @override
   Future<void> togglePower() async {}
@@ -970,11 +986,6 @@ class FuchsiaDevice extends Device {
   Future<void> reboot() async {
     // Unsupported.
   }
-
-  @override
-  Future<void> home() async {
-    // It does nothing for fuchsia.
-  }
 }
 
 /// Path to the `adb` executable.
@@ -982,22 +993,23 @@ String get adbPath {
   final String? androidHome = Platform.environment['ANDROID_HOME'] ?? Platform.environment['ANDROID_SDK_ROOT'];
 
   if (androidHome == null) {
-    throw const DeviceException('The ANDROID_SDK_ROOT environment variable is '
-        'missing. The variable must point to the Android '
-        'SDK directory containing platform-tools.');
+    throw const DeviceException(
+      'The ANDROID_SDK_ROOT environment variable is '
+      'missing. The variable must point to the Android '
+      'SDK directory containing platform-tools.'
+    );
   }
 
   final String adbPath = path.join(androidHome, 'platform-tools/adb');
 
-  if (!canRun(adbPath)) {
+  if (!canRun(adbPath))
     throw DeviceException('adb not found at: $adbPath');
-  }
 
   return path.absolute(adbPath);
 }
 
 class FakeDevice extends Device {
-  const FakeDevice({required this.deviceId});
+  const FakeDevice({ required this.deviceId });
 
   @override
   final String deviceId;
@@ -1013,6 +1025,9 @@ class FakeDevice extends Device {
 
   @override
   Future<void> sendToSleep() async {}
+
+  @override
+  Future<void> home() async {}
 
   @override
   Future<void> togglePower() async {}
@@ -1041,11 +1056,6 @@ class FakeDevice extends Device {
   @override
   Future<void> reboot() async {
     // Unsupported.
-  }
-
-  @override
-  Future<void> home() async {
-    // It does nothing for fakedevice.
   }
 }
 
@@ -1088,8 +1098,10 @@ class FakeDeviceDiscovery implements DeviceDiscovery {
       print('Choose device by ID: $matchedId');
       return;
     }
-    throw DeviceException('Device with ID $deviceId is not found for operating system: '
-        '$deviceOperatingSystem');
+    throw DeviceException(
+      'Device with ID $deviceId is not found for operating system: '
+      '$deviceOperatingSystem'
+      );
   }
 
   @override
@@ -1107,5 +1119,6 @@ class FakeDeviceDiscovery implements DeviceDiscovery {
   }
 
   @override
-  Future<void> performPreflightTasks() async {}
+  Future<void> performPreflightTasks() async {
+  }
 }

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -42,9 +42,8 @@ bool _isTaskRegistered = false;
 /// It is OK for a [task] to perform many things. However, only one task can be
 /// registered per Dart VM.
 Future<TaskResult> task(TaskFunction task) async {
-  if (_isTaskRegistered) {
+  if (_isTaskRegistered)
     throw StateError('A task is already registered');
-  }
 
   _isTaskRegistered = true;
 
@@ -61,19 +60,20 @@ Future<TaskResult> task(TaskFunction task) async {
 
 class _TaskRunner {
   _TaskRunner(this.task) {
-    registerExtension('ext.cocoonRunTask', (String method, Map<String, String> parameters) async {
+    registerExtension('ext.cocoonRunTask',
+        (String method, Map<String, String> parameters) async {
       final Duration? taskTimeout = parameters.containsKey('timeoutInMinutes')
-          ? Duration(minutes: int.parse(parameters['timeoutInMinutes']!))
-          : null;
+        ? Duration(minutes: int.parse(parameters['timeoutInMinutes']!))
+        : null;
       // This is only expected to be passed in unit test runs so they do not
       // kill the Dart process that is running them and waste time running config.
       final bool runFlutterConfig = parameters['runFlutterConfig'] != 'false';
       final bool runProcessCleanup = parameters['runProcessCleanup'] != 'false';
-      final TaskResult result =
-          await run(taskTimeout, runProcessCleanup: runProcessCleanup, runFlutterConfig: runFlutterConfig);
+      final TaskResult result = await run(taskTimeout, runProcessCleanup: runProcessCleanup, runFlutterConfig: runFlutterConfig);
       return ServiceExtensionResponse.result(json.encode(result.toJson()));
     });
-    registerExtension('ext.cocoonRunnerReady', (String method, Map<String, String> parameters) async {
+    registerExtension('ext.cocoonRunnerReady',
+        (String method, Map<String, String> parameters) async {
       return ServiceExtensionResponse.result('"ready"');
     });
   }
@@ -100,8 +100,7 @@ class _TaskRunner {
   /// Signals that this task runner finished running the task.
   Future<TaskResult> get whenDone => _completer.future;
 
-  Future<TaskResult> run(
-    Duration? taskTimeout, {
+  Future<TaskResult> run(Duration? taskTimeout, {
     bool runFlutterConfig = true,
     bool runProcessCleanup = true,
   }) async {
@@ -128,18 +127,15 @@ class _TaskRunner {
 
       if (runFlutterConfig) {
         print('enabling configs for macOS, Linux, Windows, and Web...');
-        final int configResult = await exec(
-            path.join(flutterDirectory.path, 'bin', 'flutter'),
-            <String>[
-              'config',
-              '-v',
-              '--enable-macos-desktop',
-              '--enable-windows-desktop',
-              '--enable-linux-desktop',
-              '--enable-web',
-              if (localEngine != null) ...<String>['--local-engine', localEngine!],
-            ],
-            canFail: true);
+        final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+          'config',
+          '-v',
+          '--enable-macos-desktop',
+          '--enable-windows-desktop',
+          '--enable-linux-desktop',
+          '--enable-web',
+          if (localEngine != null) ...<String>['--local-engine', localEngine!],
+        ], canFail: true);
         if (configResult != 0) {
           print('Failed to enable configuration, tasks may not run.');
         }
@@ -148,8 +144,10 @@ class _TaskRunner {
       }
 
       final Device? device = await _getWorkingDeviceIfAvailable();
+      
       // Some tests assume the phone is in home
       await device?.home();
+
       late TaskResult result;
       IOSink? sink;
       try {
@@ -159,9 +157,8 @@ class _TaskRunner {
         }
 
         Future<TaskResult> futureResult = _performTask();
-        if (taskTimeout != null) {
+        if (taskTimeout != null)
           futureResult = futureResult.timeout(taskTimeout);
-        }
 
         result = await futureResult;
       } finally {
@@ -240,9 +237,8 @@ class _TaskRunner {
   /// Causes the Dart VM to stay alive until a request to run the task is
   /// received via the VM service protocol.
   void keepVmAliveUntilTaskRunRequested() {
-    if (_taskStarted) {
+    if (_taskStarted)
       throw StateError('Task already started.');
-    }
 
     // Merely creating this port object will cause the VM to stay alive and keep
     // the VM service server running until the port is disposed of.
@@ -280,9 +276,8 @@ class _TaskRunner {
       // are catching errors coming from arbitrary (and untrustworthy) task
       // code. Our goal is to convert the failure into a readable message.
       // Propagating it further is not useful.
-      if (!completer.isCompleted) {
+      if (!completer.isCompleted)
         completer.complete(TaskResult.failure(message));
-      }
     });
     return completer.future;
   }

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -144,7 +144,7 @@ class _TaskRunner {
       }
 
       final Device? device = await _getWorkingDeviceIfAvailable();
-      
+
       // Some tests assume the phone is in home
       await device?.home();
 

--- a/dev/devicelab/lib/framework/framework.dart
+++ b/dev/devicelab/lib/framework/framework.dart
@@ -42,8 +42,9 @@ bool _isTaskRegistered = false;
 /// It is OK for a [task] to perform many things. However, only one task can be
 /// registered per Dart VM.
 Future<TaskResult> task(TaskFunction task) async {
-  if (_isTaskRegistered)
+  if (_isTaskRegistered) {
     throw StateError('A task is already registered');
+  }
 
   _isTaskRegistered = true;
 
@@ -60,20 +61,19 @@ Future<TaskResult> task(TaskFunction task) async {
 
 class _TaskRunner {
   _TaskRunner(this.task) {
-    registerExtension('ext.cocoonRunTask',
-        (String method, Map<String, String> parameters) async {
+    registerExtension('ext.cocoonRunTask', (String method, Map<String, String> parameters) async {
       final Duration? taskTimeout = parameters.containsKey('timeoutInMinutes')
-        ? Duration(minutes: int.parse(parameters['timeoutInMinutes']!))
-        : null;
+          ? Duration(minutes: int.parse(parameters['timeoutInMinutes']!))
+          : null;
       // This is only expected to be passed in unit test runs so they do not
       // kill the Dart process that is running them and waste time running config.
       final bool runFlutterConfig = parameters['runFlutterConfig'] != 'false';
       final bool runProcessCleanup = parameters['runProcessCleanup'] != 'false';
-      final TaskResult result = await run(taskTimeout, runProcessCleanup: runProcessCleanup, runFlutterConfig: runFlutterConfig);
+      final TaskResult result =
+          await run(taskTimeout, runProcessCleanup: runProcessCleanup, runFlutterConfig: runFlutterConfig);
       return ServiceExtensionResponse.result(json.encode(result.toJson()));
     });
-    registerExtension('ext.cocoonRunnerReady',
-        (String method, Map<String, String> parameters) async {
+    registerExtension('ext.cocoonRunnerReady', (String method, Map<String, String> parameters) async {
       return ServiceExtensionResponse.result('"ready"');
     });
   }
@@ -100,7 +100,8 @@ class _TaskRunner {
   /// Signals that this task runner finished running the task.
   Future<TaskResult> get whenDone => _completer.future;
 
-  Future<TaskResult> run(Duration? taskTimeout, {
+  Future<TaskResult> run(
+    Duration? taskTimeout, {
     bool runFlutterConfig = true,
     bool runProcessCleanup = true,
   }) async {
@@ -127,15 +128,18 @@ class _TaskRunner {
 
       if (runFlutterConfig) {
         print('enabling configs for macOS, Linux, Windows, and Web...');
-        final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
-          'config',
-          '-v',
-          '--enable-macos-desktop',
-          '--enable-windows-desktop',
-          '--enable-linux-desktop',
-          '--enable-web',
-          if (localEngine != null) ...<String>['--local-engine', localEngine!],
-        ], canFail: true);
+        final int configResult = await exec(
+            path.join(flutterDirectory.path, 'bin', 'flutter'),
+            <String>[
+              'config',
+              '-v',
+              '--enable-macos-desktop',
+              '--enable-windows-desktop',
+              '--enable-linux-desktop',
+              '--enable-web',
+              if (localEngine != null) ...<String>['--local-engine', localEngine!],
+            ],
+            canFail: true);
         if (configResult != 0) {
           print('Failed to enable configuration, tasks may not run.');
         }
@@ -144,6 +148,8 @@ class _TaskRunner {
       }
 
       final Device? device = await _getWorkingDeviceIfAvailable();
+      // Some tests assume the phone is in home
+      await device?.home();
       late TaskResult result;
       IOSink? sink;
       try {
@@ -153,8 +159,9 @@ class _TaskRunner {
         }
 
         Future<TaskResult> futureResult = _performTask();
-        if (taskTimeout != null)
+        if (taskTimeout != null) {
           futureResult = futureResult.timeout(taskTimeout);
+        }
 
         result = await futureResult;
       } finally {
@@ -233,8 +240,9 @@ class _TaskRunner {
   /// Causes the Dart VM to stay alive until a request to run the task is
   /// received via the VM service protocol.
   void keepVmAliveUntilTaskRunRequested() {
-    if (_taskStarted)
+    if (_taskStarted) {
       throw StateError('Task already started.');
+    }
 
     // Merely creating this port object will cause the VM to stay alive and keep
     // the VM service server running until the port is disposed of.
@@ -272,8 +280,9 @@ class _TaskRunner {
       // are catching errors coming from arbitrary (and untrustworthy) task
       // code. Our goal is to convert the failure into a readable message.
       // Propagating it further is not useful.
-      if (!completer.isCompleted)
+      if (!completer.isCompleted) {
         completer.complete(TaskResult.failure(message));
+      }
     });
     return completer.future;
   }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -246,8 +246,8 @@ TaskFunction createComplexLayoutCompileTest() {
 
 TaskFunction createFlutterViewStartupTest() {
   return StartupTest(
-    '${flutterDirectory.path}/examples/flutter_view',
-    reportMetrics: false,
+      '${flutterDirectory.path}/examples/flutter_view',
+      reportMetrics: false,
   ).run;
 }
 
@@ -269,9 +269,8 @@ TaskFunction createBasicMaterialCompileTest() {
       await flutter('create', options: <String>['--template=app', sampleAppName]);
     });
 
-    if (!sampleDir.existsSync()) {
+    if (!sampleDir.existsSync())
       throw 'Failed to create default Flutter app in ${sampleDir.path}';
-    }
 
     return CompileTest(sampleDir.path).run();
   };
@@ -294,7 +293,8 @@ TaskFunction createTextfieldPerfE2ETest() {
 }
 
 TaskFunction createStackSizeTest() {
-  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
+  final String testDirectory =
+      '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
   const String testTarget = 'test_driver/run_app.dart';
   const String testDriver = 'test_driver/stack_size_perf_test.dart';
   return () {
@@ -309,10 +309,8 @@ TaskFunction createStackSizeTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t',
-        testTarget,
-        '--driver',
-        testDriver,
+        '-t', testTarget,
+        '--driver', testDriver,
         '-d',
         deviceId,
       ]);
@@ -392,7 +390,8 @@ TaskFunction createsMultiWidgetConstructPerfE2ETest() {
 }
 
 TaskFunction createsScrollSmoothnessPerfTest() {
-  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/complex_layout';
+  final String testDirectory =
+      '${flutterDirectory.path}/dev/benchmarks/complex_layout';
   const String testTarget = 'test/measure_scroll_smoothness.dart';
   return () {
     return inDirectory<TaskResult>(testDirectory, () async {
@@ -406,8 +405,7 @@ TaskFunction createsScrollSmoothnessPerfTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t',
-        testTarget,
+        '-t', testTarget,
         '-d',
         deviceId,
       ]);
@@ -429,7 +427,6 @@ TaskFunction createsScrollSmoothnessPerfTest() {
           }
         }
       }
-
       addResult(data['resample on with 90Hz input'], '_with_resampler_90Hz');
       addResult(data['resample on with 59Hz input'], '_with_resampler_59Hz');
       addResult(data['resample off with 90Hz input'], '_without_resampler_90Hz');
@@ -444,7 +441,8 @@ TaskFunction createsScrollSmoothnessPerfTest() {
 }
 
 TaskFunction createFramePolicyIntegrationTest() {
-  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
+  final String testDirectory =
+      '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
   const String testTarget = 'test/frame_policy.dart';
   return () {
     return inDirectory<TaskResult>(testDirectory, () async {
@@ -458,8 +456,7 @@ TaskFunction createFramePolicyIntegrationTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t',
-        testTarget,
+        '-t', testTarget,
         '-d',
         deviceId,
       ]);
@@ -469,10 +466,14 @@ TaskFunction createFramePolicyIntegrationTest() {
       final Map<String, dynamic> fullLiveData = data['fullyLive'] as Map<String, dynamic>;
       final Map<String, dynamic> benchmarkLiveData = data['benchmarkLive'] as Map<String, dynamic>;
       final Map<String, dynamic> dataFormatted = <String, dynamic>{
-        'average_delay_fullyLive_millis': fullLiveData['average_delay_millis'],
-        'average_delay_benchmarkLive_millis': benchmarkLiveData['average_delay_millis'],
-        '90th_percentile_delay_fullyLive_millis': fullLiveData['90th_percentile_delay_millis'],
-        '90th_percentile_delay_benchmarkLive_millis': benchmarkLiveData['90th_percentile_delay_millis'],
+        'average_delay_fullyLive_millis':
+          fullLiveData['average_delay_millis'],
+        'average_delay_benchmarkLive_millis':
+          benchmarkLiveData['average_delay_millis'],
+        '90th_percentile_delay_fullyLive_millis':
+          fullLiveData['90th_percentile_delay_millis'],
+        '90th_percentile_delay_benchmarkLive_millis':
+          benchmarkLiveData['90th_percentile_delay_millis'],
       };
 
       return TaskResult.success(
@@ -537,7 +538,7 @@ Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations
 
 /// Measure application startup performance.
 class StartupTest {
-  const StartupTest(this.testDirectory, {this.reportMetrics = true, this.target = 'lib/main.dart'});
+  const StartupTest(this.testDirectory, { this.reportMetrics = true, this.target = 'lib/main.dart' });
 
   final String testDirectory;
   final bool reportMetrics;
@@ -585,7 +586,7 @@ class StartupTest {
         case DeviceOperatingSystem.ios:
           await flutter('build', options: <String>[
             'ios',
-            '-v',
+             '-v',
             '--profile',
             '--target=$target',
           ]);
@@ -599,19 +600,18 @@ class StartupTest {
       const int maxFailures = 3;
       int currentFailures = 0;
       for (int i = 0; i < iterations; i += 1) {
-        final int result = await flutter('run',
-            options: <String>[
-              '--no-android-gradle-daemon',
-              '--no-publish-port',
-              '--verbose',
-              '--profile',
-              '--trace-startup',
-              '--target=$target',
-              '-d',
-              device.deviceId,
-              if (applicationBinaryPath != null) '--use-application-binary=$applicationBinaryPath',
-            ],
-            canFail: true);
+        final int result = await flutter('run', options: <String>[
+          '--no-android-gradle-daemon',
+          '--no-publish-port',
+          '--verbose',
+          '--profile',
+          '--trace-startup',
+          '--target=$target',
+          '-d',
+          device.deviceId,
+          if (applicationBinaryPath != null)
+            '--use-application-binary=$applicationBinaryPath',
+         ], canFail: true);
         if (result == 0) {
           final Map<String, dynamic> data = json.decode(
             file('${_testOutputDirectory(testDirectory)}/start_up_info.json').readAsStringSync(),
@@ -626,7 +626,9 @@ class StartupTest {
                 '-d',
                 device.deviceId,
                 '--out',
-                hostAgent.dumpDirectory!.childFile('screenshot_startup_failure_$currentFailures.png').path,
+                hostAgent.dumpDirectory!
+                    .childFile('screenshot_startup_failure_$currentFailures.png')
+                    .path,
               ],
               canFail: true,
             );
@@ -646,9 +648,8 @@ class StartupTest {
 
       final Map<String, dynamic> averageResults = _average(results, iterations);
 
-      if (!reportMetrics) {
+      if (!reportMetrics)
         return TaskResult.success(averageResults);
-      }
 
       return TaskResult.success(averageResults, benchmarkScoreKeys: <String>[
         'timeToFirstFrameMicros',
@@ -701,7 +702,7 @@ class DevtoolsStartupTest {
         case DeviceOperatingSystem.ios:
           await flutter('build', options: <String>[
             'ios',
-            '-v',
+             '-v',
             '--profile',
           ]);
           applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
@@ -719,12 +720,16 @@ class DevtoolsStartupTest {
         '--profile',
         '-d',
         device.deviceId,
-        if (applicationBinaryPath != null) '--use-application-binary=$applicationBinaryPath',
-      ]);
+        if (applicationBinaryPath != null)
+          '--use-application-binary=$applicationBinaryPath',
+       ]);
       final Completer<void> completer = Completer<void>();
       bool sawLine = false;
-      process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String line) {
-        print('[STDOUT]: $line');
+      process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((String line) {
+          print('[STDOUT]: $line');
         // Wait for devtools output.
         if (line.contains('The Flutter DevTools debugger and profiler')) {
           sawLine = true;
@@ -735,8 +740,7 @@ class DevtoolsStartupTest {
       unawaited(process.exitCode.whenComplete(() {
         didExit = true;
       }));
-      await Future.any(
-          <Future<void>>[completer.future, Future<void>.delayed(const Duration(minutes: 5)), process.exitCode]);
+      await Future.any(<Future<void>>[completer.future, Future<void>.delayed(const Duration(minutes: 5)), process.exitCode]);
       if (!didExit) {
         process.stdin.writeln('q');
         await process.exitCode;
@@ -748,9 +752,8 @@ class DevtoolsStartupTest {
         device.deviceId,
       ]);
 
-      if (sawLine) {
+      if (sawLine)
         return TaskResult.success(null, benchmarkScoreKeys: <String>[]);
-      }
       return TaskResult.failure('Did not see line "The Flutter DevTools debugger and profiler" in output');
     });
   }
@@ -771,25 +774,22 @@ class PerfTest {
     this.benchmarkScoreKeys,
     this.dartDefine = '',
     String? resultFilename,
-  }) : _resultFilename = resultFilename;
+  }): _resultFilename = resultFilename;
 
   const PerfTest.e2e(
     this.testDirectory,
     this.testTarget, {
     this.measureCpuGpu = false,
     this.measureMemory = false,
-    this.testDriver = 'test_driver/e2e_test.dart',
+    this.testDriver =  'test_driver/e2e_test.dart',
     this.needsFullTimeline = false,
     this.benchmarkScoreKeys = _kCommonScoreKeys,
     this.dartDefine = '',
     String resultFilename = 'e2e_perf_summary',
-  })  : saveTraceFile = false,
-        timelineFileName = null,
-        _resultFilename = resultFilename;
+  }) : saveTraceFile = false, timelineFileName = null, _resultFilename = resultFilename;
 
   /// The directory where the app under test is defined.
   final String testDirectory;
-
   /// The main entry-point file of the application, as run on the device.
   final String testTarget;
   // The prefix name of the filename such as `<timelineFileName>.timeline_summary.json`.
@@ -797,19 +797,14 @@ class PerfTest {
   String get traceFilename => '$timelineFileName.timeline';
   String get resultFilename => _resultFilename ?? '$timelineFileName.timeline_summary';
   final String? _resultFilename;
-
   /// The test file to run on the host.
   final String? testDriver;
-
   /// Whether to collect CPU and GPU metrics.
   final bool measureCpuGpu;
-
   /// Whether to collect memory metrics.
   final bool measureMemory;
-
   /// Whether to collect full timeline, meaning if `--trace-startup` flag is needed.
   final bool needsFullTimeline;
-
   /// Whether to save the trace timeline file `*.timeline.json`.
   final bool saveTraceFile;
 
@@ -844,9 +839,9 @@ class PerfTest {
 
   @protected
   Future<TaskResult> internalRun({
-    bool cacheSkSL = false,
-    String? existingApp,
-    String? writeSkslFileName,
+      bool cacheSkSL = false,
+      String? existingApp,
+      String? writeSkslFileName,
   }) {
     return inDirectory<TaskResult>(testDirectory, () async {
       final Device device = await devices.workingDevice;
@@ -854,20 +849,27 @@ class PerfTest {
       final String deviceId = device.deviceId;
 
       await flutter('drive', options: <String>[
-        if (localEngine != null) ...<String>['--local-engine', localEngine!],
-        if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath!],
+        if (localEngine != null)
+          ...<String>['--local-engine', localEngine!],
+        if (localEngineSrcPath != null)
+          ...<String>['--local-engine-src-path', localEngineSrcPath!],
         '--no-dds',
         '--no-android-gradle-daemon',
         '-v',
         '--verbose-system-logs',
         '--profile',
-        if (needsFullTimeline) '--trace-startup', // Enables "endless" timeline event buffering.
+        if (needsFullTimeline)
+          '--trace-startup', // Enables "endless" timeline event buffering.
         '-t', testTarget,
-        if (testDriver != null) ...<String>['--driver', testDriver!],
-        if (existingApp != null) ...<String>['--use-existing-app', existingApp],
-        if (writeSkslFileName != null) ...<String>['--write-sksl-on-exit', writeSkslFileName],
+        if (testDriver != null)
+          ...<String>['--driver', testDriver!],
+        if (existingApp != null)
+          ...<String>['--use-existing-app', existingApp],
+        if (writeSkslFileName != null)
+          ...<String>['--write-sksl-on-exit', writeSkslFileName],
         if (cacheSkSL) '--cache-sksl',
-        if (dartDefine.isNotEmpty) ...<String>['--dart-define', dartDefine],
+        if (dartDefine.isNotEmpty)
+          ...<String>['--dart-define', dartDefine],
         '-d',
         deviceId,
       ]);
@@ -888,26 +890,26 @@ class PerfTest {
       return TaskResult.success(
         data,
         detailFiles: <String>[
-          if (saveTraceFile) '${_testOutputDirectory(testDirectory)}/$traceFilename.json',
+          if (saveTraceFile)
+            '${_testOutputDirectory(testDirectory)}/$traceFilename.json',
         ],
-        benchmarkScoreKeys: benchmarkScoreKeys ??
-            <String>[
-              ..._kCommonScoreKeys,
-              'average_vsync_transitions_missed',
-              '90th_percentile_vsync_transitions_missed',
-              '99th_percentile_vsync_transitions_missed',
-              if (measureCpuGpu && !isAndroid) ...<String>[
-                // See https://github.com/flutter/flutter/issues/68888
-                if (data['average_cpu_usage'] != null) 'average_cpu_usage',
-                if (data['average_gpu_usage'] != null) 'average_gpu_usage',
-              ],
-              if (measureMemory && !isAndroid) ...<String>[
-                // See https://github.com/flutter/flutter/issues/68888
-                if (data['average_memory_usage'] != null) 'average_memory_usage',
-                if (data['90th_percentile_memory_usage'] != null) '90th_percentile_memory_usage',
-                if (data['99th_percentile_memory_usage'] != null) '99th_percentile_memory_usage',
-              ],
-            ],
+        benchmarkScoreKeys: benchmarkScoreKeys ?? <String>[
+          ..._kCommonScoreKeys,
+          'average_vsync_transitions_missed',
+          '90th_percentile_vsync_transitions_missed',
+          '99th_percentile_vsync_transitions_missed',
+          if (measureCpuGpu && !isAndroid) ...<String>[
+            // See https://github.com/flutter/flutter/issues/68888
+            if (data['average_cpu_usage'] != null) 'average_cpu_usage',
+            if (data['average_gpu_usage'] != null) 'average_gpu_usage',
+          ],
+          if (measureMemory && !isAndroid) ...<String>[
+            // See https://github.com/flutter/flutter/issues/68888
+            if (data['average_memory_usage'] != null) 'average_memory_usage',
+            if (data['90th_percentile_memory_usage'] != null) '90th_percentile_memory_usage',
+            if (data['99th_percentile_memory_usage'] != null) '99th_percentile_memory_usage',
+          ],
+        ],
       );
     });
   }
@@ -952,27 +954,28 @@ class PerfTestWithSkSL extends PerfTest {
     bool needsFullTimeline = true,
     List<String>? benchmarkScoreKeys,
   }) : super(
-          testDirectory,
-          testTarget,
-          timelineFileName,
-          measureCpuGpu: measureCpuGpu,
-          testDriver: testDriver,
-          needsFullTimeline: needsFullTimeline,
-          benchmarkScoreKeys: benchmarkScoreKeys,
-        );
+    testDirectory,
+    testTarget,
+    timelineFileName,
+    measureCpuGpu: measureCpuGpu,
+    testDriver: testDriver,
+    needsFullTimeline: needsFullTimeline,
+    benchmarkScoreKeys: benchmarkScoreKeys,
+  );
+
 
   PerfTestWithSkSL.e2e(
     String testDirectory,
     String testTarget, {
-    String testDriver = 'test_driver/e2e_test.dart',
+    String testDriver =  'test_driver/e2e_test.dart',
     String resultFilename = 'e2e_perf_summary',
   }) : super.e2e(
-          testDirectory,
-          testTarget,
-          testDriver: testDriver,
-          needsFullTimeline: false,
-          resultFilename: resultFilename,
-        );
+    testDirectory,
+    testTarget,
+    testDriver: testDriver,
+    needsFullTimeline: false,
+    resultFilename: resultFilename,
+  );
 
   @override
   Future<TaskResult> run() async {
@@ -1030,13 +1033,15 @@ class PerfTestWithSkSL extends PerfTest {
       _flutterPath,
       <String>[
         'run',
-        if (localEngine != null) ...<String>['--local-engine', localEngine!],
-        if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath!],
+        if (localEngine != null)
+          ...<String>['--local-engine', localEngine!],
+        if (localEngineSrcPath != null)
+          ...<String>['--local-engine-src-path', localEngineSrcPath!],
         '--no-dds',
-        if (deviceOperatingSystem == DeviceOperatingSystem.ios) ...<String>[
-          '--device-timeout',
-          '5',
-        ],
+        if (deviceOperatingSystem == DeviceOperatingSystem.ios)
+          ...<String>[
+            '--device-timeout', '5',
+          ],
         '--verbose',
         '--verbose-system-logs',
         '--purge-persistent-cache',
@@ -1044,14 +1049,11 @@ class PerfTestWithSkSL extends PerfTest {
         '--profile',
         if (skslPath != null) '--bundle-sksl-path=$skslPath',
         if (cacheSkSL) '--cache-sksl',
-        '-d',
-        _device.deviceId,
-        '-t',
-        testTarget,
+        '-d', _device.deviceId,
+        '-t', testTarget,
         '--endless-trace-buffer',
         if (appBinary != null) ...<String>['--use-application-binary', _appBinary],
-        '--vmservice-out-file',
-        _vmserviceFileName,
+        '--vmservice-out-file', _vmserviceFileName,
       ],
     );
 
@@ -1171,7 +1173,7 @@ class WebCompileTest {
     final ProcessResult result = await Process.run('du', <String>['-k', fileName]);
     sizeMetrics['${metric}_dart2js_size'] = _parseDu(result.stdout as String);
 
-    await Process.run('gzip', <String>['-k', '9', fileName]);
+    await Process.run('gzip',<String>['-k', '9', fileName]);
     final ProcessResult resultGzip = await Process.run('du', <String>['-k', '$fileName.gz']);
     sizeMetrics['${metric}_dart2js_size_gzip'] = _parseDu(resultGzip.stdout as String);
 
@@ -1186,7 +1188,7 @@ class WebCompileTest {
 /// Measures how long it takes to compile a Flutter app and how big the compiled
 /// code is.
 class CompileTest {
-  const CompileTest(this.testDirectory, {this.reportPackageContentSizes = false});
+  const CompileTest(this.testDirectory, { this.reportPackageContentSizes = false });
 
   final String testDirectory;
   final bool reportPackageContentSizes;
@@ -1197,8 +1199,7 @@ class CompileTest {
       await device.unlock();
       await flutter('packages', options: <String>['get']);
 
-      final Map<String, dynamic> compileRelease =
-          await _compileApp(reportPackageContentSizes: reportPackageContentSizes);
+      final Map<String, dynamic> compileRelease = await _compileApp(reportPackageContentSizes: reportPackageContentSizes);
       final Map<String, dynamic> compileDebug = await _compileDebug(
         clean: true,
         metricKey: 'debug_full_compile_millis',
@@ -1219,7 +1220,7 @@ class CompileTest {
     });
   }
 
-  static Future<Map<String, dynamic>> _compileApp({bool reportPackageContentSizes = false}) async {
+  static Future<Map<String, dynamic>> _compileApp({ bool reportPackageContentSizes = false }) async {
     await flutter('clean');
     final Stopwatch watch = Stopwatch();
     int releaseSizeInBytes;
@@ -1235,19 +1236,21 @@ class CompileTest {
         await flutter('build', options: options);
         watch.stop();
         final Directory appBuildDirectory = dir(path.join(cwd, 'build/ios/Release-iphoneos'));
-        final Directory? appBundle = appBuildDirectory.listSync().whereType<Directory?>().singleWhere(
-            (Directory? directory) => directory != null && path.extension(directory.path) == '.app',
-            orElse: () => null);
+        final Directory? appBundle = appBuildDirectory
+            .listSync()
+            .whereType<Directory?>()
+            .singleWhere((Directory? directory) =>
+              directory != null && path.extension(directory.path) == '.app',
+              orElse: () => null);
         if (appBundle == null) {
           throw 'Failed to find app bundle in ${appBuildDirectory.path}';
         }
-        final String appPath = appBundle.path;
+        final String appPath =  appBundle.path;
         // IPAs are created manually, https://flutter.dev/ios-release/
         await exec('tar', <String>['-zcf', 'build/app.ipa', appPath]);
         releaseSizeInBytes = await file('$cwd/build/app.ipa').length();
-        if (reportPackageContentSizes) {
+        if (reportPackageContentSizes)
           metrics.addAll(await getSizesFromIosApp(appPath));
-        }
         break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
@@ -1261,9 +1264,8 @@ class CompileTest {
         final String apkPath = '$cwd/build/app/outputs/flutter-apk/app-release.apk';
         final File apk = file(apkPath);
         releaseSizeInBytes = apk.lengthSync();
-        if (reportPackageContentSizes) {
+        if (reportPackageContentSizes)
           metrics.addAll(await getSizesFromApk(apkPath));
-        }
         break;
       case DeviceOperatingSystem.androidArm64:
         options.insert(0, 'apk');
@@ -1276,9 +1278,8 @@ class CompileTest {
         final String apkPath = '$cwd/build/app/outputs/flutter-apk/app-release.apk';
         final File apk = file(apkPath);
         releaseSizeInBytes = apk.lengthSync();
-        if (reportPackageContentSizes) {
+        if (reportPackageContentSizes)
           metrics.addAll(await getSizesFromApk(apkPath));
-        }
         break;
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
@@ -1332,11 +1333,8 @@ class CompileTest {
 
   static Future<Map<String, dynamic>> getSizesFromIosApp(String appPath) async {
     // Thin the binary to only contain one architecture.
-    final String xcodeBackend =
-        path.join(flutterDirectory.path, 'packages', 'flutter_tools', 'bin', 'xcode_backend.sh');
-    await exec(xcodeBackend, <String>[
-      'thin'
-    ], environment: <String, String>{
+    final String xcodeBackend = path.join(flutterDirectory.path, 'packages', 'flutter_tools', 'bin', 'xcode_backend.sh');
+    await exec(xcodeBackend, <String>['thin'], environment: <String, String>{
       'ARCHS': 'arm64',
       'WRAPPER_NAME': path.basename(appPath),
       'TARGET_BUILD_DIR': path.dirname(appPath),
@@ -1352,7 +1350,7 @@ class CompileTest {
   }
 
   static Future<Map<String, dynamic>> getSizesFromApk(String apkPath) async {
-    final String output = await eval('unzip', <String>['-v', apkPath]);
+    final  String output = await eval('unzip', <String>['-v', apkPath]);
     final List<String> lines = output.split('\n');
     final Map<String, _UnzipListEntry> fileToMetadata = <String, _UnzipListEntry>{};
 
@@ -1414,9 +1412,8 @@ class MemoryTest {
 
       final StreamSubscription<String> adb = device!.logcat.listen(
         (String data) {
-          if (data.contains('==== MEMORY BENCHMARK ==== $_nextMessage ====')) {
+          if (data.contains('==== MEMORY BENCHMARK ==== $_nextMessage ===='))
             _receivedNextMessage?.complete();
-          }
         },
       );
 
@@ -1465,8 +1462,7 @@ class MemoryTest {
       '--verbose',
       '--release',
       '--no-resident',
-      '-d',
-      device!.deviceId,
+      '-d', device!.deviceId,
       test,
     ]);
     print('awaiting "ready" message...');
@@ -1530,11 +1526,9 @@ class DevToolsMemoryTest {
       await flutter(
         'drive',
         options: <String>[
-          '-d',
-          _device.deviceId,
+          '-d', _device.deviceId,
           '--profile',
-          '--profile-memory',
-          _kJsonFileName,
+          '--profile-memory', _kJsonFileName,
           '--no-publish-port',
           '-v',
           driverTest,
@@ -1568,7 +1562,9 @@ class DevToolsMemoryTest {
   static const String _kJsonFileName = 'devtools_memory.json';
 }
 
-enum ReportedDurationTestFlavor { debug, profile, release }
+enum ReportedDurationTestFlavor {
+  debug, profile, release
+}
 
 String _reportedDurationTestToString(ReportedDurationTestFlavor flavor) {
   switch (flavor) {
@@ -1619,11 +1615,11 @@ class ReportedDurationTest {
         '--no-fast-start',
         '--${_reportedDurationTestToString(flavor)}',
         '--no-resident',
-        '-d',
-        device!.deviceId,
+        '-d', device!.deviceId,
         test,
       ]);
-      final int duration = await durationCompleter.future.timeout(const Duration(minutes: 5));
+
+      final int duration = await durationCompleter.future;
       print('terminating...');
       await device!.stop(package);
       await adb.cancel();
@@ -1673,7 +1669,7 @@ class _UnzipListEntry {
     final List<String> data = line.trim().split(RegExp(r'\s+'));
     assert(data.length == 8);
     return _UnzipListEntry._(
-      uncompressedSize: int.parse(data[0]),
+      uncompressedSize:  int.parse(data[0]),
       compressedSize: int.parse(data[2]),
       path: data[7],
     );
@@ -1683,10 +1679,10 @@ class _UnzipListEntry {
     required this.uncompressedSize,
     required this.compressedSize,
     required this.path,
-  })  : assert(uncompressedSize != null),
-        assert(compressedSize != null),
-        assert(compressedSize <= uncompressedSize),
-        assert(path != null);
+  }) : assert(uncompressedSize != null),
+       assert(compressedSize != null),
+       assert(compressedSize <= uncompressedSize),
+       assert(path != null);
 
   final int uncompressedSize;
   final int compressedSize;

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -246,8 +246,8 @@ TaskFunction createComplexLayoutCompileTest() {
 
 TaskFunction createFlutterViewStartupTest() {
   return StartupTest(
-      '${flutterDirectory.path}/examples/flutter_view',
-      reportMetrics: false,
+    '${flutterDirectory.path}/examples/flutter_view',
+    reportMetrics: false,
   ).run;
 }
 
@@ -269,8 +269,9 @@ TaskFunction createBasicMaterialCompileTest() {
       await flutter('create', options: <String>['--template=app', sampleAppName]);
     });
 
-    if (!sampleDir.existsSync())
+    if (!sampleDir.existsSync()) {
       throw 'Failed to create default Flutter app in ${sampleDir.path}';
+    }
 
     return CompileTest(sampleDir.path).run();
   };
@@ -293,8 +294,7 @@ TaskFunction createTextfieldPerfE2ETest() {
 }
 
 TaskFunction createStackSizeTest() {
-  final String testDirectory =
-      '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
+  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
   const String testTarget = 'test_driver/run_app.dart';
   const String testDriver = 'test_driver/stack_size_perf_test.dart';
   return () {
@@ -309,8 +309,10 @@ TaskFunction createStackSizeTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t', testTarget,
-        '--driver', testDriver,
+        '-t',
+        testTarget,
+        '--driver',
+        testDriver,
         '-d',
         deviceId,
       ]);
@@ -390,8 +392,7 @@ TaskFunction createsMultiWidgetConstructPerfE2ETest() {
 }
 
 TaskFunction createsScrollSmoothnessPerfTest() {
-  final String testDirectory =
-      '${flutterDirectory.path}/dev/benchmarks/complex_layout';
+  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/complex_layout';
   const String testTarget = 'test/measure_scroll_smoothness.dart';
   return () {
     return inDirectory<TaskResult>(testDirectory, () async {
@@ -405,7 +406,8 @@ TaskFunction createsScrollSmoothnessPerfTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t', testTarget,
+        '-t',
+        testTarget,
         '-d',
         deviceId,
       ]);
@@ -427,6 +429,7 @@ TaskFunction createsScrollSmoothnessPerfTest() {
           }
         }
       }
+
       addResult(data['resample on with 90Hz input'], '_with_resampler_90Hz');
       addResult(data['resample on with 59Hz input'], '_with_resampler_59Hz');
       addResult(data['resample off with 90Hz input'], '_without_resampler_90Hz');
@@ -441,8 +444,7 @@ TaskFunction createsScrollSmoothnessPerfTest() {
 }
 
 TaskFunction createFramePolicyIntegrationTest() {
-  final String testDirectory =
-      '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
+  final String testDirectory = '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks';
   const String testTarget = 'test/frame_policy.dart';
   return () {
     return inDirectory<TaskResult>(testDirectory, () async {
@@ -456,7 +458,8 @@ TaskFunction createFramePolicyIntegrationTest() {
         '-v',
         '--verbose-system-logs',
         '--profile',
-        '-t', testTarget,
+        '-t',
+        testTarget,
         '-d',
         deviceId,
       ]);
@@ -466,14 +469,10 @@ TaskFunction createFramePolicyIntegrationTest() {
       final Map<String, dynamic> fullLiveData = data['fullyLive'] as Map<String, dynamic>;
       final Map<String, dynamic> benchmarkLiveData = data['benchmarkLive'] as Map<String, dynamic>;
       final Map<String, dynamic> dataFormatted = <String, dynamic>{
-        'average_delay_fullyLive_millis':
-          fullLiveData['average_delay_millis'],
-        'average_delay_benchmarkLive_millis':
-          benchmarkLiveData['average_delay_millis'],
-        '90th_percentile_delay_fullyLive_millis':
-          fullLiveData['90th_percentile_delay_millis'],
-        '90th_percentile_delay_benchmarkLive_millis':
-          benchmarkLiveData['90th_percentile_delay_millis'],
+        'average_delay_fullyLive_millis': fullLiveData['average_delay_millis'],
+        'average_delay_benchmarkLive_millis': benchmarkLiveData['average_delay_millis'],
+        '90th_percentile_delay_fullyLive_millis': fullLiveData['90th_percentile_delay_millis'],
+        '90th_percentile_delay_benchmarkLive_millis': benchmarkLiveData['90th_percentile_delay_millis'],
       };
 
       return TaskResult.success(
@@ -538,7 +537,7 @@ Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations
 
 /// Measure application startup performance.
 class StartupTest {
-  const StartupTest(this.testDirectory, { this.reportMetrics = true, this.target = 'lib/main.dart' });
+  const StartupTest(this.testDirectory, {this.reportMetrics = true, this.target = 'lib/main.dart'});
 
   final String testDirectory;
   final bool reportMetrics;
@@ -586,7 +585,7 @@ class StartupTest {
         case DeviceOperatingSystem.ios:
           await flutter('build', options: <String>[
             'ios',
-             '-v',
+            '-v',
             '--profile',
             '--target=$target',
           ]);
@@ -600,18 +599,19 @@ class StartupTest {
       const int maxFailures = 3;
       int currentFailures = 0;
       for (int i = 0; i < iterations; i += 1) {
-        final int result = await flutter('run', options: <String>[
-          '--no-android-gradle-daemon',
-          '--no-publish-port',
-          '--verbose',
-          '--profile',
-          '--trace-startup',
-          '--target=$target',
-          '-d',
-          device.deviceId,
-          if (applicationBinaryPath != null)
-            '--use-application-binary=$applicationBinaryPath',
-         ], canFail: true);
+        final int result = await flutter('run',
+            options: <String>[
+              '--no-android-gradle-daemon',
+              '--no-publish-port',
+              '--verbose',
+              '--profile',
+              '--trace-startup',
+              '--target=$target',
+              '-d',
+              device.deviceId,
+              if (applicationBinaryPath != null) '--use-application-binary=$applicationBinaryPath',
+            ],
+            canFail: true);
         if (result == 0) {
           final Map<String, dynamic> data = json.decode(
             file('${_testOutputDirectory(testDirectory)}/start_up_info.json').readAsStringSync(),
@@ -626,9 +626,7 @@ class StartupTest {
                 '-d',
                 device.deviceId,
                 '--out',
-                hostAgent.dumpDirectory!
-                    .childFile('screenshot_startup_failure_$currentFailures.png')
-                    .path,
+                hostAgent.dumpDirectory!.childFile('screenshot_startup_failure_$currentFailures.png').path,
               ],
               canFail: true,
             );
@@ -648,8 +646,9 @@ class StartupTest {
 
       final Map<String, dynamic> averageResults = _average(results, iterations);
 
-      if (!reportMetrics)
+      if (!reportMetrics) {
         return TaskResult.success(averageResults);
+      }
 
       return TaskResult.success(averageResults, benchmarkScoreKeys: <String>[
         'timeToFirstFrameMicros',
@@ -702,7 +701,7 @@ class DevtoolsStartupTest {
         case DeviceOperatingSystem.ios:
           await flutter('build', options: <String>[
             'ios',
-             '-v',
+            '-v',
             '--profile',
           ]);
           applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
@@ -720,16 +719,12 @@ class DevtoolsStartupTest {
         '--profile',
         '-d',
         device.deviceId,
-        if (applicationBinaryPath != null)
-          '--use-application-binary=$applicationBinaryPath',
-       ]);
+        if (applicationBinaryPath != null) '--use-application-binary=$applicationBinaryPath',
+      ]);
       final Completer<void> completer = Completer<void>();
       bool sawLine = false;
-      process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((String line) {
-          print('[STDOUT]: $line');
+      process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String line) {
+        print('[STDOUT]: $line');
         // Wait for devtools output.
         if (line.contains('The Flutter DevTools debugger and profiler')) {
           sawLine = true;
@@ -740,7 +735,8 @@ class DevtoolsStartupTest {
       unawaited(process.exitCode.whenComplete(() {
         didExit = true;
       }));
-      await Future.any(<Future<void>>[completer.future, Future<void>.delayed(const Duration(minutes: 5)), process.exitCode]);
+      await Future.any(
+          <Future<void>>[completer.future, Future<void>.delayed(const Duration(minutes: 5)), process.exitCode]);
       if (!didExit) {
         process.stdin.writeln('q');
         await process.exitCode;
@@ -752,8 +748,9 @@ class DevtoolsStartupTest {
         device.deviceId,
       ]);
 
-      if (sawLine)
+      if (sawLine) {
         return TaskResult.success(null, benchmarkScoreKeys: <String>[]);
+      }
       return TaskResult.failure('Did not see line "The Flutter DevTools debugger and profiler" in output');
     });
   }
@@ -774,22 +771,25 @@ class PerfTest {
     this.benchmarkScoreKeys,
     this.dartDefine = '',
     String? resultFilename,
-  }): _resultFilename = resultFilename;
+  }) : _resultFilename = resultFilename;
 
   const PerfTest.e2e(
     this.testDirectory,
     this.testTarget, {
     this.measureCpuGpu = false,
     this.measureMemory = false,
-    this.testDriver =  'test_driver/e2e_test.dart',
+    this.testDriver = 'test_driver/e2e_test.dart',
     this.needsFullTimeline = false,
     this.benchmarkScoreKeys = _kCommonScoreKeys,
     this.dartDefine = '',
     String resultFilename = 'e2e_perf_summary',
-  }) : saveTraceFile = false, timelineFileName = null, _resultFilename = resultFilename;
+  })  : saveTraceFile = false,
+        timelineFileName = null,
+        _resultFilename = resultFilename;
 
   /// The directory where the app under test is defined.
   final String testDirectory;
+
   /// The main entry-point file of the application, as run on the device.
   final String testTarget;
   // The prefix name of the filename such as `<timelineFileName>.timeline_summary.json`.
@@ -797,14 +797,19 @@ class PerfTest {
   String get traceFilename => '$timelineFileName.timeline';
   String get resultFilename => _resultFilename ?? '$timelineFileName.timeline_summary';
   final String? _resultFilename;
+
   /// The test file to run on the host.
   final String? testDriver;
+
   /// Whether to collect CPU and GPU metrics.
   final bool measureCpuGpu;
+
   /// Whether to collect memory metrics.
   final bool measureMemory;
+
   /// Whether to collect full timeline, meaning if `--trace-startup` flag is needed.
   final bool needsFullTimeline;
+
   /// Whether to save the trace timeline file `*.timeline.json`.
   final bool saveTraceFile;
 
@@ -839,9 +844,9 @@ class PerfTest {
 
   @protected
   Future<TaskResult> internalRun({
-      bool cacheSkSL = false,
-      String? existingApp,
-      String? writeSkslFileName,
+    bool cacheSkSL = false,
+    String? existingApp,
+    String? writeSkslFileName,
   }) {
     return inDirectory<TaskResult>(testDirectory, () async {
       final Device device = await devices.workingDevice;
@@ -849,27 +854,20 @@ class PerfTest {
       final String deviceId = device.deviceId;
 
       await flutter('drive', options: <String>[
-        if (localEngine != null)
-          ...<String>['--local-engine', localEngine!],
-        if (localEngineSrcPath != null)
-          ...<String>['--local-engine-src-path', localEngineSrcPath!],
+        if (localEngine != null) ...<String>['--local-engine', localEngine!],
+        if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath!],
         '--no-dds',
         '--no-android-gradle-daemon',
         '-v',
         '--verbose-system-logs',
         '--profile',
-        if (needsFullTimeline)
-          '--trace-startup', // Enables "endless" timeline event buffering.
+        if (needsFullTimeline) '--trace-startup', // Enables "endless" timeline event buffering.
         '-t', testTarget,
-        if (testDriver != null)
-          ...<String>['--driver', testDriver!],
-        if (existingApp != null)
-          ...<String>['--use-existing-app', existingApp],
-        if (writeSkslFileName != null)
-          ...<String>['--write-sksl-on-exit', writeSkslFileName],
+        if (testDriver != null) ...<String>['--driver', testDriver!],
+        if (existingApp != null) ...<String>['--use-existing-app', existingApp],
+        if (writeSkslFileName != null) ...<String>['--write-sksl-on-exit', writeSkslFileName],
         if (cacheSkSL) '--cache-sksl',
-        if (dartDefine.isNotEmpty)
-          ...<String>['--dart-define', dartDefine],
+        if (dartDefine.isNotEmpty) ...<String>['--dart-define', dartDefine],
         '-d',
         deviceId,
       ]);
@@ -890,26 +888,26 @@ class PerfTest {
       return TaskResult.success(
         data,
         detailFiles: <String>[
-          if (saveTraceFile)
-            '${_testOutputDirectory(testDirectory)}/$traceFilename.json',
+          if (saveTraceFile) '${_testOutputDirectory(testDirectory)}/$traceFilename.json',
         ],
-        benchmarkScoreKeys: benchmarkScoreKeys ?? <String>[
-          ..._kCommonScoreKeys,
-          'average_vsync_transitions_missed',
-          '90th_percentile_vsync_transitions_missed',
-          '99th_percentile_vsync_transitions_missed',
-          if (measureCpuGpu && !isAndroid) ...<String>[
-            // See https://github.com/flutter/flutter/issues/68888
-            if (data['average_cpu_usage'] != null) 'average_cpu_usage',
-            if (data['average_gpu_usage'] != null) 'average_gpu_usage',
-          ],
-          if (measureMemory && !isAndroid) ...<String>[
-            // See https://github.com/flutter/flutter/issues/68888
-            if (data['average_memory_usage'] != null) 'average_memory_usage',
-            if (data['90th_percentile_memory_usage'] != null) '90th_percentile_memory_usage',
-            if (data['99th_percentile_memory_usage'] != null) '99th_percentile_memory_usage',
-          ],
-        ],
+        benchmarkScoreKeys: benchmarkScoreKeys ??
+            <String>[
+              ..._kCommonScoreKeys,
+              'average_vsync_transitions_missed',
+              '90th_percentile_vsync_transitions_missed',
+              '99th_percentile_vsync_transitions_missed',
+              if (measureCpuGpu && !isAndroid) ...<String>[
+                // See https://github.com/flutter/flutter/issues/68888
+                if (data['average_cpu_usage'] != null) 'average_cpu_usage',
+                if (data['average_gpu_usage'] != null) 'average_gpu_usage',
+              ],
+              if (measureMemory && !isAndroid) ...<String>[
+                // See https://github.com/flutter/flutter/issues/68888
+                if (data['average_memory_usage'] != null) 'average_memory_usage',
+                if (data['90th_percentile_memory_usage'] != null) '90th_percentile_memory_usage',
+                if (data['99th_percentile_memory_usage'] != null) '99th_percentile_memory_usage',
+              ],
+            ],
       );
     });
   }
@@ -954,28 +952,27 @@ class PerfTestWithSkSL extends PerfTest {
     bool needsFullTimeline = true,
     List<String>? benchmarkScoreKeys,
   }) : super(
-    testDirectory,
-    testTarget,
-    timelineFileName,
-    measureCpuGpu: measureCpuGpu,
-    testDriver: testDriver,
-    needsFullTimeline: needsFullTimeline,
-    benchmarkScoreKeys: benchmarkScoreKeys,
-  );
-
+          testDirectory,
+          testTarget,
+          timelineFileName,
+          measureCpuGpu: measureCpuGpu,
+          testDriver: testDriver,
+          needsFullTimeline: needsFullTimeline,
+          benchmarkScoreKeys: benchmarkScoreKeys,
+        );
 
   PerfTestWithSkSL.e2e(
     String testDirectory,
     String testTarget, {
-    String testDriver =  'test_driver/e2e_test.dart',
+    String testDriver = 'test_driver/e2e_test.dart',
     String resultFilename = 'e2e_perf_summary',
   }) : super.e2e(
-    testDirectory,
-    testTarget,
-    testDriver: testDriver,
-    needsFullTimeline: false,
-    resultFilename: resultFilename,
-  );
+          testDirectory,
+          testTarget,
+          testDriver: testDriver,
+          needsFullTimeline: false,
+          resultFilename: resultFilename,
+        );
 
   @override
   Future<TaskResult> run() async {
@@ -1033,15 +1030,13 @@ class PerfTestWithSkSL extends PerfTest {
       _flutterPath,
       <String>[
         'run',
-        if (localEngine != null)
-          ...<String>['--local-engine', localEngine!],
-        if (localEngineSrcPath != null)
-          ...<String>['--local-engine-src-path', localEngineSrcPath!],
+        if (localEngine != null) ...<String>['--local-engine', localEngine!],
+        if (localEngineSrcPath != null) ...<String>['--local-engine-src-path', localEngineSrcPath!],
         '--no-dds',
-        if (deviceOperatingSystem == DeviceOperatingSystem.ios)
-          ...<String>[
-            '--device-timeout', '5',
-          ],
+        if (deviceOperatingSystem == DeviceOperatingSystem.ios) ...<String>[
+          '--device-timeout',
+          '5',
+        ],
         '--verbose',
         '--verbose-system-logs',
         '--purge-persistent-cache',
@@ -1049,11 +1044,14 @@ class PerfTestWithSkSL extends PerfTest {
         '--profile',
         if (skslPath != null) '--bundle-sksl-path=$skslPath',
         if (cacheSkSL) '--cache-sksl',
-        '-d', _device.deviceId,
-        '-t', testTarget,
+        '-d',
+        _device.deviceId,
+        '-t',
+        testTarget,
         '--endless-trace-buffer',
         if (appBinary != null) ...<String>['--use-application-binary', _appBinary],
-        '--vmservice-out-file', _vmserviceFileName,
+        '--vmservice-out-file',
+        _vmserviceFileName,
       ],
     );
 
@@ -1173,7 +1171,7 @@ class WebCompileTest {
     final ProcessResult result = await Process.run('du', <String>['-k', fileName]);
     sizeMetrics['${metric}_dart2js_size'] = _parseDu(result.stdout as String);
 
-    await Process.run('gzip',<String>['-k', '9', fileName]);
+    await Process.run('gzip', <String>['-k', '9', fileName]);
     final ProcessResult resultGzip = await Process.run('du', <String>['-k', '$fileName.gz']);
     sizeMetrics['${metric}_dart2js_size_gzip'] = _parseDu(resultGzip.stdout as String);
 
@@ -1188,7 +1186,7 @@ class WebCompileTest {
 /// Measures how long it takes to compile a Flutter app and how big the compiled
 /// code is.
 class CompileTest {
-  const CompileTest(this.testDirectory, { this.reportPackageContentSizes = false });
+  const CompileTest(this.testDirectory, {this.reportPackageContentSizes = false});
 
   final String testDirectory;
   final bool reportPackageContentSizes;
@@ -1199,7 +1197,8 @@ class CompileTest {
       await device.unlock();
       await flutter('packages', options: <String>['get']);
 
-      final Map<String, dynamic> compileRelease = await _compileApp(reportPackageContentSizes: reportPackageContentSizes);
+      final Map<String, dynamic> compileRelease =
+          await _compileApp(reportPackageContentSizes: reportPackageContentSizes);
       final Map<String, dynamic> compileDebug = await _compileDebug(
         clean: true,
         metricKey: 'debug_full_compile_millis',
@@ -1220,7 +1219,7 @@ class CompileTest {
     });
   }
 
-  static Future<Map<String, dynamic>> _compileApp({ bool reportPackageContentSizes = false }) async {
+  static Future<Map<String, dynamic>> _compileApp({bool reportPackageContentSizes = false}) async {
     await flutter('clean');
     final Stopwatch watch = Stopwatch();
     int releaseSizeInBytes;
@@ -1236,21 +1235,19 @@ class CompileTest {
         await flutter('build', options: options);
         watch.stop();
         final Directory appBuildDirectory = dir(path.join(cwd, 'build/ios/Release-iphoneos'));
-        final Directory? appBundle = appBuildDirectory
-            .listSync()
-            .whereType<Directory?>()
-            .singleWhere((Directory? directory) =>
-              directory != null && path.extension(directory.path) == '.app',
-              orElse: () => null);
+        final Directory? appBundle = appBuildDirectory.listSync().whereType<Directory?>().singleWhere(
+            (Directory? directory) => directory != null && path.extension(directory.path) == '.app',
+            orElse: () => null);
         if (appBundle == null) {
           throw 'Failed to find app bundle in ${appBuildDirectory.path}';
         }
-        final String appPath =  appBundle.path;
+        final String appPath = appBundle.path;
         // IPAs are created manually, https://flutter.dev/ios-release/
         await exec('tar', <String>['-zcf', 'build/app.ipa', appPath]);
         releaseSizeInBytes = await file('$cwd/build/app.ipa').length();
-        if (reportPackageContentSizes)
+        if (reportPackageContentSizes) {
           metrics.addAll(await getSizesFromIosApp(appPath));
+        }
         break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
@@ -1264,8 +1261,9 @@ class CompileTest {
         final String apkPath = '$cwd/build/app/outputs/flutter-apk/app-release.apk';
         final File apk = file(apkPath);
         releaseSizeInBytes = apk.lengthSync();
-        if (reportPackageContentSizes)
+        if (reportPackageContentSizes) {
           metrics.addAll(await getSizesFromApk(apkPath));
+        }
         break;
       case DeviceOperatingSystem.androidArm64:
         options.insert(0, 'apk');
@@ -1278,8 +1276,9 @@ class CompileTest {
         final String apkPath = '$cwd/build/app/outputs/flutter-apk/app-release.apk';
         final File apk = file(apkPath);
         releaseSizeInBytes = apk.lengthSync();
-        if (reportPackageContentSizes)
+        if (reportPackageContentSizes) {
           metrics.addAll(await getSizesFromApk(apkPath));
+        }
         break;
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
@@ -1333,8 +1332,11 @@ class CompileTest {
 
   static Future<Map<String, dynamic>> getSizesFromIosApp(String appPath) async {
     // Thin the binary to only contain one architecture.
-    final String xcodeBackend = path.join(flutterDirectory.path, 'packages', 'flutter_tools', 'bin', 'xcode_backend.sh');
-    await exec(xcodeBackend, <String>['thin'], environment: <String, String>{
+    final String xcodeBackend =
+        path.join(flutterDirectory.path, 'packages', 'flutter_tools', 'bin', 'xcode_backend.sh');
+    await exec(xcodeBackend, <String>[
+      'thin'
+    ], environment: <String, String>{
       'ARCHS': 'arm64',
       'WRAPPER_NAME': path.basename(appPath),
       'TARGET_BUILD_DIR': path.dirname(appPath),
@@ -1350,7 +1352,7 @@ class CompileTest {
   }
 
   static Future<Map<String, dynamic>> getSizesFromApk(String apkPath) async {
-    final  String output = await eval('unzip', <String>['-v', apkPath]);
+    final String output = await eval('unzip', <String>['-v', apkPath]);
     final List<String> lines = output.split('\n');
     final Map<String, _UnzipListEntry> fileToMetadata = <String, _UnzipListEntry>{};
 
@@ -1412,8 +1414,9 @@ class MemoryTest {
 
       final StreamSubscription<String> adb = device!.logcat.listen(
         (String data) {
-          if (data.contains('==== MEMORY BENCHMARK ==== $_nextMessage ===='))
+          if (data.contains('==== MEMORY BENCHMARK ==== $_nextMessage ====')) {
             _receivedNextMessage?.complete();
+          }
         },
       );
 
@@ -1462,7 +1465,8 @@ class MemoryTest {
       '--verbose',
       '--release',
       '--no-resident',
-      '-d', device!.deviceId,
+      '-d',
+      device!.deviceId,
       test,
     ]);
     print('awaiting "ready" message...');
@@ -1526,9 +1530,11 @@ class DevToolsMemoryTest {
       await flutter(
         'drive',
         options: <String>[
-          '-d', _device.deviceId,
+          '-d',
+          _device.deviceId,
           '--profile',
-          '--profile-memory', _kJsonFileName,
+          '--profile-memory',
+          _kJsonFileName,
           '--no-publish-port',
           '-v',
           driverTest,
@@ -1562,9 +1568,7 @@ class DevToolsMemoryTest {
   static const String _kJsonFileName = 'devtools_memory.json';
 }
 
-enum ReportedDurationTestFlavor {
-  debug, profile, release
-}
+enum ReportedDurationTestFlavor { debug, profile, release }
 
 String _reportedDurationTestToString(ReportedDurationTestFlavor flavor) {
   switch (flavor) {
@@ -1615,11 +1619,11 @@ class ReportedDurationTest {
         '--no-fast-start',
         '--${_reportedDurationTestToString(flavor)}',
         '--no-resident',
-        '-d', device!.deviceId,
+        '-d',
+        device!.deviceId,
         test,
       ]);
-
-      final int duration = await durationCompleter.future;
+      final int duration = await durationCompleter.future.timeout(const Duration(minutes: 5));
       print('terminating...');
       await device!.stop(package);
       await adb.cancel();
@@ -1669,7 +1673,7 @@ class _UnzipListEntry {
     final List<String> data = line.trim().split(RegExp(r'\s+'));
     assert(data.length == 8);
     return _UnzipListEntry._(
-      uncompressedSize:  int.parse(data[0]),
+      uncompressedSize: int.parse(data[0]),
       compressedSize: int.parse(data[2]),
       path: data[7],
     );
@@ -1679,10 +1683,10 @@ class _UnzipListEntry {
     required this.uncompressedSize,
     required this.compressedSize,
     required this.path,
-  }) : assert(uncompressedSize != null),
-       assert(compressedSize != null),
-       assert(compressedSize <= uncompressedSize),
-       assert(path != null);
+  })  : assert(uncompressedSize != null),
+        assert(compressedSize != null),
+        assert(compressedSize <= uncompressedSize),
+        assert(path != null);
 
   final int uncompressedSize;
   final int compressedSize;


### PR DESCRIPTION
This is necessary to ensure all the android tests start from the home
screen. Some tests like the android views crash if they are started with
the top level settings menu visible.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
