### PR TITLE
Fixes ‍‍`RenderTransform‍`'s `paint` method when `filterQuality` is not null.

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2398,8 +2398,12 @@ class RenderTransform extends RenderProxyBox {
           layer = null;
         }
       } else {
+        final Matrix4 effectiveFilterTransform =
+            Matrix4.translationValues(offset.dx, offset.dy, 0.0)
+              ..multiply(transform)
+              ..translate(-offset.dx, -offset.dy);
         final ui.ImageFilter filter = ui.ImageFilter.matrix(
-          transform.storage,
+          effectiveFilterTransform.storage,
           filterQuality: filterQuality!,
         );
         if (layer is ImageFilterLayer) {

--- a/packages/flutter/test/rendering/transform_test.dart
+++ b/packages/flutter/test/rendering/transform_test.dart
@@ -31,12 +31,53 @@ void main() {
     expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(25.0, 75.0)));
     expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(50.0, 50.0)));
   });
+  
+  test('RenderTransform - identity with filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.identity(),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
+      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(inner.globalToLocal(Offset.zero), equals(Offset.zero));
+    expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(100.0, 100.0)));
+    expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(25.0, 75.0)));
+    expect(inner.globalToLocal(const Offset(50.0, 50.0)), equals(const Offset(50.0, 50.0)));
+    expect(inner.localToGlobal(Offset.zero), equals(Offset.zero));
+    expect(inner.localToGlobal(const Offset(100.0, 100.0)), equals(const Offset(100.0, 100.0)));
+    expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(25.0, 75.0)));
+    expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(50.0, 50.0)));
+  });
 
   test('RenderTransform - identity with internal offset', () {
     RenderBox inner;
     final RenderBox sizer = RenderTransform(
       transform: Matrix4.identity(),
       alignment: Alignment.center,
+      child: RenderPadding(
+        padding: const EdgeInsets.only(left: 20.0),
+        child: inner = RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(inner.globalToLocal(Offset.zero), equals(const Offset(-20.0, 0.0)));
+    expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(80.0, 100.0)));
+    expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(5.0, 75.0)));
+    expect(inner.globalToLocal(const Offset(50.0, 50.0)), equals(const Offset(30.0, 50.0)));
+    expect(inner.localToGlobal(Offset.zero), equals(const Offset(20.0, 0.0)));
+    expect(inner.localToGlobal(const Offset(100.0, 100.0)), equals(const Offset(120.0, 100.0)));
+    expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(45.0, 75.0)));
+    expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(70.0, 50.0)));
+  });
+  
+  test('RenderTransform - identity with internal offset and filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.identity(),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
       child: RenderPadding(
         padding: const EdgeInsets.only(left: 20.0),
         child: inner = RenderSizedBox(const Size(80.0, 100.0)),
@@ -70,6 +111,25 @@ void main() {
     expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(75.0, 275.0)));
     expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(100.0, 250.0)));
   });
+  
+  test('RenderTransform - translation with filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.translationValues(50.0, 200.0, 0.0),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
+      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(inner.globalToLocal(Offset.zero), equals(const Offset(-50.0, -200.0)));
+    expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(50.0, -100.0)));
+    expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(-25.0, -125.0)));
+    expect(inner.globalToLocal(const Offset(50.0, 50.0)), equals(const Offset(0.0, -150.0)));
+    expect(inner.localToGlobal(Offset.zero), equals(const Offset(50.0, 200.0)));
+    expect(inner.localToGlobal(const Offset(100.0, 100.0)), equals(const Offset(150.0, 300.0)));
+    expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(75.0, 275.0)));
+    expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(100.0, 250.0)));
+  });
 
   test('RenderTransform - translation with internal offset', () {
     RenderBox inner;
@@ -91,6 +151,29 @@ void main() {
     expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(95.0, 275.0)));
     expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(120.0, 250.0)));
   });
+  
+  test('RenderTransform - translation with internal offset and filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.translationValues(50.0, 200.0, 0.0),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
+      child: RenderPadding(
+        padding: const EdgeInsets.only(left: 20.0),
+        child: inner = RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(inner.globalToLocal(Offset.zero), equals(const Offset(-70.0, -200.0)));
+    expect(inner.globalToLocal(const Offset(100.0, 100.0)), equals(const Offset(30.0, -100.0)));
+    expect(inner.globalToLocal(const Offset(25.0, 75.0)), equals(const Offset(-45.0, -125.0)));
+    expect(inner.globalToLocal(const Offset(50.0, 50.0)), equals(const Offset(-20.0, -150.0)));
+    expect(inner.localToGlobal(Offset.zero), equals(const Offset(70.0, 200.0)));
+    expect(inner.localToGlobal(const Offset(100.0, 100.0)), equals(const Offset(170.0, 300.0)));
+    expect(inner.localToGlobal(const Offset(25.0, 75.0)), equals(const Offset(95.0, 275.0)));
+    expect(inner.localToGlobal(const Offset(50.0, 50.0)), equals(const Offset(120.0, 250.0)));
+  });
+
 
   test('RenderTransform - rotation', () {
     RenderBox inner;
@@ -109,12 +192,53 @@ void main() {
     expect(round(inner.localToGlobal(const Offset(25.0, 75.0))), equals(const Offset(75.0, 25.0)));
     expect(round(inner.localToGlobal(const Offset(50.0, 50.0))), equals(const Offset(50.0, 50.0)));
   });
+  
+  test('RenderTransform - rotation with filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.rotationZ(math.pi),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
+      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(round(inner.globalToLocal(Offset.zero)), equals(const Offset(100.0, 100.0)));
+    expect(round(inner.globalToLocal(const Offset(100.0, 100.0))), equals(Offset.zero));
+    expect(round(inner.globalToLocal(const Offset(25.0, 75.0))), equals(const Offset(75.0, 25.0)));
+    expect(round(inner.globalToLocal(const Offset(50.0, 50.0))), equals(const Offset(50.0, 50.0)));
+    expect(round(inner.localToGlobal(Offset.zero)), equals(const Offset(100.0, 100.0)));
+    expect(round(inner.localToGlobal(const Offset(100.0, 100.0))), equals(Offset.zero));
+    expect(round(inner.localToGlobal(const Offset(25.0, 75.0))), equals(const Offset(75.0, 25.0)));
+    expect(round(inner.localToGlobal(const Offset(50.0, 50.0))), equals(const Offset(50.0, 50.0)));
+  });
 
   test('RenderTransform - rotation with internal offset', () {
     RenderBox inner;
     final RenderBox sizer = RenderTransform(
       transform: Matrix4.rotationZ(math.pi),
       alignment: Alignment.center,
+      child: RenderPadding(
+        padding: const EdgeInsets.only(left: 20.0),
+        child: inner = RenderSizedBox(const Size(80.0, 100.0)),
+      ),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+    expect(round(inner.globalToLocal(Offset.zero)), equals(const Offset(80.0, 100.0)));
+    expect(round(inner.globalToLocal(const Offset(100.0, 100.0))), equals(const Offset(-20.0, 0.0)));
+    expect(round(inner.globalToLocal(const Offset(25.0, 75.0))), equals(const Offset(55.0, 25.0)));
+    expect(round(inner.globalToLocal(const Offset(50.0, 50.0))), equals(const Offset(30.0, 50.0)));
+    expect(round(inner.localToGlobal(Offset.zero)), equals(const Offset(80.0, 100.0)));
+    expect(round(inner.localToGlobal(const Offset(100.0, 100.0))), equals(const Offset(-20.0, 0.0)));
+    expect(round(inner.localToGlobal(const Offset(25.0, 75.0))), equals(const Offset(55.0, 25.0)));
+    expect(round(inner.localToGlobal(const Offset(50.0, 50.0))), equals(const Offset(30.0, 50.0)));
+  });
+  
+  test('RenderTransform - rotation with internal offset and filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: Matrix4.rotationZ(math.pi),
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
       child: RenderPadding(
         padding: const EdgeInsets.only(left: 20.0),
         child: inner = RenderSizedBox(const Size(80.0, 100.0)),
@@ -150,12 +274,50 @@ void main() {
       equals(100 - round(inner.globalToLocal(const Offset(25.0, 83.0))).dy),
     );
   });
+  
+   test('RenderTransform - perspective - globalToLocal with filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: rotateAroundXAxis(math.pi * 0.25), // at pi/4, we are about 70 pixels high
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
+      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+
+    expect(round(inner.globalToLocal(const Offset(25.0, 50.0))), equals(const Offset(25.0, 50.0)));
+    expect(inner.globalToLocal(const Offset(25.0, 17.0)).dy, greaterThan(0.0));
+    expect(inner.globalToLocal(const Offset(25.0, 17.0)).dy, lessThan(10.0));
+    expect(inner.globalToLocal(const Offset(25.0, 83.0)).dy, greaterThan(90.0));
+    expect(inner.globalToLocal(const Offset(25.0, 83.0)).dy, lessThan(100.0));
+    expect(
+      round(inner.globalToLocal(const Offset(25.0, 17.0))).dy,
+      equals(100 - round(inner.globalToLocal(const Offset(25.0, 83.0))).dy),
+    );
+  });
 
   test('RenderTransform - perspective - localToGlobal', () {
     RenderBox inner;
     final RenderBox sizer = RenderTransform(
       transform: rotateAroundXAxis(math.pi * 0.4999), // at pi/2, we're seeing the box on its edge,
       alignment: Alignment.center,
+      child: inner = RenderSizedBox(const Size(100.0, 100.0)),
+    );
+    layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);
+
+    // the inner widget has a height of about half a pixel at this rotation, so
+    // everything should end up around the middle of the outer box.
+    expect(inner.localToGlobal(const Offset(25.0, 50.0)), equals(const Offset(25.0, 50.0)));
+    expect(round(inner.localToGlobal(const Offset(25.0, 75.0))), equals(const Offset(25.0, 50.0)));
+    expect(round(inner.localToGlobal(const Offset(25.0, 100.0))), equals(const Offset(25.0, 50.0)));
+  });
+  
+  test('RenderTransform - perspective - localToGlobal with filter quality', () {
+    RenderBox inner;
+    final RenderBox sizer = RenderTransform(
+      transform: rotateAroundXAxis(math.pi * 0.4999), // at pi/2, we're seeing the box on its edge,
+      alignment: Alignment.center,
+      filterQuality: FilterQuality.medium,
       child: inner = RenderSizedBox(const Size(100.0, 100.0)),
     );
     layout(sizer, constraints: BoxConstraints.tight(const Size(100.0, 100.0)), alignment: Alignment.topLeft);


### PR DESCRIPTION
This **PR** fixes #95091.

<details><summary>Description: </summary>

This **PR** changes the behaviour of  the `paint` method of the `RenderTransform`when `RenderTransform` has a non-null `filterQuality`.

The following code is the `paint` method of `RenderTransform` :

```dart
@override
  void paint(PaintingContext context, Offset offset) {
    if (child != null) {
      final Matrix4 transform = _effectiveTransform!;
      if (filterQuality == null) {
        final Offset? childOffset = MatrixUtils.getAsTranslation(transform);
        if (childOffset == null) {
          layer = context.pushTransform(
            needsCompositing,
            offset,
            transform,
            super.paint,
            oldLayer: layer is TransformLayer ? layer as TransformLayer? : null,
          );
        } else {
          super.paint(context, offset + childOffset);
          layer = null;
        }
      } else {
        final ui.ImageFilter filter = ui.ImageFilter.matrix(
          transform.storage,
          filterQuality: filterQuality!,
        );
        if (layer is ImageFilterLayer) {
          final ImageFilterLayer filterLayer = layer! as ImageFilterLayer;
          filterLayer.imageFilter = filter;
        } else {
          layer = ImageFilterLayer(imageFilter: filter);
        }
        context.pushLayer(layer!, super.paint, offset);
      }
    }
  }
```

If `filterQuality` is not set, `paint` method uses the `pushTransform` and passes the `offset` that is passed to it to `pushTransform`.
`pushTransform` creates an `effectiveTransform` and it applies `offset` parameter.then `effectiveTransform` that is included the `offset` is passed to the `pushLayer` or canvas.

The following code is the `pushTransform` method of `PaintingContext` : 

```dart
  TransformLayer? pushTransform(bool needsCompositing, Offset offset,
      Matrix4 transform, PaintingContextCallback painter,
      {TransformLayer? oldLayer}) {
    final Matrix4 effectiveTransform =
        Matrix4.translationValues(offset.dx, offset.dy, 0.0)
          ..multiply(transform)
          ..translate(-offset.dx, -offset.dy);
    if (needsCompositing) {
      final TransformLayer layer = oldLayer ?? TransformLayer();
      layer.transform = effectiveTransform;
      pushLayer(
        layer,
        painter,
        offset,
        childPaintBounds: MatrixUtils.inverseTransformRect(
            effectiveTransform, estimatedBounds),
      );
      return layer;
    } else {
      canvas
        ..save()
        ..transform(effectiveTransform.storage);
      painter(this, offset);
      canvas.restore();
      return null;
    }
  }
```

But if `filterQuality` is set, `paint` method uses the `ImageFilterLayer`, but in this case `offset` is not applied.

Therefore I changed the behaviour of `paint` method when `filterQuality` is set.
I defined a new `effectiveFilterTransform` variable and I applied `offset` to it like `pushTransform` method.

```dart
final Matrix4 effectiveFilterTransform =
            Matrix4.translationValues(offset.dx, offset.dy, 0.0)
              ..multiply(transform)
              ..translate(-offset.dx, -offset.dy);
```

```dart
@override
  void paint(PaintingContext context, Offset offset) {
    if (child != null) {
      final Matrix4 transform = _effectiveTransform!;
      if (filterQuality == null) {
        final Offset? childOffset = MatrixUtils.getAsTranslation(transform);
        if (childOffset == null) {
          layer = context.pushTransform(
            needsCompositing,
            offset,
            transform,
            super.paint,
            oldLayer: layer is TransformLayer ? layer as TransformLayer? : null,
          );
        } else {
          super.paint(context, offset + childOffset);
          layer = null;
        }
      } else {
        final Matrix4 effectiveFilterTransform =
            Matrix4.translationValues(offset.dx, offset.dy, 0.0)
              ..multiply(transform)
              ..translate(-offset.dx, -offset.dy);

        final ui.ImageFilter filter = ui.ImageFilter.matrix(
          effectiveFilterTransform.storage,
          filterQuality: filterQuality!,
        );
        if (layer is ImageFilterLayer) {
          final ImageFilterLayer filterLayer = layer! as ImageFilterLayer;
          filterLayer.imageFilter = filter;
        } else {
          layer = ImageFilterLayer(imageFilter: filter);
        }
        context.pushLayer(layer!, super.paint, offset);
      }
    }
  }
```


</details>

<details><summary>Example:</summary>

```dart
main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: HomePage(),
    );
  }
}

class HomePage extends StatelessWidget {
  const HomePage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
        body: Center(
      child: Transform(
        // filterQuality: FilterQuality.medium,
        alignment: Alignment.center,
        transformHitTests: true,
        transform: Matrix4.diagonal3Values(2, 2, 0)..rotateZ(pi / 4),
        child: ConstrainedBox(
          constraints: BoxConstraints.tight(
            const Size(50, 75),
          ),
          child: const ColoredBox(
            color: Colors.orange,
          ),
        ),
      ),
    ));
  }
}
```

| before bug fixing - without filterQuality  | Before bug fixing - with filterQuality | after bug fixing - with filterQuality | 
| ------------- | ------------- | ------------- |
| ![Screenshot from 2021-12-11 17-44-46](https://user-images.githubusercontent.com/44123678/145679742-4502e57c-602b-4684-86a8-4fb2da31fb78.png)  | ![Screenshot from 2021-12-11 17-46-38](https://user-images.githubusercontent.com/44123678/145679823-dd62baa8-c330-48e5-8e8f-b15d2491081b.png)  | ![Screenshot from 2021-12-11 17-49-56](https://user-images.githubusercontent.com/44123678/145679904-c6d581ad-299e-4917-b1a3-2eb9f1a9ab81.png)  |
|  OK  | Not OK  | OK  |
</details>





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
