### PR TITLE
[DropdownButton] Merge custom `TextStyle` with `DefaultTextStyle`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1227,7 +1227,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  TextStyle? get _textStyle => widget.style ?? Theme.of(context).textTheme.subtitle1;
+  TextStyle? get _textStyle => Theme.of(context).textTheme.subtitle1?.merge(widget.style);
 
   void _handleTap() {
     final TextDirection? textDirection = Directionality.maybeOf(context);

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1227,7 +1227,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  TextStyle? get _textStyle => Theme.of(context).textTheme.subtitle1?.merge(widget.style);
+  TextStyle? get _textStyle {
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
+     return widget.style != null ? defaultTextStyle.style.merge(widget.style) : Theme.of(context).textTheme.subtitle1;
+  }
 
   void _handleTap() {
     final TextDirection? textDirection = Directionality.maybeOf(context);

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -945,6 +945,35 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('Dropdown button text style can be merged with default subtitle text style', (WidgetTester tester) async {
+    const String value = 'foo';
+    final UniqueKey itemKey = UniqueKey();
+
+    await tester.pumpWidget(TestApp(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: DropdownButton<String>(
+          value: value,
+          items: <DropdownMenuItem<String>>[
+            DropdownMenuItem<String>(              
+              key: itemKey,
+              value: 'foo',
+              child: const Text(value),
+            ),
+          ],
+          isDense: true,
+          onChanged: (_) { },
+          style: const TextStyle(fontSize: 14),
+        ),
+      ),
+    ));
+
+    await expectLater(
+      find.byType(Text),
+      matchesGoldenFile('dropdown_test.text_style.png'),
+    );
+  });
+  
   testWidgets('Dropdown menu scrolls to first item in long lists', (WidgetTester tester) async {
     // Open the dropdown menu
     final Key buttonKey = UniqueKey();

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -955,7 +955,7 @@ void main() {
         child: DropdownButton<String>(
           value: value,
           items: <DropdownMenuItem<String>>[
-            DropdownMenuItem<String>(              
+            DropdownMenuItem<String>(
               key: itemKey,
               value: 'foo',
               child: const Text(value),
@@ -973,7 +973,7 @@ void main() {
       matchesGoldenFile('dropdown_test.text_style.png'),
     );
   });
-  
+
   testWidgets('Dropdown menu scrolls to first item in long lists', (WidgetTester tester) async {
     // Open the dropdown menu
     final Key buttonKey = UniqueKey();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/68004

Instead of red, it now shows white text on white background



Added golden test 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
