### PR TITLE
[tools] Catch exception thrown when reading `plugin.xml` 

### DIFF
--- a/packages/flutter_tools/lib/src/intellij/intellij.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij.dart
@@ -127,10 +127,14 @@ class IntelliJPlugins {
     }
 
     for (final File file in mainJarFileList) {
-      final Archive archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
-      final ArchiveFile? archiveFile = archive.findFile('META-INF/plugin.xml');
-      if (archiveFile != null) {
-        return archiveFile;
+      try {
+        final Archive archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+        final ArchiveFile? archiveFile = archive.findFile('META-INF/plugin.xml');
+        if (archiveFile != null) {
+          return archiveFile;
+        }
+      } on FormatException {
+        return null;
       }
     }
     return null;


### PR DESCRIPTION
Related https://github.com/flutter/flutter/issues/94060

This PR catches the exception thrown when reading `plugin.xml` from`dart.jar`, complete details https://github.com/flutter/flutter/issues/94060#issuecomment-993352087

When plugin version can't be accessed, validation message is adjusted to `Plugin installed` and this is already a default behavior when null is returned, instead of the exception. 

https://github.com/flutter/flutter/blob/ed1d075acc42edd3a1e6acb0df88964e0bf19bf2/packages/flutter_tools/lib/src/intellij/intellij.dart#L136

### Before
```console
[☠] IntelliJ IDEA Community Edition (the doctor check crashed)
    ✗ Due to an error, the doctor check did not complete. If the error message below is not helpful, please let us know about this issue at https://github.com/flutter/flutter/issues.
    ✗ FormatException: Unexpected extension byte (at offset 5)
```
### After
```console
[✓] IntelliJ IDEA Community Edition (version 2021.3)
    • IntelliJ at C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2021.3
    • Flutter plugin version 63.1.4
    • Dart plugin installed
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
