### PR TITLE
Improve sync*/async* opt outs

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -160,8 +160,8 @@ Future<void> run(List<String> arguments) async {
 
 Future<void> verifyNoSyncAsyncStar(String workingDirectory, {int minimumMatches = 2000 }) async {
   final RegExp syncPattern = RegExp(r'\s*?a?sync\*\s*?{');
-  const String ignorePattern = 'no_sync_async_star';
-  final RegExp commentPattern = RegExp(r'^\s*?///?');
+  final RegExp ignorePattern = RegExp(r'^\s*?// The following uses a?sync\* because:? ');
+  final RegExp commentPattern = RegExp(r'^\s*?//');
   final List<String> errors = <String>[];
   await for (final File file in _allFiles(workingDirectory, 'dart', minimumMatches: minimumMatches)) {
     if (file.path.contains('test')) {
@@ -173,8 +173,19 @@ Future<void> verifyNoSyncAsyncStar(String workingDirectory, {int minimumMatches 
       if (line.startsWith(commentPattern)) {
         continue;
       }
-      if (line.contains(syncPattern) && !line.contains(ignorePattern) && (index == 0 || !lines[index - 1].contains(ignorePattern))) {
-        errors.add('${file.path}:$index: sync*/async* without an ignore (no_sync_async_star).');
+      if (line.contains(syncPattern)) {
+        int lookBehindIndex = index - 1;
+        bool hasExplanation = false;
+        while (lookBehindIndex >= 0 && lines[lookBehindIndex].startsWith(commentPattern)) {
+          if (lines[lookBehindIndex].startsWith(ignorePattern)) {
+            hasExplanation = true;
+            break;
+          }
+          lookBehindIndex -= 1;
+        }
+        if (!hasExplanation) {
+          errors.add('${file.path}:$index: sync*/async* without an explanation.');
+        }
       }
     }
   }

--- a/examples/api/lib/widgets/async/stream_builder.0.dart
+++ b/examples/api/lib/widgets/async/stream_builder.0.dart
@@ -4,6 +4,8 @@
 
 // Flutter code sample for StreamBuilder
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
@@ -30,11 +32,17 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
-  // ignore: no_sync_async_star
-  final Stream<int> _bids = (() async* {
-    await Future<void>.delayed(const Duration(seconds: 1));
-    yield 1;
-    await Future<void>.delayed(const Duration(seconds: 1));
+  final Stream<int> _bids = (() {
+    late final StreamController<int> controller;
+    controller = StreamController<int>(
+      onListen: () async {
+        await Future<void>.delayed(const Duration(seconds: 1));
+        controller.add(1);
+        await Future<void>.delayed(const Duration(seconds: 1));
+        await controller.close();
+      },
+    );
+    return controller.stream;
   })();
 
   @override

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -795,7 +795,8 @@ class RenderTable extends RenderBox {
   /// column, in row order, starting from the first row.
   ///
   /// This is a lazily-evaluated iterable.
-  // flutter_ignore: no_sync_async_star
+  // The following uses sync* because it is public API documented to return a
+  // lazy iterable.
   Iterable<RenderBox> column(int x) sync* {
     for (int y = 0; y < rows; y += 1) {
       final int xy = x + y * columns;
@@ -809,7 +810,8 @@ class RenderTable extends RenderBox {
   /// row, in column order, starting with the first column.
   ///
   /// This is a lazily-evaluated iterable.
-  // flutter_ignore: no_sync_async_star
+  // The following uses sync* because it is public API documented to return a
+  // lazy iterable.
   Iterable<RenderBox> row(int y) sync* {
     final int start = y * columns;
     final int end = (y + 1) * columns;


### PR DESCRIPTION
Following up on suggestion from https://github.com/flutter/flutter/pull/95200#issuecomment-992856888

In trying to write an explanation for the example I realized it would really be better refactored to not use async* anyway, so I did that. I updated the two remaining usages of sync* to have explanations.

I shortened the text suggested to make it a little easier to keep under 80 cols in normal comments.