### PR TITLE
Update expansion_panel.dart and add iconColor

### DIFF
--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -162,6 +162,9 @@ class ExpansionPanelRadio extends ExpansionPanel {
         headerBuilder: headerBuilder,
         canTapOnHeader: canTapOnHeader,
         backgroundColor: backgroundColor,
+        iconColor: iconColor,
+        expandedIconColor: expandedIconColor,
+        disabledIconColor: disabledIconColor,
       );
 
   /// The value that uniquely identifies a radio panel so that the currently

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -85,21 +85,21 @@ class ExpansionPanel {
        assert(body != null),
        assert(isExpanded != null),
        assert(canTapOnHeader != null);
-    
+
   /// Specifies the color of the icon inside the header.
   ///
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
   /// [Colors.white60] when it is [Brightness.dark].
   final Color? iconColor;
-     
+
   /// The color of the icon when the header is expanded.
   ///
   /// Defaults to [Colors.black54] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
   /// [Colors.white] when it is [Brightness.dark].
   final Color? expandedIconColor;
-    
+
   /// The color of the icon when it is disabled,
   /// i.e. if [canTapOnHeader] is true.
   ///

--- a/packages/flutter/lib/src/material/expansion_panel.dart
+++ b/packages/flutter/lib/src/material/expansion_panel.dart
@@ -78,10 +78,35 @@ class ExpansionPanel {
     this.isExpanded = false,
     this.canTapOnHeader = false,
     this.backgroundColor,
+    this.iconColor,
+    this.expandedIconColor,
+    this.disabledIconColor,
   }) : assert(headerBuilder != null),
        assert(body != null),
        assert(isExpanded != null),
        assert(canTapOnHeader != null);
+    
+  /// Specifies the color of the icon inside the header.
+  ///
+  /// Defaults to [Colors.black54] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white60] when it is [Brightness.dark].
+  final Color? iconColor;
+     
+  /// The color of the icon when the header is expanded.
+  ///
+  /// Defaults to [Colors.black54] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white] when it is [Brightness.dark].
+  final Color? expandedIconColor;
+    
+  /// The color of the icon when it is disabled,
+  /// i.e. if [canTapOnHeader] is true.
+  ///
+  /// Defaults to [Colors.black38] when the theme's
+  /// [ThemeData.brightness] is [Brightness.light] and to
+  /// [Colors.white38] when it is [Brightness.dark].
+  final Color? disabledIconColor;
 
   /// The widget builder that builds the expansion panels' header.
   final ExpansionPanelHeaderBuilder headerBuilder;
@@ -126,6 +151,9 @@ class ExpansionPanelRadio extends ExpansionPanel {
     required this.value,
     required ExpansionPanelHeaderBuilder headerBuilder,
     required Widget body,
+    Color? iconColor,
+    Color? expandedIconColor,
+    Color? disabledIconColor,
     bool canTapOnHeader = false,
     Color? backgroundColor,
   }) : assert(value != null),
@@ -359,6 +387,9 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         margin: const EdgeInsetsDirectional.only(end: 8.0),
         child: ExpandIcon(
           isExpanded: _isChildExpanded(index),
+          color: child.iconColor,
+          expandedColor: child.expandedIconColor,
+          disabledColor: child.disabledIconColor,
           padding: const EdgeInsets.all(16.0),
           onPressed: !child.canTapOnHeader
               ? (bool isExpanded) => _handlePressed(isExpanded, index)


### PR DESCRIPTION
Add a color value for the header icon and add a color value for when the icon is disabled (canTapOnHeader = true) and add a color value for when the header is expanded

before :
![Screenshot-20211215010206-2466x114](https://user-images.githubusercontent.com/41499466/146082794-c957212f-596a-490e-875b-42bd405814fe.png)

after :
![Screenshot-20211215010231-2460x118](https://user-images.githubusercontent.com/41499466/146082826-750c7178-d295-44da-b668-365aca8f3980.png)

issues are fixed by this PR : #80295


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
