### PR TITLE
Build Flutter iOS plugins with all valid architectures

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -52,6 +52,11 @@ def flutter_additional_ios_build_settings(target)
   release_framework_dir = File.expand_path(File.join(artifacts_dir, 'ios-release', 'Flutter.xcframework'), __FILE__)
 
   target.build_configurations.each do |build_configuration|
+    # Build both x86_64 and arm64 simulator archs for all dependencies. If a single plugin does not support arm64 simulators,
+    # the app and all frameworks will fall back to x86_64. Unfortunately that case is not detectable in this script.
+    # Therefore all pods must have a x86_64 slice available, or linking a x86_64 app will fail.
+    build_configuration.build_settings['ONLY_ACTIVE_ARCH'] = 'NO' if build_configuration.type == :debug
+
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir
     Dir.new(configuration_engine_dir).each_child do |xcframework_file|

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -33,9 +33,6 @@ end
 def flutter_additional_ios_build_settings(target)
   return unless target.platform_name == :ios
 
-  # Return if it's not a Flutter plugin (transitive dependency).
-  return unless target.dependencies.any? { |dependency| dependency.name == 'Flutter' }
-
   # [target.deployment_target] is a [String] formatted as "8.0".
   inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
 
@@ -56,6 +53,9 @@ def flutter_additional_ios_build_settings(target)
     # the app and all frameworks will fall back to x86_64. Unfortunately that case is not detectable in this script.
     # Therefore all pods must have a x86_64 slice available, or linking a x86_64 app will fail.
     build_configuration.build_settings['ONLY_ACTIVE_ARCH'] = 'NO' if build_configuration.type == :debug
+
+    # Skip other updates if it's not a Flutter plugin (transitive dependency).
+    next unless target.dependencies.any? { |dependency| dependency.name == 'Flutter' }
 
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir


### PR DESCRIPTION
Always build Flutter plugins and their dependencies with all valid iOS architectures so that, if a single plugin does not support arm64 simulators, the app and all frameworks can fall back to x86_64.

Regressed in https://github.com/flutter/flutter/pull/90915.  That change started telling Xcode which device the binaries would run on, and so Xcode only built arm64 binaries on M1 Macs simulators.  However `google_sign_in` doesn't support arm64 simulators, so when the tool correctly dropped the executable build to x86_64, the other dependencies do not contain `x86_64` and linking fails.

Fixes https://github.com/flutter/flutter/issues/94914

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
