### PR TITLE
Make NavigationRail.selectedIndex nullable

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -98,8 +98,7 @@ class NavigationRail extends StatefulWidget {
     this.useIndicator,
     this.indicatorColor,
   }) :  assert(destinations != null && destinations.length >= 2),
-        assert(selectedIndex != null),
-        assert(0 <= selectedIndex && selectedIndex < destinations.length),
+        assert(selectedIndex == null || (0 <= selectedIndex && selectedIndex < destinations.length)),
         assert(elevation == null || elevation > 0),
         assert(minWidth == null || minWidth > 0),
         assert(minExtendedWidth == null || minExtendedWidth > 0),
@@ -160,8 +159,8 @@ class NavigationRail extends StatefulWidget {
   final List<NavigationRailDestination> destinations;
 
   /// The index into [destinations] for the current selected
-  /// [NavigationRailDestination].
-  final int selectedIndex;
+  /// [NavigationRailDestination] or null if no destination is selected.
+  final int? selectedIndex;
 
   /// Called when one of the [destinations] is selected.
   ///
@@ -357,8 +356,12 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
     }
 
     if (widget.selectedIndex != oldWidget.selectedIndex) {
-      _destinationControllers[oldWidget.selectedIndex].reverse();
-      _destinationControllers[widget.selectedIndex].forward();
+      if (oldWidget.selectedIndex != null) {
+        _destinationControllers[oldWidget.selectedIndex!].reverse();
+      }
+      if (widget.selectedIndex != null) {
+        _destinationControllers[widget.selectedIndex!].forward();
+      }
       return;
     }
   }
@@ -475,7 +478,9 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
       )..addListener(_rebuild);
     });
     _destinationAnimations = _destinationControllers.map((AnimationController controller) => controller.view).toList();
-    _destinationControllers[widget.selectedIndex].value = 1.0;
+    if (widget.selectedIndex != null) {
+      _destinationControllers[widget.selectedIndex!].value = 1.0;
+    }
     _extendedController = AnimationController(
       duration: kThemeAnimationDuration,
       vsync: this,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -65,7 +65,7 @@ void main() {
     );
 
     final Iterable<Semantics> semantics = tester.widgetList<Semantics>(find.byType(Semantics));
-    expect(semantics.where((Semantics s) => s.properties.selected == true), isEmpty);
+    expect(semantics.where((Semantics s) => s.properties.selected ?? false), isEmpty);
   });
 
   testWidgets('backgroundColor can be changed', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2011,6 +2011,61 @@ void main() {
     expect(_labelOpacity(tester, 'Ghi'), equals(1.0));
   });
 
+  testWidgets('Changing destinations animate for selectedIndex=null', (WidgetTester tester) async {
+    int? selectedIndex = 0;
+    late StateSetter stateSetter;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            stateSetter = setState;
+            return Scaffold(
+              body: Row(
+                children: <Widget>[
+                  NavigationRail(
+                    destinations: _destinations(),
+                    selectedIndex: selectedIndex,
+                    labelType: NavigationRailLabelType.selected,
+                  ),
+                  const Expanded(
+                    child: Text('body'),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Unset the selected index.
+    stateSetter(() {
+      selectedIndex = null;
+    });
+
+    // The first destination animates out.
+    expect(_labelOpacity(tester, 'Abc'), equals(1.0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 25));
+    expect(_labelOpacity(tester, 'Abc'), equals(0.5));
+    await tester.pumpAndSettle();
+    expect(_labelOpacity(tester, 'Abc'), equals(0.0));
+
+    // Set the selected index to the first destination.
+    stateSetter(() {
+      selectedIndex = 0;
+    });
+
+    // The first destination animates in.
+    expect(_labelOpacity(tester, 'Abc'), equals(0.0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(_labelOpacity(tester, 'Abc'), equals(0.5));
+    await tester.pumpAndSettle();
+    expect(_labelOpacity(tester, 'Abc'), equals(1.0));
+  });
+
   testWidgets('Semantics - labelType=[none]', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -55,6 +55,19 @@ void main() {
     expect(actualUnselectedIconTheme.fontSize, equals(unselectedIconTheme.size));
   });
 
+  testWidgets('No selected destination when selectedIndex is null', (WidgetTester tester) async {
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        selectedIndex: null,
+        destinations: _destinations(),
+      ),
+    );
+
+    final Iterable<Semantics> semantics = tester.widgetList<Semantics>(find.byType(Semantics));
+    expect(semantics.where((Semantics s) => s.properties.selected == true), isEmpty);
+  });
+
   testWidgets('backgroundColor can be changed', (WidgetTester tester) async {
     await _pumpNavigationRail(
       tester,


### PR DESCRIPTION
This PR makes `NavigationRail.selectedIndex` nullable so `NavigationRail` supports not having an active destination.
The test uses the `Semantics` to check for `selected` because the `_RailDestination` widget is private, I hope that's okay.

Fixes #95330.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
