### PR TITLE
[flutter_conductor] support commits past tagged stable release

### DIFF
--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -26,6 +26,7 @@ enum VersionType {
   /// A master channel flutter version from git describe.
   ///
   /// Example: '1.2.3-4.0.pre-10-gabc123'.
+  /// Example: '1.2.3-10-gabc123'.
   gitDescribe,
 }
 
@@ -33,7 +34,7 @@ final Map<VersionType, RegExp> versionPatterns = <VersionType, RegExp>{
   VersionType.stable: RegExp(r'^(\d+)\.(\d+)\.(\d+)$'),
   VersionType.development: RegExp(r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre$'),
   VersionType.latest: RegExp(r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre\.(\d+)$'),
-  VersionType.gitDescribe: RegExp(r'^(\d+)\.(\d+)\.(\d+)-(\d+)\.(\d+)\.pre-(\d+)-g[a-f0-9]+$'),
+  VersionType.gitDescribe: RegExp(r'^(\d+)\.(\d+)\.(\d+)-((\d+)\.(\d+)\.pre-)?(\d+)-g[a-f0-9]+$'),
 };
 
 class Version {
@@ -63,9 +64,8 @@ class Version {
         assert(commits != null);
         break;
       case VersionType.gitDescribe:
-        throw ConductorException(
-          'VersionType.gitDescribe not supported! Use VersionType.latest instead.',
-        );
+        assert(commits != null);
+        break;
     }
   }
 
@@ -130,19 +130,20 @@ class Version {
     match = versionPatterns[VersionType.gitDescribe]!.firstMatch(versionString);
     if (match != null) {
       // parse latest
-      final List<int> parts = match.groups(
-        <int>[1, 2, 3, 4, 5, 6],
-      ).map(
-        (String? s) => int.parse(s!),
-      ).toList();
+      final int x = int.parse(match.group(1)!);
+      final int y = int.parse(match.group(2)!);
+      final int z = int.parse(match.group(3)!);
+      final int? m = int.tryParse(match.group(5) ?? '');
+      final int? n = int.tryParse(match.group(6) ?? '');
+      final int commits = int.parse(match.group(7)!);
       return Version(
-        x: parts[0],
-        y: parts[1],
-        z: parts[2],
-        m: parts[3],
-        n: parts[4],
-        commits: parts[5],
-        type: VersionType.latest,
+        x: x,
+        y: y,
+        z: z,
+        m: m,
+        n: n,
+        commits: commits,
+        type: VersionType.gitDescribe,
       );
     }
     throw Exception('${versionString.trim()} cannot be parsed');

--- a/dev/conductor/core/test/version_test.dart
+++ b/dev/conductor/core/test/version_test.dart
@@ -16,7 +16,13 @@ void main() {
       } on Exception catch (exception) {
         fail('Failed parsing "$versionString" with:\n$exception');
       }
-      expect(version, isA<Version>());
+      expect(version.x, 2);
+      expect(version.y, 8);
+      expect(version.z, 0);
+      expect(version.m, isNull);
+      expect(version.n, isNull);
+      expect(version.commits, 1);
+      expect(version.type, VersionType.gitDescribe);
     });
   });
   group('Version.increment()', () {

--- a/dev/conductor/core/test/version_test.dart
+++ b/dev/conductor/core/test/version_test.dart
@@ -7,6 +7,18 @@ import 'package:conductor_core/src/version.dart';
 import './common.dart';
 
 void main() {
+  group('Version.fromString()', () {
+    test('parses commits past a tagged stable', () {
+      const String versionString = '2.8.0-1-g2ef5ad67fe';
+      final Version version;
+      try {
+        version = Version.fromString(versionString);
+      } on Exception catch (exception) {
+        fail('Failed parsing "$versionString" with:\n$exception');
+      }
+      expect(version, isA<Version>());
+    });
+  });
   group('Version.increment()', () {
     test('throws exception on nonsensical `level`', () {
       final List<String> levels = <String>['f', '0', 'xyz'];


### PR DESCRIPTION
There was a bug in the regex for `gitDescribe` type of version strings. It did not cover untagged commits past a stable version.

https://github.com/flutter/flutter/issues/95346