### PR TITLE
Move android tests from mac to linux

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1449,6 +1449,16 @@ targets:
       task_name: backdrop_filter_perf__e2e_summary
     scheduler: luci
 
+  - name: Linux_android backdrop_filter_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: backdrop_filter_perf__timeline_summary
+    scheduler: luci
+
   - name: Linux_android basic_material_app_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1459,6 +1469,16 @@ targets:
       task_name: basic_material_app_android__compile
     scheduler: luci
 
+  - name: Linux_android channels_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: channels_integration_test
+    scheduler: luci
+
   - name: Linux_android color_filter_and_fade_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1467,6 +1487,16 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: color_filter_and_fade_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android color_filter_and_fade_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: color_filter_and_fade_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_android complex_layout_android__compile
@@ -1523,6 +1553,42 @@ targets:
         ]
     scheduler: luci
 
+  - name: Linux_android complex_layout_scroll_perf__memory
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: complex_layout_scroll_perf__memory
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
+    scheduler: luci
+
+  - name: Linux_android complex_layout_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: complex_layout_scroll_perf__timeline_summary
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
+    scheduler: luci
+
   - name: Linux_android complex_layout_semantics_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1531,6 +1597,24 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: complex_layout_semantics_perf
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
+    scheduler: luci
+
+  - name: Linux_android complex_layout__start_up
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: complex_layout__start_up
       dependencies: >-
         [
           {"dependency": "open_jdk", "version": "11"}
@@ -1561,6 +1645,26 @@ targets:
       task_name: cubic_bezier_perf_sksl_warmup__e2e_summary
     scheduler: luci
 
+  - name: Linux_android cubic_bezier_perf_sksl_warmup__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: cubic_bezier_perf_sksl_warmup__timeline_summary
+    scheduler: luci
+
+  - name: Linux_android cubic_bezier_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: cubic_bezier_perf__timeline_summary
+    scheduler: luci
+
   - name: Linux_android cull_opacity_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1569,6 +1673,16 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: cull_opacity_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android cull_opacity_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: cull_opacity_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_android devtools_profile_start_test
@@ -1581,6 +1695,46 @@ targets:
       task_name: devtools_profile_start_test
     scheduler: luci
 
+  - name: Linux_android drive_perf_debug_warning
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: drive_perf_debug_warning
+    scheduler: luci
+
+  - name: Linux_android embedded_android_views_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: embedded_android_views_integration_test
+    scheduler: luci
+
+  - name: Linux_android external_ui_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: external_ui_integration_test
+    scheduler: luci
+
+  - name: Linux_android fading_child_animation_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: fading_child_animation_perf__timeline_summary
+    scheduler: luci
+
   - name: Linux_android fast_scroll_heavy_gridview__memory
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1589,6 +1743,26 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: fast_scroll_heavy_gridview__memory
+    scheduler: luci
+
+  - name: Linux_android fast_scroll_large_images__memory
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: fast_scroll_large_images__memory
+    scheduler: luci
+
+  - name: Linux_android flavors_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: flavors_test
     scheduler: luci
 
   - name: Linux_android flutter_engine_group_performance
@@ -1692,6 +1866,16 @@ targets:
       task_name: flutter_test_performance
     scheduler: luci
 
+  - name: Linux_android flutter_view__start_up
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: flutter_view__start_up
+    scheduler: luci
+
   - name: Linux_android frame_policy_delay_test_android
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1700,6 +1884,36 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: frame_policy_delay_test_android
+    scheduler: luci
+
+  - name: Linux_android fullscreen_textfield_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: fullscreen_textfield_perf__timeline_summary
+    scheduler: luci
+
+  - name: Linux_android hello_world__memory
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: hello_world__memory
+    scheduler: luci
+
+  - name: Linux_android home_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: home_scroll_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_android hot_mode_dev_cycle_linux__benchmark
@@ -1713,6 +1927,16 @@ targets:
       - dev/**
     scheduler: luci
 
+  - name: Linux_android hybrid_android_views_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: hybrid_android_views_integration_test
+    scheduler: luci
+
   - name: Linux_android image_list_jit_reported_duration
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1723,6 +1947,16 @@ targets:
       task_name: image_list_jit_reported_duration
     scheduler: luci
 
+  - name: Linux_android imagefiltered_transform_animation_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: imagefiltered_transform_animation_perf__timeline_summary
+    scheduler: luci
+
   - name: Linux_android image_list_reported_duration
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1731,6 +1965,46 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: image_list_reported_duration
+    scheduler: luci
+
+  - name: Linux_android integration_ui_driver
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: integration_ui_driver
+    scheduler: luci
+
+  - name: Linux_android integration_ui_keyboard_resize
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: integration_ui_keyboard_resize
+    scheduler: luci
+
+  - name: Linux_android integration_ui_screenshot
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: integration_ui_screenshot
+    scheduler: luci
+
+  - name: Linux_android integration_ui_textfield
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: integration_ui_textfield
     scheduler: luci
 
   - name: Linux_android large_image_changer_perf_android
@@ -1773,6 +2047,16 @@ targets:
       task_name: new_gallery__crane_perf
     scheduler: luci
 
+  - name: Linux_android new_gallery__transition_perf
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: new_gallery__transition_perf
+    scheduler: luci
+
   - name: Linux_android picture_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1781,6 +2065,16 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: picture_cache_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android picture_cache_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: picture_cache_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_android platform_channels_benchmarks
@@ -1793,6 +2087,26 @@ targets:
       task_name: platform_channels_benchmarks
     scheduler: luci
 
+  - name: Linux_android platform_channel_sample_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: platform_channel_sample_test
+    scheduler: luci
+
+  - name: Linux_android platform_interaction_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: platform_interaction_test
+    scheduler: luci
+
   - name: Linux_android platform_views_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1801,6 +2115,16 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: platform_views_scroll_perf__timeline_summary
+    scheduler: luci
+
+  - name: Linux_android platform_view__start_up
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: platform_view__start_up
     scheduler: luci
 
   - name: Linux_android routing_test
@@ -1813,6 +2137,16 @@ targets:
       task_name: routing_test
     scheduler: luci
 
+  - name: Linux_android service_extensions_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: service_extensions_test
+    scheduler: luci
+
   - name: Linux_android textfield_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1821,6 +2155,34 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: textfield_perf__e2e_summary
+    scheduler: luci
+
+  - name: Linux_android textfield_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: textfield_perf__timeline_summary
+    scheduler: luci
+
+  - name: Linux_android tiles_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: tiles_scroll_perf__timeline_summary
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
     scheduler: luci
 
   - name: Linux_android web_size__compile_test
@@ -2620,210 +2982,6 @@ targets:
       task_name: android_semantics_integration_test
     scheduler: luci
 
-  - name: Mac_android backdrop_filter_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: backdrop_filter_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android channels_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: channels_integration_test
-    scheduler: luci
-
-  - name: Mac_android color_filter_and_fade_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: color_filter_and_fade_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android complex_layout__start_up
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: complex_layout__start_up
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
-    scheduler: luci
-
-  - name: Mac_android complex_layout_scroll_perf__memory
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: complex_layout_scroll_perf__memory
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
-    scheduler: luci
-
-  - name: Mac_android complex_layout_scroll_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: complex_layout_scroll_perf__timeline_summary
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
-    scheduler: luci
-
-  - name: Mac_android cubic_bezier_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: cubic_bezier_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android cubic_bezier_perf_sksl_warmup__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: cubic_bezier_perf_sksl_warmup__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android cull_opacity_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: cull_opacity_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android drive_perf_debug_warning
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: drive_perf_debug_warning
-    scheduler: luci
-
-  - name: Mac_android embedded_android_views_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: embedded_android_views_integration_test
-    scheduler: luci
-
-  - name: Mac_android external_ui_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: external_ui_integration_test
-    scheduler: luci
-
-  - name: Mac_android fading_child_animation_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: fading_child_animation_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android fast_scroll_large_images__memory
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: fast_scroll_large_images__memory
-    scheduler: luci
-
-  - name: Mac_android flavors_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: flavors_test
-    scheduler: luci
-
-  - name: Mac_android flutter_view__start_up
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: flutter_view__start_up
-    scheduler: luci
-
-  - name: Mac_android fullscreen_textfield_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: fullscreen_textfield_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android hello_world__memory
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: hello_world__memory
-    scheduler: luci
-
   - name: Mac_android hello_world_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2832,16 +2990,6 @@ targets:
       tags: >
         ["devicelab","android","mac"]
       task_name: hello_world_android__compile
-    scheduler: luci
-
-  - name: Mac_android home_scroll_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: home_scroll_perf__timeline_summary
     scheduler: luci
 
   - name: Mac_android hot_mode_dev_cycle__benchmark
@@ -2854,26 +3002,6 @@ targets:
       task_name: hot_mode_dev_cycle__benchmark
     scheduler: luci
 
-  - name: Mac_android hybrid_android_views_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: hybrid_android_views_integration_test
-    scheduler: luci
-
-  - name: Mac_android imagefiltered_transform_animation_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: imagefiltered_transform_animation_perf__timeline_summary
-    scheduler: luci
-
   - name: Mac_android integration_test_test
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2882,16 +3010,6 @@ targets:
       tags: >
         ["devicelab","android","mac"]
       task_name: integration_test_test
-    scheduler: luci
-
-  - name: Mac_android integration_ui_driver
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: integration_ui_driver
     scheduler: luci
 
   - name: Mac_android integration_ui_frame_number
@@ -2904,36 +3022,6 @@ targets:
       task_name: integration_ui_frame_number
     scheduler: luci
 
-  - name: Mac_android integration_ui_keyboard_resize
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: integration_ui_keyboard_resize
-    scheduler: luci
-
-  - name: Mac_android integration_ui_screenshot
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: integration_ui_screenshot
-    scheduler: luci
-
-  - name: Mac_android integration_ui_textfield
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: integration_ui_textfield
-    scheduler: luci
-
   - name: Mac_android microbenchmarks
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2942,56 +3030,6 @@ targets:
       tags: >
         ["devicelab","android","mac"]
       task_name: microbenchmarks
-    scheduler: luci
-
-  - name: Mac_android new_gallery__transition_perf
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: new_gallery__transition_perf
-    scheduler: luci
-
-  - name: Mac_android picture_cache_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: picture_cache_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android platform_channel_sample_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: platform_channel_sample_test
-    scheduler: luci
-
-  - name: Mac_android platform_interaction_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: platform_interaction_test
-    scheduler: luci
-
-  - name: Mac_android platform_view__start_up
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: platform_view__start_up
     scheduler: luci
 
   - name: Mac_android run_release_test
@@ -3005,16 +3043,6 @@ targets:
       task_name: run_release_test
     scheduler: luci
 
-  - name: Mac_android service_extensions_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: service_extensions_test
-    scheduler: luci
-
   - name: Mac_android flutter_gallery_mac__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3023,34 +3051,6 @@ targets:
       tags: >
         ["devicelab","android","mac"]
       task_name: flutter_gallery_mac__start_up
-    scheduler: luci
-
-  - name: Mac_android textfield_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: textfield_perf__timeline_summary
-    scheduler: luci
-
-  - name: Mac_android tiles_scroll_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: tiles_scroll_perf__timeline_summary
-      dependencies: >-
-        [
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      caches: >-
-        [
-          {"name": "openjdk", "path": "java11"}
-        ]
     scheduler: luci
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary


### PR DESCRIPTION
This moves most mac/android tests to linux.

This list has been validated in staging pool for the recent 50 commits:
https://ci.chromium.org/p/flutter/g/devicelab_staging/console

https://github.com/flutter/flutter/issues/74522