### PR TITLE
[wip] Flutter JS Bootstrap RFC

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -149,16 +149,33 @@ Future<void> main() async {
 }
 ''';
     } else {
+
+// TODO: Add the FlutterLoader code to the if-case above (with plugins)!
+
       contents = '''
 // @dart=${languageVersion.major}.${languageVersion.minor}
 
 import 'dart:ui' as ui;
 
+import 'package:flutter_web_plugins/flutter_loader.dart';
+
 import '$mainImport' as entrypoint;
 
 Future<void> main() async {
-  await ui.webOnlyInitializePlatform();
-  entrypoint.main();
+  if (isFlutterJsLoaderConfigured) {
+    FlutterLoader(
+      initEngine: () async {
+        await ui.webOnlyInitializePlatform();
+      },
+      runApp: () {
+        entrypoint.main();
+      }
+    )..notifyFlutterReady();
+  } else {
+    // Legacy mode
+    await ui.webOnlyInitializePlatform();
+    entrypoint.main();
+  }
 }
 ''';
     }

--- a/packages/flutter_tools/templates/app_shared/web/flutter.js.tmpl
+++ b/packages/flutter_tools/templates/app_shared/web/flutter.js.tmpl
@@ -1,0 +1,132 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * This script installs service_worker.js to provide PWA functionality to
+ *     application. For more information, see:
+ *     https://developers.google.com/web/fundamentals/primers/service-workers
+ */
+
+if (!_flutter) {
+  var _flutter = {};
+}
+_flutter.loader = null;
+
+(function() {
+  "use strict";
+  class FlutterLoader {
+    // TODO: Move the below methods to "#private" once supported by all the browsers
+    // we support. In the meantime, we use the "revealing module" pattern.
+
+    // Watchdog to prevent injecting the main entrypoint multiple times.
+    _scriptLoaded = false;
+
+    // Resolver for the pending promise returned by loadMainDartJs.
+    _didLoadMainDartJsResolve = null;
+
+    /**
+     * Initializes the main.dart.js with/without serviceWorker.
+     * @param {*} options 
+     * @returns a Promise that will eventually resolve with an EngineInitializer,
+     * or will be rejected with the error caused by the loader.
+     */
+    loadMainDartJs(options) {
+      const { 
+        entrypointUrl = 'main.dart.js', 
+        serviceWorker,
+      } = options;
+      return this._loadWithServiceWorker(entrypointUrl, serviceWorker);
+    }
+
+    /**
+     * Resolves the promise created by loadMainDartJs. Called by Flutter.
+     * Needs to be weirdly bound like it is, so "this" is preserved across
+     * the JS <-> Flutter jumps.
+     * @param {*} engineInitializer 
+     */
+    didLoadMainDartJs = (function(engineInitializer) {
+      if (typeof this._didLoadMainDartJsResolve != 'function') {
+        console.warn('Do not call didLoadMainDartJs by hand. Start with loadMainDartJs instead.');
+      }
+      this._didLoadMainDartJsResolve(engineInitializer);
+    }).bind(this);
+
+    _loadMainDartJs(entrypointUrl) {
+      if (this._scriptLoaded) {
+        return null;
+      }
+  
+      this._scriptLoaded = true;
+  
+      return new Promise((resolve, reject) => {
+        let scriptTag = document.createElement('script');
+        scriptTag.src = entrypointUrl;
+        scriptTag.type = 'application/javascript';
+        this._didLoadMainDartJsResolve = resolve; // Cache the resolve, so it can be called from Flutter.
+        scriptTag.addEventListener('error', reject);
+        document.body.append(scriptTag);
+      });
+    }
+  
+    _waitForServiceWorkerActivation(serviceWorker, entrypointUrl) {
+      return new Promise((resolve, _) => {
+        serviceWorker.addEventListener('statechange', () => {
+          if (serviceWorker.state == 'activated') {
+            console.log('Installed new service worker.');
+            resolve(this._loadMainDartJs(entrypointUrl));
+          }
+        });
+      });
+    }
+  
+    _loadWithServiceWorker(entrypointUrl, serviceWorkerOptions) {
+      if (!('serviceWorker' in navigator) || serviceWorkerOptions == null) {
+        console.warn('Service worker not supported (or configured). Falling back to plain <script> tag.', serviceWorkerOptions);
+        return this._loadMainDartJs(entrypointUrl);
+      }
+
+      const { 
+        serviceWorkerVersion,
+        timeoutMillis = 4000,
+      } = serviceWorkerOptions;
+  
+      var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
+      let loader = navigator.serviceWorker.register(serviceWorkerUrl)
+          .then((reg) => {
+            if (!reg.active && (reg.installing || reg.waiting)) {
+              // No active web worker and we have installed or are installing
+              // one for the first time. Simply wait for it to activate.
+              return this._waitForServiceWorkerActivation(reg.installing || reg.waiting, entrypointUrl);
+            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
+              // When the app updates the serviceWorkerVersion changes, so we
+              // need to ask the service worker to update.
+              console.log('New service worker available.');
+              reg.update();
+              return this._waitForServiceWorkerActivation(reg.installing, entrypointUrl);
+            } else {
+              // Existing service worker is still good.
+              console.log('Loading app from service worker.');
+              return this._loadMainDartJs(entrypointUrl);
+            }
+          });
+  
+      // Timeout race promise
+      let timeout;
+      if (timeoutMillis > 0) {
+        timeout = new Promise((resolve, _) => {
+          setTimeout(() => {
+            if (!this._scriptLoaded) {
+              console.warn('Failed to load app from service worker. Falling back to plain <script> tag.');
+              resolve(this._loadMainDartJs(entrypointUrl));
+            }
+          }, timeoutMillis);
+        });
+      }
+  
+      return Promise.race([loader, timeout]);
+    }  
+  }
+
+  _flutter.loader = new FlutterLoader();
+}());

--- a/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
@@ -31,74 +31,33 @@
 
   <title>{{projectName}}</title>
   <link rel="manifest" href="manifest.json">
+
+  <script>
+    // This script tag belongs to the Flutter Web build, do not touch.
+    var serviceWorkerVersion = null;
+  </script>
+  <!-- This script adds the flutter initialization JS code -->
+  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
-    if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plain <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
+    window.addEventListener('load', function(ev) {
+      _flutter.loader.loadMainDartJs({
+        entrypointUrl: 'main.dart.js',
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+          timeoutMillis: 4000
+        }
+      }).then(function(engineInitializer) {
+        return engineInitializer.initializeEngine({
+          // Engine config
+        });
+      }).then(function(appRunner) {
+        return appRunner.runApp({
+          // App startup parameters
+        });
       });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
-    }
+    });
   </script>
 </body>
 </html>

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -122,6 +122,7 @@
         "templates/app_shared/web/icons/Icon-512.png.copy.tmpl",
         "templates/app_shared/web/icons/Icon-maskable-192.png.img.tmpl",
         "templates/app_shared/web/icons/Icon-maskable-512.png.img.tmpl",
+        "templates/app_shared/web/flutter.js.tmpl",
         "templates/app_shared/web/index.html.tmpl",
         "templates/app_shared/web/manifest.json.tmpl",
         "templates/app_shared/windows.tmpl/.gitignore",

--- a/packages/flutter_web_plugins/lib/flutter_loader.dart
+++ b/packages/flutter_web_plugins/lib/flutter_loader.dart
@@ -1,0 +1,5 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'src/loader/flutter_loader.dart';

--- a/packages/flutter_web_plugins/lib/src/loader/flutter_loader.dart
+++ b/packages/flutter_web_plugins/lib/src/loader/flutter_loader.dart
@@ -1,0 +1,92 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:js/js.dart';
+
+import 'js_interop/flutter_js_loader.dart';
+import 'js_interop/promise_js.dart';
+
+/// `true` if the new flutter loader configuration is present in the DOM.
+final bool isFlutterJsLoaderConfigured = didLoadMainDartJs != null;
+
+/// A class that controls the coarse lifecycle of a Flutter app.
+// TODO(dit): Make this an abstract class and provide a Promise-based implementation
+// (this one), and another one that doesn't wait for anything.
+// Use a factory method to return the correct instance, so the user doesn't even
+// have to worry about it.
+//
+//   ```dart
+//     FlutterLoader loader = FlutterLoader.createLoader(initEngine, runApp, cleanApp);
+//     // FlutterLoader may be a PromiseFlutterLoader or an AutomaticFlutterLoader (for example)
+//     loader.notifyFlutterReady(); // Do things
+//   ```
+// TODO(dit): FlutterLoader might not be the best name for these classes though...
+class FlutterLoader {
+  /// Construct a FlutterLoader
+  FlutterLoader({
+    this.initEngine, this.runApp, this.cleanApp
+  });
+
+  // TODO(dit): Be more strict with the below typedefs, so we can add incoming params for each function.
+  // TODO(dit): Make the below private members.
+
+  /// A function to initialize the engine
+  final Function? initEngine;
+  /// A function to run the app
+  final Function? runApp;
+  /// A function to clear the app (optional)
+  final Function? cleanApp;
+
+  /// Notifies JS that Flutter is up and running.
+  void notifyFlutterReady() {
+    assert(isFlutterJsLoaderConfigured, '_flutter.loader is not correctly configured. Check your index.html!');
+    didLoadMainDartJs!(_prepareEngineInitializer());
+  }
+
+  // Calls a function that may be null and/or async, and wraps it in a Future<Object?>
+  Future<Object?> _safeCall(Function? fn) async {
+    if (fn != null) {
+      // ignore: avoid_dynamic_calls
+      return Future<Object?>.value(fn());
+    }
+  }
+
+  /// Creates an engineInitializer that runs our encapsulated initEngine function.
+  FlutterEngineInitializer _prepareEngineInitializer() {
+    // Return an object that has a initEngine method...
+    return FlutterEngineInitializer(initializeEngine: allowInterop((InitializeEngineFnParameters? params) {
+      // `params` coming from Javascript may be used to configure the engine intialization.
+      // The internal `initEngine` function must accept those params, and then this
+      // code needs to be slightly modified to pass them to the initEngine call below.
+      return Promise<FlutterAppRunner>(allowInterop((PromiseResolver<FlutterAppRunner> resolve, PromiseRejecter _) async {
+        await _safeCall(initEngine);
+        // Resolve with an actual AppRunner object, created in a similar way
+        // to how the FlutterEngineInitializer was created
+        resolve(_prepareAppRunner());
+      }));
+    }));
+  }
+
+  /// Creates an appRunner that runs our encapsulated runApp function.
+  FlutterAppRunner _prepareAppRunner() {
+    return FlutterAppRunner(runApp: allowInterop((RunAppFnParameters? params) {
+      // `params` coming from JS may be used to configure the run app method.
+      return Promise<FlutterAppCleaner>(allowInterop((PromiseResolver<FlutterAppCleaner> resolve, PromiseRejecter _) async {
+        await _safeCall(runApp);
+        // Next step is an AppCleaner
+        resolve(_prepareAppCleaner());
+      }));
+    }));
+  }
+
+  /// Clean the app that was injected above.
+  FlutterAppCleaner _prepareAppCleaner() {
+    return FlutterAppCleaner(cleanApp: allowInterop((CleanAppFnParameters? params) {
+      return Promise<bool>(allowInterop((PromiseResolver<bool> resolve, PromiseRejecter _) async {
+        await _safeCall(cleanApp);
+        resolve(true);
+      }));
+    }));
+  }
+}

--- a/packages/flutter_web_plugins/lib/src/loader/js_interop/flutter_js_loader.dart
+++ b/packages/flutter_web_plugins/lib/src/loader/js_interop/flutter_js_loader.dart
@@ -1,0 +1,93 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS('_flutter.loader')
+library flutter_js_loader;
+
+import 'package:js/js.dart';
+import 'package:meta/meta.dart';
+
+import 'promise_js.dart';
+
+/// Typedef for the function that notifies JS that the main entrypoint is up and running.
+/// As a parameter, a [FlutterEngineInitializer] instance is passed to JS, so the
+/// programmer can control the initialization sequence.
+typedef DidLoadMainDartJsFn = void Function(FlutterEngineInitializer);
+
+/// A hook to notify JavaScript that Flutter is up and running!
+/// This is setup by flutter.js when the main entrypoint bundle is injected,
+/// in `window._flutter.loader.didLoadMainDartJs`.
+@JS('didLoadMainDartJs')
+external DidLoadMainDartJsFn? get didLoadMainDartJs;
+
+// FlutterEngineInitializer
+
+/// A class that exposes a function that continues initializing the engine,
+/// and returns the promise of a FlutterAppInitializer.
+@JS()
+@anonymous
+abstract class FlutterEngineInitializer {
+  /// Creates an instance of [FlutterEngineInitializer].
+  external factory FlutterEngineInitializer({
+    @required InitializeEngineFn initializeEngine,
+  });
+}
+
+/// The shape of the object that can be passed as parameter to the
+/// initializeEngine function of the FlutterEngineInitializer object
+/// (when called from JS).
+@JS()
+@anonymous
+abstract class InitializeEngineFnParameters {
+}
+
+/// Typedef for the function that initializes the flutter engine.
+typedef InitializeEngineFn = Promise<FlutterAppRunner> Function(InitializeEngineFnParameters?);
+
+// FlutterAppRunner
+
+/// A class that exposes a function that runs the Flutter app,
+/// and returns a promise of a FlutterAppCleaner.
+@JS()
+@anonymous
+abstract class FlutterAppRunner {
+  /// Runs a flutter app
+  external factory FlutterAppRunner({
+    @required RunAppFn runApp, // Returns an App
+  });
+}
+
+/// The shape of the object that can be passed as parameter to the
+/// runApp function of the FlutterAppRunner object (from JS).
+@JS()
+@anonymous
+abstract class RunAppFnParameters {
+}
+
+/// Typedef for the function that runs the flutter app main entrypoint.
+typedef RunAppFn = Promise<FlutterAppCleaner> Function(RunAppFnParameters?);
+
+// FlutterAppCleaner
+
+/// A class that exposes a function that cleans up the App that is currently
+/// running. Returns a promise of a boolean value, which resolves to true if
+/// the app has been cleaned up successfully.
+@JS()
+@anonymous
+abstract class FlutterAppCleaner {
+  /// Cleans a Flutter app
+  external factory FlutterAppCleaner({
+    @required CleanAppFn cleanApp,
+  });
+}
+
+/// The shape of the object that can be passed as parameter to the
+/// cleanApp function of the FlutterAppRunner object (from JS).
+@JS()
+@anonymous
+abstract class CleanAppFnParameters {
+}
+
+/// Typedef for the function that cleans the flutter app initialized by the functions above.
+typedef CleanAppFn = Promise<bool> Function (CleanAppFnParameters?);

--- a/packages/flutter_web_plugins/lib/src/loader/js_interop/promise_js.dart
+++ b/packages/flutter_web_plugins/lib/src/loader/js_interop/promise_js.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library promise_js;
+
+import 'package:js/js.dart';
+
+/// Type-safe JS Promises
+@JS('Promise')
+abstract class Promise<T> {
+  /// A constructor for a JS promise
+  external factory Promise(PromiseExecutor<T> executor);
+}
+
+/// The type of function that is used to create a Promise<T>
+typedef PromiseExecutor<T> = void Function(PromiseResolver<T> resolve, PromiseRejecter reject);
+/// The type of function used to resolve a Promise<T>
+typedef PromiseResolver<T> = void Function(T result);
+/// The type of function used to reject a Promise (of any <T>)
+typedef PromiseRejecter = void Function(Object? error);


### PR DESCRIPTION
# This PR is now out of date

> ----
> But not abandoned; **work on this feature continues in:**
> 
> * https://github.com/flutter/engine/pull/32017
> * https://github.com/flutter/flutter/pull/100177
> ----


## Old description

This is a first attempt at yielding full control to the programmer over the initialization of a Flutter Web app.

Currently, Flutter Web apps start as soon as possible, and take over the whole screen. With this change, the startup of an App can be split in three stages (four, if we count the cleanup stage too):

* Injecting the serviceworker/main.dart.js
* Initializing the engine
* Running the flutter app
* Cleaning the app (currently not implemented)

To achieve this, some JS-interop and Promise-wrangling is needed. The new workflow is as follows:

* The user injects flutter.js in their index.html, and once that script is loaded, calls `_flutter.loader.loadMainDartJs`
* flutter.js injects main.dart.js, and sets up a `_flutter.loader.didLoadMainDartJs` callback. (This callback must be in a known location, because the first time Flutter calls JS, it needs to do so from a known place.)
* The Dart wrapper script detects that the `_flutter.loader` has been used in JS, and sets up a `FlutterLoader` object that controls de lifecycle of the app.
* The `FlutterLoader` calls `didLoadMainDartJs` in JS, with an instance of an `EngineInitializer`.
  * This resolves the promise returned by `loadMainDartJs` in step 1.
* From this moment on, the loading of the application is a sequence of Promise-based objects that let the user walk through the three (four) stages described above:

```
loadMainDartJs -> EngineInitializer.initializeEngine -> AppRunner.runApp -> AppCleaner.cleanApp (optional)
```

The new API above allows users to write their own (informative) splash screens, for example:

* https://dit-tests.web.app (the red circles should turn green as the app loads, and the button becomes enabled once the app is ready to start. The app only starts when the button is pressed).

### Backwards compatibility

This will be backwards compatible with old versions of index.html, but testing that hasn't been a priority of this first PoC.

### Testing

No tests yet, but I've tried to minimize the amount of code living in "untestable" parts of the app (template files, and build scripts), and add as much as possible into flutter_web_plugins, where it's somewhat testable.

(Tests are probably failing now)

This is a WIP/RFC/Draft PR, so for now, there's no issues/checklist.


### Manual testing

Clone this branch into your flutter/flutter fork, and ensure that your `flutter` binary is the one coming from your Github checkout.

With the new version of flutter on your box, you'll be able to create a new app normally by using `flutter create`. That should come with the new flutter.js and index.html templates.

In order to get the see any changes you make in your test app that you just created, you'll need to add this to its pubspec.yaml:

```yaml
dependency_overrides:
  flutter_web_plugins:
    path: /usr/local/google/home/dit/github/flutter/packages/flutter_web_plugins
```

And then be pretty nuclear with rebuilding your flutter tool. In my case, I've ended up using:

```
rm -fr web && flutter create . && flutter clean && rm ~/github/flutter/bin/cache/flutter_tools.* && flutter run -d chrome
```

To ensure that changes in every type of file (dependency, template, application...) are applied at once. YMMV here.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
