### PR TITLE
Updated Stateless and Stateful widget docstrings

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -438,9 +438,9 @@ abstract class Widget extends DiagnosticableTree {
 ///  * Use `const` widgets where possible, and provide a `const` constructor for
 ///    the widget so that users of the widget can also do so.
 ///
-///  * When you need to create a reusable piece of UI, prefer using a widget 
-///    rather than a helper method. For example, if you're using a function to 
-///    build a widget, a [State.setState] call would require Flutter to entirely 
+///  * When you need to create a reusable piece of UI, prefer using a widget
+///    rather than a helper method. For example, if you're using a function to
+///    build a widget, a [State.setState] call would require Flutter to entirely
 ///    rebuild the returned wrapping widget. If you used a [Widget] instead,
 ///    Flutter would be able to efficiently re-render only those parts that
 ///    really need to be updated. Furthermore, if the widget you created is
@@ -660,9 +660,9 @@ abstract class StatelessWidget extends Widget {
 ///  * Use `const` widgets where possible. (This is equivalent to caching a
 ///    widget and re-using it.)
 ///
-///  * When you need to create a reusable piece of UI, prefer using a widget 
-///    rather than a helper method. For example, if you're using a function to 
-///    build a widget, a [State.setState] call would require Flutter to entirely 
+///  * When you need to create a reusable piece of UI, prefer using a widget
+///    rather than a helper method. For example, if you're using a function to
+///    build a widget, a [State.setState] call would require Flutter to entirely
 ///    rebuild the returned wrapping widget. If you used a [Widget] instead,
 ///    Flutter would be able to efficiently re-render only those parts that
 ///    really need to be updated. Furthermore, if the widget you created is

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -438,13 +438,13 @@ abstract class Widget extends DiagnosticableTree {
 ///  * Use `const` widgets where possible, and provide a `const` constructor for
 ///    the widget so that users of the widget can also do so.
 ///
-///  * When you need to create a reusable piece of UI, prefer using a widget
-///    rather than a helper method. For example, if you're using a function to
+///  * When trying to create a reusable piece of UI, prefer using a widget
+///    rather than a helper method. For example, if there was a function used to
 ///    build a widget, a [State.setState] call would require Flutter to entirely
-///    rebuild the returned wrapping widget. If you used a [Widget] instead,
+///    rebuild the returned wrapping widget. If a [Widget] was used instead,
 ///    Flutter would be able to efficiently re-render only those parts that
-///    really need to be updated. Furthermore, if the widget you created is
-///    `const`, Flutter would short-circuit most of the rebuild work.
+///    really need to be updated. Even better, if the created widget is `const`,
+///    Flutter would short-circuit most of the rebuild work.
 ///
 ///  * Consider refactoring the stateless widget into a stateful widget so that
 ///    it can use some of the techniques described at [StatefulWidget], such as
@@ -654,19 +654,19 @@ abstract class StatelessWidget extends Widget {
 ///    efficient for a widget to be re-used than for a new (but
 ///    identically-configured) widget to be created. Factoring out the stateful
 ///    part into a widget that takes a child argument is a common way of doing
-///    this. Alternatively, you could create a `final` variable inside the state
-///    and assign to it the widget you want to cache.
+///    this. Another caching strategy consists of assigning a widget to a
+///    `final` state variable which can be used in the build method.
 ///
 ///  * Use `const` widgets where possible. (This is equivalent to caching a
 ///    widget and re-using it.)
 ///
-///  * When you need to create a reusable piece of UI, prefer using a widget
-///    rather than a helper method. For example, if you're using a function to
+///  * When trying to create a reusable piece of UI, prefer using a widget
+///    rather than a helper method. For example, if there was a function used to
 ///    build a widget, a [State.setState] call would require Flutter to entirely
-///    rebuild the returned wrapping widget. If you used a [Widget] instead,
+///    rebuild the returned wrapping widget. If a [Widget] was used instead,
 ///    Flutter would be able to efficiently re-render only those parts that
-///    really need to be updated. Furthermore, if the widget you created is
-///    `const`, Flutter would short-circuit most of the rebuild work.
+///    really need to be updated. Even better, if the created widget is `const`,
+///    Flutter would short-circuit most of the rebuild work.
 ///
 ///  * Avoid changing the depth of any created subtrees or changing the type of
 ///    any widgets in the subtree. For example, rather than returning either the

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -438,6 +438,14 @@ abstract class Widget extends DiagnosticableTree {
 ///  * Use `const` widgets where possible, and provide a `const` constructor for
 ///    the widget so that users of the widget can also do so.
 ///
+///  * When you need to create a reusable piece of UI, prefer using a widget 
+///    rather than a helper method. For example, if you're using a function to 
+///    build a widget, a [State.setState] call would require Flutter to entirely 
+///    rebuild the returned wrapping widget. If you used a [Widget] instead,
+///    Flutter would be able to efficiently re-render only those parts that
+///    really need to be updated. Furthermore, if the widget you created is
+///    `const`, Flutter would short-circuit most of the rebuild work.
+///
 ///  * Consider refactoring the stateless widget into a stateful widget so that
 ///    it can use some of the techniques described at [StatefulWidget], such as
 ///    caching common parts of subtrees and using [GlobalKey]s when changing the
@@ -646,10 +654,19 @@ abstract class StatelessWidget extends Widget {
 ///    efficient for a widget to be re-used than for a new (but
 ///    identically-configured) widget to be created. Factoring out the stateful
 ///    part into a widget that takes a child argument is a common way of doing
-///    this.
+///    this. Alternatively, you could create a `final` variable inside the state
+///    and assign to it the widget you want to cache.
 ///
 ///  * Use `const` widgets where possible. (This is equivalent to caching a
 ///    widget and re-using it.)
+///
+///  * When you need to create a reusable piece of UI, prefer using a widget 
+///    rather than a helper method. For example, if you're using a function to 
+///    build a widget, a [State.setState] call would require Flutter to entirely 
+///    rebuild the returned wrapping widget. If you used a [Widget] instead,
+///    Flutter would be able to efficiently re-render only those parts that
+///    really need to be updated. Furthermore, if the widget you created is
+///    `const`, Flutter would short-circuit most of the rebuild work.
 ///
 ///  * Avoid changing the depth of any created subtrees or changing the type of
 ///    any widgets in the subtree. For example, rather than returning either the


### PR DESCRIPTION
I have updated the [Stateful](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) and [Stateless](https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html) widgets documentations to include a bullet point about preferring widgets over helper methods

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].