### PR TITLE
Correct missing return statements in nullably-typed functions

### DIFF
--- a/examples/api/lib/widgets/actions/action.action_overridable.0.dart
+++ b/examples/api/lib/widgets/actions/action.action_overridable.0.dart
@@ -43,6 +43,7 @@ class DigitInputState extends State<DigitInput> {
     onInvoke: (DeleteCharacterIntent intent) {
       // For simplicity we delete everything in the section.
       widget.controller.clear();
+      return null;
     },
   );
 
@@ -84,7 +85,7 @@ class _DeleteDigit extends Action<DeleteCharacterIntent> {
 
   final _SimpleUSPhoneNumberEntryState state;
   @override
-  Object? invoke(DeleteCharacterIntent intent) {
+  void invoke(DeleteCharacterIntent intent) {
     assert(callingAction != null);
     callingAction?.invoke(intent);
 

--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -273,4 +273,6 @@ String? _validateFlutterDir(String dirPath, { String? flutterRoot }) {
     case FileSystemEntityType.notFound:
       return null;
   }
+  // In the case of any other [FileSystemEntityType]s, like the deprecated ones, return null.
+  return null;
 }


### PR DESCRIPTION
Adds null statements at the end of functions which have implicit `null` returns. These functions all have nullable return types (and not `void`, dynamic`, and upcoming analysis encourages such functions to have explicit returns).

*List which issues are fixed by this PR. You must list at least one issue.* https://github.com/flutter/flutter/issues/94759

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
