### PR TITLE
Fix alignment of matrix for Transform+filterQuality when offset

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2398,8 +2398,10 @@ class RenderTransform extends RenderProxyBox {
           layer = null;
         }
       } else {
+        final Matrix4 effectiveTransform = Matrix4.translationValues(offset.dx, offset.dy, 0.0)
+          ..multiply(transform)..translate(-offset.dx, -offset.dy);
         final ui.ImageFilter filter = ui.ImageFilter.matrix(
-          transform.storage,
+          effectiveTransform.storage,
           filterQuality: filterQuality!,
         );
         if (layer is ImageFilterLayer) {

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -444,11 +444,11 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(extractMatrix(layer.imageFilter), <double>[
-      0.7071067811865476, 0.7071067811865475, 0.0, 0.0,
-      -0.7071067811865475, 0.7071067811865476, 0.0, 0.0,
+    expect(extractMatrix(layer.imageFilter), <dynamic>[
+      moreOrLessEquals(0.7071067811865476), moreOrLessEquals(0.7071067811865475), 0.0, 0.0,
+      moreOrLessEquals(-0.7071067811865475), moreOrLessEquals(0.7071067811865476), 0.0, 0.0,
       0.0, 0.0, 1.0, 0.0,
-      329.28932188134524, -194.97474683058323, 0.0, 1.0]
+      moreOrLessEquals(329.28932188134524), moreOrLessEquals(-194.97474683058329), 0.0, 1.0]
     );
   });
 
@@ -466,11 +466,11 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(extractMatrix(layer.imageFilter), <double>[
-      0.7071067811865476, 0.7071067811865475, 0.0, 0.0,
-      -0.7071067811865475, 0.7071067811865476, 0.0, 0.0,
+    expect(extractMatrix(layer.imageFilter), <dynamic>[
+      moreOrLessEquals(0.7071067811865476), moreOrLessEquals(0.7071067811865475), 0.0, 0.0,
+      moreOrLessEquals(-0.7071067811865475), moreOrLessEquals(0.7071067811865476), 0.0, 0.0,
       0.0, 0.0, 1.0, 0.0,
-      329.28932188134524, -194.97474683058329, 0.0, 1.0]
+      moreOrLessEquals(329.28932188134524), moreOrLessEquals(-194.97474683058329), 0.0, 1.0]
     );
   });
 

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -402,7 +402,7 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
-    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
     expect(layer.imageFilter.toString(),
            'ImageFilter.matrix(['
                '1.0, 0.0, 0.0, 0.0, '
@@ -421,7 +421,7 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
-    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
     expect(layer.imageFilter.toString(),
            'ImageFilter.matrix(['
                '3.14159, 0.0, 0.0, 0.0, '
@@ -440,7 +440,7 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
-    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
     expect(layer.imageFilter.toString(),
            'ImageFilter.matrix(['
                '0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
@@ -463,7 +463,7 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
-    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
     expect(layer.imageFilter.toString(),
         'ImageFilter.matrix([0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
             '-0.7071067811865475, 0.7071067811865476, 0.0, 0.0, '

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -393,6 +393,11 @@ void main() {
     skip: isBrowser, // due to https://github.com/flutter/flutter/issues/49857
   );
 
+  List<double> extractMatrix(ui.ImageFilter? filter) {
+    final List<String> numbers = filter.toString().split('[').last.split(']').first.split(',');
+    return numbers.map<double>((String str) => double.parse(str.trim())).toList();
+  }
+
   testWidgets('Transform.translate with FilterQuality produces filter layer', (WidgetTester tester) async {
     await tester.pumpWidget(
       Transform.translate(
@@ -403,13 +408,12 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(layer.imageFilter.toString(),
-           'ImageFilter.matrix(['
-               '1.0, 0.0, 0.0, 0.0, '
-               '0.0, 1.0, 0.0, 0.0, '
-               '0.0, 0.0, 1.0, 0.0, '
-               '25.0, 25.0, 0.0, 1.0], '
-               'FilterQuality.low)');
+    expect(extractMatrix(layer.imageFilter), <double>[
+      1.0, 0.0, 0.0, 0.0,
+      0.0, 1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      25.0, 25.0, 0.0, 1.0]
+    );
   });
 
   testWidgets('Transform.scale with FilterQuality produces filter layer', (WidgetTester tester) async {
@@ -422,13 +426,12 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(layer.imageFilter.toString(),
-           'ImageFilter.matrix(['
-               '3.14159, 0.0, 0.0, 0.0, '
-               '0.0, 3.14159, 0.0, 0.0, '
-               '0.0, 0.0, 1.0, 0.0, '
-               '-856.636, -642.477, 0.0, 1.0], '
-               'FilterQuality.low)');
+    expect(extractMatrix(layer.imageFilter), <double>[
+      3.14159, 0.0, 0.0, 0.0,
+      0.0, 3.14159, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      -856.636, -642.477, 0.0, 1.0]
+    );
   });
 
   testWidgets('Transform.rotate with FilterQuality produces filter layer', (WidgetTester tester) async {
@@ -441,13 +444,12 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(layer.imageFilter.toString(),
-           'ImageFilter.matrix(['
-               '0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
-               '-0.7071067811865475, 0.7071067811865476, 0.0, 0.0, '
-               '0.0, 0.0, 1.0, 0.0, '
-               '329.28932188134524, -194.97474683058323, 0.0, 1.0], '
-               'FilterQuality.low)');
+    expect(extractMatrix(layer.imageFilter), <double>[
+      0.7071067811865476, 0.7071067811865475, 0.0, 0.0,
+      -0.7071067811865475, 0.7071067811865476, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      329.28932188134524, -194.97474683058323, 0.0, 1.0]
+    );
   });
 
   testWidgets('Offset Transform.rotate with FilterQuality produces filter layer', (WidgetTester tester) async {
@@ -464,12 +466,12 @@ void main() {
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
     final ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
-    expect(layer.imageFilter.toString(),
-        'ImageFilter.matrix([0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
-            '-0.7071067811865475, 0.7071067811865476, 0.0, 0.0, '
-            '0.0, 0.0, 1.0, 0.0, '
-            '329.28932188134524, -194.97474683058329, 0.0, 1.0], '
-            'FilterQuality.low)');
+    expect(extractMatrix(layer.imageFilter), <double>[
+      0.7071067811865476, 0.7071067811865475, 0.0, 0.0,
+      -0.7071067811865475, 0.7071067811865476, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      329.28932188134524, -194.97474683058329, 0.0, 1.0]
+    );
   });
 
   testWidgets('Transform layers update to match child and filterQuality', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -402,6 +402,14 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
+    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    expect(layer.imageFilter.toString(),
+           'ImageFilter.matrix(['
+               '1.0, 0.0, 0.0, 0.0, '
+               '0.0, 1.0, 0.0, 0.0, '
+               '0.0, 0.0, 1.0, 0.0, '
+               '25.0, 25.0, 0.0, 1.0], '
+               'FilterQuality.low)');
   });
 
   testWidgets('Transform.scale with FilterQuality produces filter layer', (WidgetTester tester) async {
@@ -413,6 +421,14 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
+    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    expect(layer.imageFilter.toString(),
+           'ImageFilter.matrix(['
+               '3.14159, 0.0, 0.0, 0.0, '
+               '0.0, 3.14159, 0.0, 0.0, '
+               '0.0, 0.0, 1.0, 0.0, '
+               '-856.636, -642.477, 0.0, 1.0], '
+               'FilterQuality.low)');
   });
 
   testWidgets('Transform.rotate with FilterQuality produces filter layer', (WidgetTester tester) async {
@@ -424,6 +440,36 @@ void main() {
       ),
     );
     expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
+    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    expect(layer.imageFilter.toString(),
+           'ImageFilter.matrix(['
+               '0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
+               '-0.7071067811865475, 0.7071067811865476, 0.0, 0.0, '
+               '0.0, 0.0, 1.0, 0.0, '
+               '329.28932188134524, -194.97474683058323, 0.0, 1.0], '
+               'FilterQuality.low)');
+  });
+
+  testWidgets('Offset Transform.rotate with FilterQuality produces filter layer', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      SizedBox(width: 400, height: 400,
+        child: Center(
+          child: Transform.rotate(
+            angle: math.pi / 4,
+            filterQuality: FilterQuality.low,
+            child: const SizedBox(width: 100, height: 100),
+          ),
+        ),
+      ),
+    );
+    expect(tester.layers.whereType<ImageFilterLayer>().length, 1);
+    ImageFilterLayer layer = tester.layers.whereType<ImageFilterLayer>().first;
+    expect(layer.imageFilter.toString(),
+        'ImageFilter.matrix([0.7071067811865476, 0.7071067811865475, 0.0, 0.0, '
+            '-0.7071067811865475, 0.7071067811865476, 0.0, 0.0, '
+            '0.0, 0.0, 1.0, 0.0, '
+            '329.28932188134524, -194.97474683058329, 0.0, 1.0], '
+            'FilterQuality.low)');
   });
 
   testWidgets('Transform layers update to match child and filterQuality', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/95091

Transform was not taking the offset into account when computing an image filtered transform.