### PR TITLE
Remove unused code from android_device.dart

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -244,7 +244,6 @@ class AndroidDevice extends Device {
 
   AdbLogReader? _logReader;
   AdbLogReader? _pastLogReader;
-  AndroidDevicePortForwarder? _portForwarder;
 
   List<String> adbCommandForDevice(List<String> args) {
     return <String>[_androidSdk.adbPath!, '-s', id, ...args];
@@ -844,7 +843,6 @@ class AndroidDevice extends Device {
   Future<void> dispose() async {
     _logReader?._stop();
     _pastLogReader?._stop();
-    await _portForwarder?.dispose();
   }
 }
 


### PR DESCRIPTION
Left over code during the last null safety migration (https://github.com/flutter/flutter/pull/92128).

cc @jmagman