### PR TITLE
feat(flutter_tools): Added doctor path printing on verbose

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -25,6 +25,7 @@ class UserMessages {
   String engineRevision(String revision) => 'Engine revision $revision';
   String dartRevision(String revision) => 'Dart version $revision';
   String devToolsVersion(String version) => 'DevTools version $version';
+  String userPath(String? path) => 'PATH = $path';
   String pubMirrorURL(String url) => 'Pub download mirror $url';
   String flutterMirrorURL(String url) => 'Flutter download mirror $url';
   String get flutterBinariesDoNotRun =>

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -372,6 +372,11 @@ class Doctor {
       _logger.printStatus('');
     }
 
+    if(verbose) {
+      final String? path = globals.platform.environment['PATH'];
+      _logger.printStatus('🔨 PATH: $path\n');
+    }
+
     if (issues > 0) {
       _logger.printStatus('${showColor ? globals.terminal.color('!', TerminalColor.yellow) : '!'}'
         ' Doctor found issues in $issues categor${issues > 1 ? "ies" : "y"}.', hangingIndent: 2);

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -372,11 +372,6 @@ class Doctor {
       _logger.printStatus('');
     }
 
-    if(verbose) {
-      final String? path = globals.platform.environment['PATH'];
-      _logger.printStatus('🔨 PATH: $path\n');
-    }
-
     if (issues > 0) {
       _logger.printStatus('${showColor ? globals.terminal.color('!', TerminalColor.yellow) : '!'}'
         ' Doctor found issues in $issues categor${issues > 1 ? "ies" : "y"}.', hangingIndent: 2);
@@ -463,6 +458,7 @@ class FlutterValidator extends DoctorValidator {
       messages.add(ValidationMessage(_userMessages.engineRevision(version.engineRevisionShort)));
       messages.add(ValidationMessage(_userMessages.dartRevision(version.dartSdkVersion)));
       messages.add(ValidationMessage(_userMessages.devToolsVersion(_devToolsVersion())));
+      messages.add(ValidationMessage(_userMessages.userPath(_platform.environment['PATH'])));
       final String? pubUrl = _platform.environment['PUB_HOSTED_URL'];
       if (pubUrl != null) {
         messages.add(ValidationMessage(_userMessages.pubMirrorURL(pubUrl)));

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -453,8 +453,14 @@ void main() {
               '    ! Maybe a hint will help the user\n'
               '    • An extra message with some verbose details\n'
               '\n'
+              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
+              '\n'
               '! Doctor found issues in 4 categories.\n'
       ));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform(environment: <String, String>{
+        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
+      }),
     });
   });
 
@@ -530,9 +536,17 @@ void main() {
         '    • An extra message with\n'
         '      some verbose details\n'
         '\n'
+        '🔨 PATH:\n'
+        '/usr/bin:/usr/local/bin:/home/\n'
+        'user/.bin\n'
+        '\n'
         '! Doctor found issues in 4\n'
         '  categories.\n'
     ));
+  }, overrides: <Type, Generator>{
+    Platform: () => FakePlatform(environment: <String, String>{
+      'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
+    }),
   });
 
 
@@ -548,8 +562,14 @@ void main() {
               '    • A helpful message\n'
               '    ✗ A useful error message\n'
               '\n'
+              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
+              '\n'
               '! Doctor found issues in 1 category.\n'
       ));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform(environment: <String, String>{
+        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
+      }),
     });
 
     testUsingContext('validate merging assigns statusInfo and title', () async {
@@ -560,8 +580,14 @@ void main() {
               '    • A helpful message\n'
               '    • A different message\n'
               '\n'
+              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
+              '\n'
               '• No issues found!\n'
       ));
+    }, overrides: <Type, Generator>{
+      Platform: () => FakePlatform(environment: <String, String>{
+        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
+      }),
     });
   });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -453,14 +453,8 @@ void main() {
               '    ! Maybe a hint will help the user\n'
               '    • An extra message with some verbose details\n'
               '\n'
-              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
-              '\n'
               '! Doctor found issues in 4 categories.\n'
       ));
-    }, overrides: <Type, Generator>{
-      Platform: () => FakePlatform(environment: <String, String>{
-        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
-      }),
     });
   });
 
@@ -536,17 +530,9 @@ void main() {
         '    • An extra message with\n'
         '      some verbose details\n'
         '\n'
-        '🔨 PATH:\n'
-        '/usr/bin:/usr/local/bin:/home/\n'
-        'user/.bin\n'
-        '\n'
         '! Doctor found issues in 4\n'
         '  categories.\n'
     ));
-  }, overrides: <Type, Generator>{
-    Platform: () => FakePlatform(environment: <String, String>{
-      'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
-    }),
   });
 
 
@@ -562,14 +548,8 @@ void main() {
               '    • A helpful message\n'
               '    ✗ A useful error message\n'
               '\n'
-              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
-              '\n'
               '! Doctor found issues in 1 category.\n'
       ));
-    }, overrides: <Type, Generator>{
-      Platform: () => FakePlatform(environment: <String, String>{
-        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
-      }),
     });
 
     testUsingContext('validate merging assigns statusInfo and title', () async {
@@ -580,14 +560,8 @@ void main() {
               '    • A helpful message\n'
               '    • A different message\n'
               '\n'
-              '🔨 PATH: /usr/bin:/usr/local/bin:/home/user/.bin\n'
-              '\n'
               '• No issues found!\n'
       ));
-    }, overrides: <Type, Generator>{
-      Platform: () => FakePlatform(environment: <String, String>{
-        'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
-      }),
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -188,6 +188,31 @@ void main() {
     ));
   });
 
+  testWithoutContext('FlutterValidator shows PATH environment variable when set', () async {
+    final FlutterValidator flutterValidator = FlutterValidator(
+      platform: FakePlatform(
+        localeName: 'en_US.UTF-8',
+        environment: <String, String> {
+          'PATH': '/usr/bin:/usr/local/bin:/home/user/.bin',
+        },
+      ),
+      flutterVersion: () => FakeFlutterVersion(frameworkVersion: '1.0.0'),
+      devToolsVersion: () => '2.8.0',
+      userMessages: UserMessages(),
+      artifacts: Artifacts.test(),
+      fileSystem: MemoryFileSystem.test(),
+      processManager: FakeProcessManager.any(),
+      operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
+      flutterRoot: () => 'sdk/flutter',
+    );
+
+    expect(await flutterValidator.validate(), _matchDoctorValidation(
+      validationType: ValidationType.installed,
+      statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
+      messages: contains(const ValidationMessage('PATH = /usr/bin:/usr/local/bin:/home/user/.bin')),
+    ));
+  });
+
   group('FlutterValidator shows flutter upstream remote', () {
     testWithoutContext('default url', () async {
       final FlutterValidator flutterValidator = FlutterValidator(


### PR DESCRIPTION
Hi,

This PR adds printing of environment PATH as part of doctor verbose just above the issue count to aid in triage as per issue.

*List which issues are fixed by this PR. You must list at least one issue.*
[83727](https://github.com/flutter/flutter/issues/83727)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
