### PR TITLE
Improve `intrinsic sizing` , `dryLayout` and `performLayout` in the `RenderFlex` if `crossAxisAlignment` is baseline.

### DIFF
--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -508,7 +508,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       child.parentData = FlexParentData();
   }
 
-  bool get _canComputeIntrinsics => crossAxisAlignment != CrossAxisAlignment.baseline;
+  bool get _canComputeIntrinsics => crossAxisAlignment != CrossAxisAlignment.baseline || direction == Axis.vertical;
 
   double _getIntrinsicSize({
     required Axis sizingDirection,

--- a/packages/flutter/lib/src/rendering/flex.dart
+++ b/packages/flutter/lib/src/rendering/flex.dart
@@ -937,7 +937,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     double actualSize = sizes.mainSize;
     double crossSize = sizes.crossSize;
     double maxBaselineDistance = 0.0;
-    if (crossAxisAlignment == CrossAxisAlignment.baseline) {
+    if (crossAxisAlignment == CrossAxisAlignment.baseline && direction == Axis.horizontal) {
       RenderBox? child = firstChild;
       double maxSizeAboveBaseline = 0;
       double maxSizeBelowBaseline = 0;


### PR DESCRIPTION
This PR fixes #95400 and #95398.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.




