### PR TITLE
feat(flutter_tools): Changed NoIdeValidator validation type from error to warning

### DIFF
--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -285,7 +285,7 @@ class NoIdeValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     return ValidationResult(
-      ValidationType.missing,
+      ValidationType.notAvailable,
       globals.userMessages.noIdeInstallationInfo.map((String ideInfo) => ValidationMessage(ideInfo)).toList(),
       statusInfo: globals.userMessages.noIdeStatusInfo,
     );

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -285,6 +285,7 @@ class NoIdeValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     return ValidationResult(
+      // Info hint to user they do not have a supported IDE installed
       ValidationType.notAvailable,
       globals.userMessages.noIdeInstallationInfo.map((String ideInfo) => ValidationMessage(ideInfo)).toList(),
       statusInfo: globals.userMessages.noIdeStatusInfo,

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -88,7 +88,7 @@ void main() {
 
     testUsingContext('No IDE Validator includes expected installation messages', () async {
       final ValidationResult result = await NoIdeValidator().validate();
-      expect(result.type, ValidationType.missing);
+      expect(result.type, ValidationType.notAvailable);
 
       expect(
         result.messages.map((ValidationMessage vm) => vm.message),


### PR DESCRIPTION
Hi,

This PR changes the NoIdeValidator ValidationType to `notAvailable` to avoid confusing newcomers to flutter. 

*List which issues are fixed by this PR. You must list at least one issue.*
[78098](https://github.com/flutter/flutter/issues/78098)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
