### PR TITLE
Cannot be empty

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -339,7 +339,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
   }
 
   @override
-  ValueChanged<bool?>? get onChanged => widget.onChanged;
+  ValueChanged<bool> get onChanged => widget.onChanged;
 
   @override
   bool get tristate => widget.tristate;


### PR DESCRIPTION
*because it only generates a boolean value when triggered (onChanged)*