### PR TITLE
Add "padding" parameter to the Scrollbar widget

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -129,7 +129,7 @@ class CupertinoScrollbar extends RawScrollbar {
   /// dragging the scrollbar.
   final Radius radiusWhileDragging;
   
-  /// The amount of space by which to inset the child.
+  /// The amount of space by which to inset the [child].
   final EdgeInsets? padding;
 
   @override

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -98,6 +98,7 @@ class CupertinoScrollbar extends RawScrollbar {
          pressDuration: const Duration(milliseconds: 100),
          notificationPredicate: notificationPredicate ?? defaultScrollNotificationPredicate,
          scrollbarOrientation: scrollbarOrientation,
+         padding: padding,
        );
 
   /// Default value for [thickness] if it's not specified in [CupertinoScrollbar].

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -79,6 +79,7 @@ class CupertinoScrollbar extends RawScrollbar {
     this.radiusWhileDragging = defaultRadiusWhileDragging,
     ScrollNotificationPredicate? notificationPredicate,
     ScrollbarOrientation? scrollbarOrientation,
+    this.padding,
   }) : assert(thickness != null),
        assert(thickness < double.infinity),
        assert(thicknessWhileDragging != null),
@@ -127,6 +128,9 @@ class CupertinoScrollbar extends RawScrollbar {
   /// from [radius] to this value, then animate back when the user stops
   /// dragging the scrollbar.
   final Radius radiusWhileDragging;
+  
+  /// The amount of space by which to inset the child.
+  final EdgeInsets? padding;
 
   @override
   RawScrollbarState<CupertinoScrollbar> createState() => _CupertinoScrollbarState();
@@ -164,7 +168,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
       ..mainAxisMargin = _kScrollbarMainAxisMargin
       ..crossAxisMargin = _kScrollbarCrossAxisMargin
       ..radius = _radius
-      ..padding = MediaQuery.of(context).padding
+      ..padding = widget.padding ?? MediaQuery.of(context).padding
       ..minLength = _kScrollbarMinLength
       ..minOverscrollLength = _kScrollbarMinOverscrollLength
       ..scrollbarOrientation = widget.scrollbarOrientation;

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -98,7 +98,6 @@ class CupertinoScrollbar extends RawScrollbar {
          pressDuration: const Duration(milliseconds: 100),
          notificationPredicate: notificationPredicate ?? defaultScrollNotificationPredicate,
          scrollbarOrientation: scrollbarOrientation,
-         padding: padding,
        );
 
   /// Default value for [thickness] if it's not specified in [CupertinoScrollbar].

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -128,7 +128,7 @@ class CupertinoScrollbar extends RawScrollbar {
   /// from [radius] to this value, then animate back when the user stops
   /// dragging the scrollbar.
   final Radius radiusWhileDragging;
-  
+
   /// The amount of space by which to inset the [child].
   final EdgeInsets? padding;
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -85,6 +85,7 @@ class Scrollbar extends StatelessWidget {
     this.notificationPredicate,
     this.interactive,
     this.scrollbarOrientation,
+    this.padding,
   }) : super(key: key);
 
   /// {@macro flutter.widgets.Scrollbar.child}

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -150,7 +150,7 @@ class Scrollbar extends StatelessWidget {
 
   /// {@macro flutter.widgets.Scrollbar.scrollbarOrientation}
   final ScrollbarOrientation? scrollbarOrientation;
-  
+
   /// The amount of space by which to inset the [child].
   final EdgeInsets? padding;
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -150,6 +150,9 @@ class Scrollbar extends StatelessWidget {
 
   /// {@macro flutter.widgets.Scrollbar.scrollbarOrientation}
   final ScrollbarOrientation? scrollbarOrientation;
+  
+  /// The amount of space by which to inset the [child].
+  final EdgeInsets? padding;
 
   @override
   Widget build(BuildContext context) {
@@ -163,6 +166,7 @@ class Scrollbar extends StatelessWidget {
         controller: controller,
         notificationPredicate: notificationPredicate,
         scrollbarOrientation: scrollbarOrientation,
+        padding: padding,
         child: child,
       );
     }
@@ -177,6 +181,7 @@ class Scrollbar extends StatelessWidget {
       notificationPredicate: notificationPredicate,
       interactive: interactive,
       scrollbarOrientation: scrollbarOrientation,
+      padding: padding,
       child: child,
     );
   }
@@ -196,6 +201,7 @@ class _MaterialScrollbar extends RawScrollbar {
     ScrollNotificationPredicate? notificationPredicate,
     bool? interactive,
     ScrollbarOrientation? scrollbarOrientation,
+    this.padding,
   }) : super(
          key: key,
          child: child,
@@ -214,6 +220,7 @@ class _MaterialScrollbar extends RawScrollbar {
   final bool? trackVisibility;
   final bool? showTrackOnHover;
   final double? hoverThickness;
+  final EdgeInsets? padding;
 
   @override
   _MaterialScrollbarState createState() => _MaterialScrollbarState();
@@ -373,7 +380,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
       ..crossAxisMargin = _scrollbarTheme.crossAxisMargin ?? (_useAndroidScrollbar ? 0.0 : _kScrollbarMargin)
       ..mainAxisMargin = _scrollbarTheme.mainAxisMargin ?? 0.0
       ..minLength = _scrollbarTheme.minThumbLength ?? _kScrollbarMinLength
-      ..padding = MediaQuery.of(context).padding
+      ..padding = widget.padding ?? MediaQuery.of(context).padding
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..ignorePointer = !enableGestures;
   }


### PR DESCRIPTION
In the current implementation `Scrollbar` widget hardcodes padding value by assigning `MediaQuery.of(context).padding` to it under the hood. This PR adds custom `padding` parameter, which allows to easily override it. 

Providing custom padding to the Scrollbar could be useful in cases where Scrollbar undesirably overlaps content at the top or at the bottom of the scrolling view. The common case of this issue is having `CustomSrollView` with `SliverAppBar` as a child, wrapped in the Scrollbar:

```
Scrollbar(
   child: CustomScrollView(
     slivers: [
         SliverAppBar(
            expandedHeight: 200,
            ...
```

In this use case, there's currently no way to prevent scrollbar from overlapping `SliverAppBar`. And with custom `padding` param, it could be resolved like this:

```
Scrollbar(
   padding: const EdgeInsets.only(top: 200),
   child: CustomScrollView(
     slivers: [
         SliverAppBar(
            expandedHeight: 200,
            ...
```

This PR is intended to provide a workaround for https://github.com/flutter/flutter/issues/13253 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
