### PR TITLE
Pass autofillHints value to EditableText

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1217,6 +1217,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
       child: UnmanagedRestorationScope(
         bucket: bucket,
         child: EditableText(
+          autofillHints: widget.autofillHints,
           key: editableTextKey,
           readOnly: widget.readOnly || !_isEnabled,
           toolbarOptions: widget.toolbarOptions,


### PR DESCRIPTION
Hi,

Currently, autofillHint property of TextFormField is not working because its value is not propagated down the widget tree.
This PR passes the autofillHints value to the EditableText within the RepaintBoundary widget.
This solves the #95522

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
