### PR TITLE
Call image stream listeners asynchronously if added asynchronously

### DIFF
--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -492,7 +492,6 @@ abstract class ImageStreamCompleter with Diagnosticable {
   bool _hadAtLeastOneListener = false;
 
   /// Whether the future listeners added to this completer are initial listeners.
-  ///
   /// This can be set to true when an [ImageStream] adds its initial listeners to this completer.
   /// This ultimately controls the synchronousCall parameter for the listener callbacks.
   /// When adding cached listeners to a completer, [_addingInitialListeners] can be

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -340,9 +340,9 @@ class ImageStream with Diagnosticable {
     if (_listeners != null) {
       final List<ImageStreamListener> initialListeners = _listeners!;
       _listeners = null;
-      _completer!._addingInitialListeners = false;
-      initialListeners.forEach(_completer!.addListener);
       _completer!._addingInitialListeners = true;
+      initialListeners.forEach(_completer!.addListener);
+      _completer!._addingInitialListeners = false;
     }
   }
 
@@ -498,7 +498,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// the listener callbacks. When adding cached listeners to a completer,
   /// [_addingInitialListeners] can be set to false to indicate to the listeners
   /// that they are being called asynchronously.
-  bool _addingInitialListeners = true;
+  bool _addingInitialListeners = false;
 
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]
   /// object is available or an error is reported. If a concrete image is
@@ -515,7 +515,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     _listeners.add(listener);
     if (_currentImage != null) {
       try {
-        listener.onImage(_currentImage!.clone(), _addingInitialListeners);
+        listener.onImage(_currentImage!.clone(), !_addingInitialListeners);
       } catch (exception, stack) {
         reportError(
           context: ErrorDescription('by a synchronously-called image listener'),

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -492,10 +492,12 @@ abstract class ImageStreamCompleter with Diagnosticable {
   bool _hadAtLeastOneListener = false;
 
   /// Whether the future listeners added to this completer are initial listeners.
-  /// This can be set to true when an [ImageStream] adds its initial listeners to this completer.
-  /// This ultimately controls the synchronousCall parameter for the listener callbacks.
-  /// When adding cached listeners to a completer, [_addingInitialListeners] can be
-  /// set to false to indicate to the listeners that they are being called asynchronously.
+  ///
+  /// This can be set to true when an [ImageStream] adds its initial listeners to
+  /// this completer. This ultimately controls the synchronousCall parameter for
+  /// the listener callbacks. When adding cached listeners to a completer,
+  /// [_addingInitialListeners] can be set to false to indicate to the listeners
+  /// that they are being called asynchronously.
   bool _addingInitialListeners = true;
 
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -495,7 +495,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
   ///
   /// This can be set to true when an [ImageStream] adds its initial listeners to this completer.
   /// This ultimately controls the synchronousCall parameter for the listener callbacks.
-  /// When adding cached listeners to a completer, [_addingInitialListeners] can be 
+  /// When adding cached listeners to a completer, [_addingInitialListeners] can be
   /// set to false to indicate to the listeners that they are being called asynchronously.
   bool _addingInitialListeners = true;
 

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -340,9 +340,9 @@ class ImageStream with Diagnosticable {
     if (_listeners != null) {
       final List<ImageStreamListener> initialListeners = _listeners!;
       _listeners = null;
-      _completer!._hasInitialListeners = false;
+      _completer!._addingInitialListeners = false;
       initialListeners.forEach(_completer!.addListener);
-      _completer!._hasInitialListeners = true;
+      _completer!._addingInitialListeners = true;
     }
   }
 
@@ -491,12 +491,13 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// if all [keepAlive] handles get disposed.
   bool _hadAtLeastOneListener = false;
 
-  /// Whether the listeners were added before a completer was attached
+  /// Whether the future listeners added to this completer are initial listeners.
   ///
-  /// This ultimately controls the synchronousCall parameter on the listeners.
-  /// When adding cached listeners after a completer was attached, [_hasInitialListeners] can 
-  /// be set to false to indicate to the listeners that they are being called asynchronously.
-  bool _hasInitialListeners = true;
+  /// This can be set to true when an [ImageStream] adds its initial listeners to this completer.
+  /// This ultimately controls the synchronousCall parameter for the listener callbacks.
+  /// When adding cached listeners to a completer, [_addingInitialListeners] can be 
+  /// set to false to indicate to the listeners that they are being called asynchronously.
+  bool _addingInitialListeners = true;
 
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]
   /// object is available or an error is reported. If a concrete image is
@@ -513,7 +514,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     _listeners.add(listener);
     if (_currentImage != null) {
       try {
-        listener.onImage(_currentImage!.clone(), _hasInitialListeners);
+        listener.onImage(_currentImage!.clone(), _addingInitialListeners);
       } catch (exception, stack) {
         reportError(
           context: ErrorDescription('by a synchronously-called image listener'),

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -340,7 +340,9 @@ class ImageStream with Diagnosticable {
     if (_listeners != null) {
       final List<ImageStreamListener> initialListeners = _listeners!;
       _listeners = null;
+      _completer!.synchronousCall = false;
       initialListeners.forEach(_completer!.addListener);
+      _completer!.synchronousCall = true;
     }
   }
 
@@ -489,6 +491,9 @@ abstract class ImageStreamCompleter with Diagnosticable {
   /// if all [keepAlive] handles get disposed.
   bool _hadAtLeastOneListener = false;
 
+  /// Whether the listeners should be called synchronously
+  bool synchronousCall = true;
+
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]
   /// object is available or an error is reported. If a concrete image is
   /// already available, or if an error has been already reported, this object
@@ -504,7 +509,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     _listeners.add(listener);
     if (_currentImage != null) {
       try {
-        listener.onImage(_currentImage!.clone(), true);
+        listener.onImage(_currentImage!.clone(), synchronousCall);
       } catch (exception, stack) {
         reportError(
           context: ErrorDescription('by a synchronously-called image listener'),

--- a/packages/flutter/lib/src/painting/image_stream.dart
+++ b/packages/flutter/lib/src/painting/image_stream.dart
@@ -340,9 +340,9 @@ class ImageStream with Diagnosticable {
     if (_listeners != null) {
       final List<ImageStreamListener> initialListeners = _listeners!;
       _listeners = null;
-      _completer!.synchronousCall = false;
+      _completer!._synchronousCall = false;
       initialListeners.forEach(_completer!.addListener);
-      _completer!.synchronousCall = true;
+      _completer!._synchronousCall = true;
     }
   }
 
@@ -492,7 +492,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
   bool _hadAtLeastOneListener = false;
 
   /// Whether the listeners should be called synchronously
-  bool synchronousCall = true;
+  bool _synchronousCall = true;
 
   /// Adds a listener callback that is called whenever a new concrete [ImageInfo]
   /// object is available or an error is reported. If a concrete image is
@@ -509,7 +509,7 @@ abstract class ImageStreamCompleter with Diagnosticable {
     _listeners.add(listener);
     if (_currentImage != null) {
       try {
-        listener.onImage(_currentImage!.clone(), synchronousCall);
+        listener.onImage(_currentImage!.clone(), _synchronousCall);
       } catch (exception, stack) {
         reportError(
           context: ErrorDescription('by a synchronously-called image listener'),

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -861,12 +861,10 @@ void main() {
 
   test('ImageStream, setCompleter before addListener - synchronousCall should be true', () async {
     final Image image = await createTestImage(width: 100, height: 100);
-    final SynchronousTestImageProvider imageProvider = SynchronousTestImageProvider(image);
-    const ImageConfiguration imageConfiguration = ImageConfiguration(size: Size(100.0, 100.0));
     final OneFrameImageStreamCompleter imageStreamCompleter =
-        OneFrameImageStreamCompleter(SynchronousFuture<ImageInfo>(TestImageInfo(await imageProvider.obtainKey(imageConfiguration), image: image)));
+        OneFrameImageStreamCompleter(SynchronousFuture<ImageInfo>(TestImageInfo(1, image: image)));
 
-    final ImageStream imageStream = imageProvider.createStream(imageConfiguration);
+    final ImageStream imageStream = ImageStream();
     imageStream.setCompleter(imageStreamCompleter);
 
     bool? synchronouslyCalled;
@@ -879,12 +877,10 @@ void main() {
 
   test('ImageStream, setCompleter after addListener - synchronousCall should be false', () async {
     final Image image = await createTestImage(width: 100, height: 100);
-    final SynchronousTestImageProvider imageProvider = SynchronousTestImageProvider(image);
-    const ImageConfiguration imageConfiguration = ImageConfiguration(size: Size(100.0, 100.0));
     final OneFrameImageStreamCompleter imageStreamCompleter =
-        OneFrameImageStreamCompleter(SynchronousFuture<ImageInfo>(TestImageInfo(await imageProvider.obtainKey(imageConfiguration), image: image)));
+        OneFrameImageStreamCompleter(SynchronousFuture<ImageInfo>(TestImageInfo(1, image: image)));
 
-    final ImageStream imageStream = imageProvider.createStream(imageConfiguration);
+    final ImageStream imageStream = ImageStream();
 
     bool? synchronouslyCalled;
     imageStream.addListener(ImageStreamListener((ImageInfo image, bool synchronousCall) {

--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/scheduler.dart' show timeDilation, SchedulerBinding;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../image_data.dart';
-import 'decoration_test.dart';
 import 'fake_codec.dart';
 import 'mocks_for_image_cache.dart';
 
@@ -77,6 +76,24 @@ class FakeEventReportingImageStreamCompleter extends ImageStreamCompleter {
         },
       );
     }
+  }
+}
+
+class SynchronousTestImageProvider extends ImageProvider<int> {
+  const SynchronousTestImageProvider(this.image);
+
+  final Image image;
+
+  @override
+  Future<int> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<int>(1);
+  }
+
+  @override
+  ImageStreamCompleter load(int key, DecoderCallback decode) {
+    return OneFrameImageStreamCompleter(
+      SynchronousFuture<ImageInfo>(TestImageInfo(key, image: image)),
+    );
   }
 }
 


### PR DESCRIPTION
Image stream listeners are not called with the `synchronousCall` parameter set to false when added to the image stream without a completer attached. This means that the `_onChanged` method inside `DecorationImagePainter._handleImage` is not getting called in asynchronous scenarios and the image is not being painted when ready.

The PR fixes the following scenario: #95372 

To quote my comment from the issue: 

> This issue is caused by the fact that, after putting the App into the background, the AssetManifest.json is reloaded. It needs to be loaded and parsed before we can access the asset bundle and find the corresponding image. This delays the loading of the image in such a way that the image stream listeners do not get called synchronously. Without putting the app into the background, the manifest does not need to be loaded and parsed again, because it is cached. This means that the image stream listeners get called synchronously and the image is ready during the same paint call just before its about to be painted. When calling the image stream listeners asynchronously, the image is not ready during the same paint and needs to be painted later. In this case, the _onChanged callback (markNeedsPaint) that is called inside the DecorationImagePainter._handleImage image stream listener is not called because synchronousCall is incorrectly set to true.

When called asynchronously, the image stream listener will get attached to the image stream _before_ a completer is attached. In this case, the listeners will get cached and executed as soon as a completer is attached. 

This PR will execute these listeners with the `synchronousCall` parameter set to false when they were cached and setCompleter was called after adding listeners to the stream.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
