### PR TITLE
Improve iOS fidelity of `barrierColor`s and edge decorations for full-screen Cupertino page transitions

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -25,6 +25,17 @@ const int _kMaxDroppedSwipePageForwardAnimationTime = 800; // Milliseconds.
 // user releases a page mid swipe.
 const int _kMaxPageBackAnimationTime = 300; // Milliseconds.
 
+/// Barrier color used for a barrier visible during transitions for Cupertino
+/// page routes. This barrier color is only used for full-screen page routes with
+/// `fullscreenDialog: false`.
+///
+/// By default, `fullScreenDialog` Cupertino route transitions have no
+/// `barrierColor`, and [CupertinoDialogRoute]s and [CupertinoModalPopupRoute]s
+/// have a `barrierColor` defined by [kCupertinoModalBarrierColor].
+///
+/// A relatively rigorous eyeball estimation.
+const Color _kCupertinoPageTransitionBarrierColor = Color(0x18000000);
+
 /// Barrier color for a Cupertino modal barrier.
 ///
 /// Extracted from https://developer.apple.com/design/resources/.
@@ -126,7 +137,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   Duration get transitionDuration => const Duration(milliseconds: 400);
 
   @override
-  Color? get barrierColor => null;
+  Color? get barrierColor => fullscreenDialog ? null : _kCupertinoPageTransitionBarrierColor;
 
   @override
   String? get barrierLabel => null;
@@ -791,9 +802,8 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
     end: const _CupertinoEdgeShadowDecoration._(
       // Eyeballed gradient used to mimic a drop shadow on the start side only.
       <Color>[
-        Color(0x38000000),
-        Color(0x12000000),
         Color(0x04000000),
+        Color(0x02000000),
         Color(0x00000000),
       ],
     ),

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -26,7 +26,9 @@ const int _kMaxDroppedSwipePageForwardAnimationTime = 800; // Milliseconds.
 const int _kMaxPageBackAnimationTime = 300; // Milliseconds.
 
 /// Barrier color used for a barrier visible during transitions for Cupertino
-/// page routes. This barrier color is only used for full-screen page routes with
+/// page routes.
+///
+/// This barrier color is only used for full-screen page routes with
 /// `fullscreenDialog: false`.
 ///
 /// By default, `fullScreenDialog` Cupertino route transitions have no
@@ -803,7 +805,6 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
       // Eyeballed gradient used to mimic a drop shadow on the start side only.
       <Color>[
         Color(0x04000000),
-        Color(0x02000000),
         Color(0x00000000),
       ],
     ),

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -31,7 +31,7 @@ const int _kMaxPageBackAnimationTime = 300; // Milliseconds.
 /// This barrier color is only used for full-screen page routes with
 /// `fullscreenDialog: false`.
 ///
-/// By default, `fullScreenDialog` Cupertino route transitions have no
+/// By default, `fullscreenDialog` Cupertino route transitions have no
 /// `barrierColor`, and [CupertinoDialogRoute]s and [CupertinoModalPopupRoute]s
 /// have a `barrierColor` defined by [kCupertinoModalBarrierColor].
 ///

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -973,6 +974,111 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, isNull);
+    });
+
+    testWidgets('when route is not fullscreenDialog, it has a _CupertinoEdgeShadowDecoration', (WidgetTester tester) async {
+      PaintPattern paintsShadowRect({required double dx, required Color color}) {
+        return paints..something((Symbol methodName, List<dynamic> arguments) {
+          if (methodName != #drawRect)
+            return false;
+          final Rect rect = arguments[0] as Rect;
+          final Color paintColor = (arguments[1] as Paint).color;
+          if (rect.top != 0 || rect.width != 1.0 || rect.height != 600)
+            return false; // Skip rects that aren't 1px-wide shadows
+          return ((rect.left - dx).abs() < 1) && (paintColor.value == color.value);
+        });
+      }
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox.expand(),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        buildRoute(fullscreenDialog: false),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1));
+
+      final RenderBox box = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+
+      // Animation starts with effectively no shadow
+      expect(box, paintsShadowRect(dx: 795, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 785, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 775, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 765, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 755, color: const Color(0x00000000)));
+
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Part-way through the transition, the shadow is approaching the full gradient
+      expect(box, paintsShadowRect(dx: 296, color: const Color(0x03000000)));
+      expect(box, paintsShadowRect(dx: 286, color: const Color(0x02000000)));
+      expect(box, paintsShadowRect(dx: 276, color: const Color(0x01000000)));
+      expect(box, paintsShadowRect(dx: 266, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 266, color: const Color(0x00000000)));
+
+      await tester.pumpAndSettle();
+
+      // At the end of the transition, the shadow is a gradient between
+      // 0x04000000 and 0x00000000 and is now offscreen
+      expect(box, paintsShadowRect(dx: -1, color: const Color(0x04000000)));
+      expect(box, paintsShadowRect(dx: -10, color: const Color(0x03000000)));
+      expect(box, paintsShadowRect(dx: -20, color: const Color(0x02000000)));
+      expect(box, paintsShadowRect(dx: -30, color: const Color(0x01000000)));
+      expect(box, paintsShadowRect(dx: -40, color: const Color(0x00000000)));
+
+      // Start animation in reverse
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(box, paintsShadowRect(dx: 498, color: const Color(0x04000000)));
+      expect(box, paintsShadowRect(dx: 488, color: const Color(0x03000000)));
+      expect(box, paintsShadowRect(dx: 478, color: const Color(0x02000000)));
+      expect(box, paintsShadowRect(dx: 468, color: const Color(0x01000000)));
+      expect(box, paintsShadowRect(dx: 458, color: const Color(0x00000000)));
+
+      await tester.pump(const Duration(milliseconds: 250));
+
+      // At the end of the animation, the shadow approaches full transparency
+      expect(box, paintsShadowRect(dx: 794, color: const Color(0x01000000)));
+      expect(box, paintsShadowRect(dx: 784, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 774, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 764, color: const Color(0x00000000)));
+      expect(box, paintsShadowRect(dx: 754, color: const Color(0x00000000)));
+    });
+
+    testWidgets('when route is fullScreenDialog, it has no visible _CupertinoEdgeShadowDecoration', (WidgetTester tester) async {
+      PaintPattern paintsNoShadows() {
+        return paints..everything((Symbol methodName, List<dynamic> arguments) {
+          if (methodName != #drawRect)
+            return true;
+          final Rect rect = arguments[0] as Rect;
+          return rect.width != 1.0; // No 1-px shadow rects are drawn
+        });
+      }
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox.expand(),
+        ),
+      );
+
+      final RenderBox box = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        buildRoute(fullscreenDialog: true),
+      );
+
+      await tester.pumpAndSettle();
+      expect(box, paintsNoShadows());
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+
+      await tester.pumpAndSettle();
+      expect(box, paintsNoShadows());
     });
   });
 

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1069,8 +1069,14 @@ void main() {
             return true;
           final Rect rect = arguments[0] as Rect;
           // _CupertinoEdgeShadowDecoration draws the shadows with a series of
-          // differently colored 1px rects. Verify that no 1px rects are drawn.
-          return rect.width != 1.0;
+          // differently colored 1px rects. Skip all rects not drawn by a
+          // _CupertinoEdgeShadowDecoration.
+          if (rect.width != 1.0)
+            return true;
+          throw '''
+    Expected: no rects with a width of 1px.
+          Found: $rect.
+          ''';
         });
       }
 

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -937,6 +937,45 @@ void main() {
     );
   });
 
+  group('Cupertino page transitions', () {
+    CupertinoPageRoute<void> buildRoute({required bool fullscreenDialog}) {
+      return CupertinoPageRoute<void>(
+        fullscreenDialog: fullscreenDialog,
+        builder: (_) => const SizedBox(),
+      );
+    }
+
+    testWidgets('when route is not fullScreenDialog, it has a barrierColor', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox.expand(),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        buildRoute(fullscreenDialog: false),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, const Color(0x18000000));
+    });
+
+    testWidgets('when route is a fullScreenDialog, it has no barrierColor', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox.expand(),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        buildRoute(fullscreenDialog: true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, isNull);
+    });
+  });
+
   testWidgets('ModalPopup overlay dark mode', (WidgetTester tester) async {
     late StateSetter stateSetter;
     Brightness brightness = Brightness.light;


### PR DESCRIPTION
This PR improves the fidelity of Cupertino page transitions to the animations used in native iOS, by:
- Adding the correct `barrierColor` to any `PageRoute` mixing in the `CupertinoRouteTransitionMixin` that is not a `fullscreenDialog`, and
- Softening the gradient used on the starting edge of the `_CupertinoEdgeShadowDecoration`

The color values used here are those that were initially suggested by @weakvar in #95511 (not sure quite how they came up with them), although I did take some time to do some pixel-by-pixel comparisons, and they seem to be correct.

This PR fixes https://github.com/flutter/flutter/issues/95511.

## Recordings (slowed down for ease of observation):

<details><summary>Before</summary>

### Native iOS

https://user-images.githubusercontent.com/7915388/146699339-ed941b88-8478-454c-acbe-42e228681420.mov

### Flutter

https://user-images.githubusercontent.com/7915388/146699574-766167e7-94f7-4b3e-94b8-f970944b3c26.mov

</details>

<details><summary>After:</summary>

### Native iOS

https://user-images.githubusercontent.com/7915388/146699339-ed941b88-8478-454c-acbe-42e228681420.mov

### Flutter

https://user-images.githubusercontent.com/7915388/146699537-b26956ae-4938-4242-a11d-d8e606a33e4b.mov

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. 
(waiting for them to actually pass here, but they all looked good on the branch)