### PR TITLE
Fix showSearch not showing Toolbar on empty text

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -263,7 +263,9 @@ abstract class SearchDelegate<T> {
   set query(String value) {
     assert(query != null);
     _queryTextController.text = value;
-    _queryTextController.selection = TextSelection.fromPosition(TextPosition(offset: _queryTextController.text.length));
+    if (value.isNotEmpty) {
+      _queryTextController.selection = TextSelection.fromPosition(TextPosition(offset: _queryTextController.text.length));
+    }
   }
 
   /// Transition from the suggestions returned by [buildSuggestions] to the

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -46,6 +46,22 @@ void main() {
     );
   });
 
+  testWidgets('Double tapping empty TextField opens the Toolbar', (WidgetTester tester) async {
+    final _TestSearchDelegate delegate = _TestSearchDelegate();
+
+    await tester.pumpWidget(TestHomePage(delegate: delegate));
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Double tap shows the Toolbar.
+    expect(find.text('Paste'), findsNothing);
+    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(find.text('Paste'), findsOneWidget);
+  });
+
   testWidgets('Can open and close search', (WidgetTester tester) async {
     final _TestSearchDelegate delegate = _TestSearchDelegate();
     final List<String> selectedResults = <String>[];


### PR DESCRIPTION
Changes the setter of `query` in `SearchDelegate` to only be called when the text is not empty. While initialization the setter gets called with an empty value and the corresponding `TextSelection` change prevents the `Toolbar` to show up properly on double tap.

Fixes issue https://github.com/flutter/flutter/issues/95588

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
