### PR TITLE
Allow Clip.none as a valid clipBehavior

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1300,18 +1300,18 @@ class ClipRectLayer extends ContainerLayer {
   /// The [clipRect] argument must not be null before the compositing phase of
   /// the pipeline.
   ///
-  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
-  /// [Clip.none], no clipping will be applied.
+  /// The [clipBehavior] argument must not be null, and must not be [Clip.none].
   ClipRectLayer({
     Rect? clipRect,
     Clip clipBehavior = Clip.hardEdge,
   }) : _clipRect = clipRect,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null);
+       assert(clipBehavior != null),
+       assert(clipBehavior != Clip.none);
 
   /// The rectangle to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly re-composited after this property is changed
+  /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
   Rect? get clipRect => _clipRect;
   Rect? _clipRect;
@@ -1325,7 +1325,7 @@ class ClipRectLayer extends ContainerLayer {
   /// {@template flutter.rendering.ClipRectLayer.clipBehavior}
   /// Controls how to clip.
   ///
-  /// Must not be set to null. If set to [Clip.none], no clipping is applied.
+  /// Must not be set to null or [Clip.none].
   /// {@endtemplate}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -1333,6 +1333,7 @@ class ClipRectLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
+    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1350,7 +1351,7 @@ class ClipRectLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipRect != null);
     assert(clipBehavior != null);
-    bool enabled = true && clipBehavior != Clip.none;
+    bool enabled = true;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;
@@ -1386,18 +1387,18 @@ class ClipRRectLayer extends ContainerLayer {
   /// Creates a layer with a rounded-rectangular clip.
   ///
   /// The [clipRRect] and [clipBehavior] properties must be non-null before the
-  /// compositing phase of the pipeline. If [clipBehavior] is [Clip.none], no
-  /// clipping will be applied.
+  /// compositing phase of the pipeline.
   ClipRRectLayer({
     RRect? clipRRect,
     Clip clipBehavior = Clip.antiAlias,
   }) : _clipRRect = clipRRect,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null);
+       assert(clipBehavior != null),
+       assert(clipBehavior != Clip.none);
 
   /// The rounded-rect to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly re-composited after this property is changed
+  /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
   RRect? get clipRRect => _clipRRect;
   RRect? _clipRRect;
@@ -1415,6 +1416,7 @@ class ClipRRectLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
+    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1432,7 +1434,7 @@ class ClipRRectLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipRRect != null);
     assert(clipBehavior != null);
-    bool enabled = true && clipBehavior != Clip.none;
+    bool enabled = true;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;
@@ -1468,18 +1470,18 @@ class ClipPathLayer extends ContainerLayer {
   /// Creates a layer with a path-based clip.
   ///
   /// The [clipPath] and [clipBehavior] properties must be non-null before the
-  /// compositing phase of the pipeline. If [clipBehavior] is [Clip.none], no
-  /// clipping will be applied.
+  /// compositing phase of the pipeline.
   ClipPathLayer({
     Path? clipPath,
     Clip clipBehavior = Clip.antiAlias,
   }) : _clipPath = clipPath,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null);
+       assert(clipBehavior != null),
+       assert(clipBehavior != Clip.none);
 
   /// The path to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly re-composited after this property is changed
+  /// The scene must be explicitly recomposited after this property is changed
   /// (as described at [Layer]).
   Path? get clipPath => _clipPath;
   Path? _clipPath;
@@ -1497,6 +1499,7 @@ class ClipPathLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
+    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1514,7 +1517,7 @@ class ClipPathLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipPath != null);
     assert(clipBehavior != null);
-    bool enabled = true && clipBehavior != Clip.none;
+    bool enabled = true;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1300,18 +1300,18 @@ class ClipRectLayer extends ContainerLayer {
   /// The [clipRect] argument must not be null before the compositing phase of
   /// the pipeline.
   ///
-  /// The [clipBehavior] argument must not be null, and must not be [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   ClipRectLayer({
     Rect? clipRect,
     Clip clipBehavior = Clip.hardEdge,
   }) : _clipRect = clipRect,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none);
+       assert(clipBehavior != null);
 
   /// The rectangle to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly recomposited after this property is changed
+  /// The scene must be explicitly re-composited after this property is changed
   /// (as described at [Layer]).
   Rect? get clipRect => _clipRect;
   Rect? _clipRect;
@@ -1325,7 +1325,7 @@ class ClipRectLayer extends ContainerLayer {
   /// {@template flutter.rendering.ClipRectLayer.clipBehavior}
   /// Controls how to clip.
   ///
-  /// Must not be set to null or [Clip.none].
+  /// Must not be set to null. If set to [Clip.none], no clipping is applied.
   /// {@endtemplate}
   ///
   /// Defaults to [Clip.hardEdge].
@@ -1333,7 +1333,6 @@ class ClipRectLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
-    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1351,7 +1350,7 @@ class ClipRectLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipRect != null);
     assert(clipBehavior != null);
-    bool enabled = true;
+    bool enabled = true && clipBehavior != Clip.none;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;
@@ -1387,18 +1386,18 @@ class ClipRRectLayer extends ContainerLayer {
   /// Creates a layer with a rounded-rectangular clip.
   ///
   /// The [clipRRect] and [clipBehavior] properties must be non-null before the
-  /// compositing phase of the pipeline.
+  /// compositing phase of the pipeline. If [clipBehavior] is [Clip.none], no
+  /// clipping will be applied.
   ClipRRectLayer({
     RRect? clipRRect,
     Clip clipBehavior = Clip.antiAlias,
   }) : _clipRRect = clipRRect,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none);
+       assert(clipBehavior != null);
 
   /// The rounded-rect to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly recomposited after this property is changed
+  /// The scene must be explicitly re-composited after this property is changed
   /// (as described at [Layer]).
   RRect? get clipRRect => _clipRRect;
   RRect? _clipRRect;
@@ -1416,7 +1415,6 @@ class ClipRRectLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
-    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1434,7 +1432,7 @@ class ClipRRectLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipRRect != null);
     assert(clipBehavior != null);
-    bool enabled = true;
+    bool enabled = true && clipBehavior != Clip.none;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;
@@ -1470,18 +1468,18 @@ class ClipPathLayer extends ContainerLayer {
   /// Creates a layer with a path-based clip.
   ///
   /// The [clipPath] and [clipBehavior] properties must be non-null before the
-  /// compositing phase of the pipeline.
+  /// compositing phase of the pipeline. If [clipBehavior] is [Clip.none], no
+  /// clipping will be applied.
   ClipPathLayer({
     Path? clipPath,
     Clip clipBehavior = Clip.antiAlias,
   }) : _clipPath = clipPath,
        _clipBehavior = clipBehavior,
-       assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none);
+       assert(clipBehavior != null);
 
   /// The path to clip in the parent's coordinate system.
   ///
-  /// The scene must be explicitly recomposited after this property is changed
+  /// The scene must be explicitly re-composited after this property is changed
   /// (as described at [Layer]).
   Path? get clipPath => _clipPath;
   Path? _clipPath;
@@ -1499,7 +1497,6 @@ class ClipPathLayer extends ContainerLayer {
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
     assert(value != null);
-    assert(value != Clip.none);
     if (value != _clipBehavior) {
       _clipBehavior = value;
       markNeedsAddToScene();
@@ -1517,7 +1514,7 @@ class ClipPathLayer extends ContainerLayer {
   void addToScene(ui.SceneBuilder builder) {
     assert(clipPath != null);
     assert(clipBehavior != null);
-    bool enabled = true;
+    bool enabled = true && clipBehavior != Clip.none;
     assert(() {
       enabled = !debugDisableClipLayers;
       return true;

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1454,9 +1454,9 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    _updateClip();
     if (child != null) {
       if (clipBehavior != Clip.none) {
+        _updateClip();
         layer = context.pushClipRect(
           needsCompositing,
           offset,
@@ -1545,9 +1545,9 @@ class RenderClipRRect extends _RenderCustomClip<RRect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    _updateClip();
     if (child != null) {
       if (clipBehavior != Clip.none) {
+        _updateClip();
         layer = context.pushClipRRect(
           needsCompositing,
           offset,
@@ -1631,9 +1631,9 @@ class RenderClipOval extends _RenderCustomClip<Rect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    _updateClip();
     if (child != null) {
       if (clipBehavior != Clip.none) {
+        _updateClip();
         layer = context.pushClipPath(
           needsCompositing,
           offset,
@@ -1709,9 +1709,9 @@ class RenderClipPath extends _RenderCustomClip<Path> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    _updateClip();
     if (child != null) {
       if (clipBehavior != Clip.none) {
+        _updateClip();
         layer = context.pushClipPath(
           needsCompositing,
           offset,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1429,13 +1429,13 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
   /// If [clipper] is null, the clip will match the layout size and position of
   /// the child.
   ///
-  /// The [clipBehavior] must not be null or [Clip.none].
+  /// The [clipBehavior] must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   RenderClipRect({
     RenderBox? child,
     CustomClipper<Rect>? clipper,
     Clip clipBehavior = Clip.antiAlias,
   }) : assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none),
        super(child: child, clipper: clipper, clipBehavior: clipBehavior);
 
   @override
@@ -1454,16 +1454,21 @@ class RenderClipRect extends _RenderCustomClip<Rect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    _updateClip();
     if (child != null) {
-      _updateClip();
-      layer = context.pushClipRect(
-        needsCompositing,
-        offset,
-        _clip!,
-        super.paint,
-        clipBehavior: clipBehavior,
-        oldLayer: layer as ClipRectLayer?,
-      );
+      if (clipBehavior != Clip.none) {
+        layer = context.pushClipRect(
+          needsCompositing,
+          offset,
+          _clip!,
+          super.paint,
+          clipBehavior: clipBehavior,
+          oldLayer: layer as ClipRectLayer?,
+        );
+      } else {
+        context.paintChild(child!, offset);
+        layer = null;
+      }
     } else {
       layer = null;
     }
@@ -1495,14 +1500,14 @@ class RenderClipRRect extends _RenderCustomClip<RRect> {
   ///
   /// If [clipper] is non-null, then [borderRadius] is ignored.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   RenderClipRRect({
     RenderBox? child,
     BorderRadius borderRadius = BorderRadius.zero,
     CustomClipper<RRect>? clipper,
     Clip clipBehavior = Clip.antiAlias,
   }) : assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none),
        _borderRadius = borderRadius,
        super(child: child, clipper: clipper, clipBehavior: clipBehavior) {
     assert(_borderRadius != null || clipper != null);
@@ -1540,15 +1545,22 @@ class RenderClipRRect extends _RenderCustomClip<RRect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    _updateClip();
     if (child != null) {
-      _updateClip();
-      layer = context.pushClipRRect(
-        needsCompositing,
-        offset,
-        _clip!.outerRect,
-        _clip!,
-        super.paint, clipBehavior: clipBehavior, oldLayer: layer as ClipRRectLayer?,
-      );
+      if (clipBehavior != Clip.none) {
+        layer = context.pushClipRRect(
+          needsCompositing,
+          offset,
+          _clip!.outerRect,
+          _clip!,
+          super.paint,
+          clipBehavior: clipBehavior,
+          oldLayer: layer as ClipRRectLayer?,
+        );
+      } else {
+        context.paintChild(child!, offset);
+        layer = null;
+      }
     } else {
       layer = null;
     }
@@ -1578,13 +1590,13 @@ class RenderClipOval extends _RenderCustomClip<Rect> {
   /// If [clipper] is null, the oval will be inscribed into the layout size and
   /// position of the child.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   RenderClipOval({
     RenderBox? child,
     CustomClipper<Rect>? clipper,
     Clip clipBehavior = Clip.antiAlias,
   }) : assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none),
        super(child: child, clipper: clipper, clipBehavior: clipBehavior);
 
   Rect? _cachedRect;
@@ -1619,17 +1631,22 @@ class RenderClipOval extends _RenderCustomClip<Rect> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    _updateClip();
     if (child != null) {
-      _updateClip();
-      layer = context.pushClipPath(
-        needsCompositing,
-        offset,
-        _clip!,
-        _getClipPath(_clip!),
-        super.paint,
-        clipBehavior: clipBehavior,
-        oldLayer: layer as ClipPathLayer?,
-      );
+      if (clipBehavior != Clip.none) {
+        layer = context.pushClipPath(
+          needsCompositing,
+          offset,
+          _clip!,
+          _getClipPath(_clip!),
+          super.paint,
+          clipBehavior: clipBehavior,
+          oldLayer: layer as ClipPathLayer?,
+        );
+      } else {
+        context.paintChild(child!, offset);
+        layer = null;
+      }
     } else {
       layer = null;
     }
@@ -1667,13 +1684,13 @@ class RenderClipPath extends _RenderCustomClip<Path> {
   /// consider using a [RenderClipRect], which can achieve the same effect more
   /// efficiently.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   RenderClipPath({
     RenderBox? child,
     CustomClipper<Path>? clipper,
     Clip clipBehavior = Clip.antiAlias,
   }) : assert(clipBehavior != null),
-       assert(clipBehavior != Clip.none),
        super(child: child, clipper: clipper, clipBehavior: clipBehavior);
 
   @override
@@ -1692,17 +1709,22 @@ class RenderClipPath extends _RenderCustomClip<Path> {
 
   @override
   void paint(PaintingContext context, Offset offset) {
+    _updateClip();
     if (child != null) {
-      _updateClip();
-      layer = context.pushClipPath(
-        needsCompositing,
-        offset,
-        Offset.zero & size,
-        _clip!,
-        super.paint,
-        clipBehavior: clipBehavior,
-        oldLayer: layer as ClipPathLayer?,
-      );
+      if (clipBehavior != Clip.none) {
+        layer = context.pushClipPath(
+          needsCompositing,
+          offset,
+          Offset.zero & size,
+          _clip!,
+          super.paint,
+          clipBehavior: clipBehavior,
+          oldLayer: layer as ClipPathLayer?,
+        );
+      } else {
+        context.paintChild(child!, offset);
+        layer = null;
+      }
     } else {
       layer = null;
     }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -662,10 +662,15 @@ class ClipRect extends SingleChildRenderObjectWidget {
   /// If [clipper] is null, the clip will match the layout size and position of
   /// the child.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
-  const ClipRect({ Key? key, this.clipper, this.clipBehavior = Clip.hardEdge, Widget? child })
-      : assert(clipBehavior != null),
-        super(key: key, child: child);
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
+  const ClipRect({
+    Key? key,
+    this.clipper,
+    this.clipBehavior = Clip.hardEdge,
+    Widget? child,
+  }) : assert(clipBehavior != null),
+       super(key: key, child: child);
 
   /// If non-null, determines which clip to use.
   final CustomClipper<Rect>? clipper;
@@ -677,13 +682,11 @@ class ClipRect extends SingleChildRenderObjectWidget {
 
   @override
   RenderClipRect createRenderObject(BuildContext context) {
-    assert(clipBehavior != Clip.none);
     return RenderClipRect(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderClipRect renderObject) {
-    assert(clipBehavior != Clip.none);
     renderObject
       ..clipper = clipper
       ..clipBehavior = clipBehavior;
@@ -723,7 +726,8 @@ class ClipRRect extends SingleChildRenderObjectWidget {
   ///
   /// If [clipper] is non-null, then [borderRadius] is ignored.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   const ClipRRect({
     Key? key,
     this.borderRadius = BorderRadius.zero,
@@ -752,13 +756,15 @@ class ClipRRect extends SingleChildRenderObjectWidget {
 
   @override
   RenderClipRRect createRenderObject(BuildContext context) {
-    assert(clipBehavior != Clip.none);
-    return RenderClipRRect(borderRadius: borderRadius!, clipper: clipper, clipBehavior: clipBehavior);
+    return RenderClipRRect(
+      borderRadius: borderRadius!,
+      clipper: clipper,
+      clipBehavior: clipBehavior,
+    );
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderClipRRect renderObject) {
-    assert(clipBehavior != Clip.none);
     renderObject
       ..borderRadius = borderRadius!
       ..clipBehavior = clipBehavior
@@ -793,10 +799,15 @@ class ClipOval extends SingleChildRenderObjectWidget {
   /// If [clipper] is null, the oval will be inscribed into the layout size and
   /// position of the child.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
-  const ClipOval({Key? key, this.clipper, this.clipBehavior = Clip.antiAlias, Widget? child})
-      : assert(clipBehavior != null),
-        super(key: key, child: child);
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
+  const ClipOval({
+    Key? key,
+    this.clipper,
+    this.clipBehavior = Clip.antiAlias,
+    Widget? child,
+  }) : assert(clipBehavior != null),
+       super(key: key, child: child);
 
   /// If non-null, determines which clip to use.
   ///
@@ -816,13 +827,11 @@ class ClipOval extends SingleChildRenderObjectWidget {
 
   @override
   RenderClipOval createRenderObject(BuildContext context) {
-    assert(clipBehavior != Clip.none);
     return RenderClipOval(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderClipOval renderObject) {
-    assert(clipBehavior != Clip.none);
     renderObject
       ..clipper = clipper
       ..clipBehavior = clipBehavior;
@@ -866,7 +875,8 @@ class ClipPath extends SingleChildRenderObjectWidget {
   /// consider using a [ClipRect], which can achieve the same effect more
   /// efficiently.
   ///
-  /// The [clipBehavior] argument must not be null or [Clip.none].
+  /// The [clipBehavior] argument must not be null. If [clipBehavior] is
+  /// [Clip.none], no clipping will be applied.
   const ClipPath({
     Key? key,
     this.clipper,
@@ -886,7 +896,6 @@ class ClipPath extends SingleChildRenderObjectWidget {
     Widget? child,
   }) {
     assert(clipBehavior != null);
-    assert(clipBehavior != Clip.none);
     assert(shape != null);
     return Builder(
       key: key,
@@ -917,13 +926,11 @@ class ClipPath extends SingleChildRenderObjectWidget {
 
   @override
   RenderClipPath createRenderObject(BuildContext context) {
-    assert(clipBehavior != Clip.none);
     return RenderClipPath(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   @override
   void updateRenderObject(BuildContext context, RenderClipPath renderObject) {
-    assert(clipBehavior != Clip.none);
     renderObject
       ..clipper = clipper
       ..clipBehavior = clipBehavior;
@@ -1014,7 +1021,8 @@ class PhysicalModel extends SingleChildRenderObjectWidget {
       shape: shape,
       clipBehavior: clipBehavior,
       borderRadius: borderRadius,
-      elevation: elevation, color: color,
+      elevation: elevation,
+      color: color,
       shadowColor: shadowColor,
     );
   }

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -87,6 +87,10 @@ void main() {
     await tester.pumpWidget(const ClipRect(clipBehavior: Clip.antiAlias));
 
     expect(renderClip.clipBehavior, equals(Clip.antiAlias));
+
+    await tester.pumpWidget(const ClipRect(clipBehavior: Clip.none));
+
+    expect(renderClip.clipBehavior, equals(Clip.none));
   });
 
   test('ClipRRect constructs with the right default values', () {
@@ -105,6 +109,10 @@ void main() {
     await tester.pumpWidget(const ClipRRect(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(const ClipRRect(clipBehavior: Clip.none));
+
+    expect(renderClip.clipBehavior, equals(Clip.none));
   });
 
   testWidgets('ClipOval updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
@@ -117,6 +125,10 @@ void main() {
     await tester.pumpWidget(const ClipOval(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(const ClipOval(clipBehavior: Clip.none));
+
+    expect(renderClip.clipBehavior, equals(Clip.none));
   });
 
   testWidgets('ClipPath updates clipBehavior in updateRenderObject', (WidgetTester tester) async {
@@ -129,6 +141,10 @@ void main() {
     await tester.pumpWidget(const ClipPath(clipBehavior: Clip.hardEdge));
 
     expect(renderClip.clipBehavior, equals(Clip.hardEdge));
+
+    await tester.pumpWidget(const ClipPath(clipBehavior: Clip.none));
+
+    expect(renderClip.clipBehavior, equals(Clip.none));
   });
 
   testWidgets('ClipPath', (WidgetTester tester) async {


### PR DESCRIPTION
Reference internal bug: b/210103825

This makes it valid to use Clip.none as a clipBehavior, resulting in no clipping.
In cases where clipping is desired conditionally, if you were to add a clipping widget to the tree, and then remove it, Flutter is unable to preserve state in the subtree because the widget types won't match. This has become apparent in the stretching overscroll indicator where such conditional clipping is occurring.

Follow-up change should update the overscroll indicator to prevent state deactivation here: https://github.com/flutter/flutter/blob/0287449c14aedc236d4e3f44577c4c82648c9ad8/packages/flutter/lib/src/widgets/overscroll_indicator.dart#L788

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
