### PR TITLE
retry curl without `--continue-at -` flag

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -120,7 +120,6 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     if [ $curlExitCode != 33 ]; then
       return $curlExitCode
     fi
-    >&2 echo "Retrying download without \`--continue-at -\` flag"
     curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
   } || {
     >&2 echo

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -116,13 +116,16 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   fi
 
   curl ${verbose_curl} --retry 3 --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
-    >&2 echo
-    >&2 echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
-    >&2 echo "If you're located in China, please see this page:"
-    >&2 echo "  https://flutter.dev/community/china"
-    >&2 echo
-    rm -f -- "$DART_SDK_ZIP"
-    exit 1
+    >&2 echo "Retrying download without \`--continue-at -\` flag"
+    curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
+      echo >&2
+      echo >&2 "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
+      echo >&2 "If you're located in China, please see this page:"
+      echo >&2 "  https://flutter.dev/community/china"
+      echo >&2
+      rm -f -- "$DART_SDK_ZIP"
+      exit 1
+    }
   }
   unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
     >&2 echo

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -123,11 +123,11 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     >&2 echo "Retrying download without \`--continue-at -\` flag"
     curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
   } || {
-    echo >&2
-    echo >&2 "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
-    echo >&2 "If you're located in China, please see this page:"
-    echo >&2 "  https://flutter.dev/community/china"
-    echo >&2
+    >&2 echo
+    >&2 echo "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
+    >&2 echo "If you're located in China, please see this page:"
+    >&2 echo "  https://flutter.dev/community/china"
+    >&2 echo
     rm -f -- "$DART_SDK_ZIP"
     exit 1
   }

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -116,16 +116,20 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   fi
 
   curl ${verbose_curl} --retry 3 --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
+    curlExitCode=$?
+    if [ $curlExitCode != 33 ]; then
+      return $curlExitCode
+    fi
     >&2 echo "Retrying download without \`--continue-at -\` flag"
-    curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
-      echo >&2
-      echo >&2 "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
-      echo >&2 "If you're located in China, please see this page:"
-      echo >&2 "  https://flutter.dev/community/china"
-      echo >&2
-      rm -f -- "$DART_SDK_ZIP"
-      exit 1
-    }
+    curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
+  } || {
+    echo >&2
+    echo >&2 "Failed to retrieve the Dart SDK from: $DART_SDK_URL"
+    echo >&2 "If you're located in China, please see this page:"
+    echo >&2 "  https://flutter.dev/community/china"
+    echo >&2
+    rm -f -- "$DART_SDK_ZIP"
+    exit 1
   }
   unzip -o -q "$DART_SDK_ZIP" -d "$FLUTTER_ROOT/bin/cache" || {
     >&2 echo

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -117,6 +117,15 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
 
   curl ${verbose_curl} --retry 3 --continue-at - --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1 || {
     curlExitCode=$?
+    # Handle range errors specially: retry again with disabled ranges (`--continue-at -` argument)
+    # When this could happen:
+    # - missing support of ranges in proxy servers
+    # - curl with broken handling of completed downloads
+    #   This is not a proper fix, but doesn't require any user input
+    # - mirror of flutter storage without support of ranges
+    #
+    # 33  HTTP range error. The range "command" didn't work.
+    # https://man7.org/linux/man-pages/man1/curl.1.html#EXIT_CODES
     if [ $curlExitCode != 33 ]; then
       return $curlExitCode
     fi


### PR DESCRIPTION
Try to fallback to curl without `--continue-at` flag if `curl` exits with code `33`
```
curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume.
```

closes:
#14521

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
