### PR TITLE
Migrate flutter_device_manager to null safety

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -204,6 +204,7 @@ Future<T> runInContext<T>(
           platform: globals.platform,
           featureFlags: featureFlags,
         ),
+        fuchsiaSdk: globals.fuchsiaSdk,
         operatingSystemUtils: globals.os,
         terminal: globals.terminal,
         customDevicesConfig: globals.customDevicesConfig,

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
-import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
 import 'android/android_device_discovery.dart';
@@ -42,26 +39,26 @@ import 'windows/windows_workflow.dart';
 /// A provider for all of the device discovery instances.
 class FlutterDeviceManager extends DeviceManager {
   FlutterDeviceManager({
-    @required Logger logger,
-    @required Platform platform,
-    @required ProcessManager processManager,
-    @required FileSystem fileSystem,
-    @required AndroidSdk androidSdk,
-    @required FeatureFlags featureFlags,
-    @required IOSSimulatorUtils iosSimulatorUtils,
-    @required XCDevice xcDevice,
-    @required AndroidWorkflow androidWorkflow,
-    @required IOSWorkflow iosWorkflow,
-    @required FuchsiaWorkflow fuchsiaWorkflow,
-    @required FlutterVersion flutterVersion,
-    @required Artifacts artifacts,
-    @required MacOSWorkflow macOSWorkflow,
-    @required UserMessages userMessages,
-    @required OperatingSystemUtils operatingSystemUtils,
-    @required WindowsWorkflow windowsWorkflow,
-    @required Terminal terminal,
-    @required CustomDevicesConfig customDevicesConfig,
-    @required UwpTool uwptool,
+    required Logger logger,
+    required Platform platform,
+    required ProcessManager processManager,
+    required FileSystem fileSystem,
+    required AndroidSdk androidSdk,
+    required FeatureFlags featureFlags,
+    required IOSSimulatorUtils iosSimulatorUtils,
+    required XCDevice xcDevice,
+    required AndroidWorkflow androidWorkflow,
+    required IOSWorkflow iosWorkflow,
+    required FuchsiaWorkflow fuchsiaWorkflow,
+    required FlutterVersion flutterVersion,
+    required Artifacts artifacts,
+    required MacOSWorkflow macOSWorkflow,
+    required UserMessages userMessages,
+    required OperatingSystemUtils operatingSystemUtils,
+    required WindowsWorkflow windowsWorkflow,
+    required Terminal terminal,
+    required CustomDevicesConfig customDevicesConfig,
+    required UwpTool uwptool,
   }) : deviceDiscoverers =  <DeviceDiscovery>[
     AndroidDevices(
       logger: logger,

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -53,6 +53,7 @@ class FlutterDeviceManager extends DeviceManager {
     required FlutterVersion flutterVersion,
     required Artifacts artifacts,
     required MacOSWorkflow macOSWorkflow,
+    required FuchsiaSdk fuchsiaSdk,
     required UserMessages userMessages,
     required OperatingSystemUtils operatingSystemUtils,
     required WindowsWorkflow windowsWorkflow,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -16,7 +16,6 @@ import '../globals.dart' as globals;
 import '../project.dart';
 
 import 'fuchsia_pm.dart';
-import 'fuchsia_sdk.dart';
 
 Future<void> _timedBuildStep(String name, Future<void> Function() action) async {
   final Stopwatch sw = Stopwatch()..start();
@@ -55,7 +54,7 @@ Future<void> buildFuchsia({
   }
 
   await _timedBuildStep('fuchsia-kernel-compile',
-    () => fuchsiaSdk!.fuchsiaKernelCompiler.build(
+    () => globals.fuchsiaSdk!.fuchsiaKernelCompiler.build(
       fuchsiaProject: fuchsiaProject, target: targetPath, buildInfo: buildInfo));
 
   if (buildInfo.usesAot) {
@@ -214,7 +213,7 @@ Future<void> _buildPackage(
   manifestFile.writeAsStringSync('meta/package=$pkgDir/meta/package\n',
       mode: FileMode.append);
 
-  final FuchsiaPM? fuchsiaPM = fuchsiaSdk?.fuchsiaPM;
+  final FuchsiaPM? fuchsiaPM = globals.fuchsiaSdk?.fuchsiaPM;
   if (fuchsiaPM == null) {
     return;
   }

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -83,7 +83,7 @@ class _FuchsiaLogReader extends DeviceLogReader {
   Stream<String>? _logLines;
   @override
   Stream<String> get logLines {
-    final Stream<String>? logStream = fuchsiaSdk?.syslogs(_device.id);
+    final Stream<String>? logStream = globals.fuchsiaSdk?.syslogs(_device.id);
     _logLines ??= _processLogs(logStream);
     return _logLines ?? const Stream<String>.empty();
   }
@@ -158,7 +158,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
   FuchsiaDevices({
     required Platform platform,
     required FuchsiaWorkflow fuchsiaWorkflow,
-    FuchsiaSdk? fuchsiaSdk,
+    required FuchsiaSdk fuchsiaSdk,
     required Logger logger,
   }) : _platform = platform,
        _fuchsiaWorkflow = fuchsiaWorkflow,
@@ -168,7 +168,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
 
   final Platform _platform;
   final FuchsiaWorkflow _fuchsiaWorkflow;
-  final FuchsiaSdk? _fuchsiaSdk;
+  final FuchsiaSdk _fuchsiaSdk;
   final Logger _logger;
 
   @override
@@ -183,7 +183,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
       return <Device>[];
     }
     // TODO(omerlevran): Remove once soft transition is complete fxb/67602.
-    final List<String>? text = (await _fuchsiaSdk?.listDevices(
+    final List<String>? text = (await _fuchsiaSdk.listDevices(
       timeout: timeout,
     ))?.split('\n');
     if (text == null || text.isEmpty) {
@@ -213,7 +213,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
     final String name = words[1];
 
      // TODO(omerlevran): Add support for resolve on the FuchsiaSdk Object.
-    final String? resolvedHost = await _fuchsiaSdk?.fuchsiaFfx.resolve(name);
+    final String? resolvedHost = await _fuchsiaSdk.fuchsiaFfx.resolve(name);
     if (resolvedHost == null) {
       _logger.printError('Failed to resolve host for Fuchsia device `$name`');
       return null;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -158,7 +158,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
   FuchsiaDevices({
     required Platform platform,
     required FuchsiaWorkflow fuchsiaWorkflow,
-    required FuchsiaSdk fuchsiaSdk,
+    FuchsiaSdk? fuchsiaSdk,
     required Logger logger,
   }) : _platform = platform,
        _fuchsiaWorkflow = fuchsiaWorkflow,
@@ -168,7 +168,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
 
   final Platform _platform;
   final FuchsiaWorkflow _fuchsiaWorkflow;
-  final FuchsiaSdk _fuchsiaSdk;
+  final FuchsiaSdk? _fuchsiaSdk;
   final Logger _logger;
 
   @override
@@ -183,7 +183,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
       return <Device>[];
     }
     // TODO(omerlevran): Remove once soft transition is complete fxb/67602.
-    final List<String>? text = (await _fuchsiaSdk.listDevices(
+    final List<String>? text = (await _fuchsiaSdk?.listDevices(
       timeout: timeout,
     ))?.split('\n');
     if (text == null || text.isEmpty) {
@@ -213,7 +213,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
     final String name = words[1];
 
      // TODO(omerlevran): Add support for resolve on the FuchsiaSdk Object.
-    final String? resolvedHost = await _fuchsiaSdk.fuchsiaFfx.resolve(name);
+    final String? resolvedHost = await _fuchsiaSdk?.fuchsiaFfx.resolve(name);
     if (resolvedHost == null) {
       _logger.printError('Failed to resolve host for Fuchsia device `$name`');
       return null;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_pm.dart
@@ -10,8 +10,6 @@ import '../base/process.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 
-import 'fuchsia_sdk.dart';
-
 /// This is a basic wrapper class for the Fuchsia SDK's `pm` tool.
 class FuchsiaPM {
   /// Initializes the staging area at [buildPath] for creating the Fuchsia
@@ -199,7 +197,7 @@ class FuchsiaPackageServer {
       return false;
     }
     // initialize a new repo.
-    final FuchsiaPM? fuchsiaPM = fuchsiaSdk?.fuchsiaPM;
+    final FuchsiaPM? fuchsiaPM = globals.fuchsiaSdk?.fuchsiaPM;
     if (fuchsiaPM == null || !await fuchsiaPM.newrepo(_repo)) {
       globals.printError('Failed to create a new package server repo');
       return false;
@@ -232,7 +230,7 @@ class FuchsiaPackageServer {
     if (_process == null) {
       return false;
     }
-    return (await fuchsiaSdk?.fuchsiaPM.publish(_repo, package.path)) == true;
+    return (await globals.fuchsiaSdk?.fuchsiaPM.publish(_repo, package.path)) == true;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_sdk.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/platform.dart';
@@ -14,9 +13,6 @@ import '../globals.dart' as globals;
 import 'fuchsia_ffx.dart';
 import 'fuchsia_kernel_compiler.dart';
 import 'fuchsia_pm.dart';
-
-/// The [FuchsiaSdk] instance.
-FuchsiaSdk? get fuchsiaSdk => context.get<FuchsiaSdk>();
 
 /// Returns [true] if the current platform supports Fuchsia targets.
 bool isFuchsiaSupportedPlatform(Platform platform) {

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -66,6 +66,7 @@ AndroidStudio? get androidStudio => context.get<AndroidStudio>();
 AndroidSdk? get androidSdk => context.get<AndroidSdk>();
 FlutterVersion get flutterVersion => context.get<FlutterVersion>()!;
 FuchsiaArtifacts? get fuchsiaArtifacts => context.get<FuchsiaArtifacts>();
+FuchsiaSdk? get fuchsiaSdk => context.get<FuchsiaSdk>();
 Usage get flutterUsage => context.get<Usage>()!;
 XcodeProjectInterpreter? get xcodeProjectInterpreter => context.get<XcodeProjectInterpreter>();
 XCDevice? get xcdevice => context.get<XCDevice>();


### PR DESCRIPTION
Part of #71511

Move `fuchsiaSdk` into `globals` library https://github.com/flutter/flutter/issues/47161 and pass into `FlutterDeviceManager` from the `context_runner`.

Re-remove `globals_null_migrated.dart` #92948, it was incorrectly re-added in #92031 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
