### PR TITLE
Provide Appbar's `foregroundColor` to package license page titles

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -921,12 +921,14 @@ class _PackageLicensePageTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Color? color = Theme.of(context).appBarTheme.foregroundColor;
+
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text(title, style: theme.headline6),
-        Text(subtitle, style: theme.subtitle2),
+        Text(title, style: theme.headline6?.copyWith(color: color)),
+        Text(subtitle, style: theme.subtitle2?.copyWith(color: color)),
       ],
     );
   }

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -289,11 +289,11 @@ void main() {
 
     const TextStyle titleTextStyle = TextStyle(
       fontSize: 20,
-      color: Colors.black,
+      color: Colors.indigo,
     );
     const TextStyle subtitleTextStyle = TextStyle(
       fontSize: 15,
-      color: Colors.red,
+      color: Colors.indigo,
     );
 
     await tester.pumpWidget(
@@ -315,6 +315,7 @@ void main() {
               headline6: titleTextStyle,
               subtitle2: subtitleTextStyle,
             ),
+            foregroundColor: Colors.indigo,
           ),
         ),
         home: const Center(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94150

Page title inside MasterDetailScaffold in showLicense page is using Appbar theme foreground as it is direct title parameter
https://github.com/flutter/flutter/blob/2b46ea447fc1d692752ba297722a45143385f30a/packages/flutter/lib/src/material/about.dart#L1466

However, the package license page has a custom widget with two titles, which doesn't have access to foregroundColor from Appbar

https://github.com/flutter/flutter/blob/2b46ea447fc1d692752ba297722a45143385f30a/packages/flutter/lib/src/material/about.dart#L924-L931

This PR add  Appbar theme foreground color to these titles for package license page

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
