### PR TITLE
Add missing return null to default_text_editing_shortcuts.dart

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -108,6 +108,7 @@ import 'text_editing_intents.dart';
 ///                       setState(() {
 ///                         _counter++;
 ///                       });
+///                       return null;
 ///                     },
 ///                   ),
 ///                   DecrementCounterIntent: CallbackAction<DecrementCounterIntent>(
@@ -115,6 +116,7 @@ import 'text_editing_intents.dart';
 ///                       setState(() {
 ///                         _counter--;
 ///                       });
+///                       return null;
 ///                     },
 ///                   ),
 ///                 },


### PR DESCRIPTION
Adds null statements at the end of functions which have implicit null returns. These functions all have nullable return types (and not void, dynamic`, and upcoming analysis encourages such functions to have explicit returns).

List which issues are fixed by this PR. You must list at least one issue. #94759

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
