### PR TITLE
Add ability for `ModalRoutes` to ignore pointers during transitions and do so on `Cupertino` routes

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -236,7 +236,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   }
 
   @override
-  bool ignorePointerWhenCurrentDuringTransitions = true;
+  bool get ignorePointerWhenCurrentDuringTransitions => true;
 
   // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
   // gesture is detected. The returned controller handles all of the subsequent
@@ -1053,7 +1053,7 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   Duration get transitionDuration => _kModalPopupTransitionDuration;
 
   @override
-  bool ignorePointerWhenCurrentDuringTransitions = true;
+  bool get ignorePointerWhenCurrentDuringTransitions => true;
 
   Animation<double>? _animation;
 
@@ -1357,5 +1357,5 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
       );
 
   @override
-  bool ignorePointerWhenCurrentDuringTransitions = true;
+  bool get ignorePointerWhenCurrentDuringTransitions => true;
 }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -236,7 +236,7 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
   }
 
   @override
-  bool get ignorePointerWhenCurrentDuringTransitions => true;
+  bool get ignorePointerDuringTransitions => true;
 
   // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
   // gesture is detected. The returned controller handles all of the subsequent
@@ -1053,7 +1053,7 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   Duration get transitionDuration => _kModalPopupTransitionDuration;
 
   @override
-  bool get ignorePointerWhenCurrentDuringTransitions => true;
+  bool get ignorePointerDuringTransitions => true;
 
   Animation<double>? _animation;
 
@@ -1357,5 +1357,5 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
       );
 
   @override
-  bool get ignorePointerWhenCurrentDuringTransitions => true;
+  bool get ignorePointerDuringTransitions => true;
 }

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -235,6 +235,9 @@ mixin CupertinoRouteTransitionMixin<T> on PageRoute<T> {
     return result;
   }
 
+  @override
+  bool ignorePointerWhenCurrentDuringTransitions = true;
+
   // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
   // gesture is detected. The returned controller handles all of the subsequent
   // drag events.
@@ -1049,6 +1052,9 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
   @override
   Duration get transitionDuration => _kModalPopupTransitionDuration;
 
+  @override
+  bool ignorePointerWhenCurrentDuringTransitions = true;
+
   Animation<double>? _animation;
 
   late Tween<Offset> _offsetTween;
@@ -1349,4 +1355,7 @@ class CupertinoDialogRoute<T> extends RawDialogRoute<T> {
         barrierLabel: barrierLabel ?? CupertinoLocalizations.of(context).modalBarrierDismissLabel,
         barrierColor: barrierColor ?? CupertinoDynamicColor.resolve(kCupertinoModalBarrierColor, context),
       );
+
+  @override
+  bool ignorePointerWhenCurrentDuringTransitions = true;
 }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1451,13 +1451,13 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   final ValueNotifier<bool> _ignorePointerNotifier = ValueNotifier<bool>(false);
 
   void _maybeUpdateIgnorePointer() {
-    bool _isTransitioning(Animation<double>? animation) {
+    bool isTransitioning(Animation<double>? animation) {
       return animation?.status == AnimationStatus.forward || animation?.status == AnimationStatus.reverse;
     }
     _ignorePointerNotifier.value = !isCurrent ||
         (navigator?.userGestureInProgress ?? false) ||
         (ignorePointerDuringTransitions &&
-            (_isTransitioning(animation) || _isTransitioning(secondaryAnimation)));
+            (isTransitioning(animation) || isTransitioning(secondaryAnimation)));
   }
 
   final List<WillPopCallback> _willPopCallbacks = <WillPopCallback>[];

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1204,9 +1204,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   void install() {
     super.install();
     _animationProxy = ProxyAnimation(super.animation)
-      ..addStatusListener(_maybeUpdateIgnorePointer);
+      ..addStatusListener(_handleAnimationStatusChanged);
     _secondaryAnimationProxy = ProxyAnimation(super.secondaryAnimation)
-      ..addStatusListener(_maybeUpdateIgnorePointer);
+      ..addStatusListener(_handleAnimationStatusChanged);
+    navigator!.userGestureInProgressNotifier.addListener(_maybeUpdateIgnorePointer);
+  }
+
+  void _handleAnimationStatusChanged(AnimationStatus status) {
+    _maybeUpdateIgnorePointer();
   }
 
   @override
@@ -1445,7 +1450,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   bool get _ignorePointer => _ignorePointerNotifier.value;
   final ValueNotifier<bool> _ignorePointerNotifier = ValueNotifier<bool>(false);
 
-  void _maybeUpdateIgnorePointer(AnimationStatus status) {
+  void _maybeUpdateIgnorePointer() {
     bool _isTransitioning(Animation<double>? animation) {
       return animation?.status == AnimationStatus.forward || animation?.status == AnimationStatus.reverse;
     }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1194,7 +1194,6 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// This value should generally be true for Cupertino routes.
   ///
   /// Returns false by default.
-  ///
   @protected
   bool get ignorePointerWhenCurrentDuringTransitions => false;
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1182,8 +1182,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     return child;
   }
 
-  /// Whether this route should ignore pointers when it is the current route and
-  /// transitions are in progress.
+  /// Whether this route should ignore pointers when transitions are in progress.
   ///
   /// Pointers always are ignored when [isCurrent] is false (e.g., when a route
   /// has a new route pushed on top of it, or during a route's exit transition
@@ -1191,19 +1190,23 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   /// transitions where this route is the current route (e.g., after the route
   /// above this route pops, or during this route's entrance transition).
   ///
-  /// This value should generally be true for Cupertino routes.
-  ///
   /// Returns false by default.
+  ///
+  /// See also:
+  ///
+  ///  * [CupertinoRouteTransitionMixin], [CupertinoModalPopupRoute], and
+  ///    [CupertinoDialogRoute], which use this property to specify that
+  ///    Cupertino routes ignore pointers during transitions.
   @protected
-  bool get ignorePointerWhenCurrentDuringTransitions => false;
+  bool get ignorePointerDuringTransitions => false;
 
   @override
   void install() {
     super.install();
     _animationProxy = ProxyAnimation(super.animation)
-      ..addStatusListener((_) => _maybeUpdateIgnorePointer());
+      ..addStatusListener(_maybeUpdateIgnorePointer);
     _secondaryAnimationProxy = ProxyAnimation(super.secondaryAnimation)
-      ..addStatusListener((_) => _maybeUpdateIgnorePointer());
+      ..addStatusListener(_maybeUpdateIgnorePointer);
   }
 
   @override
@@ -1442,14 +1445,14 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   bool get _ignorePointer => _ignorePointerNotifier.value;
   final ValueNotifier<bool> _ignorePointerNotifier = ValueNotifier<bool>(false);
 
-  void _maybeUpdateIgnorePointer() {
+  void _maybeUpdateIgnorePointer(AnimationStatus status) {
     bool _isTransitioning(Animation<double>? animation) {
       return animation?.status == AnimationStatus.forward || animation?.status == AnimationStatus.reverse;
     }
     // Pointers are implicitly ignored here during Cupertino user pop gestures, as
     // full-screen Cupertino page routes ignore pointers during transitions by default.
     _ignorePointerNotifier.value = !isCurrent ||
-        (ignorePointerWhenCurrentDuringTransitions &&
+        (ignorePointerDuringTransitions &&
             (_isTransitioning(animation) || _isTransitioning(secondaryAnimation)));
   }
 

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -1449,9 +1449,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     bool _isTransitioning(Animation<double>? animation) {
       return animation?.status == AnimationStatus.forward || animation?.status == AnimationStatus.reverse;
     }
-    // Pointers are implicitly ignored here during Cupertino user pop gestures, as
-    // full-screen Cupertino page routes ignore pointers during transitions by default.
     _ignorePointerNotifier.value = !isCurrent ||
+        (navigator?.userGestureInProgress ?? false) ||
         (ignorePointerDuringTransitions &&
             (_isTransitioning(animation) || _isTransitioning(secondaryAnimation)));
   }

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -29,13 +29,13 @@ void main() {
     );
 
     await tester.tap(find.text('Go'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    expect(find.text('Action Sheet'), findsOneWidget);
+    expect(find.byType(CupertinoActionSheet), findsOneWidget);
 
-    await tester.tapAt(const Offset(20.0, 20.0));
-    await tester.pump();
-    expect(find.text('Action Sheet'), findsNothing);
+    await tester.tap(find.byType(ModalBarrier).last);
+    await tester.pumpAndSettle();
+    expect(find.byType(CupertinoActionSheet), findsNothing);
   });
 
   testWidgets('Verify that a tap on title section (not buttons) does not dismiss an action sheet', (WidgetTester tester) async {
@@ -867,7 +867,7 @@ void main() {
     expect(find.byType(CupertinoActionSheet), findsNothing);
   });
 
-  testWidgets('Modal barrier is pressed during transition', (WidgetTester tester) async {
+  testWidgets('Modal barrier cannot be dismissed during transition', (WidgetTester tester) async {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesActionSheet(
         CupertinoActionSheet(
@@ -906,21 +906,20 @@ void main() {
     await tester.pump(const Duration(milliseconds: 60));
     expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(337.1, epsilon: 0.1));
 
-    // Exit animation
+    // Attempt to dismiss
     await tester.tapAt(const Offset(20.0, 20.0));
     await tester.pump(const Duration(milliseconds: 60));
 
-    await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(374.3, epsilon: 0.1));
+    // Enter animation is continuing
+    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(325.4, epsilon: 0.1));
 
-    await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, moreOrLessEquals(470.0, epsilon: 0.1));
+    await tester.pumpAndSettle();
 
-    await tester.pump(const Duration(milliseconds: 60));
-    expect(tester.getTopLeft(find.byType(CupertinoActionSheet)).dy, 600.0);
+    // Attempt to dismiss again
+    await tester.tapAt(const Offset(20.0, 20.0));
+    await tester.pumpAndSettle();
 
     // Action sheet has disappeared
-    await tester.pump(const Duration(milliseconds: 60));
     expect(find.byType(CupertinoActionSheet), findsNothing);
   });
 
@@ -952,7 +951,7 @@ void main() {
     );
 
     await tester.tap(find.text('Go'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(
       semantics,

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1074,6 +1074,8 @@ void main() {
     transition = tester.firstWidget(fadeTransitionFinder);
     expect(transition.opacity.value, moreOrLessEquals(1.0, epsilon: 0.001));
 
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text('Delete'));
 
     // Exit animation, look at reverse FadeTransition.

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -691,6 +691,11 @@ void main() {
 
       await tester.tap(find.text('Home'), warnIfMissed: false); // Home route is not tappable
       expect(homeTapped, false);
+
+      await tester.pumpAndSettle(); // Transition completes
+
+      await tester.tap(find.text('Home'));
+      expect(homeTapped, true);
     });
 
     testWidgets('fullscreenDialog CupertinoPageRoute ignores pointers when route on top of it pops', (WidgetTester tester) async {
@@ -721,6 +726,11 @@ void main() {
 
       await tester.tap(find.text('Home'), warnIfMissed: false); // Home route is not tappable
       expect(homeTapped, false);
+
+      await tester.pumpAndSettle(); // Transition completes
+
+      await tester.tap(find.text('Home'));
+      expect(homeTapped, true);
     });
 
     testWidgets('CupertinoPageRoute ignores pointers when user pop gesture is in progress', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -442,6 +442,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 40));
     expect(tester.getTopLeft(find.byType(Placeholder)).dy, moreOrLessEquals(0.0, epsilon: 0.1));
 
+    await tester.pumpAndSettle();
+
     // Exit animation
     await tester.tap(find.text('Close'));
     await tester.pump();
@@ -547,6 +549,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 40));
     expect(tester.getTopLeft(find.byType(Placeholder)).dx, moreOrLessEquals(-267.0, epsilon: 1.0));
 
+    await tester.pumpAndSettle();
+
     // Exit animation
     await tester.tap(find.text('Close'));
     await tester.pump();
@@ -636,6 +640,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 40));
     expect(tester.getTopLeft(find.byType(Placeholder)).dx, 0.0);
 
+    await tester.pumpAndSettle();
+
     // Exit animation
     await tester.tap(find.text('Close'));
     await tester.pump();
@@ -653,6 +659,211 @@ void main() {
 
   testWidgets('FullscreenDialog CupertinoPageRoute has no parallax when fullscreenDialog route is pushed on top', (WidgetTester tester) async {
     await testNoParallax(tester, fromFullscreenDialog: true);
+  });
+
+  group('Route interactivity during transition animations', () {
+    testWidgets('CupertinoPageRoute ignores pointers when route on top of it pops', (WidgetTester tester) async {
+      final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+      bool homeTapped = false;
+      await tester.pumpWidget(
+        CupertinoApp(
+          navigatorKey: navigatorKey,
+          home: TextButton(
+            onPressed: () => homeTapped = true,
+            child: const Text('Home'),
+          ),
+        ),
+      );
+
+      navigatorKey.currentState!.push<void>(
+        CupertinoPageRoute<void>(
+          builder: (_) => const Text('Page 2'),
+        )
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsOneWidget);
+
+      navigatorKey.currentState!.pop();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Page 2'), findsOneWidget); // Transition still in progress
+
+      await tester.tap(find.text('Home'), warnIfMissed: false); // Home route is not tappable
+      expect(homeTapped, false);
+    });
+
+    testWidgets('fullscreenDialog CupertinoPageRoute ignores pointers when route on top of it pops', (WidgetTester tester) async {
+      bool homeTapped = false;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: TextButton(
+            onPressed: () => homeTapped = true,
+            child: const Text('Home'),
+          ),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push<void>(
+        CupertinoPageRoute<void>(
+          fullscreenDialog: true,
+          builder: (_) => const Text('Page 2'),
+        )
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsOneWidget);
+
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Page 2'), findsOneWidget); // Transition still in progress
+
+      await tester.tap(find.text('Home'), warnIfMissed: false); // Home route is not tappable
+      expect(homeTapped, false);
+    });
+
+    testWidgets('CupertinoPageRoute ignores pointers when user pop gesture is in progress', (WidgetTester tester) async {
+      bool homeTapped = false;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: TextButton(
+            onPressed: () => homeTapped = true,
+            child: const Text('Page 1'),
+          ),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        CupertinoPageRoute<void>(
+          builder: (_) => const Text('Page 2'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 1'), findsNothing);
+
+      final TestGesture swipeGesture = await tester.startGesture(const Offset(5, 100));
+
+      await swipeGesture.moveBy(const Offset(100, 0));
+      await tester.pump();
+
+      expect(find.text('Page 1'), findsOneWidget);
+      expect(tester.state<NavigatorState>(find.byType(Navigator)).userGestureInProgress, true);
+
+      await tester.tap(find.text('Page 1'), warnIfMissed: false);
+      expect(homeTapped, false);
+    });
+
+    testWidgets('CupertinoPageRoute ignores pointers when it is pushed on top of other route', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          onGenerateRoute: (_) => CupertinoPageRoute<void>(
+            builder: (_) => const Text('Home'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Home'));
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        CupertinoPageRoute<void>(
+          builder: (_) => const Text('Page 2'),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Home'), findsOneWidget); // Transition still in progress
+
+      // Can't test directly for taps because route is interactive but offstage
+      // One ignore pointer for each of two overlay entries (ModalScope, ModalBarrier) on each of two routes
+      expect(find.byType(IgnorePointer, skipOffstage: false), findsNWidgets(4));
+      final List<Element> ignorePointers = find.byType(IgnorePointer, skipOffstage: false).evaluate().toList();
+      expect((ignorePointers.first.widget as IgnorePointer).ignoring, true); // Home modalBarrier
+      expect((ignorePointers[1].widget as IgnorePointer).ignoring, true);    // Home modalScope
+      expect((ignorePointers[2].widget as IgnorePointer).ignoring, true);    // Page 2 modalBarrier
+      expect((ignorePointers.last.widget as IgnorePointer).ignoring, true);  // Page 2 modalScope
+    });
+
+    testWidgets('showCupertinoDialog ignores pointers until transition completes', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () {
+                  showCupertinoModalPopup<void>(
+                    context: context,
+                    builder: (BuildContext innerContext) => TextButton(
+                      onPressed: Navigator.of(innerContext).pop,
+                      child: const Text('dialog'),
+                    ),
+                  );
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Open the dialog.
+      await tester.tap(find.byType(TextButton));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Trigger pop while the transition is in progress
+      await tester.tap(find.text('dialog'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      // Transition is over and the dialog has not been dismissed
+      expect(find.text('dialog'), findsOneWidget);
+
+      await tester.tap(find.text('dialog'));
+      await tester.pumpAndSettle();
+
+      // The dialog has not been dismissed
+      expect(find.text('dialog'), findsNothing);
+    });
+
+    testWidgets('showCupertinoModalPopup ignores pointers until transition completes', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () {
+                  showCupertinoModalPopup<void>(
+                    context: context,
+                    builder: (BuildContext innerContext) => TextButton(
+                      onPressed: Navigator.of(innerContext).pop,
+                      child: const Text('modal'),
+                    ),
+                  );
+                },
+                child: const Text('Show modal'),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Open the modal popup
+      await tester.tap(find.byType(TextButton));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Trigger pop while the transition is in progress
+      await tester.tap(find.text('modal'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      // Transition is over and the dialog has not been dismissed
+      expect(find.text('modal'), findsOneWidget);
+
+      await tester.tap(find.text('modal'));
+      await tester.pumpAndSettle();
+
+      // The dialog has not been dismissed
+      expect(find.text('modal'), findsNothing);
+    });
   });
 
   testWidgets('Animated push/pop is not linear', (WidgetTester tester) async {

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -432,6 +432,7 @@ void main() {
         routes: routes,
       ),
     );
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
     await tester.tap(find.text('PUSH'));
     expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
     expect(find.text('PUSH'), findsNothing);
@@ -790,8 +791,8 @@ void main() {
 
     // Tapping the "page" route's back button doesn't do anything either.
     await tester.tap(find.byTooltip('Back'), warnIfMissed: false);
-    await tester.pumpAndSettle();
-    expect(tester.getTopLeft(find.byKey(pageScaffoldKey)), const Offset(400, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(find.byKey(pageScaffoldKey, skipOffstage: false)), const Offset(400, 0));
     expect(tester.getTopLeft(find.byKey(homeScaffoldKey)).dx, lessThan(0));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1373,8 +1373,17 @@ void main() {
 
     testWidgets('does not ignore pointers when route on top of it pops', (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
-          home: Text('Home'),
+        MaterialApp(
+          theme: ThemeData(
+            pageTransitionsTheme: const PageTransitionsTheme(
+              builders: <TargetPlatform, PageTransitionsBuilder>{
+                // Use a transitions builder that will keep the underlying content
+                // partially visible during a transition
+                TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+              },
+            )
+          ),
+          home: const Text('Home'),
         ),
       );
 

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -440,7 +440,7 @@ void main() {
 
       await tester.tap(find.text('Next'));
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
 
       await tester.pageBack();
       await tester.pump();


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/54090

## Summary

Currently, the Flutter implementation of `TransitionRoute`/`ModalRoute` ensures that, for all material and Cupertino page route transitions, if the route is the current route, then the route is interactive. When the route isn't current, it can't be interacted with. This is the correct logic for android, but on iOS, transitions must be fully complete before the current route can process tap events.

This PR adds in the ability for routes to opt-in to the behavior described for native iOS: when the current route is transitioning (e.g., a route has just been pushed on top of it, or the route is in its own entrance animation, etc.), it can be set to ignore pointers until the transition is over.

This behavior would now be configurable via the `ignorePointerDuringTransitions` field on `ModalRoute`.

The implementation here is based on routes tracking whether pointers should be ignored via a notifier that could update any time the `animation`'s or `secondaryAnimation`'s status changes. This should be probably the most performant approach, firstly because rebuilds on the overlay's `_ModalScope`'s existing `IgnorePointer` will only happen when the value of whether the route should intercept pointers changes, and because whether routes should be interactive could actually change any time there is a change in an animation status.

With this change, it's no longer necessary to track for user gestures in `_ModalScope`, because that logic is already covered by the AnimationStatus-based approach described above.

**Alternatives considered:**
- Not doing this at all (but as a developer, personally I'd really like the ability to configure this to minimize errant extra navigation during transitions)
- Track whether transitions are in progress on the navigator, similarly to how its done for `userGestureInProgress` (but this gets very messy because of how often secondary animations get updated without an animation completing its full cycle)
- Not changing `TransitionRoute` at all (this became necessary because we need to consult the `nextRoute`'s animation status to decide whether the current route should ignore pointers, for example, after popping a fullscreen dialog route)

## Recordings (slowed down for ease of observation):

<details><summary>Native iOS</summary>

### Native iOS behavior:

https://user-images.githubusercontent.com/7915388/147303281-27061deb-e1f7-4ccb-9e0c-4b7b03638280.mov

</details>

<details><summary>Flutter (before)</summary>

#### Cupertino:

https://user-images.githubusercontent.com/7915388/147303681-dbdd4d13-7c88-4870-9880-cbcde6ec4d2d.mov

#### Material:

https://user-images.githubusercontent.com/7915388/147303712-baefcef2-6ffb-4abf-86b7-ab8569320b05.mov

</details>

<details><summary>Flutter (after)</summary>

#### Cupertino:

https://user-images.githubusercontent.com/7915388/147303557-5b25db8b-be85-4630-80b0-a87be37d67a9.mov

#### Material:

https://user-images.githubusercontent.com/7915388/147303559-120720b0-5716-4666-a526-509a990fd317.mov

</details>

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. (fixing up a few now)