### PR TITLE
Update default android page transition in the skeleton app

### DIFF
--- a/packages/flutter_tools/templates/skeleton/lib/src/app.dart.tmpl
+++ b/packages/flutter_tools/templates/skeleton/lib/src/app.dart.tmpl
@@ -25,6 +25,19 @@ class MyApp extends StatelessWidget {
     return AnimatedBuilder(
       animation: settingsController,
       builder: (BuildContext context, Widget? child) {
+        // Define a PageTransitionsTheme and provide it to an app's theme to
+        // override the default page transition animations that are used
+        // on each platform to match native behavior. In this case, using a
+        // ZoomPageTransitionsBuilder will make animations on Android devices
+        // match the default animations seen on Android 10 and above.
+        const pageTransitionsTheme = PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: ZoomPageTransitionsBuilder(),
+            TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+            TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+          },
+        );
+
         return MaterialApp(
           // Providing a restorationScopeId allows the Navigator built by the
           // MaterialApp to restore the navigation stack when a user leaves and
@@ -56,8 +69,13 @@ class MyApp extends StatelessWidget {
           // Define a light and dark color theme. Then, read the user's
           // preferred ThemeMode (light, dark, or system default) from the
           // SettingsController to display the correct theme.
-          theme: ThemeData(),
-          darkTheme: ThemeData.dark(),
+          theme: ThemeData(
+            pageTransitionsTheme: pageTransitionsTheme,
+          ),
+          darkTheme: ThemeData(
+            brightness: Brightness.dark,
+            pageTransitionsTheme: pageTransitionsTheme,
+          ),
           themeMode: settingsController.themeMode,
 
           // Define a function to handle named routes in order to support

--- a/packages/flutter_tools/templates/skeleton/test/implementation_test.dart.test.tmpl
+++ b/packages/flutter_tools/templates/skeleton/test/implementation_test.dart.test.tmpl
@@ -75,10 +75,6 @@ void main() {
     await tester.pumpAndSettle();
 
     final app = find.byType(MaterialApp).evaluate().single.widget as MaterialApp;
-    // The theme overrides the default page transition builders
-    // with a custom implementation
-    final defaultBuilders = const PageTransitionsTheme().builders;
-    expect(app.theme!.pageTransitionsTheme.builders != defaultBuilders, true);
 
     // The app uses the same PageTransitionsTheme for the light and dark themes
     expect(
@@ -86,11 +82,15 @@ void main() {
       app.darkTheme!.pageTransitionsTheme.builders,
     );
 
-    // The app uses the ZoomPageTransitionsBuilder for TargetPlatform.android
+    // The app overrides the default builder for TargetPlatform.android with
+    // ZoomPageTransitionsBuilder
+    final appBuilders = app.theme!.pageTransitionsTheme.builders;
+    final defaultBuilders = const PageTransitionsTheme().builders;
     expect(
-      app.theme!.pageTransitionsTheme.builders[TargetPlatform.android],
-      isA<ZoomPageTransitionsBuilder>(),
+      appBuilders[TargetPlatform.android] != defaultBuilders[TargetPlatform.android],
+      true,
     );
+    expect(appBuilders[TargetPlatform.android], isA<ZoomPageTransitionsBuilder>());
   });
 }
 

--- a/packages/flutter_tools/templates/skeleton/test/implementation_test.dart.test.tmpl
+++ b/packages/flutter_tools/templates/skeleton/test/implementation_test.dart.test.tmpl
@@ -66,6 +66,32 @@ void main() {
       expect(findApp(ThemeMode.light), findsOneWidget);
     });
   });
+
+  testWidgets('overrides PageTransitionsTheme with ZoomPageTransitionsBuilder for Android', (WidgetTester tester) async {
+    final controller = SettingsController(SettingsService());
+    await controller.loadSettings();
+
+    await tester.pumpWidget(MyApp(settingsController: controller));
+    await tester.pumpAndSettle();
+
+    final app = find.byType(MaterialApp).evaluate().single.widget as MaterialApp;
+    // The theme overrides the default page transition builders
+    // with a custom implementation
+    final defaultBuilders = const PageTransitionsTheme().builders;
+    expect(app.theme!.pageTransitionsTheme.builders != defaultBuilders, true);
+
+    // The app uses the same PageTransitionsTheme for the light and dark themes
+    expect(
+      app.theme!.pageTransitionsTheme.builders,
+      app.darkTheme!.pageTransitionsTheme.builders,
+    );
+
+    // The app uses the ZoomPageTransitionsBuilder for TargetPlatform.android
+    expect(
+      app.theme!.pageTransitionsTheme.builders[TargetPlatform.android],
+      isA<ZoomPageTransitionsBuilder>(),
+    );
+  });
 }
 
 Finder findApp(ThemeMode themeMode) => find.byWidgetPredicate(


### PR DESCRIPTION
This PR updates the skeleton app template to define custom page transitions to better match the native transitions most commonly seen on Android 10 and above.

This should be reverted once https://github.com/flutter/flutter/pull/88482 has been relanded (or, more specifically, whenever someone makes an update that updates the default `PageTransitionsTheme._builders` to use the `ZoomPageTransitionBuilder` on Android).

This PR fixes https://github.com/flutter/flutter/issues/92439.

https://user-images.githubusercontent.com/7915388/147396920-0d8a92c9-a963-4182-9b85-f11a80690d8d.mov

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.