### PR TITLE
Use a more appropriate curve on ScrollsToTop

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2561,8 +2561,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     if (_primaryScrollController != null && _primaryScrollController.hasClients) {
       _primaryScrollController.animateTo(
         0.0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.linear, // TODO(ianh): Use a more appropriate curve.
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOutQuart,
       );
     }
   }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -400,6 +400,21 @@ void main() {
     expect(scrollable.position.pixels, equals(500.0));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }));
 
+  testWidgets('Tapping the status bar scrolls to top use a more appropriate curve',
+          (WidgetTester tester) async {
+        await tester
+            .pumpWidget(_buildStatusBarTestApp(debugDefaultTargetPlatformOverride));
+        final ScrollableState scrollable = tester.state(find.byType(Scrollable));
+        scrollable.position.jumpTo(500.0);
+        expect(scrollable.position.pixels, equals(500.0));
+        await tester.tapAt(const Offset(100.0, 10.0));
+        await tester.pumpAndSettle();
+        expect(scrollable.position.pixels, equals(0.0));
+      },
+      variant: const TargetPlatformVariant(
+          <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS}));
+
+
   testWidgets('Bottom sheet cannot overlap app bar', (WidgetTester tester) async {
     final Key sheetKey = UniqueKey();
 


### PR DESCRIPTION
This PR changes animation curves and duration when clicking status bar on iOS or macOS.

Fixes #95846

I found iOS uses **cubic bézier curve** and duration is 200 milliseconds.
So, I changed 300 milliseconds and linear animation to 200 milliseconds and **easeInOutQuart** curves.

Nothing to change documentation

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
