### PR TITLE
Support ShapeDecoration lerp between gradient and color

### DIFF
--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -237,12 +237,31 @@ class ShapeDecoration extends Decoration {
       if (t == 1.0)
         return b;
     }
+
+    Color? lerpColor = Color.lerp(a?.color, b?.color, t);
+    Gradient? lerpGradient = Gradient.lerp(a?.gradient, b?.gradient, t);
+    final DecorationImage? lerpImage = t < 0.5 ? a!.image : b!.image; // TODO(ianh): cross-fade the image
+    final List<BoxShadow>? lerpShadows = BoxShadow.lerpList(a?.shadows, b?.shadows, t);
+    final ShapeBorder lerpShape = ShapeBorder.lerp(a?.shape, b?.shape, t)!;
+
+    // The [color] and [gradient] properties are mutually exclusive, one (or
+    // both) of them must be null.
+    if (lerpColor != null && lerpGradient != null) {
+      if (t < 0.5) {
+        lerpColor = a?.color == null ? null : lerpColor;
+        lerpGradient = a?.gradient == null ? null : lerpGradient;
+      } else {
+        lerpColor = b?.color == null ? null : lerpColor;
+        lerpGradient = b?.gradient == null ? null : lerpGradient;
+      }
+    }
+
     return ShapeDecoration(
-      color: Color.lerp(a?.color, b?.color, t),
-      gradient: Gradient.lerp(a?.gradient, b?.gradient, t),
-      image: t < 0.5 ? a!.image : b!.image, // TODO(ianh): cross-fade the image
-      shadows: BoxShadow.lerpList(a?.shadows, b?.shadows, t),
-      shape: ShapeBorder.lerp(a?.shape, b?.shape, t)!,
+      color: lerpColor,
+      gradient: lerpGradient,
+      image: lerpImage,
+      shadows: lerpShadows,
+      shape: lerpShape,
     );
   }
 

--- a/packages/flutter/test/painting/shape_decoration_test.dart
+++ b/packages/flutter/test/painting/shape_decoration_test.dart
@@ -55,6 +55,30 @@ void main() {
     expect(b.hitTest(size, const Offset(20.0, 50.0)), isTrue);
   });
 
+  test('ShapeDecoration lerp between gradient and color', () {
+    // Regression test for https://github.com/flutter/flutter/issues/93953
+
+    const Color colorR = Color(0xffff0000);
+    const Color colorG = Color(0xff00ff00);
+    const Gradient gradient = LinearGradient(colors: <Color>[colorR, colorG]);
+    const ShapeDecoration a = ShapeDecoration(
+      color: colorR,
+      shape: CircleBorder(),
+    );
+    const ShapeDecoration b = ShapeDecoration(
+      gradient: gradient,
+      shape: RoundedRectangleBorder(),
+    );
+    expect(ShapeDecoration.lerp(a, b, 0.0), a);
+    expect(ShapeDecoration.lerp(a, b, 1.0), b);
+
+    expect(ShapeDecoration.lerp(a, b, 0.49)!.color, isNotNull);
+    expect(ShapeDecoration.lerp(a, b, 0.49)!.gradient, null);
+
+    expect(ShapeDecoration.lerp(a, b, 0.5)!.color, null);
+    expect(ShapeDecoration.lerp(a, b, 0.5)!.gradient, isNotNull);
+  });
+
   test('ShapeDecoration.image RTL test', () async {
     final ui.Image image = await createTestImage(width: 100, height: 200);
     final List<int> log = <int>[];


### PR DESCRIPTION
Fixes #93953

`ShapeDecoration` 's [color] and [gradient] properties are mutually exclusive, one (or both) of them must be null.

This change supports it lerp between color and gradient.
