### PR TITLE
[flutter_tools] Remove previous temp dirs on startup

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p; // flutter_ignore: package_path_import
 import 'package:process/process.dart';
 
 import 'common.dart' show throwToolExit;
+import 'file_system.dart';
 import 'platform.dart';
 
 // The Flutter tool hits file system and process errors that only the end-user can address.
@@ -150,6 +151,13 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
   set currentDirectory(dynamic path) {
     _cachedPath = null;
     delegate.currentDirectory = path;
+  }
+
+  void deletePreviousTempDirs() {
+    // this is not relevant with test file systems
+    if (delegate is LocalFileSystem) {
+      (delegate as LocalFileSystem).deletePreviousTempDirs();
+    }
   }
 
   @override

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -187,6 +187,12 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
   void deletePreviousTempDirs() {
     final List<FileSystemEntity> tempEntities = super.systemTempDirectory.listSync();
 
+    if (_systemTemp != null) {
+      throw StateError(
+        'Tried to delete temp directories created by the Flutter tool after the '
+        'current invocation created a temp directory at ${_systemTemp!.path}');
+    }
+
     for (final FileSystemEntity entity in tempEntities) {
       if (entity is Directory) {
         if (entity.path.contains(r'flutter_tools.')) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -124,9 +124,9 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         ),
       if (windowsWorkflow!.appliesToHostPlatform)
         visualStudioValidator!,
-      if (ideValidators.isNotEmpty)
-        ...ideValidators
-      else
+      //if (ideValidators.isNotEmpty)
+      //  ...ideValidators
+      //else
         NoIdeValidator(),
       if (proxyValidator.shouldShow)
         proxyValidator,

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -124,9 +124,9 @@ class _DefaultDoctorValidatorsProvider implements DoctorValidatorsProvider {
         ),
       if (windowsWorkflow!.appliesToHostPlatform)
         visualStudioValidator!,
-      //if (ideValidators.isNotEmpty)
-      //  ...ideValidators
-      //else
+      if (ideValidators.isNotEmpty)
+        ...ideValidators
+      else
         NoIdeValidator(),
       if (proxyValidator.shouldShow)
         proxyValidator,

--- a/packages/flutter_tools/lib/src/pre_run_validator.dart
+++ b/packages/flutter_tools/lib/src/pre_run_validator.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'base/common.dart';
+import 'base/error_handling_io.dart';
 import 'base/file_system.dart';
 import 'cache.dart';
 
@@ -50,8 +51,8 @@ class _DefaultPreRunValidator implements PreRunValidator {
   // Delete any temp dirs created by previous tool invocations
   void _deletePreviousToolTempDirs() {
     // this is not relevant with test file systems
-    if (fileSystem is LocalFileSystem) {
-      (fileSystem as LocalFileSystem).deletePreviousTempDirs();
+    if (fileSystem is ErrorHandlingFileSystem) {
+      (fileSystem as ErrorHandlingFileSystem).deletePreviousTempDirs();
     }
   }
 }

--- a/packages/flutter_tools/lib/src/pre_run_validator.dart
+++ b/packages/flutter_tools/lib/src/pre_run_validator.dart
@@ -28,10 +28,15 @@ class _DefaultPreRunValidator implements PreRunValidator {
 
   @override
   void validate() {
-    // If a user downloads the Flutter SDK via a pre-built archive and there is
-    // an error during extraction, the user could have a valid Dart snapshot of
-    // the tool but not the source directory. We still need the source, so
-    // validate the source directory exists and toolExit if not.
+    _ensureToolsDirExists();
+    _deletePreviousToolTempDirs();
+  }
+
+  // If a user downloads the Flutter SDK via a pre-built archive and there is
+  // an error during extraction, the user could have a valid Dart snapshot of
+  // the tool but not the source directory. We still need the source, so
+  // validate the source directory exists and toolExit if not.
+  void _ensureToolsDirExists() {
     if (!_toolsDir.existsSync()) {
       throwToolExit(
         'Flutter SDK installation appears corrupted: expected to find the '
@@ -39,6 +44,14 @@ class _DefaultPreRunValidator implements PreRunValidator {
         'https://flutter.dev/setup for instructions on how to re-install '
         'Flutter.',
       );
+    }
+  }
+
+  // Delete any temp dirs created by previous tool invocations
+  void _deletePreviousToolTempDirs() {
+    // this is not relevant with test file systems
+    if (fileSystem is LocalFileSystem) {
+      (fileSystem as LocalFileSystem).deletePreviousTempDirs();
     }
   }
 }

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -144,43 +144,6 @@ void main() {
       expect(fsUtils.escapePath(r'foo\cool.dart'), r'foo\cool.dart');
     });
   });
-
-  group('LocalFileSystem', () {
-    late FakeProcessSignal fakeSignal;
-    late ProcessSignal signalUnderTest;
-
-    setUp(() {
-      fakeSignal = FakeProcessSignal();
-      signalUnderTest = ProcessSignal(fakeSignal);
-    });
-
-    testWithoutContext('deletes system temp entry on a fatal signal', () async {
-      final Completer<void> completer = Completer<void>();
-      final Signals signals = Signals.test();
-      final LocalFileSystem localFileSystem = LocalFileSystem.test(
-        signals: signals,
-        fatalSignals: <ProcessSignal>[signalUnderTest],
-      );
-      final Directory temp = localFileSystem.systemTempDirectory;
-
-      signals.addHandler(signalUnderTest, (ProcessSignal s) {
-        completer.complete();
-      });
-
-      expect(temp.existsSync(), isTrue);
-
-      fakeSignal.controller.add(fakeSignal);
-      await completer.future;
-
-      expect(temp.existsSync(), isFalse);
-    });
-  });
 }
 
-class FakeProcessSignal extends Fake implements io.ProcessSignal {
-  final StreamController<io.ProcessSignal> controller = StreamController<io.ProcessSignal>();
-
-  @override
-  Stream<io.ProcessSignal> watch() => controller.stream;
-}
 class FakeFile extends Fake implements File { }

--- a/packages/flutter_tools/test/general.shard/base/file_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/file_system_test.dart
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:io' as io;
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/signals.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
+++ b/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/signals.dart';
+import 'package:test/fake.dart';
+
+import '../src/common.dart';
+
+void main() {
+  group('LocalFileSystem', () {
+    late FakeProcessSignal fakeSignal;
+    late ProcessSignal signalUnderTest;
+
+    setUp(() {
+      fakeSignal = FakeProcessSignal();
+      signalUnderTest = ProcessSignal(fakeSignal);
+    });
+
+    testWithoutContext('cleans up previous temp dirs on instantiation', () async {
+      final Signals signals = Signals.test();
+      final Directory oldTempDir = LocalFileSystem.test(signals: signals)
+          .systemTempDirectory
+          .createTempSync('foo');
+      expect(oldTempDir.existsSync(), true);
+      final LocalFileSystem localFileSystem = LocalFileSystem.test(
+        signals: signals,
+        fatalSignals: <ProcessSignal>[signalUnderTest],
+      );
+      localFileSystem.deletePreviousTempDirs();
+      expect(oldTempDir.existsSync(), false, reason: '${oldTempDir.path} still exists!');
+    });
+
+    testWithoutContext('deletes system temp entry on a fatal signal', () async {
+      final Completer<void> completer = Completer<void>();
+      final Signals signals = Signals.test();
+      final LocalFileSystem localFileSystem = LocalFileSystem.test(
+        signals: signals,
+        fatalSignals: <ProcessSignal>[signalUnderTest],
+      );
+      final Directory temp = localFileSystem.systemTempDirectory;
+
+      signals.addHandler(signalUnderTest, (ProcessSignal s) {
+        completer.complete();
+      });
+
+      expect(temp.existsSync(), isTrue);
+
+      fakeSignal.controller.add(fakeSignal);
+      await completer.future;
+
+      expect(temp.existsSync(), isFalse);
+    });
+  });
+}
+
+class FakeProcessSignal extends Fake implements io.ProcessSignal {
+  final StreamController<io.ProcessSignal> controller = StreamController<io.ProcessSignal>();
+
+  @override
+  Stream<io.ProcessSignal> watch() => controller.stream;
+}

--- a/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
+++ b/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
@@ -21,6 +21,7 @@ void main() {
       final Directory oldTempDir = LocalFileSystem.test(signals: signals)
           .systemTempDirectory
           .createTempSync('foo');
+      oldTempDir.childFile('bar.txt').writeAsStringSync('Hello, world!');
       // since we do not call .dispose() on the fs, the temp directory is not
       // deleted
       expect(oldTempDir.existsSync(), true);

--- a/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
+++ b/packages/flutter_tools/test/integration.shard/local_file_system_test.dart
@@ -22,7 +22,7 @@ void main() {
       signalUnderTest = ProcessSignal(fakeSignal);
     });
 
-    testWithoutContext('cleans up previous temp dirs on instantiation', () async {
+    testWithoutContext('.deletePreviousTempDirs() deletes previous temp dirs', () async {
       final Signals signals = Signals.test();
       final Directory oldTempDir = LocalFileSystem.test(signals: signals)
           .systemTempDirectory


### PR DESCRIPTION
On tool startup, look for temp directories created by previous invocations and try to delete them.

Fixes https://github.com/flutter/flutter/issues/54213