### PR TITLE
Fix `paints..something` and `paints..everything` succeeding when they should fail

### DIFF
--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1435,20 +1435,13 @@ class _EverythingPaintPredicate extends _PaintPredicate {
 
   @override
   void match(Iterator<RecordedInvocation> call) {
-    // do {
-    //   final RecordedInvocation currentCall = call.current;
-    //   if (!currentCall.invocation.isMethod)
-    //     throw 'It called $currentCall, which was not a method, when the paint pattern expected a method call';
-    //   if (!_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments))
-    //     return;
-    // } while (call.moveNext());
-    while (call.moveNext()) {
+    do {
       final RecordedInvocation currentCall = call.current;
       if (!currentCall.invocation.isMethod)
         throw 'It called $currentCall, which was not a method, when the paint pattern expected a method call';
       if (!_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments))
         return;
-    }
+    } while (call.moveNext());
   }
 
   bool _runPredicate(Symbol methodName, List<dynamic> arguments) {

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -1440,23 +1440,17 @@ class _EverythingPaintPredicate extends _PaintPredicate {
       if (!currentCall.invocation.isMethod)
         throw 'It called $currentCall, which was not a method, when the paint pattern expected a method call';
       if (!_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments))
-        return;
+        throw 'It painted something that the predicate passed to an "everything" step '
+              'in the paint pattern considered incorrect.\n';
     } while (call.moveNext());
   }
 
   bool _runPredicate(Symbol methodName, List<dynamic> arguments) {
-    final bool predicateSucceeded;
     try {
-      predicateSucceeded = predicate(methodName, arguments);
+      return predicate(methodName, arguments);
     } on String catch (s) {
       throw 'It painted something that the predicate passed to an "everything" step '
             'in the paint pattern considered incorrect:\n      $s\n  ';
-    }
-    if (predicateSucceeded) {
-      return true;
-    } else {
-      throw 'It painted something that the predicate passed to an "everything" step '
-            'in the paint pattern considered incorrect.\n';
     }
   }
 

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -426,6 +426,10 @@ abstract class PaintPattern {
   /// The predicate will be applied to each [Canvas] call until it returns false
   /// or all of the method calls have been tested.
   ///
+  /// If the predicate returns false, then the [paints] [Matcher] is considered
+  /// to have failed. If all calls are tested without failing, then the [paints]
+  /// [Matcher] is considered a success.
+  ///
   /// If the predicate throws a [String], then the [paints] [Matcher] is
   /// considered to have failed. The thrown string is used in the message
   /// displayed from the test framework and should be complete sentence
@@ -831,7 +835,11 @@ class _TestRecordingCanvasPatternMatcher extends _TestRecordingCanvasMatcher imp
       return false;
     } on String catch (s) {
       description.writeln(s);
-      description.write('The stack of the offending call was:\n${call.current.stackToString(indent: "  ")}\n');
+      try {
+        description.write('The stack of the offending call was:\n${call.current.stackToString(indent: "  ")}\n');
+      } on TypeError catch (_) {
+        // All calls have been evaluated
+      }
       return false;
     }
     return true;
@@ -1393,13 +1401,18 @@ class _SomethingPaintPredicate extends _PaintPredicate {
 
   @override
   void match(Iterator<RecordedInvocation> call) {
-    assert(predicate != null);
     RecordedInvocation currentCall;
+    bool testedAllCalls = false;
     do {
+      if (testedAllCalls) {
+        throw 'It painted methods that the predicate passed to a "something" step, '
+              'in the paint pattern, none of which were considered correct.';
+      }
       currentCall = call.current;
       if (!currentCall.invocation.isMethod)
         throw 'It called $currentCall, which was not a method, when the paint pattern expected a method call';
-    } while (call.moveNext() && !_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments));
+      testedAllCalls = !call.moveNext();
+    } while (!_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments));
   }
 
   bool _runPredicate(Symbol methodName, List<dynamic> arguments) {
@@ -1422,7 +1435,13 @@ class _EverythingPaintPredicate extends _PaintPredicate {
 
   @override
   void match(Iterator<RecordedInvocation> call) {
-    assert(predicate != null);
+    // do {
+    //   final RecordedInvocation currentCall = call.current;
+    //   if (!currentCall.invocation.isMethod)
+    //     throw 'It called $currentCall, which was not a method, when the paint pattern expected a method call';
+    //   if (!_runPredicate(currentCall.invocation.memberName, currentCall.invocation.positionalArguments))
+    //     return;
+    // } while (call.moveNext());
     while (call.moveNext()) {
       final RecordedInvocation currentCall = call.current;
       if (!currentCall.invocation.isMethod)
@@ -1433,11 +1452,18 @@ class _EverythingPaintPredicate extends _PaintPredicate {
   }
 
   bool _runPredicate(Symbol methodName, List<dynamic> arguments) {
+    final bool predicateSucceeded;
     try {
-      return predicate(methodName, arguments);
+      predicateSucceeded = predicate(methodName, arguments);
     } on String catch (s) {
       throw 'It painted something that the predicate passed to an "everything" step '
             'in the paint pattern considered incorrect:\n      $s\n  ';
+    }
+    if (predicateSucceeded) {
+      return true;
+    } else {
+      throw 'It painted something that the predicate passed to an "everything" step '
+            'in the paint pattern considered incorrect.\n';
     }
   }
 

--- a/packages/flutter/test/rendering/mock_canvas_test.dart
+++ b/packages/flutter/test/rendering/mock_canvas_test.dart
@@ -1,0 +1,246 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'mock_canvas.dart';
+
+class MyPainter extends CustomPainter {
+  const MyPainter({
+    required this.color,
+  });
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawColor(color, BlendMode.color);
+  }
+
+  @override
+  bool shouldRepaint(MyPainter oldDelegate) {
+    return true;
+  }
+}
+
+@immutable
+class MethodAndArguments {
+  const MethodAndArguments(this.method, this.arguments);
+
+  final Symbol method;
+  final List<dynamic> arguments;
+
+  @override
+  bool operator ==(Object other) {
+    if (!(other is MethodAndArguments && other.method == method)) {
+      return false;
+    }
+    for (int i = 0; i < arguments.length; i++) {
+      if (arguments[i] != other.arguments[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => method.hashCode;
+
+  @override
+  String toString() => '$method, $arguments';
+}
+
+void main() {
+  group('something', () {
+    testWidgets('matches when the predicate returns true', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        paints..something((Symbol method, List<dynamic> arguments) {
+          methodsAndArguments.add(MethodAndArguments(method, arguments));
+          return method == #drawColor;
+        }),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          // The #restore call is never evaluated
+        ],
+      );
+    });
+
+    testWidgets('fails when the predicate always returns false', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        isNot(
+          paints..something((Symbol method, List<dynamic> arguments) {
+            methodsAndArguments.add(MethodAndArguments(method, arguments));
+            return false;
+          }),
+        ),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          const MethodAndArguments(#restore, <dynamic>[]),
+        ],
+      );
+    });
+
+    testWidgets('fails when the predicate throws', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        isNot(
+          paints..something((Symbol method, List<dynamic> arguments) {
+            methodsAndArguments.add(MethodAndArguments(method, arguments));
+            if (method == #save) {
+              return false;
+            }
+            if (method == #drawColor) {
+              throw 'fail';
+            }
+            return true;
+          }),
+        ),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          // The #restore call is never evaluated
+        ],
+      );
+    });
+  });
+
+  group('everything', () {
+    testWidgets('matches when the predicate always returns true', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        paints..everything((Symbol method, List<dynamic> arguments) {
+          methodsAndArguments.add(MethodAndArguments(method, arguments));
+          return true;
+        }),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          const MethodAndArguments(#restore, <dynamic>[]),
+        ],
+      );
+    });
+
+    testWidgets('fails when the predicate returns false', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        isNot(
+          paints..everything((Symbol method, List<dynamic> arguments) {
+            methodsAndArguments.add(MethodAndArguments(method, arguments));
+            // returns false on #drawColor
+            return method == #restore || method == #save;
+          }),
+        ),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          // The #restore call is never evaluated
+        ],
+      );
+    });
+
+    testWidgets('fails if the predicate ever throws', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CustomPaint(
+          painter: MyPainter(color: Colors.transparent),
+          child: SizedBox(width: 50, height: 50),
+        ),
+      );
+
+      final List<MethodAndArguments> methodsAndArguments = <MethodAndArguments>[];
+
+      expect(
+        tester.renderObject(find.byType(CustomPaint)),
+        isNot(
+          paints..everything((Symbol method, List<dynamic> arguments) {
+            methodsAndArguments.add(MethodAndArguments(method, arguments));
+            if (method == #drawColor) {
+              throw 'failed ';
+            }
+            return true;
+          }),
+        ),
+      );
+
+      expect(
+        methodsAndArguments,
+        <MethodAndArguments>[
+          const MethodAndArguments(#save, <dynamic>[]),
+          const MethodAndArguments(#drawColor, <dynamic>[Colors.transparent, BlendMode.color]),
+          // The #restore call is never evaluated
+        ],
+      );
+    });
+  });
+}

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2142,6 +2142,9 @@ void main() {
 
       // Show prompt rect when told to.
       verifyAutocorrectionRectVisibility(expectVisible: true);
+      // Verify twice because the rect is drawn twice and paints..something()
+      // matches eagerly on the first success
+      verifyAutocorrectionRectVisibility(expectVisible: true);
 
       // Text changed, prompt rect goes away.
       controller.text = '12345';

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2142,13 +2142,13 @@ void main() {
 
       // Show prompt rect when told to.
       verifyAutocorrectionRectVisibility(expectVisible: true);
-      // Verify twice because the rect is drawn twice and paints..something()
-      // matches eagerly on the first success
-      verifyAutocorrectionRectVisibility(expectVisible: true);
 
       // Text changed, prompt rect goes away.
       controller.text = '12345';
       await tester.pump();
+      // TODO: I think this test has been silently broken for a long time, because
+      // previously, paints..everything() was accidentally skipping every one if its
+      // first calls, and here, the first call fails the expectation
       verifyAutocorrectionRectVisibility(expectVisible: false);
 
       state.showAutocorrectionPromptRect(0, 1);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2143,12 +2143,8 @@ void main() {
       // Show prompt rect when told to.
       verifyAutocorrectionRectVisibility(expectVisible: true);
 
-      // Text changed, prompt rect goes away.
-      controller.text = '12345';
+      await tester.enterText(find.byType(EditableText), '12345');
       await tester.pump();
-      // TODO: I think this test has been silently broken for a long time, because
-      // previously, paints..everything() was accidentally skipping every one if its
-      // first calls, and here, the first call fails the expectation
       verifyAutocorrectionRectVisibility(expectVisible: false);
 
       state.showAutocorrectionPromptRect(0, 1);
@@ -2159,6 +2155,8 @@ void main() {
       // Unfocus, prompt rect should go away.
       focusNode.unfocus();
       await tester.pump();
+      // TODO: This is now failing because there's another drawRect happening
+      //  and I don't know why
       verifyAutocorrectionRectVisibility(expectVisible: false);
     },
   );

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2154,9 +2154,8 @@ void main() {
 
       // Unfocus, prompt rect should go away.
       focusNode.unfocus();
-      await tester.pump();
-      // TODO: This is now failing because there's another drawRect happening
-      //  and I don't know why
+      await tester.pumpAndSettle();
+
       verifyAutocorrectionRectVisibility(expectVisible: false);
     },
   );


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/95981

The current implementations of `paints..everything` and `paints..something` look incorrect when compared to how they're described in the docs. In short, my understanding is that these methods are supposed to behave as follows:

- `everything`: tests all calls until one returns false or throws, and only succeeds if all calls succeed
- `something`: tests all calls until one returns true or throws, and only fails if all calls fail

As of right now, this isn't what happens. Main differences:
1. `everything` skips the first call
2. `something` doesn't fail if all calls fail, but only if a call throws
3. `everything` doesn't fail if all calls fail, but only if a call throws

This is a WIP until I figure out the test failure I'm getting on `editable_text_test`. I think this test either always should've been failing, or regressed silently because of the errant `everything` implementation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
