### PR TITLE
Allow `Checkbox`es in `DataTable`s to inherit colors from `CheckboxTheme`

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -701,9 +701,6 @@ class DataTable extends StatelessWidget {
         ),
         child: Center(
           child: Checkbox(
-            // TODO(per): Remove when Checkbox has theme, https://github.com/flutter/flutter/issues/53420.
-            activeColor: themeData.colorScheme.primary,
-            checkColor: themeData.colorScheme.onPrimary,
             value: checked,
             onChanged: onCheckboxChanged,
             tristate: tristate,

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1298,8 +1298,16 @@ void main() {
     );
   });
 
-  testWidgets('DataRow renders checkbox with colors from Theme', (WidgetTester tester) async {
-    final ThemeData _themeData = ThemeData.light();
+  testWidgets('DataRow renders checkbox with colors from CheckboxTheme', (WidgetTester tester) async {
+    const Color fillColor = Color(0xFF00FF00);
+    const Color checkColor = Color(0xFF0000FF);
+
+    final ThemeData _themeData = ThemeData(
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.all(fillColor),
+        checkColor: MaterialStateProperty.all(checkColor),
+      )
+    );
     Widget buildTable() {
       return MaterialApp(
         theme: _themeData,
@@ -1312,6 +1320,7 @@ void main() {
             ],
             rows: <DataRow>[
               DataRow(
+                selected: true,
                 onSelectChanged: (bool? checked) {},
                 cells: const <DataCell>[
                   DataCell(Text('Content1')),
@@ -1323,13 +1332,25 @@ void main() {
       );
     }
 
-    Checkbox lastCheckbox() {
-      return tester.widgetList<Checkbox>(find.byType(Checkbox)).last;
+    RenderObject lastCheckboxPainter() {
+      return tester.renderObject(
+        find.descendant(of: find.byType(Checkbox), matching: find.byType(CustomPaint)).last,
+      );
+    }
+
+    PaintPattern paintsPath(PaintingStyle style, Color color) {
+      return paints..something((Symbol method, List<dynamic> arguments) {
+        if (method != #drawPath)
+          return false;
+        final Paint paint = arguments[1] as Paint;
+        return paint.style == PaintingStyle.fill && paint.color == color;
+      });
     }
 
     await tester.pumpWidget(buildTable());
-    expect(lastCheckbox().activeColor, _themeData.colorScheme.primary);
-    expect(lastCheckbox().checkColor, _themeData.colorScheme.onPrimary);
+    await tester.pump();
+    expect(lastCheckboxPainter(), paintsPath(PaintingStyle.fill, fillColor));
+    expect(lastCheckboxPainter(), paintsPath(PaintingStyle.stroke, checkColor));
   });
 
   testWidgets('DataRow renders custom colors when selected', (WidgetTester tester) async {

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1306,7 +1306,7 @@ void main() {
       checkboxTheme: CheckboxThemeData(
         fillColor: MaterialStateProperty.all(fillColor),
         checkColor: MaterialStateProperty.all(checkColor),
-      )
+      ),
     );
     Widget buildTable() {
       return MaterialApp(
@@ -1332,25 +1332,15 @@ void main() {
       );
     }
 
-    RenderObject lastCheckboxPainter() {
-      return tester.renderObject(
-        find.descendant(of: find.byType(Checkbox), matching: find.byType(CustomPaint)).last,
-      );
-    }
-
-    PaintPattern paintsPath(PaintingStyle style, Color color) {
-      return paints..something((Symbol method, List<dynamic> arguments) {
-        if (method != #drawPath)
-          return false;
-        final Paint paint = arguments[1] as Paint;
-        return paint.style == PaintingStyle.fill && paint.color == color;
-      });
-    }
-
     await tester.pumpWidget(buildTable());
-    await tester.pump();
-    expect(lastCheckboxPainter(), paintsPath(PaintingStyle.fill, fillColor));
-    expect(lastCheckboxPainter(), paintsPath(PaintingStyle.stroke, checkColor));
+
+    expect(
+      Material.of(tester.element(find.byType(Checkbox).last)),
+      paints
+        ..path()
+        ..path(color: fillColor)
+        ..path(color: checkColor),
+    );
   });
 
   testWidgets('DataRow renders custom colors when selected', (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/96004

This PR resolves a stale TODO left in the `DataTable` code (see the issue for details), by removing the hardcoded values from `DataTable` controlling the checkboxes colors, which instead allows them to inherit those values for the `checkColor` and `fillColor` from the `CheckboxTheme` rather than `ColorScheme.primary` and `ColorScheme.onPrimary`. 

### Before and after:
<img width="300" src="https://user-images.githubusercontent.com/7915388/147841714-c3c94e2a-8d24-4d05-a847-fc586cb4d714.png"> <img width="300" src="https://user-images.githubusercontent.com/7915388/147842386-95cd8e5b-e99a-493e-82a5-1fb22f28c401.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.