### PR TITLE
Update example code and docs for InteractiveViewer.builder

### DIFF
--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -117,13 +117,13 @@ class _TableBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int firstRow = (viewport.top / cellHeight).floor();
-    int lastRow = (viewport.bottom / cellHeight).ceil();
-    int firstCol = (viewport.left / cellWidth).floor();
-    int lastCol = (viewport.right / cellWidth).ceil();
+    final int firstRow = (viewport.top / cellHeight).floor();
+    final int lastRow = (viewport.bottom / cellHeight).ceil();
+    final int firstCol = (viewport.left / cellWidth).floor();
+    final int lastCol = (viewport.right / cellWidth).ceil();
 
-    int totalCells = (lastRow - firstRow) * (lastCol - firstCol);
-    debugPrint("Total cells: $totalCells");
+    final int totalCells = (lastRow - firstRow) * (lastCol - firstCol);
+    debugPrint('Total cells: $totalCells');
 
     return SizedBox(
         // Stack needs constraints, even though we then Clip.none outside of them.

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -31,11 +31,8 @@ class _IVBuilderExample extends StatefulWidget {
 }
 
 class _IVBuilderExampleState extends State<_IVBuilderExample> {
-  final TransformationController _transformationController =
-      TransformationController();
-
-  static const double _cellWidth = 200.0;
-  static const double _cellHeight = 26.0;
+  static const double _cellWidth = 160.0;
+  static const double _cellHeight = 80.0;
 
   // Returns the axis aligned bounding box for the given Quad, which might not be axis aligned.
   Rect axisAlignedBoundingBox(Quad quad) {
@@ -71,9 +68,7 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
         builder: (BuildContext context, BoxConstraints constraints) {
           return InteractiveViewer.builder(
             boundaryMargin: const EdgeInsets.all(double.infinity),
-            transformationController: _transformationController,
             builder: (BuildContext context, Quad viewport) {
-              // A simple extension of Table that builds cells.
               return _TableBuilder(
                   cellWidth: _cellWidth,
                   cellHeight: _cellHeight,
@@ -86,7 +81,7 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
                           ? Colors.white
                           : Colors.grey.withOpacity(0.1),
                       child: Align(
-                        alignment: Alignment.centerLeft,
+                        alignment: Alignment.center,
                         child: Text('$row x $column'),
                       ),
                     );
@@ -122,11 +117,12 @@ class _TableBuilder extends StatelessWidget {
     final int firstCol = (viewport.left / cellWidth).floor();
     final int lastCol = (viewport.right / cellWidth).ceil();
 
-    final int totalCells = (lastRow - firstRow) * (lastCol - firstCol);
-    debugPrint('Total cells: $totalCells');
+    // This will create and render exactly (lastRow - firstRow) * (lastCol - firstCol) cells
 
     return SizedBox(
         // Stack needs constraints, even though we then Clip.none outside of them.
+        // InteractiveViewer.builder always sets constrained to false, giving infinite constraints to the child.
+        // See: https://master-api.flutter.dev/flutter/widgets/InteractiveViewer/constrained.html
         width: 1,
         height: 1,
         child: Stack(

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -5,7 +5,6 @@
 // Flutter code sample for InteractiveViewer.builder
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:vector_math/vector_math_64.dart' show Quad, Vector3;
 
 void main() => runApp(const IVBuilderExampleApp());
@@ -38,71 +37,31 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
   static const double _cellWidth = 200.0;
   static const double _cellHeight = 26.0;
 
-  // Returns true iff the given cell is currently visible. Caches viewport
-  // calculations.
-  Quad? _cachedViewport;
-  late int _firstVisibleRow;
-  late int _firstVisibleColumn;
-  late int _lastVisibleRow;
-  late int _lastVisibleColumn;
-  bool _isCellVisible(int row, int column, Quad viewport) {
-    if (viewport != _cachedViewport) {
-      final Rect aabb = _axisAlignedBoundingBox(viewport);
-      _cachedViewport = viewport;
-      _firstVisibleRow = (aabb.top / _cellHeight).floor();
-      _firstVisibleColumn = (aabb.left / _cellWidth).floor();
-      _lastVisibleRow = (aabb.bottom / _cellHeight).floor();
-      _lastVisibleColumn = (aabb.right / _cellWidth).floor();
-    }
-    return row >= _firstVisibleRow &&
-        row <= _lastVisibleRow &&
-        column >= _firstVisibleColumn &&
-        column <= _lastVisibleColumn;
-  }
-
-  // Returns the axis aligned bounding box for the given Quad, which might not
-  // be axis aligned.
-  Rect _axisAlignedBoundingBox(Quad quad) {
-    double? xMin;
-    double? xMax;
-    double? yMin;
-    double? yMax;
+  // Returns the axis aligned bounding box for the given Quad, which might not be axis aligned.
+  Rect axisAlignedBoundingBox(Quad quad) {
+    double xMin = quad.point0.x;
+    double xMax = quad.point0.x;
+    double yMin = quad.point0.y;
+    double yMax = quad.point0.y;
     for (final Vector3 point in <Vector3>[
-      quad.point0,
       quad.point1,
       quad.point2,
       quad.point3
     ]) {
-      if (xMin == null || point.x < xMin) {
+      if (point.x < xMin) {
         xMin = point.x;
-      }
-      if (xMax == null || point.x > xMax) {
+      } else if (point.x > xMax) {
         xMax = point.x;
       }
-      if (yMin == null || point.y < yMin) {
+
+      if (point.y < yMin) {
         yMin = point.y;
-      }
-      if (yMax == null || point.y > yMax) {
+      } else if (point.y > yMax) {
         yMax = point.y;
       }
     }
-    return Rect.fromLTRB(xMin!, yMin!, xMax!, yMax!);
-  }
 
-  void _onChangeTransformation() {
-    setState(() {});
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _transformationController.addListener(_onChangeTransformation);
-  }
-
-  @override
-  void dispose() {
-    _transformationController.removeListener(_onChangeTransformation);
-    super.dispose();
+    return Rect.fromLTRB(xMin, yMin, xMax, yMax);
   }
 
   @override
@@ -111,23 +70,18 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           return InteractiveViewer.builder(
-            alignPanAxis: true,
-            scaleEnabled: false,
+            boundaryMargin: const EdgeInsets.all(double.infinity),
             transformationController: _transformationController,
             builder: (BuildContext context, Quad viewport) {
               // A simple extension of Table that builds cells.
               return _TableBuilder(
-                  rowCount: 60,
-                  columnCount: 6,
                   cellWidth: _cellWidth,
+                  cellHeight: _cellHeight,
+                  viewport: axisAlignedBoundingBox(viewport),
                   builder: (BuildContext context, int row, int column) {
-                    if (!_isCellVisible(row, column, viewport)) {
-                      debugPrint('removing cell ($row, $column)');
-                      return Container(height: _cellHeight);
-                    }
-                    debugPrint('building cell ($row, $column)');
                     return Container(
                       height: _cellHeight,
+                      width: _cellWidth,
                       color: row % 2 + column % 2 == 1
                           ? Colors.white
                           : Colors.grey.withOpacity(0.1),
@@ -150,38 +104,41 @@ typedef _CellBuilder = Widget Function(
 
 class _TableBuilder extends StatelessWidget {
   const _TableBuilder({
-    required this.rowCount,
-    required this.columnCount,
     required this.cellWidth,
+    required this.cellHeight,
+    required this.viewport,
     required this.builder,
-  })  : assert(rowCount > 0),
-        assert(columnCount > 0);
+  });
 
-  final int rowCount;
-  final int columnCount;
   final double cellWidth;
+  final double cellHeight;
+  final Rect viewport;
   final _CellBuilder builder;
 
   @override
   Widget build(BuildContext context) {
-    return Table(
-      // ignore: prefer_const_literals_to_create_immutables
-      columnWidths: <int, TableColumnWidth>{
-        for (int column = 0; column < columnCount; column++)
-          column: FixedColumnWidth(cellWidth),
-      },
-      // ignore: prefer_const_literals_to_create_immutables
-      children: <TableRow>[
-        for (int row = 0; row < rowCount; row++)
-          // ignore: prefer_const_constructors
-          TableRow(
-            // ignore: prefer_const_literals_to_create_immutables
-            children: <Widget>[
-              for (int column = 0; column < columnCount; column++)
-                builder(context, row, column),
-            ],
-          ),
-      ],
-    );
+    int firstRow = (viewport.top / cellHeight).floor();
+    int lastRow = (viewport.bottom / cellHeight).ceil();
+    int firstCol = (viewport.left / cellWidth).floor();
+    int lastCol = (viewport.right / cellWidth).ceil();
+
+    int totalCells = (lastRow - firstRow) * (lastCol - firstCol);
+    debugPrint("Total cells: $totalCells");
+
+    return SizedBox(
+        // Stack needs constraints, even though we then Clip.none outside of them.
+        width: 1,
+        height: 1,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: <Widget>[
+            for (int row = firstRow; row < lastRow; row++)
+              for (int col = firstCol; col < lastCol; col++)
+                Positioned(
+                    left: col * cellWidth,
+                    top: row * cellHeight,
+                    child: builder(context, row, col)),
+          ],
+        ));
   }
 }

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -81,7 +81,6 @@ class _IVBuilderExampleState extends State<_IVBuilderExample> {
                           ? Colors.white
                           : Colors.grey.withOpacity(0.1),
                       child: Align(
-                        alignment: Alignment.center,
                         child: Text('$row x $column'),
                       ),
                     );

--- a/examples/api/test/widgets/interactive_viewer/interactive_viewer.builder.0_test.dart
+++ b/examples/api/test/widgets/interactive_viewer/interactive_viewer.builder.0_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/widgets/interactive_viewer/interactive_viewer.builder.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('has correct items on screen', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.IVBuilderExampleApp(),
+    );
+
+    final Finder positionedFinder = find.byType(Positioned);
+    final Finder zeroFinder = find.text('0 x 0');
+    final Finder nineFinder = find.text('0 x 9');
+
+    expect(positionedFinder, findsNWidgets(35));
+    expect(zeroFinder, findsOneWidget);
+    expect(nineFinder, findsNothing);
+
+    const Offset firstLocation = Offset(750.0, 100.0);
+    final TestGesture gesture = await tester.startGesture(firstLocation);
+
+    const Offset secondLocation = Offset(50.0, 100.0);
+    await gesture.moveTo(secondLocation);
+    await tester.pump();
+
+    expect(positionedFinder, findsNWidgets(42));
+    expect(nineFinder, findsOneWidget);
+    expect(zeroFinder, findsNothing);
+  });
+}

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -41,6 +41,10 @@ typedef InteractiveViewerWidgetBuilder = Widget Function(BuildContext context, Q
 /// robust positioning of an InteractiveViewer child that works for all screen
 /// sizes and child sizes.
 ///
+/// See [Lazy Flutter performance](https://www.youtube.com/watch?v=qax_nOpgz7E)
+/// for a video on using an InteractiveViewer to performantly view subsets of
+/// a large set of widgets using the builder constructor.
+///
 /// The [child] must not be null.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -37,19 +37,15 @@ typedef InteractiveViewerWidgetBuilder = Widget Function(BuildContext context, Q
 /// don't set [clipBehavior] or be sure that the InteractiveViewer widget is the
 /// size of the area that should be interactive.
 ///
-/// See [flutter-go](https://github.com/justinmc/flutter-go) for an example of
-/// robust positioning of an InteractiveViewer child that works for all screen
-/// sizes and child sizes.
-///
-/// See [Lazy Flutter performance](https://www.youtube.com/watch?v=qax_nOpgz7E)
-/// for a video on using an InteractiveViewer to performantly view subsets of
-/// a large set of widgets using the builder constructor.
-///
 /// The [child] must not be null.
 ///
 /// See also:
 ///   * The [Flutter Gallery's transformations demo](https://github.com/flutter/gallery/blob/master/lib/demos/reference/transformations_demo.dart),
 ///     which includes the use of InteractiveViewer.
+///   * The [flutter-go demo](https://github.com/justinmc/flutter-go), which includes robust positioning of an InteractiveViewer child
+///     that works for all screen sizes and child sizes.
+///   * The [Lazy Flutter Performance Session](https://www.youtube.com/watch?v=qax_nOpgz7E), which includes the use of an InteractiveViewer to
+///     performantly view subsets of a large set of widgets using the builder constructor.
 ///
 /// {@tool dartpad}
 /// This example shows a simple Container that can be panned and zoomed.


### PR DESCRIPTION
Fixes #96005

The old example code laid out every single cell and did visibility checks on each of them. This resulted in poor performance and is not a viable pattern to copy.

This takes inspiration from the official [youtube video](https://www.youtube.com/watch?v=qax_nOpgz7E) on this builder form to turn this example into an infinite grid. This also adds this video to the documentation because it's really low in the SEO yet very valuable to understand the builder constructor. 

While performance can still be hit (especially in debug mode) it degrades with # of cells on screen, rather than # of cells in total. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

