### PR TITLE
Adds `onReorderStart` and `onReorderEnd` arguments to `ReorderableList`.

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -64,6 +64,8 @@ class ReorderableListView extends StatefulWidget {
     Key? key,
     required List<Widget> children,
     required this.onReorder,
+    this.onReorderStart,
+    this.onReorderEnd,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -131,6 +133,8 @@ class ReorderableListView extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.onReorderStart,
+    this.onReorderEnd,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -167,6 +171,12 @@ class ReorderableListView extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorder}
   final ReorderCallback onReorder;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderStart}
+  final void Function(int index)? onReorderStart;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
+  final void Function(int index)? onReorderEnd;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -479,6 +489,8 @@ class _ReorderableListViewState extends State<ReorderableListView> {
             prototypeItem: widget.prototypeItem,
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
+            onReorderStart: widget.onReorderStart,
+            onReorderEnd: widget.onReorderEnd,
             proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
           ),
         ),

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -114,6 +114,8 @@ class ReorderableList extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.onReorderStart,
+    this.onReorderEnd,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -165,6 +167,34 @@ class ReorderableList extends StatefulWidget {
   /// of the items.
   /// {@endtemplate}
   final ReorderCallback onReorder;
+
+  /// {@template flutter.widgets.reorderable_list.onReorderStart}
+  /// A callback that is called when an item is selected to be dragged.
+  ///
+  /// The index parameter of the callback is the index of the selected item.
+  ///
+  /// See also:
+  ///
+  ///   * [onReorderEnd], which is a called when the selected item is dropped.
+  ///   * [onReorder], which reports that a list item has been dragged to a new
+  ///     location.
+  /// {@endtemplate}
+  final void Function(int index)? onReorderStart;
+
+  /// {@template flutter.widgets.reorderable_list.onReorderEnd}
+  /// A callback that is called when the selected item is dropped.
+  ///
+  /// The index parameter of the callback is the index where the item is
+  /// dropped. Unlike [onReorder], this is called even when the list item is
+  /// dropped in the same location.
+  ///
+  /// See also:
+  ///
+  ///   * [onReorderStart], which is a called when an item is selected.
+  ///   * [onReorder], which reports that a list item has been dragged to a new
+  ///     location.
+  /// {@endtemplate}
+  final void Function(int index)? onReorderEnd;
 
   /// {@template flutter.widgets.reorderable_list.proxyDecorator}
   /// A callback that allows the app to add an animated decoration around
@@ -360,6 +390,8 @@ class ReorderableListState extends State<ReorderableList> {
             itemBuilder: widget.itemBuilder,
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
+            onReorderStart: widget.onReorderStart,
+            onReorderEnd: widget.onReorderEnd,
             proxyDecorator: widget.proxyDecorator,
           ),
         ),
@@ -400,6 +432,8 @@ class SliverReorderableList extends StatefulWidget {
     required this.itemBuilder,
     required this.itemCount,
     required this.onReorder,
+    this.onReorderStart,
+    this.onReorderEnd,
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
@@ -418,6 +452,12 @@ class SliverReorderableList extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorder}
   final ReorderCallback onReorder;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderStart}
+  final void Function(int)? onReorderStart;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
+  final void Function(int)? onReorderEnd;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -640,6 +680,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
     assert(_dragInfo == null);
     final _ReorderableItemState item = _items[_dragIndex!]!;
     item.dragging = true;
+    widget.onReorderStart?.call(_dragIndex!);
     item.rebuild();
     _dragStartTransitionComplete = false;
     SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
@@ -702,6 +743,7 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
         }
       }
     });
+    widget.onReorderEnd?.call(_insertIndex!);
   }
 
   void _dropCompleted() {

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -169,20 +169,20 @@ class ReorderableList extends StatefulWidget {
   final ReorderCallback onReorder;
 
   /// {@template flutter.widgets.reorderable_list.onReorderStart}
-  /// A callback that is called when an item is selected to be dragged.
+  /// A callback that is called when an item drag has started.
   ///
   /// The index parameter of the callback is the index of the selected item.
   ///
   /// See also:
   ///
-  ///   * [onReorderEnd], which is a called when the selected item is dropped.
+  ///   * [onReorderEnd], which is a called when the dragged item is dropped.
   ///   * [onReorder], which reports that a list item has been dragged to a new
   ///     location.
   /// {@endtemplate}
   final void Function(int index)? onReorderStart;
 
   /// {@template flutter.widgets.reorderable_list.onReorderEnd}
-  /// A callback that is called when the selected item is dropped.
+  /// A callback that is called when the dragged item is dropped.
   ///
   /// The index parameter of the callback is the index where the item is
   /// dropped. Unlike [onReorder], this is called even when the list item is
@@ -190,7 +190,7 @@ class ReorderableList extends StatefulWidget {
   ///
   /// See also:
   ///
-  ///   * [onReorderStart], which is a called when an item is selected.
+  ///   * [onReorderStart], which is a called when an item drag has started.
   ///   * [onReorder], which reports that a list item has been dragged to a new
   ///     location.
   /// {@endtemplate}

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -6,8 +6,6 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
-import 'dart:async';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -6,6 +6,8 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -1468,6 +1470,82 @@ void main() {
       expect(find.text('item $i'), findsOneWidget);
     }
     expect(items.take(8), orderedEquals(<int>[0, 1, 2, 3, 4, 5, 6, 7]));
+  });
+
+  testWidgets('ReorderableListView calls onReorderStart and onReorderEnd correctly', (WidgetTester tester) async {
+    final List<int> items = List<int>.generate(8, (int index) => index);
+    int? startIndex, endIndex;
+    final Finder item0 = find.textContaining('item 0');
+
+    void handleReorder(int fromIndex, int toIndex) {
+      if (toIndex > fromIndex) {
+        toIndex -= 1;
+      }
+      items.insert(toIndex, items.removeAt(fromIndex));
+    }
+
+    await tester.pumpWidget(MaterialApp(
+      home: ReorderableListView.builder(
+        itemBuilder: (BuildContext context, int index) {
+          return SizedBox(
+            key: ValueKey<int>(items[index]),
+            height: 100,
+            child: ReorderableDragStartListener(
+              index: index,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text('item ${items[index]}'),
+                ],
+              ),
+            ),
+          );
+        },
+        itemCount: items.length,
+        onReorder: handleReorder,
+        onReorderStart: (int index) {
+          startIndex = index;
+        },
+        onReorderEnd: (int index) {
+          endIndex = index;
+        },
+      ),
+    ));
+
+    TestGesture drag = await tester.startGesture(tester.getCenter(item0));
+    await tester.pump(kPressTimeout);
+    // Drag enough for move to start.
+    await drag.moveBy(const Offset(0, 20));
+
+    expect(startIndex, equals(0));
+    expect(endIndex, isNull);
+
+    // Move item0 from index 0 to index 3
+    await drag.moveBy(const Offset(0, 300));
+    await tester.pumpAndSettle();
+    await drag.up();
+    await tester.pumpAndSettle();
+
+    expect(endIndex, equals(3));
+
+    startIndex = null;
+    endIndex = null;
+
+    drag = await tester.startGesture(tester.getCenter(item0));
+    await tester.pump(kPressTimeout);
+    // Drag enough for move to start.
+    await drag.moveBy(const Offset(0, 20));
+
+    expect(startIndex, equals(2));
+    expect(endIndex, isNull);
+
+    // Move item0 from index 2 to index 0
+    await drag.moveBy(const Offset(0, -200));
+    await tester.pumpAndSettle();
+    await drag.up();
+    await tester.pumpAndSettle();
+
+    expect(endIndex, equals(0));
   });
 
   testWidgets('ReorderableListView throws an error when key is not passed to its children', (WidgetTester tester) async {


### PR DESCRIPTION
Adds `onReorderStart` and `onReorderEnd` arguments to `SliverReorderableList`, `ReorderableList`, and `ReorderableListView`.

Fixes #95809 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
