### PR TITLE
Add total_ui_gc_time to benchmarks captured

### DIFF
--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -160,6 +160,7 @@ class GalleryTransitionTest {
         '90th_percentile_picture_cache_memory',
         '99th_percentile_picture_cache_memory',
         'worst_picture_cache_memory',
+        'total_ui_gc_time',
         if (measureCpuGpu && !isAndroid) ...<String>[
           // See https://github.com/flutter/flutter/issues/68888
           if (summary['average_cpu_usage'] != null) 'average_cpu_usage',

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -942,6 +942,7 @@ const List<String> _kCommonScoreKeys = <String>[
   'worst_picture_cache_memory',
   'new_gen_gc_count',
   'old_gen_gc_count',
+  'total_ui_gc_time',
 ];
 
 class PerfTestWithSkSL extends PerfTest {


### PR DESCRIPTION
This was missed in the PR (https://github.com/flutter/flutter/pull/95692/) that added this metric. This is needed for this metric to be shown in skia dashboards.
