### PR TITLE
Remove dependency of a private initializer in macOS template (fixes #96128)

### DIFF
--- a/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/MainFlutterWindow.swift
+++ b/packages/flutter_tools/templates/app_shared/macos.tmpl/Runner/MainFlutterWindow.swift
@@ -3,7 +3,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
+    let flutterViewController = FlutterViewController.init(nibName: nil, bundle: nil)
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)


### PR DESCRIPTION
In `Runner/MainFlutterWindow.swift` of Flutter's macOS template, there
is a call to `FlutterViewController.init()`, which is not defined for
the `FlutterViewController` class and will be dispatched to the
`NSViewController.init()` method by objc_msgSend. However,
`NSViewController.init()` is neither documented nor appearing in the
header file, which makes `FlutterViewController.init()` depending on a
private initializer.

This change fixes the issue (#96128) by calling
`FlutterViewController.init(nibName: nil, bundle: nil)` directly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
