### PR TITLE
Do not crash on LeaderLayer.applyTransform after retained rendering

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2229,7 +2229,7 @@ class LeaderLayer extends ContainerLayer {
   void attach(Object owner) {
     super.attach(owner);
     assert(link._leader == null);
-    _lastOffset = null;
+    assert(_debugSetLastOffset(null));
     link._leader = this;
   }
 
@@ -2237,7 +2237,7 @@ class LeaderLayer extends ContainerLayer {
   void detach() {
     assert(link._leader == this);
     link._leader = null;
-    _lastOffset = null;
+    assert(_debugSetLastOffset(null));
     super.detach();
   }
 
@@ -2246,7 +2246,17 @@ class LeaderLayer extends ContainerLayer {
   /// This is reset to null when the layer is attached or detached, to help
   /// catch cases where the follower layer ends up before the leader layer, but
   /// not every case can be detected.
-  Offset? _lastOffset;
+  Offset? _debugLastOffset;
+
+  bool _debugSetLastOffset(Offset? offset) {
+    bool result = false;
+    assert(() {
+      _debugLastOffset = offset;
+      result = true;
+      return true;
+    }());
+    return result;
+  }
 
   @override
   bool findAnnotations<S extends Object>(AnnotationResult<S> result, Offset localPosition, { required bool onlyFirst }) {
@@ -2256,14 +2266,14 @@ class LeaderLayer extends ContainerLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(offset != null);
-    _lastOffset = offset;
-    if (_lastOffset != Offset.zero)
+    assert(_debugSetLastOffset(offset));
+    if (offset != Offset.zero)
       engineLayer = builder.pushTransform(
-        Matrix4.translationValues(_lastOffset!.dx, _lastOffset!.dy, 0.0).storage,
+        Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage,
         oldLayer: _engineLayer as ui.TransformEngineLayer?,
       );
     addChildrenToScene(builder);
-    if (_lastOffset != Offset.zero)
+    if (offset != Offset.zero)
       builder.pop();
   }
 
@@ -2493,7 +2503,7 @@ class FollowerLayer extends ContainerLayer {
       'Linked LeaderLayer anchor is not in the same layer tree as the FollowerLayer.',
     );
     assert(
-      leader._lastOffset != null,
+      leader._debugLastOffset != null,
       'LeaderLayer anchor must come before FollowerLayer in paint order, but the reverse was true.',
     );
 

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2276,9 +2276,8 @@ class LeaderLayer extends ContainerLayer {
   /// children.
   @override
   void applyTransform(Layer? child, Matrix4 transform) {
-    assert(_lastOffset != null);
-    if (_lastOffset != Offset.zero)
-      transform.translate(_lastOffset!.dx, _lastOffset!.dy);
+    if (offset != Offset.zero)
+      transform.translate(offset.dx, offset.dy);
   }
 
   @override


### PR DESCRIPTION
Fixes b/205909962.

Follow-up to https://github.com/flutter/flutter/pull/92598.

With https://github.com/flutter/flutter/pull/92598 LeaderLayers may not always need `addToScene` (`alwaysNeedsAddToScene` can be false). This means, they can use retained rendering. During retained rendering, `addToScene` is not called, which means `LeaderLayer._lastOffset` may not be set. However, one may still call `applyTransform`, which prior to this change relied on `_lastOffset` to be set and would therefore crash in the retained rendering case. 

This PR changes the implementation of `LeaderLayer.applyTransform` to not rely on `_lastOffset` and instead use the `offset` property directly - the same pattern that's also used in the functionally related `OffsetLayer.applyTransform` [1].

[1] https://github.com/flutter/flutter/blob/f268f82035bf40f6bc11901aa80e83df8e76cf96/packages/flutter/lib/src/rendering/layer.dart#L1221-L1225