### PR TITLE
Add boxes around version freshness alerts

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -879,7 +879,7 @@ class VersionFreshnessValidator {
     final String updateMessage;
     switch (remoteVersionStatus) {
       case VersionCheckResult.newVersionAvailable:
-        updateMessage = newVersionAvailableMessage();
+        updateMessage = _newVersionAvailableMessage;
         break;
       case VersionCheckResult.versionIsCurrent:
       case VersionCheckResult.unknown:
@@ -887,7 +887,7 @@ class VersionFreshnessValidator {
         break;
     }
 
-    logger.printStatus(updateMessage, emphasis: true);
+    logger.printBox(updateMessage);
     await Future.wait<void>(<Future<void>>[
       stamp.store(
         newTimeWarningWasPrinted: now,
@@ -900,26 +900,13 @@ class VersionFreshnessValidator {
 
 @visibleForTesting
 String versionOutOfDateMessage(Duration frameworkAge) {
-  String warning = 'WARNING: your installation of Flutter is ${frameworkAge.inDays} days old.';
-  // Append enough spaces to match the message box width.
-  warning += ' ' * (74 - warning.length);
-
   return '''
-╔════════════════════════════════════════════════════════════════════════════╗
-║ $warning ║
-║                                                                            ║
-║ To update to the latest version, run "flutter upgrade".                    ║
-╚════════════════════════════════════════════════════════════════════════════╝
-''';
+WARNING: your installation of Flutter is ${frameworkAge.inDays} days old.
+
+To update to the latest version, run "flutter upgrade".''';
 }
 
-@visibleForTesting
-String newVersionAvailableMessage() {
-  return '''
-╔════════════════════════════════════════════════════════════════════════════╗
-║ A new version of Flutter is available!                                     ║
-║                                                                            ║
-║ To update to the latest version, run "flutter upgrade".                    ║
-╚════════════════════════════════════════════════════════════════════════════╝
-''';
-}
+const String _newVersionAvailableMessage = '''
+A new version of Flutter is available!
+
+To update to the latest version, run "flutter upgrade".''';

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -134,7 +134,7 @@ void main() {
         expect(flutterVersion.getVersionString(redactUnknownBranches: true), '$channel/1234abcd');
         expect(flutterVersion.getBranchName(redactUnknownBranches: true), channel);
 
-        _expectVersionMessage('', testLogger);
+        expect(testLogger.statusText, isEmpty);
         expect(processManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
         FlutterVersion: () => FlutterVersion(clock: _testClock),
@@ -160,7 +160,7 @@ void main() {
           latestFlutterCommitDate: getChannelOutOfDateVersion(),
         ).run();
 
-        _expectVersionMessage('', logger);
+        expect(logger.statusText, isEmpty);
       });
 
       testWithoutContext('does not ping server when version stamp is up-to-date', () async {
@@ -181,7 +181,7 @@ void main() {
           latestFlutterCommitDate: getChannelUpToDateVersion(),
         ).run();
 
-        _expectVersionMessage(newVersionAvailableMessage(), logger);
+        expect(logger.statusText, contains('A new version of Flutter is available!'));
         expect(cache.setVersionStamp, true);
       });
 
@@ -204,7 +204,7 @@ void main() {
           latestFlutterCommitDate: getChannelUpToDateVersion(),
         ).run();
 
-        _expectVersionMessage('', logger);
+        expect(logger.statusText, isEmpty);
       });
 
       testWithoutContext('pings server when version stamp is missing', () async {
@@ -221,7 +221,7 @@ void main() {
           latestFlutterCommitDate: getChannelUpToDateVersion(),
         ).run();
 
-        _expectVersionMessage(newVersionAvailableMessage(), logger);
+        expect(logger.statusText, contains('A new version of Flutter is available!'));
         expect(cache.setVersionStamp, true);
       });
 
@@ -243,7 +243,7 @@ void main() {
           latestFlutterCommitDate: getChannelUpToDateVersion(),
         ).run();
 
-        _expectVersionMessage(newVersionAvailableMessage(), logger);
+        expect(logger.statusText, contains('A new version of Flutter is available!'));
       });
 
       testWithoutContext('does not print warning when unable to connect to server if not out of date', () async {
@@ -260,7 +260,7 @@ void main() {
           // latestFlutterCommitDate defaults to null because we failed to get remote version
         ).run();
 
-        _expectVersionMessage('', logger);
+        expect(logger.statusText, isEmpty);
       });
 
       testWithoutContext('prints warning when unable to connect to server if really out of date', () async {
@@ -281,7 +281,8 @@ void main() {
           // latestFlutterCommitDate defaults to null because we failed to get remote version
         ).run();
 
-        _expectVersionMessage(versionOutOfDateMessage(_testClock.now().difference(getChannelOutOfDateVersion())), logger);
+        final Duration frameworkAge = _testClock.now().difference(getChannelOutOfDateVersion());
+        expect(logger.statusText, contains('WARNING: your installation of Flutter is ${frameworkAge.inDays} days old.'));
       });
 
       group('$VersionCheckStamp for $channel', () {
@@ -591,11 +592,6 @@ void main() {
       'FLUTTER_GIT_URL': 'https://githubmirror.com/flutter.git',
     }),
   });
-}
-
-void _expectVersionMessage(String message, BufferLogger logger) {
-  expect(logger.statusText.trim(), message.trim());
-  logger.clear();
 }
 
 class FakeCache extends Fake implements Cache {


### PR DESCRIPTION
Use `printBox` around the version freshness warning messages.  Introduced in https://github.com/flutter/flutter/pull/94391.

This added a newline before the box, and removed a newline after.  Not sure if we care about that.

Before:
![before](https://user-images.githubusercontent.com/682784/148147118-f9895d2b-7a63-4597-a80a-b106c139e084.png)
After:
![after](https://user-images.githubusercontent.com/682784/148147128-5d0a3cfc-81e6-438a-b4f0-2a076ae58e20.png)

In another terminal:
Before:
<img width="630" alt="Screen Shot 2022-01-04 at 5 33 35 PM" src="https://user-images.githubusercontent.com/682784/148147198-0b9e6cab-e094-4dfd-b6d3-1762c6d202bc.png">
After:
<img width="482" alt="Screen Shot 2022-01-04 at 5 32 00 PM" src="https://user-images.githubusercontent.com/682784/148147204-a21d1799-6d6a-4ef7-a062-fd84706b9e20.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
