### PR TITLE
stabilize the way we navigate multiple pages for E2E macrobenchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -34,5 +34,6 @@ const String kOpacityPeepholeOpacityOfColOfRowsRouteName = '$kOpacityPeepholeRou
 const String kOpacityPeepholeFadeTransitionTextRouteName = '$kOpacityPeepholeRouteName/fade_transition_text';
 
 const String kScrollableName = '/macrobenchmark_listview';
+const String kOpacityScrollableName = '$kOpacityPeepholeRouteName/listview';
 
 const String kStackSizeKey = 'stack_size';

--- a/dev/benchmarks/macrobenchmarks/lib/src/opacity_peephole.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/opacity_peephole.dart
@@ -17,7 +17,7 @@ class OpacityPeepholePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Opacity Peephole tests')),
       body: ListView(
-        key: const Key('${kOpacityPeepholeRouteName}_listview'),
+        key: const Key(kOpacityScrollableName),
         children: <Widget>[
           for (OpacityPeepholeCase variant in allOpacityPeepholeCases)
             ElevatedButton(

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_col_of_rows_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_col_of_rows_perf_e2e.dart
@@ -7,9 +7,12 @@ import 'package:macrobenchmarks/common.dart';
 import 'util.dart';
 
 void main() {
-  macroPerfTestE2E(
+  macroPerfTestMultiPageE2E(
     'opacity_peephole_col_of_rows_perf',
-    kOpacityPeepholeOpacityOfColOfRowsRouteName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, kOpacityPeepholeRouteName),
+      ScrollableButtonRoute(kOpacityScrollableName, kOpacityPeepholeOpacityOfColOfRowsRouteName)
+    ],
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
   );

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_fade_transition_text_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_fade_transition_text_perf_e2e.dart
@@ -7,9 +7,12 @@ import 'package:macrobenchmarks/common.dart';
 import 'util.dart';
 
 void main() {
-  macroPerfTestE2E(
+  macroPerfTestMultiPageE2E(
     'opacity_peephole_fade_transition_text_perf',
-    kOpacityPeepholeFadeTransitionTextRouteName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, kOpacityPeepholeRouteName),
+      ScrollableButtonRoute(kOpacityScrollableName, kOpacityPeepholeFadeTransitionTextRouteName)
+    ],
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
   );

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_grid_of_opacity_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_grid_of_opacity_perf_e2e.dart
@@ -7,9 +7,12 @@ import 'package:macrobenchmarks/common.dart';
 import 'util.dart';
 
 void main() {
-  macroPerfTestE2E(
+  macroPerfTestMultiPageE2E(
     'opacity_peephole_grid_of_opacity_perf',
-    kOpacityPeepholeGridOfOpacityRouteName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, kOpacityPeepholeRouteName),
+      ScrollableButtonRoute(kOpacityScrollableName, kOpacityPeepholeGridOfOpacityRouteName)
+    ],
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
   );

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_one_rect_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_one_rect_perf_e2e.dart
@@ -7,9 +7,12 @@ import 'package:macrobenchmarks/common.dart';
 import 'util.dart';
 
 void main() {
-  macroPerfTestE2E(
+  macroPerfTestMultiPageE2E(
     'opacity_peephole_one_rect_perf',
-    kOpacityPeepholeOneRectRouteName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, kOpacityPeepholeRouteName),
+      ScrollableButtonRoute(kOpacityScrollableName, kOpacityPeepholeOneRectRouteName)
+    ],
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
   );

--- a/dev/benchmarks/macrobenchmarks/test/opacity_peephole_opacity_of_grid_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/opacity_peephole_opacity_of_grid_perf_e2e.dart
@@ -7,9 +7,12 @@ import 'package:macrobenchmarks/common.dart';
 import 'util.dart';
 
 void main() {
-  macroPerfTestE2E(
+  macroPerfTestMultiPageE2E(
     'opacity_peephole_opacity_of_grid_perf',
-    kOpacityPeepholeOpacityOfGridRouteName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, kOpacityPeepholeRouteName),
+      ScrollableButtonRoute(kOpacityScrollableName, kOpacityPeepholeOpacityOfGridRouteName)
+    ],
     pageDelay: const Duration(seconds: 1),
     duration: const Duration(seconds: 10),
   );

--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -5,9 +5,17 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:macrobenchmarks/common.dart';
 import 'package:macrobenchmarks/main.dart' as app;
 
 typedef ControlCallback = Future<void> Function(WidgetController controller);
+
+class ScrollableButtonRoute {
+  ScrollableButtonRoute(this.listViewKey, this.buttonKey);
+
+  final String listViewKey;
+  final String buttonKey;
+}
 
 void macroPerfTestE2E(
   String testName,
@@ -17,6 +25,19 @@ void macroPerfTestE2E(
   ControlCallback? body,
   ControlCallback? setup,
 }) {
+  macroPerfTestMultiPageE2E(testName, <ScrollableButtonRoute>[
+    ScrollableButtonRoute(kScrollableName, routeName),
+  ]);
+}
+
+void macroPerfTestMultiPageE2E(
+    String testName,
+    List<ScrollableButtonRoute> routes, {
+      Duration? pageDelay,
+      Duration duration = const Duration(seconds: 3),
+      ControlCallback? body,
+      ControlCallback? setup,
+    }) {
   final WidgetsBinding _binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   assert(_binding is IntegrationTestWidgetsFlutterBinding);
   final IntegrationTestWidgetsFlutterBinding binding = _binding as IntegrationTestWidgetsFlutterBinding;
@@ -33,16 +54,26 @@ void macroPerfTestE2E(
     // See: https://github.com/flutter/flutter/issues/19434
     await tester.binding.delayed(const Duration(microseconds: 250));
 
-    expect(routeName, startsWith('/'));
-    int i = 0;
-    while (i < routeName.length) {
-      i = routeName.indexOf('/', i + 1);
-      if (i < 0) {
-        i = routeName.length;
-      }
-      final Finder button = find.byKey(ValueKey<String>(routeName.substring(0, i)), skipOffstage: false);
-      await tester.scrollUntilVisible(button, 50);
+    for (final ScrollableButtonRoute route in routes) {
+      expect(route.listViewKey, startsWith('/'));
+      expect(route.buttonKey, startsWith('/'));
+
+      // Make sure each list view page is settled
+      await tester.pumpAndSettle();
+
+      final Finder listView = find.byKey(ValueKey<String>(route.listViewKey));
+      // ListView is not a Scrollable, but it contains one
+      final Finder scrollable = find.descendant(of: listView, matching: find.byType(Scrollable));
+      // scrollable should find one widget as soon as the page is loaded
+      expect(scrollable, findsOneWidget);
+
+      final Finder button = find.byKey(ValueKey<String>(route.buttonKey), skipOffstage: false);
+      // button may or may not find a widget right away until we scroll to it
+      await tester.scrollUntilVisible(button, 50, scrollable: scrollable);
+      // After scrolling, button should find one Widget
       expect(button, findsOneWidget);
+
+      // Allow scrolling to settle
       await tester.pumpAndSettle();
       await tester.tap(button);
       // Cannot be pumpAndSettle because some tests have infinite animation.


### PR DESCRIPTION
We were getting occasional instances of navigation failures trying to drive the multi-page E2E benchmarks (currently the opacity peephole benchmarks). It looks like the code would sometimes fail to find the intended scrollable on the second page of buttons in those tests. This PR makes the navigation of the pages more explicit - allowing the tests to describe both the Key of the ListView as well as the Key of the button on each subsequent page. The default one-click benchmarks will still be compatible as the original benchmark navigation method signature will forward to the multi-page version with the appropriate explicit route to the one-click button.

Examples of reported flakes (which are all closed via marking the tests as flaky):
https://github.com/flutter/flutter/issues/95574
https://github.com/flutter/flutter/issues/95859
https://github.com/flutter/flutter/issues/95863
https://github.com/flutter/flutter/issues/95865
https://github.com/flutter/flutter/issues/96072