### PR TITLE
Deprecate `useDeleteButtonTooltip` for Chips

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -14,6 +14,99 @@
 
 version: 1
 transforms:
+  # Changes made in
+  - title: "Deprecate 'useDeleteButtonTooltip' for Chip"
+    date: 2021-12-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'Chip'
+    oneOf:
+    - if: "useDeleteButtonTooltip == 'false'"
+      changes:
+      - kind: 'addParameter'
+        index: 9
+        name: 'deleteButtonTooltipMessage'
+        style: optional_named
+        argumentValue:
+          expression: "''"
+          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    - if: "useDeleteButtonTooltip == 'true'"
+      changes:
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    variables:
+      useDeleteButtonTooltip:
+        kind: 'fragment'
+        value: 'arguments[useDeleteButtonTooltip]'
+      deleteButtonTooltipMessage:
+        kind: 'fragment'
+        value: 'arguments[deleteButtonTooltipMessage]'
+
+  # Changes made in
+  - title: "Deprecate 'useDeleteButtonTooltip' for InputChip"
+    date: 2021-12-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'InputChip'
+    oneOf:
+    - if: "useDeleteButtonTooltip == 'false'"
+      changes:
+      - kind: 'addParameter'
+        index: 9
+        name: 'deleteButtonTooltipMessage'
+        style: optional_named
+        argumentValue:
+          expression: "''"
+          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    - if: "useDeleteButtonTooltip == 'true'"
+      changes:
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    variables:
+      useDeleteButtonTooltip:
+        kind: 'fragment'
+        value: 'arguments[useDeleteButtonTooltip]'
+      deleteButtonTooltipMessage:
+        kind: 'fragment'
+        value: 'arguments[deleteButtonTooltipMessage]'
+
+  # Changes made in
+  - title: "Deprecate 'useDeleteButtonTooltip' for RawChip"
+    date: 2021-12-19
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'RawChip'
+    oneOf:
+    - if: "useDeleteButtonTooltip == 'false'"
+      changes:
+      - kind: 'addParameter'
+        index: 9
+        name: 'deleteButtonTooltipMessage'
+        style: optional_named
+        argumentValue:
+          expression: "''"
+          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    - if: "useDeleteButtonTooltip == 'true'"
+      changes:
+      - kind: 'removeParameter'
+        name: 'useDeleteButtonTooltip'
+    variables:
+      useDeleteButtonTooltip:
+        kind: 'fragment'
+        value: 'arguments[useDeleteButtonTooltip]'
+      deleteButtonTooltipMessage:
+        kind: 'fragment'
+        value: 'arguments[deleteButtonTooltipMessage]'
+
   # Changes made in https://github.com/flutter/flutter/pull/96957
   - title: "Migrate to 'thumbVisibility'"
     date: 2022-01-20

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -14,9 +14,9 @@
 
 version: 1
 transforms:
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       constructor: ''
@@ -39,9 +39,9 @@ transforms:
         kind: 'fragment'
         value: 'arguments[deleteButtonTooltipMessage]'
 
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       constructor: ''
@@ -64,9 +64,9 @@ transforms:
         kind: 'fragment'
         value: 'arguments[deleteButtonTooltipMessage]'
 
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       constructor: ''
@@ -89,9 +89,9 @@ transforms:
         kind: 'fragment'
         value: 'arguments[deleteButtonTooltipMessage]'
 
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       field: 'useDeleteButtonTooltip'
@@ -100,9 +100,9 @@ transforms:
     - kind: 'rename'
       newName: 'deleteButtonTooltipMessage'
 
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       field: 'useDeleteButtonTooltip'
@@ -111,9 +111,9 @@ transforms:
     - kind: 'rename'
       newName: 'deleteButtonTooltipMessage'
 
-  # Changes made in
+  # Changes made in https://github.com/flutter/flutter/pull/96174
   - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
-    date: 2021-12-24
+    date: 2022-01-05
     element:
       uris: [ 'material.dart' ]
       field: 'useDeleteButtonTooltip'

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,28 +15,22 @@
 version: 1
 transforms:
   # Changes made in
-  - title: "Deprecate 'useDeleteButtonTooltip' for Chip"
-    date: 2021-12-19
+  - title: "Remove 'useDeleteButtonTooltip'"
+    date: 2021-12-24
     element:
       uris: [ 'material.dart' ]
       constructor: ''
       inClass: 'Chip'
-    oneOf:
-    - if: "useDeleteButtonTooltip == 'false'"
-      changes:
-      - kind: 'addParameter'
-        index: 9
-        name: 'deleteButtonTooltipMessage'
-        style: optional_named
-        argumentValue:
-          expression: "''"
-          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
-    - if: "useDeleteButtonTooltip == 'true'"
-      changes:
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
+    changes:
+    - kind: 'addParameter'
+      index: 9
+      name: 'deleteButtonTooltipMessage'
+      style: optional_named
+      argumentValue:
+        expression: "''"
+        requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+    - kind: 'removeParameter'
+      name: 'useDeleteButtonTooltip'
     variables:
       useDeleteButtonTooltip:
         kind: 'fragment'
@@ -46,28 +40,22 @@ transforms:
         value: 'arguments[deleteButtonTooltipMessage]'
 
   # Changes made in
-  - title: "Deprecate 'useDeleteButtonTooltip' for InputChip"
-    date: 2021-12-19
+  - title: "Remove 'useDeleteButtonTooltip'"
+    date: 2021-12-24
     element:
       uris: [ 'material.dart' ]
       constructor: ''
       inClass: 'InputChip'
-    oneOf:
-    - if: "useDeleteButtonTooltip == 'false'"
-      changes:
-      - kind: 'addParameter'
-        index: 9
-        name: 'deleteButtonTooltipMessage'
-        style: optional_named
-        argumentValue:
-          expression: "''"
-          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
-    - if: "useDeleteButtonTooltip == 'true'"
-      changes:
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
+    changes:
+    - kind: 'addParameter'
+      index: 9
+      name: 'deleteButtonTooltipMessage'
+      style: optional_named
+      argumentValue:
+        expression: "''"
+        requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+    - kind: 'removeParameter'
+      name: 'useDeleteButtonTooltip'
     variables:
       useDeleteButtonTooltip:
         kind: 'fragment'
@@ -77,28 +65,22 @@ transforms:
         value: 'arguments[deleteButtonTooltipMessage]'
 
   # Changes made in
-  - title: "Deprecate 'useDeleteButtonTooltip' for RawChip"
-    date: 2021-12-19
+  - title: "Remove 'useDeleteButtonTooltip'"
+    date: 2021-12-24
     element:
       uris: [ 'material.dart' ]
       constructor: ''
       inClass: 'RawChip'
-    oneOf:
-    - if: "useDeleteButtonTooltip == 'false'"
-      changes:
-      - kind: 'addParameter'
-        index: 9
-        name: 'deleteButtonTooltipMessage'
-        style: optional_named
-        argumentValue:
-          expression: "''"
-          requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
-    - if: "useDeleteButtonTooltip == 'true'"
-      changes:
-      - kind: 'removeParameter'
-        name: 'useDeleteButtonTooltip'
+    changes:
+    - kind: 'addParameter'
+      index: 9
+      name: 'deleteButtonTooltipMessage'
+      style: optional_named
+      argumentValue:
+        expression: "''"
+        requiredIf: "useDeleteButtonTooltip == 'false' && deleteButtonTooltipMessage == ''"
+    - kind: 'removeParameter'
+      name: 'useDeleteButtonTooltip'
     variables:
       useDeleteButtonTooltip:
         kind: 'fragment'
@@ -106,6 +88,39 @@ transforms:
       deleteButtonTooltipMessage:
         kind: 'fragment'
         value: 'arguments[deleteButtonTooltipMessage]'
+
+  # Changes made in
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
+    date: 2021-12-24
+    element:
+      uris: [ 'material.dart' ]
+      field: 'useDeleteButtonTooltip'
+      inClass: 'Chip'
+    changes:
+    - kind: 'rename'
+      newName: 'deleteButtonTooltipMessage'
+
+  # Changes made in
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
+    date: 2021-12-24
+    element:
+      uris: [ 'material.dart' ]
+      field: 'useDeleteButtonTooltip'
+      inClass: 'InputChip'
+    changes:
+    - kind: 'rename'
+      newName: 'deleteButtonTooltipMessage'
+
+  # Changes made in
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
+    date: 2021-12-24
+    element:
+      uris: [ 'material.dart' ]
+      field: 'useDeleteButtonTooltip'
+      inClass: 'RawChip'
+    changes:
+    - kind: 'rename'
+      newName: 'deleteButtonTooltipMessage'
 
   # Changes made in https://github.com/flutter/flutter/pull/96957
   - title: "Migrate to 'thumbVisibility'"

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -15,7 +15,7 @@
 version: 1
 transforms:
   # Changes made in
-  - title: "Remove 'useDeleteButtonTooltip'"
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
     date: 2021-12-24
     element:
       uris: [ 'material.dart' ]
@@ -40,7 +40,7 @@ transforms:
         value: 'arguments[deleteButtonTooltipMessage]'
 
   # Changes made in
-  - title: "Remove 'useDeleteButtonTooltip'"
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
     date: 2021-12-24
     element:
       uris: [ 'material.dart' ]
@@ -65,7 +65,7 @@ transforms:
         value: 'arguments[deleteButtonTooltipMessage]'
 
   # Changes made in
-  - title: "Remove 'useDeleteButtonTooltip'"
+  - title: "Migrate 'useDeleteButtonTooltip' to 'deleteButtonTooltipMessage'"
     date: 2021-12-24
     element:
       uris: [ 'material.dart' ]

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -251,7 +251,7 @@ abstract class DeletableChipAttributes {
   /// Defaults to true.
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after'
+    'This feature was deprecated after 2.9.0-1.0.pre.290'
   )
   bool get useDeleteButtonTooltip;
 }
@@ -575,7 +575,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.shadowColor,
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after'
+      'This feature was deprecated after 2.9.0-1.0.pre.290'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
@@ -625,7 +625,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after'
+    'This feature was deprecated after 2.9.0-1.0.pre.290'
   )
   final bool useDeleteButtonTooltip;
 
@@ -755,7 +755,7 @@ class InputChip extends StatelessWidget
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after'
+      'This feature was deprecated after 2.9.0-1.0.pre.290'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(selected != null),
@@ -832,7 +832,7 @@ class InputChip extends StatelessWidget
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after'
+    'This feature was deprecated after 2.9.0-1.0.pre.290'
   )
   final bool useDeleteButtonTooltip;
 
@@ -1512,7 +1512,7 @@ class RawChip extends StatefulWidget
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after'
+      'This feature was deprecated after 2.9.0-1.0.pre.290'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
@@ -1590,7 +1590,7 @@ class RawChip extends StatefulWidget
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after'
+    'This feature was deprecated after 2.9.0-1.0.pre.290'
   )
   final bool useDeleteButtonTooltip;
 

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -239,7 +239,8 @@ abstract class DeletableChipAttributes {
 
   /// The message to be used for the chip's delete button tooltip.
   ///
-  /// If empty, the tooltip of the delete button will be disabled.
+  /// If provided with an empty string, the tooltip of the delete button will be
+  /// disabled.
   ///
   /// If null, the default [MaterialLocalizations.deleteButtonTooltip] will be
   /// used.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -252,7 +252,7 @@ abstract class DeletableChipAttributes {
   /// Defaults to true.
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after 2.9.0-1.0.pre.290'
+    'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   bool get useDeleteButtonTooltip;
 }
@@ -576,7 +576,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.shadowColor,
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after 2.9.0-1.0.pre.290'
+      'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
@@ -626,7 +626,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after 2.9.0-1.0.pre.290'
+    'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;
 
@@ -756,7 +756,7 @@ class InputChip extends StatelessWidget
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after 2.9.0-1.0.pre.290'
+      'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(selected != null),
@@ -833,7 +833,7 @@ class InputChip extends StatelessWidget
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after 2.9.0-1.0.pre.290'
+    'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;
 
@@ -1513,7 +1513,7 @@ class RawChip extends StatefulWidget
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
       'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-      'This feature was deprecated after 2.9.0-1.0.pre.290'
+      'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
@@ -1591,7 +1591,7 @@ class RawChip extends StatefulWidget
   @override
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
-    'This feature was deprecated after 2.9.0-1.0.pre.290'
+    'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;
 

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -241,14 +241,18 @@ abstract class DeletableChipAttributes {
   /// [deleteButtonTooltipMessage].
   ///
   /// Must not be null. Defaults to true.
+  @Deprecated(
+    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'This feature was deprecated after'
+  )
   bool get useDeleteButtonTooltip;
 
   /// The message to be used for the chip's delete button tooltip.
   ///
-  /// This will be shown only if [useDeleteButtonTooltip] is true.
+  /// If empty, the delete button tooltip of the chip will be disabled.
   ///
-  /// If not specified, the default [MaterialLocalizations.deleteButtonTooltip] will
-  /// be used.
+  /// If null, the default [MaterialLocalizations.deleteButtonTooltip] will be
+  /// used.
   String? get deleteButtonTooltipMessage;
 }
 
@@ -557,7 +561,6 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.deleteIcon,
     this.onDeleted,
     this.deleteIconColor,
-    this.useDeleteButtonTooltip = true,
     this.deleteButtonTooltipMessage,
     this.side,
     this.shape,
@@ -570,11 +573,15 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.materialTapTargetSize,
     this.elevation,
     this.shadowColor,
+    @Deprecated(
+      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'This feature was deprecated after'
+    )
+    this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
        assert(autofocus != null),
        assert(clipBehavior != null),
        assert(elevation == null || elevation >= 0.0),
-       assert(useDeleteButtonTooltip != null),
        super(key: key);
 
   @override
@@ -608,8 +615,6 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   @override
   final Color? deleteIconColor;
   @override
-  final bool useDeleteButtonTooltip;
-  @override
   final String? deleteButtonTooltipMessage;
   @override
   final MaterialTapTargetSize? materialTapTargetSize;
@@ -617,6 +622,12 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   final double? elevation;
   @override
   final Color? shadowColor;
+  @override
+  @Deprecated(
+    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'This feature was deprecated after'
+  )
+  final bool useDeleteButtonTooltip;
 
   @override
   Widget build(BuildContext context) {
@@ -721,7 +732,6 @@ class InputChip extends StatelessWidget
     this.deleteIcon,
     this.onDeleted,
     this.deleteIconColor,
-    this.useDeleteButtonTooltip = true,
     this.deleteButtonTooltipMessage,
     this.onPressed,
     this.pressElevation,
@@ -743,6 +753,11 @@ class InputChip extends StatelessWidget
     this.showCheckmark,
     this.checkmarkColor,
     this.avatarBorder = const CircleBorder(),
+    @Deprecated(
+      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'This feature was deprecated after'
+    )
+    this.useDeleteButtonTooltip = true,
   }) : assert(selected != null),
        assert(isEnabled != null),
        assert(label != null),
@@ -750,7 +765,6 @@ class InputChip extends StatelessWidget
        assert(autofocus != null),
        assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
-       assert(useDeleteButtonTooltip != null),
        super(key: key);
 
   @override
@@ -773,8 +787,6 @@ class InputChip extends StatelessWidget
   final VoidCallback? onDeleted;
   @override
   final Color? deleteIconColor;
-  @override
-  final bool useDeleteButtonTooltip;
   @override
   final String? deleteButtonTooltipMessage;
   @override
@@ -817,6 +829,12 @@ class InputChip extends StatelessWidget
   final Color? checkmarkColor;
   @override
   final ShapeBorder avatarBorder;
+  @override
+  @Deprecated(
+    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'This feature was deprecated after'
+  )
+  final bool useDeleteButtonTooltip;
 
   @override
   Widget build(BuildContext context) {
@@ -1469,7 +1487,6 @@ class RawChip extends StatefulWidget
     Widget? deleteIcon,
     this.onDeleted,
     this.deleteIconColor,
-    this.useDeleteButtonTooltip = true,
     this.deleteButtonTooltipMessage,
     this.onPressed,
     this.onSelected,
@@ -1493,6 +1510,11 @@ class RawChip extends StatefulWidget
     this.showCheckmark = true,
     this.checkmarkColor,
     this.avatarBorder = const CircleBorder(),
+    @Deprecated(
+      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'This feature was deprecated after'
+    )
+    this.useDeleteButtonTooltip = true,
   }) : assert(label != null),
        assert(isEnabled != null),
        assert(selected != null),
@@ -1500,7 +1522,6 @@ class RawChip extends StatefulWidget
        assert(autofocus != null),
        assert(pressElevation == null || pressElevation >= 0.0),
        assert(elevation == null || elevation >= 0.0),
-       assert(useDeleteButtonTooltip != null),
        deleteIcon = deleteIcon ?? _kDefaultDeleteIcon,
        super(key: key);
 
@@ -1518,8 +1539,6 @@ class RawChip extends StatefulWidget
   final VoidCallback? onDeleted;
   @override
   final Color? deleteIconColor;
-  @override
-  final bool useDeleteButtonTooltip;
   @override
   final String? deleteButtonTooltipMessage;
   @override
@@ -1568,6 +1587,12 @@ class RawChip extends StatefulWidget
   final Color? checkmarkColor;
   @override
   final ShapeBorder avatarBorder;
+  @override
+  @Deprecated(
+    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'This feature was deprecated after'
+  )
+  final bool useDeleteButtonTooltip;
 
   /// If set, this indicates that the chip should be disabled if all of the
   /// tap callbacks ([onSelected], [onPressed]) are null.

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -251,7 +251,7 @@ abstract class DeletableChipAttributes {
   ///
   /// Defaults to true.
   @Deprecated(
-    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'Migrate to deleteButtonTooltipMessage. '
     'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   bool get useDeleteButtonTooltip;
@@ -575,7 +575,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
     this.elevation,
     this.shadowColor,
     @Deprecated(
-      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'Migrate to deleteButtonTooltipMessage. '
       'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
@@ -625,7 +625,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   final Color? shadowColor;
   @override
   @Deprecated(
-    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'Migrate to deleteButtonTooltipMessage. '
     'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;
@@ -755,7 +755,7 @@ class InputChip extends StatelessWidget
     this.checkmarkColor,
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
-      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'Migrate to deleteButtonTooltipMessage. '
       'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
@@ -832,7 +832,7 @@ class InputChip extends StatelessWidget
   final ShapeBorder avatarBorder;
   @override
   @Deprecated(
-    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'Migrate to deleteButtonTooltipMessage. '
     'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;
@@ -1512,7 +1512,7 @@ class RawChip extends StatefulWidget
     this.checkmarkColor,
     this.avatarBorder = const CircleBorder(),
     @Deprecated(
-      'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+      'Migrate to deleteButtonTooltipMessage. '
       'This feature was deprecated after v2.10.0-0.3.pre.'
     )
     this.useDeleteButtonTooltip = true,
@@ -1590,7 +1590,7 @@ class RawChip extends StatefulWidget
   final ShapeBorder avatarBorder;
   @override
   @Deprecated(
-    'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
+    'Migrate to deleteButtonTooltipMessage. '
     'This feature was deprecated after v2.10.0-0.3.pre.'
   )
   final bool useDeleteButtonTooltip;

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -237,23 +237,23 @@ abstract class DeletableChipAttributes {
   /// non-null.
   Color? get deleteIconColor;
 
+  /// The message to be used for the chip's delete button tooltip.
+  ///
+  /// If empty, the tooltip of the delete button will be disabled.
+  ///
+  /// If null, the default [MaterialLocalizations.deleteButtonTooltip] will be
+  /// used.
+  String? get deleteButtonTooltipMessage;
+
   /// Whether to use a tooltip on the chip's delete button showing the
   /// [deleteButtonTooltipMessage].
   ///
-  /// Must not be null. Defaults to true.
+  /// Defaults to true.
   @Deprecated(
     'Set deleteButtonTooltipMessage of this Chip as an empty string instead. '
     'This feature was deprecated after'
   )
   bool get useDeleteButtonTooltip;
-
-  /// The message to be used for the chip's delete button tooltip.
-  ///
-  /// If empty, the delete button tooltip of the chip will be disabled.
-  ///
-  /// If null, the default [MaterialLocalizations.deleteButtonTooltip] will be
-  /// used.
-  String? get deleteButtonTooltipMessage;
 }
 
 /// An interface for material design chips that can have check marks.

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -198,8 +198,8 @@ Widget _chipWithOptionalDeleteButton({
   Key? labelKey,
   required bool deletable,
   TextDirection textDirection = TextDirection.ltr,
-  bool useDeleteButtonTooltip = true,
   String? chipTooltip,
+  String? deleteButtonTooltip,
   VoidCallback? onPressed = _doNothing,
 }) {
   return _wrapForChip(
@@ -211,7 +211,7 @@ Widget _chipWithOptionalDeleteButton({
           onPressed: onPressed,
           onDeleted: deletable ? _doNothing : null,
           deleteIcon: Icon(Icons.close, key: deleteButtonKey),
-          useDeleteButtonTooltip: useDeleteButtonTooltip,
+          deleteButtonTooltipMessage: deleteButtonTooltip,
           label: Text(
             deletable
               ? 'Chip with Delete Button'
@@ -3498,7 +3498,7 @@ void main() {
     await tester.pumpWidget(
       _chipWithOptionalDeleteButton(
         deletable: true,
-        useDeleteButtonTooltip: false,
+        deleteButtonTooltip: '',
       ),
     );
 
@@ -3519,13 +3519,13 @@ void main() {
     await tapGesture.up();
   });
 
-  testWidgets('useDeleteButtonTooltip only applies to tooltip', (WidgetTester tester) async {
+  testWidgets('Disabling delete button tooltip does not disable chip tooltip', (WidgetTester tester) async {
     final UniqueKey deleteButtonKey = UniqueKey();
     await tester.pumpWidget(
       _chipWithOptionalDeleteButton(
         deleteButtonKey: deleteButtonKey,
         deletable: true,
-        useDeleteButtonTooltip: false,
+        deleteButtonTooltip: '',
         chipTooltip: 'Chip Tooltip',
       ),
     );
@@ -3548,7 +3548,7 @@ void main() {
     expect(findTooltipContainer('Chip Tooltip'), findsOneWidget);
   });
 
-  testWidgets('Setting useDeleteButtonTooltip also allows Chip tooltip', (WidgetTester tester) async {
+  testWidgets('Setting delete button tooltip also allows Chip tooltip', (WidgetTester tester) async {
     final UniqueKey deleteButtonKey = UniqueKey();
     await tester.pumpWidget(
       _chipWithOptionalDeleteButton(

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -538,12 +538,14 @@ void main() {
   chip = Chip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
   chip.useDeleteButtonTooltip;
 
+  // Changes made in
   InputChip inputChip = InputChip();
   inputChip = InputChip(useDeleteButtonTooltip: false);
   inputChip = InputChip(useDeleteButtonTooltip: true);
   inputChip = InputChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
   inputChip.useDeleteButtonTooltip;
 
+  // Changes made in
   RawChip rawChip = Rawchip();
   rawChip = RawChip(useDeleteButtonTooltip: false);
   rawChip = RawChip(useDeleteButtonTooltip: true);

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -531,21 +531,21 @@ void main() {
   RawScrollbar rawScrollbar = RawScrollbar(isAlwaysShown: true);
   nowShowing = rawScrollbar.isAlwaysShown;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   Chip chip = Chip();
   chip = Chip(useDeleteButtonTooltip: false);
   chip = Chip(useDeleteButtonTooltip: true);
   chip = Chip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
   chip.useDeleteButtonTooltip;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   InputChip inputChip = InputChip();
   inputChip = InputChip(useDeleteButtonTooltip: false);
   inputChip = InputChip(useDeleteButtonTooltip: true);
   inputChip = InputChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
   inputChip.useDeleteButtonTooltip;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   RawChip rawChip = Rawchip();
   rawChip = RawChip(useDeleteButtonTooltip: false);
   rawChip = RawChip(useDeleteButtonTooltip: true);

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -530,4 +530,18 @@ void main() {
   scrollbarTheme.isAlwaysShown;
   RawScrollbar rawScrollbar = RawScrollbar(isAlwaysShown: true);
   nowShowing = rawScrollbar.isAlwaysShown;
+
+  // Changes made in
+  Chip chip = Chip();
+  chip = Chip(useDeleteButtonTooltip: false);
+  chip = Chip(useDeleteButtonTooltip: true);
+  chip = Chip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
+  InputChip inputChip = InputChip();
+  inputChip = InputChip(useDeleteButtonTooltip: false);
+  inputChip = InputChip(useDeleteButtonTooltip: true);
+  inputChip = InputChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
+  RawChip rawChip = Rawchip();
+  rawChip = RawChip(useDeleteButtonTooltip: false);
+  rawChip = RawChip(useDeleteButtonTooltip: true);
+  rawChip = RawChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -535,13 +535,18 @@ void main() {
   Chip chip = Chip();
   chip = Chip(useDeleteButtonTooltip: false);
   chip = Chip(useDeleteButtonTooltip: true);
-  chip = Chip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
+  chip = Chip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
+  chip.useDeleteButtonTooltip;
+
   InputChip inputChip = InputChip();
   inputChip = InputChip(useDeleteButtonTooltip: false);
   inputChip = InputChip(useDeleteButtonTooltip: true);
-  inputChip = InputChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
+  inputChip = InputChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
+  inputChip.useDeleteButtonTooltip;
+
   RawChip rawChip = Rawchip();
   rawChip = RawChip(useDeleteButtonTooltip: false);
   rawChip = RawChip(useDeleteButtonTooltip: true);
-  rawChip = RawChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Tooltip');
+  rawChip = RawChip(useDeleteButtonTooltip: false, deleteButtonTooltipMessage: 'Delete Tooltip');
+  rawChip.useDeleteButtonTooltip;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -508,13 +508,18 @@ void main() {
   Chip chip = Chip();
   chip = Chip(deleteButtonTooltipMessage: '');
   chip = Chip();
-  chip = Chip(deleteButtonTooltipMessage: 'Tooltip');
+  chip = Chip(deleteButtonTooltipMessage: 'Delete Tooltip');
+  chip.deleteButtonTooltipMessage;
+
   InputChip inputChip = InputChip();
   inputChip = InputChip(deleteButtonTooltipMessage: '');
   inputChip = InputChip();
-  inputChip = InputChip(deleteButtonTooltipMessage: 'Tooltip');
+  inputChip = InputChip(deleteButtonTooltipMessage: 'Delete Tooltip');
+  inputChip.deleteButtonTooltipMessage;
+
   RawChip rawChip = Rawchip();
   rawChip = RawChip(deleteButtonTooltipMessage: '');
   rawChip = RawChip();
-  rawChip = RawChip(deleteButtonTooltipMessage: 'Tooltip');
+  rawChip = RawChip(deleteButtonTooltipMessage: 'Delete Tooltip');
+  rawChip.deleteButtonTooltipMessage;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -503,4 +503,18 @@ void main() {
   scrollbarTheme.thumbVisibility;
   RawScrollbar rawScrollbar = RawScrollbar(thumbVisibility: true);
   nowShowing = rawScrollbar.thumbVisibility;
+
+  // Changes made in
+  Chip chip = Chip();
+  chip = Chip(deleteButtonTooltipMessage: '');
+  chip = Chip();
+  chip = Chip(deleteButtonTooltipMessage: 'Tooltip');
+  InputChip inputChip = InputChip();
+  inputChip = InputChip(deleteButtonTooltipMessage: '');
+  inputChip = InputChip();
+  inputChip = InputChip(deleteButtonTooltipMessage: 'Tooltip');
+  RawChip rawChip = Rawchip();
+  rawChip = RawChip(deleteButtonTooltipMessage: '');
+  rawChip = RawChip();
+  rawChip = RawChip(deleteButtonTooltipMessage: 'Tooltip');
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -511,12 +511,14 @@ void main() {
   chip = Chip(deleteButtonTooltipMessage: 'Delete Tooltip');
   chip.deleteButtonTooltipMessage;
 
+  // Changes made in
   InputChip inputChip = InputChip();
   inputChip = InputChip(deleteButtonTooltipMessage: '');
   inputChip = InputChip();
   inputChip = InputChip(deleteButtonTooltipMessage: 'Delete Tooltip');
   inputChip.deleteButtonTooltipMessage;
 
+  // Changes made in
   RawChip rawChip = Rawchip();
   rawChip = RawChip(deleteButtonTooltipMessage: '');
   rawChip = RawChip();

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -504,21 +504,21 @@ void main() {
   RawScrollbar rawScrollbar = RawScrollbar(thumbVisibility: true);
   nowShowing = rawScrollbar.thumbVisibility;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   Chip chip = Chip();
   chip = Chip(deleteButtonTooltipMessage: '');
   chip = Chip();
   chip = Chip(deleteButtonTooltipMessage: 'Delete Tooltip');
   chip.deleteButtonTooltipMessage;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   InputChip inputChip = InputChip();
   inputChip = InputChip(deleteButtonTooltipMessage: '');
   inputChip = InputChip();
   inputChip = InputChip(deleteButtonTooltipMessage: 'Delete Tooltip');
   inputChip.deleteButtonTooltipMessage;
 
-  // Changes made in
+  // Changes made in https://github.com/flutter/flutter/pull/96174
   RawChip rawChip = Rawchip();
   rawChip = RawChip(deleteButtonTooltipMessage: '');
   rawChip = RawChip();


### PR DESCRIPTION
This PR deprecates [`useDeleteButtonTooltip`](https://api.flutter.dev/flutter/material/DeletableChipAttributes/useDeleteButtonTooltip.html), for `Chip` widgets that support having a delete button. This includes the `Chip`, the `InputChip` and the ` RawChip` widget.

Instead, to disable the tooltips on the delete button of these chips, users should pass an **empty string** to [`deleteButtonTooltipMessage`](https://api.flutter.dev/flutter/material/DeletableChipAttributes/deleteButtonTooltipMessage.html).

A [dart fix](https://dart.dev/tools/dart-fix) is provided.

The migration code is shown below:

**Before:**
```dart
Chip(useDeleteButtonTooltip: false);
InputChip(useDeleteButtonTooltip: true);
RawChip rawChip = RawChip();
rawChip.useDeleteButtonTooltip;
```

**After:**
```dart
Chip(deleteButtonTooltipMessage: ‘’);
InputChip();
RawChip rawChip = RawChip();
rawChip.deleteButtonTooltipMessage;
```

The design doc for this change can be found [here](https://flutter.dev/go/chip-usedeletebuttontooltip-deprecation).

This is not a breaking change as it is only deprecating a property.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
