### PR TITLE
cupertino date picker: fixed column month width

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -450,7 +450,7 @@ class CupertinoDatePicker extends StatefulWidget {
       case _PickerColumnType.month:
         for (int i = 1; i <=12; i++) {
           final String month = localizations.datePickerMonth(i);
-          if (longestText.length < month.length)
+          if (longestText.compareTo(month).isNegative)
             longestText = month;
         }
         break;


### PR DESCRIPTION
Some smartphones within **portuguese** language has a layout break in a Cupertino date picker columns widths.

<p align="center"> 
<img src="https://user-images.githubusercontent.com/43169851/148412106-ece3bd3b-3b2c-493d-b0d6-8b9d3c0dd102.png" width="300"/>
</p>

I’ve noticed that build months columns widget according month name length size. But, it’s may have a problem when the month have letters like as: `i` or `t` per example. Because it’s a short letters in comparison with `a` or `b` per example.

However, I’ve a hope I fixed it.

<p align="center"> 
<img src="https://user-images.githubusercontent.com/43169851/148417737-15aedf5d-b192-498e-8de1-99506d1b2a0a.png" width="300"/>
</p>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
