### PR TITLE
TextEditingValue default selection docs

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -744,6 +744,9 @@ class TextEditingValue {
   ///
   /// The [text], [selection], and [composing] arguments must not be null but
   /// each have default values.
+  ///
+  /// The default value of [selection] is `TextSelection.collapsed(offset: -1)`.
+  /// This indicates that there is no selection at all.
   const TextEditingValue({
     this.text = '',
     this.selection = const TextSelection.collapsed(offset: -1),


### PR DESCRIPTION
This PR simply adds some docs about TextEditingValue's default selection, which is collapsed at index -1.  This selection value of -1 is a constant source of problems in Flutter, but if we can't eliminate it for now, we need to clearly document what it is.

Partial fix for https://github.com/flutter/flutter/issues/95978