### PR TITLE
Hide PII from doctor validators for GitHub template

### DIFF
--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -149,30 +149,18 @@ Future<int> _handleToolError(
     globals.printError('Oops; flutter has exited unexpectedly: "$error".');
 
     try {
-      String piiDoctorText;
-      String piiStrippedDoctorText;
-      try {
-        final BufferLogger logger = BufferLogger(
-          terminal: globals.terminal,
-          outputPreferences: globals.outputPreferences,
-        );
+      final BufferLogger logger = BufferLogger(
+        terminal: globals.terminal,
+        outputPreferences: globals.outputPreferences,
+      );
 
-        // Run doctor twice: once with PII for the locally saved crash report, and again without PII
-        // for the GitHub template. The GitHub template is sent to the GitHub URL shortener service,
-        // avoid leaking PII.
-        final DoctorText doctorText = DoctorText(logger);
-        piiDoctorText = await doctorText.text;
-        piiStrippedDoctorText = await doctorText.piiStrippedText;
-      } on Exception catch (error, trace) {
-        piiDoctorText = 'encountered exception: $error\n\n${trace.toString().trim()}\n';
-      }
+      final DoctorText doctorText = DoctorText(logger);
 
       final CrashDetails details = CrashDetails(
         command: _crashCommand(args),
         error: error,
         stackTrace: stackTrace,
-        doctorText: piiDoctorText,
-        piiStrippedDoctorText: piiStrippedDoctorText,
+        doctorText: doctorText,
       );
       final File file = await _createLocalCrashReport(details);
       await globals.crashReporter.informUser(details, file);

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -206,7 +206,7 @@ Future<File> _createLocalCrashReport(CrashDetails details) async {
   buffer.writeln('```\n${details.stackTrace}```\n');
 
   buffer.writeln('## flutter doctor\n');
-  buffer.writeln('```\n${details.doctorText}```');
+  buffer.writeln('```\n${await details.doctorText.text}```');
 
   try {
     crashFile.writeAsStringSync(buffer.toString());

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -19,6 +19,7 @@ import 'src/base/logger.dart';
 import 'src/base/process.dart';
 import 'src/context_runner.dart';
 import 'src/doctor.dart';
+import 'src/doctor_validator.dart';
 import 'src/globals.dart' as globals;
 import 'src/reporting/crash_reporting.dart';
 import 'src/runner/flutter_command.dart';
@@ -149,11 +150,41 @@ Future<int> _handleToolError(
     globals.printError('Oops; flutter has exited unexpectedly: "$error".');
 
     try {
+      String doctorText;
+      String piiStrippedDoctorText;
+      try {
+        final BufferLogger logger = BufferLogger(
+          terminal: globals.terminal,
+          outputPreferences: globals.outputPreferences,
+        );
+
+        // Run doctor twice: once with PII for the locally saved crash report, and again without PII
+        // for the GitHub template. The GitHub template is sent to the GitHub URL shortener service,
+        // avoid leaking PII.
+        final Doctor doctor = Doctor(logger: logger);
+
+        // Start the validator tasks only once.
+        final List<ValidatorTask> validatorTasks = doctor.startValidatorTasks();
+
+        // Run with PII.
+        await doctor.diagnose(showColor: false, startedValidatorTasks: validatorTasks);
+        doctorText = logger.statusText;
+
+        logger.clear();
+
+        // Run without PII. Do not send the doctor event a second time.
+        await doctor.diagnose(showColor: false, startedValidatorTasks: validatorTasks, showPii: false, sendEvent: false);
+        piiStrippedDoctorText = logger.statusText;
+      } on Exception catch (error, trace) {
+        doctorText = 'encountered exception: $error\n\n${trace.toString().trim()}\n';
+      }
+
       final CrashDetails details = CrashDetails(
         command: _crashCommand(args),
         error: error,
         stackTrace: stackTrace,
-        doctorText: await _doctorText(),
+        doctorText: doctorText,
+        piiStrippedDoctorText: piiStrippedDoctorText,
       );
       final File file = await _createLocalCrashReport(details);
       await globals.crashReporter.informUser(details, file);
@@ -219,22 +250,6 @@ Future<File> _createLocalCrashReport(CrashDetails details) async {
   }
 
   return crashFile;
-}
-
-Future<String> _doctorText() async {
-  try {
-    final BufferLogger logger = BufferLogger(
-      terminal: globals.terminal,
-      outputPreferences: globals.outputPreferences,
-    );
-
-    final Doctor doctor = Doctor(logger: logger);
-    await doctor.diagnose(showColor: false);
-
-    return logger.statusText;
-  } on Exception catch (error, trace) {
-    return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
-  }
 }
 
 Future<int> _exit(int code) async {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -577,9 +577,15 @@ class DoctorText {
   final Doctor _doctor;
   bool _sendDoctorEvent = true;
 
-  late final Future<String> text = () async {
+  late final Future<String> text = _runDiagnosis(true);
+  late final Future<String> piiStrippedText = _runDiagnosis(false);
+
+  // Start the validator tasks only once.
+  late final List<ValidatorTask> _validatorTasks = _doctor.startValidatorTasks();
+
+  Future<String> _runDiagnosis(bool showPii) async {
     try {
-      await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, sendEvent: _sendDoctorEvent);
+      await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, showPii: showPii, sendEvent: _sendDoctorEvent);
       // Do not send the doctor event a second time.
       _sendDoctorEvent = false;
       final String text = _logger.statusText;
@@ -588,21 +594,5 @@ class DoctorText {
     } on Exception catch (error, trace) {
       return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
     }
-  }();
-
-  late final Future<String> piiStrippedText = () async {
-    try {
-      await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, showPii: false, sendEvent: _sendDoctorEvent);
-      // Do not send the doctor event a second time.
-      _sendDoctorEvent = false;
-      final String piiStrippedText = _logger.statusText;
-      _logger.clear();
-      return piiStrippedText;
-    } on Exception catch (error, trace) {
-      return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
-    }
-  }();
-
-  // Start the validator tasks only once.
-  late final List<ValidatorTask> _validatorTasks = _doctor.startValidatorTasks();
+  }
 }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -578,21 +578,29 @@ class DoctorText {
   bool _sendDoctorEvent = true;
 
   late final Future<String> text = () async {
-    await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, sendEvent: _sendDoctorEvent);
-    // Do not send the doctor event a second time.
-    _sendDoctorEvent = false;
-    final String text = _logger.statusText;
-    _logger.clear();
-    return text;
+    try {
+      await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, sendEvent: _sendDoctorEvent);
+      // Do not send the doctor event a second time.
+      _sendDoctorEvent = false;
+      final String text = _logger.statusText;
+      _logger.clear();
+      return text;
+    } on Exception catch (error, trace) {
+      return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
+    }
   }();
 
   late final Future<String> piiStrippedText = () async {
-    await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, showPii: false, sendEvent: _sendDoctorEvent);
-    // Do not send the doctor event a second time.
-    _sendDoctorEvent = false;
-    final String piiStrippedText = _logger.statusText;
-    _logger.clear();
-    return piiStrippedText;
+    try {
+      await _doctor.diagnose(showColor: false, startedValidatorTasks: _validatorTasks, showPii: false, sendEvent: _sendDoctorEvent);
+      // Do not send the doctor event a second time.
+      _sendDoctorEvent = false;
+      final String piiStrippedText = _logger.statusText;
+      _logger.clear();
+      return piiStrippedText;
+    } on Exception catch (error, trace) {
+      return 'encountered exception: $error\n\n${trace.toString().trim()}\n';
+    }
   }();
 
   // Start the validator tasks only once.

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -221,22 +221,24 @@ class ValidationMessage {
   ///
   /// The [contextUrl] may be supplied to link to external resources. This
   /// is displayed after the informative message in verbose modes.
-  const ValidationMessage(this.message, {this.contextUrl}) : type = ValidationMessageType.information;
+  const ValidationMessage(this.message, { this.contextUrl, this.piiStrippedMessage }) : type = ValidationMessageType.information;
 
   /// Create a validation message with information for a failing validator.
-  const ValidationMessage.error(this.message)
+  const ValidationMessage.error(this.message, { this.piiStrippedMessage })
     : type = ValidationMessageType.error,
       contextUrl = null;
 
   /// Create a validation message with information for a partially failing
   /// validator.
-  const ValidationMessage.hint(this.message)
+  const ValidationMessage.hint(this.message, { this.piiStrippedMessage })
     : type = ValidationMessageType.hint,
       contextUrl = null;
 
   final ValidationMessageType type;
   final String? contextUrl;
   final String message;
+  /// Optional message with PII stripped, to show instead of [message].
+  final String? piiStrippedMessage;
 
   bool get isError => type == ValidationMessageType.error;
 

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -221,24 +221,27 @@ class ValidationMessage {
   ///
   /// The [contextUrl] may be supplied to link to external resources. This
   /// is displayed after the informative message in verbose modes.
-  const ValidationMessage(this.message, { this.contextUrl, this.piiStrippedMessage }) : type = ValidationMessageType.information;
+  const ValidationMessage(this.message, { this.contextUrl, String? piiStrippedMessage })
+      : type = ValidationMessageType.information, piiStrippedMessage = piiStrippedMessage ?? message;
 
   /// Create a validation message with information for a failing validator.
-  const ValidationMessage.error(this.message, { this.piiStrippedMessage })
+  const ValidationMessage.error(this.message, { String? piiStrippedMessage })
     : type = ValidationMessageType.error,
+      piiStrippedMessage = piiStrippedMessage ?? message,
       contextUrl = null;
 
   /// Create a validation message with information for a partially failing
   /// validator.
-  const ValidationMessage.hint(this.message, { this.piiStrippedMessage })
+  const ValidationMessage.hint(this.message, { String? piiStrippedMessage })
     : type = ValidationMessageType.hint,
+      piiStrippedMessage = piiStrippedMessage ?? message,
       contextUrl = null;
 
   final ValidationMessageType type;
   final String? contextUrl;
   final String message;
   /// Optional message with PII stripped, to show instead of [message].
-  final String? piiStrippedMessage;
+  final String piiStrippedMessage;
 
   bool get isError => type == ValidationMessageType.error;
 

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -12,6 +12,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
+import '../doctor.dart';
 import '../project.dart';
 import 'github_template.dart';
 import 'reporting.dart';
@@ -44,14 +45,12 @@ class CrashDetails {
     required this.error,
     required this.stackTrace,
     required this.doctorText,
-    String? piiStrippedDoctorText,
-  }) : piiStrippedDoctorText = piiStrippedDoctorText ?? doctorText;
+  });
 
   final String command;
   final Object error;
   final StackTrace stackTrace;
-  final String doctorText;
-  final String piiStrippedDoctorText;
+  final DoctorText doctorText;
 }
 
 /// Reports information about the crash to the user.
@@ -94,7 +93,7 @@ class CrashReporter {
       details.command,
       details.error,
       details.stackTrace,
-      details.piiStrippedDoctorText,
+      await details.doctorText.piiStrippedText,
     );
     _logger.printStatus('$gitHubTemplateURL\n', wrap: false);
   }

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -44,12 +44,14 @@ class CrashDetails {
     required this.error,
     required this.stackTrace,
     required this.doctorText,
-  });
+    String? piiStrippedDoctorText,
+  }) : piiStrippedDoctorText = piiStrippedDoctorText ?? doctorText;
 
   final String command;
   final Object error;
   final StackTrace stackTrace;
   final String doctorText;
+  final String piiStrippedDoctorText;
 }
 
 /// Reports information about the crash to the user.
@@ -92,7 +94,7 @@ class CrashReporter {
       details.command,
       details.error,
       details.stackTrace,
-      details.doctorText,
+      details.piiStrippedDoctorText,
     );
     _logger.printStatus('$gitHubTemplateURL\n', wrap: false);
   }

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/commands/build.dart';
 import 'package:flutter_tools/src/commands/config.dart';
 import 'package:flutter_tools/src/commands/doctor.dart';
 import 'package:flutter_tools/src/doctor.dart';
+import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/reporting/reporting.dart';
@@ -368,6 +369,9 @@ class FakeDoctor extends Fake implements Doctor {
     bool verbose = true,
     bool showColor = true,
     AndroidLicenseValidator androidLicenseValidator,
+    bool showPii = true,
+    List<ValidatorTask> startedValidatorTasks,
+    bool sendEvent = true,
   }) async {
     return diagnoseSucceeds;
   }

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -10,11 +10,13 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/doctor.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/crash_reporting.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/fake_http_client.dart';
@@ -91,9 +93,8 @@ void main() {
         command: 'arg1 arg2 arg3',
         error: Exception('Dummy exception'),
         stackTrace: StackTrace.current,
-        doctorText: 'Ignored',
         // Spaces are URL query encoded in the output, make it one word to make this test simpler.
-        piiStrippedDoctorText: 'NoPIIFakeDoctorText',
+        doctorText: FakeDoctorText('Ignored', 'NoPIIFakeDoctorText'),
       ),
       file,
     );
@@ -383,4 +384,17 @@ class CrashingCrashReportSender extends MockClient {
   CrashingCrashReportSender(Object exception) : super((Request request) async {
     throw exception;
   });
+}
+
+class FakeDoctorText extends Fake implements DoctorText {
+  FakeDoctorText(String text, String piiStrippedText)
+      : _text = text, _piiStrippedText = piiStrippedText;
+
+  @override
+  Future<String> get text async => _text;
+  final String _text;
+
+  @override
+  Future<String> get piiStrippedText async => _piiStrippedText;
+  final String _piiStrippedText;
 }

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -76,7 +76,7 @@ void main() {
     expect(logger.traceText, contains('Crash report sent (report ID: test-report-id)'));
   }
 
-  testWithoutContext('CrashReporter.informUser provides basic instructions', () async {
+  testWithoutContext('CrashReporter.informUser provides basic instructions without PII', () async {
     final CrashReporter crashReporter = CrashReporter(
       fileSystem: fs,
       logger: logger,
@@ -91,12 +91,17 @@ void main() {
         command: 'arg1 arg2 arg3',
         error: Exception('Dummy exception'),
         stackTrace: StackTrace.current,
-        doctorText: 'Fake doctor text'),
+        doctorText: 'Ignored',
+        // Spaces are URL query encoded in the output, make it one word to make this test simpler.
+        piiStrippedDoctorText: 'NoPIIFakeDoctorText',
+      ),
       file,
     );
 
-    expect(logger.errorText, contains('A crash report has been written to ${file.path}.'));
+    expect(logger.statusText, contains('NoPIIFakeDoctorText'));
+    expect(logger.statusText, isNot(contains('Ignored')));
     expect(logger.statusText, contains('https://github.com/flutter/flutter/issues/new'));
+    expect(logger.errorText, contains('A crash report has been written to ${file.path}.'));
   });
 
   testWithoutContext('suppress analytics', () async {

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -308,4 +308,7 @@ class FakeError extends Error {
   StackTrace get stackTrace => StackTrace.fromString('''
 #0      _File.open.<anonymous closure> (dart:io/file_impl.dart:366:9)
 #1      _rootRunUnary (dart:async/zone.dart:1141:38)''');
+
+  @override
+  String toString() => 'PII to ignore';
 }

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -198,7 +198,7 @@ void main() {
       expect(sentDetails.command, 'flutter crash');
       expect(sentDetails.error, 'an exception % --');
       expect(sentDetails.stackTrace.toString(), contains('CrashingFlutterCommand.runCommand'));
-      expect(sentDetails.doctorText, contains('[✓] Flutter'));
+      expect(await sentDetails.doctorText.text, contains('[✓] Flutter'));
     }, overrides: <Type, Generator>{
       Platform: () => FakePlatform(
         environment: <String, String>{


### PR DESCRIPTION
Create mechanism for doctor validators to output two versions: one that contains personally identifiable information (PII) and one that suppresses PII.  Use the PII output for the locally-created crash report.  Use non-PII for the crash template sent to the GitHub URL shortener, to avoid leaking PII to GitHub.

Note this doesn't actually scrub PII from the doctor validators.  That will be done in follow-up reviews.

Part of https://github.com/flutter/flutter/issues/53140.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
