### PR TITLE
Fix newline in template

### DIFF
--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -31,8 +31,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
 {{#withPluginHook}}
+
   {{pluginProjectName}}:
     # When depending on this package from a real application you should use:
     #   {{pluginProjectName}}: ^x.y.z


### PR DESCRIPTION
*This PR fixes newline character in the `pubspec.yaml.tmpl`, which caused to generate a template with 2 blank lines instead of just 1.*

**Before**
<img width="385" alt="before" src="https://user-images.githubusercontent.com/57679865/148471802-ecdab968-a166-4410-8ae4-d07ba8bdf5ef.png">
**After**
<img width="389" alt="after" src="https://user-images.githubusercontent.com/57679865/148471808-4e998b89-52a2-4032-ac9e-5caf699d21eb.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
