### PR TITLE
TextField text backgroundColor covers text selection color

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -473,22 +473,32 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   _CompositeRenderEditablePainter get _builtInForegroundPainters => _cachedBuiltInForegroundPainters ??= _createBuiltInForegroundPainters();
   _CompositeRenderEditablePainter? _cachedBuiltInForegroundPainters;
   _CompositeRenderEditablePainter _createBuiltInForegroundPainters() {
+    List<RenderEditablePainter> painters = <RenderEditablePainter>[];
+    if (paintCursorAboveText) {
+      painters = <RenderEditablePainter>[
+        _autocorrectHighlightPainter,
+        _selectionPainter,
+        _caretPainter
+      ];
+    }
     return _CompositeRenderEditablePainter(
-      painters: <RenderEditablePainter>[
-        if (paintCursorAboveText) _caretPainter,
-      ],
+      painters: painters,
     );
   }
 
   _CompositeRenderEditablePainter get _builtInPainters => _cachedBuiltInPainters ??= _createBuiltInPainters();
   _CompositeRenderEditablePainter? _cachedBuiltInPainters;
   _CompositeRenderEditablePainter _createBuiltInPainters() {
-    return _CompositeRenderEditablePainter(
-      painters: <RenderEditablePainter>[
+    List<RenderEditablePainter> painters = <RenderEditablePainter>[];
+    if (!paintCursorAboveText) {
+      painters = <RenderEditablePainter>[
         _autocorrectHighlightPainter,
         _selectionPainter,
-        if (!paintCursorAboveText) _caretPainter,
-      ],
+        _caretPainter
+      ];
+    }
+    return _CompositeRenderEditablePainter(
+      painters: painters,
     );
   }
 
@@ -1077,10 +1087,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   }
 
   /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
-  /// If the cursor should be painted on top of the text or underneath it.
+  /// If the cursor and the text selection highlight should be painted on top of the text or underneath it.
   ///
   /// By default, the cursor should be painted on top for iOS platforms and
   /// underneath for Android platforms.
+  ///
+  /// The hierarchy of the selection box follows the cursor mean that selection
+  /// box can painted above the text or under the text.
+  /// And you can use this property to change the selection box level.
   /// {@endtemplate}
   bool get paintCursorAboveText => _paintCursorOnTop;
   bool _paintCursorOnTop;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1087,7 +1087,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   }
 
   /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
-  /// If the cursor and the text selection highlight should be painted on top of the text or underneath it.
+  /// If the cursor and the selection highlight should be painted on top of the text or underneath it.
   ///
   /// By default, the cursor should be painted on top for iOS platforms and
   /// underneath for Android platforms.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1087,14 +1087,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   }
 
   /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
-  /// If the cursor and the selection highlight should be painted on top of the text or underneath it.
+  /// If the cursor and the selection highlight should be painted on top
+  /// of the text or underneath it.
   ///
   /// By default, the cursor should be painted on top for iOS platforms and
   /// underneath for Android platforms.
-  ///
-  /// The hierarchy of the selection box follows the cursor mean that selection
-  /// box can painted above the text or under the text.
-  /// And you can use this property to change the selection box level.
   /// {@endtemplate}
   bool get paintCursorAboveText => _paintCursorOnTop;
   bool _paintCursorOnTop;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -406,6 +406,45 @@ void main() {
     expect(editable, paintsExactlyCountTimes(#drawRect, 1));
   });
 
+  test('selection is paint above the text', () {
+    final TextSelectionDelegate delegate = _FakeEditableTextState();
+    final RenderEditable editable = RenderEditable(
+      backgroundCursorColor: Colors.grey,
+      selectionColor: Colors.black,
+      textDirection: TextDirection.ltr,
+      paintCursorAboveText: true,
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: delegate,
+      text: const TextSpan(
+        text: 'test',
+        style: TextStyle(
+          height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+        ),
+      ),
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      selection: const TextSelection(
+        baseOffset: 0,
+        extentOffset: 3,
+        affinity: TextAffinity.upstream,
+      ),
+    );
+
+    layout(editable);
+
+    expect(
+      editable,
+      paints
+        ..paragraph()
+        // Check that it's the black selection box, not the red cursor.
+        // cause of the `
+        ..rect(color: Colors.black),
+    );
+
+    // There is exactly one rect paint (1 selection, 0 cursor).
+    expect(editable, paintsExactlyCountTimes(#drawRect, 1));
+  });
+
   test('cursor can paint above or below the text', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final ValueNotifier<bool> showCursor = ValueNotifier<bool>(true);
@@ -439,7 +478,8 @@ void main() {
       paints
         ..paragraph()
         // Red collapsed cursor is painted, not a selection box.
-        ..rect(color: Colors.red[500]),
+        // cursor can painted above the selection
+        ..rect(color: Colors.red[500])
     );
 
     // There is exactly one rect paint (0 selection, 1 cursor).

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -406,7 +406,7 @@ void main() {
     expect(editable, paintsExactlyCountTimes(#drawRect, 1));
   });
 
-  test('selection is paint above the text', () {
+  test('selection is painted above the text', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final RenderEditable editable = RenderEditable(
       backgroundCursorColor: Colors.grey,
@@ -437,7 +437,6 @@ void main() {
       paints
         ..paragraph()
         // Check that it's the black selection box, not the red cursor.
-        // cause of the `
         ..rect(color: Colors.black),
     );
 
@@ -478,8 +477,8 @@ void main() {
       paints
         ..paragraph()
         // Red collapsed cursor is painted, not a selection box.
-        // cursor can painted above the selection
-        ..rect(color: Colors.red[500])
+        // The cursor is painted above the selection.
+        ..rect(color: Colors.red[500]),
     );
 
     // There is exactly one rect paint (0 selection, 1 cursor).


### PR DESCRIPTION
A TextField is rendered by `_RenderDecoration`, and the TextField content is painted in 
```
_RenderDecoration.paint(...) {
  doPaint(input);
}
```
The `input` is a `RenderEditable` class instance. The text background color and section highlight is painted in `_paintContents`;
So the whole flow of paint is:
`_RenderDecoration.paint` -> `RenderEditable._paintContents` ->  `textPainter paint text, _TextHighlightPainter paint selection highlight`

In `_paintContents` has a logic:
```
void _paintContents() {
    final RenderBox? foregroundChild = _foregroundRenderObject;
    final RenderBox? backgroundChild = _backgroundRenderObject;
    // _TextHighlightPainter paint the selection highlight state
    backgroundChild.paint;
    // paint the text
    textPainter.paint;
    foregroundChild.paint;
}
```

And I found in iOS platform `TextView` text highlight view is paint above the text content:
<img width="424" alt="截屏2022-01-17 上午11 07 58" src="https://user-images.githubusercontent.com/10297030/149704202-eab6c9d3-def4-4965-9264-a0d0f1807cbe.png">
 
but in current Flutter the highlight is as background and it below the content.

We can find that we first paint selection highlight state then paint text but if the text has background color it will cover the selection highlight.


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

