### PR TITLE
Reland "Ensure the engineLayer is disposed when an OpacityLayer is disabled""

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1763,11 +1763,16 @@ class OpacityLayer extends OffsetLayer {
   @override
   void addToScene(ui.SceneBuilder builder) {
     assert(alpha != null);
-    bool enabled = firstChild != null;  // don't add this layer if there's no child
+
+    // Don't add this layer if there's no child.
+    bool enabled = firstChild != null;
     if (!enabled) {
+      // Ensure the engineLayer is disposed.
+      engineLayer = null;
       // TODO(dnfield): Remove this if/when we can fix https://github.com/flutter/flutter/issues/90004
       return;
     }
+
     assert(() {
       enabled = enabled && !debugDisableOpacityLayers;
       return true;

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -637,6 +637,21 @@ void main() {
     expect(builder.addedPicture, true);
     expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
   });
+
+  test('OpacityLayer dispose its engineLayer if there are no children', () {
+    final OpacityLayer layer = OpacityLayer(alpha: 128);
+    final FakeSceneBuilder builder = FakeSceneBuilder();
+    layer.addToScene(builder);
+    expect(layer.engineLayer, null);
+
+    layer.append(PictureLayer(Rect.largest)..picture = FakePicture());
+    layer.addToScene(builder);
+    expect(layer.engineLayer, isA<FakeOpacityEngineLayer>());
+
+    layer.removeAllChildren();
+    layer.addToScene(builder);
+    expect(layer.engineLayer, null);
+  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {


### PR DESCRIPTION
Reverts flutter/flutter#94743

@ctrysbita @goderbauer @Piinks @jason-simmons fyi

The internal scuba breakages were actually regressions caused by https://github.com/flutter/flutter/pull/90017, which were missed because that PR affected 1000s of scubas by a few pixels. Compare `<redacted>/test/scuba_goldens/linux/off_to_on_step_3.png` before cl/397080291 and after. These were just unfortunately real regressions we missed.

This PR will require updating a few scuba files (something like 10 or so) internally - this is expected. /cc @renyou @angjieli fyi.

Fixes https://github.com/flutter/flutter/issues/92830 (again)
fixes https://github.com/flutter/flutter/issues/95911
fixes https://github.com/flutter/flutter/issues/94906
fixes https://github.com/flutter/flutter/issues/96087
Fixes https://github.com/flutter/flutter/issues/95270

We should CP this into stable.