### PR TITLE
Sync analysis_options.yaml with all.yaml, enable secure_pubspec_urls

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -65,6 +65,7 @@ linter:
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
+    # - avoid_final_parameters # incompatible with prefer_final_parameters
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
     - avoid_init_to_null
@@ -101,6 +102,7 @@ linter:
     - cast_nullable_to_non_nullable
     # - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/dart-lang/linter/issues/1142
+    # - conditional_uri_does_not_exist # not yet tested
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     # - curly_braces_in_flow_control_structures # not required by flutter style
@@ -132,6 +134,8 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
+    # - no_leading_underscores_for_library_prefixes # not yet tested
+    # - no_leading_underscores_for_local_identifiers  # not yet tested
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/
     - non_constant_identifier_names
@@ -179,8 +183,8 @@ linter:
     - prefer_is_not_operator
     - prefer_iterable_whereType
     # - prefer_mixin # Has false positives, see https://github.com/dart-lang/linter/issues/3018
-    - prefer_null_aware_operators
     # - prefer_null_aware_method_calls # "call()" is confusing to people new to the language since it's not documented anywhere
+    - prefer_null_aware_operators
     - prefer_relative_imports
     - prefer_single_quotes
     - prefer_spread_collections
@@ -190,7 +194,9 @@ linter:
     # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
     - recursive_getters
     # - require_trailing_commas # blocked on https://github.com/dart-lang/sdk/issues/47441
+    # - secure_pubspec_urls # not yet tested
     - sized_box_for_whitespace
+    # - sized_box_shrink_expand # not yet tested
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
@@ -209,6 +215,7 @@ linter:
     # - unnecessary_final # conflicts with prefer_final_locals
     - unnecessary_getters_setters
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
+    # - unnecessary_late # not yet tested
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_checks
@@ -224,6 +231,7 @@ linter:
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
+    # - use_decorated_box # not yet tested
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     # - use_if_null_to_convert_nulls_to_bools # blocked on https://github.com/dart-lang/sdk/issues/47436

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -135,7 +135,7 @@ linter:
     - no_default_cases
     - no_duplicate_case_values
     # - no_leading_underscores_for_library_prefixes # not yet tested
-    # - no_leading_underscores_for_local_identifiers  # not yet tested
+    # - no_leading_underscores_for_local_identifiers # not yet tested
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/
     - non_constant_identifier_names

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -194,7 +194,7 @@ linter:
     # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
     - recursive_getters
     # - require_trailing_commas # blocked on https://github.com/dart-lang/sdk/issues/47441
-    # - secure_pubspec_urls # not yet tested
+    - secure_pubspec_urls
     - sized_box_for_whitespace
     # - sized_box_shrink_expand # not yet tested
     - slash_for_doc_comments

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter
 description: A framework for writing Flutter applications
-homepage: http://flutter.dev
+homepage: https://flutter.dev
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_driver
 description: Integration and performance test API for Flutter applications
-homepage: http://flutter.dev
+homepage: https://flutter.dev
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/flutter_web_plugins/pubspec.yaml
+++ b/packages/flutter_web_plugins/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_web_plugins
 description: Library to register Flutter Web plugins
-homepage: http://flutter.dev
+homepage: https://flutter.dev
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fuchsia_remote_debug_protocol
 publish_to: none
 description: Provides an API to test/debug Flutter applications on remote Fuchsia devices and emulators.
-homepage: http://flutter.dev
+homepage: https://flutter.dev
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
Lint is considered for inclusion to the recommended set: https://github.com/dart-lang/core/issues/759.