### PR TITLE
Enable Linux_android android_semantics_integration_test in prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1400,6 +1400,7 @@ targets:
     scheduler: luci
 
   - name: Linux_android android_semantics_integration_test
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/74522
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1399,6 +1399,16 @@ targets:
       task_name: android_obfuscate_test
     scheduler: luci
 
+  - name: Linux_android android_semantics_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: android_semantics_integration_test
+    scheduler: luci
+
   - name: Linux_android android_stack_size_test
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2975,17 +2985,6 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
-
-  - name: Mac_android android_semantics_integration_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/94730
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","mac"]
-      task_name: android_semantics_integration_test
-    scheduler: luci
 
   - name: Mac_android hello_world_android__compile
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/74522

[`android_semantics_integration_test`](https://ci.chromium.org/p/flutter/builders/staging/Linux_android_staging%20android_semantics_integration_test?limit=50) has been running successfully in staging for a while, and it is ready to move to prod.

Removed the flake bug as the corresponding bug has been closed, and it was based on Mac_android.