### PR TITLE
[flutter_tools] Use proper project name in templates

### DIFF
--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -349,7 +349,8 @@ android {
       path.join(parent.path, 'hello', 'pubspec.yaml')
     );
     final String contents = pubspec.readAsStringSync();
-    final String newContents = contents.replaceFirst(RegExp(r'^flutter:$', multiLine: true), '''
+    final String newContents = contents.replaceFirst('${platformLineSep}flutter:$platformLineSep', '''
+
 flutter:
   assets:
     - lib/gallery/example_code.dart

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -349,9 +349,12 @@ android {
       path.join(parent.path, 'hello', 'pubspec.yaml')
     );
     final String contents = pubspec.readAsStringSync();
-    final String newContents = contents.replaceFirst(RegExp(r'^flutter:$', multiLine: true), '''flutter:
+    final String newContents = contents.replaceFirst(RegExp(r'^flutter:$', multiLine: true), '''
+flutter:
   assets:
-    - lib/gallery/example_code.dart''');
+    - lib/gallery/example_code.dart
+
+''');
     pubspec.writeAsStringSync(newContents);
   }
 

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -349,8 +349,7 @@ android {
       path.join(parent.path, 'hello', 'pubspec.yaml')
     );
     final String contents = pubspec.readAsStringSync();
-    final String newContents = contents.replaceFirst(r'^flutter:$', '''
-flutter:
+    final String newContents = contents.replaceFirst(RegExp(r'^flutter:$', multiLine: true), '''flutter:
   assets:
     - lib/gallery/example_code.dart''');
     pubspec.writeAsStringSync(newContents);

--- a/dev/devicelab/lib/framework/apk_utils.dart
+++ b/dev/devicelab/lib/framework/apk_utils.dart
@@ -349,12 +349,10 @@ android {
       path.join(parent.path, 'hello', 'pubspec.yaml')
     );
     final String contents = pubspec.readAsStringSync();
-    final String newContents = contents.replaceFirst('# The following section is specific to Flutter.${platformLineSep}flutter:$platformLineSep', '''
+    final String newContents = contents.replaceFirst(r'^flutter:$', '''
 flutter:
   assets:
-    - lib/gallery/example_code.dart
-
-''');
+    - lib/gallery/example_code.dart''');
     pubspec.writeAsStringSync(newContents);
   }
 

--- a/packages/flutter_tools/bin/tool_backend.dart
+++ b/packages/flutter_tools/bin/tool_backend.dart
@@ -6,7 +6,7 @@
 import 'dart:convert'; // flutter_ignore: dart_convert_import.
 import 'dart:io'; // flutter_ignore: dart_io_import.
 
-/// Executes the required flutter tasks for a desktop build.
+/// Executes the required Flutter tasks for a desktop build.
 Future<void> main(List<String> arguments) async {
   final String targetPlatform = arguments[0];
   final String buildMode = arguments[1].toLowerCase();

--- a/packages/flutter_tools/doc/daemon.md
+++ b/packages/flutter_tools/doc/daemon.md
@@ -10,7 +10,7 @@ flutter daemon
 
 It runs a persistent, JSON-RPC based server to communicate with devices. IDEs and other tools can start the flutter tool in this mode and get device addition and removal notifications, as well as being able to programmatically start and stop apps on those devices.
 
-A set of `flutter daemon` commands/events are also exposed via `flutter run --machine` and `flutter attach --machine` which allow IDEs and tools to launch and attach to flutter applications and interact to send commands like Hot Reload. The command and events that are available in these modes are documented at the bottom of this document.
+A set of `flutter daemon` commands/events are also exposed via `flutter run --machine` and `flutter attach --machine` which allow IDEs and tools to launch and attach to Flutter applications and interact to send commands like Hot Reload. The command and events that are available in these modes are documented at the bottom of this document.
 
 ## Protocol
 

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -436,7 +436,7 @@ Your $application code is in $relativeAppMain.
     int generatedCount = 0;
     final String description = argResults.wasParsed('description')
         ? stringArg('description')
-        : 'A new flutter module project.';
+        : 'A new Flutter module project.';
     templateContext['description'] = description;
     generatedCount += await renderTemplate(
       globals.fs.path.join('module', 'common'),
@@ -515,7 +515,7 @@ Your $application code is in $relativeAppMain.
     int generatedCount = 0;
     final String description = argResults.wasParsed('description')
         ? stringArg('description')
-        : 'A new flutter plugin project.';
+        : 'A new Flutter plugin project.';
     templateContext['description'] = description;
     generatedCount += await renderMerged(
       <String>['plugin', 'plugin_shared'],

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1488,7 +1488,7 @@ class LogMessage {
   final StackTrace stackTrace;
 }
 
-/// The method by which the flutter app was launched.
+/// The method by which the Flutter app was launched.
 class LaunchMode {
   const LaunchMode._(this._value);
 

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -29,7 +29,7 @@ class UpgradeCommand extends FlutterCommand {
       ..addFlag(
         'force',
         abbr: 'f',
-        help: 'Force upgrade the Flutter branch, potentially discarding local changes.',
+        help: 'Force upgrade the flutter branch, potentially discarding local changes.',
         negatable: false,
       )
       ..addFlag(

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -29,7 +29,7 @@ class UpgradeCommand extends FlutterCommand {
       ..addFlag(
         'force',
         abbr: 'f',
-        help: 'Force upgrade the flutter branch, potentially discarding local changes.',
+        help: 'Force upgrade the Flutter branch, potentially discarding local changes.',
         negatable: false,
       )
       ..addFlag(
@@ -49,7 +49,7 @@ class UpgradeCommand extends FlutterCommand {
       )
       ..addFlag(
         'verify-only',
-        help: 'Checks for any new flutter updates, without actually fetching them.',
+        help: 'Checks for any new Flutter updates, without actually fetching them.',
         negatable: false,
       );
   }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -464,7 +464,7 @@ abstract class PollingDeviceDiscovery extends DeviceDiscovery {
   String toString() => '$name device discovery';
 }
 
-/// A device is a physical hardware that can run a flutter application.
+/// A device is a physical hardware that can run a Flutter application.
 ///
 /// This may correspond to a connected iOS or Android device, or represent
 /// the host operating system in the case of Flutter Desktop.
@@ -621,7 +621,7 @@ abstract class Device {
   /// Whether this device implements support for hot restart.
   bool get supportsHotRestart => true;
 
-  /// Whether flutter applications running on this device can be terminated
+  /// Whether Flutter applications running on this device can be terminated
   /// from the VM Service.
   bool get supportsFlutterExit => true;
 

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -530,7 +530,7 @@ const String _pluginRegistrantPodspecTemplate = '''
 Pod::Spec.new do |s|
   s.name             = 'FlutterPluginRegistrant'
   s.version          = '0.0.1'
-  s.summary          = 'Registers plugins with your flutter app'
+  s.summary          = 'Registers plugins with your Flutter app'
   s.description      = <<-DESC
 Depends on all your plugins, and provides a function to register them.
                        DESC

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -297,7 +297,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     if (activeArchName != null) {
       buildCommands.add('ONLY_ACTIVE_ARCH=YES');
       // Setting ARCHS to $activeArchName will break the build if a watchOS companion app exists,
-      // as it cannot be build for the architecture of the flutter app.
+      // as it cannot be build for the architecture of the Flutter app.
       if (!hasWatchCompanion) {
         buildCommands.add('ARCHS=$activeArchName');
       }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -709,7 +709,7 @@ class FlutterVmService {
         isolateId: isolateId,
       );
       // A response of `null` indicates that `invokeFlutterExtensionRpcRaw` caught an RPCError
-      // with a missing method code. This can happen when attempting to quit a flutter app
+      // with a missing method code. This can happen when attempting to quit a Flutter app
       // that never registered the methods in the bindings.
       if (result == null) {
         return false;

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -118,7 +118,7 @@ class IosProject extends XcodeBasedProject {
   /// True, if the parent Flutter project is a module project.
   bool get isModule => parent.isModule;
 
-  /// Whether the flutter application has an iOS project.
+  /// Whether the Flutter application has an iOS project.
   bool get exists => hostAppRoot.existsSync();
 
   /// Put generated files here.

--- a/packages/flutter_tools/templates/app/README.md.tmpl
+++ b/packages/flutter_tools/templates/app/README.md.tmpl
@@ -11,6 +11,6 @@ A few resources to get you started if this is your first Flutter project:
 - [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
 - [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
 
-For help getting started with Flutter, view our
+For help getting started with Flutter development, view the
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/packages/flutter_tools/templates/app/README.md.tmpl
+++ b/packages/flutter_tools/templates/app/README.md.tmpl
@@ -8,9 +8,9 @@ This project is a starting point for a Flutter application.
 
 A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
 
 For help getting started with Flutter development, view the
-[online documentation](https://flutter.dev/docs), which offers tutorials,
+[online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -60,7 +60,7 @@ dev_dependencies:
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter.
+# The following section is specific to Flutter packages.
 flutter:
 
   # The following line ensures that the Material Icons font is

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/debug/AndroidManifest.xml.tmpl
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{androidIdentifier}}">
-    <!-- Flutter needs it to communicate with the running application
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/res/values-night/styles.xml
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/res/values-night/styles.xml
@@ -3,7 +3,7 @@
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/res/values/styles.xml
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
     <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.

--- a/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android.tmpl/app/src/profile/AndroidManifest.xml.tmpl
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{androidIdentifier}}">
-    <!-- Flutter needs it to communicate with the running application
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/packages/flutter_tools/templates/app_test_widget/test/widget_test.dart.tmpl
+++ b/packages/flutter_tools/templates/app_test_widget/test/widget_test.dart.tmpl
@@ -1,7 +1,7 @@
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
+// utility in the flutter_test package. For example, you can send tap and scroll
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 

--- a/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/res/values/styles.xml
+++ b/packages/flutter_tools/templates/module/android/host_app_common/app.tmpl/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
 </resources>

--- a/packages/flutter_tools/templates/module/common/README.md.tmpl
+++ b/packages/flutter_tools/templates/module/common/README.md.tmpl
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-For help getting started with Flutter, view our online
+For help getting started with Flutter development, view the online
 [documentation](https://flutter.dev/).
 
 For instructions integrating Flutter modules to your existing applications,

--- a/packages/flutter_tools/templates/module/common/test/widget_test.dart.tmpl
+++ b/packages/flutter_tools/templates/module/common/test/widget_test.dart.tmpl
@@ -1,7 +1,7 @@
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
+// utility in the flutter_test package. For example, you can send tap and scroll
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -19,7 +19,7 @@ dev_dependencies:
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter.
+# The following section is specific to Flutter packages.
 flutter:
 
   # To add assets to your package, add an assets section, like this:

--- a/packages/flutter_tools/templates/plugin/README.md.tmpl
+++ b/packages/flutter_tools/templates/plugin/README.md.tmpl
@@ -9,7 +9,7 @@ This project is a starting point for a Flutter
 a specialized package that includes platform-specific implementation code for
 Android and/or iOS.
 
-For help getting started with Flutter, view our
+For help getting started with Flutter development, view the
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -31,7 +31,7 @@ dev_dependencies:
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter.
+# The following section is specific to Flutter packages.
 flutter:
   # This section identifies this Flutter project as a plugin project.
   # The 'pluginClass' specifies the class (in Java, Kotlin, Swift, Objective-C, etc.)

--- a/packages/flutter_tools/templates/skeleton/README.md.tmpl
+++ b/packages/flutter_tools/templates/skeleton/README.md.tmpl
@@ -8,7 +8,7 @@ This project is a starting point for a Flutter application that follows the
 [simple app state management
 tutorial](https://flutter.dev/docs/development/data-and-backend/state-mgmt/simple).
 
-For help getting started with Flutter, view our
+For help getting started with Flutter development, view the
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 

--- a/packages/flutter_tools/templates/skeleton/test/widget_test.dart.tmpl
+++ b/packages/flutter_tools/templates/skeleton/test/widget_test.dart.tmpl
@@ -1,7 +1,7 @@
 // This is an example Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
+// utility in the flutter_test package. For example, you can send tap and scroll
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 //

--- a/packages/flutter_tools/test/integration.shard/gradle_non_android_plugin_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gradle_non_android_plugin_test.dart
@@ -21,7 +21,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  testWithoutContext('flutter app that depends on a non-Android plugin can still build for Android', () {
+  testWithoutContext('Flutter app that depends on a non-Android plugin can still build for Android', () {
     final String flutterRoot = getFlutterRoot();
     final String flutterBin = fileSystem.path.join(
       flutterRoot,

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -549,7 +549,7 @@ class BasicDeferredComponentsConfig extends DeferredComponentsConfig {
     <!-- Theme applied to the Android Window while the process is starting -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.

--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -266,7 +266,7 @@ class MultidexProject extends Project {
     <!-- Theme applied to the Android Window while the process is starting -->
     <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
-             Flutter draws its first frame -->
+             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.


### PR DESCRIPTION
- [x] Updates flutter_tools templates to generate files that properly use the project name
- [x] Updates apk_utils test function to deal with changes to templates

Cleaning up a few things while I'm here (reviewers, let me know if I should move these out to simplify the PR)
- [x] Updates help messages for flutter_tools to properly use the project name
- [x] Updates some places in the flutter_tools documentation to properly use the project name (non-exhaustively)

Fixes https://github.com/flutter/flutter/issues/96371

## Test plan

- [x] Presubmit tests pass (the ci.yaml one was stuck, but seems fine now)
- [x] Manually run the one devicelab test that is affected (gradle_plugin_light_apk_test). ~I am encountering an error "Could not find or load main class com.android.tools.apk.analyzer.ApkAnalyzerCli"  running it locally~. It passes locally.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this **PR is [test-exempt] (I think this is all documentation, but would be nice to get confirmation)**.
- [x] All existing and new tests are passing.

I tried running `flutter format` on `apk_utils.dart` but it changed the file too much, so I'm not planning on landing it.