### PR TITLE
Fix a [_ViewportElement] RenderObjectChild update bug

### DIFF
--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -212,7 +212,7 @@ class _ViewportElement extends MultiChildRenderObjectElement {
   _ViewportElement(Viewport widget) : super(widget);
 
   bool _doingMountOrUpdate = false;
-  int? _centerSlotIndex = null;
+  int? _centerSlotIndex;
 
   @override
   Viewport get widget => super.widget as Viewport;

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -243,13 +243,16 @@ class _ViewportElement extends MultiChildRenderObjectElement {
   void _updateCenter() {
     // TODO(ianh): cache the keys to make this faster
     if (widget.center != null) {
-      for (int i = 0; i < children.length; i++) {
-        if (children.elementAt(i).widget.key == widget.center) {
-          renderObject.center = children.elementAt(i).renderObject as RenderSliver?;
-          _centerSlotIndex = i;
+      int elementIndex = 0;
+      for (final Element e in children) {
+        if (e.widget.key == widget.center) {
+          renderObject.center = e.renderObject as RenderSliver?;
           break;
         }
+        elementIndex++;
       }
+      assert(elementIndex < children.length);
+      _centerSlotIndex = elementIndex;
     } else if (children.isNotEmpty) {
       renderObject.center = children.first.renderObject as RenderSliver?;
       _centerSlotIndex = 0;
@@ -264,22 +267,22 @@ class _ViewportElement extends MultiChildRenderObjectElement {
     super.insertRenderObjectChild(child, slot);
     // Once [mount]/[update] are done, the `renderObject.center` will be updated
     // in [_updateCenter].
-    if (!_doingMountOrUpdate) {
-      if (slot.index == _centerSlotIndex) {
-        renderObject.center = child as RenderSliver?;
-      }
+    if (!_doingMountOrUpdate && slot.index == _centerSlotIndex) {
+      renderObject.center = child as RenderSliver?;
     }
   }
 
-  // `moveRenderObjectChild` only happens during [update] stage.
+  @override
+  void moveRenderObjectChild(RenderObject child, IndexedSlot<Element?> oldSlot, IndexedSlot<Element?> newSlot) {
+    super.moveRenderObjectChild(child, oldSlot, newSlot);
+    assert(_doingMountOrUpdate);
+  }
 
   @override
   void removeRenderObjectChild(RenderObject child, Object? slot) {
     super.removeRenderObjectChild(child, slot);
-    if (!_doingMountOrUpdate) {
-      if (renderObject.center == child) {
-        renderObject.center = null;
-      }
+    if (!_doingMountOrUpdate && renderObject.center == child) {
+      renderObject.center = null;
     }
   }
 

--- a/packages/flutter/test/widgets/custom_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/custom_scroll_view_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/96024
-  testWidgets('CustomScrollView.center update test', (WidgetTester tester) async {
+  testWidgets('CustomScrollView.center update test 1', (WidgetTester tester) async {
     final Key centerKey = UniqueKey();
     late StateSetter setState;
     bool hasKey = false;
@@ -44,6 +44,38 @@ void main() {
       hasKey = true;
     });
 
+    await tester.pumpAndSettle();
+
+    // Pass without throw.
+  });
+
+  testWidgets('CustomScrollView.center update test 2', (WidgetTester tester) async {
+    const List<Widget> slivers1 = <Widget>[
+      SliverToBoxAdapter(key: Key('a'), child: SizedBox(height: 100.0)),
+      SliverToBoxAdapter(key: Key('b'), child: SizedBox(height: 100.0)),
+      SliverToBoxAdapter(key: Key('c'), child: SizedBox(height: 100.0)),
+    ];
+
+    const List<Widget> slivers2 = <Widget>[
+      SliverToBoxAdapter(key: Key('c'), child: SizedBox(height: 100.0)),
+      SliverToBoxAdapter(key: Key('d'), child: SizedBox(height: 100.0)),
+      SliverToBoxAdapter(key: Key('a'), child: SizedBox(height: 100.0)),
+    ];
+
+    Widget buildFrame(List<Widget> slivers, Key center) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          center: center,
+          slivers: slivers,
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(slivers1, const Key('b')));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(buildFrame(slivers2, const Key('d')));
     await tester.pumpAndSettle();
 
     // Pass without throw.

--- a/packages/flutter/test/widgets/custom_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/custom_scroll_view_test.dart
@@ -6,6 +6,49 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/96024
+  testWidgets('CustomScrollView.center update test', (WidgetTester tester) async {
+    final Key centerKey = UniqueKey();
+    late StateSetter setState;
+    bool hasKey = false;
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: CustomScrollView(
+        center: centerKey,
+        slivers: <Widget>[
+          const SliverToBoxAdapter(key: Key('a'), child: SizedBox(height: 100.0)),
+          StatefulBuilder(
+            key: centerKey,
+            builder: (BuildContext context, StateSetter setter) {
+              setState = setter;
+              if (hasKey) {
+                return const SliverToBoxAdapter(
+                  key: Key('b'),
+                  child: SizedBox(height: 100.0),
+                );
+              } else {
+                return const SliverToBoxAdapter(
+                  child: SizedBox(height: 100.0),
+                );
+              }
+            },
+          ),
+        ],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // Change the center key will trigger the old RenderObject remove and a new
+    // RenderObject insert.
+    setState(() {
+      hasKey = true;
+    });
+
+    await tester.pumpAndSettle();
+
+    // Pass without throw.
+  });
+
   testWidgets('CustomScrollView.center', (WidgetTester tester) async {
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,


### PR DESCRIPTION
Fixes #96024 
Fixes #55170
 Fixes #25861

The `RenderViewport` keep a child RO by 'center', it will be updated in [_ViewportElement.mount] or [Update].
But sometimes the child RO will be changed without [_ViewportElement] change when only the subtree of `Viewport` is dirty.
In that case, we should also update the center RO.


Similar to the root cause of [this issue](https://github.com/flutter/flutter/pull/78081), it has a similar solution.

