### PR TITLE
Add macOS ephemeral to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ unlinked_spec.ds
 
 # macOS
 **/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/ephemeral
 
 # Coverage
 coverage/


### PR DESCRIPTION
When updating the repo's packages, these macOS ephemeral directories are generated for some projects (e.g. `hello_world`). They should be ignored.