### PR TITLE
Enable no_leading_underscores_for_library_prefixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -134,7 +134,7 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
-    # - no_leading_underscores_for_library_prefixes # not yet tested
+    - no_leading_underscores_for_library_prefixes
     # - no_leading_underscores_for_local_identifiers # not yet tested
     - no_logic_in_create_state
     # - no_runtimeType_toString # ok in tests; we enable this only in packages/

--- a/packages/flutter/lib/src/foundation/bitfield.dart
+++ b/packages/flutter/lib/src/foundation/bitfield.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import '_bitfield_io.dart'
-  if (dart.library.html) '_bitfield_web.dart' as _bitfield;
+  if (dart.library.html) '_bitfield_web.dart' as bitfield;
 
 /// The largest SMI value.
 ///
@@ -11,7 +11,7 @@ import '_bitfield_io.dart'
 ///
 /// When compiling to JavaScript, this value is not supported since it is
 /// larger than the maximum safe 32bit integer.
-const int kMaxUnsignedSMI = _bitfield.kMaxUnsignedSMI;
+const int kMaxUnsignedSMI = bitfield.kMaxUnsignedSMI;
 
 /// A BitField over an enum (or other class whose values implement "index").
 /// Only the first 62 values of the enum can be used as indices.
@@ -21,7 +21,7 @@ abstract class BitField<T extends dynamic> {
   /// Creates a bit field of all zeros.
   ///
   /// The given length must be at most 62.
-  factory BitField(int length) = _bitfield.BitField<T>;
+  factory BitField(int length) = bitfield.BitField<T>;
 
   /// Creates a bit field filled with a particular value.
   ///
@@ -29,7 +29,7 @@ abstract class BitField<T extends dynamic> {
   /// the bits are filled with zeros.
   ///
   /// The given length must be at most 62.
-  factory BitField.filled(int length, bool value) = _bitfield.BitField<T>.filled;
+  factory BitField.filled(int length, bool value) = bitfield.BitField<T>.filled;
 
   /// Returns whether the bit with the given index is set to one.
   bool operator [](T index);

--- a/packages/flutter/lib/src/foundation/isolates.dart
+++ b/packages/flutter/lib/src/foundation/isolates.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import '_isolates_io.dart'
-  if (dart.library.html) '_isolates_web.dart' as _isolates;
+  if (dart.library.html) '_isolates_web.dart' as isolates;
 
 /// Signature for the callback passed to [compute].
 ///
@@ -49,4 +49,4 @@ typedef ComputeImpl = Future<R> Function<Q, R>(ComputeCallback<Q, R> callback, Q
 /// See also:
 ///
 ///   * [ComputeImpl], for function parameters and usage details.
-const ComputeImpl compute = _isolates.compute;
+const ComputeImpl compute = isolates.compute;

--- a/packages/flutter/lib/src/foundation/platform.dart
+++ b/packages/flutter/lib/src/foundation/platform.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import '_platform_io.dart'
-  if (dart.library.html) '_platform_web.dart' as _platform;
+  if (dart.library.html) '_platform_web.dart' as platform;
 
 /// The [TargetPlatform] that matches the platform on which the framework is
 /// currently executing.
@@ -36,7 +36,7 @@ import '_platform_io.dart'
 // that would mean we'd be stuck with that platform forever emulating the other,
 // and we'd never be able to introduce dedicated behavior for that platform
 // (since doing so would be a big breaking change).
-TargetPlatform get defaultTargetPlatform => _platform.defaultTargetPlatform;
+TargetPlatform get defaultTargetPlatform => platform.defaultTargetPlatform;
 
 /// The platform that user interaction should adapt to target.
 ///

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -8,7 +8,7 @@ import 'dart:ui';
 import 'package:path/path.dart' as path;
 import 'package:test_api/test_api.dart'; // ignore: deprecated_member_use
 
-import '_goldens_io.dart' if (dart.library.html) '_goldens_web.dart' as _goldens;
+import '_goldens_io.dart' if (dart.library.html) '_goldens_web.dart' as goldens;
 
 /// Compares image pixels against a golden image file.
 ///
@@ -94,7 +94,7 @@ abstract class GoldenFileComparator {
   /// Returns a [ComparisonResult] to describe the pixel differential of the
   /// [test] and [master] image bytes provided.
   static Future<ComparisonResult> compareLists(List<int> test, List<int> master) {
-    return _goldens.compareLists(test, master);
+    return goldens.compareLists(test, master);
   }
 }
 


### PR DESCRIPTION
There's a proposal to add `no_leading_underscores_for_library_prefixes` to package:lints (https://github.com/dart-lang/core/issues/758). This checks what impact that would have on the flutter code base.

In most places we don't use underscores so this lint provides some nice unification across the code base.

/cc @pq 