### PR TITLE
Increase deferred components test timeout

### DIFF
--- a/dev/integration_tests/deferred_components_test/run_release_test.sh
+++ b/dev/integration_tests/deferred_components_test/run_release_test.sh
@@ -45,7 +45,7 @@ do
     fi
     # Timeout if expected log not found
     current_time=$(date +%s)
-    if [[ $((current_time - run_start_time_seconds)) -ge 150 ]]; then
+    if [[ $((current_time - run_start_time_seconds)) -ge 300 ]]; then
         echo "Failure: Timed out, deferred component did not load."
         pkill -P $$
         exit 1


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/96403

Test should be running fine, on rare infra slowdown occasions, the emulator may take longer than expected to load.
