### PR TITLE
Made sure the MissingPluginException.toString never gets removed

### DIFF
--- a/packages/flutter/lib/src/services/message_codec.dart
+++ b/packages/flutter/lib/src/services/message_codec.dart
@@ -5,6 +5,8 @@
 
 import 'dart:typed_data';
 
+import 'dart:ui' show keepToString;
+
 import 'package:flutter/foundation.dart';
 
 import 'platform_channel.dart';
@@ -169,6 +171,9 @@ class MissingPluginException implements Exception {
   /// A human-readable error message, possibly null.
   final String? message;
 
+  // `keepToString` to avoid removal of the toString implementation and help
+  // diagnose misbehaving plugins.
+  @keepToString
   @override
   String toString() => 'MissingPluginException($message)';
 }


### PR DESCRIPTION
related issue b/209604261

When doing builds that remove toString implementations it is difficult to debug plugin errors since the name of the channel where the error is happening is being elided.

Test exempt since it is only an annotation change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
