### PR TITLE
Text selection located wrong position when selecting multiple lines over max lines

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -572,7 +572,7 @@ class TextSelectionOverlay {
         child: CompositedTransformFollower(
           link: toolbarLayerLink,
           showWhenUnlinked: false,
-          offset: -editingRegion.topLeft - Offset(0, endpoints[0].point.dy - renderObject.preferredLineHeight),
+          offset: -editingRegion.topLeft - Offset(0, -renderObject.offset.pixels),
           child: Builder(
             builder: (BuildContext context) {
               return selectionControls!.buildToolbar(

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -572,7 +572,7 @@ class TextSelectionOverlay {
         child: CompositedTransformFollower(
           link: toolbarLayerLink,
           showWhenUnlinked: false,
-          offset: -editingRegion.topLeft,
+          offset: -editingRegion.topLeft - Offset(0, endpoints[0].point.dy - renderObject.preferredLineHeight),
           child: Builder(
             builder: (BuildContext context) {
               return selectionControls!.buildToolbar(

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -547,6 +547,74 @@ void main() {
       skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
     );
+
+    testWidgets('When select multiple lines over max lines', (WidgetTester tester) async {
+      final TextEditingController controller = TextEditingController(text: 'abc\ndef\nghi\njkl\nmno\npqr');
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(800.0, 600.0)),
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: Material(
+                child: TextField(
+                  style: const TextStyle(fontSize: 32, height: 1),
+                  maxLines: 2,
+                  controller: controller,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      // Initially, the menu isn't shown at all.
+      expect(find.text('Cut'), findsNothing);
+      expect(find.text('Copy'), findsNothing);
+      expect(find.text('Paste'), findsNothing);
+      expect(find.text('Select all'), findsNothing);
+      expect(find.byType(IconButton), findsNothing);
+
+      // Tap to place the cursor in the field, then tap the handle to show the
+      // selection menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pumpAndSettle();
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 1);
+      final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
+      await tester.tapAt(handlePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(find.text('Cut'), findsNothing);
+      expect(find.text('Copy'), findsNothing);
+      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('Select all'), findsOneWidget);
+      expect(find.byType(IconButton), findsNothing);
+
+      // Tap to select all.
+      await tester.tap(find.text('Select all'));
+      await tester.pumpAndSettle();
+
+      // Only Cut, Copy, and Paste are shown.
+      expect(find.text('Cut'), findsOneWidget);
+      expect(find.text('Copy'), findsOneWidget);
+      expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('Select all'), findsNothing);
+      expect(find.byType(IconButton), findsNothing);
+
+
+      final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+      final Offset textFieldOffset = tester.getTopLeft(find.byType(TextField));
+      expect(cutOffset.dy + 25, equals(textFieldOffset.dy));
+    },
+      skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
+    );
   });
 
   group('material handles', () {

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -613,7 +613,7 @@ void main() {
       expect(cutOffset.dy + 25, equals(textFieldOffset.dy));
     },
       skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
-      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
+      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS }),
     );
   });
 


### PR DESCRIPTION
Fixes #96453

This PR fixes bugs that text selection located wrong position when selecting multiple lines over max lines.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

![image](https://user-images.githubusercontent.com/16171447/148945902-c256f28b-5b94-4754-83b5-ed406494bea3.png)
