### PR TITLE
enable more retained rendering opportunities for LeaderLayer

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -5289,7 +5289,7 @@ class RenderFollowerLayer extends RenderProxyBox {
   @override
   bool hitTest(BoxHitTestResult result, { required Offset position }) {
     // Disables the hit testing if this render object is hidden.
-    if (!link.leaderConnected && !showWhenUnlinked)
+    if (link.leader == null && !showWhenUnlinked)
       return false;
     // RenderFollowerLayer objects don't check if they are
     // themselves hit, because it's confusing to think about
@@ -5313,8 +5313,8 @@ class RenderFollowerLayer extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     final Size? leaderSize = link.leaderSize;
     assert(
-      link.leaderSize != null || (!link.leaderConnected || leaderAnchor == Alignment.topLeft),
-      '$link: layer is linked to ${link.debugLeader} but a valid leaderSize is not set. '
+      link.leaderSize != null || (link.leader == null || leaderAnchor == Alignment.topLeft),
+      '$link: layer is linked to ${link.leader} but a valid leaderSize is not set. '
       'leaderSize is required when leaderAnchor is not Alignment.topLeft '
       '(current value is $leaderAnchor).',
     );

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -176,7 +176,7 @@ void main() {
     expect(leaderLayer.link, link2);
   });
 
-  test('leader layers are always dirty when connected to follower layer', () {
+  test('leader layers not dirty when connected to follower layer', () {
     final ContainerLayer root = ContainerLayer()..attach(Object());
 
     final LayerLink link = LayerLink();
@@ -190,7 +190,7 @@ void main() {
     followerLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
     followerLayer.updateSubtreeNeedsAddToScene();
-    expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
+    expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
   });
 
   test('leader layers are not dirty when all followers disconnects', () {
@@ -204,24 +204,24 @@ void main() {
     leaderLayer.updateSubtreeNeedsAddToScene();
     expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
 
-    // Connecting a follower requires adding to scene.
+    // Connecting a follower does not require adding to scene
     final FollowerLayer follower1 = FollowerLayer(link: link);
     root.append(follower1);
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
-    expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
+    expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
 
     final FollowerLayer follower2 = FollowerLayer(link: link);
     root.append(follower2);
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
-    expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
+    expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
 
-    // Disconnecting one follower, still needs add to scene.
+    // Disconnecting one follower, still does not needs add to scene.
     follower2.remove();
     leaderLayer.debugMarkClean();
     leaderLayer.updateSubtreeNeedsAddToScene();
-    expect(leaderLayer.debugSubtreeNeedsAddToScene, true);
+    expect(leaderLayer.debugSubtreeNeedsAddToScene, false);
 
     // Disconnecting all followers goes back to not requiring add to scene.
     follower1.remove();

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -300,4 +300,22 @@ void main() {
       }
     }
   });
+
+  testWidgets('Leader after Follower asserts', (WidgetTester tester) async {
+    final LayerLink link = LayerLink();
+    await tester.pumpWidget(
+      CompositedTransformFollower(
+        link: link,
+        child: CompositedTransformTarget(
+          link: link,
+          child: const SizedBox(height: 20, width: 20),
+        ),
+      ),
+    );
+
+    expect(
+      (tester.takeException() as AssertionError).message,
+      contains('LeaderLayer anchor must come before FollowerLayer in paint order'),
+    );
+  });
 }


### PR DESCRIPTION
`alwaysNeedsAddToScene` is now false in all cases for LeaderLayer (follow-up to https://github.com/flutter/flutter/pull/92598, which made it false in only some cases).

Also:
* Simplifies the LeaderLayer / FollowerLayer implementation
* Reintroduces `LayerLink.leader`, that was removed in https://github.com/flutter/flutter/pull/92598, but proved to be pretty popular (see https://github.com/flutter/flutter/pull/96451). 