### PR TITLE
Revert `setEditingState` changes to fix Safari desktop web input regression

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2226,9 +2226,16 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _textInputConnection = _needsAutofill && currentAutofillScope != null
         ? currentAutofillScope!.attach(this, _effectiveAutofillClient.textInputConfiguration)
         : TextInput.attach(this, _effectiveAutofillClient.textInputConfiguration);
+        _textInputConnection!.show();
       _updateSizeAndTransform();
       _updateComposingRectIfNeeded();
       _updateCaretRectIfNeeded();
+      if (_needsAutofill) {
+        // Request autofill AFTER the size and the transform have been sent to
+        // the platform text input plugin.
+        _textInputConnection!.requestAutofill();
+      }
+
       final TextStyle style = widget.style;
       _textInputConnection!
         ..setStyle(
@@ -2238,13 +2245,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           textDirection: _textDirection,
           textAlign: widget.textAlign,
         )
-        ..setEditingState(localValue)
-        ..show();
-      if (_needsAutofill) {
-        // Request autofill AFTER the size and the transform have been sent to
-        // the platform text input plugin.
-        _textInputConnection!.requestAutofill();
-      }
+        ..setEditingState(localValue);
       _lastKnownRemoteTextEditingValue = localValue;
     } else {
       _textInputConnection!.show();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -6975,19 +6975,14 @@ void main() {
     ));
 
     await tester.showKeyboard(find.byType(EditableText));
-    // TextInput.show should be after TextInput.setEditingState.
-    // On Android setEditingState triggers an IME restart which may prevent
-    // the keyboard from showing if the show keyboard request comes before the
-    // restart.
-    // See: https://github.com/flutter/flutter/issues/68571.
     final List<String> logOrder = <String>[
       'TextInput.setClient',
+      'TextInput.show',
       'TextInput.setEditableSizeAndTransform',
       'TextInput.setMarkedTextRect',
+      'TextInput.requestAutofill',
       'TextInput.setStyle',
       'TextInput.setEditingState',
-      'TextInput.show',
-      'TextInput.requestAutofill',
       'TextInput.setEditingState',
       'TextInput.show',
       'TextInput.setCaretRect',
@@ -6996,68 +6991,6 @@ void main() {
       tester.testTextInput.log.map((MethodCall m) => m.method),
       logOrder,
     );
-  });
-
-  testWidgets(
-    'keyboard is requested after setEditingState after switching to a new text field',
-    (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/68571.
-      final EditableText editableText1 = EditableText(
-        showSelectionHandles: true,
-        maxLines: 2,
-        controller: TextEditingController(),
-        focusNode: FocusNode(),
-        cursorColor: Colors.red,
-        backgroundCursorColor: Colors.blue,
-        style: Typography.material2018().black.subtitle1!.copyWith(fontFamily: 'Roboto'),
-        keyboardType: TextInputType.text,
-      );
-
-      final EditableText editableText2 = EditableText(
-        showSelectionHandles: true,
-        maxLines: 2,
-        controller: TextEditingController(),
-        focusNode: FocusNode(),
-        cursorColor: Colors.red,
-        backgroundCursorColor: Colors.blue,
-        style: Typography.material2018().black.subtitle1!.copyWith(fontFamily: 'Roboto'),
-        keyboardType: TextInputType.text,
-      );
-
-      await tester.pumpWidget(MaterialApp(
-        home: Center(
-          child: Column(
-            children: <Widget>[editableText1, editableText2],
-          ),
-        ),
-      ));
-
-      await tester.tap(find.byWidget(editableText1));
-      await tester.pumpAndSettle();
-
-      tester.testTextInput.log.clear();
-      await tester.tap(find.byWidget(editableText2));
-      await tester.pumpAndSettle();
-
-      // Send TextInput.show after TextInput.setEditingState. Otherwise
-      // some Android keyboards ignore the "show keyboard" request, as the
-      // Android text input plugin restarts the input method when setEditingState
-      // is sent by the framework.
-      final List<String> logOrder = <String>[
-        'TextInput.clearClient',
-        'TextInput.setClient',
-        'TextInput.setEditableSizeAndTransform',
-        'TextInput.setMarkedTextRect',
-        'TextInput.setStyle',
-        'TextInput.setEditingState',
-        'TextInput.show',
-        'TextInput.requestAutofill',
-        'TextInput.setCaretRect',
-      ];
-      expect(
-        tester.testTextInput.log.map((MethodCall m) => m.method),
-        logOrder,
-      );
   });
 
   testWidgets('setEditingState is not called when text changes', (WidgetTester tester) async {
@@ -7089,12 +7022,12 @@ void main() {
 
     final List<String> logOrder = <String>[
       'TextInput.setClient',
+      'TextInput.show',
       'TextInput.setEditableSizeAndTransform',
       'TextInput.setMarkedTextRect',
+      'TextInput.requestAutofill',
       'TextInput.setStyle',
       'TextInput.setEditingState',
-      'TextInput.show',
-      'TextInput.requestAutofill',
       'TextInput.setEditingState',
       'TextInput.show',
       'TextInput.setCaretRect',
@@ -7140,12 +7073,12 @@ void main() {
 
     final List<String> logOrder = <String>[
       'TextInput.setClient',
+      'TextInput.show',
       'TextInput.setEditableSizeAndTransform',
       'TextInput.setMarkedTextRect',
+      'TextInput.requestAutofill',
       'TextInput.setStyle',
       'TextInput.setEditingState',
-      'TextInput.show',
-      'TextInput.requestAutofill',
       'TextInput.setEditingState',
       'TextInput.show',
       'TextInput.setCaretRect',


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/96411

This was regressed in https://github.com/flutter/flutter/pull/92945 which fixed the secure keyboard issue but it broke EditableText for Safari Desktop for some reason which is much more critical regression than secure keyboard causing the keyboard to disappear. 

The issue can be reproduced using` EditableText` or `TextField` running Safari Web Desktop,  `TextFormField` don't reproduce this

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Material App',
      theme: ThemeData.dark(),
      home: const Home(),
    );
  }
}

class Home extends StatefulWidget {
  const Home({Key? key}) : super(key: key);

  @override
  State<Home> createState() => _HomeState();
}

class _HomeState extends State<Home> {
  final TextEditingController _controller =
      TextEditingController(text: 'Hello World!');

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Material App Bar'),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
          children: <Widget>[
             TextField(
              controller: _controller,
              decoration: InputDecoration(hintText: 'TextField'),
            ),
            TextFormField(
              decoration: const InputDecoration(hintText: 'TextFormField'),
            ),
            EditableText(
              controller: _controller,
              backgroundCursorColor: Colors.red,
              focusNode: FocusNode(),
              cursorColor: Colors.white,

              style: const TextStyle(
                fontSize: 22,
              ),
              // ignore: avoid_print
              onChanged: (String value) => print('onChanged: $value'),
            ),
          ],
        ),
      ),
    );
  }
}

``` 
	
</details>


Here in this PR, I have reverted those changes manually in a clean way.

cc: @LongCatIsLooong 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
