### PR TITLE
Explain how MaterialApp renders text style in absence of Material Widget

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -57,7 +57,7 @@ enum ThemeMode {
 /// adding material-design specific functionality, such as [AnimatedTheme] and
 /// [GridPaper].
 ///
-/// The [MaterialApp] passes a fallback [TextStyle] to [WidgetsApp] which is used in 
+/// The [MaterialApp] passes a fallback [TextStyle] to [WidgetsApp] which is used in
 /// absense of [Material] widgets. The [Material] widgets builds a [DefaultTextStyle]
 /// which assigns a [TextTheme]. If you see the fallback [TextStyle] instead of
 /// [DefaultTextStyle], ensure a [Material] widget is one of the ancestor of your widgets.

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -157,7 +157,9 @@ enum ThemeMode {
 /// If the [Text] widget doesn't have a [Material] widget then it uses a fallback
 /// [TextStyle] which doesn't have a [Material] style [TextTheme].
 ///
-/// The fix is to wrap the [Text] widget with a [Material] widget such as [Scaffold].
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/material_textsyle.png)
+///
+/// The fix is to wrap the [Text] widget with a [Material] widget such as [Scaffold]:
 ///
 /// ```dart
 /// MaterialApp(

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -57,6 +57,11 @@ enum ThemeMode {
 /// adding material-design specific functionality, such as [AnimatedTheme] and
 /// [GridPaper].
 ///
+/// The [MaterialApp] passes a fallback [TextStyle] to [WidgetsApp] which is used in 
+/// absense of [Material] widgets. The [Material] widgets builds a [DefaultTextStyle]
+/// which assigns a [TextTheme]. If you see the fallback [TextStyle] instead of
+/// [DefaultTextStyle], ensure a [Material] widget is one of the ancestor of your widgets.
+///
 /// The [MaterialApp] configures the top-level [Navigator] to search for routes
 /// in the following order:
 ///

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -58,7 +58,7 @@ enum ThemeMode {
 /// [GridPaper].
 ///
 /// The [MaterialApp] passes a fallback [TextStyle] to [WidgetsApp] which is used in
-/// absense of [Material] widgets. The [Material] widgets builds a [DefaultTextStyle]
+/// absence of a [Material] widget. The [Material] widgets builds a [DefaultTextStyle]
 /// which assigns a [TextTheme]. If you see the fallback [TextStyle] instead of
 /// [DefaultTextStyle], ensure a [Material] widget is one of the ancestor of your widgets.
 ///
@@ -150,6 +150,25 @@ enum ThemeMode {
 /// ```
 /// {@end-tool}
 ///
+/// ## Troubleshooting
+///
+/// ### Why my text is red with yellow underlines?
+///
+/// If the [Text] widget doesn't have a [Material] widget then it uses a fallback
+/// [TextStyle] which doesn't have a [Material] style [TextTheme].
+///
+/// The fix is to wrap the [Text] widget with a [Material] widget such as [Scaffold].
+///
+/// ```dart
+/// MaterialApp(
+///   title: 'Material App',
+///   home: Scaffold(
+///     body: Center(
+///       child: Text('Hello World'),
+///     ),
+///   ),
+/// )
+/// ```
 /// See also:
 ///
 ///  * [Scaffold], which provides standard app elements like an [AppBar] and a [Drawer].

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -57,10 +57,10 @@ enum ThemeMode {
 /// adding material-design specific functionality, such as [AnimatedTheme] and
 /// [GridPaper].
 ///
-/// The [MaterialApp] passes a fallback [TextStyle] to [WidgetsApp] which is used in
-/// absence of a [Material] widget. The [Material] widgets builds a [DefaultTextStyle]
-/// which assigns a [TextTheme]. If you see the fallback [TextStyle] instead of
-/// [DefaultTextStyle], ensure a [Material] widget is one of the ancestor of your widgets.
+/// [MaterialApp] configures its [WidgetsApp.textStyle] with an ugly red/yellow
+/// text style that's intended to warn the developer that their app hasn't defined
+/// a default text style. Typically the app's [Scaffold] builds a [Material] widget
+/// whose default [Material.textStyle] defines the text style for the entire scaffold.
 ///
 /// The [MaterialApp] configures the top-level [Navigator] to search for routes
 /// in the following order:
@@ -152,14 +152,15 @@ enum ThemeMode {
 ///
 /// ## Troubleshooting
 ///
-/// ### Why my text is red with yellow underlines?
+/// ### Why is my app's text red with yellow underlines?
 ///
-/// If the [Text] widget doesn't have a [Material] widget then it uses a fallback
-/// [TextStyle] which doesn't have a [Material] style [TextTheme].
+/// [Text] widgets that lack a [Material] ancestor will be rendered with an ugly
+/// red/yellow text style.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/material_textsyle.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/material_app_unspecified_textstyle.png)
 ///
-/// The fix is to wrap the [Text] widget with a [Material] widget such as [Scaffold]:
+/// The typical fix is to give the widget a [Scaffold] ancestor. The [Scaffold] creates
+/// a [Material] widget that defines its default text style.
 ///
 /// ```dart
 /// MaterialApp(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/94993

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
