### PR TITLE
BottomNavigationBar takes label color from selectedLabelStyle instead of selectedItemColor

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -921,10 +921,12 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     switch (_effectiveType) {
       case BottomNavigationBarType.fixed:
         colorTween = ColorTween(
-          begin: widget.unselectedItemColor
+          begin: widget.unselectedLabelStyle?.color
+            ?? widget.unselectedItemColor
             ?? bottomTheme.unselectedItemColor
             ?? themeData.unselectedWidgetColor,
-          end: widget.selectedItemColor
+          end: widget.selectedLabelStyle?.color
+            ?? widget.selectedItemColor
             ?? bottomTheme.selectedItemColor
             ?? widget.fixedColor
             ?? themeColor,
@@ -932,10 +934,12 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
         break;
       case BottomNavigationBarType.shifting:
         colorTween = ColorTween(
-          begin: widget.unselectedItemColor
+          begin: widget.unselectedLabelStyle?.color
+            ??  widget.unselectedItemColor
             ?? bottomTheme.unselectedItemColor
             ?? themeData.colorScheme.surface,
-          end: widget.selectedItemColor
+          end: widget.selectedLabelStyle?.color
+            ?? widget.selectedItemColor
             ?? bottomTheme.selectedItemColor
             ?? themeData.colorScheme.surface,
         );

--- a/packages/flutter/test/widgets/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/widgets/bottom_navigation_bar_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/widgets/bottom_navigation_bar_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomNavigationBar label color is taken from selectedLabelStyle',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            selectedItemColor: Colors.green,
+            unselectedItemColor: Colors.grey,
+            selectedLabelStyle: const TextStyle(
+              color: Colors.red,
+            ),
+            unselectedLabelStyle: const TextStyle(
+              color: Colors.grey,
+            ),
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.home),
+                label: 'Home',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.settings),
+                label: 'Settings',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Check if given color is in at least one of the DefaultTextStyle widgets.
+    bool _hasColor(Iterable<DefaultTextStyle> defaultTextStyles, Color color) {
+      return defaultTextStyles
+          .where((DefaultTextStyle defaultTextStyle) => defaultTextStyle.style.color == color)
+          .isNotEmpty;
+    }
+
+    final Iterable<DefaultTextStyle> defaultTextStyles =
+        tester.widgetList<DefaultTextStyle>(find.widgetWithText(DefaultTextStyle, 'Home'));
+
+    // There must be a red color in defaultTextStyles.
+    expect(
+      _hasColor(defaultTextStyles, Colors.red),
+      true,
+    );
+
+    // There must not be a green color in defaultTextStyles.
+    expect(
+      _hasColor(defaultTextStyles, Colors.green),
+      false,
+    );
+  });
+}


### PR DESCRIPTION
*BottomNavigationBar should take label color from selectedLabelStyle if it is provided, and also same for unselectedLabelStyle. But instead, it was taking the color from selectedItemColor. Problem has fixed with this PR.*

*#96480*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
