### PR TITLE
Improve Gradle retry logic

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -422,7 +422,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
             // The expected wait times are: 100ms, 200ms, 400ms, and so on...
             final int waitTime = min(pow(2, retry).toInt() * 100, kMaxRetryTime.inMicroseconds);
             retry += 1;
-            _logger.printStatus('Retrying Gradle Build: #$retry, wait time: $waitTime');
+            _logger.printStatus('Retrying Gradle Build: #$retry, wait time: ${waitTime}ms');
             await Future<void>.delayed(Duration(milliseconds: waitTime));
             await buildGradleApp(
               project: project,

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -409,7 +409,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
           'Gradle task $assembleTask failed with exit code $exitCode',
           exitCode: exitCode,
         );
-      } 
+      }
       final GradleBuildStatus status = await detectedGradleError!.handler(
         line: detectedGradleErrorLine!,
         project: project,

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -226,8 +226,8 @@ final GradleHandledError networkErrorHandler = GradleHandledError(
     required bool multidexEnabled,
   }) async {
     globals.printError(
-      '${globals.logger.terminal.warningMark} Gradle threw an error while downloading artifacts from the network. '
-      'Retrying to download...'
+      '${globals.logger.terminal.warningMark} '
+      'Gradle threw an error while downloading artifacts from the network.'
     );
     try {
       final String? homeDir = globals.platform.environment['HOME'];

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -215,8 +215,8 @@ void main() {
         message: 'Gradle task assembleRelease failed with exit code 1'
       ));
 
-      expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100'));
-      expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200'));
+      expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100ms'));
+      expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200ms'));
 
       expect(testFnCalled, equals(maxRetries + 1));
       expect(testUsage.events, contains(

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -218,7 +218,7 @@ void main() {
       expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100'));
       expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200'));
 
-      expect(testFnCalled, equals(3));
+      expect(testFnCalled, equals(testFnCalled + 1));
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -218,7 +218,7 @@ void main() {
       expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100'));
       expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200'));
 
-      expect(testFnCalled, equals(testFnCalled + 1));
+      expect(testFnCalled, equals(maxRetries + 1));
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -138,7 +138,8 @@ void main() {
         gradleUtils: FakeGradleUtils(),
         platform: FakePlatform(),
       );
-      processManager.addCommand(const FakeCommand(
+
+      const FakeCommand fakeCmd = FakeCommand(
         command: <String>[
           'gradlew',
           '-q',
@@ -151,23 +152,15 @@ void main() {
           'assembleRelease',
         ],
         exitCode: 1,
-        stderr: '\nSome gradle message\n'
-      ));
-      processManager.addCommand(const FakeCommand(
-        command: <String>[
-          'gradlew',
-          '-q',
-          '-Ptarget-platform=android-arm,android-arm64,android-x64',
-          '-Ptarget=lib/main.dart',
-          '-Pbase-application-name=io.flutter.app.FlutterApplication',
-          '-Pdart-obfuscation=false',
-          '-Ptrack-widget-creation=false',
-          '-Ptree-shake-icons=false',
-          'assembleRelease',
-        ],
-        exitCode: 1,
-        stderr: '\nSome gradle message\n'
-      ));
+        stderr: '\nSome gradle message\n',
+      );
+
+      processManager.addCommand(fakeCmd);
+
+      const int maxRetries = 2;
+      for (int i = 0; i < maxRetries; i++) {
+        processManager.addCommand(fakeCmd);
+      }
 
       fileSystem.directory('android')
         .childFile('build.gradle')
@@ -186,6 +179,7 @@ void main() {
       int testFnCalled = 0;
       await expectLater(() async {
        await builder.buildGradleApp(
+          maxRetries: maxRetries,
           project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
           androidBuildInfo: const AndroidBuildInfo(
             BuildInfo(
@@ -221,7 +215,10 @@ void main() {
         message: 'Gradle task assembleRelease failed with exit code 1'
       ));
 
-      expect(testFnCalled, equals(2));
+      expect(logger.statusText, contains('Retrying Gradle Build: #1, wait time: 100'));
+      expect(logger.statusText, contains('Retrying Gradle Build: #2, wait time: 200'));
+
+      expect(testFnCalled, equals(3));
       expect(testUsage.events, contains(
         const TestUsageEvent(
           'build',

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -102,8 +102,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -133,8 +132,7 @@ at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)''';
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -155,8 +153,7 @@ Exception in thread "main" java.lang.RuntimeException: Timeout of 120000 reached
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -193,8 +190,7 @@ Exception in thread "main" javax.net.ssl.SSLHandshakeException: Remote host clos
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -223,8 +219,7 @@ Exception in thread "main" java.io.FileNotFoundException: https://downloads.grad
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -264,8 +259,7 @@ Exception in thread "main" java.net.SocketException: Connection reset
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -292,8 +286,7 @@ A problem occurred configuring root project 'android'.
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{
@@ -324,8 +317,7 @@ A problem occurred configuring root project 'android'.
 
       expect(testLogger.errorText,
         contains(
-          'Gradle threw an error while downloading artifacts from the network. '
-          'Retrying to download...'
+          'Gradle threw an error while downloading artifacts from the network.'
         )
       );
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
Related issue: https://github.com/flutter/flutter/issues/96550

Helps:
https://github.com/flutter/flutter/issues/96790
https://github.com/flutter/flutter/issues/96792

Improves the Gradle retry logic, so it retries up to 10 times after a first failure, and uses exponential backoff. 
This is useful for network failures.