### PR TITLE
[flutter_tools] add validation of paths of contained files to os_utils _unpackArchive()

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -539,10 +539,26 @@ class _WindowsUtils extends OperatingSystemUtils {
         continue;
       }
 
-      final File destFile = _fileSystem.file(_fileSystem.path.join(
-        targetDirectory.path,
-        archiveFile.name,
-      ));
+      final File destFile = _fileSystem.file(
+        _fileSystem.path.normalize(
+          _fileSystem.path.join(
+            targetDirectory.path,
+            archiveFile.name,
+          ),
+        ),
+      );
+
+      // Validate that the destFile is within the targetDirectory we want to
+      // extract to.
+      //
+      // See https://snyk.io/research/zip-slip-vulnerability for more context.
+      if (!destFile.path.startsWith(targetDirectory.path)) {
+        throw StateError(
+          'Tried to extract the file ${destFile.path} outside of the target '
+          'directory ${targetDirectory.path}',
+        );
+      }
+
       if (!destFile.parent.existsSync()) {
         destFile.parent.createSync(recursive: true);
       }

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -552,10 +552,10 @@ class _WindowsUtils extends OperatingSystemUtils {
       // extract to.
       //
       // See https://snyk.io/research/zip-slip-vulnerability for more context.
-      if (!destFile.path.startsWith(targetDirectory.path)) {
+      if (!destFile.absolute.path.startsWith(targetDirectory.absolute.path)) {
         throw StateError(
-          'Tried to extract the file ${destFile.path} outside of the target '
-          'directory ${targetDirectory.path}',
+          'Tried to extract the file ${destFile.absolute.path} outside of the '
+          'target directory ${targetDirectory.absolute.path}',
         );
       }
 

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -540,7 +540,7 @@ class _WindowsUtils extends OperatingSystemUtils {
       }
 
       final File destFile = _fileSystem.file(
-        _fileSystem.path.normalize(
+        _fileSystem.path.canonicalize(
           _fileSystem.path.join(
             targetDirectory.path,
             archiveFile.name,
@@ -552,10 +552,16 @@ class _WindowsUtils extends OperatingSystemUtils {
       // extract to.
       //
       // See https://snyk.io/research/zip-slip-vulnerability for more context.
-      if (!destFile.absolute.path.startsWith(targetDirectory.absolute.path)) {
+      final String destinationFileCanonicalPath = _fileSystem.path.canonicalize(
+        destFile.path,
+      );
+      final String targetDirectoryCanonicalPath = _fileSystem.path.canonicalize(
+        targetDirectory.path,
+      );
+      if (!destinationFileCanonicalPath.startsWith(targetDirectoryCanonicalPath)) {
         throw StateError(
-          'Tried to extract the file ${destFile.absolute.path} outside of the '
-          'target directory ${targetDirectory.absolute.path}',
+          'Tried to extract the file $destinationFileCanonicalPath outside of the '
+          'target directory $targetDirectoryCanonicalPath',
         );
       }
 

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -509,7 +509,7 @@ void main() {
       const String content = 'hello, world!';
       final Archive archive = Archive()..addFile(
         // This file would be extracted outside of the target extraction dir
-        ArchiveFile(r'..\..\..\target-file.txt', content.length, content.codeUnits),
+        ArchiveFile(r'..\..\..\Target File.txt', content.length, content.codeUnits),
       );
       final List<int> zipData = ZipEncoder().encode(archive)!;
       fakeZipFile.writeAsBytesSync(zipData);

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
@@ -495,6 +496,33 @@ void main() {
         processManager: fakeProcessManager,
       );
       expect(utils.name, 'Pretty Name');
+    });
+
+    // See https://snyk.io/research/zip-slip-vulnerability for more context
+    testWithoutContext('Windows validates paths when unzipping', () {
+      // on POSIX systems we use the `unzip` binary, which will fail to extract
+      // files with paths outside the target directory
+      final OperatingSystemUtils utils = createOSUtils(FakePlatform(operatingSystem: 'windows'));
+      final MemoryFileSystem fs = MemoryFileSystem.test();
+      final File fakeZipFile = fs.file('archive.zip');
+      final Directory targetDirectory = fs.directory('output')..createSync(recursive: true);
+      const String content = 'hello, world!';
+      final Archive archive = Archive()..addFile(
+        // This file would be extracted outside of the target extraction dir
+        ArchiveFile(r'..\..\..\target-file.txt', content.length, content.codeUnits),
+      );
+      final List<int> zipData = ZipEncoder().encode(archive)!;
+      fakeZipFile.writeAsBytesSync(zipData);
+      expect(
+        () => utils.unzip(fakeZipFile, targetDirectory),
+        throwsA(
+          isA<StateError>().having(
+            (StateError error) => error.message,
+            'correct error message',
+            contains('Tried to extract the file '),
+          ),
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
Per https://snyk.io/research/zip-slip-vulnerability:

> The vulnerability is exploited using a specially crafted archive that holds directory traversal filenames (e.g. ../../evil.sh).

> The contents of this zip file have to be hand crafted. Archive creation tools don’t typically allow users to add files with these paths, despite the zip specification allowing it. However, with the right tools, it’s easy to create files with these paths.
> The second thing you’ll need to exploit this vulnerability is to extract the archive, either using your own code or a library. The vulnerability exists when the extraction code omits validation on the file paths in the archive. An example of a vulnerable code snippet (example shown in Java) can be seen below.

As noted in the issue (#96547), we only use this code to extract archives that have been published as part of engine builds, so I do not believe this vulnerability is critical; however, it could be used as part of an orchestrated attack including compromising pre-built archives.

Fixes https://github.com/flutter/flutter/issues/96547