### PR TITLE
Add ability to control if bottom child focus can be excluded in `AnimatedCrossFade`

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -208,12 +208,12 @@ class AnimatedCrossFade extends StatefulWidget {
   /// result in the widgets jumping about when the cross-fade state is changed.
   final AnimatedCrossFadeBuilder layoutBuilder;
 
-  /// When true, this is equivalent to wrapping bottom widget with an [ExcludeFocus]
-  /// widget while it is on the bottom of the crosss-fade stack.
+  /// When true, this is equivalent to wrapping the bottom widget with an [ExcludeFocus]
+  /// widget while it is at the bottom of the cross-fade stack.
   ///
-  /// Defaults to true, when it is false, the bottom widget in the crosss-fade stack can
-  /// remain in focus until the top widget requests focus, this is useful for when
-  /// animating between different [TextField]s so the keyboard remain open during the
+  /// Defaults to true. When it is false, the bottom widget in the cross-fade stack 
+  /// can remain in focus until the top widget requests focus. This is useful for
+  /// animating between different [TextField]s so the keyboard remains open during the
   /// cross-fade animation.
   final bool excludeBottomFocus;
 

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -208,9 +208,13 @@ class AnimatedCrossFade extends StatefulWidget {
   /// result in the widgets jumping about when the cross-fade state is changed.
   final AnimatedCrossFadeBuilder layoutBuilder;
 
-  /// Whether to exclude focus from the bottom child widget.
+  /// When true, this is equivalent to wrapping bottom widget with an [ExcludeFocus]
+  /// widget while it is on the bottom of the crosss-fade stack.
   ///
-  /// Defaults to true.
+  /// Defaults to true, when it is false, the bottom widget in the crosss-fade stack can 
+  /// remain in focus until the top widget requests focus, this is useful for when 
+  /// animating between different [TextField]s so the keyboard remain open during the
+  /// cross-fade animation.
   final bool excludeBottomFocus;
 
   /// The default layout algorithm used by [AnimatedCrossFade].

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -211,8 +211,8 @@ class AnimatedCrossFade extends StatefulWidget {
   /// When true, this is equivalent to wrapping bottom widget with an [ExcludeFocus]
   /// widget while it is on the bottom of the crosss-fade stack.
   ///
-  /// Defaults to true, when it is false, the bottom widget in the crosss-fade stack can 
-  /// remain in focus until the top widget requests focus, this is useful for when 
+  /// Defaults to true, when it is false, the bottom widget in the crosss-fade stack can
+  /// remain in focus until the top widget requests focus, this is useful for when
   /// animating between different [TextField]s so the keyboard remain open during the
   /// cross-fade animation.
   final bool excludeBottomFocus;

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -211,7 +211,7 @@ class AnimatedCrossFade extends StatefulWidget {
   /// When true, this is equivalent to wrapping the bottom widget with an [ExcludeFocus]
   /// widget while it is at the bottom of the cross-fade stack.
   ///
-  /// Defaults to true. When it is false, the bottom widget in the cross-fade stack 
+  /// Defaults to true. When it is false, the bottom widget in the cross-fade stack
   /// can remain in focus until the top widget requests focus. This is useful for
   /// animating between different [TextField]s so the keyboard remains open during the
   /// cross-fade animation.

--- a/packages/flutter/lib/src/widgets/animated_cross_fade.dart
+++ b/packages/flutter/lib/src/widgets/animated_cross_fade.dart
@@ -130,6 +130,7 @@ class AnimatedCrossFade extends StatefulWidget {
     required this.duration,
     this.reverseDuration,
     this.layoutBuilder = defaultLayoutBuilder,
+    this.excludeBottomFocus = true,
   }) : assert(firstChild != null),
        assert(secondChild != null),
        assert(firstCurve != null),
@@ -139,6 +140,7 @@ class AnimatedCrossFade extends StatefulWidget {
        assert(crossFadeState != null),
        assert(duration != null),
        assert(layoutBuilder != null),
+       assert(excludeBottomFocus != null),
        super(key: key);
 
   /// The child that is visible when [crossFadeState] is
@@ -205,6 +207,11 @@ class AnimatedCrossFade extends StatefulWidget {
   /// [AnimatedCrossFade] is being forced to a particular size, then it can
   /// result in the widgets jumping about when the cross-fade state is changed.
   final AnimatedCrossFadeBuilder layoutBuilder;
+
+  /// Whether to exclude focus from the bottom child widget.
+  ///
+  /// Defaults to true.
+  final bool excludeBottomFocus;
 
   /// The default layout algorithm used by [AnimatedCrossFade].
   ///
@@ -345,6 +352,7 @@ class _AnimatedCrossFadeState extends State<AnimatedCrossFade> with TickerProvid
       child: IgnorePointer(
         child: ExcludeSemantics( // Always exclude the semantics of the widget that's fading out.
           child: ExcludeFocus(
+            excluding: widget.excludeBottomFocus,
             child: FadeTransition(
               opacity: bottomAnimation,
               child: bottomChild,

--- a/packages/flutter/test/widgets/animated_cross_fade_test.dart
+++ b/packages/flutter/test/widgets/animated_cross_fade_test.dart
@@ -385,6 +385,31 @@ void main() {
     expect(hiddenNode.hasPrimaryFocus, isFalse);
   });
 
+  testWidgets('AnimatedCrossFade bottom child can have focus', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedCrossFade(
+          firstChild: TextButton(onPressed: () {}, child: const Text('AAA')),
+          secondChild: TextButton(onPressed: () {}, child: const Text('BBB')),
+          crossFadeState: CrossFadeState.showFirst,
+          duration: const Duration(milliseconds: 50),
+          excludeBottomFocus: false,
+        ),
+      ),
+    );
+
+    final FocusNode visibleNode = Focus.of(tester.element(find.text('AAA')), scopeOk: true);
+    visibleNode.requestFocus();
+    await tester.pump();
+    expect(visibleNode.hasPrimaryFocus, isTrue);
+
+    final FocusNode hiddenNode = Focus.of(tester.element(find.text('BBB')), scopeOk: true);
+    hiddenNode.requestFocus();
+    await tester.pump();
+    expect(hiddenNode.hasPrimaryFocus, isTrue);
+  });
+
   testWidgets('AnimatedCrossFade second child do not receive touch events',
       (WidgetTester tester) async {
     int numberOfTouchEventNoticed = 0;


### PR DESCRIPTION
This PR https://github.com/flutter/flutter/pull/87618 made it so that the bottom widget cannot have focus which caused a regression in https://github.com/flutter/flutter/issues/96324

Here in this added a parameter control to decide if bottom widget focus should be excluded or not.

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: const MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatefulWidget {
  const MyHomePage({Key? key, required this.title}) : super(key: key);

  final String title;

  @override
  State<MyHomePage> createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {
  final focusNode = FocusNode();

  @override
  Widget build(BuildContext context) {
    final viewInsets = MediaQuery.of(context).viewInsets.bottom > 0;
    const textField = TextField();
    const textField2 = TextField();

    return Scaffold(
      appBar: AppBar(
        title: Text(widget.title),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            AnimatedCrossFade(
              firstChild: textField,
              secondChild: textField2,
              crossFadeState: viewInsets
                  ? CrossFadeState.showFirst
                  : CrossFadeState.showSecond,
              duration: const Duration(milliseconds: 300),
              excludeBottomFocus: false,
            )
          ],
        ),
      ),
    );
  }
}

``` 
	
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
