### PR TITLE
Add debug informations on ios_module_test

### DIFF
--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @import XCTest;
-
 @import os.log;
 
 static const CGFloat kStandardTimeOut = 60.0;

--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -68,7 +68,7 @@ static const CGFloat kStandardTimeOut = 60.0;
       [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
       newPageAppeared = [app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeOut];
       if (!newPageAppeared) {
-        os_log(OS_LOG_DEFAULT, "A11 Tree %@", app.debugDescription);
+        os_log(OS_LOG_DEFAULT, "%@", app.debugDescription);
       }
     }
     XCTAssertTrue(newPageAppeared);

--- a/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
+++ b/dev/integration_tests/ios_host_app/FlutterUITests/FlutterUITests.m
@@ -4,6 +4,8 @@
 
 @import XCTest;
 
+@import os.log;
+
 static const CGFloat kStandardTimeOut = 60.0;
 
 @interface FlutterUITests : XCTestCase
@@ -61,10 +63,13 @@ static const CGFloat kStandardTimeOut = 60.0;
     [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
     BOOL newPageAppeared = [app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeOut];
     if (!newPageAppeared) {
-        // Sometimes, the element doesn't respond to the tap, it seems an XCUITest race condition where the tap happened
-        // too soon. Trying to tap the element again.
-        [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
-        newPageAppeared = [app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeOut];
+      // Sometimes, the element doesn't respond to the tap, it seems an XCUITest race condition where the tap happened
+      // too soon. Trying to tap the element again.
+      [self waitForAndTapElement:app.buttons[@"Flutter View (Warm)"]];
+      newPageAppeared = [app.staticTexts[@"Button tapped 0 times."] waitForExistenceWithTimeout:kStandardTimeOut];
+      if (!newPageAppeared) {
+        os_log(OS_LOG_DEFAULT, "A11 Tree %@", app.debugDescription);
+      }
     }
     XCTAssertTrue(newPageAppeared);
 

--- a/dev/integration_tests/ios_host_app/Host/MainViewController.m
+++ b/dev/integration_tests/ios_host_app/Host/MainViewController.m
@@ -12,6 +12,8 @@
 
 @interface MainViewController ()
 
+@property (weak, nonatomic) UIButton* flutterViewWarmButton;
+
 @end
 
 
@@ -39,7 +41,7 @@
   [self addButton:@"Native iOS View" action:@selector(showNative)];
   [self addButton:@"Full Screen (Cold)" action:@selector(showFullScreenCold)];
   [self addButton:@"Full Screen (Warm)" action:@selector(showFullScreenWarm)];
-  [self addButton:@"Flutter View (Warm)" action:@selector(showFlutterViewWarm)];
+  self.flutterViewWarmButton = [self addButton:@"Flutter View (Warm)" action:@selector(showFlutterViewWarm)];
   [self addButton:@"Hybrid View (Warm)" action:@selector(showHybridView)];
   [self addButton:@"Dual Flutter View (Cold)" action:@selector(showDualView)];
 }
@@ -99,26 +101,47 @@
 }
 
 - (void)showFlutterViewWarm {
-  [[self engine].navigationChannel invokeMethod:@"setInitialRoute"
+  self.flutterViewWarmButton.backgroundColor = UIColor.redColor;
+  FlutterEngine *engine = [self engine];
+  FlutterBasicMessageChannel* messageChannel = [self reloadMessageChannel];
+  NSAssert(engine != nil, @"Engine is not nil.");
+  NSAssert(engine.navigationChannel != nil, @"Engine.navigationChannel is not nil.");
+  NSAssert(messageChannel != nil, @"messageChannel is not nil.");
+
+  [engine.navigationChannel invokeMethod:@"setInitialRoute"
                                       arguments:@"/"];
-  [[self reloadMessageChannel] sendMessage:@"/"];
+  [messageChannel sendMessage:@"/"];
 
 
   FlutterViewController *flutterViewController =
       [[FlutterViewController alloc] initWithEngine:[self engine]
                                             nibName:nil
                                              bundle:nil];
+  flutterViewController.view.accessibilityLabel = @"flutter view";
+  NSAssert(self.navigationController != nil, @"self.navigationController is not nil.");
   [self.navigationController pushViewController:flutterViewController
-                                       animated:YES];
+                                       animated:NO];
+
+  if (self.navigationController.topViewController != flutterViewController) {
+    // For debugging:
+    // Some unknown issue happened caused `flutterViewController` not being pushed.
+    // We try to push an basic UIViewController to see if it would work.
+    UIViewController *viewController = [[UIViewController alloc] init];
+    viewController.view.backgroundColor = UIColor.blueColor;
+    [self.navigationController pushViewController:viewController
+                                         animated:NO];
+    NSAssert(self.navigationController.topViewController == viewController, @"self.navigationController.topViewController should be the basic view controller");
+  }
 }
 
-- (void)addButton:(NSString *)title action:(SEL)action {
+- (UIButton *)addButton:(NSString *)title action:(SEL)action {
   UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
   [button setTitle:title forState:UIControlStateNormal];
   [button addTarget:self
                 action:action
       forControlEvents:UIControlEventTouchUpInside];
   [_stackView addArrangedSubview:button];
+  return button;
 }
 
 @end


### PR DESCRIPTION
This PR adds some debug information on `ios_module_test` so we will have more information when flakes in https://github.com/flutter/flutter/issues/89175 occurs again.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
