### PR TITLE
Explicitly set verbose flag for customer testing.

### DIFF
--- a/dev/customer_testing/ci.bat
+++ b/dev/customer_testing/ci.bat
@@ -16,4 +16,4 @@ CD ..\customer_testing
 CMD /S /C "IF EXIST "..\..\bin\cache\pkg\tests\" RMDIR /S /Q ..\..\bin\cache\pkg\tests"
 git clone https://github.com/flutter/tests.git ..\..\bin\cache\pkg\tests
 FOR /F "usebackq tokens=*" %%a IN (`dart --enable-asserts ..\tools\bin\find_commit.dart ..\..\bin\cache\pkg\tests`) DO git -C ..\..\bin\cache\pkg\tests checkout %%a
-dart --enable-asserts run_tests.dart --skip-on-fetch-failure --skip-template ..\..\bin\cache\pkg\tests\registry\*.test
+dart --enable-asserts run_tests.dart --verbose --skip-on-fetch-failure --skip-template ..\..\bin\cache\pkg\tests\registry\*.test

--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -34,4 +34,4 @@ git clone https://github.com/flutter/tests.git ../../bin/cache/pkg/tests
 git -C ../../bin/cache/pkg/tests checkout `dart --enable-asserts ../tools/bin/find_commit.dart ../../bin/cache/pkg/tests`
 
 # Finally, run the tests.
-dart --enable-asserts run_tests.dart --skip-on-fetch-failure --skip-template ../../bin/cache/pkg/tests/registry/*.test
+dart --enable-asserts run_tests.dart --verbose --skip-on-fetch-failure --skip-template ../../bin/cache/pkg/tests/registry/*.test


### PR DESCRIPTION
Cirrus is currently presenting verbose information while LUCI is presenting only the final results. This PR sets the verbose in an explicit way to make the two CI behave in a similar way.

Bug: https://github.com/flutter/flutter/issues/94948
Bug: https://github.com/flutter/flutter/issues/94949
Bug: https://github.com/flutter/flutter/issues/91921

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
