### PR TITLE
RenderIndexedStack - Mark invisible children as offstage in debugDescribeProperties

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -749,4 +749,20 @@ class RenderIndexedStack extends RenderStack {
     super.debugFillProperties(properties);
     properties.add(IntProperty('index', index));
   }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    final List<DiagnosticsNode> children = <DiagnosticsNode>[];
+    int i = 0;
+    RenderObject? child = firstChild;
+    while (child != null) {
+      children.add(child.toDiagnosticsNode(
+        name: 'child ${i + 1}',
+        style: i != index! ? DiagnosticsTreeStyle.offstage : null,
+      ));
+      child = (child.parentData! as StackParentData).nextSibling;
+      i += 1;
+    }
+    return children;
+  }
 }

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -118,6 +119,33 @@ void main() {
       expect(visitedChildren.first, child2);
     });
 
+    test('debugDescribeChildren marks invisible children as offstage', () {
+      final RenderBox child1 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+      final RenderBox child2 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+      final RenderBox child3 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+
+      final RenderBox stack = RenderIndexedStack(
+        index: 2,
+        children: <RenderBox>[child1, child2, child3],
+      );
+
+      final List<DiagnosticsNode> diagnosticNodes = stack.debugDescribeChildren();
+
+      expect(diagnosticNodes[0].name, 'child 1');
+      expect(diagnosticNodes[0].style, DiagnosticsTreeStyle.offstage);
+
+      expect(diagnosticNodes[1].name, 'child 2');
+      expect(diagnosticNodes[1].style, DiagnosticsTreeStyle.offstage);
+
+      expect(diagnosticNodes[2].name, 'child 3');
+      expect(diagnosticNodes[2].style, DiagnosticsTreeStyle.sparse);
+    });
   });
 
   // More tests in ../widgets/stack_test.dart


### PR DESCRIPTION
RenderIndexedStack did not override debugDescribeProperties and thus all childrens were marked as onstage, resulting in the behaviour described in #96581. 

Inspired by @Albert221, this fixes #96581.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.