### PR TITLE
[framework] remove hashcode override for Element

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3130,29 +3130,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// in a build method if it is known that they will not change.
   @nonVirtual
   @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes, hash_and_equals
   bool operator ==(Object other) => identical(this, other);
-
-  // Custom implementation of hash code optimized for the ".of" pattern used
-  // with `InheritedWidgets`.
-  //
-  // `Element.dependOnInheritedWidgetOfExactType` relies heavily on hash-based
-  // `Set` look-ups, putting this getter on the performance critical path.
-  //
-  // The value is designed to fit within the SMI representation. This makes
-  // the cached value use less memory (one field and no extra heap objects) and
-  // cheap to compare (no indirection).
-  //
-  // See also:
-  //
-  //  * https://dart.dev/articles/dart-vm/numeric-computation, which
-  //    explains how numbers are represented in Dart.
-  @nonVirtual
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => _cachedHash;
-  final int _cachedHash = _nextHashCode = (_nextHashCode + 1) % 0xffffff;
-  static int _nextHashCode = 1;
 
   /// Information set by parent to define where this child fits in its parent's
   /// child list.

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1656,6 +1656,21 @@ The findRenderObject() method was called for the following element:
       )),
     );
   });
+
+  testWidgets('Elements use the identity hashCode', (WidgetTester tester) async {
+    final StatefulElement statefulElement = StatefulElement(const _StatefulLeaf());
+    expect(statefulElement.hashCode, identityHashCode(statefulElement));
+
+    final StatelessElement statelessElement = StatelessElement(const Placeholder());
+
+    expect(statelessElement.hashCode, identityHashCode(statelessElement));
+
+    final InheritedElement inheritedElement = InheritedElement(
+      const Directionality(textDirection: TextDirection.ltr, child: Placeholder()),
+    );
+
+    expect(inheritedElement.hashCode, identityHashCode(inheritedElement));
+  });
 }
 
 class _WidgetWithNoVisitChildren extends StatelessWidget {


### PR DESCRIPTION
Broken out from the other PR, without this change the benchmark takes 774.3 ms, with this change it takes 747.8 ms. While this is a small change, it demonstrates that the documented rationale for the hashcode override is no longer correct and can be removed without regressing performance.