### PR TITLE
Fix UNUSED_ELEMENT_PARAMETER for unused field formal parameter.

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -887,10 +887,10 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
 ///
 /// The scroll velocity is controlled by the [velocityScalar]:
 ///
-/// velocity = <distance of overscroll> * [velocityScalar].
+/// velocity = <distance of overscroll> * [_kDefaultAutoScrollVelocityScalar].
 class _EdgeDraggingAutoScroller {
   /// Creates a auto scroller that scrolls the [scrollable].
-  _EdgeDraggingAutoScroller(this.scrollable, {this.onScrollViewScrolled, this.velocityScalar = _kDefaultAutoScrollVelocityScalar});
+  _EdgeDraggingAutoScroller(this.scrollable, {this.onScrollViewScrolled});
 
   // An eyeball value
   static const double _kDefaultAutoScrollVelocityScalar = 7;
@@ -904,12 +904,6 @@ class _EdgeDraggingAutoScroller {
   /// target no longer triggers the auto scroll. This callback will be called
   /// in between each scroll.
   final VoidCallback? onScrollViewScrolled;
-
-  /// The velocity scalar per pixel over scroll.
-  ///
-  /// How the velocity scale with the over scroll distance. The auto scroll
-  /// velocity = <distance of overscroll> * velocityScalar.
-  final double velocityScalar;
 
   late Rect _dragTargetRelatedToScrollOrigin;
 
@@ -1002,7 +996,7 @@ class _EdgeDraggingAutoScroller {
       _scrolling = false;
       return;
     }
-    final Duration duration = Duration(milliseconds: (1000 / velocityScalar).round());
+    final Duration duration = Duration(milliseconds: (1000 / _kDefaultAutoScrollVelocityScalar).round());
     await scrollable.position.animateTo(
       newOffset,
       duration: duration,


### PR DESCRIPTION
We would like to land https://dart-review.googlesource.com/c/sdk/+/226962 to the Dart analyzer and fixing existing violations.

One more violation was added after https://github.com/flutter/flutter/pull/96553

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
