### PR TITLE
Prevents DropdownButton from applying borderRadius property to first and last element of the list.

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -97,7 +97,6 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   const _DropdownMenuItemButton({
     Key? key,
     this.padding,
-    required this.borderRadius,
     required this.route,
     required this.buttonRect,
     required this.constraints,
@@ -111,7 +110,6 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final BoxConstraints constraints;
   final int itemIndex;
   final bool enableFeedback;
-  final BorderRadius borderRadius;
 
   @override
   _DropdownMenuItemButtonState<T> createState() => _DropdownMenuItemButtonState<T>();
@@ -178,16 +176,6 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
       height: widget.route.itemHeight,
       child: widget.route.items[widget.itemIndex],
     );
-    final BorderRadius itemBorderRadius;
-    if (widget.route.items.length == 1) {
-      itemBorderRadius = widget.borderRadius;
-    } else if (widget.itemIndex == 0) {
-      itemBorderRadius = BorderRadius.only(topLeft: widget.borderRadius.topLeft, topRight: widget.borderRadius.topRight);
-    } else if (widget.itemIndex == widget.route.items.length - 1) {
-      itemBorderRadius = BorderRadius.only(bottomLeft: widget.borderRadius.bottomLeft, bottomRight: widget.borderRadius.bottomRight);
-    } else {
-      itemBorderRadius = BorderRadius.zero;
-    }
     // An [InkWell] is added to the item only if it is enabled
     if (dropdownMenuItem.enabled) {
       child = InkWell(
@@ -195,7 +183,6 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
         enableFeedback: widget.enableFeedback,
         onTap: _handleOnTap,
         onFocusChange: _handleFocusChange,
-        borderRadius: itemBorderRadius,
         child: child,
       );
     }
@@ -279,7 +266,6 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           constraints: widget.constraints,
           itemIndex: itemIndex,
           enableFeedback: widget.enableFeedback,
-          borderRadius: widget.borderRadius ?? BorderRadius.zero,
         ),
       ];
 
@@ -1113,11 +1099,6 @@ class DropdownButton<T> extends StatefulWidget {
   final AlignmentGeometry alignment;
 
   /// Defines the corner radii of the menu's rounded rectangle shape.
-  ///
-  /// The radii of the first menu item's top left and right corners are
-  /// defined by the corresponding properties of the [borderRadius].
-  /// Similarly, the radii of the last menu item's bottom and right corners
-  /// are defined by the corresponding properties of the [borderRadius].
   final BorderRadius? borderRadius;
 
   @override

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -3564,43 +3564,6 @@ void main() {
         ..rrect()
         ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 144.0, 208.0, radius, radius)),
     );
-
-    final InkWell firstItem = tester.widget(find.widgetWithText(InkWell, 'One'));
-    final InkWell lastItem = tester.widget(find.widgetWithText(InkWell, 'Four'));
-
-    expect(firstItem.borderRadius, const BorderRadius.vertical(top: Radius.circular(radius)));
-    expect(lastItem.borderRadius, const BorderRadius.vertical(bottom: Radius.circular(radius)));
-  });
-
-  testWidgets('borderRadius is properly applied to InkWell when there is only one item', (WidgetTester tester) async {
-    const BorderRadius borderRadius = BorderRadius.all(Radius.circular(5.0));
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: DropdownButton<String>(
-              borderRadius: borderRadius,
-              value: 'One',
-              items: const <DropdownMenuItem<String>>[
-                DropdownMenuItem<String>(
-                  value: 'One',
-                  child: Text('One')
-                ),
-              ],
-              onChanged: (_) { },
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('One'));
-    await tester.pumpAndSettle();
-
-    final InkWell menuItem = tester.widget(find.widgetWithText(InkWell, 'One'));
-
-    expect(menuItem.borderRadius, borderRadius);
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/88574
@@ -3718,11 +3681,5 @@ void main() {
         ..rrect()
         ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 800.0, 208.0, radius, radius)),
     );
-
-    final InkWell firstItem = tester.widget(find.widgetWithText(InkWell, 'One'));
-    final InkWell lastItem = tester.widget(find.widgetWithText(InkWell, 'Four'));
-
-    expect(firstItem.borderRadius, const BorderRadius.vertical(top: Radius.circular(radius)));
-    expect(lastItem.borderRadius, const BorderRadius.vertical(bottom: Radius.circular(radius)));
   });
 }


### PR DESCRIPTION
PR #84298 adds borderRadius property to the first and last element of the dropdown list. This is against material design specifications. This PR reverts this behavior.

Fixes: #96241 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
