### PR TITLE
ListTile: add themeable mouse cursor 

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -141,8 +141,6 @@ class ListTileThemeData with Diagnosticable {
   /// Overrides the default value of [ListTile.enableFeedback].
   final bool? enableFeedback;
 
-  /// {@macro flutter.material.ListTile.mouseCursor}
-  ///
   /// If specified, overrides the default value of [ListTile.mouseCursor].
   final MaterialStateProperty<MouseCursor?>? mouseCursor;
 
@@ -445,12 +443,6 @@ class ListTileTheme extends InheritedTheme {
   /// [ListTileThemeData.enableFeedback] property instead.
   bool? get enableFeedback => _data != null ? _data!.enableFeedback : _enableFeedback;
 
-  /// Overrides the default value of [ListTile.mouseCursor].
-  ///
-  /// This property is obsolete: please use the [data]
-  /// [ListTileThemeData.mouseCursor] property instead.
-  MaterialStateProperty<MouseCursor?>? get mouseCursor => _data != null ? _data!.mouseCursor : _mouseCursor;
-
   /// The [data] property of the closest instance of this class that
   /// encloses the given context.
   ///
@@ -483,7 +475,6 @@ class ListTileTheme extends InheritedTheme {
     Color? tileColor,
     Color? selectedTileColor,
     bool? enableFeedback,
-    MaterialStateProperty<MouseCursor?>? mouseCursor,
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
@@ -506,7 +497,6 @@ class ListTileTheme extends InheritedTheme {
             tileColor: tileColor ?? parent.tileColor,
             selectedTileColor: selectedTileColor ?? parent.selectedTileColor,
             enableFeedback: enableFeedback ?? parent.enableFeedback,
-            mouseCursor: mouseCursor ?? parent.mouseCursor,
             horizontalTitleGap: horizontalTitleGap ?? parent.horizontalTitleGap,
             minVerticalPadding: minVerticalPadding ?? parent.minVerticalPadding,
             minLeadingWidth: minLeadingWidth ?? parent.minLeadingWidth,
@@ -531,7 +521,6 @@ class ListTileTheme extends InheritedTheme {
         tileColor: tileColor,
         selectedTileColor: selectedTileColor,
         enableFeedback: enableFeedback,
-        mouseCursor: mouseCursor,
         horizontalTitleGap: horizontalTitleGap,
         minVerticalPadding: minVerticalPadding,
         minLeadingWidth: minLeadingWidth,
@@ -1243,8 +1232,8 @@ class ListTile extends StatelessWidget {
     };
 
     final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(mouseCursor, states)
-    ?? tileTheme.mouseCursor?.resolve(states)
-    ?? MaterialStateMouseCursor.clickable.resolve(states);
+      ?? tileTheme.mouseCursor?.resolve(states)
+      ?? MaterialStateMouseCursor.clickable.resolve(states);
 
     return InkWell(
       customBorder: shape ?? tileTheme.shape,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -99,6 +99,7 @@ class ListTileThemeData with Diagnosticable {
     this.minVerticalPadding,
     this.minLeadingWidth,
     this.enableFeedback,
+    this.mouseCursor,
   });
 
   /// Overrides the default value of [ListTile.dense].
@@ -140,6 +141,11 @@ class ListTileThemeData with Diagnosticable {
   /// Overrides the default value of [ListTile.enableFeedback].
   final bool? enableFeedback;
 
+  /// {@macro flutter.material.ListTile.mouseCursor}
+  ///
+  /// If specified, overrides the default value of [ListTile.mouseCursor].
+  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ListTileThemeData copyWith({
@@ -156,6 +162,7 @@ class ListTileThemeData with Diagnosticable {
     double? minVerticalPadding,
     double? minLeadingWidth,
     bool? enableFeedback,
+    MaterialStateProperty<MouseCursor?>? mouseCursor,
   }) {
     return ListTileThemeData(
       dense: dense ?? this.dense,
@@ -171,6 +178,7 @@ class ListTileThemeData with Diagnosticable {
       minVerticalPadding: minVerticalPadding ?? this.minVerticalPadding,
       minLeadingWidth: minLeadingWidth ?? this.minLeadingWidth,
       enableFeedback: enableFeedback ?? this.enableFeedback,
+      mouseCursor: mouseCursor ?? this.mouseCursor,
     );
   }
 
@@ -193,6 +201,7 @@ class ListTileThemeData with Diagnosticable {
       minVerticalPadding: lerpDouble(a?.minVerticalPadding, b?.minVerticalPadding, t),
       minLeadingWidth: lerpDouble(a?.minLeadingWidth, b?.minLeadingWidth, t),
       enableFeedback: t < 0.5 ? a?.enableFeedback : b?.enableFeedback,
+      mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
     );
   }
 
@@ -212,6 +221,7 @@ class ListTileThemeData with Diagnosticable {
       minVerticalPadding,
       minLeadingWidth,
       enableFeedback,
+      mouseCursor,
     );
   }
 
@@ -234,7 +244,8 @@ class ListTileThemeData with Diagnosticable {
       && other.horizontalTitleGap == horizontalTitleGap
       && other.minVerticalPadding == minVerticalPadding
       && other.minLeadingWidth == minLeadingWidth
-      && other.enableFeedback == enableFeedback;
+      && other.enableFeedback == enableFeedback
+      && other.mouseCursor == mouseCursor;
   }
 
   @override
@@ -253,6 +264,7 @@ class ListTileThemeData with Diagnosticable {
     properties.add(DoubleProperty('minVerticalPadding', minVerticalPadding, defaultValue: null));
     properties.add(DoubleProperty('minLeadingWidth', minLeadingWidth, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('enableFeedback', enableFeedback, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));
   }
 }
 
@@ -283,6 +295,7 @@ class ListTileTheme extends InheritedTheme {
     Color? tileColor,
     Color? selectedTileColor,
     bool? enableFeedback,
+    MaterialStateProperty<MouseCursor?>? mouseCursor,
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
@@ -297,6 +310,7 @@ class ListTileTheme extends InheritedTheme {
           tileColor ??
           selectedTileColor ??
           enableFeedback ??
+          mouseCursor ??
           horizontalTitleGap ??
           minVerticalPadding ??
           minLeadingWidth) == null),
@@ -311,6 +325,7 @@ class ListTileTheme extends InheritedTheme {
        _tileColor = tileColor,
        _selectedTileColor = selectedTileColor,
        _enableFeedback = enableFeedback,
+       _mouseCursor = mouseCursor,
        _horizontalTitleGap = horizontalTitleGap,
        _minVerticalPadding = minVerticalPadding,
        _minLeadingWidth = minLeadingWidth,
@@ -330,6 +345,7 @@ class ListTileTheme extends InheritedTheme {
   final double? _minVerticalPadding;
   final double? _minLeadingWidth;
   final bool? _enableFeedback;
+  final MaterialStateProperty<MouseCursor?>? _mouseCursor;
 
   /// The configuration of this theme.
   ListTileThemeData get data {
@@ -344,6 +360,7 @@ class ListTileTheme extends InheritedTheme {
       tileColor: _tileColor,
       selectedTileColor: _selectedTileColor,
       enableFeedback: _enableFeedback,
+      mouseCursor: _mouseCursor,
       horizontalTitleGap: _horizontalTitleGap,
       minVerticalPadding: _minVerticalPadding,
       minLeadingWidth: _minLeadingWidth,
@@ -428,6 +445,12 @@ class ListTileTheme extends InheritedTheme {
   /// [ListTileThemeData.enableFeedback] property instead.
   bool? get enableFeedback => _data != null ? _data!.enableFeedback : _enableFeedback;
 
+  /// Overrides the default value of [ListTile.mouseCursor].
+  ///
+  /// This property is obsolete: please use the [data]
+  /// [ListTileThemeData.mouseCursor] property instead.
+  MaterialStateProperty<MouseCursor?>? get mouseCursor => _data != null ? _data!.mouseCursor : _mouseCursor;
+
   /// The [data] property of the closest instance of this class that
   /// encloses the given context.
   ///
@@ -460,6 +483,7 @@ class ListTileTheme extends InheritedTheme {
     Color? tileColor,
     Color? selectedTileColor,
     bool? enableFeedback,
+    MaterialStateProperty<MouseCursor?>? mouseCursor,
     double? horizontalTitleGap,
     double? minVerticalPadding,
     double? minLeadingWidth,
@@ -482,6 +506,7 @@ class ListTileTheme extends InheritedTheme {
             tileColor: tileColor ?? parent.tileColor,
             selectedTileColor: selectedTileColor ?? parent.selectedTileColor,
             enableFeedback: enableFeedback ?? parent.enableFeedback,
+            mouseCursor: mouseCursor ?? parent.mouseCursor,
             horizontalTitleGap: horizontalTitleGap ?? parent.horizontalTitleGap,
             minVerticalPadding: minVerticalPadding ?? parent.minVerticalPadding,
             minLeadingWidth: minLeadingWidth ?? parent.minLeadingWidth,
@@ -506,6 +531,7 @@ class ListTileTheme extends InheritedTheme {
         tileColor: tileColor,
         selectedTileColor: selectedTileColor,
         enableFeedback: enableFeedback,
+        mouseCursor: mouseCursor,
         horizontalTitleGap: horizontalTitleGap,
         minVerticalPadding: minVerticalPadding,
         minLeadingWidth: minLeadingWidth,
@@ -951,6 +977,7 @@ class ListTile extends StatelessWidget {
   /// Inoperative if [enabled] is false.
   final GestureLongPressCallback? onLongPress;
 
+  /// {@template flutter.material.ListTile.mouseCursor}
   /// The cursor for a mouse pointer when it enters or is hovering over the
   /// widget.
   ///
@@ -959,8 +986,15 @@ class ListTile extends StatelessWidget {
   ///
   ///  * [MaterialState.selected].
   ///  * [MaterialState.disabled].
+  /// {@endtemplate}
   ///
-  /// If this property is null, [MaterialStateMouseCursor.clickable] will be used.
+  /// If null, then the value of [ListTileThemeData.mouseCursor] is used. If
+  /// that is also null, then [MaterialStateMouseCursor.clickable] is used.
+  ///
+  /// See also:
+  ///
+  ///  * [MaterialStateMouseCursor], which can be used to create a [MouseCursor]
+  ///    that is also a [MaterialStateProperty<MouseCursor>].
   final MouseCursor? mouseCursor;
 
   /// If this tile is also [enabled] then icons and text are rendered with the same color.
@@ -1203,19 +1237,20 @@ class ListTile extends StatelessWidget {
       ?? tileTheme.contentPadding?.resolve(textDirection)
       ?? _defaultContentPadding;
 
-    final MouseCursor resolvedMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
-      mouseCursor ?? MaterialStateMouseCursor.clickable,
-      <MaterialState>{
-        if (!enabled || (onTap == null && onLongPress == null)) MaterialState.disabled,
-        if (selected) MaterialState.selected,
-      },
-    );
+    final Set<MaterialState> states = <MaterialState>{
+      if (!enabled || (onTap == null && onLongPress == null)) MaterialState.disabled,
+      if (selected) MaterialState.selected,
+    };
+
+    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(mouseCursor, states)
+    ?? tileTheme.mouseCursor?.resolve(states)
+    ?? MaterialStateMouseCursor.clickable.resolve(states);
 
     return InkWell(
       customBorder: shape ?? tileTheme.shape,
       onTap: enabled ? onTap : null,
       onLongPress: enabled ? onLongPress : null,
-      mouseCursor: resolvedMouseCursor,
+      mouseCursor: effectiveMouseCursor,
       canRequestFocus: enabled,
       focusNode: focusNode,
       focusColor: focusColor,

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -513,11 +513,11 @@ void main() {
     expect(inkWellBorder(), roundedShape);
 
     // Cursor updates when hovering disabled ListTile
-    final Offset barItem = tester.getCenter(find.byKey(titleKey));
+    final Offset listTile = tester.getCenter(find.byKey(titleKey));
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();
     addTearDown(gesture.removePointer);
-    await gesture.moveTo(barItem);
+    await gesture.moveTo(listTile);
     await tester.pumpAndSettle();
     expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
   });
@@ -2112,11 +2112,11 @@ void main() {
         ),
       );
 
-      final Offset barItem = tester.getCenter(find.byKey(tileKey));
+      final Offset listTile = tester.getCenter(find.byKey(tileKey));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer();
       addTearDown(gesture.removePointer);
-      await gesture.moveTo(barItem);
+      await gesture.moveTo(listTile);
       await tester.pumpAndSettle();
       expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
     });

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2112,13 +2112,13 @@ void main() {
         ),
       );
 
-    final Offset barItem = tester.getCenter(find.byKey(tileKey));
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer();
-    addTearDown(gesture.removePointer);
-    await gesture.moveTo(barItem);
-    await tester.pumpAndSettle();
-    expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
+      final Offset barItem = tester.getCenter(find.byKey(tileKey));
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer();
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(barItem);
+      await tester.pumpAndSettle();
+      expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
     });
   });
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -513,6 +513,7 @@ void main() {
     expect(inkWellBorder(), roundedShape);
 
     // Cursor updates when hovering disabled ListTile
+    await tester.pumpWidget(buildFrame(enabled: false));
     final Offset listTile = tester.getCenter(find.byKey(titleKey));
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer();

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -71,6 +71,7 @@ void main() {
     expect(themeData.minVerticalPadding, null);
     expect(themeData.minLeadingWidth, null);
     expect(themeData.enableFeedback, null);
+    expect(themeData.mouseCursor, null);
   });
 
   testWidgets('Default ListTileThemeData debugFillProperties', (WidgetTester tester) async {
@@ -101,6 +102,7 @@ void main() {
       minVerticalPadding: 300,
       minLeadingWidth: 400,
       enableFeedback: true,
+      mouseCursor: MaterialStateMouseCursor.clickable,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -121,7 +123,8 @@ void main() {
       'horizontalTitleGap: 200.0',
       'minVerticalPadding: 300.0',
       'minLeadingWidth: 400.0',
-      'enableFeedback: true'
+      'enableFeedback: true',
+      'mouseCursor: MaterialStateMouseCursor(clickable)',
     ]);
   });
 
@@ -145,6 +148,7 @@ void main() {
             minVerticalPadding: 300,
             minLeadingWidth: 400,
             enableFeedback: true,
+            mouseCursor: MaterialStateMouseCursor.clickable,
             child: Center(
               child: Builder(
                 builder: (BuildContext context) {
@@ -171,6 +175,7 @@ void main() {
     expect(theme.minVerticalPadding, 300);
     expect(theme.minLeadingWidth, 400);
     expect(theme.enableFeedback, true);
+    expect(theme.mouseCursor, MaterialStateMouseCursor.clickable);
   });
 
   testWidgets('ListTile geometry (LTR)', (WidgetTester tester) async {
@@ -424,6 +429,13 @@ void main() {
                 selectedColor: selectedColor,
                 iconColor: iconColor,
                 textColor: textColor,
+                mouseCursor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  if (states.contains(MaterialState.disabled)) {
+                    return SystemMouseCursors.forbidden;
+                  }
+
+                  return SystemMouseCursors.click;
+                }),
               ),
               child: Builder(
                 builder: (BuildContext context) {
@@ -499,6 +511,15 @@ void main() {
     // A selected ListTile's InkWell gets the ListTileTheme's shape
     await tester.pumpWidget(buildFrame(selected: true, shape: roundedShape));
     expect(inkWellBorder(), roundedShape);
+
+    // Cursor updates when hovering disabled ListTile
+    final Offset barItem = tester.getCenter(find.byKey(titleKey));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(barItem);
+    await tester.pumpAndSettle();
+    expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
   });
 
   testWidgets('ListTile semantics', (WidgetTester tester) async {
@@ -2070,6 +2091,34 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
       expect(feedback.clickSoundCount, 1);
       expect(feedback.hapticCount, 0);
+    });
+
+    testWidgets('ListTile.mouseCursor overrides ListTileTheme.mouseCursor', (WidgetTester tester) async {
+      final Key tileKey = UniqueKey();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ListTileTheme(
+              data: const ListTileThemeData(mouseCursor: MaterialStateMouseCursor.clickable),
+              child: ListTile(
+                key: tileKey,
+                mouseCursor: MaterialStateMouseCursor.textable,
+                title: const Text('Title'),
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+    final Offset barItem = tester.getCenter(find.byKey(tileKey));
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(barItem);
+    await tester.pumpAndSettle();
+    expect(RendererBinding.instance!.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.text);
     });
   });
 


### PR DESCRIPTION
Allow themes to override ListTile's mouse cursor.

Partial fix to #88371


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
