### PR TITLE
Fix flutter web app not respecting assets path when in non-root folder

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -182,7 +182,6 @@ Future<void> runWebServiceWorkerTest({
     expectRequestCounts(<String, int>{
       'index.html': 2,
       'flutter_service_worker.js': 2,
-      '': 1,
       'main.dart.js': 1,
       'assets/NOTICES': 1,
       'assets/AssetManifest.json': 1,
@@ -209,7 +208,6 @@ Future<void> runWebServiceWorkerTest({
     });
 
     expectRequestCounts(<String, int>{
-      '': 1,
       'index.html': 2,
       // We still download some resources multiple times if the server is non-caching.
       'main.dart.js': 2,
@@ -259,7 +257,6 @@ Future<void> runWebServiceWorkerTest({
       'flutter_service_worker.js': 1,
     });
     expectRequestCounts(<String, int>{
-      '': 1,
       'index.html': 2,
       'flutter_service_worker.js': 2,
       'main.dart.js': 2,

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -136,7 +136,6 @@ Future<void> runWebServiceWorkerTest({
     });
 
     expectRequestCounts(<String, int>{
-      '': 1,
       // Even though the server is caching index.html is downloaded twice,
       // once by the initial page load, and once by the service worker.
       // Other resources are loaded once only by the service worker.

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -518,7 +518,6 @@ class WebServiceWorker extends Target {
     final String serviceWorker = generateServiceWorker(
       urlToHash,
       <String>[
-        '/',
         'main.dart.js',
         'index.html',
         'assets/NOTICES',


### PR DESCRIPTION
This pull request aims to fix #68449.
This bug is blocking the incremental integration of every flutter web-app in subdirectories for existing systems.
And also, because this bug makes every flutter web-app search in the root domain path for assets, it only allows for one flutter web-app to co-exists even if in different projects / directories.

*List which issues are fixed by this PR. You must list at least one issue.*
- Fixes #68449 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.


