### PR TITLE
Remove expensive web casts

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -906,7 +906,7 @@ class _CupertinoDialogRenderWidget extends RenderObjectWidget {
   }
 }
 
-class _CupertinoDialogRenderElement extends RenderObjectElement {
+class _CupertinoDialogRenderElement extends RenderObjectElement<_CupertinoDialogRenderWidget> {
   _CupertinoDialogRenderElement(_CupertinoDialogRenderWidget widget, {this.allowMoveRenderObjectChild = false}) : super(widget);
 
   // Whether to allow overridden method moveRenderObjectChild call or default to super.
@@ -915,9 +915,6 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
 
   Element? _contentElement;
   Element? _actionsElement;
-
-  @override
-  _CupertinoDialogRenderWidget get widget => super.widget as _CupertinoDialogRenderWidget;
 
   @override
   _RenderCupertinoDialog get renderObject => super.renderObject as _RenderCupertinoDialog;

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -5,6 +5,7 @@
 import 'dart:collection';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -511,7 +511,7 @@ class _CupertinoTextSelectionToolbarItems extends RenderObjectWidget {
 }
 
 // The custom RenderObjectElement that helps paginate the menu items.
-class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
+class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement<_CupertinoTextSelectionToolbarItems> {
   _CupertinoTextSelectionToolbarItemsElement(
     _CupertinoTextSelectionToolbarItems widget,
   ) : super(widget);
@@ -522,9 +522,6 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   // We keep a set of forgotten children to avoid O(n^2) work walking _children
   // repeatedly to remove children.
   final Set<Element> _forgottenChildren = HashSet<Element>();
-
-  @override
-  _CupertinoTextSelectionToolbarItems get widget => super.widget as _CupertinoTextSelectionToolbarItems;
 
   @override
   _RenderCupertinoTextSelectionToolbarItems get renderObject => super.renderObject as _RenderCupertinoTextSelectionToolbarItems;

--- a/packages/flutter/lib/src/foundation/_bitfield_io.dart
+++ b/packages/flutter/lib/src/foundation/_bitfield_io.dart
@@ -8,7 +8,7 @@ import 'bitfield.dart' as bitfield;
 const int kMaxUnsignedSMI = 0x3FFFFFFFFFFFFFFF; // ignore: avoid_js_rounded_ints, (VM-only code)
 
 /// The dart:io implementation of [bitfield.Bitfield].
-class BitField<T extends dynamic> implements bitfield.BitField<T> {
+class BitField<T extends Enum> implements bitfield.BitField<T> {
   /// The dart:io implementation of [bitfield.Bitfield()].
   BitField(this._length)
     : assert(_length <= _smiBits),
@@ -28,14 +28,14 @@ class BitField<T extends dynamic> implements bitfield.BitField<T> {
 
   @override
   bool operator [](T index) {
-    final int _index = index.index as int;
+    final int _index = index.index;
     assert(_index < _length);
     return (_bits & 1 << _index) > 0;
   }
 
   @override
   void operator []=(T index, bool value) {
-    final int _index = index.index as int;
+    final int _index = index.index;
     assert(_index < _length);
     if (value)
       _bits = _bits | (1 << _index);

--- a/packages/flutter/lib/src/foundation/_bitfield_web.dart
+++ b/packages/flutter/lib/src/foundation/_bitfield_web.dart
@@ -14,7 +14,7 @@ import 'bitfield.dart' as bitfield;
 const int kMaxUnsignedSMI = -1;
 
 /// The dart:html implementation of [bitfield.Bitfield].
-class BitField<T extends dynamic> implements bitfield.BitField<T> {
+class BitField<T extends Enum> implements bitfield.BitField<T> {
   /// The dart:html implementation of [bitfield.Bitfield].
   // Can remove when we have metaclasses.
   // ignore: avoid_unused_constructor_parameters

--- a/packages/flutter/lib/src/foundation/bitfield.dart
+++ b/packages/flutter/lib/src/foundation/bitfield.dart
@@ -17,7 +17,7 @@ const int kMaxUnsignedSMI = bitfield.kMaxUnsignedSMI;
 /// Only the first 62 values of the enum can be used as indices.
 ///
 /// When compiling to JavaScript, this class is not supported.
-abstract class BitField<T extends dynamic> {
+abstract class BitField<T extends Enum> {
   /// Creates a bit field of all zeros.
   ///
   /// The given length must be at most 62.

--- a/packages/flutter/lib/src/foundation/collections.dart
+++ b/packages/flutter/lib/src/foundation/collections.dart
@@ -236,7 +236,7 @@ void _movingInsertionSort<T>(
   int Function(T, T) compare,
   int start,
   int end,
-  List<T?> target,
+  List<T> target,
   int targetOffset,
 ) {
   final int length = end - start;
@@ -250,7 +250,7 @@ void _movingInsertionSort<T>(
     int max = targetOffset + i;
     while (min < max) {
       final int mid = min + ((max - min) >> 1);
-      if (compare(element, target[mid] as T) < 0) {
+      if (compare(element, target[mid]) < 0) {
         max = mid;
       } else {
         min = mid + 1;

--- a/packages/flutter/lib/src/foundation/node.dart
+++ b/packages/flutter/lib/src/foundation/node.dart
@@ -134,7 +134,7 @@ class AbstractNode<T extends AbstractNode<T>> {
       assert(node != child); // indicates we are about to create a cycle
       return true;
     }());
-    child._parent = this as T?;
+    child._parent = _unsafeCast<T?>(this);
     if (attached)
       child.attach(_owner!);
     redepthChild(child);
@@ -154,3 +154,10 @@ class AbstractNode<T extends AbstractNode<T>> {
       child.detach();
   }
 }
+
+// This allows casting without a cost in web release builds. This is intentionally only used
+// for inherited widget/state lookup, since by construction these caches are correct but
+// cannot be proven statically.
+@pragma('dart2js:tryInline')
+@pragma('dart2js:as:trust')
+T _unsafeCast<T>(dynamic any) => any as T;

--- a/packages/flutter/lib/src/foundation/node.dart
+++ b/packages/flutter/lib/src/foundation/node.dart
@@ -39,7 +39,8 @@ import 'package:meta/meta.dart';
 /// moved to be a child of A, sibling of B, then the numbers won't change. C's
 /// [depth] will still be 2. The [depth] is automatically maintained by the
 /// [adoptChild] and [dropChild] methods.
-class AbstractNode {
+@optionalTypeArgs
+class AbstractNode<T extends AbstractNode<T>> {
   /// The depth of this node in the tree.
   ///
   /// The depth of nodes in a tree monotonically increases as you traverse down
@@ -52,7 +53,7 @@ class AbstractNode {
   ///
   /// Only call this method from overrides of [redepthChildren].
   @protected
-  void redepthChild(AbstractNode child) {
+  void redepthChild(AbstractNode<T> child) {
     assert(child.owner == owner);
     if (child._depth <= _depth) {
       child._depth = _depth + 1;
@@ -115,25 +116,25 @@ class AbstractNode {
   }
 
   /// The parent of this node in the tree.
-  AbstractNode? get parent => _parent;
-  AbstractNode? _parent;
+  T? get parent => _parent;
+  T? _parent;
 
   /// Mark the given node as being a child of this node.
   ///
   /// Subclasses should call this function when they acquire a new child.
   @protected
   @mustCallSuper
-  void adoptChild(covariant AbstractNode child) {
+  void adoptChild(covariant AbstractNode<T> child) {
     assert(child != null);
     assert(child._parent == null);
     assert(() {
-      AbstractNode node = this;
+      AbstractNode<T> node = this;
       while (node.parent != null)
         node = node.parent!;
       assert(node != child); // indicates we are about to create a cycle
       return true;
     }());
-    child._parent = this;
+    child._parent = this as T?;
     if (attached)
       child.attach(_owner!);
     redepthChild(child);
@@ -144,7 +145,7 @@ class AbstractNode {
   /// Subclasses should call this function when they lose a child.
   @protected
   @mustCallSuper
-  void dropChild(covariant AbstractNode child) {
+  void dropChild(covariant AbstractNode<T> child) {
     assert(child != null);
     assert(child._parent == this);
     assert(child.attached == attached);

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -45,12 +45,13 @@ abstract class HitTestTarget {
 ///
 /// Subclass this object to pass additional information from the hit test phase
 /// to the event propagation phase.
-class HitTestEntry {
+@optionalTypeArgs
+class HitTestEntry<T extends HitTestTarget>  {
   /// Creates a hit test entry.
   HitTestEntry(this.target);
 
   /// The [HitTestTarget] encountered during the hit test.
-  final HitTestTarget target;
+  final T target;
 
   @override
   String toString() => '${describeIdentity(this)}($target)';

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -640,7 +640,7 @@ abstract class InkFeature {
     final List<RenderObject> descendants = <RenderObject>[referenceBox];
     RenderObject node = referenceBox;
     while (node != _controller) {
-      node = node.parent! as RenderObject;
+      node = node.parent!;
       descendants.add(node);
     }
     // determine the transform that gets our coordinate system to be like theirs

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -886,16 +886,13 @@ class BoxHitTestResult extends HitTestResult {
 }
 
 /// A hit test entry used by [RenderBox].
-class BoxHitTestEntry extends HitTestEntry {
+class BoxHitTestEntry extends HitTestEntry<RenderBox> {
   /// Creates a box hit test entry.
   ///
   /// The [localPosition] argument must not be null.
   BoxHitTestEntry(RenderBox target, this.localPosition)
     : assert(localPosition != null),
       super(target);
-
-  @override
-  RenderBox get target => super.target as RenderBox;
 
   /// The position of the hit test in the local coordinates of [target].
   final Offset localPosition;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2542,7 +2542,7 @@ abstract class RenderBox extends RenderObject {
       }
       return true;
     }());
-    final BoxParentData childParentData = child.parentData! as BoxParentData;
+    final BoxParentData childParentData = _unsafeCast<BoxParentData>(child.parentData);
     final Offset offset = childParentData.offset;
     transform.translate(offset.dx, offset.dy);
   }
@@ -2770,7 +2770,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
     assert(!debugNeedsLayout);
     ChildType? child = firstChild;
     while (child != null) {
-      final ParentDataType? childParentData = child.parentData as ParentDataType?;
+      final ParentDataType? childParentData = _unsafeCast<ParentDataType?>(child.parentData);
       final double? result = child.getDistanceToActualBaseline(baseline);
       if (result != null)
         return result + childParentData!.offset.dy;
@@ -2788,7 +2788,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
     double? result;
     ChildType? child = firstChild;
     while (child != null) {
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       double? candidate = child.getDistanceToActualBaseline(baseline);
       if (candidate != null) {
         candidate += childParentData.offset.dy;
@@ -2815,7 +2815,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
     ChildType? child = lastChild;
     while (child != null) {
       // The x, y parameters have the top left of the node's box as the origin.
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       final bool isHit = result.addWithPaintOffset(
         offset: childParentData.offset,
         position: position,
@@ -2840,7 +2840,7 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
   void defaultPaint(PaintingContext context, Offset offset) {
     ChildType? child = firstChild;
     while (child != null) {
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       context.paintChild(child, childParentData.offset + offset);
       child = childParentData.nextSibling;
     }
@@ -2855,10 +2855,16 @@ mixin RenderBoxContainerDefaultsMixin<ChildType extends RenderBox, ParentDataTyp
     final List<ChildType> result = <ChildType>[];
     RenderBox? child = firstChild;
     while (child != null) {
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
-      result.add(child as ChildType);
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
+      result.add(_unsafeCast<ChildType>(child));
       child = childParentData.nextSibling;
     }
     return result;
   }
 }
+
+// This allows casting without a cost in web release builds. This is intentionally only used
+// for parent data casts that are known by the framework to be safe.
+@pragma('dart2js:tryInline')
+@pragma('dart2js:as:trust')
+T _unsafeCast<T>(dynamic any) => any as T;

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2146,7 +2146,7 @@ abstract class RenderBox extends RenderObject {
     assert(!_debugDoingBaseline, 'Please see the documentation for computeDistanceToActualBaseline for the required calling conventions of this method.');
     assert(!debugNeedsLayout);
     assert(() {
-      final RenderObject? parent = this.parent as RenderObject?;
+      final RenderObject? parent = this.parent;
       if (owner!.debugDoingLayout)
         return (RenderObject.debugActiveLayout == parent) && parent!.debugDoingThisLayout;
       if (owner!.debugDoingPaint)

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -135,7 +135,7 @@ class AnnotationResult<T> {
 ///
 ///  * [RenderView.compositeFrame], which implements this recomposition protocol
 ///    for painting [RenderObject] trees on the display.
-abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
+abstract class Layer extends AbstractNode<Layer> with DiagnosticableTreeMixin {
   /// If asserts are enabled, returns whether [dispose] has
   /// been called since the last time any retained resources were created.
   ///
@@ -388,7 +388,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   Layer? _previousSibling;
 
   @override
-  void dropChild(AbstractNode child) {
+  void dropChild(AbstractNode<Layer> child) {
     if (!alwaysNeedsAddToScene) {
       markNeedsAddToScene();
     }
@@ -396,7 +396,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
   }
 
   @override
-  void adoptChild(AbstractNode child) {
+  void adoptChild(AbstractNode<Layer> child) {
     if (!alwaysNeedsAddToScene) {
       markNeedsAddToScene();
     }

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1039,7 +1039,7 @@ class RenderListWheelViewport
     // `child` will be the last RenderObject before the viewport when walking up from `target`.
     RenderObject child = target;
     while (child.parent != this)
-      child = child.parent! as RenderObject;
+      child = child.parent!;
 
     final ListWheelParentData parentData = child.parentData! as ListWheelParentData;
     final double targetOffset = parentData.offset.dy; // the so-called "centerPosition"

--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -231,11 +231,11 @@ class MouseTracker extends ChangeNotifier {
 
   LinkedHashMap<MouseTrackerAnnotation, Matrix4> _hitTestResultToAnnotations(HitTestResult result) {
     assert(result != null);
-    final LinkedHashMap<MouseTrackerAnnotation, Matrix4> annotations = <MouseTrackerAnnotation, Matrix4>{}
-        as LinkedHashMap<MouseTrackerAnnotation, Matrix4>;
+    final LinkedHashMap<MouseTrackerAnnotation, Matrix4> annotations = LinkedHashMap<MouseTrackerAnnotation, Matrix4>();
     for (final HitTestEntry entry in result.path) {
-      if (entry.target is MouseTrackerAnnotation) {
-        annotations[entry.target as MouseTrackerAnnotation] = entry.transform!;
+      final Object target = entry.target;
+      if (target is MouseTrackerAnnotation) {
+        annotations[target] = entry.transform!;
       }
     }
     return annotations;

--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: prefer_collection_literals
+
 import 'dart:collection' show LinkedHashMap;
 import 'dart:ui';
 
@@ -252,7 +254,7 @@ class MouseTracker extends ChangeNotifier {
     final Offset globalPosition = state.latestEvent.position;
     final int device = state.device;
     if (!_mouseStates.containsKey(device))
-      return <MouseTrackerAnnotation, Matrix4>{} as LinkedHashMap<MouseTrackerAnnotation, Matrix4>;
+      return LinkedHashMap<MouseTrackerAnnotation, Matrix4>();
 
     return _hitTestResultToAnnotations(hitTest(globalPosition));
   }
@@ -325,7 +327,7 @@ class MouseTracker extends ChangeNotifier {
 
         final PointerEvent lastEvent = targetState.replaceLatestEvent(event);
         final LinkedHashMap<MouseTrackerAnnotation, Matrix4> nextAnnotations = event is PointerRemovedEvent ?
-            <MouseTrackerAnnotation, Matrix4>{} as LinkedHashMap<MouseTrackerAnnotation, Matrix4> :
+            LinkedHashMap<MouseTrackerAnnotation, Matrix4>():
             _hitTestResultToAnnotations(result);
         final LinkedHashMap<MouseTrackerAnnotation, Matrix4> lastAnnotations = targetState.replaceAnnotations(nextAnnotations);
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1234,6 +1234,7 @@ class PipelineOwner {
 /// [RenderObject.markNeedsLayout] so that if a parent has queried the intrinsic
 /// or baseline information, it gets marked dirty whenever the child's geometry
 /// changes.
+@optionalTypeArgs
 abstract class RenderObject extends AbstractNode<RenderObject> with DiagnosticableTreeMixin implements HitTestTarget {
   /// Initializes internal fields for subclasses.
   RenderObject() {
@@ -1336,8 +1337,7 @@ abstract class RenderObject extends AbstractNode<RenderObject> with Diagnosticab
   /// child is added to the parent's child list.
   void setupParentData(covariant RenderObject child) {
     assert(_debugCanPerformMutations);
-    if (child.parentData is! ParentData)
-      child.parentData = ParentData();
+    child.parentData ??= ParentData();
   }
 
   /// Called by subclasses when they decide a render object is a child.
@@ -3291,7 +3291,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
   ChildType? _firstChild;
   ChildType? _lastChild;
   void _insertIntoChildList(ChildType child, { ChildType? after }) {
-    final ParentDataType childParentData = child.parentData! as ParentDataType;
+    final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
     assert(childParentData.nextSibling == null);
     assert(childParentData.previousSibling == null);
     _childCount += 1;
@@ -3300,7 +3300,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
       // insert at the start (_firstChild)
       childParentData.nextSibling = _firstChild;
       if (_firstChild != null) {
-        final ParentDataType _firstChildParentData = _firstChild!.parentData! as ParentDataType;
+        final ParentDataType _firstChildParentData = _unsafeCast<ParentDataType>(_firstChild!.parentData);
         _firstChildParentData.previousSibling = child;
       }
       _firstChild = child;
@@ -3310,7 +3310,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
       assert(_lastChild != null);
       assert(_debugUltimatePreviousSiblingOf(after, equals: _firstChild));
       assert(_debugUltimateNextSiblingOf(after, equals: _lastChild));
-      final ParentDataType afterParentData = after.parentData! as ParentDataType;
+      final ParentDataType afterParentData = _unsafeCast<ParentDataType>(after.parentData);
       if (afterParentData.nextSibling == null) {
         // insert at the end (_lastChild); we'll end up with two or more children
         assert(after == _lastChild);
@@ -3323,8 +3323,8 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
         childParentData.nextSibling = afterParentData.nextSibling;
         childParentData.previousSibling = after;
         // set up links from siblings to child
-        final ParentDataType childPreviousSiblingParentData = childParentData.previousSibling!.parentData! as ParentDataType;
-        final ParentDataType childNextSiblingParentData = childParentData.nextSibling!.parentData! as ParentDataType;
+        final ParentDataType childPreviousSiblingParentData = _unsafeCast<ParentDataType>(childParentData.previousSibling!.parentData);
+        final ParentDataType childNextSiblingParentData = _unsafeCast<ParentDataType>(childParentData.nextSibling!.parentData);
         childPreviousSiblingParentData.nextSibling = child;
         childNextSiblingParentData.previousSibling = child;
         assert(afterParentData.nextSibling == child);
@@ -3357,7 +3357,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
   }
 
   void _removeFromChildList(ChildType child) {
-    final ParentDataType childParentData = child.parentData! as ParentDataType;
+    final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
     assert(_debugUltimatePreviousSiblingOf(child, equals: _firstChild));
     assert(_debugUltimateNextSiblingOf(child, equals: _lastChild));
     assert(_childCount >= 0);
@@ -3365,14 +3365,14 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
       assert(_firstChild == child);
       _firstChild = childParentData.nextSibling;
     } else {
-      final ParentDataType childPreviousSiblingParentData = childParentData.previousSibling!.parentData! as ParentDataType;
+      final ParentDataType childPreviousSiblingParentData = _unsafeCast<ParentDataType>(childParentData.previousSibling!.parentData);
       childPreviousSiblingParentData.nextSibling = childParentData.nextSibling;
     }
     if (childParentData.nextSibling == null) {
       assert(_lastChild == child);
       _lastChild = childParentData.previousSibling;
     } else {
-      final ParentDataType childNextSiblingParentData = childParentData.nextSibling!.parentData! as ParentDataType;
+      final ParentDataType childNextSiblingParentData = _unsafeCast<ParentDataType>(childParentData.nextSibling!.parentData);
       childNextSiblingParentData.previousSibling = childParentData.previousSibling;
     }
     childParentData.previousSibling = null;
@@ -3394,7 +3394,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
   void removeAll() {
     ChildType? child = _firstChild;
     while (child != null) {
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       final ChildType? next = childParentData.nextSibling;
       childParentData.previousSibling = null;
       childParentData.nextSibling = null;
@@ -3416,7 +3416,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
     assert(after != this);
     assert(child != after);
     assert(child.parent == this);
-    final ParentDataType childParentData = child.parentData! as ParentDataType;
+    final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
     if (childParentData.previousSibling == after)
       return;
     _removeFromChildList(child);
@@ -3430,7 +3430,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
     ChildType? child = _firstChild;
     while (child != null) {
       child.attach(owner);
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       child = childParentData.nextSibling;
     }
   }
@@ -3441,7 +3441,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
     ChildType? child = _firstChild;
     while (child != null) {
       child.detach();
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       child = childParentData.nextSibling;
     }
   }
@@ -3451,7 +3451,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
     ChildType? child = _firstChild;
     while (child != null) {
       redepthChild(child);
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       child = childParentData.nextSibling;
     }
   }
@@ -3461,7 +3461,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
     ChildType? child = _firstChild;
     while (child != null) {
       visitor(child);
-      final ParentDataType childParentData = child.parentData! as ParentDataType;
+      final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
       child = childParentData.nextSibling;
     }
   }
@@ -3476,7 +3476,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
   ChildType? childBefore(ChildType child) {
     assert(child != null);
     assert(child.parent == this);
-    final ParentDataType childParentData = child.parentData! as ParentDataType;
+    final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
     return childParentData.previousSibling;
   }
 
@@ -3484,7 +3484,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
   ChildType? childAfter(ChildType child) {
     assert(child != null);
     assert(child.parent == this);
-    final ParentDataType childParentData = child.parentData! as ParentDataType;
+    final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
     return childParentData.nextSibling;
   }
 
@@ -3499,7 +3499,7 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
         if (child == lastChild)
           break;
         count += 1;
-        final ParentDataType childParentData = child.parentData! as ParentDataType;
+        final ParentDataType childParentData = _unsafeCast<ParentDataType>(child.parentData);
         child = childParentData.nextSibling!;
       }
     }
@@ -4048,3 +4048,9 @@ class DiagnosticsDebugCreator extends DiagnosticsProperty<Object> {
         level: DiagnosticLevel.hidden,
       );
 }
+
+// This allows casting without a cost in web release builds. This is intentionally only used
+// for parent data casts that are known by the framework to be safe.
+@pragma('dart2js:tryInline')
+@pragma('dart2js:as:trust')
+T _unsafeCast<T>(dynamic any) => any as T;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -1234,7 +1234,7 @@ class PipelineOwner {
 /// [RenderObject.markNeedsLayout] so that if a parent has queried the intrinsic
 /// or baseline information, it gets marked dirty whenever the child's geometry
 /// changes.
-abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin implements HitTestTarget {
+abstract class RenderObject extends AbstractNode<RenderObject> with DiagnosticableTreeMixin implements HitTestTarget {
   /// Initializes internal fields for subclasses.
   RenderObject() {
     _needsCompositing = isRepaintBoundary || alwaysNeedsCompositing;
@@ -1476,7 +1476,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
           result = true;
           break;
         }
-        node = node.parent! as RenderObject;
+        node = node.parent!;
       }
       return true;
     }());
@@ -1577,7 +1577,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     while (node != _relayoutBoundary) {
       assert(node._relayoutBoundary == _relayoutBoundary);
       assert(node.parent != null);
-      node = node.parent! as RenderObject;
+      node = node.parent!;
       if ((!node._needsLayout) && (!node._debugDoingThisLayout))
         return false;
     }
@@ -1659,7 +1659,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   void markParentNeedsLayout() {
     _needsLayout = true;
     assert(this.parent != null);
-    final RenderObject parent = this.parent! as RenderObject;
+    final RenderObject parent = this.parent!;
     if (!_doingThisLayoutWithCallback) {
       parent.markNeedsLayout();
     } else {
@@ -1818,7 +1818,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (!parentUsesSize || sizedByParent || constraints.isTight || parent is! RenderObject) {
       relayoutBoundary = this;
     } else {
-      relayoutBoundary = (parent! as RenderObject)._relayoutBoundary;
+      relayoutBoundary = parent!._relayoutBoundary;
     }
     assert(() {
       _debugCanParentUseSize = parentUsesSize;
@@ -2155,7 +2155,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       return;
     _needsCompositingBitsUpdate = true;
     if (parent is RenderObject) {
-      final RenderObject parent = this.parent! as RenderObject;
+      final RenderObject parent = this.parent!;
       if (parent._needsCompositingBitsUpdate)
         return;
       if (!isRepaintBoundary && !parent.isRepaintBoundary) {
@@ -2268,7 +2268,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         owner!.requestVisualUpdate();
       }
     } else if (parent is RenderObject) {
-      final RenderObject parent = this.parent! as RenderObject;
+      final RenderObject parent = this.parent!;
       parent.markNeedsPaint();
       assert(parent == this.parent);
     } else {
@@ -2387,7 +2387,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     assert(() {
       if (_needsCompositingBitsUpdate) {
         if (parent is RenderObject) {
-          final RenderObject parent = this.parent! as RenderObject;
+          final RenderObject parent = this.parent!;
           bool visitedByParent = false;
           parent.visitChildren((RenderObject child) {
             if (child == this) {
@@ -2523,7 +2523,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         ancestor = rootNode;
     }
     final List<RenderObject> renderers = <RenderObject>[];
-    for (RenderObject renderer = this; renderer != ancestor; renderer = renderer.parent! as RenderObject) {
+    for (RenderObject renderer = this; renderer != ancestor; renderer = renderer.parent!) {
       renderers.add(renderer);
       assert(renderer.parent != null); // Failed to find ancestor in parent chain.
     }
@@ -2648,7 +2648,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (_semantics != null && !_semantics!.isMergedIntoParent) {
       _semantics!.sendEvent(semanticsEvent);
     } else if (parent != null) {
-      final RenderObject renderParent = parent! as RenderObject;
+      final RenderObject renderParent = parent!;
       renderParent.sendSemanticsEvent(semanticsEvent);
     }
   }
@@ -2724,12 +2724,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     bool isEffectiveSemanticsBoundary = _semanticsConfiguration.isSemanticBoundary && wasSemanticsBoundary;
     RenderObject node = this;
 
-    while (!isEffectiveSemanticsBoundary && node.parent is RenderObject) {
+    while (!isEffectiveSemanticsBoundary && node.parent != null) {
       if (node != this && node._needsSemanticsUpdate)
         break;
       node._needsSemanticsUpdate = true;
 
-      node = node.parent! as RenderObject;
+      node = node.parent!;
       isEffectiveSemanticsBoundary = node._semanticsConfiguration.isSemanticBoundary;
       if (isEffectiveSemanticsBoundary && node._semantics == null) {
         // We have reached a semantics boundary that doesn't own a semantics node.
@@ -2942,9 +2942,9 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       }
       if (_relayoutBoundary != null && _relayoutBoundary != this) {
         int count = 1;
-        RenderObject? target = parent as RenderObject?;
+        RenderObject? target = parent;
         while (target != null && target != _relayoutBoundary) {
-          target = target.parent as RenderObject?;
+          target = target.parent;
           count += 1;
         }
         header += ' relayoutBoundary=up$count';
@@ -3064,7 +3064,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     Curve curve = Curves.ease,
   }) {
     if (parent is RenderObject) {
-      final RenderObject renderParent = parent! as RenderObject;
+      final RenderObject renderParent = parent!;
       renderParent.showOnScreen(
         descendant: descendant ?? this,
         rect: rect,
@@ -3991,12 +3991,12 @@ class _SemanticsGeometry {
     assert(transform != null);
     assert(clipRectTransform != null);
     assert(clipRectTransform.isIdentity());
-    RenderObject intermediateParent = child.parent! as RenderObject;
+    RenderObject intermediateParent = child.parent!;
     assert(intermediateParent != null);
     while (intermediateParent != ancestor) {
       intermediateParent.applyPaintTransform(child, transform);
-      intermediateParent = intermediateParent.parent! as RenderObject;
-      child = child.parent! as RenderObject;
+      intermediateParent = intermediateParent.parent!;
+      child = child.parent!;
       assert(intermediateParent != null);
     }
     ancestor.applyPaintTransform(child, transform);

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2386,12 +2386,13 @@ class RenderTransform extends RenderProxyBox {
       if (filterQuality == null) {
         final Offset? childOffset = MatrixUtils.getAsTranslation(transform);
         if (childOffset == null) {
+          final ContainerLayer? oldLayer = layer;
           layer = context.pushTransform(
             needsCompositing,
             offset,
             transform,
             super.paint,
-            oldLayer: layer is TransformLayer ? layer as TransformLayer? : null,
+            oldLayer: oldLayer is TransformLayer ? oldLayer : null,
           );
         } else {
           super.paint(context, offset + childOffset);
@@ -2644,15 +2645,16 @@ class RenderFittedBox extends RenderProxyBox {
 
   TransformLayer? _paintChildWithTransform(PaintingContext context, Offset offset) {
     final Offset? childOffset = MatrixUtils.getAsTranslation(_transform!);
-    if (childOffset == null)
+    if (childOffset == null) {
+      final ContainerLayer? oldLayer = layer;
       return context.pushTransform(
         needsCompositing,
         offset,
         _transform!,
         super.paint,
-        oldLayer: layer is TransformLayer ? layer! as TransformLayer : null,
+        oldLayer: oldLayer is TransformLayer ? oldLayer : null,
       );
-    else
+    } else
       super.paint(context, offset + childOffset);
     return null;
   }

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -870,7 +870,7 @@ class SliverHitTestResult extends HitTestResult {
 ///
 /// The coordinate system used by this hit test entry is relative to the
 /// [AxisDirection] of the target sliver.
-class SliverHitTestEntry extends HitTestEntry {
+class SliverHitTestEntry extends HitTestEntry<RenderSliver> {
   /// Creates a sliver hit test entry.
   ///
   /// The [mainAxisPosition] and [crossAxisPosition] arguments must not be null.
@@ -881,9 +881,6 @@ class SliverHitTestEntry extends HitTestEntry {
   }) : assert(mainAxisPosition != null),
        assert(crossAxisPosition != null),
        super(target);
-
-  @override
-  RenderSliver get target => super.target as RenderSliver;
 
   /// The distance in the [AxisDirection] from the edge of the sliver's painted
   /// area (as given by the [SliverConstraints.scrollOffset]) to the hit point.

--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -43,7 +43,7 @@ abstract class RenderAbstractViewport extends RenderObject {
     while (object != null) {
       if (object is RenderAbstractViewport)
         return object;
-      object = object.parent as RenderObject?;
+      object = object.parent;
     }
     return null;
   }
@@ -755,7 +755,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     RenderBox? pivot;
     bool onlySlivers = target is RenderSliver; // ... between viewport and `target` (`target` included).
     while (child.parent != this) {
-      final RenderObject parent = child.parent! as RenderObject;
+      final RenderObject parent = child.parent!;
       assert(parent != null, '$target must be a descendant of $this');
       if (child is RenderBox) {
         pivot = child;
@@ -1205,7 +1205,7 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     } else {
       // `descendant` is between leading and trailing edge and hence already
       //  fully shown on screen. No action necessary.
-      final Matrix4 transform = descendant.getTransformTo(viewport.parent! as RenderObject);
+      final Matrix4 transform = descendant.getTransformTo(viewport.parent);
       return MatrixUtils.transformRect(transform, rect ?? descendant.paintBounds);
     }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1511,7 +1511,7 @@ void debugResetSemanticsIdCounter() {
 /// (i.e., during [PipelineOwner.flushSemantics]), which happens after
 /// compositing. The semantics tree is then uploaded into the engine for use
 /// by assistive technology.
-class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
+class SemanticsNode extends AbstractNode<SemanticsNode> with DiagnosticableTreeMixin {
   /// Creates a semantic node.
   ///
   /// Each semantic node has a unique identifier that is assigned when the node
@@ -1847,9 +1847,6 @@ class SemanticsNode extends AbstractNode with DiagnosticableTreeMixin {
 
   @override
   SemanticsOwner? get owner => super.owner as SemanticsOwner?;
-
-  @override
-  SemanticsNode? get parent => super.parent as SemanticsNode?;
 
   @override
   void redepthChildren() {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3120,11 +3120,8 @@ class Offstage extends SingleChildRenderObjectWidget {
   SingleChildRenderObjectElement createElement() => _OffstageElement(this);
 }
 
-class _OffstageElement extends SingleChildRenderObjectElement {
+class _OffstageElement extends SingleChildRenderObjectElement<Offstage> {
   _OffstageElement(Offstage widget) : super(widget);
-
-  @override
-  Offstage get widget => super.widget as Offstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1132,16 +1132,13 @@ class RenderObjectToWidgetAdapter<T extends RenderObject> extends RenderObjectWi
 /// whose container is the [RenderView] that connects to the Flutter engine. In
 /// this usage, it is normally instantiated by the bootstrapping logic in the
 /// [WidgetsFlutterBinding] singleton created by [runApp].
-class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObjectElement {
+class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObjectElement<RenderObjectToWidgetAdapter<T>> {
   /// Creates an element that is hosted by a [RenderObject].
   ///
   /// The [RenderObject] created by this element is not automatically set as a
   /// child of the hosting [RenderObject]. To actually attach this element to
   /// the render tree, call [RenderObjectToWidgetAdapter.attachToRenderTree].
   RenderObjectToWidgetElement(RenderObjectToWidgetAdapter<T> widget) : super(widget);
-
-  @override
-  RenderObjectToWidgetAdapter<T> get widget => super.widget as RenderObjectToWidgetAdapter<T>;
 
   Element? _child;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3666,7 +3666,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
       _debugForgottenChildrenWithGlobalKey?.clear();
       return true;
     }());
-    _widget = newWidget as W;
+    _widget = _unsafeCast<W>(newWidget);
   }
 
   /// Change the slot that the given child occupies in its parent.
@@ -4217,7 +4217,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
     assert(_debugCheckStateIsActiveForAncestorLookup());
     final InheritedElement? ancestor = _inheritedLookup?[T];
     if (ancestor != null) {
-      return dependOnInheritedElement(ancestor, aspect: aspect) as T;
+      return _unsafeCast<T>(dependOnInheritedElement(ancestor, aspect: aspect));
     }
     _hadUnsatisfiedDependencies = true;
     return null;
@@ -4241,7 +4241,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
     Element? ancestor = _parent;
     while (ancestor != null && ancestor.widget.runtimeType != T)
       ancestor = ancestor._parent;
-    return ancestor?.widget as T?;
+    return _unsafeCast<T?>(ancestor?.widget);
   }
 
   @override
@@ -4254,7 +4254,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
       ancestor = ancestor._parent;
     }
     final StatefulElement? statefulAncestor = ancestor as StatefulElement?;
-    return statefulAncestor?.state as T?;
+    return _unsafeCast<T?>(statefulAncestor?.state);
   }
 
   @override
@@ -4267,7 +4267,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
         statefulAncestor = ancestor;
       ancestor = ancestor._parent;
     }
-    return statefulAncestor?.state as T?;
+    return _unsafeCast<T?>(statefulAncestor?.state);
   }
 
   @override
@@ -4276,7 +4276,7 @@ abstract class Element<W extends Widget> extends DiagnosticableTree implements B
     Element? ancestor = _parent;
     while (ancestor != null) {
       if (ancestor is RenderObjectElement && ancestor.renderObject is T)
-        return ancestor.renderObject as T;
+        return _unsafeCast<T?>(ancestor.renderObject);
       ancestor = ancestor._parent;
     }
     return null;
@@ -6557,3 +6557,10 @@ class _NullWidget extends Widget {
 bool _debugShouldReassemble(DebugReassembleConfig? config, Widget? widget) {
   return config == null || config.widgetName == null || widget?.runtimeType.toString() == config.widgetName;
 }
+
+// This allows casting without a cost in web release builds. This is intentionally only used
+// for inherited widget/state lookup, since by construction these caches are correct but
+// cannot be proven statically.
+@pragma('dart2js:tryInline')
+@pragma('dart2js:as:trust')
+T _unsafeCast<T>(dynamic any) => any as T;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4852,9 +4852,10 @@ abstract class ComponentElement<W extends Widget> extends Element<W> {
 }
 
 /// An [Element] that uses a [StatelessWidget] as its configuration.
-class StatelessElement extends ComponentElement<StatelessWidget> {
+@optionalTypeArgs
+class StatelessElement<W extends StatelessWidget> extends ComponentElement<W> {
   /// Creates an element that uses the given widget as its configuration.
-  StatelessElement(StatelessWidget widget) : super(widget);
+  StatelessElement(W widget) : super(widget);
 
   @override
   Widget build() => widget.build(this);
@@ -4869,9 +4870,10 @@ class StatelessElement extends ComponentElement<StatelessWidget> {
 }
 
 /// An [Element] that uses a [StatefulWidget] as its configuration.
-class StatefulElement extends ComponentElement<StatefulWidget> {
+@optionalTypeArgs
+class StatefulElement<W extends StatefulWidget> extends ComponentElement<W> {
   /// Creates an element that uses the given widget as its configuration.
-  StatefulElement(StatefulWidget widget)
+  StatefulElement(W widget)
       : _state = widget.createState(),
         super(widget) {
     assert(() {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3153,11 +3153,12 @@ class BuildOwner {
 ///    element.
 ///  * At this point, the element is considered "defunct" and will not be
 ///    incorporated into the tree in the future.
-abstract class Element extends DiagnosticableTree implements BuildContext {
+@optionalTypeArgs
+abstract class Element<W extends Widget> extends DiagnosticableTree implements BuildContext {
   /// Creates an element that uses the given widget as its configuration.
   ///
   /// Typically called by an override of [Widget.createElement].
-  Element(Widget widget)
+  Element(W widget)
     : assert(widget != null),
       _widget = widget;
 
@@ -3233,8 +3234,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// The configuration for this element.
   @override
-  Widget get widget => _widget!;
-  Widget? _widget;
+  W get widget => _widget!;
+  W? _widget;
 
   /// Returns true if the Element is defunct.
   ///
@@ -3665,7 +3666,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       _debugForgottenChildrenWithGlobalKey?.clear();
       return true;
     }());
-    _widget = newWidget;
+    _widget = newWidget as W;
   }
 
   /// Change the slot that the given child occupies in its parent.
@@ -4745,9 +4746,10 @@ typedef TransitionBuilder = Widget Function(BuildContext context, Widget? child)
 /// [RenderObject]s indirectly by creating other [Element]s.
 ///
 /// Contrast with [RenderObjectElement].
-abstract class ComponentElement extends Element {
+@optionalTypeArgs
+abstract class ComponentElement<W extends Widget> extends Element<W> {
   /// Creates an element that uses the given widget as its configuration.
-  ComponentElement(Widget widget) : super(widget);
+  ComponentElement(W widget) : super(widget);
 
   Element? _child;
 
@@ -4850,12 +4852,9 @@ abstract class ComponentElement extends Element {
 }
 
 /// An [Element] that uses a [StatelessWidget] as its configuration.
-class StatelessElement extends ComponentElement {
+class StatelessElement extends ComponentElement<StatelessWidget> {
   /// Creates an element that uses the given widget as its configuration.
   StatelessElement(StatelessWidget widget) : super(widget);
-
-  @override
-  StatelessWidget get widget => super.widget as StatelessWidget;
 
   @override
   Widget build() => widget.build(this);
@@ -4870,7 +4869,7 @@ class StatelessElement extends ComponentElement {
 }
 
 /// An [Element] that uses a [StatefulWidget] as its configuration.
-class StatefulElement extends ComponentElement {
+class StatefulElement extends ComponentElement<StatefulWidget> {
   /// Creates an element that uses the given widget as its configuration.
   StatefulElement(StatefulWidget widget)
       : _state = widget.createState(),
@@ -4971,7 +4970,7 @@ class StatefulElement extends ComponentElement {
     // let authors call setState from within didUpdateWidget without triggering
     // asserts.
     _dirty = true;
-    state._widget = widget as StatefulWidget;
+    state._widget = widget;
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
       final Object? debugCheckForReturnedFuture = state.didUpdateWidget(oldWidget) as dynamic;
@@ -5120,12 +5119,10 @@ class StatefulElement extends ComponentElement {
 }
 
 /// An [Element] that uses a [ProxyWidget] as its configuration.
-abstract class ProxyElement extends ComponentElement {
+@optionalTypeArgs
+abstract class ProxyElement<P extends ProxyWidget> extends ComponentElement<P> {
   /// Initializes fields for subclasses.
-  ProxyElement(ProxyWidget widget) : super(widget);
-
-  @override
-  ProxyWidget get widget => super.widget as ProxyWidget;
+  ProxyElement(P widget) : super(widget);
 
   @override
   Widget build() => widget.child;
@@ -5162,12 +5159,9 @@ abstract class ProxyElement extends ComponentElement {
 }
 
 /// An [Element] that uses a [ParentDataWidget] as its configuration.
-class ParentDataElement<T extends ParentData> extends ProxyElement {
+class ParentDataElement<T extends ParentData> extends ProxyElement<ParentDataWidget<T>> {
   /// Creates an element that uses the given widget as its configuration.
   ParentDataElement(ParentDataWidget<T> widget) : super(widget);
-
-  @override
-  ParentDataWidget<T> get widget => super.widget as ParentDataWidget<T>;
 
   void _applyParentData(ParentDataWidget<T> widget) {
     void applyParentDataToChild(Element child) {
@@ -5227,12 +5221,9 @@ class ParentDataElement<T extends ParentData> extends ProxyElement {
 }
 
 /// An [Element] that uses an [InheritedWidget] as its configuration.
-class InheritedElement extends ProxyElement {
+class InheritedElement extends ProxyElement<InheritedWidget> {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget widget) : super(widget);
-
-  @override
-  InheritedWidget get widget => super.widget as InheritedWidget;
 
   final Map<Element, Object?> _dependents = HashMap<Element, Object?>();
 
@@ -5567,12 +5558,10 @@ class InheritedElement extends ProxyElement {
 /// expose them in its implementation of the [visitChildren] method. This method
 /// is used by many of the framework's internal mechanisms, and so should be
 /// fast. It is also used by the test framework and [debugDumpApp].
-abstract class RenderObjectElement extends Element {
+@optionalTypeArgs
+abstract class RenderObjectElement<W extends RenderObjectWidget> extends Element<W> {
   /// Creates an element that uses the given widget as its configuration.
-  RenderObjectElement(RenderObjectWidget widget) : super(widget);
-
-  @override
-  RenderObjectWidget get widget => super.widget as RenderObjectWidget;
+  RenderObjectElement(W widget) : super(widget);
 
   /// The underlying [RenderObject] for this element.
   ///
@@ -6286,12 +6275,9 @@ class LeafRenderObjectElement extends RenderObjectElement {
 /// This element subclass can be used for RenderObjectWidgets whose
 /// RenderObjects use the [RenderObjectWithChildMixin] mixin. Such widgets are
 /// expected to inherit from [SingleChildRenderObjectWidget].
-class SingleChildRenderObjectElement extends RenderObjectElement {
+class SingleChildRenderObjectElement extends RenderObjectElement<SingleChildRenderObjectWidget> {
   /// Creates an element that uses the given widget as its configuration.
   SingleChildRenderObjectElement(SingleChildRenderObjectWidget widget) : super(widget);
-
-  @override
-  SingleChildRenderObjectWidget get widget => super.widget as SingleChildRenderObjectWidget;
 
   Element? _child;
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1945,7 +1945,7 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   final List<Widget> children;
 
   @override
-  MultiChildRenderObjectElement createElement() => MultiChildRenderObjectElement(this);
+  MultiChildRenderObjectElement<MultiChildRenderObjectWidget> createElement() => MultiChildRenderObjectElement(this);
 }
 
 
@@ -5221,9 +5221,10 @@ class ParentDataElement<T extends ParentData> extends ProxyElement<ParentDataWid
 }
 
 /// An [Element] that uses an [InheritedWidget] as its configuration.
-class InheritedElement extends ProxyElement<InheritedWidget> {
+@optionalTypeArgs
+class InheritedElement<W extends InheritedWidget> extends ProxyElement<W> {
   /// Creates an element that uses the given widget as its configuration.
-  InheritedElement(InheritedWidget widget) : super(widget);
+  InheritedElement(W widget) : super(widget);
 
   final Map<Element, Object?> _dependents = HashMap<Element, Object?>();
 
@@ -5429,11 +5430,7 @@ class InheritedElement extends ProxyElement<InheritedWidget> {
 /// so that they return the specific type that the element expects, e.g.:
 ///
 /// ```dart
-/// class FooElement extends RenderObjectElement {
-///
-///   @override
-///   Foo get widget => super.widget as Foo;
-///
+/// class FooElement extends RenderObjectElement<Foo> {
 ///   @override
 ///   RenderFoo get renderObject => super.renderObject as RenderFoo;
 ///
@@ -6208,9 +6205,9 @@ abstract class RenderObjectElement<W extends RenderObjectWidget> extends Element
 ///
 /// Only root elements may have their owner set explicitly. All other
 /// elements inherit their owner from their parent.
-abstract class RootRenderObjectElement extends RenderObjectElement {
+abstract class RootRenderObjectElement<W extends RenderObjectWidget> extends RenderObjectElement<W> {
   /// Initializes fields for subclasses.
-  RootRenderObjectElement(RenderObjectWidget widget) : super(widget);
+  RootRenderObjectElement(W widget) : super(widget);
 
   /// Set the owner of the element. The owner will be propagated to all the
   /// descendants of this element.
@@ -6275,9 +6272,10 @@ class LeafRenderObjectElement extends RenderObjectElement {
 /// This element subclass can be used for RenderObjectWidgets whose
 /// RenderObjects use the [RenderObjectWithChildMixin] mixin. Such widgets are
 /// expected to inherit from [SingleChildRenderObjectWidget].
-class SingleChildRenderObjectElement extends RenderObjectElement<SingleChildRenderObjectWidget> {
+@optionalTypeArgs
+class SingleChildRenderObjectElement<S extends SingleChildRenderObjectWidget> extends RenderObjectElement<S> {
   /// Creates an element that uses the given widget as its configuration.
-  SingleChildRenderObjectElement(SingleChildRenderObjectWidget widget) : super(widget);
+  SingleChildRenderObjectElement(S widget) : super(widget);
 
   Element? _child;
 
@@ -6344,14 +6342,12 @@ class SingleChildRenderObjectElement extends RenderObjectElement<SingleChildRend
 ///   [MultiChildRenderObjectElement].
 /// * [RenderObjectElement.updateChildren], which discusses why [IndexedSlot]
 ///   is used for the slots of the children.
-class MultiChildRenderObjectElement extends RenderObjectElement {
+@optionalTypeArgs
+class MultiChildRenderObjectElement<W extends MultiChildRenderObjectWidget> extends RenderObjectElement<W> {
   /// Creates an element that uses the given widget as its configuration.
-  MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget)
+  MultiChildRenderObjectElement(W widget)
     : assert(!debugChildrenHaveDuplicateKeys(widget, widget.children)),
       super(widget);
-
-  @override
-  MultiChildRenderObjectWidget get widget => super.widget as MultiChildRenderObjectWidget;
 
   @override
   ContainerRenderObjectMixin<RenderObject, ContainerParentDataMixin<RenderObject>> get renderObject {

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -954,7 +956,7 @@ class GestureDetector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
+    final Map<Type, GestureRecognizerFactory> gestures = HashMap<Type, GestureRecognizerFactory>();
 
     if (onTapDown != null ||
         onTapUp != null ||

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -180,12 +180,9 @@ abstract class InheritedModel<T> extends InheritedWidget {
 }
 
 /// An [Element] that uses a [InheritedModel] as its configuration.
-class InheritedModelElement<T> extends InheritedElement {
+class InheritedModelElement<T> extends InheritedElement<InheritedModel<T>> {
   /// Creates an element that uses the given widget as its configuration.
   InheritedModelElement(InheritedModel<T> widget) : super(widget);
-
-  @override
-  InheritedModel<T> get widget => super.widget as InheritedModel<T>;
 
   @override
   void updateDependencies(Element dependent, Object? aspect) {

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -90,13 +90,10 @@ abstract class InheritedNotifier<T extends Listenable> extends InheritedWidget {
   InheritedElement createElement() => _InheritedNotifierElement<T>(this);
 }
 
-class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
+class _InheritedNotifierElement<T extends Listenable> extends InheritedElement<InheritedNotifier<T>> {
   _InheritedNotifierElement(InheritedNotifier<T> widget) : super(widget) {
     widget.notifier?.addListener(_handleUpdate);
   }
-
-  @override
-  InheritedNotifier<T> get widget => super.widget as InheritedNotifier<T>;
 
   bool _dirty = false;
 

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -54,11 +54,8 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
   // updateRenderObject is redundant with the logic in the LayoutBuilderElement below.
 }
 
-class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderObjectElement {
+class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderObjectElement<ConstrainedLayoutBuilder<ConstraintType>> {
   _LayoutBuilderElement(ConstrainedLayoutBuilder<ConstraintType> widget) : super(widget);
-
-  @override
-  ConstrainedLayoutBuilder<ConstraintType> get widget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
 
   @override
   RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject as RenderConstrainedLayoutBuilder<ConstraintType, RenderObject>;

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -814,12 +814,9 @@ class _ListWheelScrollViewState extends State<ListWheelScrollView> {
 }
 
 /// Element that supports building children lazily for [ListWheelViewport].
-class ListWheelElement extends RenderObjectElement implements ListWheelChildManager {
+class ListWheelElement extends RenderObjectElement<ListWheelViewport> implements ListWheelChildManager {
   /// Creates an element that lazily builds children for the given widget.
   ListWheelElement(ListWheelViewport widget) : super(widget);
-
-  @override
-  ListWheelViewport get widget => super.widget as ListWheelViewport;
 
   @override
   RenderListWheelViewport get renderObject => super.renderObject as RenderListWheelViewport;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -575,11 +575,8 @@ class _Theatre extends MultiChildRenderObjectWidget {
   }
 }
 
-class _TheatreElement extends MultiChildRenderObjectElement {
+class _TheatreElement extends MultiChildRenderObjectElement<_Theatre> {
   _TheatreElement(_Theatre widget) : super(widget);
-
-  @override
-  _Theatre get widget => super.widget as _Theatre;
 
   @override
   _RenderTheatre get renderObject => super.renderObject as _RenderTheatre;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1091,7 +1091,8 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
 ///
 /// Implements [RenderSliverBoxChildManager], which lets this element manage
 /// the children of subclasses of [RenderSliverMultiBoxAdaptor].
-class SliverMultiBoxAdaptorElement extends RenderObjectElement implements RenderSliverBoxChildManager {
+@optionalTypeArgs
+class SliverMultiBoxAdaptorElement<W extends SliverMultiBoxAdaptorWidget> extends RenderObjectElement<W> implements RenderSliverBoxChildManager {
   /// Creates an element that lazily builds children for the given widget.
   ///
   /// If `replaceMovedChildren` is set to true, a new child is proactively
@@ -1103,14 +1104,11 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   /// layout offset of their children without looking at the layout offset of
   /// existing children this should be set to false (example:
   /// [RenderSliverFixedExtentList]) to avoid inflating unnecessary children.
-  SliverMultiBoxAdaptorElement(SliverMultiBoxAdaptorWidget widget, {bool replaceMovedChildren = false})
+  SliverMultiBoxAdaptorElement(W widget, {bool replaceMovedChildren = false})
      : _replaceMovedChildren = replaceMovedChildren,
        super(widget);
 
   final bool _replaceMovedChildren;
-
-  @override
-  SliverMultiBoxAdaptorWidget get widget => super.widget as SliverMultiBoxAdaptorWidget;
 
   @override
   RenderSliverMultiBoxAdaptor get renderObject => super.renderObject as RenderSliverMultiBoxAdaptor;
@@ -1674,11 +1672,8 @@ class SliverOffstage extends SingleChildRenderObjectWidget {
   SingleChildRenderObjectElement createElement() => _SliverOffstageElement(this);
 }
 
-class _SliverOffstageElement extends SingleChildRenderObjectElement {
+class _SliverOffstageElement extends SingleChildRenderObjectElement<SliverOffstage> {
   _SliverOffstageElement(SliverOffstage widget) : super(widget);
-
-  @override
-  SliverOffstage get widget => super.widget as SliverOffstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -245,7 +245,7 @@ class _FloatingHeaderState extends State<_FloatingHeader> {
   Widget build(BuildContext context) => widget.child;
 }
 
-class _SliverPersistentHeaderElement extends RenderObjectElement {
+class _SliverPersistentHeaderElement extends RenderObjectElement<_SliverPersistentHeaderRenderObjectWidget> {
   _SliverPersistentHeaderElement(
     _SliverPersistentHeaderRenderObjectWidget widget, {
     this.floating = false,
@@ -253,9 +253,6 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
        super(widget);
 
   final bool floating;
-
-  @override
-  _SliverPersistentHeaderRenderObjectWidget get widget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin get renderObject => super.renderObject as _RenderSliverPersistentHeaderForWidgetsMixin;

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -56,14 +56,11 @@ class SliverPrototypeExtentList extends SliverMultiBoxAdaptorWidget {
   }
 
   @override
-  SliverMultiBoxAdaptorElement createElement() => _SliverPrototypeExtentListElement(this);
+  SliverMultiBoxAdaptorElement<SliverPrototypeExtentList> createElement() => _SliverPrototypeExtentListElement(this);
 }
 
-class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
+class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement<SliverPrototypeExtentList> {
   _SliverPrototypeExtentListElement(SliverPrototypeExtentList widget) : super(widget);
-
-  @override
-  SliverPrototypeExtentList get widget => super.widget as SliverPrototypeExtentList;
 
   @override
   _RenderSliverPrototypeExtentList get renderObject => super.renderObject as _RenderSliverPrototypeExtentList;

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -185,14 +185,11 @@ mixin SlottedContainerRenderObjectMixin<S> on RenderBox {
 }
 
 /// Element used by the [SlottedMultiChildRenderObjectWidgetMixin].
-class SlottedRenderObjectElement<S> extends RenderObjectElement {
+class SlottedRenderObjectElement<S> extends RenderObjectElement<SlottedMultiChildRenderObjectWidgetMixin<S>> {
   /// Creates an element that uses the given widget as its configuration.
   SlottedRenderObjectElement(SlottedMultiChildRenderObjectWidgetMixin<S> widget) : super(widget);
 
   final Map<S, Element> _slotToChild = <S, Element>{};
-
-  @override
-  SlottedMultiChildRenderObjectWidgetMixin<S> get widget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
 
   @override
   SlottedContainerRenderObjectMixin<S> get renderObject => super.renderObject as SlottedContainerRenderObjectMixin<S>;

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -281,11 +281,8 @@ class Table extends RenderObjectWidget {
   }
 }
 
-class _TableElement extends RenderObjectElement {
+class _TableElement extends RenderObjectElement<Table> {
   _TableElement(Table widget) : super(widget);
-
-  @override
-  Table get widget => super.widget as Table;
 
   @override
   RenderTable get renderObject => super.renderObject as RenderTable;

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -188,7 +188,7 @@ class Viewport extends MultiChildRenderObjectWidget {
   }
 
   @override
-  MultiChildRenderObjectElement createElement() => _ViewportElement(this);
+  MultiChildRenderObjectElement<Viewport> createElement() => _ViewportElement(this);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -207,15 +207,12 @@ class Viewport extends MultiChildRenderObjectWidget {
   }
 }
 
-class _ViewportElement extends MultiChildRenderObjectElement {
+class _ViewportElement extends MultiChildRenderObjectElement<Viewport> {
   /// Creates an element that uses the given widget as its configuration.
   _ViewportElement(Viewport widget) : super(widget);
 
   bool _doingMountOrUpdate = false;
   int? _centerSlotIndex;
-
-  @override
-  Viewport get widget => super.widget as Viewport;
 
   @override
   RenderViewport get renderObject => super.renderObject as RenderViewport;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -546,7 +546,7 @@ class _ScreenshotPaintingContext extends PaintingContext {
   }) {
     RenderObject repaintBoundary = renderObject;
     while (repaintBoundary != null && !repaintBoundary.isRepaintBoundary) {
-      repaintBoundary = repaintBoundary.parent! as RenderObject;
+      repaintBoundary = repaintBoundary.parent!;
     }
     assert(repaintBoundary != null);
     final _ScreenshotData data = _ScreenshotData(target: renderObject);
@@ -1501,7 +1501,7 @@ mixin WidgetInspectorService {
     final List<RenderObject> chain = <RenderObject>[];
     while (renderObject != null) {
       chain.add(renderObject);
-      renderObject = renderObject.parent as RenderObject?;
+      renderObject = renderObject.parent;
     }
     return _followDiagnosticableChain(chain.reversed.toList());
   }
@@ -2550,7 +2550,7 @@ class _RenderInspectorOverlay extends RenderBox {
     context.addLayer(_InspectorOverlayLayer(
       overlayRect: Rect.fromLTWH(offset.dx, offset.dy, size.width, size.height),
       selection: selection,
-      rootRenderObject: parent is RenderObject ? parent! as RenderObject : null,
+      rootRenderObject: parent is RenderObject ? parent! : null,
     ));
   }
 }
@@ -2826,14 +2826,14 @@ class _InspectorOverlayLayer extends Layer {
   /// overlays in the same app (i.e. an storyboard), a selected or candidate
   /// render object may not belong to this tree.
   bool _isInInspectorRenderObjectTree(RenderObject child) {
-    RenderObject? current = child.parent as RenderObject?;
+    RenderObject? current = child.parent;
     while (current != null) {
       // We found the widget inspector render object.
       if (current is RenderStack
           && current.lastChild is _RenderInspectorOverlay) {
         return rootRenderObject == current;
       }
-      current = current.parent as RenderObject?;
+      current = current.parent;
     }
     return false;
   }

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -1226,7 +1226,7 @@ PhysicalModelLayer _findPhysicalLayer(Element element) {
   expect(element, isNotNull);
   RenderObject? object = element.renderObject;
   while (object != null && object is! RenderRepaintBoundary && object is! RenderView) {
-    object = object.parent as RenderObject?;
+    object = object.parent;
   }
   assert(object != null);
   expect(object!.debugLayer, isNotNull);

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1678,7 +1678,7 @@ PhysicalModelLayer _findPhysicalLayer(Element element) {
   expect(element, isNotNull);
   RenderObject? object = element.renderObject;
   while (object != null && object is! RenderRepaintBoundary && object is! RenderView) {
-    object = object.parent as RenderObject?;
+    object = object.parent;
   }
   expect(object!.debugLayer, isNotNull);
   expect(object.debugLayer!.firstChild, isA<PhysicalModelLayer>());

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1695,5 +1695,5 @@ Future<void> testGestureTap(WidgetTester tester, Finder tooltip) async {
 SemanticsNode findDebugSemantics(RenderObject object) {
   if (object.debugSemantics != null)
     return object.debugSemantics!;
-  return findDebugSemantics(object.parent! as RenderObject);
+  return findDebugSemantics(object.parent!);
 }

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -1315,5 +1315,5 @@ void main() {
 SemanticsNode findDebugSemantics(RenderObject object) {
   if (object.debugSemantics != null)
     return object.debugSemantics!;
-  return findDebugSemantics(object.parent! as RenderObject);
+  return findDebugSemantics(object.parent!);
 }

--- a/packages/flutter/test/rendering/non_render_object_root_test.dart
+++ b/packages/flutter/test/rendering/non_render_object_root_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'rendering_tester.dart';
 
-class RealRoot extends AbstractNode {
+class RealRoot extends AbstractNode<RenderObject> {
   RealRoot(this.child) {
     adoptChild(child);
   }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1652,7 +1652,7 @@ In order for an element to have a valid renderObject, it must be active, which m
 Instead, this element is in the _ElementLifecycle.defunct state.
 If you called this method from a State object, consider guarding it with State.mounted.
 The findRenderObject() method was called for the following element:
-  StatefulElement#00000(DEFUNCT)'''),
+  StatefulElement<StatefulWidget>#00000(DEFUNCT)'''),
       )),
     );
   });

--- a/packages/flutter/test/widgets/render_object_element_test.dart
+++ b/packages/flutter/test/widgets/render_object_element_test.dart
@@ -73,7 +73,7 @@ class SwapperWithDeprecatedOverrides extends Swapper {
   SwapperElement createElement() => SwapperElementWithDeprecatedOverrides(this);
 }
 
-abstract class SwapperElement extends RenderObjectElement {
+abstract class SwapperElement extends RenderObjectElement<Swapper> {
   SwapperElement(Swapper widget) : super(widget);
 
   Element? stable;
@@ -82,9 +82,6 @@ abstract class SwapperElement extends RenderObjectElement {
   List<dynamic> insertSlots = <dynamic>[];
   List<Pair<dynamic>> moveSlots = <Pair<dynamic>>[];
   List<dynamic> removeSlots = <dynamic>[];
-
-  @override
-  Swapper get widget => super.widget as Swapper;
 
   @override
   RenderSwapper get renderObject => super.renderObject as RenderSwapper;

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -308,7 +308,7 @@ mixin CommandHandlerFactory {
     SemanticsNode? node;
     while (renderObject != null && node == null) {
       node = renderObject.debugSemantics;
-      renderObject = renderObject.parent as RenderObject?;
+      renderObject = renderObject.parent;
     }
     if (node == null)
       throw StateError('No semantics data found');

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -23,7 +23,7 @@ Future<ui.Image> captureImage(Element element) {
   assert(element.renderObject != null);
   RenderObject renderObject = element.renderObject!;
   while (!renderObject.isRepaintBoundary) {
-    renderObject = renderObject.parent! as RenderObject;
+    renderObject = renderObject.parent!;
   }
   assert(!renderObject.debugNeedsPaint);
   final OffsetLayer layer = renderObject.debugLayer! as OffsetLayer;

--- a/packages/flutter_test/lib/src/_matchers_web.dart
+++ b/packages/flutter_test/lib/src/_matchers_web.dart
@@ -82,7 +82,7 @@ RenderObject _findRepaintBoundary(Element element) {
   assert(element.renderObject != null);
   RenderObject renderObject = element.renderObject!;
   while (!renderObject.isRepaintBoundary) {
-    renderObject = renderObject.parent! as RenderObject;
+    renderObject = renderObject.parent!;
   }
   return renderObject;
 }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1121,7 +1121,7 @@ abstract class WidgetController {
     RenderObject? renderObject = element.findRenderObject();
     SemanticsNode? result = renderObject?.debugSemantics;
     while (renderObject != null && (result == null || result.isMergedIntoParent)) {
-      renderObject = renderObject.parent as RenderObject?;
+      renderObject = renderObject.parent;
       result = renderObject?.debugSemantics;
     }
     if (result == null)


### PR DESCRIPTION
`as` casts are not free, and on the web the runtime as check implementation is in the top 2-3 hot functions. This is an attempt to remove as many as casts as possible
