### PR TITLE
Take screenshot when drive fails to start app or test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -240,22 +240,22 @@ class DriveCommand extends RunCommandBase {
     try {
       if (stringArg('use-existing-app') == null) {
         await driverService.start(
-            buildInfo,
-            device,
-            debuggingOptions,
-            ipv6,
-            applicationBinary: applicationBinary,
-            route: route,
-            userIdentifier: userIdentifier,
-            mainPath: targetFile,
-            platformArgs: <String, Object>{
-              if (traceStartup)
-                'trace-startup': traceStartup,
-              if (web)
-                '--no-launch-chrome': true,
-              if (boolArg('multidex'))
-                'multidex': true,
-            }
+          buildInfo,
+          device,
+          debuggingOptions,
+          ipv6,
+          applicationBinary: applicationBinary,
+          route: route,
+          userIdentifier: userIdentifier,
+          mainPath: targetFile,
+          platformArgs: <String, Object>{
+            if (traceStartup)
+              'trace-startup': traceStartup,
+            if (web)
+              '--no-launch-chrome': true,
+            if (boolArg('multidex'))
+              'multidex': true,
+          }
         );
       } else {
         final Uri uri = Uri.tryParse(stringArg('use-existing-app'));
@@ -285,9 +285,6 @@ class DriveCommand extends RunCommandBase {
         androidEmulator: boolArg('android-emulator'),
         profileMemory: stringArg('profile-memory'),
       );
-      if (testResult != 0 && screenshot != null) {
-        await _takeScreenshot(device);
-      }
 
       if (boolArg('keep-app-running') ?? (argResults['use-existing-app'] != null)) {
         _logger.printStatus('Leaving the application running.');

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -237,68 +237,77 @@ class DriveCommand extends RunCommandBase {
       ? null
       : _fileSystem.file(stringArg('use-application-binary'));
 
-    if (stringArg('use-existing-app') == null) {
-      await driverService.start(
-        buildInfo,
-        device,
-        debuggingOptions,
-        ipv6,
-        applicationBinary: applicationBinary,
-        route: route,
-        userIdentifier: userIdentifier,
-        mainPath: targetFile,
-        platformArgs: <String, Object>{
-          if (traceStartup)
-            'trace-startup': traceStartup,
-          if (web)
-            '--no-launch-chrome': true,
-          if (boolArg('multidex'))
-            'multidex': true,
+    try {
+      if (stringArg('use-existing-app') == null) {
+        await driverService.start(
+            buildInfo,
+            device,
+            debuggingOptions,
+            ipv6,
+            applicationBinary: applicationBinary,
+            route: route,
+            userIdentifier: userIdentifier,
+            mainPath: targetFile,
+            platformArgs: <String, Object>{
+              if (traceStartup)
+                'trace-startup': traceStartup,
+              if (web)
+                '--no-launch-chrome': true,
+              if (boolArg('multidex'))
+                'multidex': true,
+            }
+        );
+      } else {
+        final Uri uri = Uri.tryParse(stringArg('use-existing-app'));
+        if (uri == null) {
+          throwToolExit('Invalid VM Service URI: ${stringArg('use-existing-app')}');
         }
-      );
-    } else {
-      final Uri uri = Uri.tryParse(stringArg('use-existing-app'));
-      if (uri == null) {
-        throwToolExit('Invalid VM Service URI: ${stringArg('use-existing-app')}');
+        await driverService.reuseApplication(
+          uri,
+          device,
+          debuggingOptions,
+          ipv6,
+        );
       }
-      await driverService.reuseApplication(
-        uri,
-        device,
-        debuggingOptions,
-        ipv6,
+
+      final int testResult = await driverService.startTest(
+        testFile,
+        stringsArg('test-arguments'),
+        <String, String>{},
+        packageConfig,
+        chromeBinary: stringArg('chrome-binary'),
+        headless: boolArg('headless'),
+        browserDimension: stringArg('browser-dimension').split(','),
+        browserName: stringArg('browser-name'),
+        driverPort: stringArg('driver-port') != null
+          ? int.tryParse(stringArg('driver-port'))
+          : null,
+        androidEmulator: boolArg('android-emulator'),
+        profileMemory: stringArg('profile-memory'),
       );
+      if (testResult != 0 && screenshot != null) {
+        await _takeScreenshot(device);
+      }
+
+      if (boolArg('keep-app-running') ?? (argResults['use-existing-app'] != null)) {
+        _logger.printStatus('Leaving the application running.');
+      } else {
+        final File skslFile = stringArg('write-sksl-on-exit') != null
+          ? _fileSystem.file(stringArg('write-sksl-on-exit'))
+          : null;
+        await driverService.stop(userIdentifier: userIdentifier, writeSkslOnExit: skslFile);
+      }
+      if (testResult != 0) {
+        throwToolExit(null);
+      }
+    } on Exception catch(_) {
+      // On exceptions, including ToolExit, take a screenshot on the device.
+      if (screenshot != null) {
+        await _takeScreenshot(device);
+      }
+      rethrow;
     }
 
-    final int testResult = await driverService.startTest(
-      testFile,
-      stringsArg('test-arguments'),
-      <String, String>{},
-      packageConfig,
-      chromeBinary: stringArg('chrome-binary'),
-      headless: boolArg('headless'),
-      browserDimension: stringArg('browser-dimension').split(','),
-      browserName: stringArg('browser-name'),
-      driverPort: stringArg('driver-port') != null
-        ? int.tryParse(stringArg('driver-port'))
-        : null,
-      androidEmulator: boolArg('android-emulator'),
-      profileMemory: stringArg('profile-memory'),
-    );
-    if (testResult != 0 && screenshot != null) {
-      await takeScreenshot(device, screenshot, _fileSystem, _logger, _fsUtils);
-    }
-
-    if (boolArg('keep-app-running') ?? (argResults['use-existing-app'] != null)) {
-      _logger.printStatus('Leaving the application running.');
-    } else {
-      final File skslFile = stringArg('write-sksl-on-exit') != null
-        ? _fileSystem.file(stringArg('write-sksl-on-exit'))
-        : null;
-      await driverService.stop(userIdentifier: userIdentifier, writeSkslOnExit: skslFile);
-    }
-    if (testResult != 0) {
-      throwToolExit(null);
-    }
     return FlutterCommandResult.success();
   }
 
@@ -344,27 +353,20 @@ class DriveCommand extends RunCommandBase {
       <String>[packageDir, 'test_driver', ...parts.skip(1)]));
     return '${pathWithNoExtension}_test${_fileSystem.path.extension(appFile)}';
   }
-}
 
-@visibleForTesting
-Future<void> takeScreenshot(
-  Device device,
-  String screenshotPath,
-  FileSystem fileSystem,
-  Logger logger,
-  FileSystemUtils fileSystemUtils,
-) async {
-  try {
-    final Directory outputDirectory = fileSystem.directory(screenshotPath);
-    outputDirectory.createSync(recursive: true);
-    final File outputFile = fileSystemUtils.getUniqueFile(
-      outputDirectory,
-      'drive',
-      'png',
-    );
-    await device.takeScreenshot(outputFile);
-    logger.printStatus('Screenshot written to ${outputFile.path}');
-  } on Exception catch (error) {
-    logger.printError('Error taking screenshot: $error');
+  Future<void> _takeScreenshot(Device device) async {
+    try {
+      final Directory outputDirectory = _fileSystem.directory(screenshot)
+        ..createSync(recursive: true);
+      final File outputFile = _fsUtils.getUniqueFile(
+        outputDirectory,
+        'drive',
+        'png',
+      );
+      await device.takeScreenshot(outputFile);
+      _logger.printStatus('Screenshot written to ${outputFile.path}');
+    } on Exception catch (error) {
+      _logger.printError('Error taking screenshot: $error');
+    }
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -5,13 +5,17 @@
 // @dart = 2.8
 
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/application_package.dart';
+import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/drive.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -22,11 +26,13 @@ void main() {
   FileSystem fileSystem;
   BufferLogger logger;
   Platform platform;
+  FakeDeviceManager fakeDeviceManager;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     logger = BufferLogger.test();
     platform = FakePlatform();
+    fakeDeviceManager = FakeDeviceManager();
   });
 
   setUpAll(() {
@@ -37,41 +43,65 @@ void main() {
     Cache.enableLocking();
   });
 
+  testUsingContext('takes screenshot and rethrows on drive failure', () async {
+    final DriveCommand command = DriveCommand(fileSystem: fileSystem, logger: logger, platform: platform);
+    fileSystem.file('lib/main.dart').createSync(recursive: true);
+    fileSystem.file('test_driver/main_test.dart').createSync(recursive: true);
+    fileSystem.file('pubspec.yaml').createSync();
+    fileSystem.directory('drive_screenshots').createSync();
 
-  testWithoutContext('drive --screenshot writes to expected output', () async {
-    final Device screenshotDevice = ScreenshotDevice();
+    final Device screenshotDevice = ThrowingScreenshotDevice();
+    fakeDeviceManager.devices = <Device>[screenshotDevice];
 
-    await takeScreenshot(
-      screenshotDevice,
-      'drive_screenshots',
-      fileSystem,
-      logger,
-      FileSystemUtils(
-        fileSystem: fileSystem,
-        platform: platform,
-      ),
+    await expectLater(() => createTestCommandRunner(command).run(
+      <String>[
+        'drive',
+        '--no-pub',
+        '-d',
+        screenshotDevice.id,
+        '--screenshot',
+        'drive_screenshots',
+      ]),
+      throwsToolExit(message: 'cannot start app'),
     );
 
     expect(logger.statusText, contains('Screenshot written to drive_screenshots/drive_01.png'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    Pub: () => FakePub(),
+    DeviceManager: () => fakeDeviceManager,
   });
 
-  testWithoutContext('drive --screenshot errors but does not fail if screenshot fails', () async {
-    final Device screenshotDevice = ScreenshotDevice();
+  testUsingContext('drive --screenshot errors but does not fail if screenshot fails', () async {
+    final DriveCommand command = DriveCommand(fileSystem: fileSystem, logger: logger, platform: platform);
+    fileSystem.file('lib/main.dart').createSync(recursive: true);
+    fileSystem.file('test_driver/main_test.dart').createSync(recursive: true);
+    fileSystem.file('pubspec.yaml').createSync();
     fileSystem.file('drive_screenshots').createSync();
 
-    await takeScreenshot(
-      screenshotDevice,
-      'drive_screenshots',
-      fileSystem,
-      logger,
-      FileSystemUtils(
-        fileSystem: fileSystem,
-        platform: platform,
-      ),
+    final Device screenshotDevice = ThrowingScreenshotDevice();
+    fakeDeviceManager.devices = <Device>[screenshotDevice];
+
+    await expectLater(() => createTestCommandRunner(command).run(
+      <String>[
+        'drive',
+        '--no-pub',
+        '-d',
+        screenshotDevice.id,
+        '--screenshot',
+        'drive_screenshots',
+      ]),
+      throwsToolExit(message: 'cannot start app'),
     );
 
     expect(logger.statusText, isEmpty);
     expect(logger.errorText, contains('Error taking screenshot: FileSystemException: Not a directory'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    Pub: () => FakePub(),
+    DeviceManager: () => fakeDeviceManager,
   });
 
   testUsingContext('shouldRunPub is true unless user specifies --no-pub', () async {
@@ -105,7 +135,37 @@ void main() {
 // Unfortunately Device, despite not being immutable, has an `operator ==`.
 // Until we fix that, we have to also ignore related lints here.
 // ignore: avoid_implementing_value_types
-class ScreenshotDevice extends Fake implements Device {
+class ThrowingScreenshotDevice extends Fake implements Device {
+  @override
+  String get name => 'FakeDevice';
+
+  @override
+  Category get category => Category.mobile;
+
+  @override
+  String get id => 'fake_device';
+
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.android;
+
+  @override
+  bool get supportsScreenshot => true;
+
+  @override
+  Future<LaunchResult> startApp(
+    ApplicationPackage package, {
+      String mainPath,
+      String route,
+      DebuggingOptions debuggingOptions,
+      Map<String, dynamic> platformArgs,
+      bool prebuiltApplication = false,
+      bool usesTerminalUi = true,
+      bool ipv6 = false,
+      String userIdentifier,
+    }) async {
+    throwToolExit('cannot start app');
+  }
+
   @override
   Future<void> takeScreenshot(File outputFile) async {}
 }
@@ -124,4 +184,17 @@ class FakePub extends Fake implements Pub {
     bool shouldSkipThirdPartyGenerator = true,
     bool printProgress = true,
   }) async { }
+}
+
+class FakeDeviceManager extends Fake implements DeviceManager {
+  List<Device> devices = <Device>[];
+
+  @override
+  String specifiedDeviceId;
+
+  @override
+  Future<List<Device>> getDevices() async => devices;
+
+  @override
+  Future<List<Device>> findTargetDevices(FlutterProject flutterProject, {Duration timeout}) async => devices;
 }


### PR DESCRIPTION
Help debugging issues like https://github.com/flutter/flutter/issues/96401 by taking a screenshot of the device during `drive` when the app fails to start, or testing otherwise fails.

`drive --screenshot` introduced in https://github.com/flutter/flutter/pull/78822.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
