### PR TITLE
[Keyboard] Dispatch solitary synthesized `KeyEvent`s

### DIFF
--- a/packages/flutter/lib/src/services/raw_keyboard.dart
+++ b/packages/flutter/lib/src/services/raw_keyboard.dart
@@ -650,7 +650,11 @@ class RawKeyboard {
     _cachedKeyEventHandler = handler;
     _cachedKeyMessageHandler = handler == null ?
       null :
-      (KeyMessage message) => handler(message.rawEvent);
+      (KeyMessage message) {
+        if (message.rawEvent != null)
+          return handler(message.rawEvent!);
+        return false;
+      };
     ServicesBinding.instance!.keyEventManager.keyMessageHandler = _cachedKeyMessageHandler;
   }
 

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -1681,8 +1681,8 @@ class FocusManager with DiagnosticableTreeMixin, ChangeNotifier {
           results.add(node.onKeyEvent!(node, event));
         }
       }
-      if (node.onKey != null) {
-        results.add(node.onKey!(node, message.rawEvent));
+      if (node.onKey != null && message.rawEvent != null) {
+        results.add(node.onKey!(node, message.rawEvent!));
       }
       final KeyEventResult result = combineKeyEventResults(results);
       switch (result) {


### PR DESCRIPTION
This PR fixes a problem where if the keyboard embedder handler synthesized a `KeyData` without any raw key messages (which we call "solitary synthesized key events"), this key event would not be dispatched.

The assumption that all `KeyData`s come from actual key presses and are always followed by raw key messages, turns out to be false. On Web, key guards will synthesize key up events, but the guarded up events from `keyboard.dart` are separate from those from `keyboard_binding.dart`. Instead of changing the engine structure, we resolve this problem by dispatching these synthesized key events immediately if the queue is empty, instead of pushing it to the queue and waiting for the raw message. This is possible because:

- Synthesized key events don't care about and don't affect event results, so they can be dispatched freely.
- The queue is empty, so the event order won't be disrupted.

Fixes https://github.com/flutter/flutter/issues/96749.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
