### PR TITLE
Removed the date from the Next/Previous month button's semantics for the Date Picker.

### DIFF
--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -490,8 +490,6 @@ class _MonthPicker extends StatefulWidget {
 class _MonthPickerState extends State<_MonthPicker> {
   final GlobalKey _pageViewKey = GlobalKey();
   late DateTime _currentMonth;
-  late DateTime _nextMonthDate;
-  late DateTime _previousMonthDate;
   late PageController _pageController;
   late MaterialLocalizations _localizations;
   late TextDirection _textDirection;
@@ -504,8 +502,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   void initState() {
     super.initState();
     _currentMonth = widget.initialMonth;
-    _previousMonthDate = DateUtils.addMonthsToMonthDate(_currentMonth, -1);
-    _nextMonthDate = DateUtils.addMonthsToMonthDate(_currentMonth, 1);
     _pageController = PageController(initialPage: DateUtils.monthDelta(widget.firstDate, _currentMonth));
     _shortcutMap = const <ShortcutActivator, Intent>{
       SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
@@ -556,8 +552,6 @@ class _MonthPickerState extends State<_MonthPicker> {
       final DateTime monthDate = DateUtils.addMonthsToMonthDate(widget.firstDate, monthPage);
       if (!DateUtils.isSameMonth(_currentMonth, monthDate)) {
         _currentMonth = DateTime(monthDate.year, monthDate.month);
-        _previousMonthDate = DateUtils.addMonthsToMonthDate(_currentMonth, -1);
-        _nextMonthDate = DateUtils.addMonthsToMonthDate(_currentMonth, 1);
         widget.onDisplayedMonthChanged(_currentMonth);
         if (_focusedDay != null && !DateUtils.isSameMonth(_focusedDay, _currentMonth)) {
           // We have navigated to a new month with the grid focused, but the
@@ -565,6 +559,10 @@ class _MonthPickerState extends State<_MonthPicker> {
           // the same day of the month.
           _focusedDay = _focusableDayForMonth(_currentMonth, _focusedDay!.day);
         }
+        SemanticsService.announce(
+          _localizations.formatMonthYear(_currentMonth),
+          _textDirection,
+        );
       }
     });
   }
@@ -596,10 +594,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   /// Navigate to the next month.
   void _handleNextMonth() {
     if (!_isDisplayingLastMonth) {
-      SemanticsService.announce(
-        _localizations.formatMonthYear(_nextMonthDate),
-        _textDirection,
-      );
       _pageController.nextPage(
         duration: _monthScrollDuration,
         curve: Curves.ease,
@@ -610,10 +604,6 @@ class _MonthPickerState extends State<_MonthPicker> {
   /// Navigate to the previous month.
   void _handlePreviousMonth() {
     if (!_isDisplayingFirstMonth) {
-      SemanticsService.announce(
-        _localizations.formatMonthYear(_previousMonthDate),
-        _textDirection,
-      );
       _pageController.previousPage(
         duration: _monthScrollDuration,
         curve: Curves.ease,
@@ -748,8 +738,6 @@ class _MonthPickerState extends State<_MonthPicker> {
 
   @override
   Widget build(BuildContext context) {
-    final String previousTooltipText = '${_localizations.previousMonthTooltip} ${_localizations.formatMonthYear(_previousMonthDate)}';
-    final String nextTooltipText = '${_localizations.nextMonthTooltip} ${_localizations.formatMonthYear(_nextMonthDate)}';
     final Color controlColor = Theme.of(context).colorScheme.onSurface.withOpacity(0.60);
 
     return Semantics(
@@ -764,13 +752,13 @@ class _MonthPickerState extends State<_MonthPicker> {
                 IconButton(
                   icon: const Icon(Icons.chevron_left),
                   color: controlColor,
-                  tooltip: _isDisplayingFirstMonth ? null : previousTooltipText,
+                  tooltip: _isDisplayingFirstMonth ? null : _localizations.previousMonthTooltip,
                   onPressed: _isDisplayingFirstMonth ? null : _handlePreviousMonth,
                 ),
                 IconButton(
                   icon: const Icon(Icons.chevron_right),
                   color: controlColor,
-                  tooltip: _isDisplayingLastMonth ? null : nextTooltipText,
+                  tooltip: _isDisplayingLastMonth ? null : _localizations.nextMonthTooltip,
                   onPressed: _isDisplayingLastMonth ? null : _handleNextMonth,
                 ),
               ],

--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -649,7 +649,7 @@ void main() {
 
         // Prev/Next month buttons.
         expect(tester.getSemantics(previousMonthIcon), matchesSemantics(
-          label: 'Previous month December 2015',
+          label: 'Previous month',
           isButton: true,
           hasTapAction: true,
           isEnabled: true,
@@ -657,7 +657,7 @@ void main() {
           isFocusable: true,
         ));
         expect(tester.getSemantics(nextMonthIcon), matchesSemantics(
-          label: 'Next month February 2016',
+          label: 'Next month',
           isButton: true,
           hasTapAction: true,
           isEnabled: true,


### PR DESCRIPTION
The current Date Picker presents semantics for the next/previous month buttons as 'Next month, July 2022' and will update them with the next or previous date as the user selects a new month. While this is fine for the tooltips, it is verbose for the semantics and causes the button to announce itself twice (once when it is pressed and once again when the date changes). 

This PR removes the date from the semantics for these buttons so they are just 'Next month' or 'Previous month'. We also announce the new displayed month after the month changes. This should yield a smoother a11y experience when navigating the picker.

Fixes: #96643

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
