### PR TITLE
[flutter_tools] remove dummy implementation from abstract class .isEnabled()

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -53,7 +53,7 @@ abstract class FeatureFlags {
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
-  bool isEnabled(Feature feature) => false;
+  bool isEnabled(Feature feature);
 }
 
 /// All current Flutter feature flags.
@@ -141,15 +141,19 @@ const Feature flutterWindowsDesktopFeature = Feature(
   extraHelpText: 'Newer beta versions are available on the beta channel.',
   master: FeatureChannelSetting(
     available: true,
+    enabledByDefault: true,
   ),
   dev: FeatureChannelSetting(
     available: true,
+    enabledByDefault: true,
   ),
   beta: FeatureChannelSetting(
     available: true,
+    enabledByDefault: true,
   ),
   stable: FeatureChannelSetting(
     available: true,
+    enabledByDefault: true,
   ),
 );
 

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -98,7 +98,6 @@ const Feature flutterMacOSDesktopFeature = Feature(
   name: 'beta-quality support for desktop on macOS',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'FLUTTER_MACOS',
-  extraHelpText: 'Newer beta versions are available on the beta channel.',
   master: FeatureChannelSetting(
     available: true,
   ),

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -98,6 +98,7 @@ const Feature flutterMacOSDesktopFeature = Feature(
   name: 'beta-quality support for desktop on macOS',
   configSetting: 'enable-macos-desktop',
   environmentOverride: 'FLUTTER_MACOS',
+  extraHelpText: 'Newer beta versions are available on the beta channel.',
   master: FeatureChannelSetting(
     available: true,
   ),
@@ -137,7 +138,6 @@ const Feature flutterWindowsDesktopFeature = Feature(
   name: 'beta-quality support for desktop on Windows',
   configSetting: 'enable-windows-desktop',
   environmentOverride: 'FLUTTER_WINDOWS',
-  extraHelpText: 'Newer beta versions are available on the beta channel.',
   master: FeatureChannelSetting(
     available: true,
     enabledByDefault: true,

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -93,22 +93,19 @@ void main() {
     testWithoutContext('Flutter macOS desktop help string', () {
       expect(flutterMacOSDesktopFeature.generateHelpMessage(),
       'Enable or disable beta-quality support for desktop on macOS. '
-      'This setting will take effect on the master, dev, beta, and stable channels. '
-      'Newer beta versions are available on the beta channel.');
+      'This setting will take effect on the master, dev, beta, and stable channels.');
     });
 
     testWithoutContext('Flutter Linux desktop help string', () {
       expect(flutterLinuxDesktopFeature.generateHelpMessage(),
       'Enable or disable beta-quality support for desktop on Linux. '
-      'This setting will take effect on the master, dev, beta, and stable channels. '
-      'Newer beta versions are available on the beta channel.');
+      'This setting will take effect on the master, dev, beta, and stable channels.');
     });
 
     testWithoutContext('Flutter Windows desktop help string', () {
       expect(flutterWindowsDesktopFeature.generateHelpMessage(),
       'Enable or disable beta-quality support for desktop on Windows. '
-      'This setting will take effect on the master, dev, beta, and stable channels. '
-      'Newer beta versions are available on the beta channel.');
+      'This setting will take effect on the master, dev, beta, and stable channels.');
     });
 
     testWithoutContext('help string on multiple channels', () {

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -93,13 +93,15 @@ void main() {
     testWithoutContext('Flutter macOS desktop help string', () {
       expect(flutterMacOSDesktopFeature.generateHelpMessage(),
       'Enable or disable beta-quality support for desktop on macOS. '
-      'This setting will take effect on the master, dev, beta, and stable channels.');
+      'This setting will take effect on the master, dev, beta, and stable channels. '
+      'Newer beta versions are available on the beta channel.');
     });
 
     testWithoutContext('Flutter Linux desktop help string', () {
       expect(flutterLinuxDesktopFeature.generateHelpMessage(),
       'Enable or disable beta-quality support for desktop on Linux. '
-      'This setting will take effect on the master, dev, beta, and stable channels.');
+      'This setting will take effect on the master, dev, beta, and stable channels. '
+      'Newer beta versions are available on the beta channel.');
     });
 
     testWithoutContext('Flutter Windows desktop help string', () {


### PR DESCRIPTION
Remove unused implementation of `isEnabled` in abstract class to ensure that it is not used by a future implementation that does not override.