### PR TITLE
removes `Material` from tests of `FooButton`s that implement it internally

### DIFF
--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -419,20 +419,18 @@ void main() {
     final GlobalKey childKey = GlobalKey();
     bool hovering = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: ElevatedButton(
-              autofocus: true,
-              onPressed: () {},
-              onLongPress: () {},
-              onHover: (bool value) { hovering = value; },
-              focusNode: focusNode,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: ElevatedButton(
+            autofocus: true,
+            onPressed: () {},
+            onLongPress: () {},
+            onHover: (bool value) { hovering = value; },
+            focusNode: focusNode,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -447,18 +445,16 @@ void main() {
     expect(hovering, isTrue);
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: ElevatedButton(
-              focusNode: focusNode,
-              onHover: (bool value) { hovering = value; },
-              onPressed: null,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: ElevatedButton(
+            focusNode: focusNode,
+            onHover: (bool value) { hovering = value; },
+            onPressed: null,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -473,21 +469,19 @@ void main() {
     late bool hover;
 
     Widget buildFrame({ required bool enabled }) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: ElevatedButton(
-                onPressed: enabled ? () { } : null,
-                onHover: (bool value) {
-                  onHoverCount += 1;
-                  hover = value;
-                },
-                child: const Text('ElevatedButton'),
-              ),
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: ElevatedButton(
+              onPressed: enabled ? () { } : null,
+              onHover: (bool value) {
+                onHoverCount += 1;
+                hover = value;
+              },
+              child: const Text('ElevatedButton'),
             ),
           ),
         ),
@@ -537,15 +531,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'ElevatedButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: ElevatedButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: () {  },
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: () {  },
+          child: const SizedBox(),
         ),
       ),
     );
@@ -568,15 +560,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'ElevatedButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: ElevatedButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: null,
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ElevatedButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: null,
+          child: const SizedBox(),
         ),
       ),
     );
@@ -681,18 +671,16 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: ElevatedButton(
-              style: ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the semantics tree's rect and transform
-                // match the original version of this test.
-                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
-              ),
-              onPressed: () { },
-              child: const Text('ABC'),
+        child: Center(
+          child: ElevatedButton(
+            style: ButtonStyle(
+              // Specifying minimumSize to mimic the original minimumSize for
+              // RaisedButton so that the semantics tree's rect and transform
+              // match the original version of this test.
+              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
             ),
+            onPressed: () { },
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -736,14 +724,12 @@ void main() {
         data: ThemeData(materialTapTargetSize: tapTargetSize),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: ElevatedButton(
-                key: key,
-                style: style,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: ElevatedButton(
+              key: key,
+              style: style,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -763,11 +749,9 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: ElevatedButton(
-            onPressed: () { /* to make sure the button is enabled */ },
-            child: const Text('button'),
-          ),
+        child: ElevatedButton(
+          onPressed: () { /* to make sure the button is enabled */ },
+          child: const Text('button'),
         ),
       ),
     );
@@ -855,19 +839,17 @@ void main() {
       // horizontal padding is applied correctly later on
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: ElevatedButton.icon(
-              key: buttonKey,
-              style: ButtonStyle(
-                padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.fromLTRB(16, 5, 10, 12)),
-              ),
-              onPressed: () {},
-              icon: const Icon(Icons.add),
-              label: const Text(
-                'Hello',
-                key: labelKey,
-              ),
+        child: Center(
+          child: ElevatedButton.icon(
+            key: buttonKey,
+            style: ButtonStyle(
+              padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.fromLTRB(16, 5, 10, 12)),
+            ),
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text(
+              'Hello',
+              key: labelKey,
             ),
           ),
         ),

--- a/packages/flutter/test/material/flat_button_test.dart
+++ b/packages/flutter/test/material/flat_button_test.dart
@@ -395,11 +395,9 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: FlatButton(
-            child: Container(),
-            onPressed: () { /* to make sure the button is enabled */ },
-          ),
+        child: FlatButton(
+          child: Container(),
+          onPressed: () { /* to make sure the button is enabled */ },
         ),
       ),
     );
@@ -536,12 +534,10 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: FlatButton(
-              onPressed: () { },
-              child: const Text('ABC'),
-            ),
+        child: Center(
+          child: FlatButton(
+            onPressed: () { },
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -576,14 +572,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Center(
-              child: FlatButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Center(
+            child: FlatButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -597,14 +591,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 1.3),
-            child: Center(
-              child: FlatButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 1.3),
+          child: Center(
+            child: FlatButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -621,14 +613,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 3.0),
-            child: Center(
-              child: FlatButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 3.0),
+          child: Center(
+            child: FlatButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -650,13 +640,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: FlatButton(
-                key: key1,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: FlatButton(
+              key: key1,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -671,13 +659,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: FlatButton(
-                key: key2,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: FlatButton(
+              key: key2,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -897,11 +897,9 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: FloatingActionButton(
-            focusNode: focusNode,
-            onPressed: () { /* to make sure the button is enabled */ },
-          ),
+        child: FloatingActionButton(
+          focusNode: focusNode,
+          onPressed: () { /* to make sure the button is enabled */ },
         ),
       ),
     );

--- a/packages/flutter/test/material/material_button_test.dart
+++ b/packages/flutter/test/material/material_button_test.dart
@@ -431,14 +431,12 @@ void main() {
     const Color directSplashColor = Color(0xFF000011);
     const Color directHighlightColor = Color(0xFF000011);
 
-    Widget buttonWidget = Material(
-      child: Center(
-        child: MaterialButton(
-          splashColor: directSplashColor,
-          highlightColor: directHighlightColor,
-          onPressed: () { /* to make sure the button is enabled */ },
-          clipBehavior: Clip.antiAlias,
-        ),
+    Widget buttonWidget = Center(
+      child: MaterialButton(
+        splashColor: directSplashColor,
+        highlightColor: directHighlightColor,
+        onPressed: () { /* to make sure the button is enabled */ },
+        clipBehavior: Clip.antiAlias,
       ),
     );
 
@@ -459,14 +457,16 @@ void main() {
     await tester.pump(); // start gesture
     await tester.pump(const Duration(milliseconds: 200)); // wait for splash to be well under way
 
-    const Rect expectedClipRect = Rect.fromLTRB(356.0, 282.0, 444.0, 318.0);
+    // Painter is translated to the center by the Center widget and not
+    // the Material widget.
+    const Rect expectedClipRect = Rect.fromLTRB(0.0, 0.0, 88.0, 36.0);
     final Path expectedClipPath = Path()
       ..addRRect(RRect.fromRectAndRadius(
           expectedClipRect,
           const Radius.circular(2.0),
       ));
     expect(
-      Material.of(tester.element(find.byType(MaterialButton))),
+      Material.of(tester.element(find.byType(InkWell))),
       paints
         ..clipPath(pathMatcher: coversSameAreaAs(
             expectedClipPath,
@@ -479,12 +479,10 @@ void main() {
     const Color themeSplashColor1 = Color(0xFF001100);
     const Color themeHighlightColor1 = Color(0xFF001100);
 
-    buttonWidget = Material(
-      child: Center(
-        child: MaterialButton(
-          onPressed: () { /* to make sure the button is enabled */ },
-          clipBehavior: Clip.antiAlias,
-        ),
+    buttonWidget = Center(
+      child: MaterialButton(
+        onPressed: () { /* to make sure the button is enabled */ },
+        clipBehavior: Clip.antiAlias,
       ),
     );
 
@@ -503,7 +501,7 @@ void main() {
     );
 
     expect(
-      Material.of(tester.element(find.byType(MaterialButton))),
+      Material.of(tester.element(find.byType(InkWell))),
       paints
         ..clipPath(pathMatcher: coversSameAreaAs(
             expectedClipPath,
@@ -531,7 +529,7 @@ void main() {
     );
 
     expect(
-      Material.of(tester.element(find.byType(MaterialButton))),
+      Material.of(tester.element(find.byType(InkWell))),
       paints
         ..circle(color: themeSplashColor2)
         ..rect(color: themeHighlightColor2),
@@ -542,12 +540,10 @@ void main() {
 
   testWidgets('MaterialButton has no clip by default', (WidgetTester tester) async {
     final GlobalKey buttonKey = GlobalKey();
-    final Widget buttonWidget = Material(
-      child: Center(
-        child: MaterialButton(
-          key: buttonKey,
-          onPressed: () { /* to make sure the button is enabled */ },
-        ),
+    final Widget buttonWidget = Center(
+      child: MaterialButton(
+        key: buttonKey,
+        onPressed: () { /* to make sure the button is enabled */ },
       ),
     );
 
@@ -583,12 +579,10 @@ void main() {
     // enabled button
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
-      child: Material(
-        child: Center(
-          child: MaterialButton(
-            child: const Text('Button'),
-            onPressed: () { /* to make sure the button is enabled */ },
-          ),
+      child: Center(
+        child: MaterialButton(
+          child: const Text('Button'),
+          onPressed: () { /* to make sure the button is enabled */ },
         ),
       ),
     ));
@@ -618,12 +612,10 @@ void main() {
     // disabled button
     await tester.pumpWidget(const Directionality(
       textDirection: TextDirection.ltr,
-      child: Material(
-        child: Center(
-          child: MaterialButton(
-            onPressed: null, // button is disabled
-            child: Text('Button'),
-          ),
+      child: Center(
+        child: MaterialButton(
+          onPressed: null, // button is disabled
+          child: Text('Button'),
         ),
       ),
     ));
@@ -724,13 +716,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: MaterialButton(
-                key: key1,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: MaterialButton(
+              key: key1,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -745,13 +735,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: MaterialButton(
-                key: key2,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: MaterialButton(
+              key: key2,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),

--- a/packages/flutter/test/material/outline_button_test.dart
+++ b/packages/flutter/test/material/outline_button_test.dart
@@ -845,13 +845,11 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton(
-              key: buttonKey,
-              onPressed: () {},
-              child: const Text('ABC'),
-            ),
+        child: Center(
+          child: OutlineButton(
+            key: buttonKey,
+            onPressed: () {},
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -868,12 +866,10 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton(
-              onPressed: () {},
-              child: const Text('ABC'),
-            ),
+        child: Center(
+          child: OutlineButton(
+            onPressed: () {},
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -908,14 +904,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Center(
-              child: OutlineButton(
-                onPressed: () {},
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Center(
+            child: OutlineButton(
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -929,14 +923,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 1.3),
-            child: Center(
-              child: FlatButton(
-                onPressed: () {},
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 1.3),
+          child: Center(
+            child: FlatButton(
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -953,14 +945,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 3.0),
-            child: Center(
-              child: FlatButton(
-                onPressed: () {},
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 3.0),
+          child: Center(
+            child: FlatButton(
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -1043,13 +1033,11 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton(
-              materialTapTargetSize: MaterialTapTargetSize.padded,
-              onPressed: () {},
-              child: const SizedBox(width: 50.0, height: 8.0),
-            ),
+        child: Center(
+          child: OutlineButton(
+            materialTapTargetSize: MaterialTapTargetSize.padded,
+            onPressed: () {},
+            child: const SizedBox(width: 50.0, height: 8.0),
           ),
         ),
       ),
@@ -1061,13 +1049,11 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton(
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              onPressed: () {},
-              child: const SizedBox(width: 50.0, height: 8.0),
-            ),
+        child: Center(
+          child: OutlineButton(
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            onPressed: () {},
+            child: const SizedBox(width: 50.0, height: 8.0),
           ),
         ),
       ),
@@ -1080,15 +1066,13 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton.icon(
-              key: key1,
-              materialTapTargetSize: MaterialTapTargetSize.padded,
-              icon: const Icon(Icons.add_alarm),
-              label: const SizedBox(width: 50.0, height: 8.0),
-              onPressed: () { },
-            ),
+        child: Center(
+          child: OutlineButton.icon(
+            key: key1,
+            materialTapTargetSize: MaterialTapTargetSize.padded,
+            icon: const Icon(Icons.add_alarm),
+            label: const SizedBox(width: 50.0, height: 8.0),
+            onPressed: () { },
           ),
         ),
       ),
@@ -1107,15 +1091,13 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlineButton.icon(
-              key: key2,
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              icon: const Icon(Icons.add),
-              label: const SizedBox(width: 50.0, height: 8.0),
-              onPressed: () { },
-            ),
+        child: Center(
+          child: OutlineButton.icon(
+            key: key2,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            icon: const Icon(Icons.add),
+            label: const SizedBox(width: 50.0, height: 8.0),
+            onPressed: () { },
           ),
         ),
       ),

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -617,20 +617,18 @@ void main() {
     final GlobalKey childKey = GlobalKey();
     bool hovering = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: OutlinedButton(
-              autofocus: true,
-              onPressed: () {},
-              onLongPress: () {},
-              onHover: (bool value) { hovering = value; },
-              focusNode: focusNode,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: OutlinedButton(
+            autofocus: true,
+            onPressed: () {},
+            onLongPress: () {},
+            onHover: (bool value) { hovering = value; },
+            focusNode: focusNode,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -645,18 +643,16 @@ void main() {
     expect(hovering, isTrue);
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: OutlinedButton(
-              focusNode: focusNode,
-              onHover: (bool value) { hovering = value; },
-              onPressed: null,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: OutlinedButton(
+            focusNode: focusNode,
+            onHover: (bool value) { hovering = value; },
+            onPressed: null,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -671,21 +667,19 @@ void main() {
     late bool hover;
 
     Widget buildFrame({ required bool enabled }) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: OutlinedButton(
-                onPressed: enabled ? () { } : null,
-                onHover: (bool value) {
-                  onHoverCount += 1;
-                  hover = value;
-                },
-                child: const Text('OutlinedButton'),
-              ),
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: OutlinedButton(
+              onPressed: enabled ? () { } : null,
+              onHover: (bool value) {
+                onHoverCount += 1;
+                hover = value;
+              },
+              child: const Text('OutlinedButton'),
             ),
           ),
         ),
@@ -735,15 +729,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'OutlinedButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: OutlinedButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: () {  },
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: OutlinedButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: () {  },
+          child: const SizedBox(),
         ),
       ),
     );
@@ -766,15 +758,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'OutlinedButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: OutlinedButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: null,
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: OutlinedButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: null,
+          child: const SizedBox(),
         ),
       ),
     );
@@ -909,13 +899,11 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlinedButton(
-              key: buttonKey,
-              onPressed: () {},
-              child: const Text('ABC'),
-            ),
+        child: Center(
+          child: OutlinedButton(
+            key: buttonKey,
+            onPressed: () {},
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -933,18 +921,16 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: OutlinedButton(
-              style: ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the corresponding button size matches
-                // the original version of this test.
-                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
-              ),
-              onPressed: () {},
-              child: const Text('ABC'),
+        child: Center(
+          child: OutlinedButton(
+            style: ButtonStyle(
+              // Specifying minimumSize to mimic the original minimumSize for
+              // RaisedButton so that the corresponding button size matches
+              // the original version of this test.
+              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
             ),
+            onPressed: () {},
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -979,20 +965,18 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Center(
-              child: OutlinedButton(
-                style: ButtonStyle(
-                  // Specifying minimumSize to mimic the original minimumSize for
-                  // RaisedButton so that the corresponding button size matches
-                  // the original version of this test.
-                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
-                ),
-                onPressed: () {},
-                child: const Text('ABC'),
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Center(
+            child: OutlinedButton(
+              style: ButtonStyle(
+                // Specifying minimumSize to mimic the original minimumSize for
+                // RaisedButton so that the corresponding button size matches
+                // the original version of this test.
+                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
               ),
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -1006,20 +990,18 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 1.3),
-            child: Center(
-              child: OutlinedButton(
-                style: ButtonStyle(
-                  // Specifying minimumSize to mimic the original minimumSize for
-                  // RaisedButton so that the corresponding button size matches
-                  // the original version of this test.
-                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
-                ),
-                onPressed: () {},
-                child: const Text('ABC'),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 1.3),
+          child: Center(
+            child: OutlinedButton(
+              style: ButtonStyle(
+                // Specifying minimumSize to mimic the original minimumSize for
+                // RaisedButton so that the corresponding button size matches
+                // the original version of this test.
+                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
               ),
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -1036,14 +1018,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 3.0),
-            child: Center(
-              child: OutlinedButton(
-                onPressed: () {},
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 3.0),
+          child: Center(
+            child: OutlinedButton(
+              onPressed: () {},
+              child: const Text('ABC'),
             ),
           ),
         ),

--- a/packages/flutter/test/material/raised_button_test.dart
+++ b/packages/flutter/test/material/raised_button_test.dart
@@ -529,12 +529,10 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: RaisedButton(
-              onPressed: () { },
-              child: const Text('ABC'),
-            ),
+        child: Center(
+          child: RaisedButton(
+            onPressed: () { },
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -572,13 +570,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.padded),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: RaisedButton(
-                key: key1,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: RaisedButton(
+              key: key1,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -593,13 +589,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: RaisedButton(
-                key: key2,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: RaisedButton(
+              key: key2,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -613,10 +607,8 @@ void main() {
     await tester.pumpWidget(
       Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: RaisedButton(
-              onPressed: () { /* to make sure the button is enabled */ },
-            ),
+          child: RaisedButton(
+            onPressed: () { /* to make sure the button is enabled */ },
           ),
       ),
     );
@@ -696,17 +688,15 @@ void main() {
       // horizontal padding is applied correctly later on
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: RaisedButton.icon(
-              icon: const Icon(Icons.add),
-              padding: const EdgeInsets.fromLTRB(16, 5, 10, 12),
-              key: buttonKey,
-              onPressed: () {},
-              label: const Text(
-                'Hello',
-                key: labelKey,
-              ),
+        child: Center(
+          child: RaisedButton.icon(
+            icon: const Icon(Icons.add),
+            padding: const EdgeInsets.fromLTRB(16, 5, 10, 12),
+            key: buttonKey,
+            onPressed: () {},
+            label: const Text(
+              'Hello',
+              key: labelKey,
             ),
           ),
         ),

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -395,11 +395,9 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: TextButton(
-            child: Container(),
-            onPressed: () { /* to make sure the button is enabled */ },
-          ),
+        child: TextButton(
+          child: Container(),
+          onPressed: () { /* to make sure the button is enabled */ },
         ),
       ),
     );
@@ -420,14 +418,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: TextButton(
-            style: ButtonStyle(
-              overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
-            ),
-            child: Container(),
-            onPressed: () { /* to make sure the button is enabled */ },
+        child: TextButton(
+          style: ButtonStyle(
+            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
+          child: Container(),
+          onPressed: () { /* to make sure the button is enabled */ },
         ),
       ),
     );
@@ -478,18 +474,16 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: TextButton(
-              style: ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the semantics tree's rect and transform
-                // match the original version of this test.
-                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
-              ),
-              onPressed: () { },
-              child: const Text('ABC'),
+        child: Center(
+          child: TextButton(
+            style: ButtonStyle(
+              // Specifying minimumSize to mimic the original minimumSize for
+              // RaisedButton so that the semantics tree's rect and transform
+              // match the original version of this test.
+              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
             ),
+            onPressed: () { },
+            child: const Text('ABC'),
           ),
         ),
       ),
@@ -524,14 +518,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Center(
-              child: TextButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Center(
+            child: TextButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -545,14 +537,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 1.3),
-            child: Center(
-              child: TextButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 1.3),
+          child: Center(
+            child: TextButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -570,14 +560,12 @@ void main() {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: MediaQuery(
-            data: const MediaQueryData(textScaleFactor: 3.0),
-            child: Center(
-              child: TextButton(
-                onPressed: () { },
-                child: const Text('ABC'),
-              ),
+        child: MediaQuery(
+          data: const MediaQueryData(textScaleFactor: 3.0),
+          child: Center(
+            child: TextButton(
+              onPressed: () { },
+              child: const Text('ABC'),
             ),
           ),
         ),
@@ -599,13 +587,11 @@ void main() {
         data: ThemeData(materialTapTargetSize: tapTargetSize),
         child: Directionality(
           textDirection: TextDirection.ltr,
-          child: Material(
-            child: Center(
-              child: TextButton(
-                key: key,
-                child: const SizedBox(width: 50.0, height: 8.0),
-                onPressed: () { },
-              ),
+          child: Center(
+            child: TextButton(
+              key: key,
+              child: const SizedBox(width: 50.0, height: 8.0),
+              onPressed: () { },
             ),
           ),
         ),
@@ -701,20 +687,18 @@ void main() {
     final GlobalKey childKey = GlobalKey();
     bool hovering = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: TextButton(
-              autofocus: true,
-              onPressed: () {},
-              onLongPress: () {},
-              onHover: (bool value) { hovering = value; },
-              focusNode: focusNode,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: TextButton(
+            autofocus: true,
+            onPressed: () {},
+            onLongPress: () {},
+            onHover: (bool value) { hovering = value; },
+            focusNode: focusNode,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -729,18 +713,16 @@ void main() {
     expect(hovering, isTrue);
 
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: SizedBox(
-            width: 100,
-            height: 100,
-            child: TextButton(
-              focusNode: focusNode,
-              onHover: (bool value) { hovering = value; },
-              onPressed: null,
-              child: SizedBox(key: childKey),
-            ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: TextButton(
+            focusNode: focusNode,
+            onHover: (bool value) { hovering = value; },
+            onPressed: null,
+            child: SizedBox(key: childKey),
           ),
         ),
       ),
@@ -755,21 +737,19 @@ void main() {
     late bool hover;
 
     Widget buildFrame({ required bool enabled }) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 100,
-              height: 100,
-              child: TextButton(
-                onPressed: enabled ? () { } : null,
-                onHover: (bool value) {
-                  onHoverCount += 1;
-                  hover = value;
-                },
-                child: const Text('TextButton'),
-              ),
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: TextButton(
+              onPressed: enabled ? () { } : null,
+              onHover: (bool value) {
+                onHoverCount += 1;
+                hover = value;
+              },
+              child: const Text('TextButton'),
             ),
           ),
         ),
@@ -819,15 +799,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'TextButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: TextButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: () {  },
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TextButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: () {  },
+          child: const SizedBox(),
         ),
       ),
     );
@@ -850,15 +828,13 @@ void main() {
     final FocusNode node = FocusNode(debugLabel: 'TextButton Focus');
     bool gotFocus = false;
     await tester.pumpWidget(
-      Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: TextButton(
-            focusNode: node,
-            onFocusChange: (bool focused) => gotFocus = focused,
-            onPressed: null,
-            child: const SizedBox(),
-          ),
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: TextButton(
+          focusNode: node,
+          onFocusChange: (bool focused) => gotFocus = focused,
+          onPressed: null,
+          child: const SizedBox(),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #96804 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
