### PR TITLE
[Icons] Prevent double underscores after replacement

### DIFF
--- a/dev/tools/test/update_icons_test.dart
+++ b/dev/tools/test/update_icons_test.dart
@@ -36,4 +36,8 @@ void main() {
       expect(testIsStable(codepointsC, codepointsA), true);
     });
   });
+
+  test('no double underscores', () {
+    expect(Icon.generateFlutterId('abc__123'), 'abc_123');
+  });
 }

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -518,7 +518,7 @@ class Icon {
         );
       }
     }
-    
+
     // Prevent double underscores.
     flutterId = flutterId.replaceAll('__', '_');
 

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -275,10 +275,10 @@ String _regenerateIconsFile(
     String fontFamily,
     bool enforceSafetyChecks,
   ) {
-  final List<_Icon> newIcons = tokenPairMap.entries
-      .map((MapEntry<String, String> entry) => _Icon(entry, fontFamily))
+  final List<Icon> newIcons = tokenPairMap.entries
+      .map((MapEntry<String, String> entry) => Icon(entry, fontFamily))
       .toList();
-  newIcons.sort((_Icon a, _Icon b) => a._compareTo(b));
+  newIcons.sort((Icon a, Icon b) => a._compareTo(b));
 
   final StringBuffer buf = StringBuffer();
   bool generating = false;
@@ -296,13 +296,13 @@ String _regenerateIconsFile(
         // Automatically finds and generates all icon declarations.
         for (final String style in <String>['', '_outlined', '_rounded', '_sharp']) {
           try {
-            final _Icon agnosticIcon = newIcons.firstWhere(
-                (_Icon icon) => icon.id == '${ids[0]}$style',
+            final Icon agnosticIcon = newIcons.firstWhere(
+                (Icon icon) => icon.id == '${ids[0]}$style',
                 orElse: () => throw ids[0]);
-            final _Icon iOSIcon = newIcons.firstWhere(
-                (_Icon icon) => icon.id == '${ids[1]}$style',
+            final Icon iOSIcon = newIcons.firstWhere(
+                (Icon icon) => icon.id == '${ids[1]}$style',
                 orElse: () => throw ids[1]);
-            platformAdaptiveDeclarations.add(_Icon.platformAdaptiveDeclaration('$flutterId$style', agnosticIcon, iOSIcon),
+            platformAdaptiveDeclarations.add(Icon.platformAdaptiveDeclaration('$flutterId$style', agnosticIcon, iOSIcon),
             );
           } catch (e) {
             if (style == '') {
@@ -327,7 +327,7 @@ String _regenerateIconsFile(
     // Generate for Icons
     if (line.contains(_beginGeneratedMark)) {
       generating = true;
-      final String iconDeclarationsString = newIcons.map((_Icon icon) => icon.fullDeclaration).join();
+      final String iconDeclarationsString = newIcons.map((Icon icon) => icon.fullDeclaration).join();
       buf.write(iconDeclarationsString);
     } else if (line.contains(_endGeneratedMark)) {
       generating = false;
@@ -388,9 +388,9 @@ void _regenerateCodepointsFile(File oldCodepointsFile, Map<String, String> newTo
   oldCodepointsFile.writeAsStringSync(buf.toString());
 }
 
-class _Icon {
+class Icon {
   // Parse tokenPair (e.g. {"6_ft_apart_outlined": "e004"}).
-  _Icon(MapEntry<String, String> tokenPair, this.fontFamily) {
+  Icon(MapEntry<String, String> tokenPair, this.fontFamily) {
     id = tokenPair.key;
     hexCodepoint = tokenPair.value;
 
@@ -463,7 +463,7 @@ class _Icon {
   $declaration
 ''';
 
-  static String platformAdaptiveDeclaration(String fullFlutterId, _Icon agnosticIcon, _Icon iOSIcon) => '''
+  static String platformAdaptiveDeclaration(String fullFlutterId, Icon agnosticIcon, Icon iOSIcon) => '''
 
   /// Platform-adaptive icon for ${agnosticIcon.dartDoc} and ${iOSIcon.dartDoc}.;
   IconData get $fullFlutterId => !_isCupertino() ? Icons.${agnosticIcon.flutterId} : Icons.${iOSIcon.flutterId};
@@ -473,7 +473,7 @@ class _Icon {
   String toString() => id;
 
   /// Analogous to [String.compareTo]
-  int _compareTo(_Icon b) {
+  int _compareTo(Icon b) {
     if (shortId == b.shortId) {
       // Sort a regular icon before its variants.
       return id.length - b.id.length;
@@ -501,7 +501,7 @@ class _Icon {
     String flutterId = id;
     // Exact identifier rewrites.
     for (final MapEntry<String, String> rewritePair in identifierExactRewrites.entries) {
-      final String shortId = _Icon._generateShortId(id);
+      final String shortId = Icon._generateShortId(id);
       if (shortId == rewritePair.key) {
         flutterId = id.replaceFirst(
           rewritePair.key,
@@ -519,9 +519,9 @@ class _Icon {
       }
     }
     
-    // Prevent double understcores.
+    // Prevent double underscores.
     flutterId = flutterId.replaceAll('__', '_');
-    
+
     return flutterId;
   }
 }

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -518,6 +518,10 @@ class _Icon {
         );
       }
     }
+    
+    // Prevent double understcores.
+    flutterId = flutterId.replaceAll('__', '_');
+    
     return flutterId;
   }
 }

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -699,16 +699,16 @@ class Icons {
   static const IconData sixty_fps_select_outlined = IconData(0xee1b, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons md-36">6_ft_apart</i> &#x2014; material icon named "6 ft apart".
-  static const IconData six__ft_apart = IconData(0xe02a, fontFamily: 'MaterialIcons');
+  static const IconData six_ft_apart = IconData(0xe02a, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-sharp md-36">6_ft_apart</i> &#x2014; material icon named "6 ft apart" (sharp).
-  static const IconData six__ft_apart_sharp = IconData(0xe72a, fontFamily: 'MaterialIcons');
+  static const IconData six_ft_apart_sharp = IconData(0xe72a, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-round md-36">6_ft_apart</i> &#x2014; material icon named "6 ft apart" (round).
-  static const IconData six__ft_apart_rounded = IconData(0xf509, fontFamily: 'MaterialIcons');
+  static const IconData six_ft_apart_rounded = IconData(0xf509, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-outlined md-36">6_ft_apart</i> &#x2014; material icon named "6 ft apart" (outlined).
-  static const IconData six__ft_apart_outlined = IconData(0xee1c, fontFamily: 'MaterialIcons');
+  static const IconData six_ft_apart_outlined = IconData(0xee1c, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons md-36">6k</i> &#x2014; material icon named "6k".
   static const IconData six_k = IconData(0xe02b, fontFamily: 'MaterialIcons');
@@ -4803,13 +4803,13 @@ class Icons {
   static const IconData class_ = IconData(0xe165, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-sharp md-36">class</i> &#x2014; material icon named "class" (sharp).
-  static const IconData class__sharp = IconData(0xe862, fontFamily: 'MaterialIcons');
+  static const IconData class_sharp = IconData(0xe862, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-round md-36">class</i> &#x2014; material icon named "class" (round).
-  static const IconData class__rounded = IconData(0xf641, fontFamily: 'MaterialIcons');
+  static const IconData class_rounded = IconData(0xf641, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons-outlined md-36">class</i> &#x2014; material icon named "class" (outlined).
-  static const IconData class__outlined = IconData(0xef54, fontFamily: 'MaterialIcons');
+  static const IconData class_outlined = IconData(0xef54, fontFamily: 'MaterialIcons');
 
   /// <i class="material-icons md-36">clean_hands</i> &#x2014; material icon named "clean hands".
   static const IconData clean_hands = IconData(0xe166, fontFamily: 'MaterialIcons');


### PR DESCRIPTION
Some replacements result in double underscores for a small number of icons (7 currently). Handle this case.

Not technically breaking, and since this was only in the framework for a relatively short amount of time, I'm avoiding adding 7 Dart fixes.

https://github.com/flutter/flutter/issues/94894

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
