### PR TITLE
fix: paragraph may be null in HitTest

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -207,8 +207,7 @@ class TextPainter {
   /// layout changes in engine. In most cases, updating text painter properties
   /// in framework will automatically invoke this method.
   void markNeedsLayout() {
-    // _needsLayout = true;
-    _paragraph = null;
+    _needsLayout = true;
     _lineMetricsCache = null;
     _previousCaretPosition = null;
     _previousCaretPrototype = null;
@@ -646,10 +645,10 @@ class TextPainter {
     // _needsPaint is true (in which case _paragraph will be rebuilt in paint).
     if(_needsLayout) {
       _paragraph = null;
+      _needsLayout = false;
     } else if (_paragraph != null && minWidth == _lastMinWidth && maxWidth == _lastMaxWidth) {
       return;
     }
-    _needsLayout = false;
     if (_rebuildParagraphForPaint || _paragraph == null)
       _createParagraph();
     _lastMinWidth = minWidth;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -207,7 +207,8 @@ class TextPainter {
   /// layout changes in engine. In most cases, updating text painter properties
   /// in framework will automatically invoke this method.
   void markNeedsLayout() {
-    _needsLayout = true;
+    // _needsLayout = true;
+    _paragraph = null;
     _lineMetricsCache = null;
     _previousCaretPosition = null;
     _previousCaretPrototype = null;

--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -198,6 +198,8 @@ class TextPainter {
 
   bool get _debugNeedsLayout => _paragraph == null;
 
+  bool _needsLayout = true;
+
   /// Marks this text painter's layout information as dirty and removes cached
   /// information.
   ///
@@ -205,7 +207,7 @@ class TextPainter {
   /// layout changes in engine. In most cases, updating text painter properties
   /// in framework will automatically invoke this method.
   void markNeedsLayout() {
-    _paragraph = null;
+    _needsLayout = true;
     _lineMetricsCache = null;
     _previousCaretPosition = null;
     _previousCaretPrototype = null;
@@ -641,9 +643,12 @@ class TextPainter {
     assert(textDirection != null, 'TextPainter.textDirection must be set to a non-null value before using the TextPainter.');
     // Return early if the current layout information is not outdated, even if
     // _needsPaint is true (in which case _paragraph will be rebuilt in paint).
-    if (_paragraph != null && minWidth == _lastMinWidth && maxWidth == _lastMaxWidth)
+    if(_needsLayout) {
+      _paragraph = null;
+    } else if (_paragraph != null && minWidth == _lastMinWidth && maxWidth == _lastMaxWidth) {
       return;
-
+    }
+    _needsLayout = false;
     if (_rebuildParagraphForPaint || _paragraph == null)
       _createParagraph();
     _lastMinWidth = minWidth;

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1027,7 +1027,8 @@ void main() {
 
     painter.markNeedsLayout();
     painter.getPositionForOffset(Offset.zero);
-  }, skip: kIsWeb && !isCanvasKit);
+  }, skip: kIsWeb && !isCanvasKit); // // https://github.com/flutter/flutter/issues/84650
+
 }
 
 class MockCanvas extends Fake implements Canvas {

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1016,6 +1016,18 @@ void main() {
     lines = painter.computeLineMetrics();
     expect(lines.length, 1);
   }, skip: kIsWeb && !isCanvasKit); // https://github.com/flutter/flutter/issues/62819
+
+  test('TextPainter paragraph is null test', () {
+    final TextPainter painter = TextPainter()
+      ..textDirection = TextDirection.ltr;
+
+    const String text = 'A';
+    painter.text = const TextSpan(text: text, style: TextStyle(height: 1.0));
+    painter.layout();
+
+    painter.markNeedsLayout();
+    painter.getPositionForOffset(Offset.zero);
+  }, skip: kIsWeb && !isCanvasKit);
 }
 
 class MockCanvas extends Fake implements Canvas {


### PR DESCRIPTION
Hi, in textpainter, paragraph might be null in some cases (hitTest), so I postponed the timing of its emptying (just before layout).

https://github.com/flutter/flutter/issues/84650

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
