### PR TITLE
chore: Moved didUpdateWidget calls first

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -218,13 +218,13 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
 
   @override
   void didUpdateWidget(CupertinoPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (widget.scrollController != null && oldWidget.scrollController == null) {
       _controller = null;
     } else if (widget.scrollController == null && oldWidget.scrollController != null) {
       assert(_controller == null);
       _controller = FixedExtentScrollController();
-    }
-    super.didUpdateWidget(oldWidget);
+    }    
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -224,7 +224,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
     } else if (widget.scrollController == null && oldWidget.scrollController != null) {
       assert(_controller == null);
       _controller = FixedExtentScrollController();
-    }    
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -123,8 +123,8 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
 
   @override
   void didUpdateWidget(_Segment<T> oldWidget) {
-    assert(oldWidget.key == widget.key);
     super.didUpdateWidget(oldWidget);
+    assert(oldWidget.key == widget.key);    
 
     if (oldWidget.shouldScaleContent != widget.shouldScaleContent) {
       highlightPressScaleAnimation = highlightPressScaleController.drive(
@@ -213,8 +213,8 @@ class _SegmentSeparatorState extends State<_SegmentSeparator> with TickerProvide
 
   @override
   void didUpdateWidget(_SegmentSeparator oldWidget) {
-    assert(oldWidget.key == widget.key);
     super.didUpdateWidget(oldWidget);
+    assert(oldWidget.key == widget.key);    
 
     if (oldWidget.highlighted != widget.highlighted) {
       separatorOpacityController.animateTo(

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -124,7 +124,7 @@ class _SegmentState<T> extends State<_Segment<T>> with TickerProviderStateMixin<
   @override
   void didUpdateWidget(_Segment<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    assert(oldWidget.key == widget.key);    
+    assert(oldWidget.key == widget.key);
 
     if (oldWidget.shouldScaleContent != widget.shouldScaleContent) {
       highlightPressScaleAnimation = highlightPressScaleController.drive(
@@ -214,7 +214,7 @@ class _SegmentSeparatorState extends State<_SegmentSeparator> with TickerProvide
   @override
   void didUpdateWidget(_SegmentSeparator oldWidget) {
     super.didUpdateWidget(oldWidget);
-    assert(oldWidget.key == widget.key);    
+    assert(oldWidget.key == widget.key);
 
     if (oldWidget.highlighted != widget.highlighted) {
       separatorOpacityController.animateTo(

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -422,6 +422,7 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
 
   @override
   void didUpdateWidget(_CupertinoTextSelectionToolbarContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
     // If the children are changing, the current page should be reset.
     if (widget.children != oldWidget.children) {
       _page = 0;
@@ -429,7 +430,6 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
       _controller.forward();
       _controller.removeStatusListener(_statusListener);
     }
-    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -234,7 +234,7 @@ class _MaterialBannerState extends State<MaterialBanner> {
     if (widget.animation != oldWidget.animation) {
       oldWidget.animation?.removeStatusListener(_onAnimationStatusChanged);
       widget.animation?.addStatusListener(_onAnimationStatusChanged);
-    }  
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -230,11 +230,11 @@ class _MaterialBannerState extends State<MaterialBanner> {
 
   @override
   void didUpdateWidget(MaterialBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (widget.animation != oldWidget.animation) {
       oldWidget.animation?.removeStatusListener(_onAnimationStatusChanged);
       widget.animation?.addStatusListener(_onAnimationStatusChanged);
-    }
-    super.didUpdateWidget(oldWidget);
+    }  
   }
 
   @override

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2596,6 +2596,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
 
   @override
   void didUpdateWidget(Scaffold oldWidget) {
+    super.didUpdateWidget(oldWidget);
     // Update the Floating Action Button Animator, and then schedule the Floating Action Button for repositioning.
     if (widget.floatingActionButtonAnimator != oldWidget.floatingActionButtonAnimator) {
       _floatingActionButtonAnimator = widget.floatingActionButtonAnimator ?? _kDefaultFloatingActionButtonAnimator;
@@ -2628,7 +2629,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         _updatePersistentBottomSheet();
       }
     }
-    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -385,11 +385,11 @@ class _SnackBarState extends State<SnackBar> {
 
   @override
   void didUpdateWidget(SnackBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (widget.animation != oldWidget.animation) {
       oldWidget.animation!.removeStatusListener(_onAnimationStatusChanged);
       widget.animation!.addStatusListener(_onAnimationStatusChanged);
     }
-    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1092,7 +1092,7 @@ class _BackButtonListenerState extends State<BackButtonListener> {
       dispatcher?.removeCallback(oldWidget.onBackButtonPressed);
       dispatcher?.addCallback(widget.onBackButtonPressed);
       dispatcher?.takePriority();
-    }  
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/router.dart
+++ b/packages/flutter/lib/src/widgets/router.dart
@@ -1087,12 +1087,12 @@ class _BackButtonListenerState extends State<BackButtonListener> {
 
   @override
   void didUpdateWidget(covariant BackButtonListener oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (oldWidget.onBackButtonPressed != widget.onBackButtonPressed) {
       dispatcher?.removeCallback(oldWidget.onBackButtonPressed);
       dispatcher?.addCallback(widget.onBackButtonPressed);
       dispatcher?.takePriority();
-    }
-    super.didUpdateWidget(oldWidget);
+    }  
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/value_listenable_builder.dart
+++ b/packages/flutter/lib/src/widgets/value_listenable_builder.dart
@@ -164,12 +164,12 @@ class _ValueListenableBuilderState<T> extends State<ValueListenableBuilder<T>> {
 
   @override
   void didUpdateWidget(ValueListenableBuilder<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
     if (oldWidget.valueListenable != widget.valueListenable) {
       oldWidget.valueListenable.removeListener(_valueChanged);
       value = widget.valueListenable.value;
       widget.valueListenable.addListener(_valueChanged);
     }
-    super.didUpdateWidget(oldWidget);
   }
 
   @override


### PR DESCRIPTION
The documentation says that [super.didUpdateWidget](https://api.flutter.dev/flutter/widgets/State/didUpdateWidget.html) calls should always go first but this isn't always the case. 

<details>
  <summary>I made this simple program to check which Dart files in `packages/futter/lib` don't have `didUpdateWidget` calls right after the method definition. The output of this program tells which files need to be fixed</summary>
    
  ```dart
import 'dart:io';

void main() async {
  // Getting a list of all files and directories in flutter/lib
  final dir = Directory(r'D:\flutter_dev\flutter\packages\flutter\lib');
  final List<FileSystemEntity> files = await dir.list(
    recursive: true,
    followLinks: true,
  ).where((element) {
    // Skipping 'framework.dart' since it contains the method definition in the
    // widgets superclas
    if (element.path.contains('framework')) {
      return false;
    }

    // Extracting dart files only
    return element.path.endsWith('.dart');
  }).toList();

  // Total errors found
  var found = 0;

  // Needed to check if 'super.didUpdateWidget' line is right after the method
  // definition
  var currIndex = 0;

  // Iterating over all 'dart' files
  for (final file in files) {
    final content = await File(file.path).readAsLines();

    // Iterating on all Dart lines of code
    for(final line in content) {
      if (line.contains('void didUpdateWidget(')) {
        // Adds a line to the console if in this file DOES NOT call
        // super.didUpdateWidget right after the method definition
        if (!content[currIndex + 1].contains('super.didUpdate')) {
          print('${file.path}');
          found++;
          continue;
        }
      }

      currIndex++;
    }

    currIndex = 0;
  }

  // Files analyzed + errors found
  print('analyzed: ${files.length} files | $found found');
}
  ```
</details>

Fixes #96930 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.