### PR TITLE
[flutter_tools] remove old Windows tool_integration_tests shards and mark new ones non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3904,128 +3904,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Windows tool_integration_tests_1_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"},
-          {"dependency": "goldctl"},
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      shard: tool_integration_tests
-      subshard: "1_5"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Windows tool_integration_tests_2_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"},
-          {"dependency": "goldctl"},
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      shard: tool_integration_tests
-      subshard: "2_5"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Windows tool_integration_tests_3_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"},
-          {"dependency": "goldctl"},
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      shard: tool_integration_tests
-      subshard: "3_5"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Windows tool_integration_tests_4_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"},
-          {"dependency": "goldctl"},
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      shard: tool_integration_tests
-      subshard: "4_5"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Windows tool_integration_tests_5_5
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk"},
-          {"dependency": "goldctl"},
-          {"dependency": "vs_build", "version": "version:vs2019"}
-        ]
-      shard: tool_integration_tests
-      subshard: "5_5"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
   - name: Windows tool_integration_tests_1_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4050,7 +3929,6 @@ targets:
       - .ci.yaml
 
   - name: Windows tool_integration_tests_2_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4075,7 +3953,6 @@ targets:
       - .ci.yaml
 
   - name: Windows tool_integration_tests_3_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4100,7 +3977,6 @@ targets:
       - .ci.yaml
 
   - name: Windows tool_integration_tests_4_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4125,7 +4001,6 @@ targets:
       - .ci.yaml
 
   - name: Windows tool_integration_tests_5_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4150,7 +4025,6 @@ targets:
       - .ci.yaml
 
   - name: Windows tool_integration_tests_6_6
-    bringup: true # TODO(fujino): https://github.com/flutter/flutter/issues/96544
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Cleanup follow-up to https://github.com/flutter/flutter/pull/95917

Fixes https://github.com/flutter/flutter/issues/96544