### PR TITLE
Fix SDK versions for Flutter packages in analyze tests to enable null-safe mode

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -53,13 +53,13 @@ void main() {
       "name": "flutter",
       "rootUri": "$flutterRootUri/packages/flutter",
       "packageUri": "lib/",
-      "languageVersion": "2.10"
+      "languageVersion": "2.12"
     },
     {
       "name": "sky_engine",
       "rootUri": "$flutterRootUri/bin/cache/pkg/sky_engine",
       "packageUri": "lib/",
-      "languageVersion": "2.10"
+      "languageVersion": "2.12"
     },
     {
       "name": "flutter_project",


### PR DESCRIPTION
The Dart->Flutter roll failure in https://github.com/flutter/flutter/issues/96931 appears to be caused by the tests using v2.10 for Flutter SDK version which was opted-in to null-safe because of experiments that have since been removed. Using v2.12 here instead fixes the test for my locally when using the new version of the engine.

Fixes https://github.com/flutter/flutter/issues/96931.

@gaaclarke @scheglov since it's getting late here, if the bots pass and you're happy with this, feel free to land!