### PR TITLE
Add NavigationBar dartpad example 

### DIFF
--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const Material(child: Center(child: NavigationExample())),
+    );
+  }
+}
+
+class NavigationExample extends StatefulWidget {
+  const NavigationExample({Key? key}) : super(key: key);
+
+  @override
+  State<NavigationExample> createState() => _NavigationExampleState();
+}
+
+class _NavigationExampleState extends State<NavigationExample> {
+  int _currentPageIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget _buildBody() {
+      return const [
+        Center(child: Text('Page 1')),
+        Center(child: Text('Page 2')),
+        Center(child: Text('Page 3')),
+      ][_currentPageIndex];
+    }
+
+    return Scaffold(
+        bottomNavigationBar: NavigationBar(
+            onDestinationSelected: (int index) {
+              setState(() {
+                _currentPageIndex = index;
+              });
+            },
+            selectedIndex: _currentPageIndex,
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.explore),
+                label: 'Explore',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.commute),
+                label: 'Commute',
+              ),
+              NavigationDestination(
+                selectedIcon: Icon(Icons.bookmark),
+                icon: Icon(Icons.bookmark_border),
+                label: 'Saved',
+              ),
+            ]),
+        body: _buildBody());
+  }
+}

--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -32,10 +32,16 @@ class _NavigationExampleState extends State<NavigationExample> {
   @override
   Widget build(BuildContext context) {
     Widget _buildBody() {
-      return const [
-        Center(child: Text('Page 1')),
-        Center(child: Text('Page 2')),
-        Center(child: Text('Page 3')),
+      return [
+        Container(
+          color: Colors.red,
+          alignment: Alignment.center, child: Text('Page 1')),
+        Container(
+          color: Colors.green,
+          alignment: Alignment.center, child: Text('Page 2')),
+        Container(
+          color: Colors.blue,
+          alignment: Alignment.center, child: Text('Page 3')),
       ][_currentPageIndex];
     }
 

--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -1,3 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for NavigationBar
+
 import 'package:flutter/material.dart';
 
 void main() {
@@ -34,14 +40,17 @@ class _NavigationExampleState extends State<NavigationExample> {
     Widget _buildBody() {
       return [
         Container(
-          color: Colors.red,
-          alignment: Alignment.center, child: Text('Page 1')),
+            color: Colors.red,
+            alignment: Alignment.center,
+            child: Text('Page 1')),
         Container(
-          color: Colors.green,
-          alignment: Alignment.center, child: Text('Page 2')),
+            color: Colors.green,
+            alignment: Alignment.center,
+            child: Text('Page 2')),
         Container(
-          color: Colors.blue,
-          alignment: Alignment.center, child: Text('Page 3')),
+            color: Colors.blue,
+            alignment: Alignment.center,
+            child: Text('Page 3')),
       ][_currentPageIndex];
     }
 

--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -38,19 +38,19 @@ class _NavigationExampleState extends State<NavigationExample> {
   @override
   Widget build(BuildContext context) {
     Widget _buildBody() {
-      return [
+      return <Widget>[
         Container(
             color: Colors.red,
             alignment: Alignment.center,
-            child: Text('Page 1')),
+            child: const Text('Page 1')),
         Container(
             color: Colors.green,
             alignment: Alignment.center,
-            child: Text('Page 2')),
+            child: const Text('Page 2')),
         Container(
             color: Colors.blue,
             alignment: Alignment.center,
-            child: Text('Page 3')),
+            child: const Text('Page 3')),
       ][_currentPageIndex];
     }
 
@@ -62,7 +62,7 @@ class _NavigationExampleState extends State<NavigationExample> {
               });
             },
             selectedIndex: _currentPageIndex,
-            destinations: const [
+            destinations: const <Widget>[
               NavigationDestination(
                 icon: Icon(Icons.explore),
                 label: 'Explore',

--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -37,22 +37,20 @@ class _NavigationExampleState extends State<NavigationExample> {
 
   @override
   Widget build(BuildContext context) {
-    Widget _buildBody() {
-      return <Widget>[
-        Container(
-            color: Colors.red,
-            alignment: Alignment.center,
-            child: const Text('Page 1')),
-        Container(
-            color: Colors.green,
-            alignment: Alignment.center,
-            child: const Text('Page 2')),
-        Container(
-            color: Colors.blue,
-            alignment: Alignment.center,
-            child: const Text('Page 3')),
-      ][_currentPageIndex];
-    }
+    final List<Widget> buildBody = <Widget>[
+      Container(
+          color: Colors.red,
+          alignment: Alignment.center,
+          child: const Text('Page 1')),
+      Container(
+          color: Colors.green,
+          alignment: Alignment.center,
+          child: const Text('Page 2')),
+      Container(
+          color: Colors.blue,
+          alignment: Alignment.center,
+          child: const Text('Page 3')),
+    ];
 
     return Scaffold(
         bottomNavigationBar: NavigationBar(
@@ -77,6 +75,6 @@ class _NavigationExampleState extends State<NavigationExample> {
                 label: 'Saved',
               ),
             ]),
-        body: _buildBody());
+        body: buildBody.elementAt(_currentPageIndex));
   }
 }

--- a/examples/api/lib/material/navigation_bar/navigation_bar.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.dart
@@ -15,13 +15,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: const Material(child: Center(child: NavigationExample())),
-    );
+    return const MaterialApp(home: NavigationExample());
   }
 }
 
@@ -33,48 +27,51 @@ class NavigationExample extends StatefulWidget {
 }
 
 class _NavigationExampleState extends State<NavigationExample> {
-  int _currentPageIndex = 0;
+  int currentPageIndex = 0;
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> buildBody = <Widget>[
-      Container(
+    return Scaffold(
+      bottomNavigationBar: NavigationBar(
+        onDestinationSelected: (int index) {
+          setState(() {
+            currentPageIndex = index;
+          });
+        },
+        selectedIndex: currentPageIndex,
+        destinations: const <Widget>[
+          NavigationDestination(
+            icon: Icon(Icons.explore),
+            label: 'Explore',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.commute),
+            label: 'Commute',
+          ),
+          NavigationDestination(
+            selectedIcon: Icon(Icons.bookmark),
+            icon: Icon(Icons.bookmark_border),
+            label: 'Saved',
+          ),
+        ],
+      ),
+      body: <Widget>[
+        Container(
           color: Colors.red,
           alignment: Alignment.center,
-          child: const Text('Page 1')),
-      Container(
+          child: const Text('Page 1'),
+        ),
+        Container(
           color: Colors.green,
           alignment: Alignment.center,
-          child: const Text('Page 2')),
-      Container(
+          child: const Text('Page 2'),
+        ),
+        Container(
           color: Colors.blue,
           alignment: Alignment.center,
-          child: const Text('Page 3')),
-    ];
-
-    return Scaffold(
-        bottomNavigationBar: NavigationBar(
-            onDestinationSelected: (int index) {
-              setState(() {
-                _currentPageIndex = index;
-              });
-            },
-            selectedIndex: _currentPageIndex,
-            destinations: const <Widget>[
-              NavigationDestination(
-                icon: Icon(Icons.explore),
-                label: 'Explore',
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.commute),
-                label: 'Commute',
-              ),
-              NavigationDestination(
-                selectedIcon: Icon(Icons.bookmark),
-                icon: Icon(Icons.bookmark_border),
-                label: 'Saved',
-              ),
-            ]),
-        body: buildBody.elementAt(_currentPageIndex));
+          child: const Text('Page 3'),
+        ),
+      ][currentPageIndex],
+    );
   }
 }

--- a/examples/api/test/material/navigation_bar/navigation_bar_test.dart
+++ b/examples/api/test/material/navigation_bar/navigation_bar_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/navigation_bar/navigation_bar.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Navigation bar updates destination on tap',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+    final NavigationBar navigationBarWidget =
+        tester.firstWidget(find.byType(NavigationBar));
+
+    /// NavigationDestinations must be rendered
+    expect(find.text('Explore'), findsOneWidget);
+    expect(find.text('Commute'), findsOneWidget);
+    expect(find.text('Saved'), findsOneWidget);
+
+    /// initial index must be zero
+    expect(navigationBarWidget.selectedIndex, 0);
+
+    /// switch to second tab
+    await tester.tap(find.text('Commute'));
+    await tester.pumpAndSettle();
+    expect(find.text('Page 2'), findsOneWidget);
+
+    /// switch to third tab
+    await tester.tap(find.text('Saved'));
+    await tester.pumpAndSettle();
+    expect(find.text('Page 3'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -35,7 +35,7 @@ import 'tooltip.dart';
 ///
 /// {@tool dartpad}
 /// This example shows a [NavigationBar] as it is used within a [Scaffold]
-/// widget. The [NavigationBar] has three [NavigationDestination] widgets,
+/// widget. The [NavigationBar] has three [NavigationDestination] widgets
 /// and the [selectedIndex] is set to index 0. The `onDestinationSelected` callback
 /// changes the selected item's index and displays a corresponding widget in the body of the [Scaffold].
 ///

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -39,7 +39,7 @@ import 'tooltip.dart';
 /// and the [selectedIndex] is set to index 0. The `onDestinationSelected` callback
 /// changes the selected item's index and displays a corresponding widget in the body of the [Scaffold].
 ///
-/// ** See code in examples/api/lib/material/navigation_bar.dart **
+/// ** See code in examples/api/lib/material/navigation_bar/navigation_bar.dart **
 /// {@end-tool}
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -33,47 +33,19 @@ import 'tooltip.dart';
 /// This widget holds a collection of destinations (usually
 /// [NavigationDestination]s).
 ///
-/// Usage:
-/// ```dart
-/// Scaffold(
-///   bottomNavigationBar: NavigationBar(
-///     onDestinationSelected: (int index) {
-///       setState(() { _currentPageIndex = index; }),
-///     },
-///     selectedIndex: _currentPageIndex,
-///     destinations: [
-///       NavigationDestination(
-///         icon: Icon(Icons.explore),
-///         label: 'Explore',
-///       ),
-///       NavigationDestination(
-///         icon: Icon(Icons.commute),
-///         label: 'Commute',
-///       ),
-///       NavigationDestination(
-///         selectedIcon: Icon(Icons.bookmark),
-///         icon: Icon(Icons.bookmark_border),
-///         label: 'Saved',
-///       ),
-///     ],
-///   ),
-/// ),
-/// ```
-///
 /// {@tool dartpad}
-/// This example has a [NavigationBar] where each destination has its
-/// own Navigator, Scaffold, and Appbar. That means that each
-/// destination has an independent route history and (app bar) back
-/// button. A [Stack] is used to display one destination at a time and
-/// destination changes are handled by cross fade transitions. Destinations
-/// that have been completely faded out are [Offstage].
+/// This example shows a [NavigationBar] as it is used within a [Scaffold]
+/// widget. The [NavigationBar] has three [NavigationDestination] widgets,
+/// and the [selectedIndex] is set to index 0. The `onDestinationSelected` callback
+/// changes the selected item's index and displays a corresponding widget in the body of the [Scaffold].
 ///
-/// One can see that the appearance of each destination's dialogs, bottom sheet,
-/// list scrolling state, and text field state, persist when another destination
-/// is selected.
-///
-/// ** See code in examples/api/lib/material/navigation_bar/navigation_bar.0.dart **
+/// ** See code in examples/api/lib/material/navigation_bar.dart **
 /// {@end-tool}
+/// See also:
+///
+///  * [NavigationDestination]
+///  * [BottomNavigationBar]
+///  * <https://api.flutter.dev/flutter/material/NavigationDestination-class.html>
 class NavigationBar extends StatelessWidget {
   /// Creates a Material 3 Navigation Bar component.
   ///


### PR DESCRIPTION
This PR adds a dartpad example for Material 3 [NavigationBar](https://api.flutter.dev/flutter/material/NavigationBar-class.html)

Addresses https://github.com/flutter/flutter/issues/96750

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
