### PR TITLE
Preload canvaskit, potentially saving 25% load time for Web display

### DIFF
--- a/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
+++ b/packages/flutter_tools/templates/app_shared/web/index.html.tmpl
@@ -31,6 +31,9 @@
 
   <title>{{projectName}}</title>
   <link rel="manifest" href="manifest.json">
+  <link rel="preload" href="main.dart.js" as="script">
+  <link rel="preload" href="https://unpkg.com/canvaskit-wasm@0.30.0/bin/canvaskit.js" as="script">
+  <link rel="preload" href="https://unpkg.com/canvaskit-wasm@0.30.0/bin/canvaskit.wasm" as="fetch" crossorigin="anonymous">
 </head>
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to


### PR DESCRIPTION
When using the default web renderer, every Flutter app has a dependency chain: from `main.dart.js`, we need to load `canvaskit.js` from unpkg.com, and finally load `canvaskit.wasm`.

Each of this download is currently done sequentially: `main.dart.js` has to be fully downloaded, parsed and executed to trigger the next step. Since the file is 2MB even in the smallest possible project, this is already slow, and even slower on an old-ish computer.
Then, the browser needs to DNS resolve unpkg.com, do a SSL handshake, get the file, parse and execute `canvaskit.js`.
Finally, `canvaskit.js` needs to get another 2.5MB (compressed) `canvaskit.wasm` file, unzip and execute (even though modern browsers can parse wasm while streaming, alleviating this issue slightly).

Since those files are always required for any release build (having to rely on an external CDN could be another issue, especially now that per-domain caching removes any direct benefits from using a CDN), it means displaying a Flutter web app is relatively slow.

By preloading ressources (see https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) we can avoid this and start getting data as soon as possible, making better use of the client available total bandwidth.

Before this change:
![image](https://user-images.githubusercontent.com/536844/150641569-024cb4ea-fc35-4e3a-bfcf-5b4c9b8a0f15.png)

Big waterfall, with a long time between main.dart.js and canvaskit.js (parsing + compile?), and everything done sequentially: `main.dart.js` then `canvaskit.js` then `canvaskit.wasm`.

After this change:
![image](https://user-images.githubusercontent.com/536844/150641620-1798fe44-8dfa-4342-ae94-b5d771ef6323.png)

Screenshots are taken from the default application one gets from running `createapp`, but I've also tested the changes in a production application too.
**For the simple default app, all content was loaded in 330ms, rather than 450ms on my fiber connection ("Finish" on screenshots), a roughly 25% improvement.**

Related to #76009, but not a fix, more work is needed.

Especially, in a perfect world:

* this preloading wouldn't happen in debug mode. As of now, I don't see any way to control the html depending on the current mode.
* fonts would also be loaded ahead-of-time
* the URL for canvaskit would be configurable. I think it has been mentioned in #70101 but I wasn't able to get that working (I'm not a Flutter expert :cry:). If configured, the HTML definitely shouldn't preload unpkg, but instead the local file directly.
* the URL for unpkg would be shared with whatever gets used to generate main.dart.js. Right now, I hardcoded v30.0, as I wasn't sure where this came from. It would probably be better to use a new variable, e.g. `$FLUTTER_CANVASKIT_URL` as is done for `$FLUTTER_BASE_HREF`.

It those issues are blockers, then feel free to close as the implementation right now might be considered a bit shaky and could make the dev experience slightly slower on first load. However, I think the overall concept of using preload is worth investigating.

This PR has no tests, as it only includes changes to the default HTML template used for web projects.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
