### PR TITLE
Use frontend_server from the Dart SDK

### DIFF
--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -129,6 +129,10 @@ void main() {
         artifacts.getArtifactPath(Artifact.windowsUwpDesktopPath, platform: TargetPlatform.windows_uwp_x64, mode: BuildMode.release),
         fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'windows-uwp-x64-release'),
       );
+      expect(
+        artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+        fileSystem.path.join('root', 'bin', 'cache', 'dart-sdk', 'bin', 'snapshots', 'frontend_server.dart.snapshot')
+      );
     });
 
     testWithoutContext('precompiled web artifact paths are correct', () {
@@ -293,6 +297,11 @@ void main() {
       expect(
         artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path,
         fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
+        fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk', 'bin',
+          'snapshots', 'frontend_server.dart.snapshot')
       );
     });
 


### PR DESCRIPTION
This is the first part of https://github.com/flutter/flutter/issues/60007. In particular, to stop using the Engine-built frontend_server, the first step is to point the Flutter CLI at the frontend_server vended in the Dart SDK.