### PR TITLE
Adjust lipo thinning input/output for macOS

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -36,7 +36,7 @@ abstract class UnpackMacOS extends Target {
 
   @override
   List<Source> get outputs => const <Source>[
-    Source.pattern('{OUTPUT_DIR}/FlutterMacOS.framework/FlutterMacOS'),
+    Source.pattern('{OUTPUT_DIR}/FlutterMacOS.framework/Versions/A/FlutterMacOS'),
   ];
 
   @override
@@ -67,7 +67,11 @@ abstract class UnpackMacOS extends Target {
       );
     }
 
-    final File frameworkBinary = environment.outputDir.childDirectory('FlutterMacOS.framework').childFile('FlutterMacOS');
+    final File frameworkBinary = environment.outputDir
+      .childDirectory('FlutterMacOS.framework')
+      .childDirectory('Versions')
+      .childDirectory('A')
+      .childFile('FlutterMacOS');
     final String frameworkBinaryPath = frameworkBinary.path;
     if (!frameworkBinary.existsSync()) {
       throw Exception('Binary $frameworkBinaryPath does not exist, cannot thin');

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -51,8 +51,10 @@ void main() {
     );
 
     binary = environment.outputDir
-        .childDirectory('FlutterMacOS.framework')
-        .childFile('FlutterMacOS');
+      .childDirectory('FlutterMacOS.framework')
+      .childDirectory('Versions')
+      .childDirectory('A')
+      .childFile('FlutterMacOS');
 
     copyFrameworkCommand = FakeCommand(
       command: <String>[
@@ -109,7 +111,7 @@ void main() {
       throwsA(isException.having(
         (Exception exception) => exception.toString(),
         'description',
-        contains('FlutterMacOS.framework/FlutterMacOS does not exist, cannot thin'),
+        contains('FlutterMacOS.framework/Versions/A/FlutterMacOS does not exist, cannot thin'),
       )),
     );
   }, overrides: <Type, Generator>{
@@ -155,7 +157,7 @@ void main() {
 
     await const DebugUnpackMacOS().build(environment);
 
-    expect(logger.traceText, contains('Skipping lipo for non-fat file /FlutterMacOS.framework/FlutterMacOS'));
+    expect(logger.traceText, contains('Skipping lipo for non-fat file /FlutterMacOS.framework/Versions/A/FlutterMacOS'));
   });
 
   testUsingContext('thins fat framework', () async {


### PR DESCRIPTION
Code signing gets confused if the target is a fat binary in the top-level directory in a framework. This change preserves the symlink structure of the copied framework by applying lipo thinning to the underlying binary.

Without this, I get the following during code signing with a fat binary that includes x64 and arm64:
```
/MYAPP/build/macos/Build/Products/Debug/zraap.app/Contents/Frameworks/FlutterMacOS.framework/FlutterMacOS: bundle format is ambiguous (could be app or framework)
```