### PR TITLE
[framework] remove extra casts

### DIFF
--- a/packages/flutter/lib/src/foundation/collections.dart
+++ b/packages/flutter/lib/src/foundation/collections.dart
@@ -236,7 +236,7 @@ void _movingInsertionSort<T>(
   int Function(T, T) compare,
   int start,
   int end,
-  List<T?> target,
+  List<T> target,
   int targetOffset,
 ) {
   final int length = end - start;
@@ -250,7 +250,7 @@ void _movingInsertionSort<T>(
     int max = targetOffset + i;
     while (min < max) {
       final int mid = min + ((max - min) >> 1);
-      if (compare(element, target[mid] as T) < 0) {
+      if (compare(element, target[mid]) < 0) {
         max = mid;
       } else {
         min = mid + 1;

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -90,7 +90,7 @@ class _MatrixTransformPart extends _TransformPart {
 
   @override
   Matrix4 multiply(Matrix4 rhs) {
-    return matrix * rhs as Matrix4;
+    return matrix.multiplied(rhs);
   }
 }
 

--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This library intentionally uses the LinkedHashMap constructor to declare that
+// entries will be ordered. Using collection literals for this requires casting the
+// resulting map, which has a runtime cost.
+// ignore_for_file: prefer_collection_literals
+
 import 'dart:collection' show LinkedHashMap;
 import 'dart:ui';
 
@@ -231,8 +236,7 @@ class MouseTracker extends ChangeNotifier {
 
   LinkedHashMap<MouseTrackerAnnotation, Matrix4> _hitTestResultToAnnotations(HitTestResult result) {
     assert(result != null);
-    final LinkedHashMap<MouseTrackerAnnotation, Matrix4> annotations = <MouseTrackerAnnotation, Matrix4>{}
-        as LinkedHashMap<MouseTrackerAnnotation, Matrix4>;
+    final LinkedHashMap<MouseTrackerAnnotation, Matrix4> annotations = LinkedHashMap<MouseTrackerAnnotation, Matrix4>();
     for (final HitTestEntry entry in result.path) {
       if (entry.target is MouseTrackerAnnotation) {
         annotations[entry.target as MouseTrackerAnnotation] = entry.transform!;
@@ -252,7 +256,7 @@ class MouseTracker extends ChangeNotifier {
     final Offset globalPosition = state.latestEvent.position;
     final int device = state.device;
     if (!_mouseStates.containsKey(device))
-      return <MouseTrackerAnnotation, Matrix4>{} as LinkedHashMap<MouseTrackerAnnotation, Matrix4>;
+      return LinkedHashMap<MouseTrackerAnnotation, Matrix4>();
 
     return _hitTestResultToAnnotations(hitTest(globalPosition));
   }
@@ -325,7 +329,7 @@ class MouseTracker extends ChangeNotifier {
 
         final PointerEvent lastEvent = targetState.replaceLatestEvent(event);
         final LinkedHashMap<MouseTrackerAnnotation, Matrix4> nextAnnotations = event is PointerRemovedEvent ?
-            <MouseTrackerAnnotation, Matrix4>{} as LinkedHashMap<MouseTrackerAnnotation, Matrix4> :
+            LinkedHashMap<MouseTrackerAnnotation, Matrix4>() :
             _hitTestResultToAnnotations(result);
         final LinkedHashMap<MouseTrackerAnnotation, Matrix4> lastAnnotations = targetState.replaceAnnotations(nextAnnotations);
 


### PR DESCRIPTION
While investigating the runtime costs of casting in web builds, I found several that could trivially be removed.
