### PR TITLE
[flutter_tools] Fix bug in background_isolate_test.dart

### DIFF
--- a/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
+++ b/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
@@ -50,7 +50,7 @@ void main() {
 
     project.updateTestIsolatePhrase(newBackgroundMessage);
     await flutter.hotRestart();
-    await sawBackgroundMessage.future;
+    await sawNewBackgroundMessage.future;
     // Wait a tiny amount of time in case we did not kill the background isolate.
     await Future<void>.delayed(const Duration(milliseconds: 10));
     await subscription.cancel();


### PR DESCRIPTION
Related to (but does not fix) https://github.com/flutter/flutter/issues/96677. This test was awaiting the wrong future (a future that had already completed). This test is still skipped, but with this change it fails more consistently (on Windows).