### PR TITLE
Deprecate Scrollbar hoverThickness and showTrackOnHover

### DIFF
--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -54,9 +54,8 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 /// drawn when triggered by a hover event, or based on any [MaterialState] by
 /// using [ScrollbarTheme.trackVisibility].
 ///
-/// The [thickness] of the track and scrollbar thumb will increase by default
-/// in response to [MaterialState.hovered], this can be controlled using
-/// [ScrollbarThemeData.thickness] to respond to any [MaterialState].
+/// The [thickness] of the track and scrollbar thumb can be changed dynamically
+/// in response to [MaterialState]s using [ScrollbarThemeData.thickness].
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -52,7 +52,7 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///
 /// A scrollbar track can be added using [trackVisibility]. This can also be
 /// drawn when triggered by a hover event, or based on any [MaterialState] by
-/// using [ScrollbarTheme.trackVisibility].
+/// using [ScrollbarThemeData.trackVisibility].
 ///
 /// The [thickness] of the track and scrollbar thumb can be changed dynamically
 /// in response to [MaterialState]s using [ScrollbarThemeData.thickness].

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -34,11 +34,6 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 /// or [MaterialState.hovered] on desktop and web platforms. These stateful
 /// color choices can be changed using [ScrollbarThemeData.thumbColor].
 ///
-/// A scrollbar track can been drawn when triggered by a hover event, which is
-/// controlled by [showTrackOnHover]. The thickness of the track and scrollbar
-/// thumb will become larger when hovering, unless overridden by
-/// [hoverThickness].
-///
 /// {@tool dartpad}
 /// This sample shows a [Scrollbar] that executes a fade animation as scrolling
 /// occurs. The Scrollbar will fade into view as the user scrolls, and fade out
@@ -54,6 +49,14 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///
 /// ** See code in examples/api/lib/material/scrollbar/scrollbar.1.dart **
 /// {@end-tool}
+///
+/// A scrollbar track can be added using [trackVisibility]. This can also be
+/// drawn when triggered by a hover event, or based on any [MaterialState] by
+/// using [ScrollbarTheme.trackVisibility].
+///
+/// The [thickness] of the track and scrollbar thumb will increase by default
+/// in response to [MaterialState.hovered], this can be controlled using
+/// [ScrollbarThemeData.thickness] to respond to any [MaterialState].
 ///
 /// See also:
 ///
@@ -84,8 +87,6 @@ class Scrollbar extends StatelessWidget {
     this.controller,
     this.thumbVisibility,
     this.trackVisibility,
-    this.showTrackOnHover,
-    this.hoverThickness,
     this.thickness,
     this.radius,
     this.notificationPredicate,
@@ -96,6 +97,16 @@ class Scrollbar extends StatelessWidget {
       'This feature was deprecated after v2.9.0-1.0.pre.',
     )
     this.isAlwaysShown,
+    @Deprecated(
+      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
+      'This feature was deprecated after v2.9.0-1.0.pre.',
+    )
+    this.showTrackOnHover,
+    @Deprecated(
+      'Use ScrollbarThemeData.thickness to resolve based on the current state instead. '
+      'This feature was deprecated after v2.9.0-1.0.pre.',
+    )
+    this.hoverThickness,
   }) : assert(
          thumbVisibility == null || isAlwaysShown == null,
          'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
@@ -142,7 +153,7 @@ class Scrollbar extends StatelessWidget {
   /// use the global [ScrollbarThemeData.trackVisibility] or override the
   /// sub-tree's theme data.
   ///
-  /// [showTrackOnHover] can be replaced by this and will be deprecated.
+  /// Replaces deprecated [showTrackOnHover].
   final bool? trackVisibility;
 
   /// Controls if the track will show on hover and remain, including during drag.
@@ -151,7 +162,12 @@ class Scrollbar extends StatelessWidget {
   /// [ThemeData.scrollbarTheme] is used. If that is also null, the default value
   /// is false.
   ///
-  /// This will be deprecated, and [trackVisibility] is recommended.
+  /// This is deprecated, [trackVisibility] or [ScrollbarThemeData.trackVisibility]
+  /// should be used instead.
+  @Deprecated(
+    'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
+    'This feature was deprecated after v2.9.0-1.0.pre.',
+  )
   final bool? showTrackOnHover;
 
   /// The thickness of the scrollbar when a hover state is active and
@@ -160,6 +176,13 @@ class Scrollbar extends StatelessWidget {
   /// If this property is null, then [ScrollbarThemeData.thickness] of
   /// [ThemeData.scrollbarTheme] is used to resolve a thickness. If that is also
   /// null, the default value is 12.0 pixels.
+  ///
+  /// This is deprecated, use [ScrollbarThemeData.thickness] to resolve based on
+  /// the current state instead.
+  @Deprecated(
+    'Use ScrollbarThemeData.thickness to resolve based on the current state instead. '
+    'This feature was deprecated after v2.9.0-1.0.pre.',
+  )
   final double? hoverThickness;
 
   /// The thickness of the scrollbar in the cross axis of the scrollable.

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -34,7 +34,6 @@ class ScrollbarThemeData with Diagnosticable {
     this.thumbVisibility,
     this.thickness,
     this.trackVisibility,
-    this.showTrackOnHover,
     this.radius,
     this.thumbColor,
     this.trackColor,
@@ -48,6 +47,11 @@ class ScrollbarThemeData with Diagnosticable {
       'This feature was deprecated after v2.9.0-1.0.pre.',
     )
     this.isAlwaysShown,
+    @Deprecated(
+      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
+      'This feature was deprecated after v2.9.0-1.0.pre.',
+    )
+    this.showTrackOnHover,
   }) : assert(
          isAlwaysShown == null || thumbVisibility == null,
          'Scrollbar thumb appearance should only be controlled with thumbVisibility, '
@@ -73,6 +77,10 @@ class ScrollbarThemeData with Diagnosticable {
 
   /// Overrides the default value of [Scrollbar.showTrackOnHover] in all
   /// descendant [Scrollbar] widgets.
+  @Deprecated(
+    'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
+    'This feature was deprecated after v2.9.0-1.0.pre.',
+  )
   final bool? showTrackOnHover;
 
   /// Overrides the default value of [Scrollbar.isAlwaysShown] in all

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1058,6 +1058,140 @@ void main() {
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux }),
   );
 
+  testWidgets('ScrollbarThemeData.thickness replaces hoverThickness', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+          isAlwaysShown: true,
+          trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            return states.contains(MaterialState.hovered);
+          }),
+          thickness: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            if (states.contains(MaterialState.hovered))
+              return 40.0;
+            // Default thickness
+            return 8.0;
+          }),
+        )),
+        home: const SingleChildScrollView(
+          child: SizedBox(width: 4000.0, height: 4000.0),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          getStartingThumbRect(isAndroid: false),
+          _kDefaultThumbRadius,
+        ),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(794.0, 5.0));
+    await tester.pump();
+
+    expect(
+      find.byType(Scrollbar),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(756.0, 0.0, 800.0, 600.0),
+          color: const Color(0x08000000),
+        )
+        ..line(
+          p1: const Offset(756.0, 0.0),
+          p2: const Offset(756.0, 600.0),
+          strokeWidth: 1.0,
+          color: _kDefaultIdleThumbColor,
+        )
+        ..rrect(
+          rrect: RRect.fromRectAndRadius(
+            // Scrollbar thumb is larger
+            const Rect.fromLTRB(758.0, 0.0, 798.0, 90.0),
+            _kDefaultThumbRadius,
+          ),
+          // Hover color
+          color: const Color(0x80000000),
+        ),
+    );
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    }),
+  );
+
+  testWidgets('ScrollbarThemeData.trackVisibility replaces showTrackOnHover', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
+          isAlwaysShown: true,
+          trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            if (states.contains(MaterialState.hovered))
+              return true;
+            return false;
+          }),
+        )),
+        home: const SingleChildScrollView(
+          child: SizedBox(width: 4000.0, height: 4000.0),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byType(Scrollbar),
+      paints..rrect(
+        rrect: RRect.fromRectAndRadius(
+          getStartingThumbRect(isAndroid: false),
+          _kDefaultThumbRadius,
+        ),
+        color: _kDefaultIdleThumbColor,
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(kind: ui.PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(const Offset(794.0, 5.0));
+    await tester.pump();
+
+    expect(
+      find.byType(Scrollbar),
+      paints
+        ..rect(
+          rect: const Rect.fromLTRB(784.0, 0.0, 800.0, 600.0),
+          color: const Color(0x08000000),
+        )
+        ..line(
+          p1: const Offset(784.0, 0.0),
+          p2: const Offset(784.0, 600.0),
+          strokeWidth: 1.0,
+          color: _kDefaultIdleThumbColor,
+        )
+        ..rrect(
+          rrect: RRect.fromRectAndRadius(
+            // Scrollbar thumb is larger
+            const Rect.fromLTRB(786.0, 0.0, 798.0, 90.0),
+            _kDefaultThumbRadius,
+          ),
+          // Hover color
+          color: const Color(0x80000000),
+        ),
+    );
+  },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+    }),
+  );
+
   testWidgets('Scrollbar showTrackOnHover', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -1062,7 +1062,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(scrollbarTheme: ScrollbarThemeData(
-          isAlwaysShown: true,
+          thumbVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) => true),
           trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
             return states.contains(MaterialState.hovered);
           }),


### PR DESCRIPTION
Part one of several scrollbar clean up PRs to prepare for desktop scrollbars.
Original PR was #96935, but it was becoming too large
Tracking the progress overall in https://github.com/flutter/flutter/issues/96936

This PR deprecates `hoverThickness` and `showTrackOnHover` in `Scrollbar` and `ScrollbarThemeData`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
