### PR TITLE
[framework] make HitTestEntry generic

### DIFF
--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -38,19 +38,20 @@ abstract class HitTestTarget {
   HitTestTarget._();
 
   /// Override this method to receive events.
-  void handleEvent(PointerEvent event, HitTestEntry entry);
+  void handleEvent(PointerEvent event, HitTestEntry<HitTestTarget> entry);
 }
 
 /// Data collected during a hit test about a specific [HitTestTarget].
 ///
 /// Subclass this object to pass additional information from the hit test phase
 /// to the event propagation phase.
-class HitTestEntry {
+@optionalTypeArgs
+class HitTestEntry<T extends HitTestTarget> {
   /// Creates a hit test entry.
   HitTestEntry(this.target);
 
   /// The [HitTestTarget] encountered during the hit test.
-  final HitTestTarget target;
+  final T target;
 
   @override
   String toString() => '${describeIdentity(this)}($target)';

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -886,16 +886,13 @@ class BoxHitTestResult extends HitTestResult {
 }
 
 /// A hit test entry used by [RenderBox].
-class BoxHitTestEntry extends HitTestEntry {
+class BoxHitTestEntry extends HitTestEntry<RenderBox> {
   /// Creates a box hit test entry.
   ///
   /// The [localPosition] argument must not be null.
   BoxHitTestEntry(RenderBox target, this.localPosition)
     : assert(localPosition != null),
       super(target);
-
-  @override
-  RenderBox get target => super.target as RenderBox;
 
   /// The position of the hit test in the local coordinates of [target].
   final Offset localPosition;

--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -238,8 +238,9 @@ class MouseTracker extends ChangeNotifier {
     assert(result != null);
     final LinkedHashMap<MouseTrackerAnnotation, Matrix4> annotations = LinkedHashMap<MouseTrackerAnnotation, Matrix4>();
     for (final HitTestEntry entry in result.path) {
-      if (entry.target is MouseTrackerAnnotation) {
-        annotations[entry.target as MouseTrackerAnnotation] = entry.transform!;
+      final Object target = entry.target;
+      if (target is MouseTrackerAnnotation) {
+        annotations[target] = entry.transform!;
       }
     }
     return annotations;

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -870,7 +870,7 @@ class SliverHitTestResult extends HitTestResult {
 ///
 /// The coordinate system used by this hit test entry is relative to the
 /// [AxisDirection] of the target sliver.
-class SliverHitTestEntry extends HitTestEntry {
+class SliverHitTestEntry extends HitTestEntry<RenderSliver> {
   /// Creates a sliver hit test entry.
   ///
   /// The [mainAxisPosition] and [crossAxisPosition] arguments must not be null.
@@ -881,9 +881,6 @@ class SliverHitTestEntry extends HitTestEntry {
   }) : assert(mainAxisPosition != null),
        assert(crossAxisPosition != null),
        super(target);
-
-  @override
-  RenderSliver get target => super.target as RenderSliver;
 
   /// The distance in the [AxisDirection] from the edge of the sliver's painted
   /// area (as given by the [SliverConstraints.scrollOffset]) to the hit point.

--- a/packages/flutter/test/rendering/mouse_tracker_test_utils.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test_utils.dart
@@ -96,7 +96,7 @@ class TestAnnotationTarget with Diagnosticable implements MouseTrackerAnnotation
 
 // A hit test entry that can be assigned with a [TestAnnotationTarget] and an
 // optional transform matrix.
-class TestAnnotationEntry extends HitTestEntry {
+class TestAnnotationEntry extends HitTestEntry<TestAnnotationTarget> {
   TestAnnotationEntry(TestAnnotationTarget target, [Matrix4? transform])
     : transform = transform ?? Matrix4.identity(), super(target);
 


### PR DESCRIPTION
At least on the web, this is the single most expensive cast in flutter. I wrote a bit about it in https://docs.google.com/document/d/1jkI8GCT4cId3a87PV5E0XQWRd2O5HsNhmchwgDUDv_k/edit 
