### PR TITLE
Move gallery native UI test launching out of test and into setup

### DIFF
--- a/dev/integration_tests/flutter_gallery/ios/GalleryUITests/GalleryUITests.m
+++ b/dev/integration_tests/flutter_gallery/ios/GalleryUITests/GalleryUITests.m
@@ -5,20 +5,22 @@
 #import <XCTest/XCTest.h>
 
 @interface GalleryUITests : XCTestCase
+@property (strong) XCUIApplication *app;
 @end
 
 @implementation GalleryUITests
 
 - (void)setUp {
     self.continueAfterFailure = NO;
+
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app launch];
+    self.app = app;
 }
 
 - (void)testLaunch {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    [app launch];
-
     // Basic smoke test that the app launched and any element was loaded.
-    XCTAssertTrue([app.otherElements.firstMatch waitForExistenceWithTimeout:60.0]);
+    XCTAssertTrue([self.app.otherElements.firstMatch waitForExistenceWithTimeout:60.0]);
 }
 
 @end


### PR DESCRIPTION
Move `XCUIApplication` launch for gallery test out of the test and into `setUp`.  Speculative workaround for Xcode test harness crash https://github.com/flutter/flutter/issues/95193

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
