### PR TITLE
[tool] Use an arm64 Dart SDK on arm64 macOS

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -71,7 +71,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
 
   case "$(uname -s)" in
     Darwin)
-      DART_ZIP_NAME="dart-sdk-darwin-x64.zip"
+      DART_ZIP_NAME="dart-sdk-darwin-${ARCH}.zip"
       IS_USER_EXECUTABLE="-perm +100"
       ;;
     Linux)

--- a/packages/flutter_tools/test/integration.shard/cache_test.dart
+++ b/packages/flutter_tools/test/integration.shard/cache_test.dart
@@ -113,6 +113,25 @@ exit(0);
       expect(logger.hadWarningOutput, isTrue);
     });
   });
+
+  testWithoutContext('Dart SDK target arch matches host arch', () async {
+    if (platform.isWindows) {
+      return;
+    }
+    final ProcessResult dartResult = await const LocalProcessManager().run(
+      <String>[dart, '--version'],
+    );
+    // Parse 'arch' out of a string like '... "os_arch"\n'.
+    final String dartTargetArch = (dartResult.stdout as String)
+      .trim().split(' ').last.replaceAll('"', '').split('_')[1];
+    final ProcessResult unameResult = await const LocalProcessManager().run(
+      <String>['uname', '-m'],
+    );
+    final String unameArch = (unameResult.stdout as String)
+      .trim().replaceAll('aarch64', 'arm64')
+             .replaceAll('x86_64', 'x64');
+    expect(dartTargetArch, equals(unameArch));
+  });
 }
 
 class FakeArtifactUpdater extends Fake implements ArtifactUpdater {


### PR DESCRIPTION
This PR modifies the script that updates the Dart SDK to pull an arm64 Dart SDK on arm64 macOS hosts.