### PR TITLE
Fix samples so that they present properly in the docs

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -28,11 +28,6 @@ function generate_docs() {
     # >>> If you update this version, also update it in dev/bots/analyze_sample_code.dart <<<
     "$DART" pub global activate snippets 0.2.5
 
-    # Run the snippets tool once to force building of the package executable,
-    # since "dart pub global run" has issues with startup concurrency.
-    # TODO(gspencergoog): Remove once pub issue is fixed, https://github.com/dart-lang/pub/issues/3165
-    "$DART" pub global run snippets --help
-
     # This script generates a unified doc set, and creates
     # a custom index.html, placing everything into dev/docs/doc.
     (cd "$FLUTTER_ROOT/dev/tools" && "$FLUTTER" pub get)

--- a/dev/snippets/config/skeletons/sample.html
+++ b/dev/snippets/config/skeletons/sample.html
@@ -8,35 +8,18 @@
     <i class="material-icons copy-image">link</i>
   </a>
 </div>
-<div class="snippet-buttons">
-  <script>var visibleSnippet{{serial}} = "shortSnippet{{serial}}";</script>
-  <button id="shortSnippet{{serial}}Button"
-          onclick="visibleSnippet{{serial}} = showSnippet('shortSnippet{{serial}}', visibleSnippet{{serial}});"
-          selected>Sample</button>
-  <button id="longSnippet{{serial}}Button"
-          onclick="visibleSnippet{{serial}} = showSnippet('longSnippet{{serial}}', visibleSnippet{{serial}});">Sample in an App</button>
-</div>
 <div class="snippet-container">
-  <div class="snippet" id="shortSnippet{{serial}}">
+  <div class="snippet">
     {{description}}
-    <div class="copyable-container">
-      <button class="copy-button-overlay copy-button" title="Copy to clipboard"
-              onclick="copyTextToClipboard(visibleSnippet{{serial}});">
-        <i class="material-icons copy-image">assignment</i>
-      </button>
-      <pre class="language-{{language}}"><code class="language-{{language}}">{{code}}</code></pre>
-    </div>
-  </div>
-  <div class="snippet" id="longSnippet{{serial}}" hidden>
     <div class="snippet-description">To create a local project with this code sample, run:<br/>
       <span class="snippet-create-command">flutter create --sample={{id}} mysample</span>
     </div>
     <div class="copyable-container">
       <button class="copy-button-overlay copy-button" title="Copy to clipboard"
-              onclick="copyTextToClipboard(visibleSnippet{{serial}});">
+              onclick="copyTextToClipboard(longSnippet{{serial}});">
         <i class="material-icons copy-image">assignment</i>
       </button>
-      <pre class="language-{{language}}"><code class="language-{{language}}">{{app}}</code></pre>
+      <pre id="longSnippet{{serial}}" class="language-{{language}}"><code class="language-{{language}}">{{app}}</code></pre>
     </div>
   </div>
 </div>

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -381,6 +381,25 @@ void cleanOutSnippets() {
   }
 }
 
+void _sanityCheckExample(File file, RegExp regExp) {
+  if (file.existsSync()) {
+    final List<String> contents = file.readAsLinesSync();
+    bool found = false;
+    for (final String line in contents) {
+      if (regExp.matchAsPrefix(line) != null) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      throw Exception("Missing example code in ${file.path}. Either it didn't get published, publishing has changed, or the example no longer exists.");
+    }
+  } else {
+    throw Exception("Missing example code sanity test file ${file.path}. Either it didn't get published, or you might have to update the test to look at a different file.");
+  }
+}
+
+/// Runs a sanity check by running a test.
 void sanityCheckDocs() {
   final List<String> canaries = <String>[
     '$kPublishRoot/assets/overrides.css',
@@ -397,6 +416,22 @@ void sanityCheckDocs() {
     if (!File(canary).existsSync())
       throw Exception('Missing "$canary", which probably means the documentation failed to build correctly.');
   }
+  // Make sure at least one example of each kind includes source code.
+
+  // Check a "sample" example, any one will do.
+  final File sampleExample = File('$kPublishRoot/api/widgets/showGeneralDialog.html');
+  final RegExp sampleRegExp = RegExp(r'\s*<pre id="longSnippet1" class="language-dart">\s*<code class="language-dart">\s*import &#39;package:flutter&#47;material.dart&#39;;');
+  _sanityCheckExample(sampleExample, sampleRegExp);
+
+  // Check a "snippet" example, any one will do.
+  final File snippetExample = File('$kPublishRoot/api/widgets/ModalRoute/barrierColor.html');
+  final RegExp snippetRegExp = RegExp(r'\s*<pre class="language-dart" id="sample-code">.*Color get barrierColor =&gt; Theme\.of\(navigator\.context\)\.backgroundColor;.*</pre>');
+  _sanityCheckExample(snippetExample, snippetRegExp);
+
+  // Check a "dartpad" example, any one will do.
+  final File dartpadExample = File('$kPublishRoot/api/widgets/PhysicalShape-class.html');
+  final RegExp dartpadRegExp = RegExp(r'\s*<iframe class="snippet-dartpad" src="https://dartpad\.dev.*sample_id=widgets\.PhysicalShape\.\d+.*">\s*</iframe>');
+  _sanityCheckExample(dartpadExample, dartpadRegExp);
 }
 
 /// Creates a custom index.html because we try to maintain old


### PR DESCRIPTION
## Description

Currently the code samples created with `{@tool sample}` (there are only a few of these) present incorrectly: they show an empty tab initially, and you can switch to a tab with the code in it.

They should not have tabs at all, and show the code in a blue box.

This PR fixes that.

## Related Issues
 - https://github.com/flutter/flutter/issues/97223

## Tests
 - Only affects API doc templates.