### PR TITLE
Export an IPA for distribution via "flutter build ipa" without --export-options-plist

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -110,16 +110,22 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   String? get exportOptionsPlist => stringArg('export-options-plist');
 
   @override
+  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs
+      .directory(xcodeResultOutput)
+      .childDirectory('Products')
+      .childDirectory('Applications');
+
+  @override
   Future<void> validateCommand() async {
     final String? exportOptions = exportOptionsPlist;
-    if (exportOptions != null && argResults?.wasParsed('export-method') == true) {
-      throwToolExit(
-        '"--export-options-plist" is not compatible with "--export-method". Either use "--export-options-plist" and '
-        'a plist describing how the IPA should be exported by Xcode, or use "--export-method" to create a new plist.\n'
-        'See "xcodebuild -h" for available exportOptionsPlist keys.'
-      );
-    }
     if (exportOptions != null) {
+      if (argResults?.wasParsed('export-method') == true) {
+        throwToolExit(
+          '"--export-options-plist" is not compatible with "--export-method". Either use "--export-options-plist" and '
+          'a plist describing how the IPA should be exported by Xcode, or use "--export-method" to create a new plist.\n'
+          'See "xcodebuild -h" for available exportOptionsPlist keys.'
+        );
+      }
       final FileSystemEntityType type = globals.fs.typeSync(exportOptions);
       if (type == FileSystemEntityType.notFound) {
         throwToolExit(
@@ -131,12 +137,6 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     }
     return super.validateCommand();
   }
-
-  @override
-  Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs
-      .directory(xcodeResultOutput)
-      .childDirectory('Products')
-      .childDirectory('Applications');
 
   @override
   Future<FlutterCommandResult> runCommand() async {

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -87,7 +87,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final List<String> aliases = <String>['xcarchive'];
 
   @override
-  final String description = 'Build an iOS archive bundle (Mac OS X host only).';
+  final String description = 'Build an iOS archive bundle and IPA for distribution (Mac OS X host only).';
 
   @override
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.archive;

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -238,7 +238,7 @@ void main() {
         FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build fails when --export-options-plist and --app-store are used together', () async {
+  testUsingContext('ipa build fails when --export-options-plist and --export-method are used together', () async {
     final BuildCommand command = BuildCommand();
     _createMinimalMockProjectFiles();
 
@@ -248,33 +248,11 @@ void main() {
         'ipa',
         '--export-options-plist',
         'ExportOptions.plist',
-        '--app-store',
+        '--export-method',
+        'app-store',
         '--no-pub',
       ]),
-      contains('--export-options-plist is not compatible with --app-store'),
-    );
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.any(),
-    Platform: () => macosPlatform,
-    XcodeProjectInterpreter: () =>
-        FakeXcodeProjectInterpreterWithBuildSettings(),
-  });
-
-  testUsingContext('ipa build fails when --export-options-plist and --no-app-store are used together', () async {
-    final BuildCommand command = BuildCommand();
-    _createMinimalMockProjectFiles();
-
-    await expectToolExitLater(
-      createTestCommandRunner(command).run(<String>[
-        'build',
-        'ipa',
-        '--export-options-plist',
-        'ExportOptions.plist',
-        '--no-app-store',
-        '--no-pub',
-      ]),
-      contains('--export-options-plist is not compatible with --no-app-store'),
+      contains('"--export-options-plist" is not compatible with "--export-method"'),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -322,7 +300,7 @@ void main() {
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build invokes xcodebuild and archives for ad-hoc local development', () async {
+  testUsingContext('ipa build invokes xcodebuild and archives for ad-hoc distribution', () async {
     final BuildCommand command = BuildCommand();
     fakeProcessManager.addCommands(<FakeCommand>[
       xattrCommand,
@@ -332,7 +310,7 @@ void main() {
     _createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
-        const <String>['build', 'ipa', '--no-pub', '--no-app-store']
+        const <String>['build', 'ipa', '--no-pub', '--export-method', 'ad-hoc']
     );
 
     const String expectedIpaPlistContents = '''

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -7,7 +7,6 @@
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
@@ -51,7 +50,6 @@ final Platform notMacosPlatform = FakePlatform(
 void main() {
   FileSystem fileSystem;
   TestUsage usage;
-  BufferLogger logger;
   FakeProcessManager fakeProcessManager;
 
   setUpAll(() {
@@ -61,7 +59,6 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     usage = TestUsage();
-    logger = BufferLogger.test();
     fakeProcessManager = FakeProcessManager.empty();
   });
 
@@ -292,6 +289,9 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
 
     expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building App Store IPA'));
+    expect(testLogger.statusText, contains('Built IPA to /build/ios/ipa'));
+    expect(testLogger.statusText, contains('To upload to the App Store'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -330,6 +330,10 @@ void main() {
     expect(actualIpaPlistContents, expectedIpaPlistContents);
 
     expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building ad-hoc IPA'));
+    expect(testLogger.statusText, contains('Built IPA to /build/ios/ipa'));
+    // Don't instruct how to upload to the App Store.
+    expect(testLogger.statusText, isNot(contains('To upload')));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -446,13 +450,12 @@ void main() {
       ],
     );
 
-    expect(logger.statusText, contains('Built IPA to $outputPath.'));
+    expect(testLogger.statusText, contains('Built IPA to $outputPath.'));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
-    Logger: () => logger,
     XcodeProjectInterpreter: () =>
         FakeXcodeProjectInterpreterWithBuildSettings(),
   });


### PR DESCRIPTION
`flutter build ipa` has two stages for iOS distribution:
1. Archive the app into an `xcarchive` bundle.
2. Optionally, export the `xcarchive` into an `ipa` bundle for distribution to the App Store, or to a device, or enterprise distribution...

Currently to get to number 2 and create the `ipa` file users need to pass in a `--export-options-plist` file, which they need to create themselves, or know how to yank off a previously-build IPA.  Flutter's [iOS distribution docs](https://docs.flutter.dev/deployment/ios#create-a-build-archive-with-xcode) don't say what needs to go into the plist, it just points to Apple docs, or tells them to launch Xcode and create the IPA there.

> 1. Run flutter build ipa to produce a build archive.
>
>  Note: When you export your app at the end of Distribute App, Xcode will create a directory containing an IPA of your app and an ExportOptions.plist file. You can create new IPAs with the same options without launching Xcode by running flutter build ipa --export-options-plist=path/to/ExportOptions.plist. See xcodebuild -h for details about the keys in this property list.
>
> 2. Open build/ios/archive/MyApp.xcarchive in Xcode.

In this PR, if the user doesn't pass `--export-options-plist`, instead of bailing after the `xcarchive`, assume the user wants the most common case: to distribute their app to the App Store via the new `--export-method` option and its default `app-store`.  Create the plist if one isn't passed in, with reasonable defaults for the most common settings for a Flutter app.  If it fails (they haven't registered their app bundle ID for example), suggest they open the archive in Xcode and go through its wizard, as the docs currently suggest.

Allow the user to also specify `--export-method ad-hoc` or `--export-method development`.  See https://developer.apple.com/forums/thread/100614 for the distinction.

If the user has a more complicated scenario, they can continue to create their own plist via `--export-options-plist`, or open with Xcode.

We can add other options in the future for other values in the generated plist, if developers request it.

### Command logging examples

#### Success
```
$ flutter build ipa
Running "flutter pub get" in veggieseasons...                    1,814ms
Archiving dev.flutter.VeggieSeasons...
Automatically signing iOS for device deployment using specified development team in Xcode project: S8QB4VV633
Running Xcode build...
 └─Compiling, linking and signing...                        12.3s
Xcode archive done.                                         38.6s
Built /Users/m/Projects/samples/veggieseasons/build/ios/archive/Runner.xcarchive.

💪 Building with sound null safety 💪

Building App Store IPA...                                          32.3s
Built IPA to /Users/m/Projects/samples/veggieseasons/build/ios/ipa.
To upload to the App Store either:
    1. Drag and drop the "build/ios/ipa/*.ipa" bundle into the Apple Transport macOS app https://apps.apple.com/us/app/transporter/id1450874784
    2. Run "xcrun altool --upload-app --type ios -f build/ios/ipa/*.ipa --apiKey your_api_key --apiIssuer your_issuer_id".
       See "man altool" for details about how to authenticate with the App Store Connect API key.
```

#### Flag validation error
```
$ flutter build ipa --export-options-plist foo.plist --export-method ad-hoc
"--export-options-plist" is not compatible with "--export-method". Either use "--export-options-plist" and a plist describing how the IPA should be exported by Xcode, or use "--export-method" to create a new plist.
See "xcodebuild -h" for available exportOptionsPlist keys.
```

#### IPA creation failure 
The bundle identifier isn't set up, which needs to be resolved in Xcode's UI:
```
$ flutter build ipa --export-method ad-hoc
...
Built /Users/m/Projects/test_create/build/ios/archive/Runner.xcarchive.
...
Building ad-hoc IPA...                                           2,123ms
Encountered error while creating the IPA:
error: exportArchive: Failed to register bundle identifier
error: exportArchive: No profiles for 'com.example.testCreate' were found


Try distributing the app in Xcode: "open /Users/m/Projects/test_create/build/ios/archive/Runner.xcarchive"
```
#### Help text
```
    --export-method                                 Specify how the IPA will be distributed.

          [ad-hoc]                                  Distribute to designated devices that do not need to be registered with the Apple developer account. Requires a distribution certificate.
          [app-store] (default)                     Upload to the App Store.
          [development]                             Distribute only to development devices registered with the Apple developer account.
```

Fixes https://github.com/flutter/flutter/issues/97179

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
