### PR TITLE
Fix hot-restart background-isolate-test test by ensuring updated timestamp is in the future.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
+++ b/packages/flutter_tools/test/integration.shard/background_isolate_test.dart
@@ -55,7 +55,7 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 10));
     await subscription.cancel();
     await flutter.stop();
-  }, skip: true); // Flake: https://github.com/flutter/flutter/issues/96677
+  });
 
   testWithoutContext('Hot reload updates background isolates', () async {
     final RepeatingBackgroundProject project = RepeatingBackgroundProject();

--- a/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/background_project.dart
@@ -51,7 +51,8 @@ class BackgroundProject extends Project {
 
   void updateTestIsolatePhrase(String message) {
     final String newMainContents = main.replaceFirst('Isolate thread', message);
-    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents);
+    writeFile(fileSystem.path.join(dir.path, 'lib', 'main.dart'), newMainContents,
+        writeFutureModifiedDate: true);
   }
 }
 


### PR DESCRIPTION
On Windows modified timestamps are round down to a second, which can lead to missed file updates.

Fixes https://github.com/flutter/flutter/issues/96677
