### PR TITLE
`RefreshIndicator`: Add an interactive example

### DIFF
--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
@@ -11,25 +11,27 @@ void main() => runApp(const MyApp());
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'RefreshIndicator Sample';
 
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
       title: _title,
-      home: MyStatefulWidget(),
+      home: RefreshIndicatorExample(title: _title),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class RefreshIndicatorExample extends StatefulWidget {
+  const RefreshIndicatorExample({Key? key, required this.title}) : super(key: key);
+
+  final String title;
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<RefreshIndicatorExample> createState() => _RefreshIndicatorExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _RefreshIndicatorExampleState extends State<RefreshIndicatorExample> {
   final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
     GlobalKey<RefreshIndicatorState>();
 
@@ -37,12 +39,15 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Flutter Code Sample'),
+        title: Text(widget.title),
       ),
       body: RefreshIndicator(
         key: _refreshIndicatorKey,
+        color: Colors.white,
+        backgroundColor: Colors.blue,
+        strokeWidth: 4.0,
         onRefresh: () async {
-          // Add the code to be executed during refresh
+          // Replace this delay with the code to be executed during refresh
           // and return a Future when code finishs execution.
           return Future<void>.delayed(const Duration(seconds: 3));
         },

--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
@@ -1,0 +1,69 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for RefreshIndicator
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({Key? key}) : super(key: key);
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = 
+    GlobalKey<RefreshIndicatorState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter Code Sample'),
+      ),
+      body: RefreshIndicator(
+        key: _refreshIndicatorKey,
+        onRefresh: () async {
+          // Add the code to be executed during refresh
+          // and return a Future when code finishs execution.
+          return Future<void>.delayed(const Duration(seconds: 3));
+        },
+        // Pull from top to show refresh indicator.
+        child: ListView.builder(
+          itemCount: 25,
+          itemBuilder: (BuildContext context, int index) {
+            return ListTile(
+              title: Text('Item $index'),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          // Callback that shows refresh indicator.
+          _refreshIndicatorKey.currentState?.show();
+        },
+        icon: const Icon(Icons.refresh),
+        label: const Text('Show Indicator'),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
@@ -30,7 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey = 
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
     GlobalKey<RefreshIndicatorState>();
 
   @override

--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
@@ -63,7 +63,7 @@ class _RefreshIndicatorExampleState extends State<RefreshIndicatorExample> {
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
-          // Callback that shows refresh indicator.
+          // Show refresh indicator programmatically on button tap.
           _refreshIndicatorKey.currentState?.show();
         },
         icon: const Icon(Icons.refresh),

--- a/examples/api/test/material/refresh_indicator/refresh_indicator.0_test.dart
+++ b/examples/api/test/material/refresh_indicator/refresh_indicator.0_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/refresh_indicator/refresh_indicator.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Trigger RefreshIndicator - Pull from top', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    await tester.fling(find.text('Item 1'), const Offset(0.0, 300.0), 1000.0);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
+    await tester.pumpAndSettle(); // Advance pending time
+  });
+
+  testWidgets('Trigger RefreshIndicator - Button', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.getCenter(find.byType(RefreshProgressIndicator)).dy, lessThan(300.0));
+    await tester.pumpAndSettle(); // Advance pending time
+  });
+}

--- a/packages/flutter/lib/src/material/refresh_indicator.dart
+++ b/packages/flutter/lib/src/material/refresh_indicator.dart
@@ -71,6 +71,12 @@ enum RefreshIndicatorTriggerMode {
 ///
 /// The trigger mode is configured by [RefreshIndicator.triggerMode].
 ///
+/// {@tool dartpad}
+/// This example shows how [RefreshIndicator] can be triggered in different ways.
+///
+/// ** See code in examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart **
+/// {@end-tool}
+///
 /// ## Troubleshooting
 ///
 /// ### Refresh indicator does not show up


### PR DESCRIPTION
#### Here this PR adds an interactive example to showcase how `RefreshIndicator`  can be triggered in different ways
https://master-api.flutter.dev/flutter/material/RefreshIndicator-class.html

Working on a recent PR for `RefreshIndicator `, I found there is no example and I was even more surprised to know it can be triggered without swiping 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
