### PR TITLE
Add timeout to keyboard finder to diagnose flake

### DIFF
--- a/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
+++ b/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
@@ -39,7 +39,9 @@ void main() {
 
       // Bring up keyboard
       await driver.tap(textFieldFinder);
-      await driver.waitFor(keyboardVisibilityIndicatorFinder);
+
+      // TODO(jmagman): Remove timeout once flake has been diagnosed. https://github.com/flutter/flutter/issues/96787
+      await driver.waitFor(keyboardVisibilityIndicatorFinder, timeout: const Duration(seconds: 5));
 
       // Ensure that TextField is visible again
       await driver.waitFor(textFieldFinder);


### PR DESCRIPTION
Help diagnose https://github.com/flutter/flutter/issues/96787 by timing out in the test, so the `drive` tests fail and a screenshot is captured, before the process is killed.

See https://github.com/flutter/flutter/issues/96787#issuecomment-1021702062

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
