### PR TITLE
Quote format param for git command.

### DIFF
--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -8,13 +8,13 @@
 // contemporary commit is the one that was public at the time of the last commit
 // on the master branch before the current commit's branch was created.
 
+import 'dart:convert';
 import 'dart:io';
 
 const bool debugLogging = true;
 
 void log(String message) {
-  if (debugLogging)
-    print(message);
+  if (debugLogging) print(message);
 }
 
 class Commit {
@@ -28,7 +28,7 @@ class Commit {
   static Commit parse(String line) {
     log('fff[$line]');
     final int space = line.indexOf(' ');
-    return Commit(line.substring(0, space), DateTime.parse(line.substring(space+1, line.length).trimRight()));
+    return Commit(line.substring(0, space), DateTime.parse(line.substring(space + 1, line.length).trimRight()));
   }
 
   static List<Commit> parseList(String lines) {
@@ -46,10 +46,13 @@ String findCommit({
   final Commit anchor;
   if (primaryBranch == primaryTrunk) {
     log('on $primaryTrunk, using last commit as anchor');
-    anchor = Commit.parse(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']));
+    anchor = Commit.parse(
+        git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']));
   } else {
-    final List<Commit> branchCommits = Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryBranch, '--']));
-    final List<Commit> trunkCommits = Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryTrunk, '--']));
+    final List<Commit> branchCommits =
+        Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryBranch, '--']));
+    final List<Commit> trunkCommits =
+        Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryTrunk, '--']));
     if (branchCommits.isEmpty || trunkCommits.isEmpty || branchCommits.first.hash != trunkCommits.first.hash)
       throw StateError('Branch $primaryBranch does not seem to have a common history with trunk $primaryTrunk.');
     if (branchCommits.last.hash == trunkCommits.last.hash) {
@@ -57,8 +60,9 @@ String findCommit({
       anchor = trunkCommits.last;
     } else {
       int index = 0;
-      while (branchCommits.length > index && trunkCommits.length > index && branchCommits[index].hash == trunkCommits[index].hash)
-        index += 1;
+      while (branchCommits.length > index &&
+          trunkCommits.length > index &&
+          branchCommits[index].hash == trunkCommits[index].hash) index += 1;
       log('$primaryBranch branched from $primaryTrunk ${branchCommits.length - index} commits ago, trunk has advanced by ${trunkCommits.length - index} commits since then.');
       anchor = trunkCommits[index - 1];
     }
@@ -74,22 +78,25 @@ String findCommit({
 }
 
 String git(String workingDirectory, List<String> arguments) {
-  final ProcessResult result = Process.runSync('git', arguments, workingDirectory: workingDirectory);
+  final ProcessResult result = Process.runSync(
+    'git',
+    arguments,
+    workingDirectory: workingDirectory,
+    stdoutEncoding: utf8,
+  );
   if (result.exitCode != 0 || '${result.stderr}'.isNotEmpty)
     throw ProcessException('git', arguments, '${result.stdout}${result.stderr}', result.exitCode);
-  return result.stdout;
+  return '${result.stdout}';
 }
 
 void main(List<String> arguments) {
   if (arguments.isEmpty || arguments.length > 2 || arguments.contains('--help') || arguments.contains('-h')) {
-    print(
-      'Usage: dart find_commit.dart [<path-to-primary-repo>] <path-to-secondary-repo>\n'
-      'This script will find the commit in the secondary repo that was contemporary\n'
-      'when the commit in the primary repo was created. If that commit is on a\n'
-      "branch, then the date of the branch's creation is used instead.\n"
-      'If <path-to-primary-repo> is omitted, the current directory is used for the\n'
-      'primary repo.'
-    );
+    print('Usage: dart find_commit.dart [<path-to-primary-repo>] <path-to-secondary-repo>\n'
+        'This script will find the commit in the secondary repo that was contemporary\n'
+        'when the commit in the primary repo was created. If that commit is on a\n'
+        "branch, then the date of the branch's creation is used instead.\n"
+        'If <path-to-primary-repo> is omitted, the current directory is used for the\n'
+        'primary repo.');
   } else {
     final String primaryRepo = arguments.length == 1 ? '.' : arguments.first;
     final String secondaryRepo = arguments.last;

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -23,7 +23,7 @@ class Commit {
   final String hash;
   final DateTime timestamp;
 
-  static String formatArgument = '--pretty="format:%H %cI"';
+  static String formatArgument = "--pretty='%H %ci'";
 
   static Commit parse(String line) {
     log('fff[$line]');

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -45,7 +45,6 @@ String findCommit({
   final Commit anchor;
   if (primaryBranch == primaryTrunk) {
     log('on $primaryTrunk, using last commit as anchor');
-    log("zzz@$(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']))@");
     anchor = Commit.parse(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']));
   } else {
     final List<Commit> branchCommits = Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryBranch, '--']));
@@ -77,6 +76,7 @@ String git(String workingDirectory, List<String> arguments) {
   final ProcessResult result = Process.runSync('git', arguments, workingDirectory: workingDirectory);
   if (result.exitCode != 0 || '${result.stderr}'.isNotEmpty)
     throw ProcessException('git', arguments, '${result.stdout}${result.stderr}', result.exitCode);
+  log('zzz[${result.stdout}]');
   return '${result.stdout}';
 }
 

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -23,7 +23,7 @@ class Commit {
   final String hash;
   final DateTime timestamp;
 
-  static String formatArgument = '--format="%H %cI"';
+  static String formatArgument = '--pretty="format:%H %cI"';
 
   static Commit parse(String line) {
     log('fff[$line]');

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -23,7 +23,7 @@ class Commit {
   final String hash;
   final DateTime timestamp;
 
-  static String formatArgument = '--format=%H %cI';
+  static String formatArgument = '--format="%H %cI"';
 
   static Commit parse(String line) {
     final int space = line.indexOf(' ');

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -26,6 +26,7 @@ class Commit {
   static String formatArgument = '--format="%H %cI"';
 
   static Commit parse(String line) {
+    log('fff[$line]');
     final int space = line.indexOf(' ');
     return Commit(line.substring(0, space), DateTime.parse(line.substring(space+1, line.length).trimRight()));
   }

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -78,6 +78,7 @@ String findCommit({
 }
 
 String git(String workingDirectory, List<String> arguments) {
+  log('gggg[$arguments]');
   final ProcessResult result = Process.runSync(
     'git',
     arguments,

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -77,7 +77,6 @@ String git(String workingDirectory, List<String> arguments) {
   final ProcessResult result = Process.runSync('git', arguments, workingDirectory: workingDirectory);
   if (result.exitCode != 0 || '${result.stderr}'.isNotEmpty)
     throw ProcessException('git', arguments, '${result.stdout}${result.stderr}', result.exitCode);
-  log('zzz[${result.stdout}]');
   return '${result.stdout}';
 }
 

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -77,7 +77,7 @@ String git(String workingDirectory, List<String> arguments) {
   final ProcessResult result = Process.runSync('git', arguments, workingDirectory: workingDirectory);
   if (result.exitCode != 0 || '${result.stderr}'.isNotEmpty)
     throw ProcessException('git', arguments, '${result.stdout}${result.stderr}', result.exitCode);
-  return '${result.stdout}';
+  return result.stdout;
 }
 
 void main(List<String> arguments) {

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -45,6 +45,7 @@ String findCommit({
   final Commit anchor;
   if (primaryBranch == primaryTrunk) {
     log('on $primaryTrunk, using last commit as anchor');
+    log("zzz@$(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']))@");
     anchor = Commit.parse(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, '--max-count=1', primaryBranch, '--']));
   } else {
     final List<Commit> branchCommits = Commit.parseList(git(primaryRepoDirectory, <String>['log', Commit.formatArgument, primaryBranch, '--']));

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -10,7 +10,7 @@
 
 import 'dart:io';
 
-const bool debugLogging = false;
+const bool debugLogging = true;
 
 void log(String message) {
   if (debugLogging)


### PR DESCRIPTION
find_commit was not quoting the format command which was causing
failures to get the initial commit.

Bug: https://github.com/flutter/flutter/issues/97272

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
