### PR TITLE
Make DAP tests more tolerant of output that didn't come from the app being tested

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -40,8 +40,8 @@ void main() {
 
     // Once the "topLevelFunction" output arrives, we can terminate the app.
     unawaited(
-      dap.client.outputEvents
-          .firstWhere((OutputEventBody output) => output.output.startsWith('topLevelFunction'))
+      dap.client.output
+          .firstWhere((String output) => output.startsWith('topLevelFunction'))
           .whenComplete(() => dap.client.terminate()),
     );
 
@@ -70,8 +70,8 @@ void main() {
 
     // Once the "topLevelFunction" output arrives, we can terminate the app.
     unawaited(
-      dap.client.outputEvents
-          .firstWhere((OutputEventBody output) => output.output.startsWith('topLevelFunction'))
+      dap.client.stdoutOutput
+          .firstWhere((String output) => output.startsWith('topLevelFunction'))
           .whenComplete(() => dap.client.terminate()),
     );
 
@@ -118,7 +118,7 @@ void main() {
 
     // Launch the app and wait for it to print "topLevelFunction".
     await Future.wait(<Future<void>>[
-      dap.client.outputEvents.firstWhere((OutputEventBody output) => output.output.startsWith('topLevelFunction')),
+      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
       dap.client.start(
         launch: () => dap.client.launch(
           cwd: project.dir.path,
@@ -130,7 +130,7 @@ void main() {
 
     // Capture the next two output events that we expect to be the Reload
     // notification and then topLevelFunction being printed again.
-    final Future<List<String>> outputEventsFuture = dap.client.output
+    final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
         // But skip any topLevelFunctions that come before the reload.
         .skipWhile((String output) => output.startsWith('topLevelFunction'))
         .take(2)
@@ -155,7 +155,7 @@ void main() {
 
     // Launch the app and wait for it to print "topLevelFunction".
     await Future.wait(<Future<void>>[
-      dap.client.outputEvents.firstWhere((OutputEventBody output) => output.output.startsWith('topLevelFunction')),
+      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
       dap.client.start(
         launch: () => dap.client.launch(
           cwd: project.dir.path,
@@ -167,7 +167,7 @@ void main() {
 
     // Capture the next two output events that we expect to be the Restart
     // notification and then topLevelFunction being printed again.
-    final Future<List<String>> outputEventsFuture = dap.client.output
+    final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
         // But skip any topLevelFunctions that come before the restart.
         .skipWhile((String output) => output.startsWith('topLevelFunction'))
         .take(2)
@@ -233,8 +233,7 @@ void main() {
     // Launch the app and wait for it to print "topLevelFunction" so we know
     // it's up and running.
     await Future.wait(<Future<void>>[
-      dap.client.outputEvents.firstWhere((OutputEventBody output) =>
-          output.output.startsWith('topLevelFunction')),
+      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
       dap.client.start(
         launch: () => dap.client.launch(
           cwd: project.dir.path,

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -63,6 +63,11 @@ class DapTestClient {
   /// Returns a stream of the string output from [OutputEventBody] events.
   Stream<String> get output => outputEvents.map((OutputEventBody output) => output.output);
 
+  /// Returns a stream of the string output from [OutputEventBody] events with the category 'stdout'.
+  Stream<String> get stdoutOutput => outputEvents
+      .where((OutputEventBody output) => output.category == 'stdout')
+      .map((OutputEventBody output) => output.output);
+
   /// Sends a custom request to the server and waits for a response.
   Future<Response> custom(String name, [Object? args]) async {
     return sendRequest(args, overrideCommand: name);


### PR DESCRIPTION
@christopherfujino I believe this should prevent the flake in #97238 by narrowing the test to only look at the output they are about (so not being affected by other unrelated output).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
