### PR TITLE
Fix the TimePicker hour/minute field's input actions

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1413,6 +1413,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     if (newHour != null) {
       _selectedTime.value = TimeOfDay(hour: newHour, minute: _selectedTime.value.minute);
       widget.onChanged(_selectedTime.value);
+      FocusScope.of(context).requestFocus();
     }
   }
 
@@ -1429,6 +1430,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     if (newMinute != null) {
       _selectedTime.value = TimeOfDay(hour: _selectedTime.value.hour, minute: int.parse(value!));
       widget.onChanged(_selectedTime.value);
+      FocusScope.of(context).unfocus();
     }
   }
 
@@ -1505,6 +1507,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                             selectedTime: _selectedTime.value,
                             style: hourMinuteStyle,
                             autofocus: widget.autofocusHour,
+                            inputAction: TextInputAction.next,
                             validator: _validateHour,
                             onSavedSubmitted: _handleHourSavedSubmitted,
                             onChanged: _handleHourChanged,
@@ -1538,6 +1541,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                             selectedTime: _selectedTime.value,
                             style: hourMinuteStyle,
                             autofocus: widget.autofocusMinute,
+                            inputAction: TextInputAction.done,
                             validator: _validateMinute,
                             onSavedSubmitted: _handleMinuteSavedSubmitted,
                             minuteLabelText: widget.minuteLabelText,
@@ -1586,6 +1590,7 @@ class _HourTextField extends StatelessWidget {
     required this.selectedTime,
     required this.style,
     required this.autofocus,
+    required this.inputAction,
     required this.validator,
     required this.onSavedSubmitted,
     required this.onChanged,
@@ -1596,6 +1601,7 @@ class _HourTextField extends StatelessWidget {
   final TimeOfDay selectedTime;
   final TextStyle style;
   final bool? autofocus;
+  final TextInputAction inputAction;
   final FormFieldValidator<String> validator;
   final ValueChanged<String?> onSavedSubmitted;
   final ValueChanged<String> onChanged;
@@ -1609,6 +1615,7 @@ class _HourTextField extends StatelessWidget {
       selectedTime: selectedTime,
       isHour: true,
       autofocus: autofocus,
+      inputAction: inputAction,
       style: style,
       semanticHintText: hourLabelText ??  MaterialLocalizations.of(context).timePickerHourLabel,
       validator: validator,
@@ -1623,6 +1630,7 @@ class _MinuteTextField extends StatelessWidget {
     required this.selectedTime,
     required this.style,
     required this.autofocus,
+    required this.inputAction,
     required this.validator,
     required this.onSavedSubmitted,
     required this.minuteLabelText,
@@ -1632,6 +1640,7 @@ class _MinuteTextField extends StatelessWidget {
   final TimeOfDay selectedTime;
   final TextStyle style;
   final bool? autofocus;
+  final TextInputAction inputAction;
   final FormFieldValidator<String> validator;
   final ValueChanged<String?> onSavedSubmitted;
   final String? minuteLabelText;
@@ -1644,6 +1653,7 @@ class _MinuteTextField extends StatelessWidget {
       selectedTime: selectedTime,
       isHour: false,
       autofocus: autofocus,
+      inputAction: inputAction,
       style: style,
       semanticHintText: minuteLabelText ?? MaterialLocalizations.of(context).timePickerMinuteLabel,
       validator: validator,
@@ -1657,6 +1667,7 @@ class _HourMinuteTextField extends StatefulWidget {
     required this.selectedTime,
     required this.isHour,
     required this.autofocus,
+    required this.inputAction,
     required this.style,
     required this.semanticHintText,
     required this.validator,
@@ -1668,6 +1679,7 @@ class _HourMinuteTextField extends StatefulWidget {
   final TimeOfDay selectedTime;
   final bool isHour;
   final bool? autofocus;
+  final TextInputAction inputAction;
   final TextStyle style;
   final String semanticHintText;
   final FormFieldValidator<String> validator;
@@ -1783,6 +1795,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
             ],
             focusNode: focusNode,
             textAlign: TextAlign.center,
+            textInputAction: widget.inputAction,
             keyboardType: TextInputType.number,
             style: widget.style.copyWith(color: timePickerTheme.hourMinuteTextColor ?? colorScheme.onSurface),
             controller: controller.value,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -1291,6 +1291,26 @@ void _testsInput() {
     await finishPicker(tester);
     expect(result, equals(const TimeOfDay(hour: 6, minute: 45)));
   });
+
+  testWidgets('Can switch between hour/minute fields using keyboard input action', (WidgetTester tester) async {
+    await startPicker(tester, (TimeOfDay? time) { }, entryMode: TimePickerEntryMode.input);
+
+    final Finder hourFinder = find.byType(TextField).first;
+    final TextField hourField = tester.widget(hourFinder);
+    await tester.tap(hourFinder);
+    expect(hourField.focusNode!.hasFocus, isTrue);
+
+    await tester.enterText(find.byType(TextField).first, '08');
+    final Finder minuteFinder = find.byType(TextField).last;
+    final TextField minuteField = tester.widget(minuteFinder);
+    expect(hourField.focusNode!.hasFocus, isFalse);
+    expect(minuteField.focusNode!.hasFocus, isTrue);
+
+    expect(tester.testTextInput.setClientArgs!['inputAction'], equals('TextInputAction.done'));
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    expect(hourField.focusNode!.hasFocus, isFalse);
+    expect(minuteField.focusNode!.hasFocus, isFalse);
+  });
 }
 
 final Finder findDialPaint = find.descendant(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/68249

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Material App',
      theme: ThemeData.dark(),
      home: const TimePickerSample(),
    );
  }
}

class TimePickerSample extends StatelessWidget {
  const TimePickerSample({Key? key}) : super(key: key);

  Future<TimeOfDay?> _showTimePicker(BuildContext context) {
    return showTimePicker(
      initialTime: TimeOfDay.now(),
      initialEntryMode: TimePickerEntryMode.input,
      context: context,
      confirmText: 'Accept',
      cancelText: 'Reject',
      hourLabelText: 'Happy Hour',
      minuteLabelText: 'Happy Minute',
      helpText: 'Spend your time wisely',
      onEntryModeChanged: (TimePickerEntryMode mode) {
        // ignore: avoid_print
        print('Current Mode: $mode');
      },
    );
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('TimePicker Sample'),
      ),
      body: Center(
        child: OutlinedButton(
          onPressed: () => _showTimePicker(context),
          child: const Text('Show TimePicker'),
        ),
      ),
    );
  }
}
``` 
	
</details>

### Native behavior with input mode 
The hour text field has the "next" input action which shifts the focus from the hour field to the minute field.
The minute text field has the "done" input action, which hides the keyboard. 

https://user-images.githubusercontent.com/48603081/151339372-3e952ca4-df9c-459d-9ede-263fcd253349.mov

### Bug
Both hour and minute text fields have "done" action which when pressing does nothing.




https://user-images.githubusercontent.com/48603081/166164962-aac21ecc-81b1-4d34-8055-ed4e52650db7.mov


### Fix


https://user-images.githubusercontent.com/48603081/166164973-beeb2af6-9f1e-42b6-b6be-cbbcb93a255c.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
