### PR TITLE
Implement system menu bar support

### DIFF
--- a/dev/manual_tests/lib/menu_bar.dart
+++ b/dev/manual_tests/lib/menu_bar.dart
@@ -1,0 +1,382 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+const List<String> mainMenu = <String>[
+  'Menu 1',
+  'Menu 2',
+  'Menu 3',
+  'Menu 4',
+];
+
+const List<String> subMenu = <String>[
+  'Sub Menu 1',
+  'Sub Menu 2',
+  'Sub Menu 3',
+  'Sub Menu 4',
+  'Sub Menu 5',
+  'Sub Menu 6',
+  'Sub Menu 7',
+  'Sub',
+];
+
+const List<String> subSubMenu = <String>[
+  'Sub Sub Menu 1',
+  'Sub Sub Menu 2',
+  'Sub Sub Menu 3',
+];
+
+void main() {
+  debugFocusChanges = false;
+  runApp(const MaterialApp(
+    title: 'Menu Tester',
+    home: Material(child: Home()),
+  ));
+}
+
+class Home extends StatefulWidget {
+  const Home({super.key});
+
+  @override
+  State<Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
+  late MenuBarController controller;
+  bool isPlatformMenu = false;
+  VisualDensity density = VisualDensity.standard;
+  TextDirection textDirection = TextDirection.ltr;
+  bool enabled = true;
+  bool addItem = false;
+  bool checked = false;
+
+  void _itemSelected(String item) {
+    debugPrint('App: Selected item $item');
+  }
+
+  void _openItem(String item) {
+    debugPrint('App: Opened item $item');
+  }
+
+  void _closeItem(String item) {
+    debugPrint('App: Closed item $item');
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    controller = MenuBarController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Directionality(
+      textDirection: textDirection,
+      child: Builder(builder: (BuildContext context) {
+        return Theme(
+          data: theme.copyWith(visualDensity: density),
+          child: Column(
+            children: <Widget>[
+              MenuBar(
+                enabled: enabled,
+                controller: controller,
+                menus: <MenuItem>[
+                  MenuBarMenu(
+                    label: mainMenu[0],
+                    onOpen: () {
+                      _openItem(mainMenu[0]);
+                    },
+                    onClose: () {
+                      _closeItem(mainMenu[0]);
+                    },
+                    menus: <MenuItem>[
+                      MenuBarItem(
+                          label: subMenu[0],
+                          shortcut: const SingleActivator(
+                            LogicalKeyboardKey.escape,
+                            control: true,
+                          ),
+                          leadingIcon:
+                              checked ? const Icon(Icons.check_box) : const Icon(Icons.check_box_outline_blank),
+                          trailingIcon: const Icon(Icons.assessment),
+                          onSelected: () {
+                            _itemSelected(subMenu[0]);
+                            setState(() {
+                              checked = !checked;
+                            });
+                          }),
+                      MenuBarItem(
+                        label: subMenu[1],
+                        leadingIcon: const Icon(Icons.check_box),
+                        trailingIcon: const Icon(Icons.mail),
+                        onSelected: () {
+                          _itemSelected(subMenu[1]);
+                        },
+                      ),
+                    ],
+                  ),
+                  MenuBarMenu(
+                    label: mainMenu[1],
+                    onOpen: () {
+                      _openItem(mainMenu[1]);
+                    },
+                    onClose: () {
+                      _closeItem(mainMenu[1]);
+                    },
+                    menus: <MenuItem>[
+                      MenuBarItem(
+                        label: subMenu[2],
+                        shortcut: const SingleActivator(
+                          LogicalKeyboardKey.enter,
+                          control: true,
+                        ),
+                        onSelected: () {
+                          _itemSelected(subMenu[2]);
+                        },
+                      ),
+                    ],
+                  ),
+                  MenuBarMenu(
+                    label: mainMenu[2],
+                    onOpen: () {
+                      _openItem(mainMenu[2]);
+                    },
+                    onClose: () {
+                      _closeItem(mainMenu[2]);
+                    },
+                    menus: <MenuItem>[
+                      PlatformMenuItemGroup(members: <MenuItem>[
+                        MenuBarItem(
+                          label: subMenu[3],
+                          shortcut: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
+                          onSelectedIntent: const ActivateIntent(),
+                        ),
+                      ]),
+                      MenuBarMenu(
+                        label: subMenu[4],
+                        onOpen: () {
+                          _openItem(subMenu[4]);
+                        },
+                        onClose: () {
+                          _closeItem(subMenu[4]);
+                        },
+                        menus: <MenuItem>[
+                          MenuBarItem(
+                            label: subSubMenu[0],
+                            shortcut: addItem
+                                ? const SingleActivator(
+                                    LogicalKeyboardKey.f11,
+                                    control: true,
+                                  )
+                                : const SingleActivator(
+                                    LogicalKeyboardKey.f10,
+                                    control: true,
+                                  ),
+                            onSelected: () {
+                              _itemSelected(subSubMenu[0]);
+                            },
+                          ),
+                          MenuBarItem(
+                            label: subSubMenu[1],
+                            onSelected: () {
+                              _itemSelected(subSubMenu[1]);
+                            },
+                          ),
+                          if (addItem)
+                            MenuBarItem(
+                              label: subSubMenu[2],
+                              onSelected: () {
+                                _itemSelected(subSubMenu[2]);
+                              },
+                            ),
+                        ],
+                      ),
+                      MenuBarItem(
+                        label: subMenu[5],
+                        shortcut: const SingleActivator(
+                          LogicalKeyboardKey.tab,
+                          control: true,
+                        ),
+                      ),
+                      MenuBarItem(
+                        label: subMenu[6],
+                        onSelected: () {},
+                      ),
+                      MenuBarItem(
+                        label: subMenu[6],
+                        onSelected: () {},
+                      ),
+                      MenuBarItem(
+                        label: subMenu[6],
+                        onSelected: () {},
+                      ),
+                      MenuBarItem(
+                        label: subMenu[6],
+                        onSelected: () {},
+                      ),
+                      MenuBarItem(
+                        label: subMenu[7],
+                        onSelected: () {},
+                      ),
+                      MenuBarItem(
+                        label: subMenu[7],
+                        onSelected: () {},
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              Expanded(
+                child: _Controls(
+                  density: density,
+                  enabled: enabled,
+                  addItem: addItem,
+                  textDirection: textDirection,
+                  onDensityChanged: (VisualDensity value) {
+                    setState(() {
+                      density = value;
+                    });
+                  },
+                  onTextDirectionChanged: (TextDirection value) {
+                    setState(() {
+                      textDirection = value;
+                    });
+                  },
+                  onEnabledChanged: (bool value) {
+                    setState(() {
+                      enabled = value;
+                    });
+                  },
+                  onAddItemChanged: (bool value) {
+                    setState(() {
+                      addItem = value;
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _Controls extends StatelessWidget {
+  const _Controls({
+    required this.density,
+    required this.textDirection,
+    this.enabled = true,
+    this.addItem = false,
+    required this.onDensityChanged,
+    required this.onTextDirectionChanged,
+    required this.onEnabledChanged,
+    required this.onAddItemChanged,
+  });
+
+  final VisualDensity density;
+  final TextDirection textDirection;
+  final bool enabled;
+  final bool addItem;
+  final ValueChanged<VisualDensity> onDensityChanged;
+  final ValueChanged<TextDirection> onTextDirectionChanged;
+  final ValueChanged<bool> onEnabledChanged;
+  final ValueChanged<bool> onAddItemChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          ConstrainedBox(
+            constraints: const BoxConstraints.tightFor(width: 400),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                Text('Horizontal Density: ${density.horizontal.toStringAsFixed(1)}'),
+                Slider(
+                    value: density.horizontal,
+                    max: 4,
+                    min: -4,
+                    divisions: 12,
+                    onChanged: (double value) {
+                      onDensityChanged(VisualDensity(horizontal: value, vertical: density.vertical));
+                    }),
+              ],
+            ),
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints.tightFor(width: 400),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                Text('Vertical Density: ${density.vertical.toStringAsFixed(1)}'),
+                Slider(
+                    value: density.vertical,
+                    max: 4,
+                    min: -4,
+                    divisions: 12,
+                    onChanged: (double value) {
+                      onDensityChanged(VisualDensity(horizontal: density.horizontal, vertical: value));
+                    }),
+              ],
+            ),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Checkbox(
+                value: textDirection == TextDirection.rtl,
+                onChanged: (bool? value) {
+                  if (value ?? false) {
+                    onTextDirectionChanged(TextDirection.rtl);
+                  } else {
+                    onTextDirectionChanged(TextDirection.ltr);
+                  }
+                },
+              ),
+              const Text('RTL Text')
+            ],
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Checkbox(
+                value: enabled,
+                onChanged: (bool? value) {
+                  if (value ?? false) {
+                    onEnabledChanged(true);
+                  } else {
+                    onEnabledChanged(false);
+                  }
+                },
+              ),
+              const Text('Enabled')
+            ],
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Checkbox(
+                value: addItem,
+                onChanged: (bool? value) {
+                  if (value ?? false) {
+                    onAddItemChanged(true);
+                  } else {
+                    onAddItemChanged(false);
+                  }
+                },
+              ),
+              const Text('Add Item')
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/menu_bar/menu_bar.0.dart
+++ b/examples/api/lib/material/menu_bar/menu_bar.0.dart
@@ -1,0 +1,167 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for MenuBar
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void main() => runApp(const SampleApp());
+
+enum MenuSelection {
+  about,
+  showMessage,
+  colorMenu,
+  colorRed,
+  colorGreen,
+  colorBlue,
+  quit,
+}
+
+class SampleApp extends StatelessWidget {
+  const SampleApp({super.key});
+
+  static const String _title = 'MenuBar Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: Scaffold(body: MyMenuBarApp()),
+    );
+  }
+}
+
+class MyMenuBarApp extends StatefulWidget {
+  const MyMenuBarApp({super.key});
+
+  @override
+  State<MyMenuBarApp> createState() => _MyMenuBarAppState();
+}
+
+class _MyMenuBarAppState extends State<MyMenuBarApp> {
+  bool get showMessage => _showMessage;
+  bool _showMessage = false;
+  set showMessage(bool value) {
+    if (_showMessage != value) {
+      setState(() {
+        _showMessage = value;
+      });
+    }
+  }
+
+  Color get backgroundColor => _backgroundColor;
+  Color _backgroundColor = Colors.red;
+  set backgroundColor(Color value) {
+    if (_backgroundColor != value) {
+      setState(() {
+        _backgroundColor = value;
+      });
+    }
+  }
+
+  void _activate(MenuSelection selection) {
+    switch (selection) {
+      case MenuSelection.about:
+        showAboutDialog(
+          context: context,
+          applicationName: 'MenuBar Test',
+          applicationVersion: '1.0.0',
+        );
+        break;
+      case MenuSelection.showMessage:
+        showMessage = !showMessage;
+        break;
+      case MenuSelection.quit:
+        exit(0);
+      case MenuSelection.colorMenu:
+        break;
+      case MenuSelection.colorRed:
+        backgroundColor = Colors.red;
+        break;
+      case MenuSelection.colorGreen:
+        backgroundColor = Colors.green;
+        break;
+      case MenuSelection.colorBlue:
+        backgroundColor = Colors.blue;
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        MenuBar(
+          menus: <PlatformMenu>[
+            MenuBarMenu(
+              autofocus: true,
+              label: 'Test App',
+              menus: <MenuItem>[
+                MenuBarItem(
+                  label: 'About',
+                  onSelected: () => _activate(MenuSelection.about),
+                ),
+                MenuBarItem(
+                  // Add a builder so that that call to MenuBarController.of will be using
+                  // the correct context.
+                  leadingIcon: Builder(builder: (BuildContext context) {
+                    return Checkbox(
+                      value: _showMessage,
+                      onChanged: (bool? value) {
+                        showMessage = value ?? false;
+                      },
+                    );
+                  }),
+                  label: 'Show Message',
+                  onSelected: () {
+                    showMessage = !showMessage;
+                  },
+                ),
+                MenuBarMenu(
+                  label: 'Background Color',
+                  menus: <MenuItem>[
+                    MenuItemGroup(members: <MenuItem>[
+                      MenuBarItem(
+                        onSelected: () => _activate(MenuSelection.colorRed),
+                        label: 'Red Background',
+                        shortcut: const SingleActivator(LogicalKeyboardKey.keyR, control: true),
+                      ),
+                      MenuBarItem(
+                        onSelected: () => _activate(MenuSelection.colorGreen),
+                        label: 'Green Background',
+                        shortcut: const SingleActivator(LogicalKeyboardKey.keyG, control: true),
+                      ),
+                    ]),
+                    MenuBarItem(
+                      onSelected: () => _activate(MenuSelection.colorBlue),
+                      label: 'Blue Background',
+                      shortcut: const SingleActivator(LogicalKeyboardKey.keyB, control: true),
+                    ),
+                  ],
+                ),
+                // Only include the "quit" item on non-web platforms.
+                if (!kIsWeb)
+                  MenuBarItem(
+                    onSelected: () => _activate(MenuSelection.quit),
+                    label: 'Quit',
+                  ),
+              ],
+            ),
+          ],
+        ),
+        Expanded(
+          child: Container(
+            alignment: Alignment.center,
+            color: backgroundColor,
+            child: Text(_showMessage ? 'Message' : 'Application Body'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/examples/api/lib/material/menu_bar/menu_bar.1.dart
+++ b/examples/api/lib/material/menu_bar/menu_bar.1.dart
@@ -1,0 +1,172 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Example for MenuBar.adaptive.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+void main() {
+  runApp(const MaterialApp(
+    title: 'Adaptive Menu Sample',
+    home: Material(child: Home()),
+  ));
+}
+
+enum MenuSelection {
+  edit,
+  cut,
+  copy,
+  paste,
+  file,
+  open,
+  quit,
+  save,
+  saveAs,
+}
+
+String getLabel(MenuSelection selection) {
+  // Use a switch so that the analyzer will warn us if we aren't handling a
+  // case.
+  switch (selection) {
+    case MenuSelection.edit:
+      return 'Edit';
+    case MenuSelection.cut:
+      return 'Cut';
+    case MenuSelection.copy:
+      return 'Copy';
+    case MenuSelection.paste:
+      return 'Paste';
+    case MenuSelection.file:
+      return 'File';
+    case MenuSelection.open:
+      return 'Open';
+    case MenuSelection.quit:
+      return 'Quit';
+    case MenuSelection.save:
+      return 'Save';
+    case MenuSelection.saveAs:
+      return 'Save As...';
+  }
+}
+
+class Home extends StatefulWidget {
+  const Home({super.key});
+
+  @override
+  State<Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<Home> {
+  bool isPlatformMenu = false;
+  TextDirection textDirection = TextDirection.ltr;
+  bool enabled = true;
+  bool checked = false;
+
+  void _onSelected(MenuSelection item) {
+    debugPrint('Activated ${item.name}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
+    final bool meta = isMacOS;
+    final bool control = !meta;
+    final bool hasAbout = PlatformProvidedMenuItem.hasMenu(PlatformProvidedMenuItemType.about);
+    final bool hasQuit = PlatformProvidedMenuItem.hasMenu(PlatformProvidedMenuItemType.quit);
+
+    return Column(
+      children: <Widget>[
+        MenuBar.adaptive(
+          enabled: enabled,
+          menus: <MenuItem>[
+            MenuBarMenu(
+              label: getLabel(MenuSelection.file),
+              menus: <MenuItem>[
+                if (hasAbout) const PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.about),
+                MenuItemGroup(
+                  members: <MenuItem>[
+                    MenuBarItem(
+                      label: getLabel(MenuSelection.open),
+                      shortcut: SingleActivator(
+                        LogicalKeyboardKey.keyO,
+                        control: control,
+                        meta: meta,
+                      ),
+                      onSelected: () {
+                        _onSelected(MenuSelection.open);
+                      },
+                    ),
+                    MenuBarItem(
+                      label: getLabel(MenuSelection.save),
+                      shortcut: SingleActivator(
+                        LogicalKeyboardKey.keyS,
+                        control: control,
+                        meta: meta,
+                      ),
+                      onSelected: () {
+                        _onSelected(MenuSelection.save);
+                      },
+                    ),
+                    MenuBarItem(
+                      label: getLabel(MenuSelection.saveAs),
+                      shortcut: SingleActivator(
+                        LogicalKeyboardKey.keyS,
+                        shift: true,
+                        control: control,
+                        meta: meta,
+                      ),
+                      onSelected: () {
+                        _onSelected(MenuSelection.saveAs);
+                      },
+                    ),
+                  ],
+                ),
+                if (hasQuit) const PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.quit),
+              ],
+            ),
+            MenuBarMenu(
+              label: getLabel(MenuSelection.edit),
+              menus: <MenuItem>[
+                MenuBarItem(
+                  label: getLabel(MenuSelection.cut),
+                  shortcut: SingleActivator(
+                    LogicalKeyboardKey.keyX,
+                    control: control,
+                    meta: meta,
+                  ),
+                  onSelected: () => _onSelected(MenuSelection.cut),
+                ),
+                MenuBarItem(
+                  label: getLabel(MenuSelection.copy),
+                  shortcut: SingleActivator(
+                    LogicalKeyboardKey.keyC,
+                    control: control,
+                    meta: meta,
+                  ),
+                  onSelected: () => _onSelected(MenuSelection.copy),
+                ),
+                MenuBarItem(
+                  label: getLabel(MenuSelection.paste),
+                  shortcut: SingleActivator(
+                    LogicalKeyboardKey.keyV,
+                    control: control,
+                    meta: meta,
+                  ),
+                  onSelected: () => _onSelected(MenuSelection.paste),
+                ),
+              ],
+            ),
+          ],
+        ),
+        const Expanded(
+          child: Center(
+            child: Text('Body'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -103,6 +103,8 @@ export 'src/material/material_button.dart';
 export 'src/material/material_localizations.dart';
 export 'src/material/material_state.dart';
 export 'src/material/material_state_mixin.dart';
+export 'src/material/menu_bar.dart';
+export 'src/material/menu_bar_theme.dart';
 export 'src/material/mergeable_material.dart';
 export 'src/material/navigation_bar.dart';
 export 'src/material/navigation_bar_theme.dart';

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -684,5 +684,11 @@ class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
   T resolve(Set<MaterialState> states) => value;
 
   @override
-  String toString() => 'MaterialStatePropertyAll($value)';
+  String toString() {
+    if (value is double || value is double?) {
+      return 'MaterialStatePropertyAll(${debugFormatDouble(value as double?)})';
+    } else {
+      return 'MaterialStatePropertyAll($value)';
+    }
+  }
 }

--- a/packages/flutter/lib/src/material/menu_bar.dart
+++ b/packages/flutter/lib/src/material/menu_bar.dart
@@ -1,0 +1,3233 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'button_style.dart';
+import 'color_scheme.dart';
+import 'divider.dart';
+import 'icons.dart';
+import 'material.dart';
+import 'material_localizations.dart';
+import 'material_state.dart';
+import 'menu_bar_theme.dart';
+import 'text_button.dart';
+import 'text_button_theme.dart';
+import 'theme.dart';
+import 'theme_data.dart';
+
+// The time after a menu item is opened via hover during which clicks on a child
+// menu item with a submenu will be ignored by the menu item. This is so that
+// users aren't surprised by hovering over a main menu to open it, and then
+// quickly moving to a submenu and clicking on it to open it. Without this
+// delay, it often just feels like the menu opened briefly and closed when
+// clicked on, when in reality they opened it via the hover before they ever
+// clicked on it.
+const Duration _kMenuHoverClickBanDelay = Duration(milliseconds: 500);
+
+// The default size of the arrow that indicates that a menu has a submenu.
+const double _kDefaultSubmenuIconSize = 24.0;
+
+// The default spacing between the the leading icon, label, trailing icon, and
+// shortcut label in a _MenuBarItemLabel.
+const double _kLabelItemDefaultSpacing = 18.0;
+
+// The minimum spacing between the the leading icon, label, trailing icon, and
+// shortcut label in a _MenuBarItemLabel.
+const double _kLabelItemMinSpacing = 4.0;
+
+const Map<ShortcutActivator, Intent> _kMenuTraversalShortcuts = <ShortcutActivator, Intent>{
+  SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.numpadEnter): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.gameButtonA): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
+  SingleActivator(LogicalKeyboardKey.tab): NextFocusIntent(),
+  SingleActivator(LogicalKeyboardKey.tab, shift: true): PreviousFocusIntent(),
+  SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
+  SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
+  SingleActivator(LogicalKeyboardKey.arrowLeft): DirectionalFocusIntent(TraversalDirection.left),
+  SingleActivator(LogicalKeyboardKey.arrowRight): DirectionalFocusIntent(TraversalDirection.right),
+};
+
+/// A wrapper class for [MenuItem] that contains extra metadata that allows
+/// rendering of the menu item, including the parent and children for this node,
+/// forming a tree.
+class _MenuNode with Diagnosticable, DiagnosticableTreeMixin, Comparable<_MenuNode> {
+  _MenuNode({required this.item, this.parent}) : children = <_MenuNode>[] {
+    if (item.members.isNotEmpty) {
+      // Don't add groups to the parent, just the members of the group.
+      for (final MenuItem member in item.members) {
+        _MenuNode(item: member, parent: parent);
+      }
+    } else {
+      parent?.children.add(this);
+      for (final MenuItem child in item.menus) {
+        // Children get automatically linked into the menu tree by creating
+        // them.
+        _MenuNode(item: child, parent: this);
+      }
+    }
+  }
+
+  /// This is the parent of this node in the hierarchy, so that we can traverse
+  /// ancestors. The source [MenuItem] hierarchy only has children, not parents,
+  /// so this is the only way to traverse ancestors without starting at the root
+  /// each time.
+  _MenuNode? parent;
+
+  /// These are the menu nodes that wrap the children of the menu item.
+  List<_MenuNode> children;
+
+  /// The widget/menu item with the menu data in it.
+  final MenuItem item;
+
+  /// Whether or not this menu item is currently open, in order to avoid
+  /// duplicate calls to [onOpen] or [onClose].
+  bool isOpen = false;
+
+  /// The focus node that corresponds to this menu item, so that it can be
+  /// focused when set as the open menu.
+  FocusNode? focusNode;
+
+  /// The builder function that builds a submenu, if any. Will be null if there
+  /// is no submenu.
+  WidgetBuilder? menuBuilder;
+
+  /// The padding around the submenu for this item, if any. This is used to
+  /// calculate the position of the submenu, because the first item should align
+  /// with the parent button, without including the menu padding.
+  EdgeInsets? menuPadding;
+
+  /// Returns true if this menu item is a group (e.g. [MenuItemGroup]).
+  bool get isGroup => item.members.isNotEmpty;
+
+  /// Returns true if this menu has a submenu (e.g. [MenuBarMenu]).
+  bool get hasSubmenu => children.isNotEmpty;
+
+  /// Returns true if this menu is a child of the (invisible) root menu item.
+  bool get isTopLevel => parent?.parent == null;
+
+  /// Returns true if this menu is the (invisible) root of the menu item hierarchy.
+  bool get isRoot => parent == null;
+
+  // Returns all the ancestors of this node, except for the root node.
+  List<_MenuNode> get ancestors {
+    final List<_MenuNode> result = <_MenuNode>[];
+    if (parent == null) {
+      return result;
+    }
+    _MenuNode? node = parent;
+    while (node != null && node.parent != null) {
+      result.insert(0, node);
+      node = node.parent;
+    }
+    return result;
+  }
+
+  /// Returns the topmost menu for this menu item. This is the menu item that is
+  /// both an ancestor of this item and a child of the root menu item.
+  _MenuNode get topLevel {
+    assert(parent != null); // Can't request top level of root.
+    if (isTopLevel) {
+      // Top level nodes are their own topLevel.
+      return this;
+    }
+    assert(ancestors.isNotEmpty);
+    assert(ancestors.first.isTopLevel);
+    return ancestors.first;
+  }
+
+  /// Returns the index of this menu node in the parent. This is used to find
+  /// siblings, and to sort this node relative to its siblings.
+  int get parentIndex {
+    if (isRoot) {
+      // The root node has no parent index.
+      return -1;
+    }
+    final int result = parent!.children.indexOf(this);
+    assert(result != -1, 'Child not found in parent.');
+    return result;
+  }
+
+  /// Returns the next sibling for this node.
+  ///
+  /// If there is no next sibling (i.e. this is the last of the parent's
+  /// children), this returns null.
+  _MenuNode? get nextSibling {
+    if (isRoot) {
+      // The root has no next sibling.
+      return null;
+    }
+    final int thisIndex = parent!.children.indexOf(this);
+    if (parent!.children.length > thisIndex + 1) {
+      return parent!.children[thisIndex + 1];
+    } else {
+      return null;
+    }
+  }
+
+  /// Returns the previous sibling for this node.
+  ///
+  /// If there is no previous sibling (i.e. this is the first of the parent's
+  /// children), this returns null.
+  _MenuNode? get previousSibling {
+    final int thisIndex = parent?.children.indexOf(this) ?? -1;
+    if (thisIndex > 0) {
+      return parent!.children[thisIndex - 1];
+    } else {
+      return null;
+    }
+  }
+
+  /// Returns all descendants of this node, recursively, in depth order.
+  Iterable<_MenuNode> get descendants {
+    Iterable<_MenuNode> visitChildren(_MenuNode node) {
+      return <_MenuNode>[ node, for (final _MenuNode child in node.children) ... visitChildren(child)];
+    }
+
+    return visitChildren(this);
+  }
+
+  @override
+  int compareTo(_MenuNode other) {
+    final List<_MenuNode> allNodes = topLevel.parent!.descendants.toList();
+    return allNodes.indexOf(this).compareTo(allNodes.indexOf(other));
+  }
+
+  /// Returns the list of node ancestors with any of the ancestors that appear
+  /// in the [other]'s ancestors removed. Includes this node in the results.
+  List<_MenuNode> ancestorDifference(_MenuNode? other) {
+    final List<_MenuNode> myAncestors = <_MenuNode>[...ancestors, this];
+    final List<_MenuNode> otherAncestors = <_MenuNode>[
+      ...other?.ancestors ?? <_MenuNode>[],
+      if (other != null) other,
+    ];
+    int skip = 0;
+    for (; skip < myAncestors.length && skip < otherAncestors.length; skip += 1) {
+      if (myAncestors[skip] != otherAncestors[skip]) {
+        break;
+      }
+    }
+    return myAncestors.sublist(skip);
+  }
+
+  /// Get all of the registered children of the given menu that are focusable.
+  /// Used for menu traversal.
+  List<_MenuNode> get focusableChildren {
+    return children.where((_MenuNode child) => child.focusNode?.canRequestFocus ?? false).toList();
+  }
+
+  /// Called whenever this menu is opened by being set as the
+  /// [_MenuBarController.openMenu].
+  ///
+  /// Used to avoid calling [MenuItem.onOpen] unnecessarily.
+  void open() {
+    if (isOpen) {
+      return;
+    }
+    isOpen = true;
+    item.onOpen?.call();
+  }
+
+  /// Called whenever this menu is closed by another menu being set as the
+  /// [_MenuBarController.openMenu].
+  ///
+  /// Used to avoid calling [MenuItem.onClose] unnecessarily.
+  void close() {
+    if (!isOpen) {
+      return;
+    }
+    isOpen = false;
+    item.onClose?.call();
+  }
+
+  // Used for testing to verify which item this is.
+  @override
+  String toStringShort({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return item.toStringShort();
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return <DiagnosticsNode>[
+      ...children.map<DiagnosticsNode>((_MenuNode item) => item.toDiagnosticsNode()),
+    ];
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<MenuItem>('item', item));
+    properties.add(DiagnosticsProperty<_MenuNode>('parent', parent, defaultValue: null));
+    properties.add(IntProperty('numChildren', children.length, defaultValue: null));
+  }
+}
+
+/// A controller that allows control of a [MenuBar].
+///
+/// Normally, it's not necessary to create a `MenuBarController` to use a
+/// [MenuBar], but if you need to be able to close any open menus with the
+/// [closeAll] method in response to an event, you can create one and pass it to
+/// the [MenuBar].
+///
+/// If the place you wish to close all the menus (for instance, when a control
+/// in one of the icons is selected), you can call [closeAll] on the controller
+/// to do so. If the control is a descendant of the [MenuBar], you don't need to
+/// create a `MenuBarController`, since the [MenuBar] will create one
+/// automatically. You can retrieve it with the [MenuBarController.of] method.
+abstract class MenuBarController with ChangeNotifier {
+  /// A factory that constructs a [MenuBarController] for use with a [MenuBar].
+  factory MenuBarController() => _MenuBarController();
+
+  // Private constructor to prevent this class from being instantiated by
+  // anything other than the factory constructor, and from being subclassed.
+  MenuBarController._();
+
+  /// Closes any menus that are currently open.
+  void closeAll();
+
+  /// Returns true if any menu in the menu bar is open.
+  bool get menuIsOpen;
+
+  /// Returns the active menu controller in the given context, and creates a
+  /// dependency relationship that will rebuild the context when the controller
+  /// changes.
+  static MenuBarController of(BuildContext context) {
+    final MenuBarController? found = context.dependOnInheritedWidgetOfExactType<_MenuBarControllerMarker>()?.controller;
+    if (found == null) {
+      throw FlutterError('A ${context.widget.runtimeType} requested a '
+          'MenuBarController, but was not a descendant of a MenuBar: $context');
+    }
+    return found;
+  }
+
+  /// A testing method used to provide access to a testing description of the
+  /// currently open menu for tests.
+  ///
+  /// Only meant to be called by tests.
+  @visibleForTesting
+  String? get testingCurrentItem;
+
+  /// A testing method used to provide access to a testing description of the
+  /// currently focused menu item for tests.
+  ///
+  /// Only meant to be called by tests.
+  @visibleForTesting
+  String? get testingFocusedItem;
+}
+
+/// A private implementation of [MenuBarController], so that we can have a
+/// separate API for the [MenuBar] internals to use. This is the class that gets
+/// instantiated when the [MenuBarController] factory constructor is called.
+class _MenuBarController extends MenuBarController with Diagnosticable {
+  _MenuBarController()
+      : _menuBarContext = null,
+        super._();
+
+  // The root of the menu node tree.
+  _MenuNode root = _MenuNode(item: const PlatformMenu(label: 'root', menus: <MenuItem>[]));
+
+  // The serial number containing the number of times the menu hierarchy has
+  // been updated.
+  //
+  // This is used to indicate to the [_MenuNodeWrapper] that the menu hierarchy
+  // or its attributes have changed, and its dependents need updating.
+  int menuSerial = 0;
+
+  // The map of focus nodes to menus. The reverse map of the
+  // _registeredFocusNodes. This is used to look up which menu node goes with
+  // which focus node when finding the currently focused menu node.
+  final Map<FocusNode, _MenuNode> _focusNodes = <FocusNode, _MenuNode>{};
+
+  // The render boxes of all the MenuBarMenus that are displaying menu items.
+  // This is used to do hit testing to make sure that a pointer down has not
+  // hit a menu, and so to close all the menus.
+  final Set<RenderBox> _menuRenderBoxes = <RenderBox>{};
+
+  // If set, this is the overlay entry that contains all of the submenus.
+  // It is only non-null when there is a menu open.
+  OverlayEntry? _overlayEntry;
+
+  // This holds the previously focused widget when a top level menu is opened,
+  // so that when the last menu is dismissed, the focus can be restored.
+  FocusNode? _previousFocus;
+
+  // The primary focus at the time of the last pointer down event. This needs to
+  // be captured immediately before the FocusTrap unfocuses to the scope.
+  FocusNode? _focusBeforeClick;
+
+  // A menu that has been opened, but the menu widgets haven't been created yet.
+  // Once they are, then request focus on it.
+  _MenuNode? _pendingFocusedMenu;
+
+  // True when a menu is open and we are listening for pointer down events outside of
+  // the menus.
+  bool _listeningToPointerEvents = false;
+
+  // Used to tell if we've already been disposed, for both debug checks, and to
+  // avoid causing widget changes after being disposed.
+  bool _disposed = false;
+
+  @override
+  bool get menuIsOpen => openMenu != null;
+
+  final FocusScopeNode menuBarScope = FocusScopeNode(debugLabel: 'MenuBar');
+  final FocusScopeNode overlayScope = FocusScopeNode(debugLabel: 'MenuBar overlay');
+
+  /// The context of the [MenuBar] that this controller serves.
+  ///
+  /// This context must be set by the menu bar in its initState method.
+  BuildContext get menuBarContext => _menuBarContext!;
+  BuildContext? _menuBarContext;
+  set menuBarContext(BuildContext value) {
+    assert(
+      value.widget is MenuBar,
+      'A ${value.widget.runtimeType} was registered with a '
+      '$runtimeType, which is not a MenuBar.',
+    );
+    _menuBarContext = value;
+  }
+
+  /// Whether or not the menu bar is enabled for input. This is set by setting
+  /// [MenuBar.enabled] on the menu bar widget, and the menu children listen for
+  /// it to change.
+  ///
+  /// If set to false, all menus are closed, shortcuts stop working, and the
+  /// top level menu bar buttons are disabled.
+  bool get enabled => _enabled;
+  bool _enabled = true;
+  set enabled(bool value) {
+    if (_enabled != value) {
+      _enabled = value;
+      SchedulerBinding.instance.addPostFrameCallback((Duration _) {
+        if (!_enabled) {
+          closeAll();
+        }
+        _markMenuDirty();
+      });
+    }
+  }
+
+  List<_MenuNode> get openMenus {
+    return <_MenuNode>[
+      ...openMenu?.ancestors ?? <_MenuNode>[],
+      if (openMenu != null) openMenu!,
+    ];
+  }
+
+  _MenuNode? get openMenu => _openMenu;
+  _MenuNode? _openMenu;
+  set openMenu(_MenuNode? value) {
+    if (_openMenu == value) {
+      // Nothing changed.
+      return;
+    }
+    if (value != null && _openMenu == null) {
+      // We're opening the first menu, so cache the primary focus so that we can
+      // try to return to it when the menu is dismissed.
+      // If we captured a focus before the click, then use that, otherwise use
+      // the current primary focus.
+      _previousFocus = _focusBeforeClick ?? FocusManager.instance.primaryFocus;
+    }
+    if (value == null && _openMenu != null) {
+      // Closing all menus, so restore the previous focus.
+      _previousFocus?.requestFocus();
+      _previousFocus = null;
+    }
+    _focusBeforeClick = null;
+    final _MenuNode? oldMenu = _openMenu;
+    _openMenu = value;
+    oldMenu?.ancestorDifference(_openMenu).forEach((_MenuNode node) {
+      node.close();
+    });
+    _openMenu?.ancestorDifference(oldMenu).forEach((_MenuNode node) {
+      node.open();
+    });
+    if (value != null && value.focusNode?.hasPrimaryFocus != true) {
+      // Request focus on the new thing that is now open, if any, so that
+      // focus traversal starts from that location.
+      if (value.focusNode == null || !value.focusNode!.canRequestFocus) {
+        // If we don't have a focus node to ask yet, or it can't be focused yet,
+        // then keep the menu until it gets registered, or something else sets
+        // the menu.
+        _pendingFocusedMenu = value;
+      } else {
+        _pendingFocusedMenu = null;
+        value.focusNode!.requestFocus();
+      }
+    }
+    _manageOverlayEntry();
+    _markMenuDirty();
+  }
+
+  // Creates or removes the overlay entry that contains the stack of all menus.
+  void _manageOverlayEntry() {
+    if (openMenu?.topLevel != null) {
+      if (_overlayEntry == null) {
+        _overlayEntry = OverlayEntry(builder: (BuildContext context) => _MenuStack(this));
+        Navigator.of(menuBarContext).overlay!.insert(_overlayEntry!);
+      }
+    } else {
+      _overlayEntry?.remove();
+      _overlayEntry = null;
+    }
+  }
+
+  void _markMenuDirty() {
+    if (_disposed) {
+      return;
+    }
+    menuSerial += 1;
+    _overlayEntry?.markNeedsBuild();
+    notifyListeners();
+  }
+
+  // Build the node hierarchy based upon the MenuItem hierarchy.
+  void _createMenuTree(List<MenuItem> topLevel) {
+    root.children.clear();
+    _focusNodes.clear();
+    _previousFocus = null;
+    _pendingFocusedMenu = null;
+    for (final MenuItem item in topLevel) {
+      _MenuNode(
+        item: item,
+        parent: root,
+      );
+    }
+    assert(root.children.length == topLevel.length);
+  }
+
+  /// Called when updating a MenuBar widget so that the metadata about that menu
+  /// hierarchy and widget can be kept current.
+  ///
+  /// The context is the MenuBar widget's element.
+  ///
+  /// The topLevel is the list of menu items that are the top level children of
+  /// the MenuBar.
+  void update({
+    required BuildContext context,
+    required List<MenuItem> topLevel,
+    required bool enabled,
+  }) {
+    menuBarContext = context;
+    _createMenuTree(topLevel);
+    if (!_listeningToPointerEvents) {
+      GestureBinding.instance.pointerRouter.addGlobalRoute(_handlePointerEvent);
+      _listeningToPointerEvents = true;
+    }
+
+    this.enabled = enabled;
+
+    // Need to mark dirty in a post frame callback, since this update might
+    // updated part of the tree that isn't in the overlay, but calling this
+    // would request that the overlay be rebuilt.
+    SchedulerBinding.instance.addPostFrameCallback((Duration _) {
+      _markMenuDirty();
+    });
+  }
+
+  // Disconnects this controller from the menu bar, in preparation for disposal,
+  // or when the controller is being swapped out for another one.
+  void disconnect() {
+    _menuBarContext = null;
+    root.children.clear();
+    _focusNodes.clear();
+    _previousFocus = null;
+    _focusBeforeClick = null;
+    _pendingFocusedMenu = null;
+    if (_listeningToPointerEvents) {
+      GestureBinding.instance.pointerRouter.removeGlobalRoute(_handlePointerEvent);
+      _listeningToPointerEvents = false;
+    }
+  }
+
+  @override
+  void dispose() {
+    disconnect();
+    menuBarScope.dispose();
+    overlayScope.dispose();
+    super.dispose();
+    _disposed = true;
+  }
+
+  /// Closes the given menu, and any open descendant menus.
+  ///
+  /// Leaves ancestor menus open, if any.
+  ///
+  /// Notifies listeners if the menu changed.
+  void close(_MenuNode node) {
+    if (openMenu == null) {
+      // Everything is already closed.
+      return;
+    }
+    if (isAnOpenMenu(node)) {
+      // Don't call onClose, notifyListeners, etc, here, because setting
+      // openMenu will call them if needed.
+      if (node.parent == root) {
+        openMenu = null;
+      } else {
+        openMenu = node.parent;
+      }
+    }
+  }
+
+  @override
+  void closeAll() {
+    openMenu = null;
+  }
+
+  /// Returns true if the given menu or one of its ancestors is open.
+  bool isAnOpenMenu(_MenuNode menu) {
+    if (_openMenu == null) {
+      return false;
+    }
+    return _openMenu == menu || (_openMenu?.ancestors.contains(menu) ?? false);
+  }
+
+  // Handles any pointer events that occur in the app, checking them against
+  // open menus to see if the menus should be closed or not.
+  // This isn't called if no menus are open.
+  void _handlePointerEvent(PointerEvent event) {
+    if (event is! PointerDownEvent) {
+      return;
+    }
+    bool isInsideMenu = false;
+    final List<RenderBox> renderBoxes = <RenderBox?>[
+      menuBarContext.findRenderObject() as RenderBox?,
+      ..._menuRenderBoxes,
+    ].where((RenderBox? box) => box != null).cast<RenderBox>().toList();
+    for (final RenderBox renderBox in renderBoxes) {
+      assert(renderBox.attached);
+      isInsideMenu =
+          renderBox.hitTest(BoxHitTestResult(), position: renderBox.globalToLocal(event.position)) || isInsideMenu;
+    }
+    if (!isInsideMenu) {
+      closeAll();
+    } else {
+      _focusBeforeClick = FocusManager.instance.primaryFocus;
+    }
+  }
+
+  /// Registers or updates the given menu in the menu controller whenever a menu
+  /// item widget is created or updated.
+  void registerMenu({
+    required BuildContext menuContext,
+    required _MenuNode node,
+    WidgetBuilder? menuBuilder,
+    EdgeInsets? menuPadding,
+    FocusNode? buttonFocus,
+  }) {
+    if (node.focusNode != buttonFocus) {
+      node.focusNode?.removeListener(_handleItemFocus);
+      node.focusNode = buttonFocus;
+      node.focusNode?.addListener(_handleItemFocus);
+      if (buttonFocus != null) {
+        _focusNodes[buttonFocus] = node;
+      }
+    }
+
+    node.menuPadding = menuPadding;
+    node.menuBuilder = menuBuilder;
+
+    if (node == _pendingFocusedMenu) {
+      node.focusNode?.requestFocus();
+      _pendingFocusedMenu = null;
+    }
+  }
+
+  /// Unregisters the given context from the menu controller.
+  ///
+  /// If the given context corresponds to the currently open menu, then close
+  /// it.
+  void unregisterMenu(_MenuNode node) {
+    node.focusNode?.removeListener(_handleItemFocus);
+    node.focusNode = null;
+    node.menuBuilder = null;
+    _focusNodes.remove(node.focusNode);
+    if (node == _pendingFocusedMenu) {
+      _pendingFocusedMenu = null;
+    }
+    if (openMenu == node) {
+      close(node);
+    }
+  }
+
+  // Used to register the menu's render box whenever it changes, so that it can
+  // be used to do hit detection and find out if a pointer event hit a menu or
+  // not without participating in the gesture arena.
+  void registerMenuRenderObject(RenderBox menu) {
+    _menuRenderBoxes.add(menu);
+  }
+
+  // Used to unregister the menu's previous render box whenever it changes, or
+  // remove it when it is disposed.
+  void unregisterMenuRenderObject(RenderBox menu) {
+    _menuRenderBoxes.remove(menu);
+  }
+
+  // Handles focus notifications for menu items so that the focused item can be
+  // set as the currently open menu.
+  void _handleItemFocus() {
+    if (openMenu == null) {
+      // Don't traverse the menu hierarchy on focus unless the user opened a
+      // menu already.
+      return;
+    }
+    final _MenuNode? focused = focusedItem;
+    if (focused != null && !isAnOpenMenu(focused)) {
+      openMenu = focused;
+    }
+  }
+
+  _MenuNode? get focusedItem {
+    final Iterable<FocusNode> focusedItems = _focusNodes.keys.where((FocusNode node) => node.hasFocus);
+    assert(
+        focusedItems.length <= 1,
+        'The same focus node is registered to more than one MenuItem '
+        'menu:\n  ${focusedItems.first}');
+    return focusedItems.isNotEmpty ? _focusNodes[focusedItems.first] : null;
+  }
+
+  @override
+  String? get testingCurrentItem {
+    if (openMenu == null) {
+      return null;
+    }
+    return openMenus.map<String>((_MenuNode node) => node.toStringShort()).join(' > ');
+  }
+
+  @override
+  String? get testingFocusedItem {
+    if (primaryFocus?.context == null) {
+      return null;
+    }
+    return _focusNodes[primaryFocus]?.toStringShort();
+  }
+}
+
+// The InheritedWidget marker for _MenuBarController, used to find the nearest
+// ancestor _MenuBarController.
+class _MenuBarControllerMarker extends InheritedWidget {
+  const _MenuBarControllerMarker({
+    required this.controller,
+    required super.child,
+  });
+
+  final _MenuBarController controller;
+
+  @override
+  bool updateShouldNotify(covariant _MenuBarControllerMarker oldWidget) {
+    return controller != oldWidget.controller;
+  }
+}
+
+// A widget used as the main widget for the overlay entry in the
+// _MenuBarController. Since the overlay is a Stack, this widget produces a
+// Positioned widget that fills the overlay, containing its own Stack to arrange
+// the menus with. Positioning of the top level submenus is relative to the
+// position of the menu buttons.
+class _MenuStack extends StatelessWidget {
+  const _MenuStack(this.controller);
+
+  final _MenuBarController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: FocusScope(
+        node: controller.overlayScope,
+        child: Actions(
+          actions: <Type, Action<Intent>>{
+            NextFocusIntent: _MenuNextFocusAction(controller: controller),
+            PreviousFocusIntent: _MenuPreviousFocusAction(controller: controller),
+            DirectionalFocusIntent: _MenuDirectionalFocusAction(
+              controller: controller,
+            ),
+            DismissIntent: _MenuDismissAction(controller: controller),
+            VoidCallbackIntent: VoidCallbackAction(),
+          },
+          child: Shortcuts(
+            // These are here to make sure that these override any shortcut
+            // bindings from the menu items when a menu is open. If someone
+            // wants to bind an arrow or tab to a menu item, it would otherwise
+            // override the default traversal keys. We want their shortcuts to
+            // apply everywhere but override these in the menu itself, since
+            // there we have to be able to traverse the menus.
+            shortcuts: _kMenuTraversalShortcuts,
+            child: _MenuBarControllerMarker(
+              controller: controller,
+              child: Stack(
+                children: <Widget>[
+                  if (controller.openMenus.isNotEmpty)
+                    ...controller.openMenus.where((_MenuNode node) => node.menuBuilder != null).map<Widget>(
+                      (_MenuNode node) {
+                        return Builder(
+                          key: ValueKey<_MenuNode>(node),
+                          builder: node.menuBuilder!,
+                        );
+                      },
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuDismissAction extends DismissAction {
+  _MenuDismissAction({required this.controller});
+
+  final _MenuBarController controller;
+
+  @override
+  bool isEnabled(DismissIntent intent) {
+    return controller.openMenu != null;
+  }
+
+  @override
+  Object? invoke(DismissIntent intent) {
+    controller.closeAll();
+    return null;
+  }
+}
+
+class _MenuNextFocusAction extends NextFocusAction {
+  _MenuNextFocusAction({required this.controller});
+
+  final _MenuBarController controller;
+
+  @override
+  void invoke(NextFocusIntent intent) {
+    if (controller.openMenu == null) {
+      // Nothing is open, select first top level menu item.
+      if (controller.root.children.isEmpty) {
+        return;
+      }
+      controller.openMenu = controller.root.children[0];
+      return;
+    }
+    final List<_MenuNode> enabledNodes = controller.root.descendants.where((_MenuNode node) {
+      return (node.item.menus.isNotEmpty || node.item.onSelected != null || node.item.onSelectedIntent != null) &&
+          controller.enabled;
+    }).toList();
+    if (enabledNodes.isEmpty) {
+      return;
+    }
+    final int index = enabledNodes.indexOf(controller.openMenu!);
+    if (index == -1) {
+      return;
+    }
+    if (index == enabledNodes.length - 1) {
+      controller.openMenu = enabledNodes.first;
+      return;
+    }
+    controller.openMenu = enabledNodes[index + 1];
+  }
+}
+
+class _MenuPreviousFocusAction extends PreviousFocusAction {
+  _MenuPreviousFocusAction({required this.controller});
+
+  final _MenuBarController controller;
+
+  @override
+  void invoke(PreviousFocusIntent intent) {
+    if (controller.openMenu == null) {
+      // Nothing is open, select first top level menu item.
+      if (controller.root.children.isEmpty) {
+        return;
+      }
+      controller.openMenu = controller.root.children.last;
+      return;
+    }
+    final List<_MenuNode> enabledNodes = controller.root.descendants.where((_MenuNode node) {
+      return (node.item.menus.isNotEmpty || node.item.onSelected != null || node.item.onSelectedIntent != null) &&
+          controller.enabled;
+    }).toList();
+    final List<MenuItem> enabledItems = enabledNodes.map<MenuItem>((_MenuNode node) => node.item).toList();
+    if (enabledNodes.isEmpty) {
+      return;
+    }
+    final int index = enabledItems.indexOf(controller.openMenu!.item);
+    if (index == -1) {
+      return;
+    }
+    if (index == 0) {
+      controller.openMenu = enabledNodes.last;
+      return;
+    }
+    controller.openMenu = enabledNodes[index - 1];
+    return;
+  }
+}
+
+class _MenuDirectionalFocusAction extends DirectionalFocusAction {
+  /// Creates a [DirectionalFocusAction].
+  _MenuDirectionalFocusAction({required this.controller});
+
+  final _MenuBarController controller;
+
+  bool _moveForward() {
+    if (controller.openMenu == null) {
+      return false;
+    }
+    final _MenuNode? focusedItem = controller.focusedItem;
+    if (focusedItem == null) {
+      return false;
+    }
+    if (focusedItem.hasSubmenu && focusedItem.parent != controller.root) {
+      // If no submenu is open, then arrow opens the submenu.
+      if (focusedItem.children.isNotEmpty) {
+        controller.openMenu = focusedItem.children.first;
+      }
+    } else {
+      // If there's no submenu, then an arrow moves to the next top
+      // level sibling, wrapping around if need be.
+      final _MenuNode? next = focusedItem.topLevel.nextSibling;
+      if (next != null) {
+        controller.openMenu = next;
+      } else {
+        controller.openMenu = controller.root.children.isNotEmpty ? controller.root.children.first : null;
+      }
+    }
+    return true;
+  }
+
+  bool _moveBackward() {
+    if (controller.openMenu == null) {
+      return false;
+    }
+    final _MenuNode? focusedItem = controller.focusedItem;
+    if (focusedItem == null) {
+      return false;
+    }
+    // Back moves between siblings on the top level menu.
+    // Wraps around if there is no previous.
+    _MenuNode? previous;
+    if (focusedItem.isTopLevel) {
+      previous = focusedItem.previousSibling;
+    } else {
+      if (focusedItem.parent!.isTopLevel) {
+        previous = focusedItem.parent!.previousSibling;
+      } else {
+        previous = focusedItem.parent;
+      }
+    }
+    if (previous != null) {
+      controller.openMenu = previous;
+    } else {
+      controller.openMenu = controller.root.children.isNotEmpty ? controller.root.children.last : null;
+    }
+    return true;
+  }
+
+  bool _moveUp() {
+    if (controller.openMenu == null) {
+      return false;
+    }
+    final _MenuNode? focusedItem = controller.focusedItem;
+    if (focusedItem == null) {
+      return false;
+    }
+    if (focusedItem.parent == controller.root) {
+      // If you press up on a top level menu, then close all the menus.
+      controller.openMenu = null;
+      return true;
+    }
+    _MenuNode? previousFocusable = focusedItem.previousSibling;
+    while (previousFocusable != null && !previousFocusable.focusNode!.canRequestFocus) {
+      previousFocusable = previousFocusable.previousSibling;
+    }
+    if (previousFocusable != null) {
+      controller.openMenu = previousFocusable;
+    } else if (focusedItem.parent?.parent == controller.root) {
+      // If you press up on a next-to-top level menu, then move to the parent.
+      controller.openMenu = focusedItem.parent;
+    }
+    return true;
+  }
+
+  bool _moveDown() {
+    final _MenuNode? focusedItem = controller.focusedItem;
+    if (focusedItem == null) {
+      return false;
+    }
+    if (focusedItem.parent == controller.root) {
+      if (controller.openMenu == null) {
+        controller.openMenu = focusedItem;
+        return true;
+      }
+      final List<_MenuNode> children = focusedItem.focusableChildren;
+      if (children.isNotEmpty) {
+        controller.openMenu = children[0];
+      }
+      return true;
+    }
+    _MenuNode? nextFocusable = focusedItem.nextSibling;
+    while (nextFocusable != null && !nextFocusable.focusNode!.canRequestFocus) {
+      nextFocusable = nextFocusable.nextSibling;
+    }
+    if (nextFocusable != null) {
+      controller.openMenu = nextFocusable;
+    }
+    return true;
+  }
+
+  @override
+  void invoke(DirectionalFocusIntent intent) {
+    final TextDirection textDirection = Directionality.of(controller.menuBarContext);
+    switch (intent.direction) {
+      case TraversalDirection.up:
+        if (_moveUp()) {
+          return;
+        }
+        break;
+      case TraversalDirection.down:
+        if (_moveDown()) {
+          return;
+        }
+        break;
+      case TraversalDirection.left:
+        switch (textDirection) {
+          case TextDirection.rtl:
+            if (_moveForward()) {
+              return;
+            }
+            break;
+          case TextDirection.ltr:
+            if (_moveBackward()) {
+              return;
+            }
+            break;
+        }
+        break;
+      case TraversalDirection.right:
+        switch (textDirection) {
+          case TextDirection.rtl:
+            if (_moveBackward()) {
+              return;
+            }
+            break;
+          case TextDirection.ltr:
+            if (_moveForward()) {
+              return;
+            }
+            break;
+        }
+
+        break;
+    }
+    super.invoke(intent);
+  }
+}
+
+/// Provides default implementation for [MenuItem] in a [StatefulWidget], to serve
+/// as a base class for the [MenuBarItem], [MenuItemGroup] and [MenuBarMenu] classes.
+abstract class _MenuBarItemDefaults extends StatefulWidget implements PlatformMenuItem {
+  const _MenuBarItemDefaults({
+    super.key,
+    required this.label,
+    this.labelWidget,
+  });
+
+  /// A required label displayed on the entry for this item in the menu.
+  ///
+  /// This is rendered by default in a [Text] widget.
+  /// The label appearance can be overridden by using a [labelWidget] to render
+  /// a different widget in its place.
+  ///
+  /// This label is also used as the default [semanticLabel].
+  @override
+  final String label;
+
+  /// An optional widget that will be displayed in place of the default [Text]
+  /// widget containing the [label].
+  final Widget? labelWidget;
+
+  @override
+  MenuSerializableShortcut? get shortcut => null;
+
+  /// The function called when the mouse leaves or enters this menu item's
+  /// button.
+  ValueChanged<bool>? get onHover;
+
+  /// The list of top-level menu items to show in the [MenuBar].
+  ///
+  /// Each entry in this list will become a top level menu item.
+  @override
+  List<MenuItem> get menus => const <MenuItem>[];
+
+  @override
+  List<MenuItem> get descendants => const <MenuItem>[];
+
+  @override
+  Intent? get onSelectedIntent => null;
+
+  @override
+  VoidCallback? get onSelected => null;
+
+  @override
+  VoidCallback? get onOpen => null;
+
+  @override
+  VoidCallback? get onClose => null;
+
+  @override
+  List<MenuItem> get members => const <MenuItem>[];
+
+  @override
+  String toStringShort() => '${describeIdentity(this)}($label)';
+}
+
+/// A menu bar with cascading child menus.
+///
+/// This is a Material Design menu bar that resides above the main body of an
+/// application that defines a menu system for invoking callbacks or firing
+/// [Intent]s in response to user selection of the menu item.
+///
+/// The menu can be navigated by the user using the arrow keys, and can be
+/// dismissed using the escape key, or by clicking away from the menu item
+/// (anywhere that is not a part of the menu bar or cascading menus). Once a
+/// menu is open, the menu hierarchy can be navigated by hovering over the menu
+/// with the mouse.
+///
+/// Menu items can have a [MenuBarItem.shortcut] assigned to them so that if the
+/// shortcut sequence is pressed, the menu item that shortcut will be selected.
+/// If multiple menu items have the same shortcut, they will all be selected.
+///
+/// Selecting a menu item causes the [MenuBarItem.onSelected] callback to be
+/// called.
+///
+/// When a menu item with a submenu is clicked on, it toggles the visibility of
+/// the submenu. When the menu item is hovered over, the submenu will open after
+/// a slight delay, and hovering over other items will close that menu and open
+/// the newly hovered one. When those occur, [MenuBarMenu.onOpen], and
+/// [MenuBarMenu.onClose] are called, respectively.
+///
+/// {@tool dartpad}
+/// This example shows a [MenuBar] that contains a single top level menu,
+/// containing three items for "About", a checkbox menu item for showing a
+/// message, and "Quit". The items are identified with an enum value.
+///
+/// ** See code in examples/api/lib/material/menu_bar/menu_bar.0.dart **
+/// {@end-tool}
+///
+/// {@tool sample}
+/// This example shows a [MenuBar] that contains a simple menu for a desktop
+/// application.  It is set up to be adaptive, so that on macOS it will use the
+/// system menu bar, and on other systems will use a Material [MenuBar].
+///
+/// On macOS, it will add the "About" and "Quit" system-provided menu items.
+///
+/// The menu items are all identified by an enum value (`MenuSelection`).
+///
+/// ** See code in examples/api/lib/material/menu_bar/menu_bar.1.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [MenuBarMenu], a menu item which manages a submenu.
+///  * [MenuItemGroup], a menu item which collects its members into a group
+///    separated from other menu items by a divider.
+///  * [MenuBarItem], a leaf menu item which displays the label, an optional
+///    shortcut label, and optional leading and trailing icons.
+///  * [MenuBarController], a class that allows closing of menus from outside of
+///    the menu bar.
+///  * [PlatformMenuBar], which creates a menu bar that is rendered by the host
+///    platform instead of by Flutter (on macOS, for example).
+class MenuBar extends PlatformMenuBar {
+  /// Creates a const [MenuBar].
+  const MenuBar({
+    super.key,
+    this.controller,
+    this.enabled = true,
+    this.backgroundColor,
+    this.height,
+    this.padding,
+    this.elevation,
+    super.menus = const <MenuItem>[],
+  }) : _isPlatformMenu = false;
+
+  // A private constructor for the MenuBar.adaptive factory constructor to use.
+  const MenuBar._({
+    super.key,
+    this.controller,
+    this.enabled = true,
+    this.backgroundColor,
+    this.height,
+    this.padding,
+    this.elevation,
+    bool isPlatformMenu = false,
+    super.menus = const <MenuItem>[],
+  }) : _isPlatformMenu = isPlatformMenu;
+
+  /// Creates an adaptive [MenuBar] that renders using platform APIs with a
+  /// [PlatformMenuBar] on platforms that support it, and using Flutter
+  /// rendering on platforms that don't.
+  factory MenuBar.adaptive({
+    Key? key,
+    MenuBarController? controller,
+    bool enabled = true,
+    MaterialStateProperty<Color?>? backgroundColor,
+    double? height,
+    EdgeInsets? padding,
+    MaterialStateProperty<double?>? elevation,
+    List<MenuItem> menus = const <MenuItem>[],
+  }) {
+    bool isPlatformMenu;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        isPlatformMenu = false;
+        break;
+      case TargetPlatform.macOS:
+        isPlatformMenu = true;
+        break;
+    }
+
+    return MenuBar._(
+      key: key,
+      controller: controller,
+      enabled: enabled,
+      backgroundColor: backgroundColor,
+      height: height,
+      padding: padding,
+      elevation: elevation,
+      isPlatformMenu: isPlatformMenu,
+      menus: menus,
+    );
+  }
+
+  /// An optional controller that allows outside control of the menu bar.
+  ///
+  /// Setting this controller will allow you to close any open menus from
+  /// outside of the menu bar using [MenuBarController.closeAll].
+  ///
+  /// If a controller is not set, the widget will create its own controller
+  /// internally.
+  final MenuBarController? controller;
+
+  /// Whether or not this menu bar is enabled.
+  ///
+  /// When disabled, all menus are closed, the menu bar buttons are disabled,
+  /// and menu shortcuts are ignored.
+  final bool enabled;
+
+  /// The background color of the menu bar.
+  ///
+  /// Defaults to [MenuBarThemeData.barBackgroundColor] if not set.
+  final MaterialStateProperty<Color?>? backgroundColor;
+
+  /// The preferred minimum height of the menu bar.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.barHeight] if not set.
+  final double? height;
+
+  /// The padding around the contents of the menu bar itself.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.barPadding] if not set.
+  final EdgeInsets? padding;
+
+  /// The Material elevation the menu bar (if any).
+  ///
+  /// Defaults to the [MenuBarThemeData.barElevation] value of the ambient
+  /// [MenuBarTheme].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.elevation] for a description of what elevation implies.
+  final MaterialStateProperty<double?>? elevation;
+
+  /// Whether or not this should be rendered as a [PlatformMenuBar] or a
+  /// Material [MenuBar].
+  ///
+  /// If true, then a [PlatformMenuBar] will be substituted with the same
+  /// [menus], [child], and [enabled] but none of the visual attributes will
+  /// be passed along.
+  final bool _isPlatformMenu;
+
+  @override
+  State<MenuBar> createState() => _MenuBarState();
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return <DiagnosticsNode>[...menus.map<DiagnosticsNode>((MenuItem item) => item.toDiagnosticsNode())];
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('enabled', value: enabled, ifFalse: 'DISABLED'));
+    properties.add(DiagnosticsProperty<MenuBarController>('controller', controller, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<Color?>>('backgroundColor', backgroundColor, defaultValue: null));
+    properties.add(DoubleProperty('height', height, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets?>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('elevation', elevation, defaultValue: null));
+  }
+}
+
+class _MenuBarState extends State<MenuBar> {
+  late FocusNode focusNode;
+  late Map<MenuSerializableShortcut, Intent> shortcuts;
+  _MenuBarController? _controller;
+  _MenuBarController get controller {
+    // Make our own controller if the user didn't provide one.
+    if (widget.controller != null) {
+      _controller?.dispose();
+      _controller = null;
+      return widget.controller! as _MenuBarController;
+    }
+    return _controller ??= _MenuBarController();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    focusNode = FocusNode(debugLabel: 'MenuBar');
+    _updateController();
+  }
+
+  @override
+  void dispose() {
+    focusNode.dispose();
+    controller.disconnect();
+    // Only dispose of the controller if we created it in this state object.
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  void _updateController() {
+    shortcuts = _getShortcuts();
+    controller.update(context: context, topLevel: widget.menus, enabled: widget.enabled);
+  }
+
+  @override
+  void didUpdateWidget(MenuBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      (oldWidget.controller as _MenuBarController?)?.disconnect();
+    }
+    if (widget.controller != oldWidget.controller || widget.menus != oldWidget.menus) {
+      _updateController();
+    }
+    controller.enabled = widget.enabled;
+  }
+
+  void _doSelect(Intent onSelected) {
+    if (controller.enabled) {
+      Actions.maybeInvoke(FocusManager.instance.primaryFocus!.context!, onSelected);
+    }
+    controller.closeAll();
+  }
+
+  /// These are only used in debug mode to make sure there aren't any duplicate
+  /// shortcut definitions.
+  bool _debugCheckForDuplicateShortcuts() {
+    final Map<MenuSerializableShortcut, VoidCallback> shortcutCallbacks = <MenuSerializableShortcut, VoidCallback>{};
+    final Map<VoidCallback, MenuItem> callbackToMenuItem = <VoidCallback, MenuItem>{};
+    final Map<Intent, MenuItem> intentToMenuItem = <Intent, MenuItem>{};
+
+    Map<MenuSerializableShortcut, Intent> collectChildShortcuts(List<MenuItem> children) {
+      final Map<MenuSerializableShortcut, Intent> shortcuts = <MenuSerializableShortcut, Intent>{};
+      for (final MenuItem child in children) {
+        if (child.onSelected != null) {
+          callbackToMenuItem[child.onSelected!] = child;
+        }
+        if (child.onSelectedIntent != null) {
+          intentToMenuItem[child.onSelectedIntent!] = child;
+        }
+        if (child.menus.isNotEmpty) {
+          shortcuts.addAll(collectChildShortcuts(child.menus));
+        } else if (child.shortcut != null && child.onSelected != null) {
+          if (shortcuts.containsKey(child.shortcut) &&
+              (shortcutCallbacks[child.shortcut!] != child.onSelected ||
+                  shortcuts[child.shortcut] is! VoidCallbackIntent)) {
+            throw FlutterError('Duplicate callback shortcut detected.\n'
+                'The same shortcut has been bound to two different menus with '
+                'different select functions or intents: ${child.shortcut} is bound to both '
+                '${shortcuts[child.shortcut] is VoidCallbackIntent ? callbackToMenuItem[shortcutCallbacks[child.shortcut!]] : intentToMenuItem[shortcuts[child.shortcut!]]} and '
+                ' menu $child with different select callbacks or intents.');
+          }
+          shortcutCallbacks[child.shortcut!] = child.onSelected!;
+          shortcuts[child.shortcut!] = VoidCallbackIntent(child.onSelected!);
+        } else if (child.shortcut != null && child.onSelectedIntent != null) {
+          if (shortcuts.containsKey(child.shortcut) && shortcuts[child.shortcut!] != child.onSelectedIntent) {
+            throw FlutterError('Duplicate intent shortcut mapping detected.\n'
+                'The same shortcut has been bound to '
+                'two different intents: ${child.shortcut} is bound to '
+                '${shortcuts[child.shortcut!]} on '
+                '${intentToMenuItem[shortcuts[child.shortcut!]]} and '
+                '${child.onSelectedIntent} on menu $child.');
+          }
+          shortcuts[child.shortcut!] = child.onSelectedIntent!;
+        } else if (child.members.isNotEmpty) {
+          shortcuts.addAll(collectChildShortcuts(child.members));
+        }
+      }
+      return shortcuts;
+    }
+
+    collectChildShortcuts(widget.menus);
+    return true;
+  }
+
+  Map<MenuSerializableShortcut, Intent> _getShortcuts() {
+    assert(_debugCheckForDuplicateShortcuts());
+    Map<MenuSerializableShortcut, Intent> collectChildShortcuts(List<MenuItem> children) {
+      final Map<MenuSerializableShortcut, Intent> shortcuts = <MenuSerializableShortcut, Intent>{};
+      for (final MenuItem child in children) {
+        if (child.menus.isNotEmpty) {
+          // Short circuit if it's a menu item with a submenu.
+          shortcuts.addAll(collectChildShortcuts(child.menus));
+        } else if (child.shortcut != null && child.onSelected != null) {
+          // onSelected takes priority over onSelectedIntent (they can't specify
+          // both anyhow).
+          shortcuts[child.shortcut!] = VoidCallbackIntent(child.onSelected!);
+        } else if (child.shortcut != null && child.onSelectedIntent != null) {
+          shortcuts[child.shortcut!] = child.onSelectedIntent!;
+        } else if (child.members.isNotEmpty) {
+          // Groups can't have onSelected/onSelectedIntent or menus.
+          shortcuts.addAll(collectChildShortcuts(child.members));
+        }
+      }
+      return shortcuts;
+    }
+
+    final Map<MenuSerializableShortcut, Intent> shortcuts = collectChildShortcuts(widget.menus);
+    return shortcuts.map((MenuSerializableShortcut key, Intent value) {
+      return MapEntry<MenuSerializableShortcut, Intent>(key, VoidCallbackIntent(() => _doSelect(value)));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget._isPlatformMenu) {
+      return PlatformMenuBar(menus: widget.menus, child: widget.child);
+    }
+    final Set<MaterialState> state = <MaterialState>{if (!widget.enabled) MaterialState.disabled};
+    final MenuBarThemeData menuBarTheme = MenuBarTheme.of(context);
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (BuildContext context, Widget? ignoredChild) {
+        return _MenuBarControllerMarker(
+          controller: controller,
+          child: Actions(
+            actions: <Type, Action<Intent>>{
+              NextFocusIntent: _MenuNextFocusAction(controller: controller),
+              PreviousFocusIntent: _MenuPreviousFocusAction(controller: controller),
+              DirectionalFocusIntent: _MenuDirectionalFocusAction(
+                controller: controller,
+              ),
+              DismissIntent: _MenuDismissAction(controller: controller),
+            },
+            child: _ShortcutRegistration(
+              shortcuts: controller.enabled ? shortcuts : const <MenuSerializableShortcut, Intent>{},
+              child: ExcludeFocus(
+                excluding: !controller.enabled || !controller.menuIsOpen,
+                child: FocusScope(
+                  node: controller.menuBarScope,
+                  child: Shortcuts(
+                    // Make sure that these override any shortcut bindings from
+                    // the menu items when a menu is open. If someone wants to
+                    // bind an arrow or tab to a menu item, it would otherwise
+                    // override the default traversal keys. We want their
+                    // shortcut to apply everywhere but in the menu itself,
+                    // since there we have to be able to traverse menus.
+                    shortcuts: _kMenuTraversalShortcuts,
+                    child: _MenuBarTopLevelBar(
+                      elevation:
+                          (widget.elevation ?? menuBarTheme.barElevation ?? _TokenDefaultsM3(context).barElevation)
+                              .resolve(state)!,
+                      height: widget.height ?? menuBarTheme.barHeight ?? _TokenDefaultsM3(context).barHeight,
+                      enabled: controller.enabled,
+                      color: (widget.backgroundColor ??
+                              menuBarTheme.barBackgroundColor ??
+                              _TokenDefaultsM3(context).barBackgroundColor)
+                          .resolve(state)!,
+                      padding: widget.padding ?? menuBarTheme.barPadding ?? _TokenDefaultsM3(context).barPadding,
+                      children: widget.menus,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A menu item widget that displays a hierarchical cascading menu as part of a
+/// [MenuBar].
+///
+/// This widget represents an entry in a [MenuBar]. It shows a label and an
+/// arrow indicating that it has a submenu, with an optional leading or trailing
+/// icon.
+///
+/// When activated (clicked, through keyboard navigation, or via hovering with
+/// a mouse), it will open a submenu containing the [menus].
+///
+/// See also:
+///
+///  * [MenuBarItem], a widget that represents a leaf [MenuBar] item.
+///  * [MenuBar], a widget that renders data in a menu hierarchy using
+///    Flutter-rendered widgets in a Material Design style.
+///  * [PlatformMenuBar], a widget that renders similar menu bar items from a
+///    [MenuBarItem] using platform-native APIs.
+class MenuBarMenu extends _MenuBarItemDefaults implements PlatformMenu {
+  /// Creates a const [MenuBarMenu].
+  ///
+  /// The [label] attribute is required.
+  const MenuBarMenu({
+    super.key,
+    required super.label,
+    super.labelWidget,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.semanticLabel,
+    this.autofocus = false,
+    this.backgroundColor,
+    this.shape,
+    this.elevation,
+    this.padding,
+    this.buttonPadding,
+    this.buttonBackgroundColor,
+    this.buttonForegroundColor,
+    this.buttonOverlayColor,
+    this.buttonShape,
+    this.buttonTextStyle,
+    this.onOpen,
+    this.onClose,
+    this.onHover,
+    this.menus = const <MenuItem>[],
+  });
+
+  /// An optional icon to display before the label text.
+  final Widget? leadingIcon;
+
+  /// An optional icon to display after the label text.
+  final Widget? trailingIcon;
+
+  /// The semantic label to use for this menu item for its [Semantics].
+  final String? semanticLabel;
+
+  /// If true, will request focus when first built if nothing else has focus.
+  final bool autofocus;
+
+  /// The background color of the cascading menu specified by [menus].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.menuBackgroundColor] value of the
+  /// ambient [MenuBarTheme].
+  final MaterialStateProperty<Color?>? backgroundColor;
+
+  /// The shape of the cascading menu specified by [menus].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.menuShape] value of the
+  /// ambient [MenuBarTheme].
+  final MaterialStateProperty<ShapeBorder?>? shape;
+
+  /// The Material elevation of the submenu (if any).
+  ///
+  /// Defaults to the [MenuBarThemeData.barElevation] value of the ambient
+  /// [MenuBarTheme].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.elevation] for a description of what elevation is.
+  final MaterialStateProperty<double?>? elevation;
+
+  /// The padding around the outside of the contents of a [MenuBarMenu].
+  ///
+  /// Defaults to the [MenuBarThemeData.menuPadding] value of the ambient
+  /// [MenuBarTheme].
+  final EdgeInsets? padding;
+
+  /// The padding around the outside of the button that opens a [MenuBarMenu]'s
+  /// submenu.
+  ///
+  /// Defaults to the [MenuBarThemeData.itemPadding] value of the ambient
+  /// [MenuBarTheme].
+  final EdgeInsets? buttonPadding;
+
+  /// The background color of the button that opens the submenu.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemBackgroundColor] value of
+  /// the ambient [MenuBarTheme].
+  final MaterialStateProperty<Color?>? buttonBackgroundColor;
+
+  /// The foreground color of the button that opens the submenu.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemForegroundColor] value of
+  /// the ambient [MenuBarTheme].
+  final MaterialStateProperty<Color?>? buttonForegroundColor;
+
+  /// The overlay color of the button that opens the submenu.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemOverlayColor] value of
+  /// the ambient [MenuBarTheme].
+  final MaterialStateProperty<Color?>? buttonOverlayColor;
+
+  /// The shape of the button that opens the submenu.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.menuShape] value of the
+  /// ambient [MenuBarTheme].
+  final MaterialStateProperty<OutlinedBorder?>? buttonShape;
+
+  /// The text style of the button that opens the submenu.
+  ///
+  /// The color in this text style will only be used if [buttonOverlayColor]
+  /// is unset.
+  final MaterialStateProperty<TextStyle?>? buttonTextStyle;
+
+  /// Called when the button that opens the submenu is hovered over.
+  @override
+  final ValueChanged<bool>? onHover;
+
+  @override
+  final VoidCallback? onOpen;
+
+  @override
+  final VoidCallback? onClose;
+
+  @override
+  final List<MenuItem> menus;
+
+  @override
+  State<MenuBarMenu> createState() => _MenuBarMenuState();
+
+  @override
+  Iterable<Map<String, Object?>> toChannelRepresentation(PlatformMenuDelegate delegate,
+      {required int Function(MenuItem) getId}) {
+    return <Map<String, Object?>>[PlatformMenu.serialize(this, delegate, getId)];
+  }
+
+  @override
+  List<MenuItem> get descendants => PlatformMenu.getDescendants(this);
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return <DiagnosticsNode>[
+      ...menus.map<DiagnosticsNode>((MenuItem child) {
+        return child.toDiagnosticsNode();
+      })
+    ];
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<Widget>('leadingIcon', leadingIcon, defaultValue: null));
+    properties.add(StringProperty('label', label));
+    properties.add(DiagnosticsProperty<Widget>('trailingIcon', trailingIcon, defaultValue: null));
+    properties.add(StringProperty('semanticLabel', semanticLabel, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<Color?>>('backgroundColor', backgroundColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<ShapeBorder?>>('shape', shape, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('elevation', elevation, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets?>('padding', padding, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets?>('buttonPadding', buttonPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('buttonBackgroundColor', buttonBackgroundColor,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('buttonForegroundColor', buttonForegroundColor,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('buttonOverlayColor', buttonOverlayColor,
+        defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<ShapeBorder?>>('buttonShape', buttonShape, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<TextStyle?>>('buttonTextStyle', buttonTextStyle, defaultValue: null));
+  }
+}
+
+class _MenuBarMenuState extends State<MenuBarMenu> {
+  _MenuNode? menu;
+  _MenuBarController? controller;
+  bool registered = false;
+  Timer? hoverTimer;
+  Timer? clickBanTimer;
+  bool clickBan = false;
+  late FocusNode focusNode;
+
+  bool get _isAnOpenMenu {
+    return menu != null && controller!.isAnOpenMenu(menu!);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    focusNode = FocusNode(debugLabel: widget.label);
+    focusNode.addListener(_markDirty);
+  }
+
+  @override
+  void dispose() {
+    focusNode.removeListener(_markDirty);
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _updateChangedState();
+    super.didChangeDependencies();
+  }
+
+  @override
+  void didUpdateWidget(MenuBarMenu oldWidget) {
+    _updateChangedState();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  bool get enabled => controller!.enabled && widget.menus.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuBarItem._forMenu(
+      label: widget.label,
+      labelWidget: widget.labelWidget,
+      onSelected: enabled ? _maybeToggleShowMenu : null,
+      onHover: enabled ? _handleMenuHover : null,
+      focusNode: focusNode,
+      leadingIcon: widget.leadingIcon,
+      trailingIcon: widget.trailingIcon,
+      semanticLabel: widget.semanticLabel,
+      backgroundColor: widget.buttonBackgroundColor,
+      foregroundColor: widget.buttonForegroundColor,
+      overlayColor: widget.buttonOverlayColor,
+      textStyle: widget.buttonTextStyle,
+      padding: widget.buttonPadding,
+      shape: widget.buttonShape,
+      menuPadding: widget.padding ?? MenuBarTheme.of(context).menuPadding ?? _TokenDefaultsM3(context).menuPadding,
+    );
+  }
+
+  void _markDirty() {
+    setState(() {});
+  }
+
+  void _updateChangedState() {
+    menu = _MenuNodeWrapper.of(context);
+    controller = MenuBarController.of(context) as _MenuBarController;
+  }
+
+  // Shows the submenu if there is one, and it wasn't visible. Hides the menu if
+  // it was already visible.
+  void _maybeToggleShowMenu() {
+    if (clickBan) {
+      // If we just opened the menu because the user is hovering, then ignore
+      // clicks for a bit.
+      return;
+    }
+
+    if (_isAnOpenMenu) {
+      controller!.close(menu!);
+    } else {
+      controller!.openMenu = menu;
+    }
+  }
+
+  // Called when the pointer is hovering over the menu button.
+  void _handleMenuHover(bool hovering) {
+    // Cancel any click ban in place if hover changes.
+    clickBanTimer?.cancel();
+    clickBanTimer = null;
+    clickBan = false;
+
+    // Don't open the top level menu bar buttons on hover unless something else
+    // is already open. This means that the user has to first open the menu bar
+    // before hovering allows them to traverse it.
+    if (menu!.parent == controller!.root && controller!.openMenu == null) {
+      return;
+    }
+
+    if (hovering && !_isAnOpenMenu) {
+      controller!.openMenu = menu;
+      // If we just opened the menu because the user is hovering, then just
+      // ignore any clicks for a bit. Otherwise, the user hovers to the
+      // submenu, and sometimes clicks to open it just after the hover timer
+      // has run out, causing the menu to open briefly, then immediately
+      // close, which is surprising to the user.
+      clickBan = true;
+      clickBanTimer = Timer(_kMenuHoverClickBanDelay, () {
+        clickBan = false;
+        clickBanTimer = null;
+      });
+    }
+  }
+}
+
+/// An item in a [MenuBar] that can be activated by click, or via a shortcut.
+///
+/// This widget represents a leaf entry in a menu that is part of a [MenuBar].
+/// It shows a label and a hint for an associated shortcut, if any. When
+/// selected via click, hitting enter while focused, or activating the
+/// associated [shortcut], it will call its [onSelected] callback or fire its
+/// [onSelectedIntent] intent.
+///
+/// See also:
+///
+///  * [MenuBarMenu], a class that represents a sub menu in a [MenuBar] that
+///    contains [MenuItem]s.
+///  * [MenuBar], a class that renders data in a [MenuBarItem] using
+///    Flutter-rendered widgets in a Material Design style.
+///  * [PlatformMenuBar], a class that renders similar menu bar items from a
+///    [MenuBarItem] using platform-native APIs.
+class MenuBarItem extends _MenuBarItemDefaults {
+  /// Creates a const [MenuBarItem].
+  ///
+  /// The [label] attribute is required.
+  const MenuBarItem({
+    super.key,
+    required super.label,
+    super.labelWidget,
+    this.shortcut,
+    this.onSelected,
+    this.onSelectedIntent,
+    this.onHover,
+    this.focusNode,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.semanticLabel,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.overlayColor,
+    this.textStyle,
+    this.padding,
+    this.shape,
+  })  : _hasMenu = false,
+        _menuPadding = null,
+        assert(onSelected == null || onSelectedIntent == null,
+            'Only one of onSelected or onSelectedIntent may be specified');
+
+  // Used for MenuBarMenu's button, which has some slightly different behavior.
+  const MenuBarItem._forMenu({
+    required super.label,
+    super.labelWidget,
+    this.onSelected,
+    this.onHover,
+    this.focusNode,
+    this.leadingIcon,
+    this.trailingIcon,
+    this.semanticLabel,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.overlayColor,
+    this.textStyle,
+    this.padding,
+    EdgeInsets? menuPadding,
+    this.shape,
+  })  : _hasMenu = true,
+        onSelectedIntent = null,
+        shortcut = null,
+        _menuPadding = menuPadding;
+
+  @override
+  final MenuSerializableShortcut? shortcut;
+
+  @override
+  final Intent? onSelectedIntent;
+
+  @override
+  final VoidCallback? onSelected;
+
+  @override
+  final ValueChanged<bool>? onHover;
+
+  /// The focus node to use for the menu item button.
+  final FocusNode? focusNode;
+
+  /// An optional icon to display before the label text.
+  final Widget? leadingIcon;
+
+  /// An optional icon to display after the label text.
+  final Widget? trailingIcon;
+
+  /// The semantic label to use for this menu item for its [Semantics].
+  final String? semanticLabel;
+
+  /// The background color for this [MenuBarItem].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemBackgroundColor] if not set.
+  final MaterialStateProperty<Color?>? backgroundColor;
+
+  /// The foreground color for this [MenuBarItem].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemForegroundColor] if not set.
+  final MaterialStateProperty<Color?>? foregroundColor;
+
+  /// The overlay color for this [MenuBarItem].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemOverlayColor] if not set.
+  final MaterialStateProperty<Color?>? overlayColor;
+
+  /// The padding around the contents of the [MenuBarItem].
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemPadding] if not set.
+  final EdgeInsets? padding;
+
+  // The padding around the edges of a submenu. Passed in from the MenuBarMenu
+  // so that it can be given during registration with the controller.
+  final EdgeInsets? _menuPadding;
+
+  /// The text style for the text in this menu bar item.
+  ///
+  /// May be overridden inside of [labelWidget], if supplied.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemTextStyle] if not set.
+  final MaterialStateProperty<TextStyle?>? textStyle;
+
+  /// The shape of this menu bar item.
+  ///
+  /// Defaults to the value of [MenuBarThemeData.itemShape] if not set.
+  final MaterialStateProperty<OutlinedBorder?>? shape;
+
+  // Indicates that this is a button for a submenu, not just a regular item.
+  final bool _hasMenu;
+
+  @override
+  State<MenuBarItem> createState() => _MenuBarItemState();
+
+  @override
+  Iterable<Map<String, Object?>> toChannelRepresentation(PlatformMenuDelegate delegate,
+      {required int Function(MenuItem) getId}) {
+    return <Map<String, Object?>>[PlatformMenuItem.serialize(this, delegate, getId)];
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('enabled', value: onSelected != null || onSelectedIntent != null, ifFalse: 'DISABLED'));
+    properties.add(DiagnosticsProperty<FocusNode>('focusNode', focusNode, defaultValue: null));
+    properties.add(DiagnosticsProperty<Widget>('leadingIcon', leadingIcon, defaultValue: null));
+    properties.add(StringProperty('label', label));
+    properties.add(DiagnosticsProperty<Widget>('trailingIcon', trailingIcon, defaultValue: null));
+    properties.add(StringProperty('semanticLabel', semanticLabel, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets?>('padding', padding, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<Color?>>('backgroundColor', backgroundColor, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<Color?>>('foregroundColor', foregroundColor, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<Color?>>('overlayColor', overlayColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<TextStyle?>>('textStyle', textStyle, defaultValue: null));
+  }
+}
+
+class _MenuBarItemState extends State<MenuBarItem> {
+  _MenuNode? menu;
+  int menuSerial = 0;
+  late _MenuBarController controller;
+  bool registered = false;
+  Timer? hoverTimer;
+  FocusNode get focusNode => widget.focusNode ?? _focusNode!;
+  FocusNode? _focusNode;
+
+  bool get enabled {
+    return (widget.onSelected != null || widget.onSelectedIntent != null) && controller.enabled;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(debugLabel: 'MenuBarItem(${widget.label})');
+  }
+
+  @override
+  void dispose() {
+    hoverTimer?.cancel();
+    hoverTimer = null;
+    controller.unregisterMenu(menu!);
+    _focusNode?.dispose();
+    _focusNode = null;
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _updateMenuRegistration();
+    super.didChangeDependencies();
+  }
+
+  @override
+  void didUpdateWidget(MenuBarItem oldWidget) {
+    if (widget.focusNode != null) {
+      _focusNode?.dispose();
+      _focusNode = null;
+    } else {
+      _focusNode ??= FocusNode(debugLabel: 'MenuBarItem(${widget.label})');
+    }
+    _updateMenuRegistration();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MenuBarThemeData menuBarTheme = MenuBarTheme.of(context);
+    final _TokenDefaultsM3 defaultTheme = _TokenDefaultsM3(context);
+    final Size densityAdjustedSize = const Size(64, 48) + Theme.of(context).visualDensity.baseSizeAdjustment;
+    MaterialStateProperty<EdgeInsets?> resolvedPadding;
+    if (widget._hasMenu && menu!.isTopLevel) {
+      resolvedPadding =
+          MaterialStateProperty.all<EdgeInsets?>(widget.padding ?? menuBarTheme.barPadding ?? defaultTheme.barPadding);
+    } else {
+      resolvedPadding = MaterialStateProperty.all<EdgeInsets?>(
+          widget.padding ?? menuBarTheme.itemPadding ?? defaultTheme.itemPadding);
+    }
+    return TextButton(
+      style: (TextButtonTheme.of(context).style ?? const ButtonStyle()).copyWith(
+        minimumSize: MaterialStateProperty.all<Size?>(densityAdjustedSize),
+        backgroundColor:
+            widget.backgroundColor ?? menuBarTheme.itemBackgroundColor ?? defaultTheme.itemBackgroundColor,
+        foregroundColor:
+            widget.foregroundColor ?? menuBarTheme.itemForegroundColor ?? defaultTheme.itemForegroundColor,
+        overlayColor: widget.overlayColor ?? menuBarTheme.itemOverlayColor ?? defaultTheme.itemOverlayColor,
+        padding: resolvedPadding,
+        shape: widget.shape ?? menuBarTheme.itemShape ?? defaultTheme.itemShape,
+        textStyle: widget.textStyle ?? menuBarTheme.itemTextStyle ?? defaultTheme.itemTextStyle,
+      ),
+      focusNode: focusNode,
+      onHover: enabled ? _handleHover : null,
+      onPressed: enabled ? _handleSelect : null,
+      child: _MenuBarItemLabel(
+        leadingIcon: widget.leadingIcon,
+        label: widget.labelWidget ?? Text(widget.label),
+        shortcut: widget.shortcut,
+        trailingIcon: widget.trailingIcon,
+        hasSubmenu: widget._hasMenu,
+      ),
+    );
+  }
+
+  // Expands groups and adds dividers when necessary.
+  List<Widget> _expandGroups(MenuItem parent) {
+    final List<Widget> expanded = <Widget>[];
+    bool lastWasGroup = false;
+    for (final MenuItem item in parent.menus) {
+      if (lastWasGroup) {
+        expanded.add(const _MenuItemDivider());
+      }
+      if (item.members.isNotEmpty) {
+        expanded.addAll(item.members.cast<Widget>());
+        lastWasGroup = true;
+      } else {
+        expanded.add(item as Widget);
+        lastWasGroup = false;
+      }
+    }
+    return expanded;
+  }
+
+  // Wraps the given child with the appropriate Positioned widget for the
+  // submenu.
+  Widget _wrapWithPosition({
+    required BuildContext menuButtonContext,
+    required _MenuNode menuButtonNode,
+    required Widget child,
+  }) {
+    final TextDirection textDirection = Directionality.of(menuButtonContext);
+    final RenderBox button = menuButtonContext.findRenderObject()! as RenderBox;
+    final RenderBox menuBar = controller.menuBarContext.findRenderObject()! as RenderBox;
+    final RenderBox overlay = Navigator.of(menuButtonContext).overlay!.context.findRenderObject()! as RenderBox;
+
+    assert(menuButtonNode.menuPadding != null, 'Menu padding not properly set.');
+    Offset menuOrigin;
+    switch (textDirection) {
+      case TextDirection.rtl:
+        final Offset menuBarOrigin = menuBar.localToGlobal(menuBar.paintBounds.topRight);
+        if (menuButtonNode.isTopLevel) {
+          menuOrigin = button.localToGlobal(button.paintBounds.bottomRight, ancestor: overlay);
+          menuOrigin = Offset(menuBarOrigin.dx - menuOrigin.dx, menuOrigin.dy);
+        } else {
+          menuOrigin = button.localToGlobal(button.paintBounds.topLeft, ancestor: overlay);
+          menuOrigin = Offset(menuBarOrigin.dx - menuOrigin.dx, menuOrigin.dy) +
+              Offset(
+                -menuButtonNode.menuPadding!.right,
+                -menuButtonNode.menuPadding!.top,
+              );
+        }
+        break;
+      case TextDirection.ltr:
+        if (menuButtonNode.isTopLevel) {
+          menuOrigin = button.localToGlobal(button.paintBounds.bottomLeft, ancestor: menuBar);
+        } else {
+          menuOrigin = button.localToGlobal(button.paintBounds.topRight, ancestor: overlay) +
+              Offset(
+                menuButtonNode.menuPadding!.left,
+                -menuButtonNode.menuPadding!.top,
+              );
+        }
+        break;
+    }
+    return Positioned.directional(
+      textDirection: textDirection,
+      top: menuOrigin.dy,
+      start: menuOrigin.dx,
+      child: child,
+    );
+  }
+
+  // A builder for a submenu that should be positioned relative to the menu
+  // button whose context is given.
+  Widget _buildPositionedMenu(_MenuNode menuButtonNode) {
+    final _TokenDefaultsM3 defaultTheme = _TokenDefaultsM3(controller.menuBarContext);
+    final MenuBarThemeData menuBarTheme = MenuBarTheme.of(controller.menuBarContext);
+    final TextDirection textDirection = Directionality.of(controller.menuBarContext);
+    final Set<MaterialState> disabled = <MaterialState>{
+      if (!enabled) MaterialState.disabled,
+    };
+    // Because this is all in the overlay, we have to duplicate a lot of state
+    // that exists in the context of the menu button.
+    return _wrapWithPosition(
+      menuButtonContext: context,
+      menuButtonNode: menuButtonNode,
+      child: Directionality(
+        textDirection: textDirection,
+        child: InheritedTheme.captureAll(
+          controller.menuBarContext,
+          Builder(
+            builder: (BuildContext context) {
+              return _MenuNodeWrapper(
+                menu: menuButtonNode,
+                serial: menuSerial,
+                child: _MenuBarControllerMarker(
+                  controller: controller,
+                  child: _MenuBarMenuList(
+                    elevation: (menuBarTheme.menuElevation ?? defaultTheme.menuElevation).resolve(disabled)!,
+                    shape: (widget.shape ?? menuBarTheme.menuShape ?? defaultTheme.menuShape).resolve(disabled)!,
+                    backgroundColor:
+                        (widget.backgroundColor ?? menuBarTheme.menuBackgroundColor ?? defaultTheme.menuBackgroundColor)
+                            .resolve(disabled)!,
+                    menuPadding: menuButtonNode.menuPadding ?? menuBarTheme.menuPadding ?? defaultTheme.menuPadding,
+                    semanticLabel: widget.semanticLabel ?? MaterialLocalizations.of(context).popupMenuLabel,
+                    textDirection: Directionality.of(context),
+                    children: _expandGroups(menuButtonNode.item),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _updateMenuRegistration() {
+    final _MenuNode newMenu = _MenuNodeWrapper.of(context);
+    final _MenuBarController newController = MenuBarController.of(context) as _MenuBarController;
+    if (menuSerial != newController.menuSerial || newMenu != menu || newController != controller) {
+      controller = newController;
+      menu = newMenu;
+      menuSerial = controller.menuSerial;
+      newController.registerMenu(
+        menuContext: context,
+        node: newMenu,
+        buttonFocus: focusNode,
+        menuPadding: widget._menuPadding,
+        menuBuilder: menu!.hasSubmenu ? (BuildContext context) => _buildPositionedMenu(menu!) : null,
+      );
+    }
+  }
+
+  void _handleSelect() {
+    widget.onSelected?.call();
+
+    if (!widget._hasMenu) {
+      controller.closeAll();
+    }
+  }
+
+  void _handleHover(bool hovering) {
+    widget.onHover?.call(hovering);
+
+    if (!widget._hasMenu && hovering && !controller.isAnOpenMenu(menu!)) {
+      setState(() {
+        controller.openMenu = menu;
+      });
+    }
+  }
+}
+
+class _MenuItemDivider extends StatelessWidget {
+  /// Creates a [_MenuItemDivider].
+  const _MenuItemDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Divider(height: math.max(2, 16 + Theme.of(context).visualDensity.vertical * 4));
+  }
+}
+
+/// A widget that groups [MenuItem]s (e.g. [MenuBarItem]s and [MenuBarMenu]s)
+/// into sections delineated by a [Divider].
+///
+/// It inserts dividers as necessary before and after the group, only inserting
+/// them if there are other menu items before or after this group in the menu.
+class MenuItemGroup extends StatelessWidget implements MenuItem {
+  /// Creates a const [MenuItemGroup].
+  ///
+  /// The [members] attribute is required.
+  const MenuItemGroup({super.key, required this.members});
+
+  /// The members of this [MenuItemGroup].
+  ///
+  /// It empty, then this group will not appear in the menu.
+  @override
+  final List<MenuItem> members;
+
+  /// Converts this [MenuItemGroup] into a data structure accepted by the
+  /// 'flutter/menu' method channel method 'Menu.SetMenu'.
+  ///
+  /// This is used by [PlatformMenuBar] when rendering this [MenuItemGroup]
+  /// using platform APIs.
+  @override
+  Iterable<Map<String, Object?>> toChannelRepresentation(PlatformMenuDelegate delegate,
+      {required int Function(MenuItem) getId}) {
+    return PlatformMenuItemGroup.serialize(this, delegate, getId: getId);
+  }
+
+  @override
+  MenuSerializableShortcut? get shortcut => null;
+
+  @override
+  List<MenuItem> get menus => const <MenuItem>[];
+
+  @override
+  List<MenuItem> get descendants => const <MenuItem>[];
+
+  @override
+  Intent? get onSelectedIntent => null;
+
+  @override
+  VoidCallback? get onSelected => null;
+
+  @override
+  VoidCallback? get onOpen => null;
+
+  @override
+  VoidCallback? get onClose => null;
+
+  @override
+  Widget build(BuildContext context) {
+    final _MenuNode menu = _MenuNodeWrapper.of(context);
+    final bool hasDividerBefore = menu.parentIndex != 0 && !menu.previousSibling!.isGroup;
+    final bool hasDividerAfter = menu.parentIndex != (menu.parent!.children.length - 1);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (hasDividerBefore) const _MenuItemDivider(),
+        ...members.cast<Widget>(),
+        if (hasDividerAfter) const _MenuItemDivider(),
+      ],
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IterableProperty<MenuItem>('members', members));
+  }
+}
+
+/// A widget that manages the top level of menu buttons in a bar. This widget is
+/// what gets drawn in the main widget hierarchy, while the rest of the menu
+/// widgets are drawn in an overlay.
+class _MenuBarTopLevelBar extends StatelessWidget implements PreferredSizeWidget {
+  _MenuBarTopLevelBar({
+    required this.enabled,
+    required this.elevation,
+    required this.height,
+    required this.color,
+    required this.padding,
+    required this.children,
+  }) : preferredSize = Size.fromHeight(height);
+
+  /// Whether or not this [_MenuBarTopLevelBar] is enabled.
+  final bool enabled;
+
+  /// The elevation to give the material behind the menu bar.
+  final double elevation;
+
+  /// The minimum height to give the menu bar.
+  final double height;
+
+  /// The background color of the menu app bar.
+  final Color color;
+
+  /// The padding around the outside of the menu bar contents.
+  final EdgeInsets padding;
+
+  @override
+  final Size preferredSize;
+
+  /// The list of widgets to use as children of this menu bar.
+  ///
+  /// These are the top level [MenuBarMenu]s.
+  final List<MenuItem> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final _MenuBarController controller = MenuBarController.of(context) as _MenuBarController;
+
+    int index = 0;
+    final Widget appBar = Material(
+      elevation: elevation,
+      color: color,
+      child: Row(
+        children: <Widget>[
+          ...children.map<Widget>((MenuItem child) {
+            final Widget result = _MenuNodeWrapper(
+              serial: controller.menuSerial,
+              menu: controller.root.children[index],
+              child: child as Widget,
+            );
+            index += 1;
+            return result;
+          }).toList(),
+          const Spacer(),
+        ],
+      ),
+    );
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: height),
+      child: appBar,
+    );
+  }
+}
+
+/// A label widget that is used as the default label for a [MenuBarItem] or
+/// [MenuBarMenu].
+///
+/// It not only shows the [MenuBarMenu.label] or [MenuBarItem.label], but if
+/// there is a shortcut associated with the [MenuBarItem], it will display a
+/// mnemonic for the shortcut. For [MenuBarMenu]s, it will display a visual
+/// indicator that there is a submenu.
+class _MenuBarItemLabel extends StatelessWidget {
+  /// Creates a const [_MenuBarItemLabel].
+  ///
+  /// The [menuBarItem] argument is required.
+  const _MenuBarItemLabel({
+    this.leadingIcon,
+    required this.label,
+    this.trailingIcon,
+    this.shortcut,
+    required this.hasSubmenu,
+  });
+
+  /// The optional icon that comes before the [label].
+  final Widget? leadingIcon;
+
+  /// The required label widget.
+  final Widget label;
+
+  /// The optional icon that comes after the [label].
+  final Widget? trailingIcon;
+
+  /// The shortcut for this label, so that it can generate a string describing
+  /// the shortcut.
+  final MenuSerializableShortcut? shortcut;
+
+  /// Whether or not this menu has a submenu.
+  final bool hasSubmenu;
+
+  @override
+  Widget build(BuildContext context) {
+    final _MenuBarController controller = MenuBarController.of(context) as _MenuBarController;
+    final bool isTopLevelItem = _MenuNodeWrapper.of(context).parent == controller.root;
+    final VisualDensity density = Theme.of(context).visualDensity;
+    final double horizontalPadding = math.max(
+      _kLabelItemMinSpacing,
+      _kLabelItemDefaultSpacing + density.horizontal * 2,
+    );
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (BuildContext context, Widget? ignoredChild) {
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                if (leadingIcon != null) leadingIcon!,
+                Padding(
+                  padding: leadingIcon != null ? EdgeInsetsDirectional.only(start: horizontalPadding) : EdgeInsets.zero,
+                  child: label,
+                ),
+                if (trailingIcon != null)
+                  Padding(
+                    padding: EdgeInsetsDirectional.only(start: horizontalPadding),
+                    child: trailingIcon,
+                  ),
+              ],
+            ),
+            if (!isTopLevelItem) SizedBox(width: horizontalPadding),
+            if (shortcut != null && !isTopLevelItem)
+              Padding(
+                padding: EdgeInsetsDirectional.only(start: horizontalPadding),
+                child: Text(
+                  _LocalizedShortcutLabeler.instance.getShortcutLabel(
+                    shortcut!,
+                    MaterialLocalizations.of(context),
+                  ),
+                ),
+              ),
+            if (hasSubmenu && !isTopLevelItem)
+              Padding(
+                padding: EdgeInsetsDirectional.only(start: horizontalPadding),
+                child: const Icon(
+                  Icons.arrow_right, // Automatically switches with text direction.
+                  size: _kDefaultSubmenuIconSize,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// A helper class used to generate shortcut labels for a [ShortcutActivator].
+///
+/// This helper class is typically used by the [MenuBarItem] class to display a
+/// label for its assigned shortcut.
+///
+/// Call [getShortcutLabel] with the [ShortcutActivator] you wish to get a label
+/// for.
+///
+/// For instance, calling [getShortcutLabel] with `SingleActivator(trigger:
+/// LogicalKeyboardKey.keyA, control: true)` would return "⌃ A" on macOS, "Ctrl
+/// A" in an US English locale, and "Strg A" in a German locale.
+class _LocalizedShortcutLabeler {
+  _LocalizedShortcutLabeler._();
+
+  /// Return the instance for this singleton.
+  static _LocalizedShortcutLabeler get instance {
+    return _instance ??= _LocalizedShortcutLabeler._();
+  }
+
+  static _LocalizedShortcutLabeler? _instance;
+
+  // Caches the created shortcut key maps so that creating one of these isn't
+  // expensive after the first time for each unique localizations object.
+  final Map<MaterialLocalizations, Map<LogicalKeyboardKey, String>> _cachedShortcutKeys =
+      <MaterialLocalizations, Map<LogicalKeyboardKey, String>>{};
+
+  static final Map<LogicalKeyboardKey, String> _shortcutGraphicEquivalents = <LogicalKeyboardKey, String>{
+    LogicalKeyboardKey.arrowLeft: '←',
+    LogicalKeyboardKey.arrowRight: '→',
+    LogicalKeyboardKey.arrowUp: '↑',
+    LogicalKeyboardKey.arrowDown: '↓',
+    LogicalKeyboardKey.enter: '↵',
+    LogicalKeyboardKey.shift: '⇧',
+    LogicalKeyboardKey.shiftLeft: '⇧',
+    LogicalKeyboardKey.shiftRight: '⇧',
+  };
+
+  static final Set<LogicalKeyboardKey> _modifiers = <LogicalKeyboardKey>{
+    LogicalKeyboardKey.alt,
+    LogicalKeyboardKey.control,
+    LogicalKeyboardKey.meta,
+    LogicalKeyboardKey.shift,
+    LogicalKeyboardKey.altLeft,
+    LogicalKeyboardKey.controlLeft,
+    LogicalKeyboardKey.metaLeft,
+    LogicalKeyboardKey.shiftLeft,
+    LogicalKeyboardKey.altRight,
+    LogicalKeyboardKey.controlRight,
+    LogicalKeyboardKey.metaRight,
+    LogicalKeyboardKey.shiftRight,
+  };
+
+  // Tries to look up the key in an internal table, and if it can't find it,
+  // then fall back to the key's keyLabel.
+  String? _getLocalizedName(LogicalKeyboardKey key, MaterialLocalizations localizations) {
+    // Since this is an expensive table to build, we cache it based on the
+    // localization object. There's currently no way to clear the cache, but
+    // it's unlikely that more than one or two will be cached for each run, and
+    // they're not huge.
+    _cachedShortcutKeys[localizations] ??= <LogicalKeyboardKey, String>{
+      LogicalKeyboardKey.altGraph: localizations.keyboardKeyAltGraph,
+      LogicalKeyboardKey.backspace: localizations.keyboardKeyBackspace,
+      LogicalKeyboardKey.capsLock: localizations.keyboardKeyCapsLock,
+      LogicalKeyboardKey.channelDown: localizations.keyboardKeyChannelDown,
+      LogicalKeyboardKey.channelUp: localizations.keyboardKeyChannelUp,
+      LogicalKeyboardKey.delete: localizations.keyboardKeyDelete,
+      LogicalKeyboardKey.eject: localizations.keyboardKeyEject,
+      LogicalKeyboardKey.end: localizations.keyboardKeyEnd,
+      LogicalKeyboardKey.escape: localizations.keyboardKeyEscape,
+      LogicalKeyboardKey.fn: localizations.keyboardKeyFn,
+      LogicalKeyboardKey.home: localizations.keyboardKeyHome,
+      LogicalKeyboardKey.insert: localizations.keyboardKeyInsert,
+      LogicalKeyboardKey.numLock: localizations.keyboardKeyNumLock,
+      LogicalKeyboardKey.numpad1: localizations.keyboardKeyNumpad1,
+      LogicalKeyboardKey.numpad2: localizations.keyboardKeyNumpad2,
+      LogicalKeyboardKey.numpad3: localizations.keyboardKeyNumpad3,
+      LogicalKeyboardKey.numpad4: localizations.keyboardKeyNumpad4,
+      LogicalKeyboardKey.numpad5: localizations.keyboardKeyNumpad5,
+      LogicalKeyboardKey.numpad6: localizations.keyboardKeyNumpad6,
+      LogicalKeyboardKey.numpad7: localizations.keyboardKeyNumpad7,
+      LogicalKeyboardKey.numpad8: localizations.keyboardKeyNumpad8,
+      LogicalKeyboardKey.numpad9: localizations.keyboardKeyNumpad9,
+      LogicalKeyboardKey.numpad0: localizations.keyboardKeyNumpad0,
+      LogicalKeyboardKey.numpadAdd: localizations.keyboardKeyNumpadAdd,
+      LogicalKeyboardKey.numpadComma: localizations.keyboardKeyNumpadComma,
+      LogicalKeyboardKey.numpadDecimal: localizations.keyboardKeyNumpadDecimal,
+      LogicalKeyboardKey.numpadDivide: localizations.keyboardKeyNumpadDivide,
+      LogicalKeyboardKey.numpadEnter: localizations.keyboardKeyNumpadEnter,
+      LogicalKeyboardKey.numpadEqual: localizations.keyboardKeyNumpadEqual,
+      LogicalKeyboardKey.numpadMultiply: localizations.keyboardKeyNumpadMultiply,
+      LogicalKeyboardKey.numpadParenLeft: localizations.keyboardKeyNumpadParenLeft,
+      LogicalKeyboardKey.numpadParenRight: localizations.keyboardKeyNumpadParenRight,
+      LogicalKeyboardKey.numpadSubtract: localizations.keyboardKeyNumpadSubtract,
+      LogicalKeyboardKey.pageDown: localizations.keyboardKeyPageDown,
+      LogicalKeyboardKey.pageUp: localizations.keyboardKeyPageUp,
+      LogicalKeyboardKey.power: localizations.keyboardKeyPower,
+      LogicalKeyboardKey.powerOff: localizations.keyboardKeyPowerOff,
+      LogicalKeyboardKey.printScreen: localizations.keyboardKeyPrintScreen,
+      LogicalKeyboardKey.scrollLock: localizations.keyboardKeyScrollLock,
+      LogicalKeyboardKey.select: localizations.keyboardKeySelect,
+      LogicalKeyboardKey.space: localizations.keyboardKeySpace,
+    };
+    return _cachedShortcutKeys[localizations]![key];
+  }
+
+  String _getModifierLabel(LogicalKeyboardKey modifier, MaterialLocalizations localizations) {
+    assert(_modifiers.contains(modifier), '${modifier.keyLabel} is not a modifier key');
+    if (modifier == LogicalKeyboardKey.meta ||
+        modifier == LogicalKeyboardKey.metaLeft ||
+        modifier == LogicalKeyboardKey.metaRight) {
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+          return localizations.keyboardKeyMeta;
+        case TargetPlatform.windows:
+          return localizations.keyboardKeyMetaWindows;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return '⌘';
+      }
+    }
+    if (modifier == LogicalKeyboardKey.alt ||
+        modifier == LogicalKeyboardKey.altLeft ||
+        modifier == LogicalKeyboardKey.altRight) {
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          return localizations.keyboardKeyAlt;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return '⌥';
+      }
+    }
+    if (modifier == LogicalKeyboardKey.control ||
+        modifier == LogicalKeyboardKey.controlLeft ||
+        modifier == LogicalKeyboardKey.controlRight) {
+      // '⎈' (a boat helm wheel, not an asterisk) is apparently the standard
+      // icon for "control", but only seems to appear on the French Canadian
+      // keyboard. A '✲' (an open center asterisk) appears on some Microsoft
+      // keyboards. For all but macOS (which has standardized on "⌃", it seems),
+      // we just return the local translation of "Ctrl".
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+        case TargetPlatform.windows:
+          return localizations.keyboardKeyControl;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          return '⌃';
+      }
+    }
+    if (modifier == LogicalKeyboardKey.shift ||
+        modifier == LogicalKeyboardKey.shiftLeft ||
+        modifier == LogicalKeyboardKey.shiftRight) {
+      return _shortcutGraphicEquivalents[LogicalKeyboardKey.shift]!;
+    }
+    throw ArgumentError('Keyboard key ${modifier.keyLabel} is not a modifier.');
+  }
+
+  /// Returns the label to be shown to the user in the UI when a
+  /// [ShortcutActivator] is used as a keyboard shortcut.
+  ///
+  /// To keep the representation short, this will return graphical key
+  /// representations when it can. For instance, the default
+  /// [LogicalKeyboardKey.shift] will return '⇧', and the arrow keys will return
+  /// arrows.
+  ///
+  /// When [defaultTargetPlatform] is [TargetPlatform.macOS] or
+  /// [TargetPlatform.iOS], the key [LogicalKeyboardKey.meta] will show as '⌘',
+  /// [LogicalKeyboardKey.control] will show as '˄', and
+  /// [LogicalKeyboardKey.alt] will show as '⌥'.
+  String getShortcutLabel(MenuSerializableShortcut shortcut, MaterialLocalizations localizations) {
+    final ShortcutSerialization serialized = shortcut.serializeForMenu();
+    if (serialized.trigger != null) {
+      final List<String> modifiers = <String>[];
+      final LogicalKeyboardKey trigger = serialized.trigger!;
+      // These should be in this order, to match the LogicalKeySet version.
+      if (serialized.alt!) {
+        modifiers.add(_getModifierLabel(LogicalKeyboardKey.alt, localizations));
+      }
+      if (serialized.control!) {
+        modifiers.add(_getModifierLabel(LogicalKeyboardKey.control, localizations));
+      }
+      if (serialized.meta!) {
+        modifiers.add(_getModifierLabel(LogicalKeyboardKey.meta, localizations));
+      }
+      if (serialized.shift!) {
+        modifiers.add(_getModifierLabel(LogicalKeyboardKey.shift, localizations));
+      }
+      String? shortcutTrigger;
+      final int logicalKeyId = trigger.keyId;
+      if (_shortcutGraphicEquivalents.containsKey(trigger)) {
+        shortcutTrigger = _shortcutGraphicEquivalents[trigger];
+      } else {
+        // Otherwise, look it up, and if we don't have a translation for it,
+        // then fall back to the key label.
+        shortcutTrigger = _getLocalizedName(trigger, localizations);
+        if (shortcutTrigger == null && logicalKeyId & LogicalKeyboardKey.planeMask == 0x0) {
+          // If the trigger is a Unicode-character-producing key, then use the character.
+          shortcutTrigger = String.fromCharCode(logicalKeyId & LogicalKeyboardKey.valueMask).toUpperCase();
+        }
+        // Fall back to the key label if all else fails.
+        shortcutTrigger ??= trigger.keyLabel;
+      }
+      return <String>[
+        ...modifiers,
+        if (shortcutTrigger != null && shortcutTrigger.isNotEmpty) shortcutTrigger,
+      ].join(' ');
+    } else if (serialized.character != null) {
+      return serialized.character!;
+    }
+    throw UnimplementedError('Shortcut labels for ShortcutActivators that do not implement '
+        'MenuSerializableShortcut (e.g. ShortcutActivators other than SingleActivator or '
+        'CharacterActivator) are not supported.');
+  }
+}
+
+/// A menu container for [MenuBarItem]s.
+///
+/// This widget contains a column of widgets, and sizes its width to the widest
+/// child, and then forces all the other children to be that same width. It
+/// adopts a height large enough to accommodate all the children.
+///
+/// It is used by [MenuBarMenu] to render its child items.
+class _MenuBarMenuList extends StatefulWidget {
+  /// Create a const [_MenuBarMenuList].
+  ///
+  /// All parameters except `key` and [shape] are required.
+  const _MenuBarMenuList({
+    required this.backgroundColor,
+    required this.shape,
+    required this.elevation,
+    required this.menuPadding,
+    required this.semanticLabel,
+    required this.textDirection,
+    required this.children,
+  });
+
+  /// The background color of this submenu.
+  final Color backgroundColor;
+
+  /// The shape of the border on this submenu.
+  ///
+  /// Defaults to a rectangle.
+  final ShapeBorder shape;
+
+  /// The Material elevation for the menu's shadow.
+  ///
+  /// See also:
+  ///
+  ///  * [Material.elevation] for a description of what elevation implies.
+  final double elevation;
+
+  /// The padding around the inside of the menu panel.
+  final EdgeInsets menuPadding;
+
+  /// The semantic label for this submenu.
+  final String semanticLabel;
+
+  /// The text direction to use for rendering this menu.
+  final TextDirection textDirection;
+
+  /// The menu items that fill this submenu.
+  final List<Widget> children;
+
+  @override
+  State<_MenuBarMenuList> createState() => _MenuBarMenuListState();
+}
+
+class _MenuBarMenuListState extends State<_MenuBarMenuList> {
+  List<Widget> _expandGroups() {
+    int index = 0;
+    final _MenuNode parentMenu = _MenuNodeWrapper.of(context);
+    final _MenuBarController controller = MenuBarController.of(context) as _MenuBarController;
+    final List<Widget> expanded = <Widget>[];
+
+    for (final Widget child in widget.children) {
+      if (child is! MenuItem) {
+        // If it's not a menu item, then it's probably a _MenuItemDivider. Don't
+        // increment the index, or wrap non-MenuItems with _MenuNodeWrapper:
+        // they're not represented in the node tree.
+        expanded.add(child);
+        continue;
+      }
+      final MenuItem childMenuItem = child as MenuItem;
+      assert(index < parentMenu.children.length);
+      if (childMenuItem.members.isEmpty) {
+        expanded.add(
+          _MenuNodeWrapper(
+            serial: controller.menuSerial,
+            menu: parentMenu.children[index],
+            child: child,
+          ),
+        );
+        index += 1;
+      } else {
+        // Groups are expanded in the node tree, so expand them here too.
+        expanded.addAll(childMenuItem.members.map<Widget>((MenuItem member) {
+          final Widget wrapper = _MenuNodeWrapper(
+            serial: controller.menuSerial,
+            menu: parentMenu.children[index],
+            child: child,
+          );
+          index += 1;
+          return wrapper;
+        }));
+      }
+    }
+    return expanded;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: widget.backgroundColor,
+      shape: widget.shape,
+      elevation: widget.elevation,
+      child: _MenuBarMenuRenderWidget(
+        controller: MenuBarController.of(context) as _MenuBarController,
+        padding: widget.menuPadding,
+        semanticLabel: widget.semanticLabel,
+        textDirection: widget.textDirection,
+        children: _expandGroups(),
+      ),
+    );
+  }
+}
+
+/// A render widget for laying out menu bar items.
+///
+/// It finds the widest child, and then forces all of the other children to be
+/// that width.
+class _MenuBarMenuRenderWidget extends MultiChildRenderObjectWidget {
+  /// Creates a const [_MenuBarMenuRenderWidget].
+  ///
+  /// The `children` and [padding] arguments are required.
+  _MenuBarMenuRenderWidget({
+    required this.controller,
+    required super.children,
+    required this.padding,
+    this.semanticLabel,
+    this.textDirection,
+  });
+
+  /// The MenuBarController that this menu should register its render object with.
+  final _MenuBarController controller;
+
+  /// Padding around the contents of the menu bar.
+  final EdgeInsets padding;
+
+  /// The semantic label for this menu.
+  ///
+  /// Defaults to [MaterialLocalizations.menuBarMenuLabel].
+  final String? semanticLabel;
+
+  /// The text direction to use for rendering this menu.
+  ///
+  /// Defaults to the ambient text direction from [Directionality.of].
+  final TextDirection? textDirection;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderMenuBarMenu(
+      controller: controller,
+      padding: padding,
+      semanticLabel: semanticLabel ?? MaterialLocalizations.of(context).menuBarMenuLabel,
+      textDirection: textDirection ?? Directionality.of(context),
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant _RenderMenuBarMenu renderObject) {
+    renderObject
+      ..controller = controller
+      ..padding = padding
+      ..semanticLabel = semanticLabel ?? MaterialLocalizations.of(context).menuBarMenuLabel
+      ..textDirection = textDirection ?? Directionality.of(context);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsets>('padding', padding, defaultValue: null));
+    properties.add(StringProperty('semanticLabel', semanticLabel, defaultValue: null));
+    properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
+  }
+}
+
+class _RenderMenuBarMenuParentData extends ContainerBoxParentData<RenderBox> {}
+
+typedef _ChildSizingFunction = double Function(RenderBox child, double extent);
+
+class _LayoutSizes {
+  const _LayoutSizes({
+    required this.crossSize,
+    required this.allocatedSize,
+  });
+
+  final double crossSize;
+  final double allocatedSize;
+}
+
+class _RenderMenuBarMenu extends RenderBox
+    with
+        ContainerRenderObjectMixin<RenderBox, _RenderMenuBarMenuParentData>,
+        RenderBoxContainerDefaultsMixin<RenderBox, _RenderMenuBarMenuParentData>,
+        DebugOverflowIndicatorMixin {
+  _RenderMenuBarMenu({
+    required _MenuBarController controller,
+    required EdgeInsets padding,
+    required String semanticLabel,
+    required TextDirection textDirection,
+  })  : _controller = controller,
+        _padding = padding,
+        _semanticLabel = semanticLabel,
+        _textDirection = textDirection {
+    _controller.registerMenuRenderObject(this);
+  }
+
+  @override
+  void dispose() {
+    _controller.unregisterMenuRenderObject(this);
+    super.dispose();
+  }
+
+  _MenuBarController get controller => _controller;
+  _MenuBarController _controller;
+  set controller(_MenuBarController value) {
+    if (_controller != value) {
+      _controller.unregisterMenuRenderObject(this);
+      _controller = value;
+      _controller.registerMenuRenderObject(this);
+      markNeedsLayout();
+    }
+  }
+
+  EdgeInsets get padding => _padding;
+  EdgeInsets _padding;
+  set padding(EdgeInsets value) {
+    if (_padding != value) {
+      _padding = value;
+      markNeedsLayout();
+    }
+  }
+
+  String get semanticLabel => _semanticLabel;
+  String _semanticLabel;
+  set semanticLabel(String value) {
+    if (value != _semanticLabel) {
+      _semanticLabel = value;
+      markNeedsLayout();
+    }
+  }
+
+  TextDirection get textDirection => _textDirection;
+  TextDirection _textDirection;
+  set textDirection(TextDirection value) {
+    if (_textDirection != value) {
+      _textDirection = value;
+      markNeedsLayout();
+    }
+  }
+
+  @override
+  void setupParentData(RenderBox child) {
+    if (child.parentData is! _RenderMenuBarMenuParentData) {
+      child.parentData = _RenderMenuBarMenuParentData();
+    }
+  }
+
+  double _getIntrinsicSize({
+    required Axis sizingDirection,
+    required double extent,
+    required _ChildSizingFunction childSize,
+  }) {
+    if (sizingDirection == Axis.vertical) {
+      double inflexibleSpace = 0.0;
+      RenderBox? child = firstChild;
+      while (child != null) {
+        inflexibleSpace += childSize(child, extent) + padding.vertical;
+        final _RenderMenuBarMenuParentData childParentData = child.parentData! as _RenderMenuBarMenuParentData;
+        child = childParentData.nextSibling;
+      }
+      return inflexibleSpace;
+    } else {
+      double maxCrossSize = 0.0;
+      RenderBox? child = firstChild;
+      while (child != null) {
+        final double mainSize = child.getMaxIntrinsicHeight(double.infinity);
+        final double crossSize = childSize(child, mainSize) + padding.horizontal;
+        maxCrossSize = math.max(maxCrossSize, crossSize);
+        final _RenderMenuBarMenuParentData childParentData = child.parentData! as _RenderMenuBarMenuParentData;
+        child = childParentData.nextSibling;
+      }
+      return maxCrossSize;
+    }
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    return _getIntrinsicSize(
+      sizingDirection: Axis.horizontal,
+      extent: height,
+      childSize: (RenderBox child, double extent) => child.getMinIntrinsicWidth(extent),
+    );
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    return _getIntrinsicSize(
+      sizingDirection: Axis.horizontal,
+      extent: height,
+      childSize: (RenderBox child, double extent) => child.getMaxIntrinsicWidth(extent),
+    );
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    return _getIntrinsicSize(
+      sizingDirection: Axis.vertical,
+      extent: width,
+      childSize: (RenderBox child, double extent) => child.getMinIntrinsicHeight(extent),
+    );
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    return _getIntrinsicSize(
+      sizingDirection: Axis.vertical,
+      extent: width,
+      childSize: (RenderBox child, double extent) => child.getMaxIntrinsicHeight(extent),
+    );
+  }
+
+  @override
+  double? computeDistanceToActualBaseline(TextBaseline baseline) {
+    return defaultComputeDistanceToFirstActualBaseline(baseline);
+  }
+
+  _LayoutSizes _computeSizes({
+    required BoxConstraints constraints,
+    required ChildLayouter layoutChild,
+  }) {
+    assert(constraints != null);
+
+    double crossSize = 0.0;
+    double allocatedSize = 0.0;
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final _RenderMenuBarMenuParentData childParentData = child.parentData! as _RenderMenuBarMenuParentData;
+      final BoxConstraints innerConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
+      final Size childSize = layoutChild(child, innerConstraints);
+      allocatedSize += childSize.height;
+      crossSize = math.max(crossSize, childSize.width);
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
+    }
+    // Make a second pass, fixing the width of the children at the size of the
+    // widest one.
+    child = firstChild;
+    final BoxConstraints innerConstraints = BoxConstraints.tightFor(width: crossSize);
+    while (child != null) {
+      final _RenderMenuBarMenuParentData childParentData = child.parentData! as _RenderMenuBarMenuParentData;
+      layoutChild(child, innerConstraints);
+      child = childParentData.nextSibling;
+    }
+
+    return _LayoutSizes(
+      crossSize: crossSize + padding.horizontal,
+      allocatedSize: allocatedSize + padding.vertical,
+    );
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final _LayoutSizes sizes = _computeSizes(
+      layoutChild: ChildLayoutHelper.dryLayoutChild,
+      constraints: constraints,
+    );
+
+    return constraints.constrain(Size(sizes.crossSize, sizes.allocatedSize));
+  }
+
+  @override
+  void performLayout() {
+    final BoxConstraints constraints = this.constraints;
+
+    final _LayoutSizes sizes = _computeSizes(
+      layoutChild: ChildLayoutHelper.layoutChild,
+      constraints: constraints,
+    );
+
+    double actualSize = sizes.allocatedSize;
+    double crossSize = sizes.crossSize;
+
+    // Align items along the main axis.
+    size = constraints.constrain(Size(crossSize, actualSize));
+    actualSize = size.height;
+    crossSize = size.width;
+    late final double leadingSpace;
+    // flipMainAxis is used to decide whether to lay out
+    // left-to-right/top-to-bottom (false), or right-to-left/bottom-to-top
+    // (true). The _startIsTopLeft will return null if there's only one child
+    // and the relevant direction is null, in which case we arbitrarily decide
+    // not to flip, but that doesn't have any detectable effect.
+    final bool flipMainAxis = !(_startIsTopLeft(Axis.vertical, textDirection) ?? true);
+    leadingSpace = padding.top;
+
+    // Position elements
+    double childMainPosition = flipMainAxis ? actualSize - leadingSpace : leadingSpace;
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final _RenderMenuBarMenuParentData childParentData = child.parentData! as _RenderMenuBarMenuParentData;
+      final double childCrossPosition;
+      childCrossPosition = padding.left;
+      if (flipMainAxis) {
+        childMainPosition -= child.size.height;
+      }
+      childParentData.offset = Offset(childCrossPosition, childMainPosition);
+      if (!flipMainAxis) {
+        childMainPosition += child.size.height;
+      }
+      child = childParentData.nextSibling;
+    }
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return defaultHitTestChildren(result, position: position);
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) => defaultPaint(context, offset);
+
+  static bool? _startIsTopLeft(Axis direction, TextDirection? textDirection) {
+    assert(direction != null);
+    // If the relevant value of textDirection is null, this returns null too.
+    switch (direction) {
+      case Axis.horizontal:
+        switch (textDirection) {
+          case TextDirection.ltr:
+            return true;
+          case TextDirection.rtl:
+            return false;
+          case null:
+            return null;
+        }
+      case Axis.vertical:
+        return true;
+    }
+  }
+}
+
+/// An inherited widget used to provide its subtree with a [_MenuNode], so that
+/// the children of a [MenuBar] can find their associated [_MenuNode]s without
+/// having to be stateful widgets.
+///
+/// This is how a [MenuBarItem] knows what it's node is in the menu tree: it
+/// looks up the nearest [_MenuNodeWrapper] and asks for the [_MenuNode].
+class _MenuNodeWrapper extends InheritedWidget {
+  const _MenuNodeWrapper({
+    required this.serial,
+    required this.menu,
+    required super.child,
+  });
+
+  final _MenuNode menu;
+  final int serial;
+
+  static _MenuNode of(BuildContext context) {
+    final _MenuNodeWrapper? wrapper = context.dependOnInheritedWidgetOfExactType<_MenuNodeWrapper>();
+    assert(wrapper != null, 'Missing _MenuNodeWrapper for $context');
+    return wrapper!.menu;
+  }
+
+  @override
+  bool updateShouldNotify(_MenuNodeWrapper oldWidget) {
+    return oldWidget.menu != menu || oldWidget.child != child || oldWidget.serial != serial;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<_MenuNode>('menu', menu, defaultValue: null));
+  }
+}
+
+class _ShortcutRegistration extends StatefulWidget {
+  const _ShortcutRegistration({required this.shortcuts, required this.child});
+
+  final Map<MenuSerializableShortcut, Intent> shortcuts;
+  final Widget child;
+
+  @override
+  State<_ShortcutRegistration> createState() => _ShortcutRegistrationState();
+}
+
+class _ShortcutRegistrationState extends State<_ShortcutRegistration> {
+  ShortcutRegistryEntry? _entry;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _entry = ShortcutRegistry.of(context).addAll(
+      widget.shortcuts.cast<ShortcutActivator, Intent>(),
+    );
+  }
+
+  @override
+  void didUpdateWidget(_ShortcutRegistration oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.shortcuts != oldWidget.shortcuts || _entry == null) {
+      _entry?.dispose();
+      _entry = ShortcutRegistry.of(context).addAll(
+        widget.shortcuts.cast<ShortcutActivator, Intent>(),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _entry?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+// This class will eventually be auto-generated, so it should remain at the end
+// of the file.
+class _TokenDefaultsM3 extends MenuBarThemeData {
+  _TokenDefaultsM3(this.context)
+      : super(
+          barElevation: MaterialStateProperty.all<double?>(2.0),
+          menuElevation: MaterialStateProperty.all<double?>(4.0),
+          menuShape: MaterialStateProperty.all<ShapeBorder?>(_defaultBorder),
+          menuPadding: const EdgeInsets.symmetric(vertical: 8.0),
+          itemShape: MaterialStateProperty.all<OutlinedBorder?>(_defaultItemBorder),
+        );
+
+  static const RoundedRectangleBorder _defaultBorder =
+      RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.elliptical(2.0, 3.0)));
+
+  static const RoundedRectangleBorder _defaultItemBorder = RoundedRectangleBorder();
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  double get barHeight {
+    return 40 + Theme.of(context).visualDensity.baseSizeAdjustment.dy;
+  }
+
+  @override
+  EdgeInsets get barPadding {
+    return EdgeInsets.symmetric(
+      horizontal: 20 + Theme.of(context).visualDensity.baseSizeAdjustment.dx,
+    );
+  }
+
+  @override
+  MaterialStateProperty<Color?> get barBackgroundColor {
+    return MaterialStateProperty.all<Color?>(_colors.surface);
+  }
+
+  @override
+  MaterialStateProperty<double?> get barElevation => super.barElevation!;
+
+  @override
+  MaterialStateProperty<Color?> get menuBackgroundColor {
+    return MaterialStateProperty.all<Color?>(_colors.surface);
+  }
+
+  @override
+  MaterialStateProperty<double?> get menuElevation => super.menuElevation!;
+
+  @override
+  MaterialStateProperty<ShapeBorder?> get menuShape => super.menuShape!;
+
+  @override
+  EdgeInsets get menuPadding => super.menuPadding!;
+
+  @override
+  MaterialStateProperty<Color?> get itemBackgroundColor {
+    return MaterialStateProperty.all<Color?>(_colors.surface);
+  }
+
+  @override
+  MaterialStateProperty<Color?> get itemForegroundColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.38);
+      }
+      return _colors.primary;
+    });
+  }
+
+  @override
+  MaterialStateProperty<Color?> get itemOverlayColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      // Use the component default.
+      return null;
+    });
+  }
+
+  @override
+  MaterialStateProperty<TextStyle?> get itemTextStyle {
+    return MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+  }
+
+  @override
+  EdgeInsets get itemPadding {
+    final VisualDensity density = Theme.of(context).visualDensity;
+    return EdgeInsets.symmetric(
+      vertical: math.max(0, density.vertical * 2),
+      horizontal: math.max(0, 24 + density.horizontal * 2),
+    );
+  }
+
+  @override
+  MaterialStateProperty<OutlinedBorder?> get itemShape => super.itemShape!;
+}

--- a/packages/flutter/lib/src/material/menu_bar_theme.dart
+++ b/packages/flutter/lib/src/material/menu_bar_theme.dart
@@ -1,0 +1,333 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'material_state.dart';
+import 'menu_bar.dart';
+import 'theme.dart';
+
+/// Defines the visual properties of [MenuBar], [MenuBarMenu] and
+/// [MenuBarItem] widgets.
+///
+/// Descendant widgets obtain the current [MenuBarThemeData] object
+/// using `MenuBarTheme.of(context)`. Instances of
+/// [MenuBarThemeData] can be customized with
+/// [MenuBarThemeData.copyWith].
+///
+/// Typically, a [MenuBarThemeData] is specified as part of the
+/// overall [Theme] with [ThemeData.menuBarTheme]. Otherwise,
+/// [MenuBarTheme] can be used to configure its own widget subtree.
+///
+/// All [MenuBarThemeData] properties are `null` by default.
+/// If any of these properties are null, the menu bar will provide its own
+/// defaults.
+///
+/// See also:
+///
+///  * [ThemeData], which describes the overall theme information for the
+///    application.
+@immutable
+class MenuBarThemeData with Diagnosticable {
+  /// Creates the set of properties used to configure [MenuBarTheme].
+  const MenuBarThemeData({
+    this.barHeight,
+    this.barPadding,
+    this.barBackgroundColor,
+    this.barElevation,
+    this.menuBackgroundColor,
+    this.menuElevation,
+    this.menuShape,
+    this.menuPadding,
+    this.itemBackgroundColor,
+    this.itemForegroundColor,
+    this.itemOverlayColor,
+    this.itemTextStyle,
+    this.itemPadding,
+    this.itemShape,
+  });
+
+  /// The minimum height of the menu bar.
+  final double? barHeight;
+
+  /// The padding around the outside of a [MenuBar].
+  final EdgeInsets? barPadding;
+
+  /// The background color of the [MenuBar].
+  final MaterialStateProperty<Color?>? barBackgroundColor;
+
+  /// The Material elevation of the [MenuBar].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.elevation] for a description of how elevation works.
+  final MaterialStateProperty<double?>? barElevation;
+
+  /// The background color of a [MenuBarMenu].
+  final MaterialStateProperty<Color?>? menuBackgroundColor;
+
+  /// The Material elevation of the [MenuBarMenu].
+  ///
+  /// See also:
+  ///
+  ///  * [Material.elevation] for a description of how elevation works.
+  final MaterialStateProperty<double?>? menuElevation;
+
+  /// The shape around a [MenuBarMenu].
+  final MaterialStateProperty<ShapeBorder?>? menuShape;
+
+  /// The padding around the outside of a [MenuBarMenu].
+  final EdgeInsets? menuPadding;
+
+  // MenuBarItem properties
+
+  /// The background color of a [MenuBarItem].
+  final MaterialStateProperty<Color?>? itemBackgroundColor;
+
+  /// The foreground color of a [MenuBarItem], used to color the text and
+  /// shortcut labels of a [MenuBarItem].
+  final MaterialStateProperty<Color?>? itemForegroundColor;
+
+  /// The overlay color of a [MenuBarItem], used to color the overlay of a
+  /// [MenuBarItem], typically seen when the [MaterialState.hovered],
+  /// [MaterialState.selected], and/or [MaterialState.focused] states apply.
+  final MaterialStateProperty<Color?>? itemOverlayColor;
+
+  /// The text style of the [MenuBarItem]s in a [MenuBar].
+  ///
+  /// The color in this text style will only be used if [itemForegroundColor]
+  /// is unset.
+  final MaterialStateProperty<TextStyle?>? itemTextStyle;
+
+  /// The padding around the outside of an individual [MenuBarItem].
+  final EdgeInsets? itemPadding;
+
+  /// The shape around an individual [MenuBarItem].
+  final MaterialStateProperty<OutlinedBorder?>? itemShape;
+
+  /// Creates a copy of this object with the given fields replaced with the new
+  /// values.
+  MenuBarThemeData copyWith({
+    double? barHeight,
+    EdgeInsets? barPadding,
+    MaterialStateProperty<Color?>? barBackgroundColor,
+    MaterialStateProperty<double?>? barElevation,
+    MaterialStateProperty<Color?>? menuBackgroundColor,
+    MaterialStateProperty<double?>? menuElevation,
+    MaterialStateProperty<ShapeBorder?>? menuShape,
+    EdgeInsets? menuPadding,
+    MaterialStateProperty<Color?>? itemBackgroundColor,
+    MaterialStateProperty<Color?>? itemForegroundColor,
+    MaterialStateProperty<Color?>? itemOverlayColor,
+    MaterialStateProperty<TextStyle?>? itemTextStyle,
+    EdgeInsets? itemPadding,
+    MaterialStateProperty<OutlinedBorder?>? itemShape,
+  }) {
+    return MenuBarThemeData(
+      barHeight: barHeight ?? this.barHeight,
+      barPadding: barPadding ?? this.barPadding,
+      barBackgroundColor: barBackgroundColor ?? this.barBackgroundColor,
+      barElevation: barElevation ?? this.barElevation,
+      menuBackgroundColor: menuBackgroundColor ?? this.menuBackgroundColor,
+      menuElevation: menuElevation ?? this.menuElevation,
+      menuShape: menuShape ?? this.menuShape,
+      menuPadding: menuPadding ?? this.menuPadding,
+      itemBackgroundColor: itemBackgroundColor ?? this.itemBackgroundColor,
+      itemForegroundColor: itemForegroundColor ?? this.itemForegroundColor,
+      itemOverlayColor: itemOverlayColor ?? this.itemOverlayColor,
+      itemTextStyle: itemTextStyle ?? this.itemTextStyle,
+      itemPadding: itemPadding ?? this.itemPadding,
+      itemShape: itemShape ?? this.itemShape,
+    );
+  }
+
+  /// Linearly interpolate between two [MenuBarThemeData]s.
+  ///
+  /// If both arguments are null, then null is returned.
+  ///
+  /// {@macro dart.ui.shadow.lerp}
+  static MenuBarThemeData? lerp(MenuBarThemeData? a, MenuBarThemeData? b, double t) {
+    assert(t != null);
+    if (a == null && b == null) {
+      return null;
+    }
+    return MenuBarThemeData(
+      barHeight: lerpDouble(a?.barHeight, b?.barHeight, t),
+      barPadding: EdgeInsets.lerp(a?.barPadding, b?.barPadding, t),
+      barBackgroundColor: _lerpProperties<Color?>(a?.barBackgroundColor, b?.barBackgroundColor, t, Color.lerp),
+      barElevation: _lerpProperties<double?>(a?.barElevation, b?.barElevation, t, lerpDouble),
+      menuBackgroundColor: _lerpProperties<Color?>(a?.menuBackgroundColor, b?.menuBackgroundColor, t, Color.lerp),
+      menuElevation: _lerpProperties<double?>(a?.menuElevation, b?.menuElevation, t, lerpDouble),
+      menuShape: _lerpProperties<ShapeBorder?>(a?.menuShape, b?.menuShape, t, ShapeBorder.lerp),
+      menuPadding: EdgeInsets.lerp(a?.menuPadding, b?.menuPadding, t),
+      itemBackgroundColor: _lerpProperties<Color?>(a?.itemBackgroundColor, b?.itemBackgroundColor, t, Color.lerp),
+      itemForegroundColor: _lerpProperties<Color?>(a?.itemForegroundColor, b?.itemForegroundColor, t, Color.lerp),
+      itemOverlayColor: _lerpProperties<Color?>(a?.itemOverlayColor, b?.itemOverlayColor, t, Color.lerp),
+      itemTextStyle: _lerpProperties<TextStyle?>(a?.itemTextStyle, b?.itemTextStyle, t, TextStyle.lerp),
+      itemPadding: EdgeInsets.lerp(a?.itemPadding, b?.itemPadding, t),
+      itemShape: _lerpProperties<OutlinedBorder?>(
+        a?.itemShape,
+        b?.itemShape,
+        t,
+        (ShapeBorder? a, ShapeBorder? b, double t) {
+          return ShapeBorder.lerp(a, b, t) as OutlinedBorder?;
+        },
+      ),
+    );
+  }
+
+  static MaterialStateProperty<T>? _lerpProperties<T>(
+    MaterialStateProperty<T>? a,
+    MaterialStateProperty<T>? b,
+    double t,
+    T Function(T?, T?, double) lerpFunction,
+  ) {
+    // Avoid creating a _LerpProperties object for a common case.
+    if (a == null && b == null) {
+      return null;
+    }
+    return _LerpProperties<T>(a, b, t, lerpFunction);
+  }
+
+  @override
+  int get hashCode {
+    return hashValues(
+      barHeight,
+      barPadding,
+      barBackgroundColor,
+      barElevation,
+      menuBackgroundColor,
+      menuElevation,
+      menuShape,
+      menuPadding,
+      itemBackgroundColor,
+      itemForegroundColor,
+      itemOverlayColor,
+      itemTextStyle,
+      itemPadding,
+      itemShape,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is MenuBarThemeData &&
+        other.barHeight == barHeight &&
+        other.barPadding == barPadding &&
+        other.barBackgroundColor == barBackgroundColor &&
+        other.barElevation == barElevation &&
+        other.menuBackgroundColor == menuBackgroundColor &&
+        other.menuElevation == menuElevation &&
+        other.menuShape == menuShape &&
+        other.menuPadding == menuPadding &&
+        other.itemBackgroundColor == itemBackgroundColor &&
+        other.itemForegroundColor == itemForegroundColor &&
+        other.itemOverlayColor == itemOverlayColor &&
+        other.itemTextStyle == itemTextStyle &&
+        other.itemPadding == itemPadding &&
+        other.itemShape == itemShape;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('barHeight', barHeight, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('barPadding', barPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('barBackgroundColor', barBackgroundColor,
+        defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<double?>>('barElevation', barElevation, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('menuBackgroundColor', menuBackgroundColor,
+        defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<double?>>('menuElevation', menuElevation, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<ShapeBorder?>>('menuShape', menuShape, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('menuPadding', menuPadding, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('itemBackgroundColor', itemBackgroundColor,
+        defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('itemForegroundColor', itemForegroundColor,
+        defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<Color?>>('itemOverlayColor', itemOverlayColor, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty<MaterialStateProperty<TextStyle?>>('itemTextStyle', itemTextStyle, defaultValue: null));
+    properties.add(DiagnosticsProperty<EdgeInsets>('menuItemPadding', itemPadding, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<MaterialStateProperty<ShapeBorder?>>('itemShape', itemShape, defaultValue: null));
+  }
+}
+
+class _LerpProperties<T> implements MaterialStateProperty<T> {
+  const _LerpProperties(this.a, this.b, this.t, this.lerpFunction);
+
+  final MaterialStateProperty<T>? a;
+  final MaterialStateProperty<T>? b;
+  final double t;
+  final T Function(T?, T?, double) lerpFunction;
+
+  @override
+  T resolve(Set<MaterialState> states) {
+    final T? resolvedA = a?.resolve(states);
+    final T? resolvedB = b?.resolve(states);
+    return lerpFunction(resolvedA, resolvedB, t);
+  }
+}
+
+/// An inherited widget that defines the configuration for [MenuBar] and
+/// [MenuBarItem] in this widget's descendants.
+///
+/// Values specified here are used for [MenuBar] and [MenuBarItem] properties
+/// that are not given an explicit non-null value.
+///
+/// See also:
+///  * [MenuBar], a widget that manages [MenuBarItem]s.
+///  * [MenuBarItem], a widget that is a selectable item in a menu bar menu.
+///  * [MenuBarMenu], a widget that specifies an item with a cascading
+///    submenu in a [MenuBar] menu.
+class MenuBarTheme extends InheritedTheme {
+  /// Creates a theme that controls the configurations for [MenuBar] and
+  /// [MenuBarItem] in its widget subtree.
+  const MenuBarTheme({
+    super.key,
+    required this.data,
+    required super.child,
+  }) : assert(data != null);
+
+  /// The properties for [MenuBar] and [MenuBarItem] in this widget's
+  /// descendants.
+  final MenuBarThemeData data;
+
+  /// Returns the closest instance of this class's [data] value that encloses
+  /// the given context. If there is no ancestor, it returns
+  /// [ThemeData.menuBarTheme]. Applications can assume that the returned
+  /// value will not be null.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// MenuBarThemeData theme = MenuBarTheme.of(context);
+  /// ```
+  static MenuBarThemeData of(BuildContext context) {
+    final MenuBarTheme? menuBarTheme = context.dependOnInheritedWidgetOfExactType<MenuBarTheme>();
+    return menuBarTheme?.data ?? Theme.of(context).menuBarTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return MenuBarTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(MenuBarTheme oldWidget) => data != oldWidget.data;
+}

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -33,6 +33,7 @@ import 'ink_well.dart' show InteractiveInkFeatureFactory;
 import 'input_decorator.dart';
 import 'list_tile.dart';
 import 'list_tile_theme.dart';
+import 'menu_bar_theme.dart';
 import 'navigation_bar_theme.dart';
 import 'navigation_rail_theme.dart';
 import 'outlined_button_theme.dart';
@@ -341,6 +342,7 @@ class ThemeData with Diagnosticable {
     ExpansionTileThemeData? expansionTileTheme,
     FloatingActionButtonThemeData? floatingActionButtonTheme,
     ListTileThemeData? listTileTheme,
+    MenuBarThemeData? menuBarTheme,
     NavigationBarThemeData? navigationBarTheme,
     NavigationRailThemeData? navigationRailTheme,
     OutlinedButtonThemeData? outlinedButtonTheme,
@@ -549,6 +551,7 @@ class ThemeData with Diagnosticable {
     elevatedButtonTheme ??= const ElevatedButtonThemeData();
     floatingActionButtonTheme ??= const FloatingActionButtonThemeData();
     listTileTheme ??= const ListTileThemeData();
+    menuBarTheme ??= const MenuBarThemeData();
     navigationBarTheme ??= const NavigationBarThemeData();
     navigationRailTheme ??= const NavigationRailThemeData();
     outlinedButtonTheme ??= const OutlinedButtonThemeData();
@@ -641,6 +644,7 @@ class ThemeData with Diagnosticable {
       expansionTileTheme: expansionTileTheme,
       floatingActionButtonTheme: floatingActionButtonTheme,
       listTileTheme: listTileTheme,
+      menuBarTheme: menuBarTheme,
       navigationBarTheme: navigationBarTheme,
       navigationRailTheme: navigationRailTheme,
       outlinedButtonTheme: outlinedButtonTheme,
@@ -746,6 +750,7 @@ class ThemeData with Diagnosticable {
     required this.expansionTileTheme,
     required this.floatingActionButtonTheme,
     required this.listTileTheme,
+    required this.menuBarTheme,
     required this.navigationBarTheme,
     required this.navigationRailTheme,
     required this.outlinedButtonTheme,
@@ -880,6 +885,7 @@ class ThemeData with Diagnosticable {
        assert(expansionTileTheme != null),
        assert(floatingActionButtonTheme != null),
        assert(listTileTheme != null),
+       assert(menuBarTheme != null),
        assert(navigationBarTheme != null),
        assert(navigationRailTheme != null),
        assert(outlinedButtonTheme != null),
@@ -1412,6 +1418,10 @@ class ThemeData with Diagnosticable {
   /// A theme for customizing the appearance of [ListTile] widgets.
   final ListTileThemeData listTileTheme;
 
+  /// A theme for customizing the color, shape, elevation, and text style of
+  /// cascading menus.
+  final MenuBarThemeData menuBarTheme;
+
   /// A theme for customizing the background color, text style, and icon themes
   /// of a [NavigationBar].
   final NavigationBarThemeData navigationBarTheme;
@@ -1679,6 +1689,7 @@ class ThemeData with Diagnosticable {
     ExpansionTileThemeData? expansionTileTheme,
     FloatingActionButtonThemeData? floatingActionButtonTheme,
     ListTileThemeData? listTileTheme,
+    MenuBarThemeData? menuBarTheme,
     NavigationBarThemeData? navigationBarTheme,
     NavigationRailThemeData? navigationRailTheme,
     OutlinedButtonThemeData? outlinedButtonTheme,
@@ -1813,6 +1824,7 @@ class ThemeData with Diagnosticable {
       expansionTileTheme: expansionTileTheme ?? this.expansionTileTheme,
       floatingActionButtonTheme: floatingActionButtonTheme ?? this.floatingActionButtonTheme,
       listTileTheme: listTileTheme ?? this.listTileTheme,
+      menuBarTheme: menuBarTheme ?? this.menuBarTheme,
       navigationBarTheme: navigationBarTheme ?? this.navigationBarTheme,
       navigationRailTheme: navigationRailTheme ?? this.navigationRailTheme,
       outlinedButtonTheme: outlinedButtonTheme ?? this.outlinedButtonTheme,
@@ -2011,6 +2023,7 @@ class ThemeData with Diagnosticable {
       expansionTileTheme: ExpansionTileThemeData.lerp(a.expansionTileTheme, b.expansionTileTheme, t)!,
       floatingActionButtonTheme: FloatingActionButtonThemeData.lerp(a.floatingActionButtonTheme, b.floatingActionButtonTheme, t)!,
       listTileTheme: ListTileThemeData.lerp(a.listTileTheme, b.listTileTheme, t)!,
+      menuBarTheme: MenuBarThemeData.lerp(a.menuBarTheme, b.menuBarTheme, t)!,
       navigationBarTheme: NavigationBarThemeData.lerp(a.navigationBarTheme, b.navigationBarTheme, t)!,
       navigationRailTheme: NavigationRailThemeData.lerp(a.navigationRailTheme, b.navigationRailTheme, t)!,
       outlinedButtonTheme: OutlinedButtonThemeData.lerp(a.outlinedButtonTheme, b.outlinedButtonTheme, t)!,
@@ -2111,6 +2124,7 @@ class ThemeData with Diagnosticable {
         other.expansionTileTheme == expansionTileTheme &&
         other.floatingActionButtonTheme == floatingActionButtonTheme &&
         other.listTileTheme == listTileTheme &&
+        other.menuBarTheme == menuBarTheme &&
         other.navigationBarTheme == navigationBarTheme &&
         other.navigationRailTheme == navigationRailTheme &&
         other.outlinedButtonTheme == outlinedButtonTheme &&
@@ -2208,6 +2222,7 @@ class ThemeData with Diagnosticable {
       expansionTileTheme,
       floatingActionButtonTheme,
       listTileTheme,
+      menuBarTheme,
       navigationBarTheme,
       navigationRailTheme,
       outlinedButtonTheme,
@@ -2307,6 +2322,7 @@ class ThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<ExpansionTileThemeData>('expansionTileTheme', expansionTileTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<FloatingActionButtonThemeData>('floatingActionButtonTheme', floatingActionButtonTheme, defaultValue: defaultData.floatingActionButtonTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<ListTileThemeData>('listTileTheme', listTileTheme, defaultValue: defaultData.listTileTheme, level: DiagnosticLevel.debug));
+    properties.add(DiagnosticsProperty<MenuBarThemeData>('menuBarTheme', menuBarTheme, defaultValue: defaultData.menuBarTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<NavigationBarThemeData>('navigationBarTheme', navigationBarTheme, defaultValue: defaultData.navigationBarTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<NavigationRailThemeData>('navigationRailTheme', navigationRailTheme, defaultValue: defaultData.navigationRailTheme, level: DiagnosticLevel.debug));
     properties.add(DiagnosticsProperty<OutlinedButtonThemeData>('outlinedButtonTheme', outlinedButtonTheme, defaultValue: defaultData.outlinedButtonTheme, level: DiagnosticLevel.debug));

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -160,19 +160,24 @@ mixin MenuSerializableShortcut {
 }
 
 /// An abstract class for describing cascading menu hierarchies that are part of
-/// a [PlatformMenuBar].
+/// a [MenuBar] or [PlatformMenuBar].
 ///
 /// This type is also used by [PlatformMenuDelegate.setMenus] to accept the menu
 /// hierarchy to be sent to the platform, and by [PlatformMenuBar] to define the
 /// menu hierarchy.
 ///
 /// This class is abstract, and so can't be used directly. Typically subclasses
-/// like [PlatformMenuItem] are used.
+/// like [MenuBarItem] and [PlatformMenuItem] are used in practice.
 ///
 /// See also:
 ///
+///  * [MenuBar], a widget that renders menus in Flutter with a Material design
+///    style.
 ///  * [PlatformMenuBar], a widget that renders menu items using platform APIs
 ///    instead of Flutter.
+///  * [MenuBar.adaptive], a factory constructor for [MenuBar] that renders the
+///    given menu hierarchy using [PlatformMenuBar] on platforms that support
+///    it, and [MenuBar] everywhere else.
 abstract class MenuItem with Diagnosticable {
   /// Allows subclasses to have const constructors.
   const MenuItem();

--- a/packages/flutter/test/material/menu_bar_test.dart
+++ b/packages/flutter/test/material/menu_bar_test.dart
@@ -1,0 +1,1578 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late MenuBarController controller;
+  String? openPath;
+  String? focusedMenu;
+  final List<String> selected = <String>[];
+  final List<String> opened = <String>[];
+  final List<String> closed = <String>[];
+
+  void collectPath() {
+    openPath = controller.testingCurrentItem;
+  }
+
+  void onSelected(String item) {
+    selected.add(item);
+    collectPath();
+  }
+
+  void onOpen(String item) {
+    opened.add(item);
+    collectPath();
+  }
+
+  void onClose(String item) {
+    closed.add(item);
+    collectPath();
+  }
+
+  void handleFocusChange() {
+    focusedMenu = controller.testingFocusedItem;
+  }
+
+  setUp(() {
+    openPath = null;
+    focusedMenu = null;
+    selected.clear();
+    opened.clear();
+    closed.clear();
+    controller = MenuBarController();
+    collectPath();
+    focusedMenu = controller.testingFocusedItem;
+  });
+
+  tearDown(() {
+    controller.closeAll();
+  });
+
+  void listenForFocusChanges() {
+    FocusManager.instance.addListener(handleFocusChange);
+    addTearDown(() => FocusManager.instance.removeListener(handleFocusChange));
+  }
+
+  Finder findDivider() {
+    return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuItemDivider');
+  }
+
+  Finder findMenuBarMenu() {
+    return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuBarMenuList');
+  }
+
+  Finder findMenuTopLevelBar() {
+    return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuBarTopLevelBar');
+  }
+
+  Finder findMenuBarItemLabel() {
+    return find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_MenuBarItemLabel');
+  }
+
+  // Finds the mnemonic associated with the menu item that has the given label.
+  Finder findMnemonic(String label) {
+    return find
+        .descendant(
+            of: find.ancestor(of: find.text(label), matching: findMenuBarItemLabel()), matching: find.byType(Text))
+        .last;
+  }
+
+  Future<TestGesture> hoverOver(WidgetTester tester, Finder finder) async {
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(tester.getCenter(finder));
+    await tester.pumpAndSettle();
+    return gesture;
+  }
+
+  Material getMenuBarMaterial(WidgetTester tester) {
+    return tester.widget<Material>(
+      find.descendant(of: findMenuTopLevelBar(), matching: find.byType(Material)).first,
+    );
+  }
+
+  Material getSubMenuMaterial(WidgetTester tester) {
+    return tester.widget<Material>(
+      find.descendant(of: findMenuBarMenu(), matching: find.byType(Material)).first,
+    );
+  }
+
+  group('MenuBar', () {
+    testWidgets('basic menu structure', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                onSelected: onSelected,
+                onOpen: onOpen,
+                onClose: onClose,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(mainMenu[0]), findsOneWidget);
+      expect(find.text(mainMenu[1]), findsOneWidget);
+      expect(find.text(mainMenu[2]), findsOneWidget);
+      expect(find.text(subMenu1[0]), findsNothing);
+      expect(find.text(subSubMenu10[0]), findsNothing);
+      expect(opened, isEmpty);
+
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      expect(find.text(mainMenu[0]), findsOneWidget);
+      expect(find.text(mainMenu[1]), findsOneWidget);
+      expect(find.text(mainMenu[2]), findsOneWidget);
+      expect(find.text(subMenu1[0]), findsOneWidget);
+      expect(find.text(subMenu1[1]), findsOneWidget);
+      expect(find.text(subMenu1[2]), findsOneWidget);
+      expect(find.text(subSubMenu10[0]), findsNothing);
+      expect(find.text(subSubMenu10[1]), findsNothing);
+      expect(find.text(subSubMenu10[2]), findsNothing);
+      expect(opened.last, equals(mainMenu[1]));
+      opened.clear();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+
+      expect(find.text(mainMenu[0]), findsOneWidget);
+      expect(find.text(mainMenu[1]), findsOneWidget);
+      expect(find.text(mainMenu[2]), findsOneWidget);
+      expect(find.text(subMenu1[0]), findsOneWidget);
+      expect(find.text(subMenu1[1]), findsOneWidget);
+      expect(find.text(subMenu1[2]), findsOneWidget);
+      expect(find.text(subSubMenu10[0]), findsOneWidget);
+      expect(find.text(subSubMenu10[1]), findsOneWidget);
+      expect(find.text(subSubMenu10[2]), findsOneWidget);
+      expect(opened.last, equals(subMenu1[1]));
+    });
+    testWidgets('geometry', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  menus: createTestMenus(onSelected: onSelected),
+                ),
+                const Expanded(child: Placeholder()),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTWH(0, 0, 800, 48)));
+
+      // Open and make sure things are the right size.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTWH(0, 0, 800, 48)));
+      expect(tester.getRect(find.text(subMenu1[0])), equals(const Rect.fromLTRB(148.0, 73.0, 302.0, 87.0)));
+      expect(tester.getRect(find.ancestor(of: find.text(subMenu1[0]), matching: findMenuBarMenu())),
+          equals(const Rect.fromLTRB(124.0, 48.0, 386.0, 224.0)));
+      expect(tester.getRect(findDivider()), equals(const Rect.fromLTRB(124.0, 104.0, 386.0, 120.0)));
+
+      // Close and make sure it goes back where it was.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      expect(tester.getRect(find.byType(MenuBar)), equals(const Rect.fromLTWH(0, 0, 800, 48)));
+    });
+    testWidgets('visual attributes can be set', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  height: 50,
+                  elevation: MaterialStateProperty.all<double?>(10),
+                  backgroundColor: MaterialStateProperty.all(Colors.red),
+                  menus: createTestMenus(onSelected: onSelected),
+                ),
+                const Expanded(child: Placeholder()),
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(tester.getRect(findMenuTopLevelBar()), equals(const Rect.fromLTRB(0.0, 0.0, 800.0, 50.0)));
+      final Material material = getMenuBarMaterial(tester);
+      expect(material.elevation, equals(10));
+      expect(material.color, equals(Colors.red));
+    });
+    testWidgets('theme is honored', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Builder(builder: (BuildContext context) {
+              return MenuBarTheme(
+                data: MenuBarTheme.of(context).copyWith(
+                  barBackgroundColor: MaterialStateProperty.all<Color?>(Colors.green),
+                  itemTextStyle: MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.titleMedium),
+                  barElevation: MaterialStateProperty.all<double?>(20.0),
+                  barHeight: 52.0,
+                  menuBackgroundColor: MaterialStateProperty.all<Color?>(Colors.red),
+                  menuElevation: MaterialStateProperty.all<double?>(15.0),
+                  menuShape: MaterialStateProperty.all<ShapeBorder?>(const StadiumBorder()),
+                  menuPadding: const EdgeInsets.all(10.0),
+                ),
+                child: Column(
+                  children: <Widget>[
+                    MenuBar(
+                      menus: createTestMenus(onSelected: onSelected),
+                    ),
+                    const Expanded(child: Placeholder()),
+                  ],
+                ),
+              );
+            }),
+          ),
+        ),
+      );
+
+      // Open a test menu.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+      expect(tester.getRect(findMenuTopLevelBar()), equals(const Rect.fromLTRB(0.0, 0.0, 800.0, 52.0)));
+      final Material menuBarMaterial = getMenuBarMaterial(tester);
+      expect(menuBarMaterial.elevation, equals(20));
+      expect(menuBarMaterial.color, equals(Colors.green));
+
+      final Material subMenuMaterial = getSubMenuMaterial(tester);
+      expect(tester.getRect(findMenuBarMenu()), equals(const Rect.fromLTRB(136.0, 50.0, 440.0, 230.0)));
+      expect(subMenuMaterial.elevation, equals(15));
+      expect(subMenuMaterial.color, equals(Colors.red));
+    });
+    testWidgets('open and close works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(onSelected: onSelected, onOpen: onOpen, onClose: onClose),
+            ),
+          ),
+        ),
+      );
+
+      expect(openPath, isNull);
+      expect(opened, isEmpty);
+      expect(closed, isEmpty);
+
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(opened, equals(<String>[mainMenu[1]]));
+      expect(closed, isEmpty);
+      opened.clear();
+      closed.clear();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+      expect(opened, equals(<String>[subMenu1[1]]));
+      expect(closed, isEmpty);
+      opened.clear();
+      closed.clear();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(opened, isEmpty);
+      expect(closed, equals(<String>[subMenu1[1]]));
+      opened.clear();
+      closed.clear();
+
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      expect(opened, equals(<String>[mainMenu[0]]));
+      expect(closed, equals(<String>[mainMenu[1]]));
+    });
+    testWidgets('select works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(onSelected: onSelected, onOpen: onOpen, onClose: onClose),
+            ),
+          ),
+        ),
+      );
+
+      expect(openPath, isNull);
+      expect(openPath, isNull);
+
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.tap(find.text(subSubMenu10[0]));
+      await tester.pump();
+
+      expect(selected, equals(<String>[subSubMenu10[0]]));
+
+      // Selecting a non-submenu item should close all the menus.
+      expect(openPath, isNull);
+      expect(find.text(subSubMenu10[0]), findsNothing);
+      expect(find.text(subMenu1[1]), findsNothing);
+    });
+    testWidgets('diagnostics toStringDeep', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  shape: MaterialStateProperty.all<ShapeBorder?>(const RoundedRectangleBorder()),
+                  label: mainMenu[0],
+                  elevation: MaterialStateProperty.all<double?>(10.0),
+                  backgroundColor: MaterialStateProperty.all(Colors.red),
+                  menus: <MenuItem>[
+                    MenuItemGroup(
+                      members: <MenuItem>[
+                        MenuBarItem(
+                          label: subMenu0[0],
+                          semanticLabel: 'semanticLabel',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      final MenuBar menuBar = tester.widget(find.byType(MenuBar));
+      expect(
+        menuBar.toStringDeep(),
+        equalsIgnoringHashCodes(
+          'MenuBar#00000\n'
+          ' │ controller: _MenuBarController#00000\n'
+          ' └MenuBarMenu#00000(Menu 0)(label: "Menu 0", backgroundColor: MaterialStatePropertyAll(MaterialColor(primary value: Color(0xfff44336))), shape: MaterialStatePropertyAll(RoundedRectangleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none), BorderRadius.zero)), elevation: MaterialStatePropertyAll(10.0))\n'
+          '  └MenuItemGroup(members: [MenuBarItem#00000(Sub Menu 00)(DISABLED, label: "Sub Menu 00", semanticLabel: "semanticLabel")])\n',
+        ),
+      );
+    });
+    testWidgets('diagnostics', (WidgetTester tester) async {
+      const MenuBarItem item = MenuBarItem(
+        label: 'label2',
+        shortcut: SingleActivator(LogicalKeyboardKey.keyA),
+      );
+      final MenuBar menuBar = MenuBar(
+        controller: MenuBarController(),
+        enabled: false,
+        backgroundColor: MaterialStateProperty.all(Colors.red),
+        height: 40,
+        elevation: MaterialStateProperty.all<double?>(10.0),
+        menus: const <MenuItem>[item],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: menuBar,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      menuBar.debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(
+        description.join('\n'),
+        equalsIgnoringHashCodes(
+          <String>[
+            'DISABLED',
+            'controller: _MenuBarController#00000',
+            'backgroundColor: MaterialStatePropertyAll(MaterialColor(primary value: Color(0xfff44336)))',
+            'height: 40.0',
+            'elevation: MaterialStatePropertyAll(10.0)'
+          ].join('\n'),
+        ),
+      );
+    });
+    testWidgets('activation via shortcut works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  controller: controller,
+                  menus: createTestMenus(
+                    onSelected: onSelected,
+                    onOpen: onOpen,
+                    onClose: onClose,
+                    shortcuts: <String, MenuSerializableShortcut>{
+                      subSubMenu10[0]: const SingleActivator(
+                        LogicalKeyboardKey.keyA,
+                        control: true,
+                      ),
+                    },
+                  ),
+                ),
+                const Expanded(
+                  child: Center(
+                    child: Focus(
+                      autofocus: true,
+                      child: Text('Body'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+
+      expect(selected, equals(<String>[subSubMenu10[0]]));
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      expect(openPath, isNull);
+    });
+    testWidgets('Having the same shortcut assigned to more than one menu item should throw an error.',
+        (WidgetTester tester) async {
+      const SingleActivator duplicateActivator = SingleActivator(
+        LogicalKeyboardKey.keyA,
+        control: true,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                onSelected: onSelected,
+                onOpen: onOpen,
+                onClose: onClose,
+                shortcuts: <String, MenuSerializableShortcut>{
+                  subSubMenu10[0]: duplicateActivator,
+                  subSubMenu10[1]: duplicateActivator,
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception as FlutterError;
+      expect(
+        error.message,
+        contains(
+          RegExp(r'The same shortcut has been bound to two different menus with different select '
+              r'functions or intents: SingleActivator#.....\(keys: Control \+ Key A\)'),
+        ),
+      );
+    });
+    testWidgets(
+        'Having the same shortcut assigned to more than one menu item should not throw an error if they have the same callback.',
+        (WidgetTester tester) async {
+      const SingleActivator sameShortcut = SingleActivator(
+        LogicalKeyboardKey.keyA,
+        control: true,
+      );
+      void sameCallback() {}
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  label: mainMenu[0],
+                  menus: <MenuItem>[
+                    MenuBarItem(
+                      label: subMenu1[0],
+                      onSelected: sameCallback,
+                      shortcut: sameShortcut,
+                    ),
+                    MenuBarItem(
+                      label: subMenu1[1],
+                      onSelected: sameCallback,
+                      shortcut: sameShortcut,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception, isNull);
+    });
+    testWidgets('keyboard tab traversal works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  controller: controller,
+                  menus: createTestMenus(
+                    onSelected: onSelected,
+                    onOpen: onOpen,
+                    onClose: onClose,
+                  ),
+                ),
+                const Expanded(child: Placeholder()),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      listenForFocusChanges();
+
+      // Have to open a menu initially to start things going.
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 00)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 101)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 102)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 00)'));
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 102)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 101)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+
+      // Test closing a menu with enter.
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(focusedMenu, isNull);
+      expect(openPath, isNull);
+    });
+    testWidgets('keyboard directional traversal works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                onSelected: onSelected,
+                onOpen: onOpen,
+                onClose: onClose,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      listenForFocusChanges();
+
+      // Have to open a menu initially to start things going.
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 12)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 12)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Open the next submenu
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Go back, close the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Move up, should close the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 10)'));
+
+      // Move down, should reopen the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Open the next submenu again.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 101)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 102)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+
+      // Wrap around.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+
+      // Wrap around the other way.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+    });
+    testWidgets('keyboard directional traversal works in RTL mode', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Material(
+              child: MenuBar(
+                controller: controller,
+                menus: createTestMenus(
+                  onSelected: onSelected,
+                  onOpen: onOpen,
+                  onClose: onClose,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      listenForFocusChanges();
+
+      // Have to open a menu initially to start things going.
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 12)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 12)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 12)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Open the next submenu
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Go back, close the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Move up, should close the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarItem#00000(Sub Menu 10)'));
+
+      // Move down, should reopen the submenu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Open the next submenu again.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 101)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 102)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 103)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+
+      // Wrap around.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+
+      // Wrap around the other way.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+    });
+    testWidgets('hover traversal works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                onSelected: onSelected,
+                onOpen: onOpen,
+                onClose: onClose,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      listenForFocusChanges();
+
+      // Hovering when the menu is not yet open does nothing.
+      await hoverOver(tester, find.text(mainMenu[0]));
+      await tester.pump();
+      expect(focusedMenu, isNull);
+      expect(openPath, isNull);
+
+      // Have to open a menu initially to start things going.
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pumpAndSettle();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+
+      // Hovering when the menu is already  open does nothing.
+      await hoverOver(tester, find.text(mainMenu[0]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 0)'));
+
+      // Hovering over the other main menu items opens them now.
+      await hoverOver(tester, find.text(mainMenu[2]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+
+      await hoverOver(tester, find.text(mainMenu[1]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      // Hovering over the menu items focuses them.
+      await hoverOver(tester, find.text(subMenu1[0]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Menu 10)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1)'));
+
+      await hoverOver(tester, find.text(subMenu1[1]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarMenu#00000(Sub Menu 11)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      await hoverOver(tester, find.text(subSubMenu10[0]));
+      await tester.pump();
+      expect(focusedMenu, equalsIgnoringHashCodes('MenuBarItem#00000(Sub Sub Menu 100)'));
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+    });
+  });
+  group('MenuBarController', () {
+    testWidgets('enable and disable works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  controller: controller,
+                  menus: createTestMenus(
+                    onSelected: onSelected,
+                    onOpen: onOpen,
+                    onClose: onClose,
+                    shortcuts: <String, MenuSerializableShortcut>{
+                      subSubMenu10[0]: const SingleActivator(
+                        LogicalKeyboardKey.keyA,
+                        control: true,
+                      )
+                    },
+                  ),
+                ),
+                const Expanded(
+                  child: Center(
+                    child: Focus(
+                      autofocus: true,
+                      child: Text('Body'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump(); // Wait for focus.
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      // The menu should handle shortcuts.
+      expect(selected, equals(<String>[subSubMenu10[0]]));
+      expect(closed, isEmpty);
+      expect(opened, isEmpty);
+      selected.clear();
+
+      // Open a menu initially.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+      expect(opened, equals(<String>[mainMenu[1], subMenu1[1]]));
+      opened.clear();
+      expect(closed, isEmpty);
+      expect(selected, isEmpty);
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Disable the menu bar
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  controller: controller,
+                  enabled: false,
+                  menus: createTestMenus(
+                    onSelected: onSelected,
+                    onOpen: onOpen,
+                    onClose: onClose,
+                    shortcuts: <String, MenuSerializableShortcut>{
+                      subSubMenu10[0]: const SingleActivator(
+                        LogicalKeyboardKey.keyA,
+                        control: true,
+                      )
+                    },
+                  ),
+                ),
+                const Expanded(
+                  child: Center(
+                    child: Focus(
+                      autofocus: true,
+                      child: Text('Body'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // The menu should go away,
+      expect(openPath, isNull);
+      expect(closed, equals(<String>[mainMenu[1], subMenu1[1]]));
+      closed.clear();
+      expect(opened, isEmpty);
+      expect(selected, isEmpty);
+
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      // The menu should not respond to the tap.
+      expect(openPath, isNull);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      // The menu should not handle shortcuts.
+      expect(selected, isEmpty);
+
+      // Re-enable the menu bar.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Column(
+              children: <Widget>[
+                MenuBar(
+                  controller: controller,
+                  menus: createTestMenus(
+                    onSelected: onSelected,
+                    onOpen: onOpen,
+                    onClose: onClose,
+                    shortcuts: <String, MenuSerializableShortcut>{
+                      subSubMenu10[0]: const SingleActivator(
+                        LogicalKeyboardKey.keyA,
+                        control: true,
+                      )
+                    },
+                  ),
+                ),
+                const Expanded(
+                  child: Center(
+                    child: Focus(
+                      autofocus: true,
+                      child: Text('Body'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      // The menu should now handle shortcuts.
+      expect(selected, equals(<String>[subSubMenu10[0]]));
+
+      // The menu should again accept taps.
+      await tester.tap(find.text(mainMenu[2]));
+      await tester.pump();
+
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 2)'));
+      expect(closed, isEmpty);
+      expect(opened, equals(<String>[mainMenu[2]]));
+      // Item disabled by its parameter should still be disabled.
+      final TextButton button =
+          tester.widget(find.ancestor(of: find.text(subMenu2[0]), matching: find.byType(TextButton)));
+      expect(button.onPressed, isNull);
+      expect(button.onHover, isNull);
+      closed.clear();
+    });
+    testWidgets('closing via controller works', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                onSelected: onSelected,
+                onOpen: onOpen,
+                onClose: onClose,
+                shortcuts: <String, MenuSerializableShortcut>{
+                  subSubMenu10[0]: const SingleActivator(
+                    LogicalKeyboardKey.keyA,
+                    control: true,
+                  )
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Open a menu initially.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+      expect(opened, equals(<String>[mainMenu[1], subMenu1[1]]));
+      opened.clear();
+      expect(openPath, equalsIgnoringHashCodes('MenuBarMenu#00000(Menu 1) > MenuBarMenu#00000(Sub Menu 11)'));
+
+      // Close menus using the controller
+      controller.closeAll();
+      await tester.pump();
+
+      // The menu should go away,
+      expect(openPath, isNull);
+      expect(closed, equals(<String>[mainMenu[1], subMenu1[1]]));
+      expect(opened, isEmpty);
+    });
+  });
+  group('MenuBarItem', () {
+    testWidgets('Shortcut mnemonics are displayed', (WidgetTester tester) async {
+      final MenuBarController controller = MenuBarController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                shortcuts: <String, MenuSerializableShortcut>{
+                  subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
+                  subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
+                  subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
+                  subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.keyD, meta: true),
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Open a menu initially.
+      await tester.tap(find.text(mainMenu[1]));
+      await tester.pump();
+
+      await tester.tap(find.text(subMenu1[1]));
+      await tester.pump();
+
+      Text mnemonic0;
+      Text mnemonic1;
+      Text mnemonic2;
+      Text mnemonic3;
+
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+          mnemonic0 = tester.widget(findMnemonic(subSubMenu10[0]));
+          expect(mnemonic0.data, equals('Ctrl A'));
+          mnemonic1 = tester.widget(findMnemonic(subSubMenu10[1]));
+          expect(mnemonic1.data, equals('⇧ B'));
+          mnemonic2 = tester.widget(findMnemonic(subSubMenu10[2]));
+          expect(mnemonic2.data, equals('Alt C'));
+          mnemonic3 = tester.widget(findMnemonic(subSubMenu10[3]));
+          expect(mnemonic3.data, equals('Meta D'));
+          break;
+        case TargetPlatform.windows:
+          mnemonic0 = tester.widget(findMnemonic(subSubMenu10[0]));
+          expect(mnemonic0.data, equals('Ctrl A'));
+          mnemonic1 = tester.widget(findMnemonic(subSubMenu10[1]));
+          expect(mnemonic1.data, equals('⇧ B'));
+          mnemonic2 = tester.widget(findMnemonic(subSubMenu10[2]));
+          expect(mnemonic2.data, equals('Alt C'));
+          mnemonic3 = tester.widget(findMnemonic(subSubMenu10[3]));
+          expect(mnemonic3.data, equals('Win D'));
+          break;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          mnemonic0 = tester.widget(findMnemonic(subSubMenu10[0]));
+          expect(mnemonic0.data, equals('⌃ A'));
+          mnemonic1 = tester.widget(findMnemonic(subSubMenu10[1]));
+          expect(mnemonic1.data, equals('⇧ B'));
+          mnemonic2 = tester.widget(findMnemonic(subSubMenu10[2]));
+          expect(mnemonic2.data, equals('⌥ C'));
+          mnemonic3 = tester.widget(findMnemonic(subSubMenu10[3]));
+          expect(mnemonic3.data, equals('⌘ D'));
+          break;
+      }
+
+      debugPrint('Updating tree');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                shortcuts: <String, MenuSerializableShortcut>{
+                  subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.arrowRight),
+                  subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.arrowLeft),
+                  subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.arrowUp),
+                  subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.arrowDown),
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      debugPrint('Should be rebuilt now');
+
+      mnemonic0 = tester.widget(findMnemonic(subSubMenu10[0]));
+      expect(mnemonic0.data, equals('→'));
+      mnemonic1 = tester.widget(findMnemonic(subSubMenu10[1]));
+      expect(mnemonic1.data, equals('←'));
+      mnemonic2 = tester.widget(findMnemonic(subSubMenu10[2]));
+      expect(mnemonic2.data, equals('↑'));
+      mnemonic3 = tester.widget(findMnemonic(subSubMenu10[3]));
+      expect(mnemonic3.data, equals('↓'));
+
+      // Try some weirder ones.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: createTestMenus(
+                shortcuts: <String, MenuSerializableShortcut>{
+                  subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.escape),
+                  subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.fn),
+                  subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.enter),
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      mnemonic0 = tester.widget(findMnemonic(subSubMenu10[0]));
+      expect(mnemonic0.data, equals('Esc'));
+      mnemonic1 = tester.widget(findMnemonic(subSubMenu10[1]));
+      expect(mnemonic1.data, equals('Fn'));
+      mnemonic2 = tester.widget(findMnemonic(subSubMenu10[2]));
+      expect(mnemonic2.data, equals('↵'));
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets('leadingIcon is used when set', (WidgetTester tester) async {
+      final MenuBarController controller = MenuBarController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  label: mainMenu[0],
+                  menus: <MenuItem>[
+                    MenuBarItem(
+                      leadingIcon: const Text('leadingIcon'),
+                      label: subMenu0[0],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      expect(find.text('leadingIcon'), findsOneWidget);
+    });
+    testWidgets('trailingIcon is used when set', (WidgetTester tester) async {
+      final MenuBarController controller = MenuBarController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  label: mainMenu[0],
+                  menus: <MenuItem>[
+                    MenuBarItem(
+                      label: subMenu0[0],
+                      trailingIcon: const Text('trailingIcon'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      expect(find.text('trailingIcon'), findsOneWidget);
+    });
+    testWidgets('diagnostics', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  shape: MaterialStateProperty.all<ShapeBorder?>(const RoundedRectangleBorder()),
+                  label: mainMenu[0],
+                  elevation: MaterialStateProperty.all<double?>(10.0),
+                  backgroundColor: MaterialStateProperty.all(Colors.red),
+                  menus: <MenuItem>[
+                    MenuItemGroup(
+                      members: <MenuItem>[
+                        MenuBarItem(
+                          label: subMenu0[0],
+                          semanticLabel: 'semanticLabel',
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      final MenuBarMenu submenu = tester.widget(find.byType(MenuBarMenu));
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      submenu.debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description, <String>[
+        'label: "Menu 0"',
+        'backgroundColor: MaterialStatePropertyAll(MaterialColor(primary value: Color(0xfff44336)))',
+        'shape: MaterialStatePropertyAll(RoundedRectangleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none), BorderRadius.zero))',
+        'elevation: MaterialStatePropertyAll(10.0)',
+      ]);
+    });
+  });
+  group('LocalizedShortcutLabeler', () {
+    testWidgets('getShortcutLabel returns the right labels', (WidgetTester tester) async {
+      String expectedMeta;
+      String expectedCtrl;
+      String expectedAlt;
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+        case TargetPlatform.linux:
+          expectedCtrl = 'Ctrl';
+          expectedMeta = 'Meta';
+          expectedAlt = 'Alt';
+          break;
+        case TargetPlatform.windows:
+          expectedCtrl = 'Ctrl';
+          expectedMeta = 'Win';
+          expectedAlt = 'Alt';
+          break;
+        case TargetPlatform.iOS:
+        case TargetPlatform.macOS:
+          expectedCtrl = '⌃';
+          expectedMeta = '⌘';
+          expectedAlt = '⌥';
+          break;
+      }
+
+      const SingleActivator allModifiers = SingleActivator(
+        LogicalKeyboardKey.keyA,
+        control: true,
+        meta: true,
+        shift: true,
+        alt: true,
+      );
+      final String allExpected = '$expectedAlt $expectedCtrl $expectedMeta ⇧ A';
+      const CharacterActivator charShortcuts = CharacterActivator('ñ');
+      const String charExpected = 'ñ';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: MenuBar(
+              controller: controller,
+              menus: <MenuItem>[
+                MenuBarMenu(
+                  label: mainMenu[0],
+                  menus: <MenuItem>[
+                    MenuBarItem(
+                      label: subMenu1[0],
+                      shortcut: allModifiers,
+                    ),
+                    MenuBarItem(
+                      label: subMenu1[1],
+                      shortcut: charShortcuts,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text(mainMenu[0]));
+      await tester.pump();
+
+      expect(find.text(allExpected), findsOneWidget);
+      expect(find.text(charExpected), findsOneWidget);
+    }, variant: TargetPlatformVariant.all());
+  });
+}
+
+const List<String> mainMenu = <String>[
+  'Menu 0',
+  'Menu 1',
+  'Menu 2',
+];
+
+const List<String> subMenu0 = <String>[
+  'Sub Menu 00',
+];
+
+const List<String> subMenu1 = <String>[
+  'Sub Menu 10',
+  'Sub Menu 11',
+  'Sub Menu 12',
+];
+
+const List<String> subSubMenu10 = <String>[
+  'Sub Sub Menu 100',
+  'Sub Sub Menu 101',
+  'Sub Sub Menu 102',
+  'Sub Sub Menu 103',
+];
+
+const List<String> subMenu2 = <String>[
+  'Sub Menu 20',
+];
+
+List<MenuItem> createTestMenus({
+  void Function(String)? onSelected,
+  void Function(String)? onOpen,
+  void Function(String)? onClose,
+  Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
+  bool includeStandard = false,
+}) {
+  final List<MenuItem> result = <MenuItem>[
+    MenuBarMenu(
+      label: mainMenu[0],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
+      menus: <MenuItem>[
+        MenuBarItem(
+          label: subMenu0[0],
+          onSelected: onSelected != null ? () => onSelected(subMenu0[0]) : null,
+          shortcut: shortcuts[subMenu0[0]],
+        ),
+      ],
+    ),
+    MenuBarMenu(
+      label: mainMenu[1],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
+      menus: <MenuItem>[
+        MenuItemGroup(
+          members: <MenuItem>[
+            MenuBarItem(
+              label: subMenu1[0],
+              onSelected: onSelected != null ? () => onSelected(subMenu1[0]) : null,
+              shortcut: shortcuts[subMenu1[0]],
+            ),
+          ],
+        ),
+        MenuBarMenu(
+          label: subMenu1[1],
+          onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
+          onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
+          menus: <MenuItem>[
+            MenuItemGroup(
+              members: <MenuItem>[
+                MenuBarItem(
+                  label: subSubMenu10[0],
+                  onSelected: onSelected != null ? () => onSelected(subSubMenu10[0]) : null,
+                  shortcut: shortcuts[subSubMenu10[0]],
+                ),
+              ],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[1],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[1]) : null,
+              shortcut: shortcuts[subSubMenu10[1]],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[2],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[2]) : null,
+              shortcut: shortcuts[subSubMenu10[2]],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[3],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[3]) : null,
+              shortcut: shortcuts[subSubMenu10[3]],
+            ),
+          ],
+        ),
+        MenuBarItem(
+          label: subMenu1[2],
+          onSelected: onSelected != null ? () => onSelected(subMenu1[2]) : null,
+          shortcut: shortcuts[subMenu1[2]],
+        ),
+      ],
+    ),
+    MenuBarMenu(
+      label: mainMenu[2],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
+      menus: <MenuItem>[
+        MenuBarItem(
+          // Always disabled.
+          label: subMenu2[0],
+          shortcut: shortcuts[subMenu2[0]],
+        ),
+      ],
+    ),
+  ];
+  return result;
+}

--- a/packages/flutter/test/material/menu_bar_theme_test.dart
+++ b/packages/flutter/test/material/menu_bar_theme_test.dart
@@ -1,0 +1,127 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('defaults are used when no theme is specified.', (WidgetTester tester) async {
+
+  });
+}
+
+const List<String> mainMenu = <String>[
+  'Menu 0',
+  'Menu 1',
+  'Menu 2',
+];
+
+const List<String> subMenu0 = <String>[
+  'Sub Menu 00',
+];
+
+const List<String> subMenu1 = <String>[
+  'Sub Menu 10',
+  'Sub Menu 11',
+  'Sub Menu 12',
+];
+
+const List<String> subSubMenu10 = <String>[
+  'Sub Sub Menu 100',
+  'Sub Sub Menu 101',
+  'Sub Sub Menu 102',
+  'Sub Sub Menu 103',
+];
+
+const List<String> subMenu2 = <String>[
+  'Sub Menu 20',
+];
+
+List<MenuItem> createTestMenus({
+  void Function(String)? onSelected,
+  void Function(String)? onOpen,
+  void Function(String)? onClose,
+  Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
+  bool includeStandard = false,
+}) {
+  final List<MenuItem> result = <MenuItem>[
+    MenuBarMenu(
+      label: mainMenu[0],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
+      menus: <MenuItem>[
+        MenuBarItem(
+          label: subMenu0[0],
+          onSelected: onSelected != null ? () => onSelected(subMenu0[0]) : null,
+          shortcut: shortcuts[subMenu0[0]],
+        ),
+      ],
+    ),
+    MenuBarMenu(
+      label: mainMenu[1],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
+      menus: <MenuItem>[
+        MenuItemGroup(
+          members: <MenuItem>[
+            MenuBarItem(
+              label: subMenu1[0],
+              onSelected: onSelected != null ? () => onSelected(subMenu1[0]) : null,
+              shortcut: shortcuts[subMenu1[0]],
+            ),
+          ],
+        ),
+        MenuBarMenu(
+          label: subMenu1[1],
+          onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
+          onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
+          menus: <MenuItem>[
+            MenuItemGroup(
+              members: <MenuItem>[
+                MenuBarItem(
+                  label: subSubMenu10[0],
+                  onSelected: onSelected != null ? () => onSelected(subSubMenu10[0]) : null,
+                  shortcut: shortcuts[subSubMenu10[0]],
+                ),
+              ],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[1],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[1]) : null,
+              shortcut: shortcuts[subSubMenu10[1]],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[2],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[2]) : null,
+              shortcut: shortcuts[subSubMenu10[2]],
+            ),
+            MenuBarItem(
+              label: subSubMenu10[3],
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[3]) : null,
+              shortcut: shortcuts[subSubMenu10[3]],
+            ),
+          ],
+        ),
+        MenuBarItem(
+          label: subMenu1[2],
+          onSelected: onSelected != null ? () => onSelected(subMenu1[2]) : null,
+          shortcut: shortcuts[subMenu1[2]],
+        ),
+      ],
+    ),
+    MenuBarMenu(
+      label: mainMenu[2],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
+      menus: <MenuItem>[
+        MenuBarItem(
+          // Always disabled.
+          label: subMenu2[0],
+          shortcut: shortcuts[subMenu2[0]],
+        ),
+      ],
+    ),
+  ];
+  return result;
+}

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -683,6 +683,7 @@ void main() {
       expansionTileTheme: const ExpansionTileThemeData(backgroundColor: Colors.black),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(backgroundColor: Colors.black),
       listTileTheme: const ListTileThemeData(),
+      menuBarTheme: MenuBarThemeData(barBackgroundColor: MaterialStateProperty.all(Colors.black)),
       navigationBarTheme: const NavigationBarThemeData(backgroundColor: Colors.black),
       navigationRailTheme: const NavigationRailThemeData(backgroundColor: Colors.black),
       outlinedButtonTheme: OutlinedButtonThemeData(style: OutlinedButton.styleFrom(primary: Colors.blue)),
@@ -795,6 +796,7 @@ void main() {
       expansionTileTheme: const ExpansionTileThemeData(backgroundColor: Colors.black),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(backgroundColor: Colors.white),
       listTileTheme: const ListTileThemeData(),
+      menuBarTheme: MenuBarThemeData(menuBackgroundColor: MaterialStateProperty.all(Colors.white)),
       navigationBarTheme: const NavigationBarThemeData(backgroundColor: Colors.white),
       navigationRailTheme: const NavigationRailThemeData(backgroundColor: Colors.white),
       outlinedButtonTheme: const OutlinedButtonThemeData(),
@@ -893,6 +895,7 @@ void main() {
       expansionTileTheme: otherTheme.expansionTileTheme,
       floatingActionButtonTheme: otherTheme.floatingActionButtonTheme,
       listTileTheme: otherTheme.listTileTheme,
+      menuBarTheme: otherTheme.menuBarTheme,
       navigationBarTheme: otherTheme.navigationBarTheme,
       navigationRailTheme: otherTheme.navigationRailTheme,
       outlinedButtonTheme: otherTheme.outlinedButtonTheme,
@@ -990,6 +993,7 @@ void main() {
     expect(themeDataCopy.expansionTileTheme, equals(otherTheme.expansionTileTheme));
     expect(themeDataCopy.floatingActionButtonTheme, equals(otherTheme.floatingActionButtonTheme));
     expect(themeDataCopy.listTileTheme, equals(otherTheme.listTileTheme));
+    expect(themeDataCopy.menuBarTheme, equals(otherTheme.menuBarTheme));
     expect(themeDataCopy.navigationBarTheme, equals(otherTheme.navigationBarTheme));
     expect(themeDataCopy.navigationRailTheme, equals(otherTheme.navigationRailTheme));
     expect(themeDataCopy.outlinedButtonTheme, equals(otherTheme.outlinedButtonTheme));
@@ -1124,6 +1128,7 @@ void main() {
       'elevatedButtonTheme',
       'floatingActionButtonTheme',
       'listTileTheme',
+      'menuBarTheme',
       'navigationBarTheme',
       'navigationRailTheme',
       'outlinedButtonTheme',

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -205,7 +205,7 @@ void main() {
       );
     });
   });
-  group('PlatformMenuBarItem', () {
+  group('MenuBarItem', () {
     testWidgets('diagnostics', (WidgetTester tester) async {
       const PlatformMenuItem childItem = PlatformMenuItem(
         label: 'label',


### PR DESCRIPTION
## Description

This implements a prototype of `MenuBar` widgets that can both render a Material menu bar, and speak to a bundled plugin on the engine that will create and manage system generated menu bars on macOS, Windows, and Linux (a.k.a. `PlatformMenuBar`, submitted already).

This implementation of the `MenuBar` uses a `MenuBarController` to manager most of the communincation between widgets that need to occur to implement the menu bar. The `MenuBar` uses a hierarchy of `MenuBarItem` widgets which extend `MenuItem` so that they are also useful for configuring a platform provided menu.

For the Material `MenuBar`, `MenuBarItem` widgets have an internal `_MenuNode` assigned by looking for a wrapping `_MenuNodeWrapper`, and then they register attributes with that node (things like the focus node associated with the button, and the menu builder function for the submenus).

## Related Issues
 - https://github.com/flutter/flutter/issues/23600

## Tests
 - Many tests for all of the `MenuBar` operations and configuration.

## Design Doc
- https://flutter.dev/go/cascading-menus