### PR TITLE
Mark `Windows tool_integration_tests_1_6` flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3922,6 +3922,7 @@ targets:
 
   - name: Windows tool_integration_tests_1_6
     recipe: flutter/flutter_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/97158
     timeout: 60
     properties:
       add_recipes_cq: "true"


### PR DESCRIPTION
`Windows tool_integration_tests_1_6` has flaked four times today, manually mark the builder as flaky.

https://github.com/flutter/flutter/issues/97158