### PR TITLE
Fix typo: recieve => receive

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
@@ -135,7 +135,7 @@ final List<Object> _testsProjectExpectedOutput = <Object>[
 /// A helper that verifies a full set of expected test results for the
 /// [TestsProject] script.
 void _expectStandardTestsProjectResults(TestEvents events) {
-  // Check we recieved all expected test events passed through from
+  // Check we received all expected test events passed through from
   // package:test.
   final List<Object> eventNames =
       events.testNotifications.map((Map<String, Object?> e) => e['type']!).toList();

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -76,7 +76,7 @@ class DapTestClient {
   /// Returns a Future that completes with the next [event] event.
   Future<Event> event(String event) => _eventController.stream.firstWhere(
       (Event e) => e.event == event,
-      orElse: () => throw 'Did not recieve $event event before stream closed');
+      orElse: () => throw 'Did not receive $event event before stream closed');
 
   /// Returns a stream for [event] events.
   Stream<Event> events(String event) {
@@ -190,13 +190,13 @@ class DapTestClient {
   /// event for [extension].
   Future<Map<String, Object?>> serviceExtensionAdded(String extension) => serviceExtensionAddedEvents.firstWhere(
       (Map<String, Object?> body) => body['extensionRPC'] == extension,
-      orElse: () => throw 'Did not recieve $extension extension added event before stream closed');
+      orElse: () => throw 'Did not receive $extension extension added event before stream closed');
 
   /// Returns a Future that completes with the next serviceExtensionStateChanged
   /// event for [extension].
   Future<Map<String, Object?>> serviceExtensionStateChanged(String extension) => serviceExtensionStateChangedEvents.firstWhere(
       (Map<String, Object?> body) => body['extension'] == extension,
-      orElse: () => throw 'Did not recieve $extension extension state changed event before stream closed');
+      orElse: () => throw 'Did not receive $extension extension state changed event before stream closed');
 
   /// Initializes the debug adapter and launches [program]/[cwd] or calls the
   /// custom [launch] method.
@@ -285,7 +285,7 @@ class _OutgoingRequest {
 extension DapTestClientExtension on DapTestClient {
   /// Collects all output events until the program terminates.
   ///
-  /// These results include all events in the order they are recieved, including
+  /// These results include all events in the order they are received, including
   /// console, stdout and stderr.
   ///
   /// Only one of [start] or [launch] may be provided. Use [start] to customise
@@ -325,7 +325,7 @@ extension DapTestClientExtension on DapTestClient {
 
   /// Collects all output and test events until the program terminates.
   ///
-  /// These results include all events in the order they are recieved, including
+  /// These results include all events in the order they are received, including
   /// console, stdout, stderr and test notifications from the test JSON reporter.
   ///
   /// Only one of [start] or [launch] may be provided. Use [start] to customise


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

## PR:

* `packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart` recieved → **received**
* `packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart` recieve → **receive**, recieved → **received**

