### PR TITLE
Migrate bots/test.dart from `pub run` to `dart run`

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -850,8 +850,8 @@ Future<void> _runFrameworkTests() async {
 
   Future<void> runPrivateTests() async {
     final List<String> args = <String>[
-      'run',
       '--sound-null-safety',
+      'run',
       'test_private.dart',
     ];
     final Map<String, String> environment = <String, String>{

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -852,7 +852,7 @@ Future<void> _runFrameworkTests() async {
     final List<String> args = <String>[
       '--sound-null-safety',
       'run',
-      'test_private.dart',
+      'bin/test_private.dart',
     ];
     final Map<String, String> environment = <String, String>{
       'FLUTTER_ROOT': flutterRoot,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -34,7 +34,6 @@ final String bat = Platform.isWindows ? '.bat' : '';
 final String flutterRoot = path.dirname(path.dirname(path.dirname(path.fromUri(Platform.script))));
 final String flutter = path.join(flutterRoot, 'bin', 'flutter$bat');
 final String dart = path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart$exe');
-final String pub = path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'pub$bat');
 final String pubCache = path.join(flutterRoot, '.pub-cache');
 final String toolRoot = path.join(flutterRoot, 'packages', 'flutter_tools');
 final String engineVersionFile = path.join(flutterRoot, 'bin', 'internal', 'engine.version');
@@ -340,7 +339,7 @@ Future<void> _runSmokeTests() async {
 }
 
 Future<void> _runGeneralToolTests() async {
-  await _pubRunTest(
+  await _dartRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     testPaths: <String>[path.join('test', 'general.shard')],
     enableFlutterToolAsserts: false,
@@ -352,7 +351,7 @@ Future<void> _runGeneralToolTests() async {
 }
 
 Future<void> _runCommandsToolTests() async {
-  await _pubRunTest(
+  await _dartRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     forceSingleCore: true,
     testPaths: <String>[path.join('test', 'commands.shard')],
@@ -360,7 +359,7 @@ Future<void> _runCommandsToolTests() async {
 }
 
 Future<void> _runWebToolTests() async {
-  await _pubRunTest(
+  await _dartRunTest(
     path.join(flutterRoot, 'packages', 'flutter_tools'),
     forceSingleCore: true,
     testPaths: <String>[path.join('test', 'web.shard')],
@@ -375,7 +374,7 @@ Future<void> _runIntegrationToolTests() async {
       .map<String>((FileSystemEntity entry) => path.relative(entry.path, from: toolsPath))
       .where((String testPath) => path.basename(testPath).endsWith('_test.dart')).toList();
 
-  await _pubRunTest(
+  await _dartRunTest(
     toolsPath,
     forceSingleCore: true,
     testPaths: _selectIndexOfTotalSubshard<String>(allTests),
@@ -862,7 +861,7 @@ Future<void> _runFrameworkTests() async {
     };
     adjustEnvironmentToEnableFlutterAsserts(environment);
     await runCommand(
-      pub,
+      dart,
       args,
       workingDirectory: path.join(flutterRoot, 'packages', 'flutter', 'test_private'),
       environment: environment,
@@ -872,9 +871,9 @@ Future<void> _runFrameworkTests() async {
   Future<void> runMisc() async {
     print('${green}Running package tests$reset for directories other than packages/flutter');
     await runExampleTests();
-    await _pubRunTest(path.join(flutterRoot, 'dev', 'bots'));
-    await _pubRunTest(path.join(flutterRoot, 'dev', 'devicelab'), ensurePrecompiledTool: false); // See https://github.com/flutter/flutter/issues/86209
-    await _pubRunTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
+    await _dartRunTest(path.join(flutterRoot, 'dev', 'bots'));
+    await _dartRunTest(path.join(flutterRoot, 'dev', 'devicelab'), ensurePrecompiledTool: false); // See https://github.com/flutter/flutter/issues/86209
+    await _dartRunTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
     // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/pull/91127 has landed.
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing'), fatalWarnings: false);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'manual_tests'));
@@ -1605,7 +1604,7 @@ Future<void> _runFlutterWebTest(String webRenderer, String workingDirectory, Lis
 // properly when overriding the local engine (for example, because some platform
 // dependent targets are only built on some engines).
 // See https://github.com/flutter/flutter/issues/72368
-Future<void> _pubRunTest(String workingDirectory, {
+Future<void> _dartRunTest(String workingDirectory, {
   List<String>? testPaths,
   bool enableFlutterToolAsserts = true,
   bool useBuildRunner = false,
@@ -1674,7 +1673,7 @@ Future<void> _pubRunTest(String workingDirectory, {
     Stream<String> testOutput;
     try {
       testOutput = runAndGetStdout(
-        pub,
+        dart,
         args,
         workingDirectory: workingDirectory,
         environment: environment,
@@ -1685,7 +1684,7 @@ Future<void> _pubRunTest(String workingDirectory, {
     await _processTestOutput(formatter, testOutput);
   } else {
     await runCommand(
-      pub,
+      dart,
       args,
       workingDirectory: workingDirectory,
       environment: environment,


### PR DESCRIPTION
toplevel `pub` doesn't exist anymore as a top level executable as from Dart 2.17.

Breaking change announcement:

* https://github.com/dart-lang/sdk/issues/46100

This landed in the Dart SDK: https://dart-review.googlesource.com/c/sdk/+/229541 This breaks everything that still tries to use it.

* https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8823468713275524977/+/u/flutter_test_framework_tests/stdout
* https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8823468713275524977/+/u/flutter_test_tool_tests/stdout

This migrate `bots/test.dart` from `pub run` to `dart run`.