### PR TITLE
Add enterprise iOS distribution method

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -70,13 +70,14 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     argParser.addOption(
       'export-method',
       defaultsTo: 'app-store',
-      allowed: <String>['app-store', 'ad-hoc', 'development'],
+      allowed: <String>['app-store', 'ad-hoc', 'development', 'enterprise'],
       help: 'Specify how the IPA will be distributed.',
       allowedHelp: <String, String>{
         'app-store': 'Upload to the App Store.',
-        'ad-hoc': 'Distribute to designated devices that do not need to be registered with the Apple developer account. '
+        'ad-hoc': 'Test on designated devices that do not need to be registered with the Apple developer account. '
                   'Requires a distribution certificate.',
-        'development': 'Distribute only to development devices registered with the Apple developer account.',
+        'development': 'Test only on development devices registered with the Apple developer account.',
+        'enterprise': 'Distribute an app registered with the Apple Developer Enterprise Program.',
       },
     );
     argParser.addOption(


### PR DESCRIPTION
Support `enterprise` IPA export method type.  https://help.apple.com/xcode/mac/current/#/devba5e7054d

https://github.com/flutter/flutter/blob/dff9126d797efa26f9ab4615c30e25f9220824c5/packages/flutter_tools/lib/src/commands/build_ios.dart#L244-L246

Follow-up to https://github.com/flutter/flutter/pull/97243 and https://github.com/flutter/flutter/issues/97179

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
