### PR TITLE
Revert "Export an IPA for distribution via "flutter build ipa" without --export-options-plist"

### DIFF
--- a/dev/devicelab/bin/tasks/ios_content_validation_test.dart
+++ b/dev/devicelab/bin/tasks/ios_content_validation_test.dart
@@ -19,8 +19,6 @@ Future<void> main() async {
         await inDirectory(flutterProject.rootPath, () async {
           await flutter('build', options: <String>[
             'xcarchive',
-            '--export-method',
-            'development',
           ]);
         });
 


### PR DESCRIPTION
Reverts flutter/flutter#97243 and #97615

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8823379044405740673/+/u/run_ios_content_validation_test/test_stdout

Tried to fix-forward with https://github.com/flutter/flutter/pull/97615 but it failed in a different way, it passed on my machine.
```
[ios_content_validation_test] [STDOUT] stdout: Building development IPA...                                      1,116ms
[ios_content_validation_test] [STDOUT] stderr: Encountered error while creating the IPA:
[ios_content_validation_test] [STDOUT] stderr: error: exportArchive: "Runner.app" requires a provisioning profile.
```