### PR TITLE
[flutter_tool] allow disabling profile mode timeline traces

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -177,8 +177,12 @@ List<String> buildModeOptions(BuildMode mode, List<String> dartDefines) {
       ];
     case BuildMode.profile:
       return <String>[
-        '-Ddart.vm.profile=true',
-        '-Ddart.vm.product=false',
+        // These checks allow the CLI to override the value of this define for
+        // benchmarks with most timeline traces disabled.
+        if (!dartDefines.any((String define) => define.startsWith('dart.vm.profile')))
+          '-Ddart.vm.profile=true',
+        if (!dartDefines.any((String define) => define.startsWith('dart.vm.product')))
+          '-Ddart.vm.product=false',
       ];
     case BuildMode.release:
       return <String>[

--- a/packages/flutter_tools/test/general.shard/compile_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_test.dart
@@ -89,16 +89,27 @@ void main() {
     ]);
   });
 
-  testWithoutContext('buildModeOptions removes matching profile define', () {
+  testWithoutContext('buildModeOptions removes matching profile define in debug mode', () {
     expect(buildModeOptions(BuildMode.debug, <String>['dart.vm.profile=true']), <String>[
       '-Ddart.vm.product=false',
       '--enable-asserts',
     ]);
   });
 
-  testWithoutContext('buildModeOptions removes both matching profile and release define', () {
+  testWithoutContext('buildModeOptions removes both matching profile and release define in debug mode', () {
     expect(buildModeOptions(BuildMode.debug, <String>['dart.vm.profile=true', 'dart.vm.product=true']), <String>[
       '--enable-asserts',
+    ]);
+  });
+
+  testWithoutContext('buildModeOptions removes matching profile define in profile mode', () {
+    expect(buildModeOptions(BuildMode.profile, <String>['dart.vm.profile=true']), <String>[
+      '-Ddart.vm.product=false',
+    ]);
+  });
+
+  testWithoutContext('buildModeOptions removes both matching profile and release define in profile mode', () {
+    expect(buildModeOptions(BuildMode.profile, <String>['dart.vm.profile=false', 'dart.vm.product=true']), <String>[
     ]);
   });
 }


### PR DESCRIPTION
I've found that for certain interactions and microbenchmarks, the use of !kReleaseMode guarded timeline traces in the framework (such as https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/framework.dart#L2622-L2640 ) can contribute a non-trivial amount of overhead.

To allow disabling these locally while still being able to use devtools/CPU profiler, lets allow the same trick we do for debug mode testing of "profile mode" - namely letting local dart defines override the preconfigured ones.

Running with `flutter run --dart-define=dart.vm.product=true --dart-define=dart.vm.profile=false --profile` will now remove most debug and profile mode overhead while still allowing some profiling.