### PR TITLE
Add support for attachRequest in DAP, running "flutter attach"

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -27,18 +27,20 @@ Arguments common to both `launchRequest` and `attachRequest` are:
 - `bool? evaluateToStringInDebugViews` - whether to invoke `toString()` in expression evaluation requests (inc. hovers/watch windows) (if not supplied, defaults to `false`)
 - `bool? sendLogsToClient` - used to proxy all VM Service traffic back to the client in custom `dart.log` events (has performance implications, intended for troubleshooting) (if not supplied, defaults to `false`)
 - `List<String>? additionalProjectPaths` - paths of any projects (outside of `cwd`) that are open in the users workspace
-- `String? cwd` - the working directory for the Dart process to be spawned in
-
-Arguments specific to `launchRequest` are:
-
+- `String? cwd` - the working directory for the Flutter process to be spawned in
 - `bool? noDebug` - whether to run in debug or noDebug mode (if not supplied, defaults to debug)
-- `String program` - the path of the Flutter application to run
-- `List<String>? args` - arguments to be passed to the Flutter program
-- `List<String>? toolArgs` - arguments for the `flutter run` or `flutter test` commands
+- `List<String>? toolArgs` - arguments for the `flutter run`, `flutter attach` or `flutter test` commands
 - `String? customTool` - an optional tool to run instead of `flutter` - the custom tool must be completely compatible with the tool/command it is replacing
 - `int? customToolReplacesArgs` - the number of arguments to delete from the beginning of the argument list when invoking `customTool` - e.g. setting `customTool` to `flutter_test_wrapper` and `customToolReplacesArgs` to `1` for a test run would invoke `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart` (if larger than the number of computed arguments all arguments will be removed, if not supplied will default to `0`)
 
-`attachRequest` is not currently supported, but will be documented here when it is.
+Arguments specific to `launchRequest` are:
+
+- `String program` - the path of the Flutter application to run
+- `List<String>? args` - arguments to be passed to the Flutter program
+
+Arguments specific to `attachRequest` are:
+
+- `String? vmServiceUri` - the VM Service URI to attach to (if not supplied, Flutter will try to discover it from the device)
 
 ## Custom Requests
 

--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -28,13 +28,13 @@ Arguments common to both `launchRequest` and `attachRequest` are:
 - `bool? sendLogsToClient` - used to proxy all VM Service traffic back to the client in custom `dart.log` events (has performance implications, intended for troubleshooting) (if not supplied, defaults to `false`)
 - `List<String>? additionalProjectPaths` - paths of any projects (outside of `cwd`) that are open in the users workspace
 - `String? cwd` - the working directory for the Flutter process to be spawned in
-- `bool? noDebug` - whether to run in debug or noDebug mode (if not supplied, defaults to debug)
 - `List<String>? toolArgs` - arguments for the `flutter run`, `flutter attach` or `flutter test` commands
 - `String? customTool` - an optional tool to run instead of `flutter` - the custom tool must be completely compatible with the tool/command it is replacing
 - `int? customToolReplacesArgs` - the number of arguments to delete from the beginning of the argument list when invoking `customTool` - e.g. setting `customTool` to `flutter_test_wrapper` and `customToolReplacesArgs` to `1` for a test run would invoke `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart` (if larger than the number of computed arguments all arguments will be removed, if not supplied will default to `0`)
 
 Arguments specific to `launchRequest` are:
 
+- `bool? noDebug` - whether to run in debug or noDebug mode (if not supplied, defaults to debug)
 - `String program` - the path of the Flutter application to run
 - `List<String>? args` - arguments to be passed to the Flutter program
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -83,11 +83,41 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   @override
   bool get terminateOnVmServiceClose => false;
 
+  /// Whether or not the user requested to debug (via noDebug).
+  ///
+  /// This field is always `false` until a launchRequest or attachRequest has been
+  /// received and is then set according to the noDebug value.
+  ///
+  /// If `false`, we will not connect to the VM Service and some functionality
+  /// will not be available. Functionality provided via the daemon (hot reload
+  /// etc.) will still be available.
+  ///
+  /// debug/noDebug here refers to the DAP "debug" mode and not the Flutter
+    // debug mode (vs Profile/Release). It is possible for the user to "Run"
+    // from VS Code (eg. not want to hit breakpoints/etc.) but still be running
+    // a debug build.
+  bool debug = false;
+
   /// Called by [attachRequest] to request that we actually connect to the app to be debugged.
   @override
   Future<void> attachImpl() async {
-    sendOutput('console', '\nAttach is not currently supported');
-    handleSessionTerminate();
+    final FlutterAttachRequestArguments args = this.args as FlutterAttachRequestArguments;
+
+    debug = !(args.noDebug ?? false);
+    final String? vmServiceUri = args.vmServiceUri;
+    final List<String> toolArgs = <String>[
+      'attach',
+      '--machine',
+      if (vmServiceUri != null)
+      ...<String>['--debug-uri', vmServiceUri],
+    ];
+
+    await _startProcess(
+      toolArgs: toolArgs,
+      customTool: args.customTool,
+      customToolReplacesArgs: args.customToolReplacesArgs,
+      userToolArgs: args.toolArgs,
+    );
   }
 
   /// [customRequest] handles any messages that do not match standard messages in the spec.
@@ -171,34 +201,47 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   Future<void> launchImpl() async {
     final FlutterLaunchRequestArguments args = this.args as FlutterLaunchRequestArguments;
 
-    // "debug"/"noDebug" refers to the DAP "debug" mode and not the Flutter
-    // debug mode (vs Profile/Release). It is possible for the user to "Run"
-    // from VS Code (eg. not want to hit breakpoints/etc.) but still be running
-    // a debug build.
-    final bool debug = !(args.noDebug ?? false);
-    final String? program = args.program;
-
+    debug = !(args.noDebug ?? false);
     final List<String> toolArgs = <String>[
       'run',
       '--machine',
       if (debug) '--start-paused',
     ];
 
+    await _startProcess(
+      toolArgs: toolArgs,
+      customTool: args.customTool,
+      customToolReplacesArgs: args.customToolReplacesArgs,
+      targetProgram: args.program,
+      userToolArgs: args.toolArgs,
+      userArgs: args.args,
+    );
+  }
+
+  /// Starts the `flutter` process to run/attach to the required app.
+  Future<void> _startProcess({
+    required String? customTool,
+    required int? customToolReplacesArgs,
+    required List<String> toolArgs,
+    required List<String>? userToolArgs,
+    String? targetProgram,
+    List<String>? userArgs,
+  }) async {
     // Handle customTool and deletion of any arguments for it.
-    final String executable = args.customTool ?? fileSystem.path.join(Cache.flutterRoot!, 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
-    final int? removeArgs = args.customToolReplacesArgs;
-    if (args.customTool != null && removeArgs != null) {
+    final String executable = customTool ?? fileSystem.path.join(Cache.flutterRoot!, 'bin', platform.isWindows ? 'flutter.bat' : 'flutter');
+    final int? removeArgs = customToolReplacesArgs;
+    if (customTool != null && removeArgs != null) {
       toolArgs.removeRange(0, math.min(removeArgs, toolArgs.length));
     }
 
     final List<String> processArgs = <String>[
       ...toolArgs,
-      ...?args.toolArgs,
-      if (program != null) ...<String>[
+      ...?userToolArgs,
+      if (targetProgram != null) ...<String>[
         '--target',
-        program,
+        targetProgram,
       ],
-      ...?args.args,
+      ...?userArgs,
     ];
 
     // Find the package_config file for this script. This is used by the
@@ -207,12 +250,12 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     // be correctly classes as "my code", "sdk" or "external packages".
     // TODO(dantup): Remove this once https://github.com/dart-lang/sdk/issues/45530
     // is done as it will not be necessary.
-    final String? possibleRoot = program == null
+    final String? possibleRoot = targetProgram == null
         ? args.cwd
-        : fileSystem.path.isAbsolute(program)
-            ? fileSystem.path.dirname(program)
+        : fileSystem.path.isAbsolute(targetProgram)
+            ? fileSystem.path.dirname(targetProgram)
             : fileSystem.path.dirname(
-                fileSystem.path.normalize(fileSystem.path.join(args.cwd ?? '', args.program)));
+                fileSystem.path.normalize(fileSystem.path.join(args.cwd ?? '', targetProgram)));
     if (possibleRoot != null) {
       final File? packageConfig = findPackageConfigFile(possibleRoot);
       if (packageConfig != null) {
@@ -330,8 +373,6 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   void _handleDebugPort(Map<String, Object?> params) {
     // When running in noDebug mode, Flutter may still provide us a VM Service
     // URI, but we will not connect it because we don't want to do any debugging.
-    final FlutterLaunchRequestArguments args = this.args as FlutterLaunchRequestArguments;
-    final bool debug = !(args.noDebug ?? false);
     if (!debug) {
       return;
     }
@@ -411,13 +452,13 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     // general output printed by the user.
     final String outputCategory = _receivedAppStarted ? 'stdout' : 'console';
 
-      // Output in stdout can include both user output (eg. print) and Flutter
-      // daemon output. Since it's not uncommon for users to print JSON while
-      // debugging, we must try to detect which messages are likely Flutter
-      // messages as reliably as possible, as trying to process users output
-      // as a Flutter message may result in an unhandled error that will
-      // terminate the debug adater in a way that does not provide feedback
-      // because the standard crash violates the DAP protocol.
+    // Output in stdout can include both user output (eg. print) and Flutter
+    // daemon output. Since it's not uncommon for users to print JSON while
+    // debugging, we must try to detect which messages are likely Flutter
+    // messages as reliably as possible, as trying to process users output
+    // as a Flutter message may result in an unhandled error that will
+    // terminate the debug adater in a way that does not provide feedback
+    // because the standard crash violates the DAP protocol.
     Object? jsonData;
     try {
       jsonData = jsonDecode(data);
@@ -459,9 +500,6 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     bool fullRestart, [
     String? reason,
   ]) async {
-    final DartCommonLaunchAttachRequestArguments args = this.args;
-    final bool debug =
-        args is! FlutterLaunchRequestArguments || args.noDebug != true;
     try {
       await sendFlutterRequest('app.restart', <String, Object?>{
         'appId': _appId,

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -93,9 +93,9 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   /// etc.) will still be available.
   ///
   /// debug/noDebug here refers to the DAP "debug" mode and not the Flutter
-    // debug mode (vs Profile/Release). It is possible for the user to "Run"
-    // from VS Code (eg. not want to hit breakpoints/etc.) but still be running
-    // a debug build.
+  /// debug mode (vs Profile/Release). It is possible for the user to "Run"
+  /// from VS Code (eg. not want to hit breakpoints/etc.) but still be running
+  /// a debug build.
   bool debug = false;
 
   /// Called by [attachRequest] to request that we actually connect to the app to be debugged.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -100,9 +100,9 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   bool get debug {
     final DartCommonLaunchAttachRequestArguments args = this.args;
     if (args is FlutterLaunchRequestArguments) {
-    // Invert DAP's noDebug flag, treating it as false (so _do_ debug) if not
-    // provided.
-    return !(args.noDebug ?? false);
+      // Invert DAP's noDebug flag, treating it as false (so _do_ debug) if not
+      // provided.
+      return !(args.noDebug ?? false);
     }
 
     // Otherwise (attach), always debug.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -50,16 +50,17 @@ class FlutterAttachRequestArguments
   static FlutterAttachRequestArguments fromJson(Map<String, Object?> obj) =>
       FlutterAttachRequestArguments.fromMap(obj);
 
-  /// If noDebug is true we still skip attaching to the VM Service (allowing only a subset of functionality like hot reload).
+  /// If noDebug is true we skip attaching to the VM Service (allowing only a subset of functionality like hot reload).
   ///
   /// Unlike Dart's attach, we support noDebug for Flutter's attach because we
-  /// do not _require_ a VM Service connection because we can run "flutter attach".
+  /// do not _require_ a VM Service connection because we can run "flutter attach"
+  /// that can discover the VM Service from the device.
   final bool? noDebug;
 
   /// Arguments to be passed to the tool that will run [program] (for example, the VM or Flutter tool).
   final List<String>? toolArgs;
 
-    /// An optional tool to run instead of "flutter".
+  /// An optional tool to run instead of "flutter".
   ///
   /// In combination with [customToolReplacesArgs] allows invoking a custom
   /// tool instead of "flutter" to launch scripts/tests. The custom tool must be

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -7,12 +7,17 @@ import 'package:dds/dap.dart';
 /// An implementation of [AttachRequestArguments] that includes all fields used by the Flutter debug adapter.
 ///
 /// This class represents the data passed from the client editor to the debug
-/// adapter in attachRequest, which is a request to start debugging an
+/// adapter in attachRequest, which is a request to attach to/debug a running
 /// application.
 class FlutterAttachRequestArguments
     extends DartCommonLaunchAttachRequestArguments
     implements AttachRequestArguments {
   FlutterAttachRequestArguments({
+    this.noDebug,
+    this.toolArgs,
+    this.customTool,
+    this.customToolReplacesArgs,
+    this.vmServiceUri,
     Object? restart,
     String? name,
     String? cwd,
@@ -34,11 +39,57 @@ class FlutterAttachRequestArguments
           sendLogsToClient: sendLogsToClient,
         );
 
-  FlutterAttachRequestArguments.fromMap(Map<String, Object?> obj):
+  FlutterAttachRequestArguments.fromMap(Map<String, Object?> obj)
+      : noDebug = obj['noDebug'] as bool?,
+        toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
+        customTool = obj['customTool'] as String?,
+        customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
+        vmServiceUri = obj['vmServiceUri'] as String?,
         super.fromMap(obj);
 
   static FlutterAttachRequestArguments fromJson(Map<String, Object?> obj) =>
       FlutterAttachRequestArguments.fromMap(obj);
+
+  /// If noDebug is true we still skip attaching to the VM Service (allowing only a subset of functionality like hot reload).
+  ///
+  /// Unlike Dart's attach, we support noDebug for Flutter's attach because we
+  /// do not _require_ a VM Service connection because we can run "flutter attach".
+  final bool? noDebug;
+
+  /// Arguments to be passed to the tool that will run [program] (for example, the VM or Flutter tool).
+  final List<String>? toolArgs;
+
+    /// An optional tool to run instead of "flutter".
+  ///
+  /// In combination with [customToolReplacesArgs] allows invoking a custom
+  /// tool instead of "flutter" to launch scripts/tests. The custom tool must be
+  /// completely compatible with the tool/command it is replacing.
+  ///
+  /// This field should be a full absolute path if the tool may not be available
+  /// in `PATH`.
+  final String? customTool;
+
+  /// The number of arguments to delete from the beginning of the argument list
+  /// when invoking [customTool].
+  ///
+  /// For example, setting [customTool] to `flutter_test_wrapper` and
+  /// `customToolReplacesArgs` to `1` for a test run would invoke
+  /// `flutter_test_wrapper foo_test.dart` instead of `flutter test foo_test.dart`.
+  final int? customToolReplacesArgs;
+
+  /// The VM Service URI of the running Flutter app to connect to.
+  final String? vmServiceUri;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+        ...super.toJson(),
+        if (noDebug != null) 'noDebug': noDebug,
+        if (toolArgs != null) 'toolArgs': toolArgs,
+        if (customTool != null) 'customTool': customTool,
+        if (customToolReplacesArgs != null)
+          'customToolReplacesArgs': customToolReplacesArgs,
+        if (vmServiceUri != null) 'vmServiceUri': vmServiceUri,
+      };
 }
 
 /// An implementation of [LaunchRequestArguments] that includes all fields used by the Flutter debug adapter.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -13,7 +13,6 @@ class FlutterAttachRequestArguments
     extends DartCommonLaunchAttachRequestArguments
     implements AttachRequestArguments {
   FlutterAttachRequestArguments({
-    this.noDebug,
     this.toolArgs,
     this.customTool,
     this.customToolReplacesArgs,
@@ -40,8 +39,7 @@ class FlutterAttachRequestArguments
         );
 
   FlutterAttachRequestArguments.fromMap(Map<String, Object?> obj)
-      : noDebug = obj['noDebug'] as bool?,
-        toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
+      : toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
         customTool = obj['customTool'] as String?,
         customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
         vmServiceUri = obj['vmServiceUri'] as String?,
@@ -49,13 +47,6 @@ class FlutterAttachRequestArguments
 
   static FlutterAttachRequestArguments fromJson(Map<String, Object?> obj) =>
       FlutterAttachRequestArguments.fromMap(obj);
-
-  /// If noDebug is true we skip attaching to the VM Service (allowing only a subset of functionality like hot reload).
-  ///
-  /// Unlike Dart's attach, we support noDebug for Flutter's attach because we
-  /// do not _require_ a VM Service connection because we can run "flutter attach"
-  /// that can discover the VM Service from the device.
-  final bool? noDebug;
 
   /// Arguments to be passed to the tool that will run [program] (for example, the VM or Flutter tool).
   final List<String>? toolArgs;
@@ -84,7 +75,6 @@ class FlutterAttachRequestArguments
   @override
   Map<String, Object?> toJson() => <String, Object?>{
         ...super.toJson(),
-        if (noDebug != null) 'noDebug': noDebug,
         if (toolArgs != null) 'toolArgs': toolArgs,
         if (customTool != null) 'customTool': customTool,
         if (customToolReplacesArgs != null)

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -4,9 +4,11 @@
 
 import 'dart:async';
 
+import 'package:dds/dap.dart';
 import 'package:dds/src/dap/protocol_generated.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../test_data/basic_project.dart';
@@ -34,236 +36,324 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  testWithoutContext('can run and terminate a Flutter app in debug mode', () async {
-    final BasicProject project = BasicProject();
-    await project.setUpIn(tempDir);
+  group('launch', () {
+    testWithoutContext('can run and terminate a Flutter app in debug mode', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
 
-    // Once the "topLevelFunction" output arrives, we can terminate the app.
-    unawaited(
-      dap.client.output
-          .firstWhere((String output) => output.startsWith('topLevelFunction'))
-          .whenComplete(() => dap.client.terminate()),
-    );
+      // Once the "topLevelFunction" output arrives, we can terminate the app.
+      unawaited(
+        dap.client.output
+            .firstWhere((String output) => output.startsWith('topLevelFunction'))
+            .whenComplete(() => dap.client.terminate()),
+      );
 
-    final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
-      launch: () => dap.client
-          .launch(
-            cwd: project.dir.path,
-            toolArgs: <String>['-d', 'flutter-tester'],
-          ),
-    );
+      final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
+        launch: () => dap.client
+            .launch(
+              cwd: project.dir.path,
+              toolArgs: <String>['-d', 'flutter-tester'],
+            ),
+      );
 
-    final String output = _uniqueOutputLines(outputEvents);
+      final String output = _uniqueOutputLines(outputEvents);
 
-    expectLines(output, <Object>[
-      'Launching $relativeMainPath on Flutter test device in debug mode...',
-      startsWith('Connecting to VM Service at'),
-      'topLevelFunction',
-      '',
-      startsWith('Exited'),
-    ]);
-  });
+      expectLines(output, <Object>[
+        'Launching $relativeMainPath on Flutter test device in debug mode...',
+        startsWith('Connecting to VM Service at'),
+        'topLevelFunction',
+        '',
+        startsWith('Exited'),
+      ]);
+    });
 
-  testWithoutContext('can run and terminate a Flutter app in noDebug mode', () async {
-    final BasicProject project = BasicProject();
-    await project.setUpIn(tempDir);
+    testWithoutContext('can run and terminate a Flutter app in noDebug mode', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
 
-    // Once the "topLevelFunction" output arrives, we can terminate the app.
-    unawaited(
-      dap.client.stdoutOutput
-          .firstWhere((String output) => output.startsWith('topLevelFunction'))
-          .whenComplete(() => dap.client.terminate()),
-    );
+      // Once the "topLevelFunction" output arrives, we can terminate the app.
+      unawaited(
+        dap.client.stdoutOutput
+            .firstWhere((String output) => output.startsWith('topLevelFunction'))
+            .whenComplete(() => dap.client.terminate()),
+      );
 
-    final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
-      launch: () => dap.client
-          .launch(
+      final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
+        launch: () => dap.client
+            .launch(
+              cwd: project.dir.path,
+              noDebug: true,
+              toolArgs: <String>['-d', 'flutter-tester'],
+            ),
+      );
+
+      final String output = _uniqueOutputLines(outputEvents);
+
+      expectLines(output, <Object>[
+        'Launching $relativeMainPath on Flutter test device in debug mode...',
+        'topLevelFunction',
+        '',
+        startsWith('Exited'),
+      ]);
+    });
+
+    testWithoutContext('correctly outputs launch errors and terminates', () async {
+      final CompileErrorProject project = CompileErrorProject();
+      await project.setUpIn(tempDir);
+
+      final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
+        launch: () => dap.client
+            .launch(
+              cwd: project.dir.path,
+              toolArgs: <String>['-d', 'flutter-tester'],
+            ),
+      );
+
+      final String output = _uniqueOutputLines(outputEvents);
+      expect(output, contains('this code does not compile'));
+      expect(output, contains('Exception: Failed to build'));
+      expect(output, contains('Exited (1)'));
+    });
+
+    testWithoutContext('can hot reload', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
+
+      // Launch the app and wait for it to print "topLevelFunction".
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.launch(
             cwd: project.dir.path,
             noDebug: true,
             toolArgs: <String>['-d', 'flutter-tester'],
           ),
-    );
+        ),
+      ], eagerError: true);
 
-    final String output = _uniqueOutputLines(outputEvents);
+      // Capture the next two output events that we expect to be the Reload
+      // notification and then topLevelFunction being printed again.
+      final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
+          // But skip any topLevelFunctions that come before the reload.
+          .skipWhile((String output) => output.startsWith('topLevelFunction'))
+          .take(2)
+          .toList();
 
-    expectLines(output, <Object>[
-      'Launching $relativeMainPath on Flutter test device in debug mode...',
-      'topLevelFunction',
-      '',
-      startsWith('Exited'),
-    ]);
-  });
+      await dap.client.hotReload();
 
-  testWithoutContext('correctly outputs launch errors and terminates', () async {
-    final CompileErrorProject project = CompileErrorProject();
-    await project.setUpIn(tempDir);
+      expectLines(
+          (await outputEventsFuture).join(),
+          <Object>[
+            startsWith('Reloaded'),
+            'topLevelFunction',
+          ],
+      );
 
-    final List<OutputEventBody> outputEvents = await dap.client.collectAllOutput(
-      launch: () => dap.client
-          .launch(
+      await dap.client.terminate();
+    });
+
+    testWithoutContext('can hot restart', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
+
+      // Launch the app and wait for it to print "topLevelFunction".
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.launch(
+            cwd: project.dir.path,
+            noDebug: true,
+            toolArgs: <String>['-d', 'flutter-tester'],
+          ),
+        ),
+      ], eagerError: true);
+
+      // Capture the next two output events that we expect to be the Restart
+      // notification and then topLevelFunction being printed again.
+      final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
+          // But skip any topLevelFunctions that come before the restart.
+          .skipWhile((String output) => output.startsWith('topLevelFunction'))
+          .take(2)
+          .toList();
+
+      await dap.client.hotRestart();
+
+      expectLines(
+          (await outputEventsFuture).join(),
+          <Object>[
+            startsWith('Restarted application'),
+            'topLevelFunction',
+          ],
+      );
+
+      await dap.client.terminate();
+    });
+
+    testWithoutContext('can hot restart when exceptions occur on outgoing isolates', () async {
+      final BasicProjectThatThrows project = BasicProjectThatThrows();
+      await project.setUpIn(tempDir);
+
+      // Launch the app and wait for it to stop at an exception.
+      late int originalThreadId, newThreadId;
+      await Future.wait(<Future<void>>[
+        // Capture the thread ID of the stopped thread.
+        dap.client.stoppedEvents.first.then((StoppedEventBody event) => originalThreadId = event.threadId!),
+        dap.client.start(
+          exceptionPauseMode: 'All', // Ensure we stop on all exceptions
+          launch: () => dap.client.launch(
             cwd: project.dir.path,
             toolArgs: <String>['-d', 'flutter-tester'],
           ),
-    );
-
-    final String output = _uniqueOutputLines(outputEvents);
-    expect(output, contains('this code does not compile'));
-    expect(output, contains('Exception: Failed to build'));
-    expect(output, contains('Exited (1)'));
-  });
-
-  testWithoutContext('can hot reload', () async {
-    final BasicProject project = BasicProject();
-    await project.setUpIn(tempDir);
-
-    // Launch the app and wait for it to print "topLevelFunction".
-    await Future.wait(<Future<void>>[
-      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
-      dap.client.start(
-        launch: () => dap.client.launch(
-          cwd: project.dir.path,
-          noDebug: true,
-          toolArgs: <String>['-d', 'flutter-tester'],
         ),
-      ),
-    ], eagerError: true);
+      ], eagerError: true);
 
-    // Capture the next two output events that we expect to be the Reload
-    // notification and then topLevelFunction being printed again.
-    final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
-        // But skip any topLevelFunctions that come before the reload.
-        .skipWhile((String output) => output.startsWith('topLevelFunction'))
-        .take(2)
-        .toList();
+      // Hot restart, ensuring it completes and capturing the ID of the new thread
+      // to pause.
+      await Future.wait(<Future<void>>[
+        // Capture the thread ID of the newly stopped thread.
+        dap.client.stoppedEvents.first.then((StoppedEventBody event) => newThreadId = event.threadId!),
+        dap.client.hotRestart(),
+      ], eagerError: true);
 
-    await dap.client.hotReload();
+      // We should not have stopped on the original thread, but the new thread
+      // from after the restart.
+      expect(newThreadId, isNot(equals(originalThreadId)));
 
-    expectLines(
-        (await outputEventsFuture).join(),
-        <Object>[
-          startsWith('Reloaded'),
-          'topLevelFunction',
-        ],
-    );
+      await dap.client.terminate();
+    });
 
-    await dap.client.terminate();
-  });
+    testWithoutContext('sends events for extension state updates', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
+      const String debugPaintRpc = 'ext.flutter.debugPaint';
 
-  testWithoutContext('can hot restart', () async {
-    final BasicProject project = BasicProject();
-    await project.setUpIn(tempDir);
+      // Create a future to capture the isolate ID when the debug paint service
+      // extension loads, as we'll need that to call it later.
+      final Future<String> isolateIdForDebugPaint = dap.client
+          .serviceExtensionAdded(debugPaintRpc)
+          .then((Map<String, Object?> body) => body['isolateId']! as String);
 
-    // Launch the app and wait for it to print "topLevelFunction".
-    await Future.wait(<Future<void>>[
-      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
-      dap.client.start(
-        launch: () => dap.client.launch(
-          cwd: project.dir.path,
-          noDebug: true,
-          toolArgs: <String>['-d', 'flutter-tester'],
+      // Launch the app and wait for it to print "topLevelFunction" so we know
+      // it's up and running.
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.launch(
+            cwd: project.dir.path,
+            toolArgs: <String>['-d', 'flutter-tester'],
+          ),
         ),
-      ),
-    ], eagerError: true);
+      ], eagerError: true);
 
-    // Capture the next two output events that we expect to be the Restart
-    // notification and then topLevelFunction being printed again.
-    final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
-        // But skip any topLevelFunctions that come before the restart.
-        .skipWhile((String output) => output.startsWith('topLevelFunction'))
-        .take(2)
-        .toList();
+      // Capture the next relevant state-change event (which should occur as a
+      // result of the call below).
+      final Future<Map<String, Object?>> stateChangeEventFuture =
+          dap.client.serviceExtensionStateChanged(debugPaintRpc);
 
-    await dap.client.hotRestart();
-
-    expectLines(
-        (await outputEventsFuture).join(),
-        <Object>[
-          startsWith('Restarted application'),
-          'topLevelFunction',
-        ],
-    );
-
-    await dap.client.terminate();
-  });
-
-  testWithoutContext('can hot restart when exceptions occur on outgoing isolates', () async {
-    final BasicProjectThatThrows project = BasicProjectThatThrows();
-    await project.setUpIn(tempDir);
-
-    // Launch the app and wait for it to stop at an exception.
-    late int originalThreadId, newThreadId;
-    await Future.wait(<Future<void>>[
-      // Capture the thread ID of the stopped thread.
-      dap.client.stoppedEvents.first.then((StoppedEventBody event) => originalThreadId = event.threadId!),
-      dap.client.start(
-        exceptionPauseMode: 'All', // Ensure we stop on all exceptions
-        launch: () => dap.client.launch(
-          cwd: project.dir.path,
-          toolArgs: <String>['-d', 'flutter-tester'],
-        ),
-      ),
-    ], eagerError: true);
-
-    // Hot restart, ensuring it completes and capturing the ID of the new thread
-    // to pause.
-    await Future.wait(<Future<void>>[
-      // Capture the thread ID of the newly stopped thread.
-      dap.client.stoppedEvents.first.then((StoppedEventBody event) => newThreadId = event.threadId!),
-      dap.client.hotRestart(),
-    ], eagerError: true);
-
-    // We should not have stopped on the original thread, but the new thread
-    // from after the restart.
-    expect(newThreadId, isNot(equals(originalThreadId)));
-
-    await dap.client.terminate();
-  });
-
-  testWithoutContext('sends events for extension state updates', () async {
-    final BasicProject project = BasicProject();
-    await project.setUpIn(tempDir);
-    const String debugPaintRpc = 'ext.flutter.debugPaint';
-
-    // Create a future to capture the isolate ID when the debug paint service
-    // extension loads, as we'll need that to call it later.
-    final Future<String> isolateIdForDebugPaint = dap.client
-        .serviceExtensionAdded(debugPaintRpc)
-        .then((Map<String, Object?> body) => body['isolateId']! as String);
-
-    // Launch the app and wait for it to print "topLevelFunction" so we know
-    // it's up and running.
-    await Future.wait(<Future<void>>[
-      dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
-      dap.client.start(
-        launch: () => dap.client.launch(
-          cwd: project.dir.path,
-          toolArgs: <String>['-d', 'flutter-tester'],
-        ),
-      ),
-    ], eagerError: true);
-
-    // Capture the next relevant state-change event (which should occur as a
-    // result of the call below).
-    final Future<Map<String, Object?>> stateChangeEventFuture =
-        dap.client.serviceExtensionStateChanged(debugPaintRpc);
-
-    // Enable debug paint to trigger the state change.
-    await dap.client.custom(
-      'callService',
-      <String, Object?>{
-        'method': debugPaintRpc,
-        'params': <String, Object?>{
-          'enabled': true,
-          'isolateId': await isolateIdForDebugPaint,
+      // Enable debug paint to trigger the state change.
+      await dap.client.custom(
+        'callService',
+        <String, Object?>{
+          'method': debugPaintRpc,
+          'params': <String, Object?>{
+            'enabled': true,
+            'isolateId': await isolateIdForDebugPaint,
+          },
         },
-      },
-    );
+      );
 
-    // Ensure the event occurred, and its value was as expected.
-    final Map<String, Object?> stateChangeEvent = await stateChangeEventFuture;
-    expect(stateChangeEvent['value'], 'true'); // extension state change values are always strings
+      // Ensure the event occurred, and its value was as expected.
+      final Map<String, Object?> stateChangeEvent = await stateChangeEventFuture;
+      expect(stateChangeEvent['value'], 'true'); // extension state change values are always strings
 
-    await dap.client.terminate();
+      await dap.client.terminate();
+    });
+  });
+
+  group('attach', () {
+    late SimpleFlutterRunner testProcess;
+    late BasicProject project;
+    late String breakpointFilePath;
+    late int breakpointLine;
+    setUp(() async {
+      project = BasicProject();
+      await project.setUpIn(tempDir);
+      testProcess = await SimpleFlutterRunner.start(tempDir);
+
+      breakpointFilePath = globals.fs.path.join(project.dir.path, 'lib', 'main.dart');
+      breakpointLine = project.buildMethodBreakpointLine;
+    });
+
+    tearDown(() async {
+      testProcess.process.kill();
+      await testProcess.process.exitCode;
+    });
+
+    testWithoutContext('can attach to an already-running Flutter app and reload', () async {
+      final Uri vmServiceUri = await testProcess.vmServiceUri;
+
+      // Launch the app and wait for it to print "topLevelFunction".
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.attach(
+            cwd: project.dir.path,
+            toolArgs: <String>['-d', 'flutter-tester'],
+            vmServiceUri: vmServiceUri.toString(),
+          ),
+        ),
+      ], eagerError: true);
+
+      // Capture the "Reloaded" output and events immediately after.
+      final Future<List<String>> outputEventsFuture = dap.client.stdoutOutput
+          .skipWhile((String output) => !output.startsWith('Reloaded'))
+          .take(4)
+          .toList();
+
+      // Perform the reload, and expect we get the Reloaded output followed
+      // by printed output, to ensure the app is running again.
+      await dap.client.hotReload();
+      expectLines(
+          (await outputEventsFuture).join(),
+          <Object>[
+            startsWith('Reloaded'),
+            'topLevelFunction',
+          ],
+          allowExtras: true,
+      );
+
+      await dap.client.terminate();
+    });
+
+    testWithoutContext('can attach to an already-running Flutter app and hit breakpoints', () async {
+      final Uri vmServiceUri = await testProcess.vmServiceUri;
+
+      // Launch the app and wait for it to print "topLevelFunction".
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.attach(
+            cwd: project.dir.path,
+            toolArgs: <String>['-d', 'flutter-tester'],
+            vmServiceUri: vmServiceUri.toString(),
+          ),
+        ),
+      ], eagerError: true);
+
+      // Set a breakpoint and expect to hit it.
+      final Future<StoppedEventBody> stoppedFuture = dap.client.stoppedEvents.firstWhere((StoppedEventBody e) => e.reason == 'breakpoint');
+      await Future.wait(<Future<void>>[
+        stoppedFuture,
+        dap.client.setBreakpoint(breakpointFilePath, breakpointLine),
+      ], eagerError: true);
+      final int threadId = (await stoppedFuture).threadId!;
+
+      // Remove the breakpoint and resume.
+      await dap.client.clearBreakpoints(breakpointFilePath);
+      await dap.client.continue_(threadId);
+
+      await dap.client.terminate();
+    });
   });
 }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -133,7 +133,7 @@ class DapTestClient {
     return responses[1] as Response; // Return the initialize response.
   }
 
-  /// Send a launchRequest to the server, asking it to start a Dart program.
+  /// Send a launchRequest to the server, asking it to start a Flutter app.
   Future<Response> launch({
     String? program,
     List<String>? args,
@@ -141,7 +141,6 @@ class DapTestClient {
     String? cwd,
     bool? noDebug,
     List<String>? additionalProjectPaths,
-    String? console,
     bool? debugSdkLibraries,
     bool? debugExternalPackageLibraries,
     bool? evaluateGettersInDebugViews,
@@ -165,8 +164,42 @@ class DapTestClient {
         sendLogsToClient: captureVmServiceTraffic,
       ),
       // We can't automatically pick the command when using a custom type
-      // (DartLaunchRequestArguments).
+      // (FlutterLaunchRequestArguments).
       overrideCommand: 'launch',
+    );
+  }
+
+  /// Send an attachRequest to the server, asking it to attach to an already-running Flutter app.
+  Future<Response> attach({
+    List<String>? toolArgs,
+    String? vmServiceUri,
+    String? cwd,
+    bool? noDebug,
+    List<String>? additionalProjectPaths,
+    bool? debugSdkLibraries,
+    bool? debugExternalPackageLibraries,
+    bool? evaluateGettersInDebugViews,
+    bool? evaluateToStringInDebugViews,
+  }) {
+    return sendRequest(
+      FlutterAttachRequestArguments(
+        cwd: cwd,
+        noDebug: noDebug,
+        toolArgs: toolArgs,
+        vmServiceUri: vmServiceUri,
+        additionalProjectPaths: additionalProjectPaths,
+        debugSdkLibraries: debugSdkLibraries,
+        debugExternalPackageLibraries: debugExternalPackageLibraries,
+        evaluateGettersInDebugViews: evaluateGettersInDebugViews,
+        evaluateToStringInDebugViews: evaluateToStringInDebugViews,
+        // When running out of process, VM Service traffic won't be available
+        // to the client-side logger, so force logging on which sends VM Service
+        // traffic in a custom event.
+        sendLogsToClient: captureVmServiceTraffic,
+      ),
+      // We can't automatically pick the command when using a custom type
+      // (FlutterAttachRequestArguments).
+      overrideCommand: 'attach',
     );
   }
 
@@ -354,6 +387,35 @@ extension DapTestClientExtension on DapTestClient {
     return TestEvents(
       output: await outputEventsFuture,
       testNotifications: await testNotificationEventsFuture,
+    );
+  }
+
+  /// Sets a breakpoint at [line] in [file].
+  Future<void> setBreakpoint(String filePath, int line) async {
+    await sendRequest(
+      SetBreakpointsArguments(
+        source: Source(path: filePath),
+        breakpoints: <SourceBreakpoint>[
+          SourceBreakpoint(line: line),
+        ],
+      ),
+    );
+  }
+
+  /// Sends a continue request for the given thread.
+  ///
+  /// Returns a Future that completes when the server returns a corresponding
+  /// response.
+  Future<Response> continue_(int threadId) =>
+      sendRequest(ContinueArguments(threadId: threadId));
+
+  /// Clears breakpoints in [file].
+  Future<void> clearBreakpoints(String filePath) async {
+    await sendRequest(
+      SetBreakpointsArguments(
+        source: Source(path: filePath),
+        breakpoints: <SourceBreakpoint>[],
+      ),
     );
   }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -174,7 +174,6 @@ class DapTestClient {
     List<String>? toolArgs,
     String? vmServiceUri,
     String? cwd,
-    bool? noDebug,
     List<String>? additionalProjectPaths,
     bool? debugSdkLibraries,
     bool? debugExternalPackageLibraries,
@@ -184,7 +183,6 @@ class DapTestClient {
     return sendRequest(
       FlutterAttachRequestArguments(
         cwd: cwd,
-        noDebug: noDebug,
         toolArgs: toolArgs,
         vmServiceUri: vmServiceUri,
         additionalProjectPaths: additionalProjectPaths,

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -5,7 +5,13 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dds/dap.dart';
 import 'package:dds/src/dap/logging.dart';
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/convert.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:test/test.dart';
 
 import 'test_client.dart';
@@ -44,6 +50,72 @@ void expectLines(
       actual.replaceAll('\r\n', '\n').trim().split('\n'),
       equals(expected),
     );
+  }
+}
+
+/// Manages running a simple Flutter app to be used in tests that need to attach
+/// to an existing process.
+class SimpleFlutterRunner {
+  SimpleFlutterRunner(this.process) {
+    process.stdout.transform(ByteToLineTransformer()).listen(_handleStdout);
+    process.stderr.transform(utf8.decoder).listen(_handleStderr);
+    unawaited(process.exitCode.then(_handleExitCode));
+  }
+
+  void _handleExitCode(int code) {
+      if (!_vmServiceUriCompleter.isCompleted) {
+        _vmServiceUriCompleter.completeError('Flutter process ended without producing a VM Service URI');
+      }
+    }
+
+  void _handleStderr(String err) {
+    if (!_vmServiceUriCompleter.isCompleted) {
+      _vmServiceUriCompleter.completeError(err);
+    }
+  }
+
+  void _handleStdout(String outputLine) {
+    try {
+      final Object? json = jsonDecode(outputLine);
+      // Flutter --machine output is wrapped in [brackets] so will deserialize
+      // as a list with one item.
+      if (json is List && json.length == 1) {
+        final Object? message = json.single;
+        // Parse the add.debugPort event which contains our VM Service URI.
+        if (message is Map<String, Object?> && message['event'] == 'app.debugPort') {
+          final String vmServiceUri = (message['params']! as Map<String, Object?>)['wsUri']! as String;
+          if (!_vmServiceUriCompleter.isCompleted) {
+            _vmServiceUriCompleter.complete(Uri.parse(vmServiceUri));
+          }
+        }
+      }
+    } on FormatException {
+      // `flutter run` writes a lot of text to stdout so just ignore anything
+      // that's not valid JSON.
+    }
+  }
+
+  final Process process;
+  final Completer<Uri> _vmServiceUriCompleter = Completer<Uri>();
+   Future<Uri> get vmServiceUri => _vmServiceUriCompleter.future;
+
+  static Future<SimpleFlutterRunner> start(Directory projectDirectory) async {
+    final String flutterToolPath = globals.fs.path.join(Cache.flutterRoot!, 'bin', globals.platform.isWindows ? 'flutter.bat' : 'flutter');
+
+    final List<String> args = <String>[
+      'run',
+      '--machine',
+      '-d',
+      'flutter-tester',
+    ];
+
+    final Process process = await Process.start(
+      flutterToolPath,
+      args,
+      workingDirectory: projectDirectory.path,
+    );
+
+    return SimpleFlutterRunner(process);
   }
 }
 


### PR DESCRIPTION
This adds support for `attachRequest` in the DAP server. This works much like `launchRequest` but instead of running `flutter run` it runs `flutter attach` (and as such has a restricted set of flags that can be passed).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
