### PR TITLE
Revert "Mark `Windows tool_integration_tests_1_6` flaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3926,7 +3926,6 @@ targets:
 
   - name: Windows tool_integration_tests_1_6
     recipe: flutter/flutter_drone
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/97158
     timeout: 60
     properties:
       add_recipes_cq: "true"


### PR DESCRIPTION
Reverts flutter/flutter#97458

Timeout has been extended to 45 min from 30 min, and tests are consistently passing.