### PR TITLE
Export an IPA for distribution via "flutter build ipa" without --export-options-plist

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:meta/meta.dart';
 
 import '../base/analyze_size.dart';
 import '../base/common.dart';
@@ -67,11 +68,23 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   BuildIOSArchiveCommand({required bool verboseHelp})
       : super(verboseHelp: verboseHelp) {
     argParser.addOption(
+      'export-method',
+      defaultsTo: 'app-store',
+      allowed: <String>['app-store', 'ad-hoc', 'development', 'enterprise'],
+      help: 'Specify how the IPA will be distributed.',
+      allowedHelp: <String, String>{
+        'app-store': 'Upload to the App Store.',
+        'ad-hoc': 'Test on designated devices that do not need to be registered with the Apple developer account. '
+                  'Requires a distribution certificate.',
+        'development': 'Test only on development devices registered with the Apple developer account.',
+        'enterprise': 'Distribute an app registered with the Apple Developer Enterprise Program.',
+      },
+    );
+    argParser.addOption(
       'export-options-plist',
       valueHelp: 'ExportOptions.plist',
-      // TODO(jmagman): Update help text with link to Flutter docs.
       help:
-          'Optionally export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
+          'Export an IPA with these options. See "xcodebuild -h" for available exportOptionsPlist keys.',
     );
   }
 
@@ -82,7 +95,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
   final List<String> aliases = <String>['xcarchive'];
 
   @override
-  final String description = 'Build an iOS archive bundle (Mac OS X host only).';
+  final String description = 'Build an iOS archive bundle and IPA for distribution (Mac OS X host only).';
 
   @override
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.archive;
@@ -105,9 +118,16 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       .childDirectory('Applications');
 
   @override
-  Future<FlutterCommandResult> runCommand() async {
+  Future<void> validateCommand() async {
     final String? exportOptions = exportOptionsPlist;
     if (exportOptions != null) {
+      if (argResults?.wasParsed('export-method') == true) {
+        throwToolExit(
+          '"--export-options-plist" is not compatible with "--export-method". Either use "--export-options-plist" and '
+          'a plist describing how the IPA should be exported by Xcode, or use "--export-method" to create a new plist.\n'
+          'See "xcodebuild -h" for available exportOptionsPlist keys.'
+        );
+      }
       final FileSystemEntityType type = globals.fs.typeSync(exportOptions);
       if (type == FileSystemEntityType.notFound) {
         throwToolExit(
@@ -117,13 +137,14 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
             '"$exportOptions" is not a file. See "xcodebuild -h" for available keys.');
       }
     }
+    return super.validateCommand();
+  }
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
     final FlutterCommandResult xcarchiveResult = await super.runCommand();
     final BuildInfo buildInfo = await getBuildInfo();
     displayNullSafetyMode(buildInfo);
-
-    if (exportOptions == null) {
-      return xcarchiveResult;
-    }
 
     // xcarchive failed or not at expected location.
     if (xcarchiveResult.exitStatus != ExitStatus.success) {
@@ -135,9 +156,20 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     final BuildableIOSApp app = await buildableIOSApp;
     Status? status;
     RunResult? result;
-    final String outputPath = globals.fs.path.absolute(app.ipaOutputPath);
+    final String relativeOutputPath = app.ipaOutputPath;
+    final String absoluteOutputPath = globals.fs.path.absolute(relativeOutputPath);
+    final String absoluteArchivePath = globals.fs.path.absolute(app.archiveBundleOutputPath);
+    final String exportMethod = stringArg('export-method')!;
+    final bool isAppStoreUpload = exportMethod  == 'app-store';
+    File? generatedExportPlist;
     try {
-      status = globals.logger.startProgress('Building IPA...');
+      final String exportMethodDisplayName = isAppStoreUpload ? 'App Store' : exportMethod;
+      status = globals.logger.startProgress('Building $exportMethodDisplayName IPA...');
+      String? exportOptions = exportOptionsPlist;
+      if (exportOptions == null) {
+        generatedExportPlist = _createExportPlist();
+        exportOptions = generatedExportPlist.path;
+      }
 
       result = await globals.processUtils.run(
         <String>[
@@ -149,14 +181,15 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
             '-allowProvisioningUpdates',
           ],
           '-archivePath',
-          globals.fs.path.absolute(app.archiveBundleOutputPath),
+          absoluteArchivePath,
           '-exportPath',
-          outputPath,
+          absoluteOutputPath,
           '-exportOptionsPlist',
           globals.fs.path.absolute(exportOptions),
         ],
       );
     } finally {
+      generatedExportPlist?.deleteSync();
       status?.stop();
     }
 
@@ -171,12 +204,71 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
       LineSplitter.split(result.stderr)
           .where((String line) => line.contains('error: '))
           .forEach(errorMessage.writeln);
-      throwToolExit('Encountered error while building IPA:\n$errorMessage');
+
+      globals.printError('Encountered error while creating the IPA:');
+      globals.printError(errorMessage.toString());
+      globals.printError('Try distributing the app in Xcode: "open $absoluteArchivePath"');
+
+      // Even though the IPA step didn't succeed, the xcarchive did.
+      // Still count this as success since the user has been instructed about how to
+      // recover in Xcode.
+      return FlutterCommandResult.success();
     }
 
-    globals.printStatus('Built IPA to $outputPath.');
+    globals.printStatus('Built IPA to $absoluteOutputPath.');
+
+    if (isAppStoreUpload) {
+      globals.printStatus('To upload to the App Store either:');
+      globals.printStatus(
+        '1. Drag and drop the "$relativeOutputPath/*.ipa" bundle into the Apple Transport macOS app https://apps.apple.com/us/app/transporter/id1450874784',
+        indent: 4,
+      );
+      globals.printStatus(
+        '2. Run "xcrun altool --upload-app --type ios -f $relativeOutputPath/*.ipa --apiKey your_api_key --apiIssuer your_issuer_id".',
+        indent: 4,
+      );
+      globals.printStatus(
+        'See "man altool" for details about how to authenticate with the App Store Connect API key.',
+        indent: 7,
+      );
+    }
 
     return FlutterCommandResult.success();
+  }
+
+  File _createExportPlist() {
+    // Create the plist to be passed into xcodebuild -exportOptionsPlist.
+    final StringBuffer plistContents = StringBuffer('''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+''');
+
+    plistContents.write('''
+        <string>${stringArg('export-method')}</string>
+    ''');
+    if (xcodeBuildResult?.xcodeBuildExecution?.buildSettings['ENABLE_BITCODE'] != 'YES') {
+      // Bitcode is off by default in Flutter iOS apps.
+      plistContents.write('''
+    <key>uploadBitcode</key>
+        <false/>
+    </dict>
+</plist>
+''');
+    } else {
+      plistContents.write('''
+</dict>
+</plist>
+''');
+    }
+
+    final File tempPlist = globals.fs.systemTempDirectory
+        .createTempSync('flutter_build_ios.').childFile('ExportOptions.plist');
+    tempPlist.writeAsStringSync(plistContents.toString());
+
+    return tempPlist;
   }
 }
 
@@ -208,6 +300,10 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   };
 
   XcodeBuildAction get xcodeBuildAction;
+
+  /// The result of the Xcode build command. Null until it finishes.
+  @protected
+  XcodeBuildResult? xcodeBuildResult;
   EnvironmentType get environmentType;
   bool get configOnly;
   bool get shouldCodesign;
@@ -271,6 +367,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
       buildAction: xcodeBuildAction,
       deviceID: globals.deviceManager?.specifiedDeviceId,
     );
+    xcodeBuildResult = result;
 
     if (!result.success) {
       await diagnoseXcodeBuildFailure(result, globals.flutterUsage, globals.logger);

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -7,7 +7,6 @@
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
@@ -18,9 +17,14 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import '../../general.shard/ios/xcresult_test_data.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInterpreter {
+  FakeXcodeProjectInterpreterWithBuildSettings({ this.overrides = const <String, String>{} });
+
+  final Map<String, String> overrides;
+
   @override
   Future<Map<String, String>> getBuildSettings(
       String projectPath, {
@@ -28,6 +32,7 @@ class FakeXcodeProjectInterpreterWithBuildSettings extends FakeXcodeProjectInter
         Duration timeout = const Duration(minutes: 1),
       }) async {
     return <String, String>{
+      ...overrides,
       'PRODUCT_BUNDLE_IDENTIFIER': 'io.flutter.someProject',
       'DEVELOPMENT_TEAM': 'abc',
     };
@@ -50,7 +55,7 @@ final Platform notMacosPlatform = FakePlatform(
 void main() {
   FileSystem fileSystem;
   TestUsage usage;
-  BufferLogger logger;
+  FakeProcessManager fakeProcessManager;
 
   setUpAll(() {
     Cache.disableLocking();
@@ -59,7 +64,7 @@ void main() {
   setUp(() {
     fileSystem = MemoryFileSystem.test();
     usage = TestUsage();
-    logger = BufferLogger.test();
+    fakeProcessManager = FakeProcessManager.empty();
   });
 
   // Sets up the minimal mock project files necessary to look like a Flutter project.
@@ -127,21 +132,33 @@ void main() {
     );
   }
 
-  const FakeCommand exportArchiveCommand = FakeCommand(
-    command: <String>[
-      'xcrun',
-      'xcodebuild',
-      '-exportArchive',
-      '-allowProvisioningDeviceRegistration',
-      '-allowProvisioningUpdates',
-      '-archivePath',
-      '/build/ios/archive/Runner.xcarchive',
-      '-exportPath',
-      '/build/ios/ipa',
-      '-exportOptionsPlist',
-      '/ExportOptions.plist'
-    ],
-  );
+  FakeCommand _exportArchiveCommand({
+    String exportOptionsPlist =  '/ExportOptions.plist',
+    File cachePlist,
+  }) {
+    return FakeCommand(
+      command: <String>[
+        'xcrun',
+        'xcodebuild',
+        '-exportArchive',
+        '-allowProvisioningDeviceRegistration',
+        '-allowProvisioningUpdates',
+        '-archivePath',
+        '/build/ios/archive/Runner.xcarchive',
+        '-exportPath',
+        '/build/ios/ipa',
+        '-exportOptionsPlist',
+        exportOptionsPlist,
+      ],
+      onRun: () {
+        // exportOptionsPlist will be cleaned up within the command.
+        // Save it somewhere else so test expectations can be run on it.
+        if (cachePlist != null) {
+          cachePlist.writeAsStringSync(fileSystem.file(_exportOptionsPlist).readAsStringSync());
+        }
+      }
+    );
+  }
 
   testUsingContext('ipa build fails when there is no ios project', () async {
     final BuildCommand command = BuildCommand();
@@ -235,37 +252,251 @@ void main() {
         FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build invokes xcode build', () async {
+  testUsingContext('ipa build fails when --export-options-plist and --export-method are used together', () async {
     final BuildCommand command = BuildCommand();
+    _createMinimalMockProjectFiles();
+
+    await expectToolExitLater(
+      createTestCommandRunner(command).run(<String>[
+        'build',
+        'ipa',
+        '--export-options-plist',
+        'ExportOptions.plist',
+        '--export-method',
+        'app-store',
+        '--no-pub',
+      ]),
+      contains('"--export-options-plist" is not compatible with "--export-method"'),
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => FakeProcessManager.any(),
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () =>
+        FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('ipa build reports when IPA fails', () async {
+    final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      const FakeCommand(
+        command: <String>[
+          'xcrun',
+          'xcodebuild',
+          '-exportArchive',
+          '-allowProvisioningDeviceRegistration',
+          '-allowProvisioningUpdates',
+          '-archivePath',
+          '/build/ios/archive/Runner.xcarchive',
+          '-exportPath',
+          '/build/ios/ipa',
+          '-exportOptionsPlist',
+          _exportOptionsPlist,
+        ],
+        exitCode: 1,
+        stderr: 'error: exportArchive: "Runner.app" requires a provisioning profile.'
+      )
+    ]);
     _createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'ipa', '--no-pub']
     );
+
     expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building App Store IPA'));
+    expect(testLogger.errorText, contains('Encountered error while creating the IPA:'));
+    expect(testLogger.errorText, contains('error: exportArchive: "Runner.app" requires a provisioning profile.'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
+  testUsingContext('ipa build invokes xcodebuild and archives for app store', () async {
+    final File cachedExportOptionsPlist = fileSystem.file('/CachedExportOptions.plist');
+    final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist, cachePlist: cachedExportOptionsPlist),
+    ]);
+    _createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'ipa', '--no-pub']
+    );
+
+    const String expectedIpaPlistContents = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+        <string>app-store</string>
+        <key>uploadBitcode</key>
+        <false/>
+    </dict>
+</plist>
+''';
+
+    final String actualIpaPlistContents = fileSystem.file(cachedExportOptionsPlist).readAsStringSync();
+    expect(actualIpaPlistContents, expectedIpaPlistContents);
+
+    expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building App Store IPA'));
+    expect(testLogger.statusText, contains('Built IPA to /build/ios/ipa'));
+    expect(testLogger.statusText, contains('To upload to the App Store'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('ipa build invokes xcodebuild and archives for ad-hoc distribution', () async {
+    final File cachedExportOptionsPlist = fileSystem.file('/CachedExportOptions.plist');
+    final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist, cachePlist: cachedExportOptionsPlist),
+    ]);
+    _createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'ipa', '--no-pub', '--export-method', 'ad-hoc']
+    );
+
+    const String expectedIpaPlistContents = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+        <string>ad-hoc</string>
+        <key>uploadBitcode</key>
+        <false/>
+    </dict>
+</plist>
+''';
+
+    final String actualIpaPlistContents = fileSystem.file(cachedExportOptionsPlist).readAsStringSync();
+    expect(actualIpaPlistContents, expectedIpaPlistContents);
+
+    expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building ad-hoc IPA'));
+    expect(testLogger.statusText, contains('Built IPA to /build/ios/ipa'));
+    // Don't instruct how to upload to the App Store.
+    expect(testLogger.statusText, isNot(contains('To upload')));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('ipa build invokes xcodebuild and archives for enterprise distribution', () async {
+    final File cachedExportOptionsPlist = fileSystem.file('/CachedExportOptions.plist');
+    final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist, cachePlist: cachedExportOptionsPlist),
+    ]);
+    _createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'ipa', '--no-pub', '--export-method', 'enterprise']
+    );
+
+    const String expectedIpaPlistContents = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+        <string>enterprise</string>
+        <key>uploadBitcode</key>
+        <false/>
+    </dict>
+</plist>
+''';
+
+    final String actualIpaPlistContents = fileSystem.file(cachedExportOptionsPlist).readAsStringSync();
+    expect(actualIpaPlistContents, expectedIpaPlistContents);
+
+    expect(testLogger.statusText, contains('build/ios/archive/Runner.xcarchive'));
+    expect(testLogger.statusText, contains('Building enterprise IPA'));
+    expect(testLogger.statusText, contains('Built IPA to /build/ios/ipa'));
+    // Don't instruct how to upload to the App Store.
+    expect(testLogger.statusText, isNot(contains('To upload')));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+  });
+
+  testUsingContext('ipa build invokes xcodebuild and archives with bitcode on', () async {
+    final File cachedExportOptionsPlist = fileSystem.file('/CachedExportOptions.plist');
+    final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist, cachePlist: cachedExportOptionsPlist),
+    ]);
+    _createMinimalMockProjectFiles();
+
+    await createTestCommandRunner(command).run(
+        const <String>['build', 'ipa', '--no-pub',]
+    );
+
+    const String expectedIpaPlistContents = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>method</key>
+        <string>app-store</string>
+    </dict>
+</plist>
+''';
+
+    final String actualIpaPlistContents = fileSystem.file(cachedExportOptionsPlist).readAsStringSync();
+    expect(actualIpaPlistContents, expectedIpaPlistContents);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
+    Platform: () => macosPlatform,
+    XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(
+      overrides: <String, String>{'ENABLE_BITCODE': 'YES'},
+    ),
+  });
+
   testUsingContext('ipa build invokes xcode build with verbosity', () async {
     final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(verbose: true),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
+    ]);
     _createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
       const <String>['build', 'ipa', '--no-pub', '-v']
     );
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(verbose: true),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
@@ -295,19 +526,7 @@ void main() {
     fileSystem.file('build/ios/archive/Runner.xcarchive/Products/Applications/Runner.app/Frameworks/App.framework/App')
       ..createSync(recursive: true)
       ..writeAsBytesSync(List<int>.generate(10000, (int index) => 0));
-
-    await createTestCommandRunner(command).run(
-      const <String>['build', 'ipa', '--no-pub', '--analyze-size']
-    );
-
-    expect(testLogger.statusText, contains('A summary of your iOS bundle analysis can be found at'));
-    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
-    expect(usage.events, contains(
-      const TestUsageEvent('code-size-analysis', 'ios'),
-    ));
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
+    fakeProcessManager.addCommands(<FakeCommand>[
       xattrCommand,
       _setUpFakeXcodeBuildHandler(onRun: () {
         fileSystem.file('build/flutter_size_01/snapshot.arm64.json')
@@ -325,19 +544,39 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync('{}');
       }),
-    ]),
+      _exportArchiveCommand(exportOptionsPlist: _exportOptionsPlist),
+    ]);
+
+    await createTestCommandRunner(command).run(
+      const <String>['build', 'ipa', '--no-pub', '--analyze-size']
+    );
+
+    expect(testLogger.statusText, contains('A summary of your iOS bundle analysis can be found at'));
+    expect(testLogger.statusText, contains('flutter pub global activate devtools; flutter pub global run devtools --appSizeBase='));
+    expect(usage.events, contains(
+      const TestUsageEvent('code-size-analysis', 'ios'),
+    ));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
     Usage: () => usage,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build invokes xcode build export archive', () async {
+  testUsingContext('ipa build invokes xcode build export archive when passed plist', () async {
     final String outputPath =
         fileSystem.path.absolute(fileSystem.path.join('build', 'ios', 'ipa'));
     final File exportOptions = fileSystem.file('ExportOptions.plist')
       ..createSync();
     final BuildCommand command = BuildCommand();
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(),
+      _exportArchiveCommand(),
+    ]);
     _createMinimalMockProjectFiles();
 
     await createTestCommandRunner(command).run(
@@ -350,23 +589,25 @@ void main() {
       ],
     );
 
-    expect(logger.statusText, contains('Built IPA to $outputPath.'));
+    expect(testLogger.statusText, contains('Built IPA to $outputPath.'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-          xattrCommand,
-          _setUpFakeXcodeBuildHandler(),
-          exportArchiveCommand,
-        ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
-    Logger: () => logger,
     XcodeProjectInterpreter: () =>
         FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
   testUsingContext('Trace error if xcresult is empty.', () async {
     final BuildCommand command = BuildCommand();
-
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
+        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
+      }),
+      _setUpXCResultCommand(),
+    ]);
     _createMinimalMockProjectFiles();
 
     await expectLater(
@@ -375,22 +616,23 @@ void main() {
     );
 
     expect(testLogger.traceText, contains('xcresult parser: Unrecognized top level json format.'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
-        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
-      }),
-      _setUpXCResultCommand(),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
   testUsingContext('Display xcresult issues on console if parsed.', () async {
     final BuildCommand command = BuildCommand();
-
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
+        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
+      }),
+      _setUpXCResultCommand(stdout: kSampleResultJsonWithIssues),
+    ]);
     _createMinimalMockProjectFiles();
 
     await expectLater(
@@ -400,22 +642,23 @@ void main() {
 
     expect(testLogger.errorText, contains("Use of undeclared identifier 'asdas'"));
     expect(testLogger.errorText, contains('/Users/m/Projects/test_create/ios/Runner/AppDelegate.m:7:56'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
-        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
-      }),
-      _setUpXCResultCommand(stdout: kSampleResultJsonWithIssues),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
   testUsingContext('Do not display xcresult issues that needs to be discarded.', () async {
     final BuildCommand command = BuildCommand();
-
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
+        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
+      }),
+      _setUpXCResultCommand(stdout: kSampleResultJsonWithIssuesToBeDiscarded),
+    ]);
     _createMinimalMockProjectFiles();
 
     await expectLater(
@@ -427,22 +670,20 @@ void main() {
     expect(testLogger.errorText, contains('/Users/m/Projects/test_create/ios/Runner/AppDelegate.m:7:56'));
     expect(testLogger.errorText, isNot(contains('Command PhaseScriptExecution failed with a nonzero exit code')));
     expect(testLogger.warningText, isNot(contains("The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.")));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
-        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
-      }),
-      _setUpXCResultCommand(stdout: kSampleResultJsonWithIssuesToBeDiscarded),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
   testUsingContext('Trace if xcresult bundle does not exist.', () async {
     final BuildCommand command = BuildCommand();
-
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(exitCode: 1),
+    ]);
     _createMinimalMockProjectFiles();
 
     await expectLater(
@@ -451,13 +692,10 @@ void main() {
     );
 
     expect(testLogger.traceText, contains('The xcresult bundle are not generated. Displaying xcresult is disabled.'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(exitCode: 1),
-      _setUpXCResultCommand(stdout: kSampleResultJsonWithIssues),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
@@ -465,7 +703,13 @@ void main() {
 
   testUsingContext('Extra error message for provision profile issue in xcresulb bundle.', () async {
     final BuildCommand command = BuildCommand();
-
+    fakeProcessManager.addCommands(<FakeCommand>[
+      xattrCommand,
+      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
+        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
+      }),
+      _setUpXCResultCommand(stdout: kSampleResultJsonWithProvisionIssue),
+    ]);
     _createMinimalMockProjectFiles();
 
     await expectLater(
@@ -478,18 +722,14 @@ void main() {
     expect(testLogger.errorText, contains('Verify that the Bundle Identifier in your project is your signing id in Xcode'));
     expect(testLogger.errorText, contains('open ios/Runner.xcworkspace'));
     expect(testLogger.errorText, contains("Also try selecting 'Product > Build' to fix the problem:"));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
-      xattrCommand,
-      _setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
-        fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
-      }),
-      _setUpXCResultCommand(stdout: kSampleResultJsonWithProvisionIssue),
-    ]),
+    ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 }
 
 const String _xcBundleFilePath = '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle';
+const String _exportOptionsPlist = '/.tmp_rand0/flutter_build_ios.rand0/ExportOptions.plist';


### PR DESCRIPTION
Reland https://github.com/flutter/flutter/pull/97243 reverted in https://github.com/flutter/flutter/pull/97614.

Instead of making the IPA a tool failure, instead log the error but exit successfully since the step 1 below still succeeded.
_________

`flutter build ipa` has two stages for iOS distribution:
1. Archive the app into an `xcarchive` bundle.
2. Optionally, export the `xcarchive` into an `ipa` bundle for distribution to the App Store, or to a device, or enterprise distribution...

Currently to get to number 2 and create the `ipa` file users need to pass in a `--export-options-plist` file, which they need to create themselves, or know how to yank off a previously-build IPA.  Flutter's [iOS distribution docs](https://docs.flutter.dev/deployment/ios#create-a-build-archive-with-xcode) don't say what needs to go into the plist, it just points to Apple docs, or tells them to launch Xcode and create the IPA there.

> 1. Run flutter build ipa to produce a build archive.
>
>  Note: When you export your app at the end of Distribute App, Xcode will create a directory containing an IPA of your app and an ExportOptions.plist file. You can create new IPAs with the same options without launching Xcode by running flutter build ipa --export-options-plist=path/to/ExportOptions.plist. See xcodebuild -h for details about the keys in this property list.
>
> 2. Open build/ios/archive/MyApp.xcarchive in Xcode.

In this PR, if the user doesn't pass `--export-options-plist`, instead of bailing after the `xcarchive`, assume the user wants the most common case: to distribute their app to the App Store via the new `--export-method` option and its default `app-store`.  Create the plist if one isn't passed in, with reasonable defaults for the most common settings for a Flutter app.  If it fails (they haven't registered their app bundle ID for example), suggest they open the archive in Xcode and go through its wizard, as the docs currently suggest.

Allow the user to also specify `--export-method ad-hoc` or `--export-method development` or `--export-method enterprise`.  See https://developer.apple.com/forums/thread/100614 for the distinction.

If the user has a more complicated scenario, they can continue to create their own plist via `--export-options-plist`, or open with Xcode.

We can add other options in the future for other values in the generated plist, if developers request it.

### Command logging examples

#### Success
```
$ flutter build ipa
Running "flutter pub get" in veggieseasons...                    1,814ms
Archiving dev.flutter.VeggieSeasons...
Automatically signing iOS for device deployment using specified development team in Xcode project: S8QB4VV633
Running Xcode build...
 └─Compiling, linking and signing...                        12.3s
Xcode archive done.                                         38.6s
Built /Users/m/Projects/samples/veggieseasons/build/ios/archive/Runner.xcarchive.

💪 Building with sound null safety 💪

Building App Store IPA...                                          32.3s
Built IPA to /Users/m/Projects/samples/veggieseasons/build/ios/ipa.
To upload to the App Store either:
    1. Drag and drop the "build/ios/ipa/*.ipa" bundle into the Apple Transport macOS app https://apps.apple.com/us/app/transporter/id1450874784
    2. Run "xcrun altool --upload-app --type ios -f build/ios/ipa/*.ipa --apiKey your_api_key --apiIssuer your_issuer_id".
       See "man altool" for details about how to authenticate with the App Store Connect API key.
```

#### Flag validation error
```
$ flutter build ipa --export-options-plist foo.plist --export-method ad-hoc
"--export-options-plist" is not compatible with "--export-method". Either use "--export-options-plist" and a plist describing how the IPA should be exported by Xcode, or use "--export-method" to create a new plist.
See "xcodebuild -h" for available exportOptionsPlist keys.
```

#### IPA creation failure 
The bundle identifier isn't set up, which needs to be resolved in Xcode's UI:
```
$ flutter build ipa --export-method ad-hoc
...
Built /Users/m/Projects/test_create/build/ios/archive/Runner.xcarchive.
...
Building ad-hoc IPA...                                           2,123ms
Encountered error while creating the IPA:
error: exportArchive: Failed to register bundle identifier
error: exportArchive: No profiles for 'com.example.testCreate' were found


Try distributing the app in Xcode: "open /Users/m/Projects/test_create/build/ios/archive/Runner.xcarchive"
```
#### Help text
```
    --export-method                                 Specify how the IPA will be distributed.

          [ad-hoc]                                  Distribute to designated devices that do not need to be registered with the Apple developer account. Requires a distribution certificate.
          [app-store] (default)                     Upload to the App Store.
          [development]                             Distribute only to development devices registered with the Apple developer account.
```

Fixes https://github.com/flutter/flutter/issues/97179

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
