### PR TITLE
Update SliverChildDelegate docs

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -106,6 +106,14 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///    using the [AutomaticKeepAliveClientMixin], then implementing the
 ///    [AutomaticKeepAliveClientMixin.wantKeepAlive] getter and calling
 ///    [AutomaticKeepAliveClientMixin.updateKeepAlive].
+///
+/// ## Using more than one delegate in a viewport
+///
+/// If multiple delegates are used in a single scroll view, the first child of
+/// each delegate will always be laid out, even if it extends beyond the
+/// currently viewable area. This is because at least one child is required in
+/// order to [estimateMaxScrollOffset] for the whole scroll view, as it uses the
+/// currently built children to estimate the remaining children's extent.
 /// {@endtemplate}
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -107,7 +107,7 @@ int _kDefaultSemanticIndexCallback(Widget _, int localIndex) => localIndex;
 ///    [AutomaticKeepAliveClientMixin.wantKeepAlive] getter and calling
 ///    [AutomaticKeepAliveClientMixin.updateKeepAlive].
 ///
-/// ## Using more than one delegate in a viewport
+/// ## Using more than one delegate in a [Viewport]
 ///
 /// If multiple delegates are used in a single scroll view, the first child of
 /// each delegate will always be laid out, even if it extends beyond the
@@ -795,6 +795,14 @@ abstract class SliverMultiBoxAdaptorWidget extends SliverWithKeepAliveWidget {
   ///
   /// The children are constructed lazily using this delegate to avoid creating
   /// more children than are visible through the [Viewport].
+  ///
+  /// ## Using more than one delegate in a [Viewport]
+  ///
+  /// If multiple delegates are used in a single scroll view, the first child of
+  /// each delegate will always be laid out, even if it extends beyond the
+  /// currently viewable area. This is because at least one child is required in
+  /// order to [estimateMaxScrollOffset] for the whole scroll view, as it uses the
+  /// currently built children to estimate the remaining children's extent.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -801,8 +801,9 @@ abstract class SliverMultiBoxAdaptorWidget extends SliverWithKeepAliveWidget {
   /// If multiple delegates are used in a single scroll view, the first child of
   /// each delegate will always be laid out, even if it extends beyond the
   /// currently viewable area. This is because at least one child is required in
-  /// order to [estimateMaxScrollOffset] for the whole scroll view, as it uses the
-  /// currently built children to estimate the remaining children's extent.
+  /// order to estimate the max scroll offset for the whole scroll view, as it
+  /// uses the currently built children to estimate the remaining children's
+  /// extent.
   ///
   /// See also:
   ///


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/95028

This adds documentation to SliverChildDelegate (and subclasses SliverChildListDelegate and SliverChildBuilderDelegate by way of template) that using more than one delegate in a scroll view expects to see at least a single child built for each so that the scroll offset can be estimated for the entire viewport.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
