### PR TITLE
Updated the FAB defaults to only use function overrides for computed values.

### DIFF
--- a/dev/tools/gen_defaults/lib/fab_template.dart
+++ b/dev/tools/gen_defaults/lib/fab_template.dart
@@ -13,7 +13,30 @@ class FABTemplate extends TokenTemplate {
 class _M3Defaults extends FloatingActionButtonThemeData {
   _M3Defaults(this.context, this.type, this.hasChild)
     : _colors = Theme.of(context).colorScheme,
-      _textTheme = Theme.of(context).textTheme;
+      _textTheme = Theme.of(context).textTheme,
+      super(
+        elevation: ${elevation("md.comp.fab.primary.container.elevation")},
+        focusElevation: ${elevation("md.comp.fab.primary.focus.container.elevation")},
+        hoverElevation: ${elevation("md.comp.fab.primary.hover.container.elevation")},
+        highlightElevation: ${elevation("md.comp.fab.primary.pressed.container.elevation")},
+        enableFeedback: true,
+        sizeConstraints: const BoxConstraints.tightFor(
+          width: ${tokens["md.comp.fab.primary.container.width"]},
+          height: ${tokens["md.comp.fab.primary.container.height"]},
+        ),
+        smallSizeConstraints: const BoxConstraints.tightFor(
+          width: ${tokens["md.comp.fab.primary.small.container.width"]},
+          height: ${tokens["md.comp.fab.primary.small.container.height"]},
+        ),
+        largeSizeConstraints: const BoxConstraints.tightFor(
+          width: ${tokens["md.comp.fab.primary.large.container.width"]},
+          height: ${tokens["md.comp.fab.primary.large.container.height"]},
+        ),
+        extendedSizeConstraints: const BoxConstraints.tightFor(
+          height: ${tokens["md.comp.extended-fab.primary.container.height"]},
+        ),
+        extendedIconLabelSpacing: 8.0,
+      );
 
   final BuildContext context;
   final _FloatingActionButtonType type;
@@ -26,12 +49,8 @@ class _M3Defaults extends FloatingActionButtonThemeData {
   @override Color? get foregroundColor => _colors.${color("md.comp.fab.primary.icon")};
   @override Color? get backgroundColor => _colors.${color("md.comp.fab.primary.container")};
   @override Color? get splashColor => _colors.${color("md.comp.fab.primary.pressed.state-layer")};
-  @override double get elevation => ${elevation("md.comp.fab.primary.container.elevation")};
   @override Color? get focusColor => _colors.${color("md.comp.fab.primary.focus.state-layer")};
-  @override double get focusElevation => ${elevation("md.comp.fab.primary.focus.container.elevation")};
   @override Color? get hoverColor => _colors.${color("md.comp.fab.primary.hover.state-layer")};
-  @override double get hoverElevation => ${elevation("md.comp.fab.primary.hover.container.elevation")};
-  @override double get highlightElevation => ${elevation("md.comp.fab.primary.pressed.container.elevation")};
 
   @override
   ShapeBorder? get shape {
@@ -47,8 +66,6 @@ class _M3Defaults extends FloatingActionButtonThemeData {
      }
   }
 
-  @override bool? get enableFeedback => true;
-
   @override
   double? get iconSize {
     switch (type) {
@@ -59,30 +76,6 @@ class _M3Defaults extends FloatingActionButtonThemeData {
     }
   }
 
-  @override
-  BoxConstraints? get sizeConstraints => const BoxConstraints.tightFor(
-    width: ${tokens["md.comp.fab.primary.container.width"]},
-    height: ${tokens["md.comp.fab.primary.container.height"]},
-  );
-
-  @override
-  BoxConstraints? get smallSizeConstraints => const BoxConstraints.tightFor(
-    width: ${tokens["md.comp.fab.primary.small.container.width"]},
-    height: ${tokens["md.comp.fab.primary.small.container.height"]},
-  );
-
-  @override
-  BoxConstraints? get largeSizeConstraints => const BoxConstraints.tightFor(
-    width: ${tokens["md.comp.fab.primary.large.container.width"]},
-    height: ${tokens["md.comp.fab.primary.large.container.height"]},
-  );
-
-  @override
-  BoxConstraints? get extendedSizeConstraints => const BoxConstraints.tightFor(
-    height: ${tokens["md.comp.extended-fab.primary.container.height"]},
-  );
-
-  @override double? get extendedIconLabelSpacing => 8.0;
   @override EdgeInsetsGeometry? get extendedPadding => EdgeInsetsDirectional.only(start: hasChild && _isExtended ? 16.0 : 20.0, end: 20.0);
   @override TextStyle? get extendedTextStyle => _textTheme.${textStyle("md.comp.extended-fab.primary.label-text")};
 }

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -720,7 +720,30 @@ class _RenderChildOverflowBox extends RenderAligningShiftedBox {
 class _M2Defaults extends FloatingActionButtonThemeData {
   _M2Defaults(BuildContext context, this.type, this.hasChild)
       : _theme = Theme.of(context),
-        _colors = Theme.of(context).colorScheme;
+        _colors = Theme.of(context).colorScheme,
+        super(
+          elevation: 6,
+          focusElevation: 6,
+          hoverElevation: 8,
+          highlightElevation: 12,
+          enableFeedback: true,
+          sizeConstraints: const BoxConstraints.tightFor(
+            width: 56.0,
+            height: 56.0,
+          ),
+          smallSizeConstraints: const BoxConstraints.tightFor(
+            width: 40.0,
+            height: 40.0,
+          ),
+          largeSizeConstraints: const BoxConstraints.tightFor(
+            width: 96.0,
+            height: 96.0,
+          ),
+          extendedSizeConstraints: const BoxConstraints.tightFor(
+            height: 48.0,
+          ),
+          extendedIconLabelSpacing: 8.0,
+        );
 
   final _FloatingActionButtonType type;
   final bool hasChild;
@@ -735,38 +758,9 @@ class _M2Defaults extends FloatingActionButtonThemeData {
   @override Color? get focusColor => _theme.focusColor;
   @override Color? get hoverColor => _theme.hoverColor;
   @override Color? get splashColor => _theme.splashColor;
-  @override double? get elevation => 6;
-  @override double? get focusElevation => 6;
-  @override double? get hoverElevation => 8;
-  @override double? get highlightElevation => 12;
   @override ShapeBorder? get shape => _isExtended ? const StadiumBorder() : const CircleBorder();
-  @override bool? get enableFeedback => true;
   @override double? get iconSize => _isLarge ? 36.0 : 24.0;
 
-  @override
-  BoxConstraints? get sizeConstraints => const BoxConstraints.tightFor(
-    width: 56.0,
-    height: 56.0,
-  );
-
-  @override
-  BoxConstraints? get smallSizeConstraints => const BoxConstraints.tightFor(
-    width: 40.0,
-    height: 40.0,
-  );
-
-  @override
-  BoxConstraints? get largeSizeConstraints => const BoxConstraints.tightFor(
-    width: 96.0,
-    height: 96.0,
-  );
-
-  @override
-  BoxConstraints? get extendedSizeConstraints => const BoxConstraints.tightFor(
-    height: 48.0,
-  );
-
-  @override double? get extendedIconLabelSpacing => 8.0;
   @override EdgeInsetsGeometry? get extendedPadding => EdgeInsetsDirectional.only(start: hasChild && _isExtended ? 16.0 : 20.0, end: 20.0);
   @override TextStyle? get extendedTextStyle => _theme.textTheme.button!.copyWith(letterSpacing: 1.2);
 }
@@ -781,7 +775,30 @@ class _M2Defaults extends FloatingActionButtonThemeData {
 class _M3Defaults extends FloatingActionButtonThemeData {
   _M3Defaults(this.context, this.type, this.hasChild)
     : _colors = Theme.of(context).colorScheme,
-      _textTheme = Theme.of(context).textTheme;
+      _textTheme = Theme.of(context).textTheme,
+      super(
+        elevation: 6.0,
+        focusElevation: 6.0,
+        hoverElevation: 8.0,
+        highlightElevation: 6.0,
+        enableFeedback: true,
+        sizeConstraints: const BoxConstraints.tightFor(
+          width: 56.0,
+          height: 56.0,
+        ),
+        smallSizeConstraints: const BoxConstraints.tightFor(
+          width: 40.0,
+          height: 40.0,
+        ),
+        largeSizeConstraints: const BoxConstraints.tightFor(
+          width: 96.0,
+          height: 96.0,
+        ),
+        extendedSizeConstraints: const BoxConstraints.tightFor(
+          height: 56.0,
+        ),
+        extendedIconLabelSpacing: 8.0,
+      );
 
   final BuildContext context;
   final _FloatingActionButtonType type;
@@ -794,12 +811,8 @@ class _M3Defaults extends FloatingActionButtonThemeData {
   @override Color? get foregroundColor => _colors.onPrimaryContainer;
   @override Color? get backgroundColor => _colors.primaryContainer;
   @override Color? get splashColor => _colors.onPrimaryContainer.withOpacity(0.12);
-  @override double get elevation => 6.0;
   @override Color? get focusColor => _colors.onPrimaryContainer.withOpacity(0.12);
-  @override double get focusElevation => 6.0;
   @override Color? get hoverColor => _colors.onPrimaryContainer.withOpacity(0.08);
-  @override double get hoverElevation => 8.0;
-  @override double get highlightElevation => 6.0;
 
   @override
   ShapeBorder? get shape {
@@ -815,8 +828,6 @@ class _M3Defaults extends FloatingActionButtonThemeData {
      }
   }
 
-  @override bool? get enableFeedback => true;
-
   @override
   double? get iconSize {
     switch (type) {
@@ -827,30 +838,6 @@ class _M3Defaults extends FloatingActionButtonThemeData {
     }
   }
 
-  @override
-  BoxConstraints? get sizeConstraints => const BoxConstraints.tightFor(
-    width: 56.0,
-    height: 56.0,
-  );
-
-  @override
-  BoxConstraints? get smallSizeConstraints => const BoxConstraints.tightFor(
-    width: 40.0,
-    height: 40.0,
-  );
-
-  @override
-  BoxConstraints? get largeSizeConstraints => const BoxConstraints.tightFor(
-    width: 96.0,
-    height: 96.0,
-  );
-
-  @override
-  BoxConstraints? get extendedSizeConstraints => const BoxConstraints.tightFor(
-    height: 56.0,
-  );
-
-  @override double? get extendedIconLabelSpacing => 8.0;
   @override EdgeInsetsGeometry? get extendedPadding => EdgeInsetsDirectional.only(start: hasChild && _isExtended ? 16.0 : 20.0, end: 20.0);
   @override TextStyle? get extendedTextStyle => _textTheme.labelLarge;
 }


### PR DESCRIPTION
The new `FloatingActionButtonThemeData` subclasses that we introduced in the [Material 3 migration](https://github.com/flutter/flutter/pull/94486) contributed to the increased size of the basic material web app (#96601).

This PR modifies the subclasses to only use function overrides for properties that aren't constants and hence need to be computed at run time. This reduces the compressed JS code by around ~200 bytes in my local testing. While not a lot, it may help if we do this for all migrated components going forward.

Fixes: https://github.com/flutter/flutter/issues/96601

I didn't update any tests, as this is just a refactor and shouldn't effect any tests.
