### PR TITLE
Update stretching overscroll clip behavior

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -785,10 +785,11 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
           // Only clip if the viewport dimension is smaller than that of the
           // screen size in the main axis. If the viewport takes up the whole
           // screen, overflow from transforming the viewport is irrelevant.
-          if (stretch != 0.0 && viewportDimension != mainAxisSize) {
-            return ClipRect(child: transform);
-          }
-          return transform;
+          return ClipRect(
+            clipBehavior: stretch != 0.0 && viewportDimension != mainAxisSize
+              ? Clip.hardEdge : Clip.none,
+            child: transform,
+          );
         },
       ),
     );

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -395,7 +395,7 @@ void main() {
   });
 
   testWidgets('Clip behavior is updated as needed', (WidgetTester tester) async {
-    // Regression test for b/210103825
+    // Regression test for https://github.com/flutter/flutter/pull/97678
     await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -6,6 +6,7 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -388,6 +389,64 @@ void main() {
       find.byType(Column),
       matchesGoldenFile('overscroll_stretch.no_overflow.png'),
     );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('Clip behavior is updated as needed', (WidgetTester tester) async {
+    // Regression test for b/210103825
+    await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(800.0, 600.0)),
+          child: ScrollConfiguration(
+              behavior: const ScrollBehavior().copyWith(overscroll: false),
+              child: Column(
+                children: <Widget>[
+                  StretchingOverscrollIndicator(
+                    axisDirection: AxisDirection.down,
+                    child: SizedBox(
+                      height: 300,
+                      child: ListView.builder(
+                        itemCount: 20,
+                        itemBuilder: (BuildContext context, int index){
+                          return Padding(
+                            padding: const EdgeInsets.all(10.0),
+                            child: Text('Index $index'),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  Opacity(
+                    opacity: 0.5,
+                    child: Container(
+                      color: const Color(0xD0FF0000),
+                      height: 100,
+                    ),
+                  )
+                ],
+              )
+          ),
+        )
+    ));
+
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
+    RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Currently not clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start.
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
+    renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Now clipping
+    expect(renderClip.clipBehavior, equals(Clip.hardEdge));
 
     await gesture.up();
     await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -395,7 +395,7 @@ void main() {
   });
 
   testWidgets('Clip behavior is updated as needed', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/pull/97678
+    // Regression test for https://github.com/flutter/flutter/issues/97867
     await tester.pumpWidget(Directionality(
         textDirection: TextDirection.ltr,
         child: MediaQuery(


### PR DESCRIPTION
Follow up to https://github.com/flutter/flutter/pull/95593

Fixes https://github.com/flutter/flutter/pull/97867

Now that Clip.none is a valid clipBehavior for ClipRect, we can update the stretching overscroll indicator to resolve internal customer issue b/210103825

This issue pointed out that state deactivation was happening in the customer's scroll view because the clipping widget was being removed from the tree, rather than just modifying the clip behavior, forcing everything to be rebuilt.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
