### PR TITLE
Update flutter_tools to look for new VM service message

### DIFF
--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -190,7 +190,7 @@ Future<TaskResult> runTask(
       .transform<String>(const LineSplitter())
       .listen((String line) {
     if (!uri.isCompleted) {
-      final Uri? serviceUri = parseServiceUri(line, prefix: 'Observatory listening on ');
+      final Uri? serviceUri = parseServiceUri(line, prefix: RegExp('(Observatory|Dart VM Service) listening on '));
       if (serviceUri != null)
         uri.complete(serviceUri);
     }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -688,7 +688,7 @@ class _WidgetInspectorService = Object with WidgetInspectorService;
 ///
 /// Calls to this object are typically made from GUI tools such as the [Flutter
 /// IntelliJ Plugin](https://github.com/flutter/flutter-intellij/blob/master/README.md)
-/// using the [Dart VM Service protocol](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service.md).
+/// using the [Dart VM Service](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service.md).
 /// This class uses its own object id and manages object lifecycles itself
 /// instead of depending on the [object ids](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service.md#getobject)
 /// specified by the VM Service Protocol because the VM Service Protocol ids

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -281,3 +281,7 @@ PreRunValidator get preRunValidator => context.get<PreRunValidator>() ?? const N
 
 // TODO(fujino): Migrate to 'main' https://github.com/flutter/flutter/issues/95041
 const String kDefaultFrameworkChannel = 'master';
+
+// Used to build RegExp instances which can detect the VM service message.
+const String kServicePrefixRegExp = '(?:Observatory|The Dart VM service is)';
+final RegExp kVMServiceMessageRegExp = RegExp(kServicePrefixRegExp + r' listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -313,7 +313,7 @@ class IOSDeployDebugger {
 
         // (lldb)     run
         // success
-        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: Observatory listening on http://127.0.0.1:57782/
+        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: Dart VM Service listening on http://127.0.0.1:57782/
         if (_lldbRun.hasMatch(line)) {
           _logger.printTrace(line);
           _debuggerState = _IOSDeployDebuggerState.launching;

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -313,7 +313,7 @@ class IOSDeployDebugger {
 
         // (lldb)     run
         // success
-        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: Dart VM Service listening on http://127.0.0.1:57782/
+        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: The Dart VM Service is listening on http://127.0.0.1:57782/
         if (_lldbRun.hasMatch(line)) {
           _logger.printTrace(line);
           _debuggerState = _IOSDeployDebuggerState.launching;

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -313,7 +313,7 @@ class IOSDeployDebugger {
 
         // (lldb)     run
         // success
-        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: The Dart VM Service is listening on http://127.0.0.1:57782/
+        // 2020-09-15 13:42:25.185474-0700 Runner[477:181141] flutter: The Dart VM service is listening on http://127.0.0.1:57782/
         if (_lldbRun.hasMatch(line)) {
           _logger.printTrace(line);
           _debuggerState = _IOSDeployDebuggerState.launching;

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -757,8 +757,8 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   }
 
   // Match the log prefix (in order to shorten it):
-  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) Observatory listening on http://127.0.0.1:57701/
-  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Observatory listening on http://127.0.0.1:57701/
+  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
+  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
   static final RegExp _mapRegex = RegExp(r'\S+ +\S+ +(?:\S+) (.+?(?=\[))\[\d+\]\)?: (\(.*?\))? *(.*)$');
 
   // Jan 31 19:23:28 --- last message repeated 1 time ---

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -757,8 +757,8 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   }
 
   // Match the log prefix (in order to shorten it):
-  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
-  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
+  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
+  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
   static final RegExp _mapRegex = RegExp(r'\S+ +\S+ +(?:\S+) (.+?(?=\[))\[\d+\]\)?: (\(.*?\))? *(.*)$');
 
   // Jan 31 19:23:28 --- last message repeated 1 time ---

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -757,8 +757,8 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
   }
 
   // Match the log prefix (in order to shorten it):
-  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
-  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
+  // * Xcode 8: Sep 13 15:28:51 cbracken-macpro localhost Runner[37195]: (Flutter) The Dart VM service is listening on http://127.0.0.1:57701/
+  // * Xcode 9: 2017-09-13 15:26:57.228948-0700  localhost Runner[37195]: (Flutter) The Dart VM service is listening on http://127.0.0.1:57701/
   static final RegExp _mapRegex = RegExp(r'\S+ +\S+ +(?:\S+) (.+?(?=\[))\[\d+\]\)?: (\(.*?\))? *(.*)$');
 
   // Jan 31 19:23:28 --- last message repeated 1 time ---

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -14,7 +14,8 @@ import 'device_port_forwarder.dart';
 class ProtocolDiscovery {
   ProtocolDiscovery._(
     this.logReader,
-    this.serviceName, {
+    this.serviceName,
+    this.servicePrefixRegExp, {
     this.portForwarder,
     required this.throttleDuration,
     this.hostPort,
@@ -39,9 +40,11 @@ class ProtocolDiscovery {
     required Logger logger,
   }) {
     const String kObservatoryService = 'Observatory';
+    const String kServicePrefixRegExp = '(?:Observatory|Dart VM Service)';
     return ProtocolDiscovery._(
       logReader,
       kObservatoryService,
+      kServicePrefixRegExp,
       portForwarder: portForwarder,
       throttleDuration: throttleDuration ?? const Duration(milliseconds: 200),
       hostPort: hostPort,
@@ -53,6 +56,7 @@ class ProtocolDiscovery {
 
   final DeviceLogReader logReader;
   final String serviceName;
+  final String servicePrefixRegExp;
   final DevicePortForwarder? portForwarder;
   final int? hostPort;
   final int? devicePort;
@@ -104,7 +108,7 @@ class ProtocolDiscovery {
   }
 
   Match? _getPatternMatch(String line) {
-    final RegExp r = RegExp(RegExp.escape(serviceName) + r' listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
+    final RegExp r = RegExp(servicePrefixRegExp + r' listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
     return r.firstMatch(line);
   }
 

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -40,7 +40,7 @@ class ProtocolDiscovery {
     required Logger logger,
   }) {
     const String kObservatoryService = 'Observatory';
-    const String kServicePrefixRegExp = '(?:Observatory|Dart VM Service)';
+    const String kServicePrefixRegExp = '(?:Observatory|The Dart VM Service is)';
     return ProtocolDiscovery._(
       logReader,
       kObservatoryService,

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -8,7 +8,7 @@ import 'base/io.dart';
 import 'base/logger.dart';
 import 'device.dart';
 import 'device_port_forwarder.dart';
-import 'globals.dart';
+import 'globals.dart' as globals;
 
 /// Discovers a specific service protocol on a device, and forwards the service
 /// protocol device port to the host.
@@ -105,7 +105,7 @@ class ProtocolDiscovery {
   }
 
   Match? _getPatternMatch(String line) {
-    return kVMServiceMessageRegExp.firstMatch(line);
+    return globals.kVMServiceMessageRegExp.firstMatch(line);
   }
 
   Uri? _getObservatoryUri(String line) {

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -8,14 +8,14 @@ import 'base/io.dart';
 import 'base/logger.dart';
 import 'device.dart';
 import 'device_port_forwarder.dart';
+import 'globals.dart';
 
 /// Discovers a specific service protocol on a device, and forwards the service
 /// protocol device port to the host.
 class ProtocolDiscovery {
   ProtocolDiscovery._(
     this.logReader,
-    this.serviceName,
-    this.servicePrefixRegExp, {
+    this.serviceName, {
     this.portForwarder,
     required this.throttleDuration,
     this.hostPort,
@@ -40,11 +40,9 @@ class ProtocolDiscovery {
     required Logger logger,
   }) {
     const String kObservatoryService = 'Observatory';
-    const String kServicePrefixRegExp = '(?:Observatory|The Dart VM Service is)';
     return ProtocolDiscovery._(
       logReader,
       kObservatoryService,
-      kServicePrefixRegExp,
       portForwarder: portForwarder,
       throttleDuration: throttleDuration ?? const Duration(milliseconds: 200),
       hostPort: hostPort,
@@ -56,7 +54,6 @@ class ProtocolDiscovery {
 
   final DeviceLogReader logReader;
   final String serviceName;
-  final String servicePrefixRegExp;
   final DevicePortForwarder? portForwarder;
   final int? hostPort;
   final int? devicePort;
@@ -108,8 +105,7 @@ class ProtocolDiscovery {
   }
 
   Match? _getPatternMatch(String line) {
-    final RegExp r = RegExp(servicePrefixRegExp + r' listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)');
-    return r.firstMatch(line);
+    return kVMServiceMessageRegExp.firstMatch(line);
   }
 
   Uri? _getObservatoryUri(String line) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -367,7 +367,7 @@ class FlutterDevice {
       return;
     }
     _loggingSubscription = logStream.listen((String line) {
-      if (!line.contains('Observatory listening on http')) {
+      if (!line.contains(RegExp('(Observatory|Dart VM Service) listening on http'))) {
         globals.printStatus(line, wrap: false);
       }
     });

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -367,7 +367,7 @@ class FlutterDevice {
       return;
     }
     _loggingSubscription = logStream.listen((String line) {
-      if (!line.contains(RegExp('(Observatory|The Dart VM Service is) listening on http'))) {
+      if (!line.contains(globals.kVMServiceMessageRegExp)) {
         globals.printStatus(line, wrap: false);
       }
     });

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -367,7 +367,7 @@ class FlutterDevice {
       return;
     }
     _loggingSubscription = logStream.listen((String line) {
-      if (!line.contains(RegExp('(Observatory|Dart VM Service) listening on http'))) {
+      if (!line.contains(RegExp('(Observatory|The Dart VM Service is) listening on http'))) {
         globals.printStatus(line, wrap: false);
       }
     });

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -33,9 +33,9 @@ class CoverageCollector extends TestWatcher {
   }
 
   void _logMessage(String line, { bool error = false }) {
-    if (!verbose) {
+/*    if (!verbose) {
       return;
-    }
+    }*/
     if (error) {
       globals.printError(line);
     } else {

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -33,9 +33,9 @@ class CoverageCollector extends TestWatcher {
   }
 
   void _logMessage(String line, { bool error = false }) {
-/*    if (!verbose) {
+    if (!verbose) {
       return;
-    }*/
+    }
     if (error) {
       globals.printError(line);
     } else {

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -295,6 +295,10 @@ class FlutterTesterTestDevice extends TestDevice {
     @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
     const String observatoryString = 'Dart VM Service listening on ';
+    final RegExp messageRegExp = RegExp(
+        r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)'
+      );
+
     for (final Stream<List<int>> stream in <Stream<List<int>>>[
       process.stderr,
       process.stdout,
@@ -306,9 +310,10 @@ class FlutterTesterTestDevice extends TestDevice {
             (String line) async {
           logger.printTrace('test $id: Shell: $line');
 
-          if (line.startsWith(observatoryString)) {
+          final match = messageRegExp.firstMatch(line);
+          if (match != null) {
             try {
-              final Uri uri = Uri.parse(line.substring(observatoryString.length));
+              final Uri uri = Uri.parse(match[1]);
               if (reportObservatoryUri != null) {
                 await reportObservatoryUri(uri);
               }

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -294,7 +294,6 @@ class FlutterTesterTestDevice extends TestDevice {
     @required Process process,
     @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
-    const String observatoryString = 'Dart VM Service listening on ';
     final RegExp messageRegExp = RegExp(
         r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)'
       );
@@ -310,7 +309,7 @@ class FlutterTesterTestDevice extends TestDevice {
             (String line) async {
           logger.printTrace('test $id: Shell: $line');
 
-          final match = messageRegExp.firstMatch(line);
+          final Match match = messageRegExp.firstMatch(line);
           if (match != null) {
             try {
               final Uri uri = Uri.parse(match[1]);

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -294,7 +294,7 @@ class FlutterTesterTestDevice extends TestDevice {
     @required Process process,
     @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
-    const String observatoryString = 'Observatory listening on ';
+    const String observatoryString = 'Dart VM Service listening on ';
     for (final Stream<List<int>> stream in <Stream<List<int>>>[
       process.stderr,
       process.stdout,

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -20,7 +20,7 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../convert.dart';
 import '../device.dart';
-import '../globals.dart';
+import '../globals.dart' as globals;
 import '../project.dart';
 import '../vmservice.dart';
 
@@ -306,7 +306,7 @@ class FlutterTesterTestDevice extends TestDevice {
             (String line) async {
           logger.printTrace('test $id: Shell: $line');
 
-          final Match match = kVMServiceMessageRegExp.firstMatch(line);
+          final Match match = globals.kVMServiceMessageRegExp.firstMatch(line);
           if (match != null) {
             try {
               final Uri uri = Uri.parse(match[1]);

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -20,6 +20,7 @@ import '../base/os.dart';
 import '../base/platform.dart';
 import '../convert.dart';
 import '../device.dart';
+import '../globals.dart';
 import '../project.dart';
 import '../vmservice.dart';
 
@@ -294,10 +295,6 @@ class FlutterTesterTestDevice extends TestDevice {
     @required Process process,
     @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
-    final RegExp messageRegExp = RegExp(
-        r'(?:Observatory|The Dart VM Service is) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)'
-      );
-
     for (final Stream<List<int>> stream in <Stream<List<int>>>[
       process.stderr,
       process.stdout,
@@ -309,7 +306,7 @@ class FlutterTesterTestDevice extends TestDevice {
             (String line) async {
           logger.printTrace('test $id: Shell: $line');
 
-          final Match match = messageRegExp.firstMatch(line);
+          final Match match = kVMServiceMessageRegExp.firstMatch(line);
           if (match != null) {
             try {
               final Uri uri = Uri.parse(match[1]);

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -295,7 +295,7 @@ class FlutterTesterTestDevice extends TestDevice {
     @required Future<void> Function(Uri uri) reportObservatoryUri,
   }) {
     final RegExp messageRegExp = RegExp(
-        r'(?:Observatory|Dart VM Service) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)'
+        r'(?:Observatory|The Dart VM Service is) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)'
       );
 
     for (final Stream<List<int>> stream in <Stream<List<int>>>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -104,7 +104,7 @@ void main() {
       testUsingContext('finds observatory port and forwards', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -133,7 +133,7 @@ void main() {
       testUsingContext('Fails with tool exit on bad Observatory uri', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
           fakeLogReader.dispose();
           return fakeLogReader;
         };
@@ -148,7 +148,7 @@ void main() {
       testUsingContext('accepts filesystem parameters', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -223,7 +223,7 @@ void main() {
       testUsingContext('exits when observatory-port is specified and debug-port is not', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Observatory listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -104,7 +104,7 @@ void main() {
       testUsingContext('finds observatory port and forwards', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -133,7 +133,7 @@ void main() {
       testUsingContext('Fails with tool exit on bad Observatory uri', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
           fakeLogReader.dispose();
           return fakeLogReader;
         };
@@ -148,7 +148,7 @@ void main() {
       testUsingContext('accepts filesystem parameters', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -223,7 +223,7 @@ void main() {
       testUsingContext('exits when observatory-port is specified and debug-port is not', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('Dart VM Service listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -104,7 +104,7 @@ void main() {
       testUsingContext('finds observatory port and forwards', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -133,7 +133,7 @@ void main() {
       testUsingContext('Fails with tool exit on bad Observatory uri', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           fakeLogReader.dispose();
           return fakeLogReader;
         };
@@ -148,7 +148,7 @@ void main() {
       testUsingContext('accepts filesystem parameters', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);
@@ -223,7 +223,7 @@ void main() {
       testUsingContext('exits when observatory-port is specified and debug-port is not', () async {
         device.onGetLogReader = () {
           fakeLogReader.addLine('Foo');
-          fakeLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:$devicePort');
+          fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
         testDeviceManager.addDevice(device);

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -200,7 +200,7 @@ void main() {
         '10',
         'app.apk'
       ],
-      stdout: '\n\nObservatory listening on http://127.0.0.1:456\n\n',
+      stdout: '\n\nDart VM Service listening on http://127.0.0.1:456\n\n',
     ));
     processManager.addCommand(kShaCommand);
     processManager.addCommand(const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -200,7 +200,7 @@ void main() {
         '10',
         'app.apk'
       ],
-      stdout: '\n\nThe Dart VM Service is listening on http://127.0.0.1:456\n\n',
+      stdout: '\n\nThe Dart VM service is listening on http://127.0.0.1:456\n\n',
     ));
     processManager.addCommand(kShaCommand);
     processManager.addCommand(const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -200,7 +200,7 @@ void main() {
         '10',
         'app.apk'
       ],
-      stdout: '\n\nDart VM Service listening on http://127.0.0.1:456\n\n',
+      stdout: '\n\nThe Dart VM Service is listening on http://127.0.0.1:456\n\n',
     ));
     processManager.addCommand(kShaCommand);
     processManager.addCommand(const FakeCommand(

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -370,7 +370,7 @@ void main() {
       FakeCommand(
         command: testConfig.runDebugCommand,
         completer: runDebugCompleter,
-        stdout: 'Observatory listening on http://127.0.0.1:12345/abcd/\n',
+        stdout: 'Dart VM Service listening on http://127.0.0.1:12345/abcd/\n',
       ),
       FakeCommand(
         command: testConfig.forwardPortCommand,
@@ -411,7 +411,7 @@ void main() {
         FakeCommand(
           command: testConfigNonForwarding.runDebugCommand,
           completer: runDebugCompleter,
-          stdout: 'Observatory listening on http://192.168.178.123:12345/abcd/\n'
+          stdout: 'Dart VM Service listening on http://192.168.178.123:12345/abcd/\n'
         ),
       ]
     );
@@ -456,7 +456,7 @@ void main() {
           FakeCommand(
             command: testConfig.runDebugCommand,
             completer: runDebugCompleter,
-            stdout: 'Observatory listening on http://127.0.0.1:12345/abcd/\n',
+            stdout: 'Dart VM Service listening on http://127.0.0.1:12345/abcd/\n',
           ),
           FakeCommand(
             command: testConfig.forwardPortCommand,

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -370,7 +370,7 @@ void main() {
       FakeCommand(
         command: testConfig.runDebugCommand,
         completer: runDebugCompleter,
-        stdout: 'The Dart VM Service is listening on http://127.0.0.1:12345/abcd/\n',
+        stdout: 'The Dart VM service is listening on http://127.0.0.1:12345/abcd/\n',
       ),
       FakeCommand(
         command: testConfig.forwardPortCommand,
@@ -411,7 +411,7 @@ void main() {
         FakeCommand(
           command: testConfigNonForwarding.runDebugCommand,
           completer: runDebugCompleter,
-          stdout: 'The Dart VM Service is listening on http://192.168.178.123:12345/abcd/\n'
+          stdout: 'The Dart VM service is listening on http://192.168.178.123:12345/abcd/\n'
         ),
       ]
     );
@@ -456,7 +456,7 @@ void main() {
           FakeCommand(
             command: testConfig.runDebugCommand,
             completer: runDebugCompleter,
-            stdout: 'The Dart VM Service is listening on http://127.0.0.1:12345/abcd/\n',
+            stdout: 'The Dart VM service is listening on http://127.0.0.1:12345/abcd/\n',
           ),
           FakeCommand(
             command: testConfig.forwardPortCommand,

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -370,7 +370,7 @@ void main() {
       FakeCommand(
         command: testConfig.runDebugCommand,
         completer: runDebugCompleter,
-        stdout: 'Dart VM Service listening on http://127.0.0.1:12345/abcd/\n',
+        stdout: 'The Dart VM Service is listening on http://127.0.0.1:12345/abcd/\n',
       ),
       FakeCommand(
         command: testConfig.forwardPortCommand,
@@ -411,7 +411,7 @@ void main() {
         FakeCommand(
           command: testConfigNonForwarding.runDebugCommand,
           completer: runDebugCompleter,
-          stdout: 'Dart VM Service listening on http://192.168.178.123:12345/abcd/\n'
+          stdout: 'The Dart VM Service is listening on http://192.168.178.123:12345/abcd/\n'
         ),
       ]
     );
@@ -456,7 +456,7 @@ void main() {
           FakeCommand(
             command: testConfig.runDebugCommand,
             completer: runDebugCompleter,
-            stdout: 'Dart VM Service listening on http://127.0.0.1:12345/abcd/\n',
+            stdout: 'The Dart VM Service is listening on http://127.0.0.1:12345/abcd/\n',
           ),
           FakeCommand(
             command: testConfig.forwardPortCommand,

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -81,7 +81,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'Observatory listening on http://127.0.0.1/0\n',
+          stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -118,7 +118,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'Observatory listening on http://127.0.0.1/0\n',
+          stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -140,7 +140,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'Observatory listening on http://127.0.0.1/0\n',
+        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -202,7 +202,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'Observatory listening on http://127.0.0.1/0\n',
+        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -251,7 +251,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug', 'arg1', 'arg2'],
-        stdout: 'Observatory listening on http://127.0.0.1/0\n',
+        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
         completer: completer,
       ),
     ]);

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -81,7 +81,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
+          stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -118,7 +118,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
+          stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -140,7 +140,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -202,7 +202,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -251,7 +251,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug', 'arg1', 'arg2'],
-        stdout: 'Dart VM Service listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
         completer: completer,
       ),
     ]);

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -81,7 +81,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
+          stdout: 'The Dart VM service is listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -118,7 +118,7 @@ void main() {
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>['debug'],
-          stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
+          stdout: 'The Dart VM service is listening on http://127.0.0.1/0\n',
           completer: completer,
         ),
       ]);
@@ -140,7 +140,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM service is listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -202,7 +202,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug'],
-        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM service is listening on http://127.0.0.1/0\n',
         completer: completer,
         environment: const <String, String>{
           'FLUTTER_ENGINE_SWITCH_1': 'enable-dart-profiling=true',
@@ -251,7 +251,7 @@ void main() {
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: const <String>['debug', 'arg1', 'arg2'],
-        stdout: 'The Dart VM Service is listening on http://127.0.0.1/0\n',
+        stdout: 'The Dart VM service is listening on http://127.0.0.1/0\n',
         completer: completer,
       ),
     ]);

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -247,7 +247,7 @@ void main() {
             '--packages=.dart_tool/package_config.json',
             'example.dill'
           ],
-          stdout: 'Observatory listening on http://localhost:1234',
+          stdout: 'Dart VM Service listening on http://localhost:1234',
           stderr: 'failure',
         )
       ]);

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -247,7 +247,7 @@ void main() {
             '--packages=.dart_tool/package_config.json',
             'example.dill'
           ],
-          stdout: 'Dart VM Service listening on http://localhost:1234',
+          stdout: 'The Dart VM Service is listening on http://localhost:1234',
           stderr: 'failure',
         )
       ]);

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -247,7 +247,7 @@ void main() {
             '--packages=.dart_tool/package_config.json',
             'example.dill'
           ],
-          stdout: 'The Dart VM Service is listening on http://localhost:1234',
+          stdout: 'The Dart VM service is listening on http://localhost:1234',
           stderr: 'failure',
         )
       ]);

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -128,7 +128,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Observatory listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -166,7 +166,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Observatory listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -206,7 +206,7 @@ void main() {
     Timer.run(() async {
       await Future<void>.delayed(const Duration(milliseconds: 1));
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Observatory listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -311,7 +311,7 @@ void main() {
 
     // Start writing messages to the log reader.
     Timer.run(() {
-      deviceLogReader.addLine('Observatory listening on http://127.0.0.1:1234');
+      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:1234');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -128,7 +128,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -166,7 +166,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -206,7 +206,7 @@ void main() {
     Timer.run(() async {
       await Future<void>.delayed(const Duration(milliseconds: 1));
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -311,7 +311,7 @@ void main() {
 
     // Start writing messages to the log reader.
     Timer.run(() {
-      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:1234');
+      deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:1234');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -128,7 +128,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -166,7 +166,7 @@ void main() {
     // Start writing messages to the log reader.
     Timer.run(() {
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -206,7 +206,7 @@ void main() {
     Timer.run(() async {
       await Future<void>.delayed(const Duration(milliseconds: 1));
       deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:456');
+      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:456');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,
@@ -311,7 +311,7 @@ void main() {
 
     // Start writing messages to the log reader.
     Timer.run(() {
-      deviceLogReader.addLine('Dart VM Service listening on http://127.0.0.1:1234');
+      deviceLogReader.addLine('The Dart VM Service is listening on http://127.0.0.1:1234');
     });
 
     final LaunchResult launchResult = await device.startApp(iosApp,

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -495,7 +495,7 @@ void main() {
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: Observatory listening on http://127.0.0.1:64213/1Uoeu523990=/
+Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: Dart VM Service listening on http://127.0.0.1:64213/1Uoeu523990=/
 Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ))
           ..addCommand(const FakeCommand(
@@ -514,7 +514,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'flutter: Observatory listening on http://127.0.0.1:64213/1Uoeu523990=/',
+          'flutter: Dart VM Service listening on http://127.0.0.1:64213/1Uoeu523990=/',
         ]);
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
@@ -529,7 +529,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) Observatory listening on http://127.0.0.1:57701/
+2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) ))))))))))
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) #0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)'''
           ))
@@ -549,7 +549,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'Observatory listening on http://127.0.0.1:57701/',
+          'Dart VM Service listening on http://127.0.0.1:57701/',
           '))))))))))',
           '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
         ]);

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -495,7 +495,7 @@ void main() {
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: The Dart VM Service is listening on http://127.0.0.1:64213/1Uoeu523990=/
+Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: The Dart VM service is listening on http://127.0.0.1:64213/1Uoeu523990=/
 Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ))
           ..addCommand(const FakeCommand(
@@ -514,7 +514,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'flutter: The Dart VM Service is listening on http://127.0.0.1:64213/1Uoeu523990=/',
+          'flutter: The Dart VM service is listening on http://127.0.0.1:64213/1Uoeu523990=/',
         ]);
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
@@ -529,7 +529,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
+2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) The Dart VM service is listening on http://127.0.0.1:57701/
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) ))))))))))
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) #0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)'''
           ))
@@ -549,7 +549,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'The Dart VM Service is listening on http://127.0.0.1:57701/',
+          'The Dart VM service is listening on http://127.0.0.1:57701/',
           '))))))))))',
           '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
         ]);

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -495,7 +495,7 @@ void main() {
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: Dart VM Service listening on http://127.0.0.1:64213/1Uoeu523990=/
+Dec 20 17:04:32 md32-11-vm1 My Super Awesome App[88374]: flutter: The Dart VM Service is listening on http://127.0.0.1:64213/1Uoeu523990=/
 Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ))
           ..addCommand(const FakeCommand(
@@ -514,7 +514,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'flutter: Dart VM Service listening on http://127.0.0.1:64213/1Uoeu523990=/',
+          'flutter: The Dart VM Service is listening on http://127.0.0.1:64213/1Uoeu523990=/',
         ]);
         expect(fakeProcessManager.hasRemainingExpectations, isFalse);
       }, overrides: <Type, Generator>{
@@ -529,7 +529,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           ..addCommand(const FakeCommand(
             command:  <String>['tail', '-n', '0', '-F', 'system.log'],
             stdout: '''
-2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) Dart VM Service listening on http://127.0.0.1:57701/
+2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) The Dart VM Service is listening on http://127.0.0.1:57701/
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) ))))))))))
 2017-09-13 15:26:57.228948-0700  localhost My Super Awesome App[37195]: (Flutter) #0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)'''
           ))
@@ -549,7 +549,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
 
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, <String>[
-          'Dart VM Service listening on http://127.0.0.1:57701/',
+          'The Dart VM Service is listening on http://127.0.0.1:57701/',
           '))))))))))',
           '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
         ]);

--- a/packages/flutter_tools/test/general.shard/preview_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/preview_device_test.dart
@@ -61,7 +61,7 @@ void main() {
           command: const <String>[
             '/.tmp_rand0/flutter_preview.rand0/splash'
           ],
-          stdout: 'Observatory listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
+          stdout: 'Dart VM Service listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
           completer: completer,
         )
       ]),

--- a/packages/flutter_tools/test/general.shard/preview_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/preview_device_test.dart
@@ -61,7 +61,7 @@ void main() {
           command: const <String>[
             '/.tmp_rand0/flutter_preview.rand0/splash'
           ],
-          stdout: 'Dart VM Service listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
+          stdout: 'The Dart VM Service is listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
           completer: completer,
         )
       ]),

--- a/packages/flutter_tools/test/general.shard/preview_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/preview_device_test.dart
@@ -61,7 +61,7 @@ void main() {
           command: const <String>[
             '/.tmp_rand0/flutter_preview.rand0/splash'
           ],
-          stdout: 'The Dart VM Service is listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
+          stdout: 'The Dart VM service is listening on http://127.0.0.1:64494/fZ_B2N6JRwY=/\n',
           completer: completer,
         )
       ]),

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('Observatory listening on http://127.0.0.1:9999');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 9999);
         expect('$uri', 'http://127.0.0.1:9999');
@@ -45,9 +45,9 @@ void main() {
 
       testWithoutContext('does not discover uri with no host', () async {
         final Future<Uri?> pendingUri = discoverer.uri;
-        logReader.addLine('Observatory listening on http12asdasdsd9999');
+        logReader.addLine('Dart VM Service listening on http12asdasdsd9999');
         await Future<void>.delayed(const Duration(milliseconds: 10));
-        logReader.addLine('Observatory listening on http://127.0.0.1:9999');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -59,7 +59,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output and no listener is attached', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('Observatory listening on http://127.0.0.1:9999');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -70,7 +70,7 @@ void main() {
       });
 
       testWithoutContext('uri throws if logs produce bad line and no listener is attached', () async {
-        logReader.addLine('Observatory listening on http://127.0.0.1:apple');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:apple');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -79,21 +79,21 @@ void main() {
 
       testWithoutContext('discovers uri if logs not yet produced output', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('Observatory listening on http://127.0.0.1:3333');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:3333');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('discovers uri with Ascii Esc code', () async {
-        logReader.addLine('Observatory listening on http://127.0.0.1:3333\x1b[');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:3333\x1b[');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('uri throws if logs produce bad line', () async {
-        logReader.addLine('Observatory listening on http://127.0.0.1:apple');
+        logReader.addLine('Dart VM Service listening on http://127.0.0.1:apple');
         expect(discoverer.uri, throwsA(isFormatException));
       });
 
@@ -116,7 +116,7 @@ void main() {
       });
 
       testWithoutContext('discovers uri if log line contains Android prefix', () async {
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:52584');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:52584');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 52584);
         expect('$uri', 'http://127.0.0.1:52584');
@@ -124,7 +124,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains auth key', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -132,7 +132,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains non-localhost', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -147,8 +147,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
@@ -163,16 +163,16 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
       });
 
       testWithoutContext('first uri in the stream is the last one from the log', () async {
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -186,9 +186,9 @@ void main() {
           throttleDuration: const Duration(milliseconds: 200),
           logger: BufferLogger.test(),
         );
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -203,8 +203,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<List<Uri>> results = discoverer.uris.toList();
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         await logReader.dispose();
 
         // Give time for throttle to finish.
@@ -228,13 +228,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
@@ -263,13 +263,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
-          logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
+          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
@@ -294,7 +294,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -315,7 +315,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 1243);
         expect('$uri', 'http://127.0.0.1:1243/PTwjm8Ii8qg=/');
@@ -336,7 +336,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -357,7 +357,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');
@@ -378,7 +378,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Observatory listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
+        logReader.addLine('I/flutter : Dart VM Service listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 9999);
         expect('$uri', 'http://127.0.0.1:9999');
@@ -45,9 +45,9 @@ void main() {
 
       testWithoutContext('does not discover uri with no host', () async {
         final Future<Uri?> pendingUri = discoverer.uri;
-        logReader.addLine('Dart VM Service listening on http12asdasdsd9999');
+        logReader.addLine('The Dart VM Service is listening on http12asdasdsd9999');
         await Future<void>.delayed(const Duration(milliseconds: 10));
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -59,7 +59,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output and no listener is attached', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -70,7 +70,7 @@ void main() {
       });
 
       testWithoutContext('uri throws if logs produce bad line and no listener is attached', () async {
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:apple');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:apple');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -79,21 +79,21 @@ void main() {
 
       testWithoutContext('discovers uri if logs not yet produced output', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:3333');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:3333');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('discovers uri with Ascii Esc code', () async {
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:3333\x1b[');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:3333\x1b[');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('uri throws if logs produce bad line', () async {
-        logReader.addLine('Dart VM Service listening on http://127.0.0.1:apple');
+        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:apple');
         expect(discoverer.uri, throwsA(isFormatException));
       });
 
@@ -116,7 +116,7 @@ void main() {
       });
 
       testWithoutContext('discovers uri if log line contains Android prefix', () async {
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:52584');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:52584');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 52584);
         expect('$uri', 'http://127.0.0.1:52584');
@@ -124,7 +124,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains auth key', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -132,7 +132,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains non-localhost', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -147,8 +147,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
@@ -163,16 +163,16 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
       });
 
       testWithoutContext('first uri in the stream is the last one from the log', () async {
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -186,9 +186,9 @@ void main() {
           throttleDuration: const Duration(milliseconds: 200),
           logger: BufferLogger.test(),
         );
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -203,8 +203,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<List<Uri>> results = discoverer.uris.toList();
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         await logReader.dispose();
 
         // Give time for throttle to finish.
@@ -228,13 +228,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
@@ -263,13 +263,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
-          logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
+          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
@@ -294,7 +294,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -315,7 +315,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 1243);
         expect('$uri', 'http://127.0.0.1:1243/PTwjm8Ii8qg=/');
@@ -336,7 +336,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -357,7 +357,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');
@@ -378,7 +378,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : Dart VM Service listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
+        logReader.addLine('I/flutter : The Dart VM Service is listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:9999');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 9999);
         expect('$uri', 'http://127.0.0.1:9999');
@@ -45,9 +45,9 @@ void main() {
 
       testWithoutContext('does not discover uri with no host', () async {
         final Future<Uri?> pendingUri = discoverer.uri;
-        logReader.addLine('The Dart VM Service is listening on http12asdasdsd9999');
+        logReader.addLine('The Dart VM service is listening on http12asdasdsd9999');
         await Future<void>.delayed(const Duration(milliseconds: 10));
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -59,7 +59,7 @@ void main() {
 
       testWithoutContext('discovers uri if logs already produced output and no listener is attached', () async {
         logReader.addLine('HELLO WORLD');
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:9999');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:9999');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -70,7 +70,7 @@ void main() {
       });
 
       testWithoutContext('uri throws if logs produce bad line and no listener is attached', () async {
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:apple');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:apple');
 
         await Future<void>.delayed(Duration.zero);
 
@@ -79,21 +79,21 @@ void main() {
 
       testWithoutContext('discovers uri if logs not yet produced output', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:3333');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:3333');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('discovers uri with Ascii Esc code', () async {
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:3333\x1b[');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:3333\x1b[');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 3333);
         expect('$uri', 'http://127.0.0.1:3333');
       });
 
       testWithoutContext('uri throws if logs produce bad line', () async {
-        logReader.addLine('The Dart VM Service is listening on http://127.0.0.1:apple');
+        logReader.addLine('The Dart VM service is listening on http://127.0.0.1:apple');
         expect(discoverer.uri, throwsA(isFormatException));
       });
 
@@ -116,7 +116,7 @@ void main() {
       });
 
       testWithoutContext('discovers uri if log line contains Android prefix', () async {
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:52584');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:52584');
         final Uri uri = (await discoverer.uri)!;
         expect(uri.port, 52584);
         expect('$uri', 'http://127.0.0.1:52584');
@@ -124,7 +124,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains auth key', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -132,7 +132,7 @@ void main() {
 
       testWithoutContext('discovers uri if log line contains non-localhost', () async {
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 54804);
         expect('$uri', 'http://127.0.0.1:54804/PTwjm8Ii8qg=/');
@@ -147,8 +147,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
@@ -163,16 +163,16 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<Uri?> uriFuture = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = (await uriFuture)!;
         expect(uri.port, 12346);
         expect('$uri', 'http://127.0.0.1:12346/PTwjm8Ii8qg=/');
       });
 
       testWithoutContext('first uri in the stream is the last one from the log', () async {
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -186,9 +186,9 @@ void main() {
           throttleDuration: const Duration(milliseconds: 200),
           logger: BufferLogger.test(),
         );
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
         final Uri uri = await discoverer.uris.first;
         expect(uri.port, 12345);
         expect('$uri', 'http://127.0.0.1:12345/PTwjm8Ii8qg=/');
@@ -203,8 +203,8 @@ void main() {
           logger: BufferLogger.test(),
         );
         final Future<List<Uri>> results = discoverer.uris.toList();
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
         await logReader.dispose();
 
         // Give time for throttle to finish.
@@ -228,13 +228,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12344/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12343/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleDuration);
 
@@ -263,13 +263,13 @@ void main() {
             discoveredUris.add(uri);
           });
 
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12346/PTwjm8Ii8qg=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qg=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
-          logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12345/PTwjm8Ii8qc=/');
+          logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:12344/PTwjm8Ii8qf=/');
 
           time.elapse(kThrottleTimeInMilliseconds);
 
@@ -294,7 +294,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -315,7 +315,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 1243);
         expect('$uri', 'http://127.0.0.1:1243/PTwjm8Ii8qg=/');
@@ -336,7 +336,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 99);
         expect('$uri', 'http://127.0.0.1:99/PTwjm8Ii8qg=/');
@@ -357,7 +357,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://127.0.0.1:54804/PTwjm8Ii8qg=/');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');
@@ -378,7 +378,7 @@ void main() {
 
         // Get next port future.
         final Future<Uri?> nextUri = discoverer.uri;
-        logReader.addLine('I/flutter : The Dart VM Service is listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
+        logReader.addLine('I/flutter : The Dart VM service is listening on http://[::1]:54777/PTwjm8Ii8qg=/\x1b[');
         final Uri uri = (await nextUri)!;
         expect(uri.port, 54777);
         expect('$uri', 'http://[::1]:54777/PTwjm8Ii8qg=/');

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -154,7 +154,7 @@ void main() {
         completer: completer,
         stdout:
         '''
-Observatory listening on $observatoryUri
+Dart VM Service listening on $observatoryUri
 Hello!
 ''',
       ));

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -154,7 +154,7 @@ void main() {
         completer: completer,
         stdout:
         '''
-The Dart VM Service is listening on $observatoryUri
+The Dart VM service is listening on $observatoryUri
 Hello!
 ''',
       ));

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -154,7 +154,7 @@ void main() {
         completer: completer,
         stdout:
         '''
-Dart VM Service listening on $observatoryUri
+The Dart VM Service is listening on $observatoryUri
 Hello!
 ''',
       ));


### PR DESCRIPTION
The Dart SDK will soon move away from the current Observatory message:

"Observatory listening on ..."

To a new message that no longer references Observatory:

"Dart VM Service listening on ..."

This change updates all tests with mocks to check for the new message and also adds support for the new message in `ProtocolDiscovery`.

See https://github.com/dart-lang/sdk/issues/46756