### PR TITLE
Include -isysroot -arch and -miphoneos-version-min when creating dummy module App.framework

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -246,6 +246,9 @@ dependencies:
       final Directory objectiveCBuildDirectory = Directory(path.join(tempDir.path, 'build-objc'));
 
       section('Build iOS Objective-C host app');
+
+      final File dummyAppFramework = File(path.join(projectDir.path, '.ios', 'Flutter', 'App.framework', 'App'));
+      checkFileNotExists(dummyAppFramework.path);
       await inDirectory(objectiveCHostApp, () async {
         await exec(
           'pod',
@@ -265,6 +268,14 @@ dependencies:
             || hostPodfileLockOutput.contains(dartPluginName)) {
           print(hostPodfileLockOutput);
           throw TaskResult.failure('Building host app Podfile.lock does not contain expected pods');
+        }
+
+        // Just running "pod install" should create a fake App.framework so CocoaPods recognizes
+        // it as a framework that needs to be embedded, before Flutter actually creates it.
+        checkFileExists(dummyAppFramework.path);
+        final String? version = await minPhoneOSVersion(dummyAppFramework.path);
+        if (version != '9.0') {
+          throw TaskResult.failure('Minimum version set to $version, expected 9.0');
         }
 
         await exec(

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -109,7 +109,8 @@ def install_flutter_application_pod(flutter_application_path)
     # CocoaPods will not embed the framework on pod install (before any build phases can run) if the dylib does not exist.
     # Create a dummy dylib.
     FileUtils.mkdir_p(app_framework_dir)
-    `echo "static const int Moo = 88;" | xcrun clang -x c -dynamiclib -o "#{app_framework_dylib}" -`
+    sdk_path = `xcrun --sdk iphoneos --show-sdk-path`.strip
+    `echo "static const int Moo = 88;" | xcrun clang -x c -arch arm64 -dynamiclib -miphoneos-version-min=9.0 -isysroot "#{sdk_path}" -o "#{app_framework_dylib}" -`
   end
 
   # Keep pod and script phase paths relative so they can be checked into source control.


### PR DESCRIPTION
These extra flags create a framework that can be recognized by CocoaPods, so it knows to embed App.framework later after Flutter creates it.

Add `otool` test, which is passing: https://ci.chromium.org/p/flutter/builders/try/Mac%20module_test_ios/11940

Fixes https://github.com/flutter/samples/issues/1004

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
