### PR TITLE
Fix Local `SwitchTheme` not being inherited by `Switch` Widget

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -12,6 +12,7 @@ import 'constants.dart';
 import 'debug.dart';
 import 'material_state.dart';
 import 'shadows.dart';
+import 'switch_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 import 'toggleable.dart';
@@ -397,9 +398,12 @@ class Switch extends StatelessWidget {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
-  Size _getSwitchSize(ThemeData theme) {
+  Size _getSwitchSize(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final SwitchThemeData switchTheme = SwitchTheme.of(context);
+
     final MaterialTapTargetSize effectiveMaterialTapTargetSize = materialTapTargetSize
-      ?? theme.switchTheme.materialTapTargetSize
+      ?? switchTheme.materialTapTargetSize
       ?? theme.materialTapTargetSize;
     switch (effectiveMaterialTapTargetSize) {
       case MaterialTapTargetSize.padded:
@@ -410,7 +414,7 @@ class Switch extends StatelessWidget {
   }
 
   Widget _buildCupertinoSwitch(BuildContext context) {
-    final Size size = _getSwitchSize(Theme.of(context));
+    final Size size = _getSwitchSize(context);
     return Focus(
       focusNode: focusNode,
       autofocus: autofocus,
@@ -433,7 +437,7 @@ class Switch extends StatelessWidget {
     return _MaterialSwitch(
       value: value,
       onChanged: onChanged,
-      size: _getSwitchSize(Theme.of(context)),
+      size: _getSwitchSize(context),
       activeColor: activeColor,
       activeTrackColor: activeTrackColor,
       inactiveThumbColor: inactiveThumbColor,
@@ -691,6 +695,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
     }
 
     final ThemeData theme = Theme.of(context);
+    final SwitchThemeData switchTheme = SwitchTheme.of(context);
 
     // Colors need to be resolved in selected and non selected states separately
     // so that they can be lerped between.
@@ -698,46 +703,46 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
     final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
     final Color effectiveActiveThumbColor = widget.thumbColor?.resolve(activeStates)
       ?? _widgetThumbColor.resolve(activeStates)
-      ?? theme.switchTheme.thumbColor?.resolve(activeStates)
+      ?? switchTheme.thumbColor?.resolve(activeStates)
       ?? _defaultThumbColor.resolve(activeStates);
     final Color effectiveInactiveThumbColor = widget.thumbColor?.resolve(inactiveStates)
       ?? _widgetThumbColor.resolve(inactiveStates)
-      ?? theme.switchTheme.thumbColor?.resolve(inactiveStates)
+      ?? switchTheme.thumbColor?.resolve(inactiveStates)
       ?? _defaultThumbColor.resolve(inactiveStates);
     final Color effectiveActiveTrackColor = widget.trackColor?.resolve(activeStates)
       ?? _widgetTrackColor.resolve(activeStates)
-      ?? theme.switchTheme.trackColor?.resolve(activeStates)
+      ?? switchTheme.trackColor?.resolve(activeStates)
       ?? _defaultTrackColor.resolve(activeStates);
     final Color effectiveInactiveTrackColor = widget.trackColor?.resolve(inactiveStates)
       ?? _widgetTrackColor.resolve(inactiveStates)
-      ?? theme.switchTheme.trackColor?.resolve(inactiveStates)
+      ?? switchTheme.trackColor?.resolve(inactiveStates)
       ?? _defaultTrackColor.resolve(inactiveStates);
 
     final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
       ?? widget.focusColor
-      ?? theme.switchTheme.overlayColor?.resolve(focusedStates)
+      ?? switchTheme.overlayColor?.resolve(focusedStates)
       ?? theme.focusColor;
 
     final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
         ?? widget.hoverColor
-        ?? theme.switchTheme.overlayColor?.resolve(hoveredStates)
+        ?? switchTheme.overlayColor?.resolve(hoveredStates)
         ?? theme.hoverColor;
 
     final Set<MaterialState> activePressedStates = activeStates..add(MaterialState.pressed);
     final Color effectiveActivePressedOverlayColor = widget.overlayColor?.resolve(activePressedStates)
-        ?? theme.switchTheme.overlayColor?.resolve(activePressedStates)
+        ?? switchTheme.overlayColor?.resolve(activePressedStates)
         ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
-        ?? theme.switchTheme.overlayColor?.resolve(inactivePressedStates)
+        ?? switchTheme.overlayColor?.resolve(inactivePressedStates)
         ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
       return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-        ?? theme.switchTheme.mouseCursor?.resolve(states)
+        ?? switchTheme.mouseCursor?.resolve(states)
         ?? MaterialStateProperty.resolveAs<MouseCursor>(MaterialStateMouseCursor.clickable, states);
     });
 
@@ -763,7 +768,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..reactionColor = effectiveActivePressedOverlayColor
             ..hoverColor = effectiveHoverOverlayColor
             ..focusColor = effectiveFocusOverlayColor
-            ..splashRadius = widget.splashRadius ?? theme.switchTheme.splashRadius ?? kRadialReactionRadius
+            ..splashRadius = widget.splashRadius ?? switchTheme.splashRadius ?? kRadialReactionRadius
             ..downPosition = downPosition
             ..isFocused = states.contains(MaterialState.focused)
             ..isHovered = states.contains(MaterialState.hovered)

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -419,6 +419,49 @@ void main() {
       reason: 'Active pressed Switch should have overlay color: $activePressedOverlayColor',
     );
   });
+
+  testWidgets('Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
+    const Color globalThemeThumbColor = Color(0xfffffff1);
+    const Color globalThemeTrackColor = Color(0xfffffff2);
+    const Color localThemeThumbColor = Color(0xffff0000);
+    const Color localThemeTrackColor = Color(0xffff0000);
+
+    Widget buildSwitch({bool selected = false, bool autofocus = false}) {
+      return MaterialApp(
+        theme: ThemeData(
+          switchTheme: SwitchThemeData(
+            thumbColor: MaterialStateProperty.all<Color>(globalThemeThumbColor),
+            trackColor: MaterialStateProperty.all<Color>(globalThemeTrackColor),
+          ),
+        ),
+        home: Scaffold(
+          body: SwitchTheme(
+            data: SwitchThemeData(
+              thumbColor: MaterialStateProperty.all<Color>(localThemeThumbColor),
+              trackColor: MaterialStateProperty.all<Color>(localThemeTrackColor),
+            ),
+            child: Switch(
+              value: selected,
+              onChanged: (bool value) {},
+              autofocus: autofocus,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildSwitch(selected: true));
+    await tester.pumpAndSettle();
+    expect(
+      _getSwitchMaterial(tester),
+      paints
+        ..rrect(color: localThemeTrackColor)
+        ..circle()
+        ..circle()
+        ..circle()
+        ..circle(color: localThemeThumbColor),
+    );
+  });
 }
 
 Future<void> _pointGestureToSwitch(WidgetTester tester) async {


### PR DESCRIPTION
Complete details in https://github.com/flutter/flutter/issues/97691#issuecomment-1028954378
Related https://github.com/flutter/flutter/issues/97691

This PR matches

https://github.com/flutter/flutter/blob/6aed693c4c961c6f3c16703ea231d01497812095/packages/flutter/lib/src/material/toggle_buttons.dart#L900-L902

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
