### PR TITLE
Fix custom-device default forwardPortSuccessRegex

### DIFF
--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -736,11 +736,12 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
           '-o', 'ExitOnForwardFailure=yes',
           if (ipv6) '-6',
           '-L', '$formattedLoopbackIp:\${hostPort}:$formattedLoopbackIp:\${devicePort}',
-          sshTarget
+          sshTarget,
+          "echo 'Port forwarding success'; read"
         ]
         : null,
       forwardPortSuccessRegex: usePortForwarding
-        ? RegExp('Linux')
+        ? RegExp('Port forwarding success')
         : null,
 
       screenshotCommand: screenshotCommand.isNotEmpty

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -264,8 +264,9 @@ class CustomDeviceConfig {
       '-o', 'ExitOnForwardFailure=yes',
       '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
       'pi@raspberrypi',
+      "echo 'Port forwarding success'; read",
     ],
-    forwardPortSuccessRegex: RegExp('Linux'),
+    forwardPortSuccessRegex: RegExp('Port forwarding success'),
     screenshotCommand: const <String>[
       'ssh',
       '-o', 'BatchMode=yes',

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -472,7 +472,7 @@ class CustomDeviceConfig {
       _kEnabled: enabled,
       _kPingCommand: pingCommand,
       _kPingSuccessRegex: pingSuccessRegex?.pattern,
-      _kPostBuildCommand: postBuildCommand,
+      _kPostBuildCommand: (postBuildCommand?.length ?? 0) > 0 ? postBuildCommand : null,
       _kInstallCommand: installCommand,
       _kUninstallCommand: uninstallCommand,
       _kRunDebugCommand: runDebugCommand,

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -552,7 +552,6 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
-              postBuildCommand: const <String>[],
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -641,7 +640,6 @@ void main() {
                 '-w', '1',
                 '192.168.178.1'
               ],
-              postBuildCommand: const <String>[],
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -730,7 +728,6 @@ void main() {
                 '-w', '1',
                 '::1'
               ],
-              postBuildCommand: const <String>[],
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -823,7 +820,6 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
-              postBuildCommand: <String>[],
               installCommand: <String>[
                 'scp',
                 '-r',
@@ -903,7 +899,6 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
-              postBuildCommand: const <String>[],
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -1227,7 +1222,6 @@ void main() {
                 'testhostname'
               ],
               pingSuccessRegex: RegExp(r'[<=]\d+ms'),
-              postBuildCommand: const <String>[],
               installCommand: const <String>[
                 'scp',
                 '-r',

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -504,6 +504,440 @@ void main() {
 
     // test add command
     testUsingContext(
+      'custom-devices add command correctly adds ssh device config on linux',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test();
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: 'testhostname',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'y',
+            screenshot: 'testscreenshot',
+            apply: 'y'
+          ),
+          fileSystem: fs,
+          processManager: FakeProcessManager.any(),
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: const <String>[
+                'ping',
+                '-c', '1',
+                '-w', '1',
+                'testhostname'
+              ],
+              postBuildCommand: const <String>[],
+              installCommand: const <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                r'${localPath}',
+                r'testuser@testhostname:/tmp/${appName}'
+              ],
+              uninstallCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testrundebug'
+              ],
+              forwardPortCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes',
+                '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
+                'testuser@testhostname'
+              ],
+              forwardPortSuccessRegex: RegExp('Linux'),
+              screenshotCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testscreenshot'
+              ],
+            )
+          )
+        );
+      }
+    );
+
+    testUsingContext(
+      'custom-devices add command correctly adds ipv4 ssh device config',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test();
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: '192.168.178.1',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'y',
+            screenshot: 'testscreenshot',
+            apply: 'y',
+          ),
+          processManager: FakeProcessManager.any(),
+          fileSystem: fs,
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: const <String>[
+                'ping',
+                '-c', '1',
+                '-w', '1',
+                '192.168.178.1'
+              ],
+              postBuildCommand: const <String>[],
+              installCommand: const <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                r'${localPath}',
+                r'testuser@192.168.178.1:/tmp/${appName}'
+              ],
+              uninstallCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@192.168.178.1',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@192.168.178.1',
+                'testrundebug'
+              ],
+              forwardPortCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes',
+                '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
+                'testuser@192.168.178.1'
+              ],
+              forwardPortSuccessRegex: RegExp('Linux'),
+              screenshotCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@192.168.178.1',
+                'testscreenshot'
+              ]
+            )
+          )
+        );
+      }
+    );
+
+    testUsingContext(
+      'custom-devices add command correctly adds ipv6 ssh device config',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test();
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: '::1',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'y',
+            screenshot: 'testscreenshot',
+            apply: 'y',
+          ),
+          fileSystem: fs,
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: const <String>[
+                'ping',
+                '-6',
+                '-c', '1',
+                '-w', '1',
+                '::1'
+              ],
+              postBuildCommand: const <String>[],
+              installCommand: const <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                '-6',
+                r'${localPath}',
+                r'testuser@[::1]:/tmp/${appName}'
+              ],
+              uninstallCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-6',
+                'testuser@[::1]',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-6',
+                'testuser@[::1]',
+                'testrundebug'
+              ],
+              forwardPortCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes',
+                '-6',
+                '-L', r'[::1]:${hostPort}:[::1]:${devicePort}',
+                'testuser@[::1]'
+              ],
+              forwardPortSuccessRegex: RegExp('Linux'),
+              screenshotCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-6',
+                'testuser@[::1]',
+                'testscreenshot'
+              ]
+            )
+          )
+        );
+      }
+    );
+
+    testUsingContext(
+      'custom-devices add command correctly adds non-forwarding ssh device config',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test();
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: 'testhostname',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'n',
+            screenshot: 'testscreenshot',
+            apply: 'y',
+          ),
+          fileSystem: fs,
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            const CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: <String>[
+                'ping',
+                '-c', '1',
+                '-w', '1',
+                'testhostname'
+              ],
+              postBuildCommand: <String>[],
+              installCommand: <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                r'${localPath}',
+                r'testuser@testhostname:/tmp/${appName}'
+              ],
+              uninstallCommand: <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testrundebug'
+              ],
+              screenshotCommand: <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testscreenshot'
+              ]
+            )
+          )
+        );
+      }
+    );
+
+    testUsingContext(
+      'custom-devices add command correctly adds non-screenshotting ssh device config',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test();
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: 'testhostname',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'y',
+            screenshot: '',
+            apply: 'y',
+          ),
+          fileSystem: fs,
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: const <String>[
+                'ping',
+                '-c', '1',
+                '-w', '1',
+                'testhostname'
+              ],
+              postBuildCommand: const <String>[],
+              installCommand: const <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                r'${localPath}',
+                r'testuser@testhostname:/tmp/${appName}'
+              ],
+              uninstallCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testrundebug'
+              ],
+              forwardPortCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes',
+                '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
+                'testuser@testhostname'
+              ],
+              forwardPortSuccessRegex: RegExp('Linux'),
+            )
+          )
+        );
+      }
+    );
+
+    testUsingContext(
       'custom-devices delete command deletes device and creates backup',
       () async {
         final MemoryFileSystem fs = MemoryFileSystem.test();
@@ -735,6 +1169,102 @@ void main() {
           anyOf(equals(defaultConfigLinux1), equals(defaultConfigLinux2))
         );
       }
+    );
+  });
+
+  group('windows', () {
+    setUp(() {
+      Cache.flutterRoot = windowsFlutterRoot;
+    });
+
+    testUsingContext(
+      'custom-devices add command correctly adds ssh device config on windows',
+      () async {
+        final MemoryFileSystem fs = MemoryFileSystem.test(style: FileSystemStyle.windows);
+
+        final CommandRunner<void> runner = createCustomDevicesCommandRunner(
+          terminal: (Platform platform) => createFakeTerminalForAddingSshDevice(
+            platform: platform,
+            id: 'testid',
+            label: 'testlabel',
+            sdkNameAndVersion: 'testsdknameandversion',
+            enabled: 'y',
+            hostname: 'testhostname',
+            username: 'testuser',
+            runDebug: 'testrundebug',
+            usePortForwarding: 'y',
+            screenshot: 'testscreenshot',
+            apply: 'y',
+          ),
+          fileSystem: fs,
+          platform: windowsPlatform,
+          featureEnabled: true
+        );
+
+        await expectLater(
+          runner.run(const <String>['custom-devices', 'add', '--no-check']),
+          completes
+        );
+
+        final CustomDevicesConfig config = CustomDevicesConfig.test(
+          fileSystem: fs,
+          directory: fs.directory('/'),
+          logger: BufferLogger.test()
+        );
+
+        expect(
+          config.devices,
+          contains(
+            CustomDeviceConfig(
+              id: 'testid',
+              label: 'testlabel',
+              sdkNameAndVersion: 'testsdknameandversion',
+              enabled: true,
+              pingCommand: const <String>[
+                'ping',
+                '-n', '1',
+                '-w', '500',
+                'testhostname'
+              ],
+              pingSuccessRegex: RegExp(r'[<=]\d+ms'),
+              postBuildCommand: const <String>[],
+              installCommand: const <String>[
+                'scp',
+                '-r',
+                '-o', 'BatchMode=yes',
+                r'${localPath}',
+                r'testuser@testhostname:/tmp/${appName}'
+              ],
+              uninstallCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                r'rm -rf "/tmp/${appName}"'
+              ],
+              runDebugCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testrundebug'
+              ],
+              forwardPortCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes',
+                '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
+                'testuser@testhostname'
+              ],
+              forwardPortSuccessRegex: RegExp('Linux'),
+              screenshotCommand: const <String>[
+                'ssh',
+                '-o', 'BatchMode=yes',
+                'testuser@testhostname',
+                'testscreenshot'
+              ]
+            )
+          )
+        );
+      },
     );
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -554,6 +554,7 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -643,6 +644,7 @@ void main() {
                 '-w', '1',
                 '192.168.178.1'
               ],
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -732,6 +734,7 @@ void main() {
                 '-w', '1',
                 '::1'
               ],
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -825,6 +828,7 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: <String>[
                 'scp',
                 '-r',
@@ -904,6 +908,7 @@ void main() {
                 '-w', '1',
                 'testhostname'
               ],
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: const <String>[
                 'scp',
                 '-r',
@@ -1228,6 +1233,7 @@ void main() {
                 'testhostname'
               ],
               pingSuccessRegex: RegExp(r'[<=]\d+ms'),
+              postBuildCommand: null, // ignore: avoid_redundant_argument_values
               installCommand: const <String>[
                 'scp',
                 '-r',

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -82,9 +82,10 @@ const String defaultConfigLinux1 = r'''
         "ExitOnForwardFailure=yes",
         "-L",
         "127.0.0.1:${hostPort}:127.0.0.1:${devicePort}",
-        "pi@raspberrypi"
+        "pi@raspberrypi",
+        "echo 'Port forwarding success'; read"
       ],
-      "forwardPortSuccessRegex": "Linux",
+      "forwardPortSuccessRegex": "Port forwarding success",
       "screenshot": [
         "ssh",
         "-o",
@@ -145,9 +146,10 @@ const String defaultConfigLinux2 = r'''
         "ExitOnForwardFailure=yes",
         "-L",
         "127.0.0.1:${hostPort}:127.0.0.1:${devicePort}",
-        "pi@raspberrypi"
+        "pi@raspberrypi",
+        "echo 'Port forwarding success'; read"
       ],
-      "forwardPortSuccessRegex": "Linux",
+      "forwardPortSuccessRegex": "Port forwarding success",
       "screenshot": [
         "ssh",
         "-o",
@@ -576,9 +578,10 @@ void main() {
                 '-o', 'BatchMode=yes',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
-                'testuser@testhostname'
+                'testuser@testhostname',
+                "echo 'Port forwarding success'; read"
               ],
-              forwardPortSuccessRegex: RegExp('Linux'),
+              forwardPortSuccessRegex: RegExp('Port forwarding success'),
               screenshotCommand: const <String>[
                 'ssh',
                 '-o', 'BatchMode=yes',
@@ -664,9 +667,10 @@ void main() {
                 '-o', 'BatchMode=yes',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
-                'testuser@192.168.178.1'
+                'testuser@192.168.178.1',
+                "echo 'Port forwarding success'; read"
               ],
-              forwardPortSuccessRegex: RegExp('Linux'),
+              forwardPortSuccessRegex: RegExp('Port forwarding success'),
               screenshotCommand: const <String>[
                 'ssh',
                 '-o', 'BatchMode=yes',
@@ -756,9 +760,10 @@ void main() {
                 '-o', 'ExitOnForwardFailure=yes',
                 '-6',
                 '-L', r'[::1]:${hostPort}:[::1]:${devicePort}',
-                'testuser@[::1]'
+                'testuser@[::1]',
+                "echo 'Port forwarding success'; read"
               ],
-              forwardPortSuccessRegex: RegExp('Linux'),
+              forwardPortSuccessRegex: RegExp('Port forwarding success'),
               screenshotCommand: const <String>[
                 'ssh',
                 '-o', 'BatchMode=yes',
@@ -923,9 +928,10 @@ void main() {
                 '-o', 'BatchMode=yes',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
-                'testuser@testhostname'
+                'testuser@testhostname',
+                "echo 'Port forwarding success'; read"
               ],
-              forwardPortSuccessRegex: RegExp('Linux'),
+              forwardPortSuccessRegex: RegExp('Port forwarding success'),
             )
           )
         );
@@ -1246,9 +1252,10 @@ void main() {
                 '-o', 'BatchMode=yes',
                 '-o', 'ExitOnForwardFailure=yes',
                 '-L', r'127.0.0.1:${hostPort}:127.0.0.1:${devicePort}',
-                'testuser@testhostname'
+                'testuser@testhostname',
+                "echo 'Port forwarding success'; read"
               ],
-              forwardPortSuccessRegex: RegExp('Linux'),
+              forwardPortSuccessRegex: RegExp('Port forwarding success'),
               screenshotCommand: const <String>[
                 'ssh',
                 '-o', 'BatchMode=yes',


### PR DESCRIPTION
This PR tries to make port forwarding verification on custom devices more reliable, by not relying on behavior that may change across different systems.

Previously we were looking for `Linux` word in target connection banner. Now we ask the remote to print a fixed string ('Port forwarding success`) and look for this given string to ensure the connection was successful.

Fix #97641 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
