### PR TITLE
Fix text selection toolbar visibility when selection is no longer visible

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -278,7 +278,6 @@ class TextSelectionOverlay {
       'Usually the Navigator created by WidgetsApp provides the overlay. Perhaps your '
       'app content was created above the Navigator with the WidgetsApp builder parameter.',
     );
-    _toolbarController = AnimationController(duration: fadeDuration, vsync: overlay!);
   }
 
   /// The context in which the selection handles should appear.
@@ -358,9 +357,6 @@ class TextSelectionOverlay {
   /// Controls the fade-in and fade-out animations for the toolbar and handles.
   static const Duration fadeDuration = Duration(milliseconds: 150);
 
-  late final AnimationController _toolbarController;
-  Animation<double> get _toolbarOpacity => _toolbarController.view;
-
   /// Retrieve current value.
   @visibleForTesting
   TextEditingValue get value => _value;
@@ -434,7 +430,6 @@ class TextSelectionOverlay {
     assert(_toolbar == null);
     _toolbar = OverlayEntry(builder: _buildToolbar);
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!.insert(_toolbar!);
-    _toolbarController.forward(from: 0.0);
   }
 
   /// Updates the overlay after the selection has changed.
@@ -496,7 +491,6 @@ class TextSelectionOverlay {
   /// To hide the whole overlay, see [hide].
   void hideToolbar() {
     assert(_toolbar != null);
-    _toolbarController.stop();
     _toolbar?.remove();
     _toolbar = null;
   }
@@ -504,7 +498,6 @@ class TextSelectionOverlay {
   /// Final cleanup.
   void dispose() {
     hide();
-    _toolbarController.dispose();
   }
 
   Widget _buildHandle(BuildContext context, _TextSelectionHandlePosition position) {


### PR DESCRIPTION
## Description
This change makes it so that the text selection toolbar hides when the text selection has moved outside of the view.

Android|Cupertino
---|---
![android-toolbar-hide](https://user-images.githubusercontent.com/948037/153061693-fb9476b1-27ad-415c-8749-50ec5f6352e7.gif)|![cupertino-toolbar-hide](https://user-images.githubusercontent.com/948037/153061704-cb07451d-ebfb-4dbe-8263-c68ad8dd2643.gif)


## Related Issues
Fixes #77889

## Tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
