### PR TITLE
Relax android semantics integration test checks

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -168,7 +168,7 @@ void main() {
               AndroidSemanticsAction.click,
             ],
             // We can't predict the a11y focus when the screen changes.
-            ignoredActions: ignoredAccessibilityFocusActions
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
 
@@ -185,12 +185,13 @@ void main() {
             isEditable: true,
             isPassword: false,
             actions: <AndroidSemanticsAction>[
-              AndroidSemanticsAction.clearAccessibilityFocus,
               AndroidSemanticsAction.click,
               AndroidSemanticsAction.copy,
               AndroidSemanticsAction.setSelection,
               AndroidSemanticsAction.setText,
             ],
+            // We can't predict the a11y focus when the screen changes.
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
 
@@ -208,13 +209,14 @@ void main() {
             isEditable: true,
             isPassword: false,
             actions: <AndroidSemanticsAction>[
-              AndroidSemanticsAction.clearAccessibilityFocus,
               AndroidSemanticsAction.click,
               AndroidSemanticsAction.copy,
               AndroidSemanticsAction.setSelection,
               AndroidSemanticsAction.setText,
               AndroidSemanticsAction.previousAtMovementGranularity,
             ],
+            // We can't predict the a11y focus when the screen changes.
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
       }, timeout: Timeout.none);
@@ -234,9 +236,10 @@ void main() {
             isFocused: false,
             isPassword: true,
             actions: <AndroidSemanticsAction>[
-              AndroidSemanticsAction.accessibilityFocus,
               AndroidSemanticsAction.click,
             ],
+            // We can't predict the a11y focus when the screen changes.
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
 
@@ -253,12 +256,13 @@ void main() {
             isEditable: true,
             isPassword: true,
             actions: <AndroidSemanticsAction>[
-              AndroidSemanticsAction.clearAccessibilityFocus,
               AndroidSemanticsAction.click,
               AndroidSemanticsAction.copy,
               AndroidSemanticsAction.setSelection,
               AndroidSemanticsAction.setText,
             ],
+            // We can't predict the a11y focus when the screen changes.
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
 
@@ -276,13 +280,14 @@ void main() {
             isEditable: true,
             isPassword: true,
             actions: <AndroidSemanticsAction>[
-              AndroidSemanticsAction.clearAccessibilityFocus,
               AndroidSemanticsAction.click,
               AndroidSemanticsAction.copy,
               AndroidSemanticsAction.setSelection,
               AndroidSemanticsAction.setText,
               AndroidSemanticsAction.previousAtMovementGranularity,
             ],
+            // We can't predict the a11y focus when the screen changes.
+            ignoredActions: ignoredAccessibilityFocusActions,
           ),
         );
       }, timeout: Timeout.none);


### PR DESCRIPTION
The test is flaked on more places whether it check for accessibility action. Since the android a11y focus system is unpredictable, I relax the test checks on those places.

fixes https://github.com/flutter/flutter/issues/97666

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
