### PR TITLE
use 'dart pub' instead of calling the pub executable directly

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -91,12 +91,12 @@ Future<void> main(List<String> arguments) async {
     pubEnvironment['PUB_CACHE'] = pubCachePath;
   }
 
-  final String pubExecutable = '$flutterRoot/bin/cache/dart-sdk/bin/pub';
+  final String dartExecutable = '$flutterRoot/bin/cache/dart-sdk/bin/dart';
 
   // Run pub.
   ProcessWrapper process = ProcessWrapper(await Process.start(
-    pubExecutable,
-    <String>['get'],
+    dartExecutable,
+    <String>['pub', 'get'],
     workingDirectory: kDocsRoot,
     environment: pubEnvironment,
   ));
@@ -112,6 +112,7 @@ Future<void> main(List<String> arguments) async {
   cleanOutSnippets();
 
   final List<String> dartdocBaseArgs = <String>[
+    'pub',
     'global',
     'run',
     if (args['checked'] as bool) '-c',
@@ -120,8 +121,9 @@ Future<void> main(List<String> arguments) async {
 
   // Verify which version of snippets and dartdoc we're using.
   final ProcessResult snippetsResult = Process.runSync(
-    pubExecutable,
+    dartExecutable,
     <String>[
+      'pub',
       'global',
       'list',
     ],
@@ -216,10 +218,10 @@ Future<void> main(List<String> arguments) async {
   ];
 
   String quote(String arg) => arg.contains(' ') ? "'$arg'" : arg;
-  print('Executing: (cd $kDocsRoot ; $pubExecutable ${dartdocArgs.map<String>(quote).join(' ')})');
+  print('Executing: (cd $kDocsRoot ; $dartExecutable ${dartdocArgs.map<String>(quote).join(' ')})');
 
   process = ProcessWrapper(await Process.start(
-    pubExecutable,
+    dartExecutable,
     dartdocArgs,
     workingDirectory: kDocsRoot,
     environment: pubEnvironment,

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -94,9 +94,9 @@ Future<void> main(List<String> arguments) async {
   final String dartExecutable = '$flutterRoot/bin/cache/dart-sdk/bin/dart';
 
   // Run pub.
-  ProcessWrapper process = ProcessWrapper(await Process.start(
-    dartExecutable,
-    <String>['pub', 'get'],
+  ProcessWrapper process = ProcessWrapper(await runPubProcess(
+    dartBinaryPath: dartExecutable,
+    arguments: <String>['get'],
     workingDirectory: kDocsRoot,
     environment: pubEnvironment,
   ));
@@ -112,7 +112,6 @@ Future<void> main(List<String> arguments) async {
   cleanOutSnippets();
 
   final List<String> dartdocBaseArgs = <String>[
-    'pub',
     'global',
     'run',
     if (args['checked'] as bool) '-c',
@@ -220,9 +219,9 @@ Future<void> main(List<String> arguments) async {
   String quote(String arg) => arg.contains(' ') ? "'$arg'" : arg;
   print('Executing: (cd $kDocsRoot ; $dartExecutable ${dartdocArgs.map<String>(quote).join(' ')})');
 
-  process = ProcessWrapper(await Process.start(
-    dartExecutable,
-    dartdocArgs,
+  process = ProcessWrapper(await runPubProcess(
+    dartBinaryPath: dartExecutable,
+    arguments: dartdocArgs,
     workingDirectory: kDocsRoot,
     environment: pubEnvironment,
   ));
@@ -466,7 +465,6 @@ void putRedirectInOldIndexLocation() {
   File('$kPublishRoot/flutter/index.html').writeAsStringSync(metaTag);
 }
 
-
 void writeSnippetsIndexFile() {
   final Directory snippetsDir = Directory(path.join(kPublishRoot, 'snippets'));
   if (snippetsDir.existsSync()) {
@@ -532,4 +530,19 @@ void printStream(Stream<List<int>> stream, { String prefix = '', List<Pattern> f
       if (!filter.any((Pattern pattern) => line.contains(pattern)))
         print('$prefix$line'.trim());
     });
+}
+
+Future<Process> runPubProcess({
+  required String dartBinaryPath,
+  required List<String> arguments,
+  String? workingDirectory,
+  Map<String, String>? environment,
+  @visibleForTesting
+  ProcessManager processManager = const LocalProcessManager(),
+}) {
+  return processManager.start(
+    <Object>[dartBinaryPath, 'pub', ...arguments],
+    workingDirectory: workingDirectory,
+    environment: environment,
+  );
 }

--- a/dev/tools/test/dartdoc_test.dart
+++ b/dev/tools/test/dartdoc_test.dart
@@ -6,7 +6,7 @@ import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../../../packages/flutter_tools/test/src/fake_process_manager.dart';
-import '../dartdoc.dart' show getBranchName;
+import '../dartdoc.dart' show getBranchName, runPubProcess;
 
 void main() {
   const String branchName = 'stable';
@@ -75,6 +75,24 @@ void main() {
       ),
       branchName,
     );
+    expect(processManager, hasNoRemainingExpectations);
+  });
+
+  test("runPubProcess doesn't use the pub binary", () {
+    final ProcessManager processManager = FakeProcessManager.list(
+      <FakeCommand>[
+        const FakeCommand(
+          command: <String>['dart', 'pub', '--one', '--two'],
+        ),
+      ],
+    );
+
+    runPubProcess(
+      dartBinaryPath: 'dart',
+      arguments: <String>['--one', '--two'],
+      processManager: processManager,
+    );
+
     expect(processManager, hasNoRemainingExpectations);
   });
 }


### PR DESCRIPTION
- use 'dart pub' instead of calling the pub executable directly (bare use of the `pub` executable is being deprecated)

*List which issues are fixed by this PR. You must list at least one issue.*

- this is part of the work towards https://github.com/dart-lang/sdk/issues/46100

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

n/a

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
