### PR TITLE
Dismiss Autocomplete with ESC

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -336,6 +336,8 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       return KeyEventResult.handled;
     } else if (_hidden && _options.isNotEmpty && (event.logicalKey == LogicalKeyboardKey.arrowUp || event.logicalKey == LogicalKeyboardKey.arrowDown)){
       _hidden = false;
+      // This would reset the index when the options are re-shown
+      // _updateHighlight(0);
       _updateOverlay();
       return KeyEventResult.handled;
     }

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -277,7 +277,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   late final Map<Type, Action<Intent>> _actionMap;
   late final _AutocompleteCallbackAction<AutocompletePreviousOptionIntent> _previousOptionAction;
   late final _AutocompleteCallbackAction<AutocompleteNextOptionIntent> _nextOptionAction;
-  late final _AutocompleteCallbackAction<AutocompleteHideOptionsIntent> _hideOptionsAction;
+  late final _AutocompleteCallbackAction<DismissIntent> _hideOptionsAction;
   Iterable<T> _options = Iterable<T>.empty();
   T? _selection;
   bool _userHidOptions = false;
@@ -287,7 +287,6 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
   static const Map<ShortcutActivator, Intent> _shortcuts = <ShortcutActivator, Intent>{
     SingleActivator(LogicalKeyboardKey.arrowUp): AutocompletePreviousOptionIntent(),
     SingleActivator(LogicalKeyboardKey.arrowDown): AutocompleteNextOptionIntent(),
-    SingleActivator(LogicalKeyboardKey.escape): AutocompleteHideOptionsIntent(),
   };
 
   // The OverlayEntry containing the options.
@@ -311,8 +310,8 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       _selection = null;
     }
 
-    // We need to make sure the options are no longer hidden if the content of
-    // the field gets changes (we want to ignore selection changes for this).
+    // Make sure the options are no longer hidden if the content of the field
+    // changes (ignore selection changes).
     if (value.text != _lastFieldText) {
       _userHidOptions = false;
       _lastFieldText = value.text;
@@ -371,7 +370,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     _updateHighlight(_highlightedOptionIndex.value + 1);
   }
 
-  void _hideOptions(AutocompleteHideOptionsIntent intent) {
+  void _hideOptions(DismissIntent intent) {
     if (!_userHidOptions) {
       _userHidOptions = true;
       _updateOverlay();
@@ -466,11 +465,11 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     _focusNode.addListener(_onChangedFocus);
     _previousOptionAction = _AutocompleteCallbackAction<AutocompletePreviousOptionIntent>(onInvoke: _highlightPreviousOption);
     _nextOptionAction = _AutocompleteCallbackAction<AutocompleteNextOptionIntent>(onInvoke: _highlightNextOption);
-    _hideOptionsAction = _AutocompleteCallbackAction<AutocompleteHideOptionsIntent>(onInvoke: _hideOptions);
+    _hideOptionsAction = _AutocompleteCallbackAction<DismissIntent>(onInvoke: _hideOptions);
     _actionMap = <Type, Action<Intent>> {
       AutocompletePreviousOptionIntent: _previousOptionAction,
       AutocompleteNextOptionIntent: _nextOptionAction,
-      AutocompleteHideOptionsIntent: _hideOptionsAction,
+      DismissIntent: _hideOptionsAction,
     };
     SchedulerBinding.instance.addPostFrameCallback((Duration _) {
       _updateOverlay();
@@ -555,12 +554,6 @@ class AutocompletePreviousOptionIntent extends Intent {
 class AutocompleteNextOptionIntent extends Intent {
   /// Creates an instance of AutocompleteNextOptionIntent.
   const AutocompleteNextOptionIntent();
-}
-
-/// An [Intent] to hide the autocomplete options list.
-class AutocompleteHideOptionsIntent extends Intent {
-  /// Creates an instance of AutocompleteHideOptionsIntent.
-  const AutocompleteHideOptionsIntent();
 }
 
 /// An inherited widget used to indicate which autocomplete option should be

--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -334,7 +334,7 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
       _hidden = true;
       _updateOverlay();
       return KeyEventResult.handled;
-    } else if (_hidden && (event.logicalKey == LogicalKeyboardKey.arrowUp || event.logicalKey == LogicalKeyboardKey.arrowDown)){
+    } else if (_hidden && _options.isNotEmpty && (event.logicalKey == LogicalKeyboardKey.arrowUp || event.logicalKey == LogicalKeyboardKey.arrowDown)){
       _hidden = false;
       _updateOverlay();
       return KeyEventResult.handled;


### PR DESCRIPTION
Allows the `Autocomplete` options to be hidden by pressing ESC. As for revealing the options again here's how it should work:
* When the text is edited (but not when moving the caret around or selecting text)
* When the field is re-focused
* When up or down arrows are pressed for navigating autocomplete options

This is mostly based off of [the angular implementation of material autocomplete](https://material.angular.io/components/autocomplete/overview#adding-a-custom-filter) but there are some discrepancies:

* Due to `_selection == null` in
https://github.com/flutter/flutter/blob/fd8d035921574d69a789201f5f707f94971b6edc/packages/flutter/lib/src/widgets/autocomplete.dart#L294
once a selection has been made the autocomplete options will not appear to show the only completed option.
* Options will not be shown on empty input by default (well it's up to `optionsBuilder`).

Another interesting detail is that in the angular material implementation the highlighted selection index gets reset when the options are hidden. This is different from something like the search bar in YouTube, where the highlighted option remains the same when the options are shown again by pressing the up or down arrow. The latter is how it works [in the current version of the PR](https://github.com/flutter/flutter/pull/97790/files#diff-4b6f96f28cfdafbb04b797dab70576f40d7866a6291f2981bc7832b475f22355R339-R340).

<details>
 <summary>Basic autocomplete sample</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const AutocompleteExampleApp());

class AutocompleteExampleApp extends StatelessWidget {
  const AutocompleteExampleApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        appBar: AppBar(
          title: const Text('Autocomplete Basic'),
        ),
        body: const Center(
          child: AutocompleteBasicExample(),
        ),
      ),
    );
  }
}

class AutocompleteBasicExample extends StatelessWidget {
  const AutocompleteBasicExample({Key? key}) : super(key: key);

  static const List<String> _kOptions = <String>[
    'aardvark',
    'bobcat',
    'chameleon',
  ];

  @override
  Widget build(BuildContext context) {
    return Autocomplete<String>(
      optionsBuilder: (TextEditingValue textEditingValue) {
        if (textEditingValue.text == '') {
          return const Iterable<String>.empty();
        }
        return _kOptions.where((String option) {
          return option.contains(textEditingValue.text.toLowerCase());
        });
      },
      onSelected: (String selection) {
        debugPrint('You just selected $selection');
      },
    );
  }
}
```
</details>

Fixes https://github.com/flutter/flutter/issues/84416

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
