### PR TITLE
[framework] inline casts on Element.widget getter to improve web performance

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -916,8 +916,6 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   Element? _contentElement;
   Element? _actionsElement;
 
-  _CupertinoDialogRenderWidget get _typedWidget => super.widget as _CupertinoDialogRenderWidget;
-
   @override
   _RenderCupertinoDialog get renderObject => super.renderObject as _RenderCupertinoDialog;
 
@@ -934,8 +932,9 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _contentElement = updateChild(_contentElement, _typedWidget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, _typedWidget.actionsSection, _AlertDialogSections.actionsSection);
+    final _CupertinoDialogRenderWidget dialogRenderWidget = widget as _CupertinoDialogRenderWidget;
+    _contentElement = updateChild(_contentElement, dialogRenderWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, dialogRenderWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override
@@ -956,8 +955,9 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void update(RenderObjectWidget newWidget) {
     super.update(newWidget);
-    _contentElement = updateChild(_contentElement, _typedWidget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, _typedWidget.actionsSection, _AlertDialogSections.actionsSection);
+    final _CupertinoDialogRenderWidget dialogRenderWidget = widget as _CupertinoDialogRenderWidget;
+    _contentElement = updateChild(_contentElement, dialogRenderWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, dialogRenderWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -917,7 +917,7 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   Element? _actionsElement;
 
   @override
-  _CupertinoDialogRenderWidget get widget => super.widget as _CupertinoDialogRenderWidget;
+  _CupertinoDialogRenderWidget get typedWidget => super.widget as _CupertinoDialogRenderWidget;
 
   @override
   _RenderCupertinoDialog get renderObject => super.renderObject as _RenderCupertinoDialog;
@@ -935,8 +935,8 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _contentElement = updateChild(_contentElement, widget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, widget.actionsSection, _AlertDialogSections.actionsSection);
+    _contentElement = updateChild(_contentElement, typedWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, typedWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override
@@ -957,8 +957,8 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void update(RenderObjectWidget newWidget) {
     super.update(newWidget);
-    _contentElement = updateChild(_contentElement, widget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, widget.actionsSection, _AlertDialogSections.actionsSection);
+    _contentElement = updateChild(_contentElement, typedWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, typedWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -916,8 +916,7 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   Element? _contentElement;
   Element? _actionsElement;
 
-  @override
-  _CupertinoDialogRenderWidget get typedWidget => super.widget as _CupertinoDialogRenderWidget;
+  _CupertinoDialogRenderWidget get _typedWidget => super.widget as _CupertinoDialogRenderWidget;
 
   @override
   _RenderCupertinoDialog get renderObject => super.renderObject as _RenderCupertinoDialog;
@@ -935,8 +934,8 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _contentElement = updateChild(_contentElement, typedWidget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, typedWidget.actionsSection, _AlertDialogSections.actionsSection);
+    _contentElement = updateChild(_contentElement, _typedWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, _typedWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override
@@ -957,8 +956,8 @@ class _CupertinoDialogRenderElement extends RenderObjectElement {
   @override
   void update(RenderObjectWidget newWidget) {
     super.update(newWidget);
-    _contentElement = updateChild(_contentElement, typedWidget.contentSection, _AlertDialogSections.contentSection);
-    _actionsElement = updateChild(_actionsElement, typedWidget.actionsSection, _AlertDialogSections.actionsSection);
+    _contentElement = updateChild(_contentElement, _typedWidget.contentSection, _AlertDialogSections.contentSection);
+    _actionsElement = updateChild(_actionsElement, _typedWidget.actionsSection, _AlertDialogSections.actionsSection);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -274,35 +274,35 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
   TextEditingController? _controller;
 
   TextEditingController? get _effectiveController =>
-      typedWidget.controller ?? _controller;
+      _typedWidget.controller ?? _controller;
 
-  CupertinoTextFormFieldRow get typedWidget =>
+  CupertinoTextFormFieldRow get _typedWidget =>
       super.widget as CupertinoTextFormFieldRow;
 
   @override
   void initState() {
     super.initState();
-    if (typedWidget.controller == null) {
+    if (_typedWidget.controller == null) {
       _controller = TextEditingController(text: widget.initialValue);
     } else {
-      typedWidget.controller!.addListener(_handleControllerChanged);
+      _typedWidget.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(CupertinoTextFormFieldRow oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (typedWidget.controller != oldWidget.controller) {
+    if (_typedWidget.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      typedWidget.controller?.addListener(_handleControllerChanged);
+      _typedWidget.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && typedWidget.controller == null) {
+      if (oldWidget.controller != null && _typedWidget.controller == null) {
         _controller =
             TextEditingController.fromValue(oldWidget.controller!.value);
       }
 
-      if (typedWidget.controller != null) {
-        setValue(typedWidget.controller!.text);
+      if (_typedWidget.controller != null) {
+        setValue(_typedWidget.controller!.text);
         if (oldWidget.controller == null) {
           _controller = null;
         }
@@ -312,7 +312,7 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    typedWidget.controller?.removeListener(_handleControllerChanged);
+    _typedWidget.controller?.removeListener(_handleControllerChanged);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -274,35 +274,35 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
   TextEditingController? _controller;
 
   TextEditingController? get _effectiveController =>
-      _typedWidget.controller ?? _controller;
+      _cupertinoTextFormFieldRow.controller ?? _controller;
 
-  CupertinoTextFormFieldRow get _typedWidget =>
+  CupertinoTextFormFieldRow get _cupertinoTextFormFieldRow =>
       super.widget as CupertinoTextFormFieldRow;
 
   @override
   void initState() {
     super.initState();
-    if (_typedWidget.controller == null) {
+    if (_cupertinoTextFormFieldRow.controller == null) {
       _controller = TextEditingController(text: widget.initialValue);
     } else {
-      _typedWidget.controller!.addListener(_handleControllerChanged);
+      _cupertinoTextFormFieldRow.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(CupertinoTextFormFieldRow oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_typedWidget.controller != oldWidget.controller) {
+    if (_cupertinoTextFormFieldRow.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      _typedWidget.controller?.addListener(_handleControllerChanged);
+      _cupertinoTextFormFieldRow.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && _typedWidget.controller == null) {
+      if (oldWidget.controller != null && _cupertinoTextFormFieldRow.controller == null) {
         _controller =
             TextEditingController.fromValue(oldWidget.controller!.value);
       }
 
-      if (_typedWidget.controller != null) {
-        setValue(_typedWidget.controller!.text);
+      if (_cupertinoTextFormFieldRow.controller != null) {
+        setValue(_cupertinoTextFormFieldRow.controller!.text);
         if (oldWidget.controller == null) {
           _controller = null;
         }
@@ -312,7 +312,7 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    _typedWidget.controller?.removeListener(_handleControllerChanged);
+    _cupertinoTextFormFieldRow.controller?.removeListener(_handleControllerChanged);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/cupertino/text_form_field_row.dart
+++ b/packages/flutter/lib/src/cupertino/text_form_field_row.dart
@@ -274,36 +274,35 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
   TextEditingController? _controller;
 
   TextEditingController? get _effectiveController =>
-      widget.controller ?? _controller;
+      typedWidget.controller ?? _controller;
 
-  @override
-  CupertinoTextFormFieldRow get widget =>
+  CupertinoTextFormFieldRow get typedWidget =>
       super.widget as CupertinoTextFormFieldRow;
 
   @override
   void initState() {
     super.initState();
-    if (widget.controller == null) {
+    if (typedWidget.controller == null) {
       _controller = TextEditingController(text: widget.initialValue);
     } else {
-      widget.controller!.addListener(_handleControllerChanged);
+      typedWidget.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(CupertinoTextFormFieldRow oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.controller != oldWidget.controller) {
+    if (typedWidget.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      widget.controller?.addListener(_handleControllerChanged);
+      typedWidget.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && widget.controller == null) {
+      if (oldWidget.controller != null && typedWidget.controller == null) {
         _controller =
             TextEditingController.fromValue(oldWidget.controller!.value);
       }
 
-      if (widget.controller != null) {
-        setValue(widget.controller!.text);
+      if (typedWidget.controller != null) {
+        setValue(typedWidget.controller!.text);
         if (oldWidget.controller == null) {
           _controller = null;
         }
@@ -313,7 +312,7 @@ class _CupertinoTextFormFieldRowState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    widget.controller?.removeListener(_handleControllerChanged);
+    typedWidget.controller?.removeListener(_handleControllerChanged);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -522,8 +522,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   // repeatedly to remove children.
   final Set<Element> _forgottenChildren = HashSet<Element>();
 
-  @override
-  _CupertinoTextSelectionToolbarItems get typedWidget => super.widget as _CupertinoTextSelectionToolbarItems;
+  _CupertinoTextSelectionToolbarItems get _typedWidget => super.widget as _CupertinoTextSelectionToolbarItems;
 
   @override
   _RenderCupertinoTextSelectionToolbarItems get renderObject => super.renderObject as _RenderCupertinoTextSelectionToolbarItems;
@@ -625,7 +624,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
     // Mount slotted children.
-    final _CupertinoTextSelectionToolbarItems toolbarItems = typedWidget;
+    final _CupertinoTextSelectionToolbarItems toolbarItems = _typedWidget;
     _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
     _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
     _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
@@ -660,7 +659,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     assert(widget == newWidget);
 
     // Update slotted children.
-    final _CupertinoTextSelectionToolbarItems toolbarItems = typedWidget;
+    final _CupertinoTextSelectionToolbarItems toolbarItems = _typedWidget;
     _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
     _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
     _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -522,8 +522,6 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   // repeatedly to remove children.
   final Set<Element> _forgottenChildren = HashSet<Element>();
 
-  _CupertinoTextSelectionToolbarItems get _typedWidget => super.widget as _CupertinoTextSelectionToolbarItems;
-
   @override
   _RenderCupertinoTextSelectionToolbarItems get renderObject => super.renderObject as _RenderCupertinoTextSelectionToolbarItems;
 
@@ -624,7 +622,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
     // Mount slotted children.
-    final _CupertinoTextSelectionToolbarItems toolbarItems = _typedWidget;
+    final _CupertinoTextSelectionToolbarItems toolbarItems = widget as _CupertinoTextSelectionToolbarItems;
     _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
     _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
     _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
@@ -659,7 +657,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     assert(widget == newWidget);
 
     // Update slotted children.
-    final _CupertinoTextSelectionToolbarItems toolbarItems = _typedWidget;
+    final _CupertinoTextSelectionToolbarItems toolbarItems = widget as _CupertinoTextSelectionToolbarItems;
     _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
     _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
     _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -523,7 +523,7 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   final Set<Element> _forgottenChildren = HashSet<Element>();
 
   @override
-  _CupertinoTextSelectionToolbarItems get widget => super.widget as _CupertinoTextSelectionToolbarItems;
+  _CupertinoTextSelectionToolbarItems get typedWidget => super.widget as _CupertinoTextSelectionToolbarItems;
 
   @override
   _RenderCupertinoTextSelectionToolbarItems get renderObject => super.renderObject as _RenderCupertinoTextSelectionToolbarItems;
@@ -625,15 +625,16 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
     // Mount slotted children.
-    _mountChild(widget.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
-    _mountChild(widget.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
-    _mountChild(widget.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
+    final _CupertinoTextSelectionToolbarItems toolbarItems = typedWidget;
+    _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
+    _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
+    _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
 
     // Mount list children.
-    _children = List<Element>.filled(widget.children.length, _NullElement.instance);
+    _children = List<Element>.filled(toolbarItems.children.length, _NullElement.instance);
     Element? previousChild;
     for (int i = 0; i < _children.length; i += 1) {
-      final Element newChild = inflateWidget(widget.children[i], IndexedSlot<Element?>(i, previousChild));
+      final Element newChild = inflateWidget(toolbarItems.children[i], IndexedSlot<Element?>(i, previousChild));
       _children[i] = newChild;
       previousChild = newChild;
     }
@@ -659,12 +660,13 @@ class _CupertinoTextSelectionToolbarItemsElement extends RenderObjectElement {
     assert(widget == newWidget);
 
     // Update slotted children.
-    _mountChild(widget.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
-    _mountChild(widget.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
-    _mountChild(widget.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
+    final _CupertinoTextSelectionToolbarItems toolbarItems = typedWidget;
+    _mountChild(toolbarItems.backButton, _CupertinoTextSelectionToolbarItemsSlot.backButton);
+    _mountChild(toolbarItems.nextButton, _CupertinoTextSelectionToolbarItemsSlot.nextButton);
+    _mountChild(toolbarItems.nextButtonDisabled, _CupertinoTextSelectionToolbarItemsSlot.nextButtonDisabled);
 
     // Update list children.
-    _children = updateChildren(_children, widget.children, forgottenChildren: _forgottenChildren);
+    _children = updateChildren(_children, toolbarItems.children, forgottenChildren: _forgottenChildren);
     _forgottenChildren.clear();
   }
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1666,13 +1666,13 @@ class DropdownButtonFormField<T> extends FormField<T> {
 
 class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
 
-  DropdownButtonFormField<T> get typedWidget => super.widget as DropdownButtonFormField<T>;
+  DropdownButtonFormField<T> get _typedWidget => super.widget as DropdownButtonFormField<T>;
 
   @override
   void didChange(T? value) {
     super.didChange(value);
-    assert(typedWidget.onChanged != null);
-    typedWidget.onChanged!(value);
+    assert(_typedWidget.onChanged != null);
+    _typedWidget.onChanged!(value);
   }
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1665,14 +1665,14 @@ class DropdownButtonFormField<T> extends FormField<T> {
 }
 
 class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
-  @override
-  DropdownButtonFormField<T> get widget => super.widget as DropdownButtonFormField<T>;
+
+  DropdownButtonFormField<T> get typedWidget => super.widget as DropdownButtonFormField<T>;
 
   @override
   void didChange(T? value) {
     super.didChange(value);
-    assert(widget.onChanged != null);
-    widget.onChanged!(value);
+    assert(typedWidget.onChanged != null);
+    typedWidget.onChanged!(value);
   }
 
   @override

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1666,13 +1666,12 @@ class DropdownButtonFormField<T> extends FormField<T> {
 
 class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
 
-  DropdownButtonFormField<T> get _typedWidget => super.widget as DropdownButtonFormField<T>;
-
   @override
   void didChange(T? value) {
     super.didChange(value);
-    assert(_typedWidget.onChanged != null);
-    _typedWidget.onChanged!(value);
+    final DropdownButtonFormField<T> dropdownButtonFormField = widget as DropdownButtonFormField<T>;
+    assert(dropdownButtonFormField.onChanged != null);
+    dropdownButtonFormField.onChanged!(value);
   }
 
   @override

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -266,9 +266,9 @@ class TextFormField extends FormField<String> {
 class _TextFormFieldState extends FormFieldState<String> {
   RestorableTextEditingController? _controller;
 
-  TextEditingController get _effectiveController => typedWidget.controller ?? _controller!.value;
+  TextEditingController get _effectiveController => _typedWidget.controller ?? _controller!.value;
 
-  TextFormField get typedWidget => super.widget as TextFormField;
+  TextFormField get _typedWidget => super.widget as TextFormField;
 
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
@@ -299,26 +299,26 @@ class _TextFormFieldState extends FormFieldState<String> {
   @override
   void initState() {
     super.initState();
-    if (typedWidget.controller == null) {
+    if (_typedWidget.controller == null) {
       _createLocalController(widget.initialValue != null ? TextEditingValue(text: widget.initialValue!) : null);
     } else {
-      typedWidget.controller!.addListener(_handleControllerChanged);
+      _typedWidget.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(TextFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (typedWidget.controller != oldWidget.controller) {
+    if (_typedWidget.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      typedWidget.controller?.addListener(_handleControllerChanged);
+      _typedWidget.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && typedWidget.controller == null) {
+      if (oldWidget.controller != null && _typedWidget.controller == null) {
         _createLocalController(oldWidget.controller!.value);
       }
 
-      if (typedWidget.controller != null) {
-        setValue(typedWidget.controller!.text);
+      if (_typedWidget.controller != null) {
+        setValue(_typedWidget.controller!.text);
         if (oldWidget.controller == null) {
           unregisterFromRestoration(_controller!);
           _controller!.dispose();
@@ -330,7 +330,7 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    typedWidget.controller?.removeListener(_handleControllerChanged);
+    _typedWidget.controller?.removeListener(_handleControllerChanged);
     _controller?.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -266,9 +266,9 @@ class TextFormField extends FormField<String> {
 class _TextFormFieldState extends FormFieldState<String> {
   RestorableTextEditingController? _controller;
 
-  TextEditingController get _effectiveController => _typedWidget.controller ?? _controller!.value;
+  TextEditingController get _effectiveController => _textFormField.controller ?? _controller!.value;
 
-  TextFormField get _typedWidget => super.widget as TextFormField;
+  TextFormField get _textFormField => super.widget as TextFormField;
 
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
@@ -299,26 +299,26 @@ class _TextFormFieldState extends FormFieldState<String> {
   @override
   void initState() {
     super.initState();
-    if (_typedWidget.controller == null) {
+    if (_textFormField.controller == null) {
       _createLocalController(widget.initialValue != null ? TextEditingValue(text: widget.initialValue!) : null);
     } else {
-      _typedWidget.controller!.addListener(_handleControllerChanged);
+      _textFormField.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(TextFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (_typedWidget.controller != oldWidget.controller) {
+    if (_textFormField.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      _typedWidget.controller?.addListener(_handleControllerChanged);
+      _textFormField.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && _typedWidget.controller == null) {
+      if (oldWidget.controller != null && _textFormField.controller == null) {
         _createLocalController(oldWidget.controller!.value);
       }
 
-      if (_typedWidget.controller != null) {
-        setValue(_typedWidget.controller!.text);
+      if (_textFormField.controller != null) {
+        setValue(_textFormField.controller!.text);
         if (oldWidget.controller == null) {
           unregisterFromRestoration(_controller!);
           _controller!.dispose();
@@ -330,7 +330,7 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    _typedWidget.controller?.removeListener(_handleControllerChanged);
+    _textFormField.controller?.removeListener(_handleControllerChanged);
     _controller?.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -266,10 +266,9 @@ class TextFormField extends FormField<String> {
 class _TextFormFieldState extends FormFieldState<String> {
   RestorableTextEditingController? _controller;
 
-  TextEditingController get _effectiveController => widget.controller ?? _controller!.value;
+  TextEditingController get _effectiveController => typedWidget.controller ?? _controller!.value;
 
-  @override
-  TextFormField get widget => super.widget as TextFormField;
+  TextFormField get typedWidget => super.widget as TextFormField;
 
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
@@ -300,26 +299,26 @@ class _TextFormFieldState extends FormFieldState<String> {
   @override
   void initState() {
     super.initState();
-    if (widget.controller == null) {
+    if (typedWidget.controller == null) {
       _createLocalController(widget.initialValue != null ? TextEditingValue(text: widget.initialValue!) : null);
     } else {
-      widget.controller!.addListener(_handleControllerChanged);
+      typedWidget.controller!.addListener(_handleControllerChanged);
     }
   }
 
   @override
   void didUpdateWidget(TextFormField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.controller != oldWidget.controller) {
+    if (typedWidget.controller != oldWidget.controller) {
       oldWidget.controller?.removeListener(_handleControllerChanged);
-      widget.controller?.addListener(_handleControllerChanged);
+      typedWidget.controller?.addListener(_handleControllerChanged);
 
-      if (oldWidget.controller != null && widget.controller == null) {
+      if (oldWidget.controller != null && typedWidget.controller == null) {
         _createLocalController(oldWidget.controller!.value);
       }
 
-      if (widget.controller != null) {
-        setValue(widget.controller!.text);
+      if (typedWidget.controller != null) {
+        setValue(typedWidget.controller!.text);
         if (oldWidget.controller == null) {
           unregisterFromRestoration(_controller!);
           _controller!.dispose();
@@ -331,7 +330,7 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   @override
   void dispose() {
-    widget.controller?.removeListener(_handleControllerChanged);
+    typedWidget.controller?.removeListener(_handleControllerChanged);
     _controller?.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3131,12 +3131,11 @@ class Offstage extends SingleChildRenderObjectWidget {
 class _OffstageElement extends SingleChildRenderObjectElement {
   _OffstageElement(Offstage widget) : super(widget);
 
-  @override
-  Offstage get typedWidget => super.widget as Offstage;
+  Offstage get _typedWidget => super.widget as Offstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!typedWidget.offstage)
+    if (!_typedWidget.offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3132,11 +3132,11 @@ class _OffstageElement extends SingleChildRenderObjectElement {
   _OffstageElement(Offstage widget) : super(widget);
 
   @override
-  Offstage get widget => super.widget as Offstage;
+  Offstage get typedWidget => super.widget as Offstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!widget.offstage)
+    if (!typedWidget.offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3131,11 +3131,9 @@ class Offstage extends SingleChildRenderObjectWidget {
 class _OffstageElement extends SingleChildRenderObjectElement {
   _OffstageElement(Offstage widget) : super(widget);
 
-  Offstage get _typedWidget => super.widget as Offstage;
-
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!_typedWidget.offstage)
+    if (!(widget as Offstage).offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1139,7 +1139,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   RenderObjectToWidgetElement(RenderObjectToWidgetAdapter<T> widget) : super(widget);
 
   @override
-  RenderObjectToWidgetAdapter<T> get widget => super.widget as RenderObjectToWidgetAdapter<T>;
+  RenderObjectToWidgetAdapter<T> get typedWidget => super.widget as RenderObjectToWidgetAdapter<T>;
 
   Element? _child;
 
@@ -1193,7 +1193,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   @pragma('vm:notify-debugger-on-exception')
   void _rebuild() {
     try {
-      _child = updateChild(_child, widget.child, _rootChildSlot);
+      _child = updateChild(_child, typedWidget.child, _rootChildSlot);
     } catch (exception, stack) {
       final FlutterErrorDetails details = FlutterErrorDetails(
         exception: exception,

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1138,8 +1138,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   /// the render tree, call [RenderObjectToWidgetAdapter.attachToRenderTree].
   RenderObjectToWidgetElement(RenderObjectToWidgetAdapter<T> widget) : super(widget);
 
-  @override
-  RenderObjectToWidgetAdapter<T> get typedWidget => super.widget as RenderObjectToWidgetAdapter<T>;
+  RenderObjectToWidgetAdapter<T> get _typedWidget => super.widget as RenderObjectToWidgetAdapter<T>;
 
   Element? _child;
 
@@ -1193,7 +1192,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   @pragma('vm:notify-debugger-on-exception')
   void _rebuild() {
     try {
-      _child = updateChild(_child, typedWidget.child, _rootChildSlot);
+      _child = updateChild(_child, _typedWidget.child, _rootChildSlot);
     } catch (exception, stack) {
       final FlutterErrorDetails details = FlutterErrorDetails(
         exception: exception,

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -1138,8 +1138,6 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   /// the render tree, call [RenderObjectToWidgetAdapter.attachToRenderTree].
   RenderObjectToWidgetElement(RenderObjectToWidgetAdapter<T> widget) : super(widget);
 
-  RenderObjectToWidgetAdapter<T> get _typedWidget => super.widget as RenderObjectToWidgetAdapter<T>;
-
   Element? _child;
 
   static const Object _rootChildSlot = Object();
@@ -1192,7 +1190,7 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RootRenderObje
   @pragma('vm:notify-debugger-on-exception')
   void _rebuild() {
     try {
-      _child = updateChild(_child, _typedWidget.child, _rootChildSlot);
+      _child = updateChild(_child, (widget as RenderObjectToWidgetAdapter<T>).child, _rootChildSlot);
     } catch (exception, stack) {
       final FlutterErrorDetails details = FlutterErrorDetails(
         exception: exception,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4359,7 +4359,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// A short, textual description of this element.
   @override
-  String toStringShort() =>_widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
+  String toStringShort() => _widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
 
   @override
   DiagnosticsNode toDiagnosticsNode({ String? name, DiagnosticsTreeStyle? style }) {
@@ -4377,7 +4377,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (_lifecycleState != _ElementLifecycle.initial) {
       properties.add(ObjectFlagProperty<int>('depth', depth, ifNull: 'no depth'));
     }
-    properties.add(ObjectFlagProperty<Widget>('widget',_widget, ifNull: 'no widget'));
+    properties.add(ObjectFlagProperty<Widget>('widget', _widget, ifNull: 'no widget'));
     properties.add(DiagnosticsProperty<Key>('key', _widget?.key, showName: false, defaultValue: null, level: DiagnosticLevel.hidden));
     _widget?.debugFillProperties(properties);
     properties.add(FlagProperty('dirty', value: dirty, ifTrue: 'dirty'));

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5570,8 +5570,7 @@ abstract class RenderObjectElement extends Element {
   /// Creates an element that uses the given widget as its configuration.
   RenderObjectElement(RenderObjectWidget widget) : super(widget);
 
-  /// A typed override of [Element.widget].
-  RenderObjectWidget get typedWidget => super.widget as RenderObjectWidget;
+  RenderObjectWidget get _typedWidget => super.widget as RenderObjectWidget;
 
   /// The underlying [RenderObject] for this element.
   ///
@@ -5650,7 +5649,7 @@ abstract class RenderObjectElement extends Element {
       _debugDoingBuild = true;
       return true;
     }());
-    _renderObject = typedWidget.createRenderObject(this);
+    _renderObject = _typedWidget.createRenderObject(this);
     assert(!_renderObject!.debugDisposed!);
     assert(() {
       _debugDoingBuild = false;
@@ -5694,7 +5693,7 @@ abstract class RenderObjectElement extends Element {
       _debugDoingBuild = true;
       return true;
     }());
-    typedWidget.updateRenderObject(this, renderObject);
+    _typedWidget.updateRenderObject(this, renderObject);
     assert(() {
       _debugDoingBuild = false;
       return true;
@@ -5930,7 +5929,7 @@ abstract class RenderObjectElement extends Element {
       'A RenderObject was disposed prior to its owning element being unmounted: '
       '$renderObject',
     );
-    final RenderObjectWidget oldWidget = typedWidget;
+    final RenderObjectWidget oldWidget = _typedWidget;
     super.unmount();
     assert(
       !renderObject.attached,
@@ -5952,7 +5951,7 @@ abstract class RenderObjectElement extends Element {
             ErrorSummary('Incorrect use of ParentDataWidget.'),
             ...parentDataWidget._debugDescribeIncorrectParentDataType(
               parentData: renderObject.parentData,
-              parentDataCreator: _ancestorRenderObjectElement!.typedWidget,
+              parentDataCreator: _ancestorRenderObjectElement!._typedWidget,
               ownershipChain: ErrorDescription(debugGetCreatorChain(10)),
             ),
           ]);
@@ -6289,6 +6288,7 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
   SingleChildRenderObjectElement(SingleChildRenderObjectWidget widget) : super(widget);
 
+  @override
   SingleChildRenderObjectWidget get _typedWidget => super.widget as SingleChildRenderObjectWidget;
 
   Element? _child;
@@ -6362,6 +6362,7 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
     : assert(!debugChildrenHaveDuplicateKeys(widget, widget.children)),
       super(widget);
 
+  @override
   MultiChildRenderObjectWidget get _typedWidget => super.widget as MultiChildRenderObjectWidget;
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3232,6 +3232,13 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   }
 
   /// The configuration for this element.
+  ///
+  /// Avoid overriding this field on [Element] subtypes to provide a more
+  /// specific widget type (i.e. [StatelessElement] and [StatelessWidget]).
+  /// Instead, cast at any callsites where the more specific type is required.
+  /// This avoids significant cast overhead on the getter which is accessed
+  /// throughout the framework internals during the build phase - and for which
+  /// the more specific type information is not used.
   @override
   Widget get widget => _widget!;
   Widget? _widget;
@@ -4359,7 +4366,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// A short, textual description of this element.
   @override
-  String toStringShort() =>_widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
+  String toStringShort() => _widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
 
   @override
   DiagnosticsNode toDiagnosticsNode({ String? name, DiagnosticsTreeStyle? style }) {
@@ -4377,7 +4384,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (_lifecycleState != _ElementLifecycle.initial) {
       properties.add(ObjectFlagProperty<int>('depth', depth, ifNull: 'no depth'));
     }
-    properties.add(ObjectFlagProperty<Widget>('widget',_widget, ifNull: 'no widget'));
+    properties.add(ObjectFlagProperty<Widget>('widget', _widget, ifNull: 'no widget'));
     properties.add(DiagnosticsProperty<Key>('key', _widget?.key, showName: false, defaultValue: null, level: DiagnosticLevel.hidden));
     _widget?.debugFillProperties(properties);
     properties.add(FlagProperty('dirty', value: dirty, ifTrue: 'dirty'));
@@ -5424,9 +5431,7 @@ class InheritedElement extends ProxyElement {
 /// intermediaries between their [widget] and their [renderObject]. It is
 /// generally recommended against specializing the [widget] getter and
 /// instead casting at the various callsites to avoid adding overhead
-/// outside of this particular implementation. If the [widget] getter
-/// is widely used, a separte getter that specializes the Widget type
-/// should be used instead.
+/// outside of this particular implementation.
 ///
 /// ```dart
 /// class FooElement extends RenderObjectElement {
@@ -5437,8 +5442,6 @@ class InheritedElement extends ProxyElement {
 ///   void _foo() {
 ///     final Foo foo = widget as Foo;
 ///   }
-///
-///   Foo get fooWidget => widget as Foo;
 ///   // ...
 /// }
 /// ```

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4208,7 +4208,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     _dependencies ??= HashSet<InheritedElement>();
     _dependencies!.add(ancestor);
     ancestor.updateDependencies(this, aspect);
-    return ancestor._typedWidget;
+    return ancestor.widget as InheritedWidget;
   }
 
   @override
@@ -4854,10 +4854,8 @@ class StatelessElement extends ComponentElement {
   /// Creates an element that uses the given widget as its configuration.
   StatelessElement(StatelessWidget widget) : super(widget);
 
-  StatelessWidget get _typedWidget => super.widget as StatelessWidget;
-
   @override
-  Widget build() => _typedWidget.build(this);
+  Widget build() => (widget as StatelessWidget).build(this);
 
   @override
   void update(StatelessWidget newWidget) {
@@ -5123,15 +5121,12 @@ abstract class ProxyElement extends ComponentElement {
   /// Initializes fields for subclasses.
   ProxyElement(ProxyWidget widget) : super(widget);
 
-  /// A typed override of [Element.widget].
-  ProxyWidget get _typedWidget => super.widget as ProxyWidget;
-
   @override
-  Widget build() => _typedWidget.child;
+  Widget build() => (widget as ProxyWidget).child;
 
   @override
   void update(ProxyWidget newWidget) {
-    final ProxyWidget oldWidget = _typedWidget;
+    final ProxyWidget oldWidget = widget as ProxyWidget;
     assert(widget != null);
     assert(widget != newWidget);
     super.update(newWidget);
@@ -5164,9 +5159,6 @@ abstract class ProxyElement extends ComponentElement {
 class ParentDataElement<T extends ParentData> extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   ParentDataElement(ParentDataWidget<T> widget) : super(widget);
-
-  @override
-  ParentDataWidget<T> get _typedWidget => super.widget as ParentDataWidget<T>;
 
   void _applyParentData(ParentDataWidget<T> widget) {
     void applyParentDataToChild(Element child) {
@@ -5215,13 +5207,13 @@ class ParentDataElement<T extends ParentData> extends ProxyElement {
   void applyWidgetOutOfTurn(ParentDataWidget<T> newWidget) {
     assert(newWidget != null);
     assert(newWidget.debugCanApplyOutOfTurn());
-    assert(newWidget.child == _typedWidget.child);
+    assert(newWidget.child == (widget as ParentDataWidget<T>).child);
     _applyParentData(newWidget);
   }
 
   @override
   void notifyClients(ParentDataWidget<T> oldWidget) {
-    _applyParentData(_typedWidget);
+    _applyParentData(widget as ParentDataWidget<T>);
   }
 }
 
@@ -5229,9 +5221,6 @@ class ParentDataElement<T extends ParentData> extends ProxyElement {
 class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget widget) : super(widget);
-
-  @override
-  InheritedWidget get _typedWidget => super.widget as InheritedWidget;
 
   final Map<Element, Object?> _dependents = HashMap<Element, Object?>();
 
@@ -5363,7 +5352,7 @@ class InheritedElement extends ProxyElement {
   /// Calls [notifyClients] to actually trigger the notifications.
   @override
   void updated(InheritedWidget oldWidget) {
-    if (_typedWidget.updateShouldNotify(oldWidget))
+    if ((widget as InheritedWidget).updateShouldNotify(oldWidget))
       super.updated(oldWidget);
   }
 
@@ -5570,8 +5559,6 @@ abstract class RenderObjectElement extends Element {
   /// Creates an element that uses the given widget as its configuration.
   RenderObjectElement(RenderObjectWidget widget) : super(widget);
 
-  RenderObjectWidget get _typedWidget => super.widget as RenderObjectWidget;
-
   /// The underlying [RenderObject] for this element.
   ///
   /// If this element has been [unmount]ed, this getter will throw.
@@ -5628,7 +5615,7 @@ abstract class RenderObjectElement extends Element {
             ErrorSummary('Incorrect use of ParentDataWidget.'),
             ErrorDescription('The following ParentDataWidgets are providing parent data to the same RenderObject:'),
             for (final ParentDataElement<ParentData> ancestor in badAncestors)
-              ErrorDescription('- ${ancestor.widget} (typically placed directly inside a ${ancestor._typedWidget.debugTypicalAncestorWidgetClass} widget)'),
+              ErrorDescription('- ${ancestor.widget} (typically placed directly inside a ${(widget as ParentDataWidget<ParentData>).debugTypicalAncestorWidgetClass} widget)'),
             ErrorDescription('However, a RenderObject can only receive parent data from at most one ParentDataWidget.'),
             ErrorHint('Usually, this indicates that at least one of the offending ParentDataWidgets listed above is not placed directly inside a compatible ancestor widget.'),
             ErrorDescription('The ownership chain for the RenderObject that received the parent data was:\n  ${debugGetCreatorChain(10)}'),
@@ -5649,7 +5636,7 @@ abstract class RenderObjectElement extends Element {
       _debugDoingBuild = true;
       return true;
     }());
-    _renderObject = _typedWidget.createRenderObject(this);
+    _renderObject = (widget as RenderObjectWidget).createRenderObject(this);
     assert(!_renderObject!.debugDisposed!);
     assert(() {
       _debugDoingBuild = false;
@@ -5693,7 +5680,7 @@ abstract class RenderObjectElement extends Element {
       _debugDoingBuild = true;
       return true;
     }());
-    _typedWidget.updateRenderObject(this, renderObject);
+    (widget as RenderObjectWidget).updateRenderObject(this, renderObject);
     assert(() {
       _debugDoingBuild = false;
       return true;
@@ -5929,7 +5916,7 @@ abstract class RenderObjectElement extends Element {
       'A RenderObject was disposed prior to its owning element being unmounted: '
       '$renderObject',
     );
-    final RenderObjectWidget oldWidget = _typedWidget;
+    final RenderObjectWidget oldWidget = widget as RenderObjectWidget;
     super.unmount();
     assert(
       !renderObject.attached,
@@ -5951,7 +5938,7 @@ abstract class RenderObjectElement extends Element {
             ErrorSummary('Incorrect use of ParentDataWidget.'),
             ...parentDataWidget._debugDescribeIncorrectParentDataType(
               parentData: renderObject.parentData,
-              parentDataCreator: _ancestorRenderObjectElement!._typedWidget,
+              parentDataCreator: _ancestorRenderObjectElement!.widget as RenderObjectWidget,
               ownershipChain: ErrorDescription(debugGetCreatorChain(10)),
             ),
           ]);
@@ -5986,7 +5973,7 @@ abstract class RenderObjectElement extends Element {
     _ancestorRenderObjectElement?.insertRenderObjectChild(renderObject, newSlot);
     final ParentDataElement<ParentData>? parentDataElement = _findAncestorParentDataElement();
     if (parentDataElement != null)
-      _updateParentData(parentDataElement._typedWidget);
+      _updateParentData(widget as ParentDataWidget<ParentData>);
   }
 
   @override
@@ -6288,9 +6275,6 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
   /// Creates an element that uses the given widget as its configuration.
   SingleChildRenderObjectElement(SingleChildRenderObjectWidget widget) : super(widget);
 
-  @override
-  SingleChildRenderObjectWidget get _typedWidget => super.widget as SingleChildRenderObjectWidget;
-
   Element? _child;
 
   @override
@@ -6309,14 +6293,14 @@ class SingleChildRenderObjectElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _child = updateChild(_child, _typedWidget.child, null);
+    _child = updateChild(_child, (widget as SingleChildRenderObjectWidget).child, null);
   }
 
   @override
   void update(SingleChildRenderObjectWidget newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _child = updateChild(_child, _typedWidget.child, null);
+    _child = updateChild(_child, (widget as SingleChildRenderObjectWidget).child, null);
   }
 
   @override
@@ -6361,9 +6345,6 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
   MultiChildRenderObjectElement(MultiChildRenderObjectWidget widget)
     : assert(!debugChildrenHaveDuplicateKeys(widget, widget.children)),
       super(widget);
-
-  @override
-  MultiChildRenderObjectWidget get _typedWidget => super.widget as MultiChildRenderObjectWidget;
 
   @override
   ContainerRenderObjectMixin<RenderObject, ContainerParentDataMixin<RenderObject>> get renderObject {
@@ -6455,10 +6436,11 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    final List<Element> children = List<Element>.filled(_typedWidget.children.length, _NullElement.instance);
+    final MultiChildRenderObjectWidget multiChildRenderObjectWidget = widget as MultiChildRenderObjectWidget;
+    final List<Element> children = List<Element>.filled(multiChildRenderObjectWidget.children.length, _NullElement.instance);
     Element? previousChild;
     for (int i = 0; i < children.length; i += 1) {
-      final Element newChild = inflateWidget(_typedWidget.children[i], IndexedSlot<Element?>(i, previousChild));
+      final Element newChild = inflateWidget(multiChildRenderObjectWidget.children[i], IndexedSlot<Element?>(i, previousChild));
       children[i] = newChild;
       previousChild = newChild;
     }
@@ -6468,9 +6450,10 @@ class MultiChildRenderObjectElement extends RenderObjectElement {
   @override
   void update(MultiChildRenderObjectWidget newWidget) {
     super.update(newWidget);
+    final MultiChildRenderObjectWidget multiChildRenderObjectWidget = widget as MultiChildRenderObjectWidget;
     assert(widget == newWidget);
-    assert(!debugChildrenHaveDuplicateKeys(widget, _typedWidget.children));
-    _children = updateChildren(_children, _typedWidget.children, forgottenChildren: _forgottenChildren);
+    assert(!debugChildrenHaveDuplicateKeys(widget, multiChildRenderObjectWidget.children));
+    _children = updateChildren(_children, multiChildRenderObjectWidget.children, forgottenChildren: _forgottenChildren);
     _forgottenChildren.clear();
   }
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4359,7 +4359,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
   /// A short, textual description of this element.
   @override
-  String toStringShort() => _widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
+  String toStringShort() =>_widget?.toStringShort() ?? '${describeIdentity(this)}(DEFUNCT)';
 
   @override
   DiagnosticsNode toDiagnosticsNode({ String? name, DiagnosticsTreeStyle? style }) {
@@ -4377,7 +4377,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (_lifecycleState != _ElementLifecycle.initial) {
       properties.add(ObjectFlagProperty<int>('depth', depth, ifNull: 'no depth'));
     }
-    properties.add(ObjectFlagProperty<Widget>('widget', _widget, ifNull: 'no widget'));
+    properties.add(ObjectFlagProperty<Widget>('widget',_widget, ifNull: 'no widget'));
     properties.add(DiagnosticsProperty<Key>('key', _widget?.key, showName: false, defaultValue: null, level: DiagnosticLevel.hidden));
     _widget?.debugFillProperties(properties);
     properties.add(FlagProperty('dirty', value: dirty, ifTrue: 'dirty'));
@@ -5421,19 +5421,24 @@ class InheritedElement extends ProxyElement {
 /// ### Specializing the getters
 ///
 /// [RenderObjectElement] objects spend much of their time acting as
-/// intermediaries between their [widget] and their [renderObject]. To make this
-/// more tractable, most [RenderObjectElement] subclasses override these getters
-/// so that they return the specific type that the element expects, e.g.:
+/// intermediaries between their [widget] and their [renderObject]. It is
+/// generally recommended against specializing the [widget] getter and
+/// instead casting at the various callsites to avoid adding overhead
+/// outside of this particular implementation. If the [widget] getter
+/// is widely used, a separte getter that specializes the Widget type
+/// should be used instead.
 ///
 /// ```dart
 /// class FooElement extends RenderObjectElement {
 ///
 ///   @override
-///   Foo get widget => super.widget as Foo;
-///
-///   @override
 ///   RenderFoo get renderObject => super.renderObject as RenderFoo;
 ///
+///   void _foo() {
+///     final Foo foo = widget as Foo;
+///   }
+///
+///   Foo get fooWidget => widget as Foo;
 ///   // ...
 /// }
 /// ```
@@ -5615,7 +5620,7 @@ abstract class RenderObjectElement extends Element {
             ErrorSummary('Incorrect use of ParentDataWidget.'),
             ErrorDescription('The following ParentDataWidgets are providing parent data to the same RenderObject:'),
             for (final ParentDataElement<ParentData> ancestor in badAncestors)
-              ErrorDescription('- ${ancestor.widget} (typically placed directly inside a ${(widget as ParentDataWidget<ParentData>).debugTypicalAncestorWidgetClass} widget)'),
+              ErrorDescription('- ${ancestor.widget} (typically placed directly inside a ${(ancestor.widget as ParentDataWidget<ParentData>).debugTypicalAncestorWidgetClass} widget)'),
             ErrorDescription('However, a RenderObject can only receive parent data from at most one ParentDataWidget.'),
             ErrorHint('Usually, this indicates that at least one of the offending ParentDataWidgets listed above is not placed directly inside a compatible ancestor widget.'),
             ErrorDescription('The ownership chain for the RenderObject that received the parent data was:\n  ${debugGetCreatorChain(10)}'),
@@ -5973,7 +5978,7 @@ abstract class RenderObjectElement extends Element {
     _ancestorRenderObjectElement?.insertRenderObjectChild(renderObject, newSlot);
     final ParentDataElement<ParentData>? parentDataElement = _findAncestorParentDataElement();
     if (parentDataElement != null)
-      _updateParentData(widget as ParentDataWidget<ParentData>);
+      _updateParentData(parentDataElement.widget as ParentDataWidget<ParentData>);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4027,7 +4027,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     }
     // Release resources to reduce the severity of memory leaks caused by
     // defunct, but accidentally retained Elements.
-    _widget = const _NullWidget();
+    _widget = null;
     _dependencies = null;
     _lifecycleState = _ElementLifecycle.defunct;
   }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -185,7 +185,7 @@ class InheritedModelElement<T> extends InheritedElement {
   InheritedModelElement(InheritedModel<T> widget) : super(widget);
 
   @override
-  InheritedModel<T> get widget => super.widget as InheritedModel<T>;
+  InheritedModel<T> get typedWidget => super.widget as InheritedModel<T>;
 
   @override
   void updateDependencies(Element dependent, Object? aspect) {
@@ -206,7 +206,7 @@ class InheritedModelElement<T> extends InheritedElement {
     final Set<T>? dependencies = getDependencies(dependent) as Set<T>?;
     if (dependencies == null)
       return;
-    if (dependencies.isEmpty || widget.updateShouldNotifyDependent(oldWidget, dependencies))
+    if (dependencies.isEmpty || typedWidget.updateShouldNotifyDependent(oldWidget, dependencies))
       dependent.didChangeDependencies();
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -184,8 +184,7 @@ class InheritedModelElement<T> extends InheritedElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedModelElement(InheritedModel<T> widget) : super(widget);
 
-  @override
-  InheritedModel<T> get typedWidget => super.widget as InheritedModel<T>;
+  InheritedModel<T> get _typedWidget => super.widget as InheritedModel<T>;
 
   @override
   void updateDependencies(Element dependent, Object? aspect) {
@@ -206,7 +205,7 @@ class InheritedModelElement<T> extends InheritedElement {
     final Set<T>? dependencies = getDependencies(dependent) as Set<T>?;
     if (dependencies == null)
       return;
-    if (dependencies.isEmpty || typedWidget.updateShouldNotifyDependent(oldWidget, dependencies))
+    if (dependencies.isEmpty || _typedWidget.updateShouldNotifyDependent(oldWidget, dependencies))
       dependent.didChangeDependencies();
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_model.dart
+++ b/packages/flutter/lib/src/widgets/inherited_model.dart
@@ -184,8 +184,6 @@ class InheritedModelElement<T> extends InheritedElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedModelElement(InheritedModel<T> widget) : super(widget);
 
-  InheritedModel<T> get _typedWidget => super.widget as InheritedModel<T>;
-
   @override
   void updateDependencies(Element dependent, Object? aspect) {
     final Set<T>? dependencies = getDependencies(dependent) as Set<T>?;
@@ -205,7 +203,7 @@ class InheritedModelElement<T> extends InheritedElement {
     final Set<T>? dependencies = getDependencies(dependent) as Set<T>?;
     if (dependencies == null)
       return;
-    if (dependencies.isEmpty || _typedWidget.updateShouldNotifyDependent(oldWidget, dependencies))
+    if (dependencies.isEmpty || (widget as InheritedModel<T>).updateShouldNotifyDependent(oldWidget, dependencies))
       dependent.didChangeDependencies();
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -95,14 +95,13 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
     widget.notifier?.addListener(_handleUpdate);
   }
 
-  @override
-  InheritedNotifier<T> get typedWidget => super.widget as InheritedNotifier<T>;
+  InheritedNotifier<T> get _typedWidget => super.widget as InheritedNotifier<T>;
 
   bool _dirty = false;
 
   @override
   void update(InheritedNotifier<T> newWidget) {
-    final T? oldNotifier = typedWidget.notifier;
+    final T? oldNotifier = _typedWidget.notifier;
     final T? newNotifier = newWidget.notifier;
     if (oldNotifier != newNotifier) {
       oldNotifier?.removeListener(_handleUpdate);
@@ -114,7 +113,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
   @override
   Widget build() {
     if (_dirty)
-      notifyClients(typedWidget);
+      notifyClients(_typedWidget);
     return super.build();
   }
 
@@ -131,7 +130,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
 
   @override
   void unmount() {
-    typedWidget.notifier?.removeListener(_handleUpdate);
+    _typedWidget.notifier?.removeListener(_handleUpdate);
     super.unmount();
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -96,13 +96,13 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
   }
 
   @override
-  InheritedNotifier<T> get widget => super.widget as InheritedNotifier<T>;
+  InheritedNotifier<T> get typedWidget => super.widget as InheritedNotifier<T>;
 
   bool _dirty = false;
 
   @override
   void update(InheritedNotifier<T> newWidget) {
-    final T? oldNotifier = widget.notifier;
+    final T? oldNotifier = typedWidget.notifier;
     final T? newNotifier = newWidget.notifier;
     if (oldNotifier != newNotifier) {
       oldNotifier?.removeListener(_handleUpdate);
@@ -114,7 +114,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
   @override
   Widget build() {
     if (_dirty)
-      notifyClients(widget);
+      notifyClients(typedWidget);
     return super.build();
   }
 
@@ -131,7 +131,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
 
   @override
   void unmount() {
-    widget.notifier?.removeListener(_handleUpdate);
+    typedWidget.notifier?.removeListener(_handleUpdate);
     super.unmount();
   }
 }

--- a/packages/flutter/lib/src/widgets/inherited_notifier.dart
+++ b/packages/flutter/lib/src/widgets/inherited_notifier.dart
@@ -95,13 +95,11 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
     widget.notifier?.addListener(_handleUpdate);
   }
 
-  InheritedNotifier<T> get _typedWidget => super.widget as InheritedNotifier<T>;
-
   bool _dirty = false;
 
   @override
   void update(InheritedNotifier<T> newWidget) {
-    final T? oldNotifier = _typedWidget.notifier;
+    final T? oldNotifier = (widget as InheritedNotifier<T>).notifier;
     final T? newNotifier = newWidget.notifier;
     if (oldNotifier != newNotifier) {
       oldNotifier?.removeListener(_handleUpdate);
@@ -113,7 +111,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
   @override
   Widget build() {
     if (_dirty)
-      notifyClients(_typedWidget);
+      notifyClients(widget as InheritedNotifier<T>);
     return super.build();
   }
 
@@ -130,7 +128,7 @@ class _InheritedNotifierElement<T extends Listenable> extends InheritedElement {
 
   @override
   void unmount() {
-    _typedWidget.notifier?.removeListener(_handleUpdate);
+    (widget as InheritedNotifier<T>).notifier?.removeListener(_handleUpdate);
     super.unmount();
   }
 }

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -57,8 +57,7 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
 class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderObjectElement {
   _LayoutBuilderElement(ConstrainedLayoutBuilder<ConstraintType> widget) : super(widget);
 
-  @override
-  ConstrainedLayoutBuilder<ConstraintType> get typedWidget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
+  ConstrainedLayoutBuilder<ConstraintType> get _typedWidget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
 
   @override
   RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject as RenderConstrainedLayoutBuilder<ConstraintType, RenderObject>;
@@ -119,7 +118,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     void layoutCallback() {
       Widget built;
       try {
-        built = typedWidget.builder(this, constraints);
+        built = _typedWidget.builder(this, constraints);
         debugWidgetBuilderValue(widget, built);
       } catch (e, stack) {
         built = ErrorWidget.builder(

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -57,8 +57,6 @@ abstract class ConstrainedLayoutBuilder<ConstraintType extends Constraints> exte
 class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderObjectElement {
   _LayoutBuilderElement(ConstrainedLayoutBuilder<ConstraintType> widget) : super(widget);
 
-  ConstrainedLayoutBuilder<ConstraintType> get _typedWidget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
-
   @override
   RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject as RenderConstrainedLayoutBuilder<ConstraintType, RenderObject>;
 
@@ -118,7 +116,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     void layoutCallback() {
       Widget built;
       try {
-        built = _typedWidget.builder(this, constraints);
+        built = (widget as ConstrainedLayoutBuilder<ConstraintType>).builder(this, constraints);
         debugWidgetBuilderValue(widget, built);
       } catch (e, stack) {
         built = ErrorWidget.builder(

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -58,7 +58,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
   _LayoutBuilderElement(ConstrainedLayoutBuilder<ConstraintType> widget) : super(widget);
 
   @override
-  ConstrainedLayoutBuilder<ConstraintType> get widget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
+  ConstrainedLayoutBuilder<ConstraintType> get typedWidget => super.widget as ConstrainedLayoutBuilder<ConstraintType>;
 
   @override
   RenderConstrainedLayoutBuilder<ConstraintType, RenderObject> get renderObject => super.renderObject as RenderConstrainedLayoutBuilder<ConstraintType, RenderObject>;
@@ -119,7 +119,7 @@ class _LayoutBuilderElement<ConstraintType extends Constraints> extends RenderOb
     void layoutCallback() {
       Widget built;
       try {
-        built = widget.builder(this, constraints);
+        built = typedWidget.builder(this, constraints);
         debugWidgetBuilderValue(widget, built);
       } catch (e, stack) {
         built = ErrorWidget.builder(

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -819,7 +819,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   ListWheelElement(ListWheelViewport widget) : super(widget);
 
   @override
-  ListWheelViewport get widget => super.widget as ListWheelViewport;
+  ListWheelViewport get typedWidget => super.widget as ListWheelViewport;
 
   @override
   RenderListWheelViewport get renderObject => super.renderObject as RenderListWheelViewport;
@@ -840,7 +840,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
 
   @override
   void update(ListWheelViewport newWidget) {
-    final ListWheelViewport oldWidget = widget;
+    final ListWheelViewport oldWidget = typedWidget;
     super.update(newWidget);
     final ListWheelChildDelegate newDelegate = newWidget.childDelegate;
     final ListWheelChildDelegate oldDelegate = oldWidget.childDelegate;
@@ -852,7 +852,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   }
 
   @override
-  int? get childCount => widget.childDelegate.estimatedChildCount;
+  int? get childCount => typedWidget.childDelegate.estimatedChildCount;
 
   @override
   void performRebuild() {
@@ -880,7 +880,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   /// will be cached. However when the element is rebuilt, the cache will be
   /// cleared.
   Widget? retrieveWidget(int index) {
-    return _childWidgets.putIfAbsent(index, () => widget.childDelegate.build(this, index));
+    return _childWidgets.putIfAbsent(index, () => typedWidget.childDelegate.build(this, index));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -818,8 +818,6 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   /// Creates an element that lazily builds children for the given widget.
   ListWheelElement(ListWheelViewport widget) : super(widget);
 
-  ListWheelViewport get _typedWidget => super.widget as ListWheelViewport;
-
   @override
   RenderListWheelViewport get renderObject => super.renderObject as RenderListWheelViewport;
 
@@ -839,7 +837,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
 
   @override
   void update(ListWheelViewport newWidget) {
-    final ListWheelViewport oldWidget = _typedWidget;
+    final ListWheelViewport oldWidget = widget as ListWheelViewport;
     super.update(newWidget);
     final ListWheelChildDelegate newDelegate = newWidget.childDelegate;
     final ListWheelChildDelegate oldDelegate = oldWidget.childDelegate;
@@ -851,7 +849,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   }
 
   @override
-  int? get childCount => _typedWidget.childDelegate.estimatedChildCount;
+  int? get childCount => (widget as ListWheelViewport).childDelegate.estimatedChildCount;
 
   @override
   void performRebuild() {
@@ -879,7 +877,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   /// will be cached. However when the element is rebuilt, the cache will be
   /// cleared.
   Widget? retrieveWidget(int index) {
-    return _childWidgets.putIfAbsent(index, () => _typedWidget.childDelegate.build(this, index));
+    return _childWidgets.putIfAbsent(index, () => (widget as ListWheelViewport).childDelegate.build(this, index));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -818,8 +818,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   /// Creates an element that lazily builds children for the given widget.
   ListWheelElement(ListWheelViewport widget) : super(widget);
 
-  @override
-  ListWheelViewport get typedWidget => super.widget as ListWheelViewport;
+  ListWheelViewport get _typedWidget => super.widget as ListWheelViewport;
 
   @override
   RenderListWheelViewport get renderObject => super.renderObject as RenderListWheelViewport;
@@ -840,7 +839,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
 
   @override
   void update(ListWheelViewport newWidget) {
-    final ListWheelViewport oldWidget = typedWidget;
+    final ListWheelViewport oldWidget = _typedWidget;
     super.update(newWidget);
     final ListWheelChildDelegate newDelegate = newWidget.childDelegate;
     final ListWheelChildDelegate oldDelegate = oldWidget.childDelegate;
@@ -852,7 +851,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   }
 
   @override
-  int? get childCount => typedWidget.childDelegate.estimatedChildCount;
+  int? get childCount => _typedWidget.childDelegate.estimatedChildCount;
 
   @override
   void performRebuild() {
@@ -880,7 +879,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   /// will be cached. However when the element is rebuilt, the cache will be
   /// cleared.
   Widget? retrieveWidget(int index) {
-    return _childWidgets.putIfAbsent(index, () => typedWidget.childDelegate.build(this, index));
+    return _childWidgets.putIfAbsent(index, () => _typedWidget.childDelegate.build(this, index));
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -62,7 +62,7 @@ abstract class Notification {
   @mustCallSuper
   bool visitAncestor(Element element) {
     if (element is StatelessElement) {
-      final StatelessWidget widget = element.widget;
+      final StatelessWidget widget = element.widget as StatelessWidget;
       if (widget is NotificationListener<Notification>) {
         if (widget._dispatch(this, element)) // that function checks the type dynamically
           return false;

--- a/packages/flutter/lib/src/widgets/notification_listener.dart
+++ b/packages/flutter/lib/src/widgets/notification_listener.dart
@@ -62,7 +62,7 @@ abstract class Notification {
   @mustCallSuper
   bool visitAncestor(Element element) {
     if (element is StatelessElement) {
-      final StatelessWidget widget = element.widget as StatelessWidget;
+      final Widget widget = element.widget;
       if (widget is NotificationListener<Notification>) {
         if (widget._dispatch(this, element)) // that function checks the type dynamically
           return false;

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -578,15 +578,14 @@ class _Theatre extends MultiChildRenderObjectWidget {
 class _TheatreElement extends MultiChildRenderObjectElement {
   _TheatreElement(_Theatre widget) : super(widget);
 
-  _Theatre get _typedWidget => super.widget as _Theatre;
-
   @override
   _RenderTheatre get renderObject => super.renderObject as _RenderTheatre;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    assert(children.length >= _typedWidget.skipCount);
-    children.skip(_typedWidget.skipCount).forEach(visitor);
+    final _Theatre theatre = widget as _Theatre;
+    assert(children.length >= theatre.skipCount);
+    children.skip(theatre.skipCount).forEach(visitor);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -579,15 +579,15 @@ class _TheatreElement extends MultiChildRenderObjectElement {
   _TheatreElement(_Theatre widget) : super(widget);
 
   @override
-  _Theatre get widget => super.widget as _Theatre;
+  _Theatre get typedWidget => super.widget as _Theatre;
 
   @override
   _RenderTheatre get renderObject => super.renderObject as _RenderTheatre;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    assert(children.length >= widget.skipCount);
-    children.skip(widget.skipCount).forEach(visitor);
+    assert(children.length >= typedWidget.skipCount);
+    children.skip(typedWidget.skipCount).forEach(visitor);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -578,16 +578,15 @@ class _Theatre extends MultiChildRenderObjectWidget {
 class _TheatreElement extends MultiChildRenderObjectElement {
   _TheatreElement(_Theatre widget) : super(widget);
 
-  @override
-  _Theatre get typedWidget => super.widget as _Theatre;
+  _Theatre get _typedWidget => super.widget as _Theatre;
 
   @override
   _RenderTheatre get renderObject => super.renderObject as _RenderTheatre;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    assert(children.length >= typedWidget.skipCount);
-    children.skip(typedWidget.skipCount).forEach(visitor);
+    assert(children.length >= _typedWidget.skipCount);
+    children.skip(_typedWidget.skipCount).forEach(visitor);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1693,12 +1693,11 @@ class SliverOffstage extends SingleChildRenderObjectWidget {
 class _SliverOffstageElement extends SingleChildRenderObjectElement {
   _SliverOffstageElement(SliverOffstage widget) : super(widget);
 
-  @override
-  SliverOffstage get typedWidget => super.widget as SliverOffstage;
+  SliverOffstage get _typedWidget => super.widget as SliverOffstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!typedWidget.offstage)
+    if (!_typedWidget.offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1127,14 +1127,14 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   final bool _replaceMovedChildren;
 
   @override
-  SliverMultiBoxAdaptorWidget get widget => super.widget as SliverMultiBoxAdaptorWidget;
+  SliverMultiBoxAdaptorWidget get typedWidget => super.widget as SliverMultiBoxAdaptorWidget;
 
   @override
   RenderSliverMultiBoxAdaptor get renderObject => super.renderObject as RenderSliverMultiBoxAdaptor;
 
   @override
   void update(covariant SliverMultiBoxAdaptorWidget newWidget) {
-    final SliverMultiBoxAdaptorWidget oldWidget = widget;
+    final SliverMultiBoxAdaptorWidget oldWidget = typedWidget;
     super.update(newWidget);
     final SliverChildDelegate newDelegate = newWidget.delegate;
     final SliverChildDelegate oldDelegate = oldWidget.delegate;
@@ -1181,7 +1181,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       }
       for (final int index in _childElements.keys.toList()) {
         final Key? key = _childElements[index]!.widget.key;
-        final int? newIndex = key == null ? null : widget.delegate.findIndexByKey(key);
+        final int? newIndex = key == null ? null : typedWidget.delegate.findIndexByKey(key);
         final SliverMultiBoxAdaptorParentData? childParentData =
           _childElements[index]!.renderObject?.parentData as SliverMultiBoxAdaptorParentData?;
 
@@ -1229,7 +1229,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   }
 
   Widget? _build(int index) {
-    return widget.delegate.build(this, index);
+    return typedWidget.delegate.build(this, index);
   }
 
   @override
@@ -1321,7 +1321,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     final int? childCount = estimatedChildCount;
     if (childCount == null)
       return double.infinity;
-    return widget.estimateMaxScrollOffset(
+    return typedWidget.estimateMaxScrollOffset(
       constraints,
       firstIndex!,
       lastIndex!,
@@ -1345,7 +1345,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   /// See also:
   ///
   ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
-  int? get estimatedChildCount => widget.delegate.estimatedChildCount;
+  int? get estimatedChildCount => typedWidget.delegate.estimatedChildCount;
 
   @override
   int get childCount {
@@ -1369,7 +1369,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           hi = max;
         } else {
           throw FlutterError(
-            'Could not find the number of children in ${widget.delegate}.\n'
+            'Could not find the number of children in ${typedWidget.delegate}.\n'
             "The childCount getter was called (implying that the delegate's builder returned null "
             'for a positive index), but even building the child with index $hi (the maximum '
             'possible integer) did not return null. Consider implementing childCount to avoid '
@@ -1400,7 +1400,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(debugAssertChildListLocked());
     final int firstIndex = _childElements.firstKey() ?? 0;
     final int lastIndex = _childElements.lastKey() ?? 0;
-    widget.delegate.didFinishLayout(firstIndex, lastIndex);
+    typedWidget.delegate.didFinishLayout(firstIndex, lastIndex);
   }
 
   int? _currentlyUpdatingChildIndex;
@@ -1695,11 +1695,11 @@ class _SliverOffstageElement extends SingleChildRenderObjectElement {
   _SliverOffstageElement(SliverOffstage widget) : super(widget);
 
   @override
-  SliverOffstage get widget => super.widget as SliverOffstage;
+  SliverOffstage get typedWidget => super.widget as SliverOffstage;
 
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!widget.offstage)
+    if (!typedWidget.offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1126,15 +1126,14 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
   final bool _replaceMovedChildren;
 
-  @override
-  SliverMultiBoxAdaptorWidget get typedWidget => super.widget as SliverMultiBoxAdaptorWidget;
+  SliverMultiBoxAdaptorWidget get _typedWidget => super.widget as SliverMultiBoxAdaptorWidget;
 
   @override
   RenderSliverMultiBoxAdaptor get renderObject => super.renderObject as RenderSliverMultiBoxAdaptor;
 
   @override
   void update(covariant SliverMultiBoxAdaptorWidget newWidget) {
-    final SliverMultiBoxAdaptorWidget oldWidget = typedWidget;
+    final SliverMultiBoxAdaptorWidget oldWidget = _typedWidget;
     super.update(newWidget);
     final SliverChildDelegate newDelegate = newWidget.delegate;
     final SliverChildDelegate oldDelegate = oldWidget.delegate;
@@ -1181,7 +1180,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       }
       for (final int index in _childElements.keys.toList()) {
         final Key? key = _childElements[index]!.widget.key;
-        final int? newIndex = key == null ? null : typedWidget.delegate.findIndexByKey(key);
+        final int? newIndex = key == null ? null : _typedWidget.delegate.findIndexByKey(key);
         final SliverMultiBoxAdaptorParentData? childParentData =
           _childElements[index]!.renderObject?.parentData as SliverMultiBoxAdaptorParentData?;
 
@@ -1229,7 +1228,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   }
 
   Widget? _build(int index) {
-    return typedWidget.delegate.build(this, index);
+    return _typedWidget.delegate.build(this, index);
   }
 
   @override
@@ -1321,7 +1320,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     final int? childCount = estimatedChildCount;
     if (childCount == null)
       return double.infinity;
-    return typedWidget.estimateMaxScrollOffset(
+    return _typedWidget.estimateMaxScrollOffset(
       constraints,
       firstIndex!,
       lastIndex!,
@@ -1345,7 +1344,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   /// See also:
   ///
   ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
-  int? get estimatedChildCount => typedWidget.delegate.estimatedChildCount;
+  int? get estimatedChildCount => _typedWidget.delegate.estimatedChildCount;
 
   @override
   int get childCount {
@@ -1369,7 +1368,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           hi = max;
         } else {
           throw FlutterError(
-            'Could not find the number of children in ${typedWidget.delegate}.\n'
+            'Could not find the number of children in ${_typedWidget.delegate}.\n'
             "The childCount getter was called (implying that the delegate's builder returned null "
             'for a positive index), but even building the child with index $hi (the maximum '
             'possible integer) did not return null. Consider implementing childCount to avoid '
@@ -1400,7 +1399,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(debugAssertChildListLocked());
     final int firstIndex = _childElements.firstKey() ?? 0;
     final int lastIndex = _childElements.lastKey() ?? 0;
-    typedWidget.delegate.didFinishLayout(firstIndex, lastIndex);
+    _typedWidget.delegate.didFinishLayout(firstIndex, lastIndex);
   }
 
   int? _currentlyUpdatingChildIndex;

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -1126,14 +1126,12 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
 
   final bool _replaceMovedChildren;
 
-  SliverMultiBoxAdaptorWidget get _typedWidget => super.widget as SliverMultiBoxAdaptorWidget;
-
   @override
   RenderSliverMultiBoxAdaptor get renderObject => super.renderObject as RenderSliverMultiBoxAdaptor;
 
   @override
   void update(covariant SliverMultiBoxAdaptorWidget newWidget) {
-    final SliverMultiBoxAdaptorWidget oldWidget = _typedWidget;
+    final SliverMultiBoxAdaptorWidget oldWidget = widget as SliverMultiBoxAdaptorWidget;
     super.update(newWidget);
     final SliverChildDelegate newDelegate = newWidget.delegate;
     final SliverChildDelegate oldDelegate = oldWidget.delegate;
@@ -1154,6 +1152,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     try {
       final SplayTreeMap<int, Element?> newChildren = SplayTreeMap<int, Element?>();
       final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
+      final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;
         if (_childElements[index] != null && _childElements[index] != newChildren[index]) {
@@ -1161,7 +1160,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           _childElements[index] = updateChild(_childElements[index], null, index);
           childrenUpdated = true;
         }
-        final Element? newChild = updateChild(newChildren[index], _build(index), index);
+        final Element? newChild = updateChild(newChildren[index], _build(index, adaptorWidget), index);
         if (newChild != null) {
           childrenUpdated = childrenUpdated || _childElements[index] != newChild;
           _childElements[index] = newChild;
@@ -1180,7 +1179,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       }
       for (final int index in _childElements.keys.toList()) {
         final Key? key = _childElements[index]!.widget.key;
-        final int? newIndex = key == null ? null : _typedWidget.delegate.findIndexByKey(key);
+        final int? newIndex = key == null ? null : adaptorWidget.delegate.findIndexByKey(key);
         final SliverMultiBoxAdaptorParentData? childParentData =
           _childElements[index]!.renderObject?.parentData as SliverMultiBoxAdaptorParentData?;
 
@@ -1227,8 +1226,8 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     }
   }
 
-  Widget? _build(int index) {
-    return _typedWidget.delegate.build(this, index);
+  Widget? _build(int index, SliverMultiBoxAdaptorWidget widget) {
+    return widget.delegate.build(this, index);
   }
 
   @override
@@ -1240,8 +1239,9 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       _currentBeforeChild = insertFirst ? null : (_childElements[index-1]!.renderObject as RenderBox?);
       Element? newChild;
       try {
+        final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
         _currentlyUpdatingChildIndex = index;
-        newChild = updateChild(_childElements[index], _build(index), index);
+        newChild = updateChild(_childElements[index], _build(index, adaptorWidget), index);
       } finally {
         _currentlyUpdatingChildIndex = null;
       }
@@ -1320,7 +1320,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     final int? childCount = estimatedChildCount;
     if (childCount == null)
       return double.infinity;
-    return _typedWidget.estimateMaxScrollOffset(
+    return (widget as SliverMultiBoxAdaptorWidget).estimateMaxScrollOffset(
       constraints,
       firstIndex!,
       lastIndex!,
@@ -1344,7 +1344,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
   /// See also:
   ///
   ///  * [SliverChildDelegate.estimatedChildCount], to which this getter defers.
-  int? get estimatedChildCount => _typedWidget.delegate.estimatedChildCount;
+  int? get estimatedChildCount => (widget as SliverMultiBoxAdaptorWidget).delegate.estimatedChildCount;
 
   @override
   int get childCount {
@@ -1357,10 +1357,11 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       // manually.
       int lo = 0;
       int hi = 1;
+      final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
       const int max = kIsWeb
         ? 9007199254740992 // max safe integer on JS (from 0 to this number x != x+1)
         : ((1 << 63) - 1);
-      while (_build(hi - 1) != null) {
+      while (_build(hi - 1, adaptorWidget) != null) {
         lo = hi - 1;
         if (hi < max ~/ 2) {
           hi *= 2;
@@ -1368,7 +1369,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
           hi = max;
         } else {
           throw FlutterError(
-            'Could not find the number of children in ${_typedWidget.delegate}.\n'
+            'Could not find the number of children in ${adaptorWidget.delegate}.\n'
             "The childCount getter was called (implying that the delegate's builder returned null "
             'for a positive index), but even building the child with index $hi (the maximum '
             'possible integer) did not return null. Consider implementing childCount to avoid '
@@ -1378,7 +1379,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
       }
       while (hi - lo > 1) {
         final int mid = (hi - lo) ~/ 2 + lo;
-        if (_build(mid - 1) == null) {
+        if (_build(mid - 1, adaptorWidget) == null) {
           hi = mid;
         } else {
           lo = mid;
@@ -1399,7 +1400,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(debugAssertChildListLocked());
     final int firstIndex = _childElements.firstKey() ?? 0;
     final int lastIndex = _childElements.lastKey() ?? 0;
-    _typedWidget.delegate.didFinishLayout(firstIndex, lastIndex);
+    (widget as SliverMultiBoxAdaptorWidget).delegate.didFinishLayout(firstIndex, lastIndex);
   }
 
   int? _currentlyUpdatingChildIndex;
@@ -1693,11 +1694,9 @@ class SliverOffstage extends SingleChildRenderObjectWidget {
 class _SliverOffstageElement extends SingleChildRenderObjectElement {
   _SliverOffstageElement(SliverOffstage widget) : super(widget);
 
-  SliverOffstage get _typedWidget => super.widget as SliverOffstage;
-
   @override
   void debugVisitOnstageChildren(ElementVisitor visitor) {
-    if (!_typedWidget.offstage)
+    if (!(widget as SliverOffstage).offstage)
       super.debugVisitOnstageChildren(visitor);
   }
 }

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -254,8 +254,6 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   final bool floating;
 
-  _SliverPersistentHeaderRenderObjectWidget get _typedWidget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
-
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin get renderObject => super.renderObject as _RenderSliverPersistentHeaderForWidgetsMixin;
 
@@ -273,7 +271,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   @override
   void update(_SliverPersistentHeaderRenderObjectWidget newWidget) {
-    final _SliverPersistentHeaderRenderObjectWidget oldWidget = _typedWidget;
+    final _SliverPersistentHeaderRenderObjectWidget oldWidget = widget as _SliverPersistentHeaderRenderObjectWidget;
     super.update(newWidget);
     final SliverPersistentHeaderDelegate newDelegate = newWidget.delegate;
     final SliverPersistentHeaderDelegate oldDelegate = oldWidget.delegate;
@@ -292,15 +290,16 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   void _build(double shrinkOffset, bool overlapsContent) {
     owner!.buildScope(this, () {
+      final _SliverPersistentHeaderRenderObjectWidget sliverPersistentHeaderRenderObjectWidget = widget as _SliverPersistentHeaderRenderObjectWidget;
       child = updateChild(
         child,
         floating
-          ? _FloatingHeader(child: _typedWidget.delegate.build(
+          ? _FloatingHeader(child: sliverPersistentHeaderRenderObjectWidget.delegate.build(
             this,
             shrinkOffset,
             overlapsContent
           ))
-          : _typedWidget.delegate.build(this, shrinkOffset, overlapsContent),
+          : sliverPersistentHeaderRenderObjectWidget.delegate.build(this, shrinkOffset, overlapsContent),
         null,
       );
     });
@@ -370,10 +369,10 @@ mixin _RenderSliverPersistentHeaderForWidgetsMixin on RenderSliverPersistentHead
   _SliverPersistentHeaderElement? _element;
 
   @override
-  double get minExtent => _element!._typedWidget.delegate.minExtent;
+  double get minExtent => (_element!.widget as _SliverPersistentHeaderRenderObjectWidget).delegate.minExtent;
 
   @override
-  double get maxExtent => _element!._typedWidget.delegate.maxExtent;
+  double get maxExtent => (_element!.widget as _SliverPersistentHeaderRenderObjectWidget).delegate.maxExtent;
 
   @override
   void updateChild(double shrinkOffset, bool overlapsContent) {

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -255,7 +255,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
   final bool floating;
 
   @override
-  _SliverPersistentHeaderRenderObjectWidget get widget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
+  _SliverPersistentHeaderRenderObjectWidget get typedWidget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin get renderObject => super.renderObject as _RenderSliverPersistentHeaderForWidgetsMixin;
@@ -274,7 +274,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   @override
   void update(_SliverPersistentHeaderRenderObjectWidget newWidget) {
-    final _SliverPersistentHeaderRenderObjectWidget oldWidget = widget;
+    final _SliverPersistentHeaderRenderObjectWidget oldWidget = typedWidget;
     super.update(newWidget);
     final SliverPersistentHeaderDelegate newDelegate = newWidget.delegate;
     final SliverPersistentHeaderDelegate oldDelegate = oldWidget.delegate;
@@ -296,12 +296,12 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
       child = updateChild(
         child,
         floating
-          ? _FloatingHeader(child: widget.delegate.build(
+          ? _FloatingHeader(child: typedWidget.delegate.build(
             this,
             shrinkOffset,
             overlapsContent
           ))
-          : widget.delegate.build(this, shrinkOffset, overlapsContent),
+          : typedWidget.delegate.build(this, shrinkOffset, overlapsContent),
         null,
       );
     });
@@ -371,10 +371,10 @@ mixin _RenderSliverPersistentHeaderForWidgetsMixin on RenderSliverPersistentHead
   _SliverPersistentHeaderElement? _element;
 
   @override
-  double get minExtent => _element!.widget.delegate.minExtent;
+  double get minExtent => _element!.typedWidget.delegate.minExtent;
 
   @override
-  double get maxExtent => _element!.widget.delegate.maxExtent;
+  double get maxExtent => _element!.typedWidget.delegate.maxExtent;
 
   @override
   void updateChild(double shrinkOffset, bool overlapsContent) {

--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -254,8 +254,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   final bool floating;
 
-  @override
-  _SliverPersistentHeaderRenderObjectWidget get typedWidget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
+  _SliverPersistentHeaderRenderObjectWidget get _typedWidget => super.widget as _SliverPersistentHeaderRenderObjectWidget;
 
   @override
   _RenderSliverPersistentHeaderForWidgetsMixin get renderObject => super.renderObject as _RenderSliverPersistentHeaderForWidgetsMixin;
@@ -274,7 +273,7 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
 
   @override
   void update(_SliverPersistentHeaderRenderObjectWidget newWidget) {
-    final _SliverPersistentHeaderRenderObjectWidget oldWidget = typedWidget;
+    final _SliverPersistentHeaderRenderObjectWidget oldWidget = _typedWidget;
     super.update(newWidget);
     final SliverPersistentHeaderDelegate newDelegate = newWidget.delegate;
     final SliverPersistentHeaderDelegate oldDelegate = oldWidget.delegate;
@@ -296,12 +295,12 @@ class _SliverPersistentHeaderElement extends RenderObjectElement {
       child = updateChild(
         child,
         floating
-          ? _FloatingHeader(child: typedWidget.delegate.build(
+          ? _FloatingHeader(child: _typedWidget.delegate.build(
             this,
             shrinkOffset,
             overlapsContent
           ))
-          : typedWidget.delegate.build(this, shrinkOffset, overlapsContent),
+          : _typedWidget.delegate.build(this, shrinkOffset, overlapsContent),
         null,
       );
     });
@@ -371,10 +370,10 @@ mixin _RenderSliverPersistentHeaderForWidgetsMixin on RenderSliverPersistentHead
   _SliverPersistentHeaderElement? _element;
 
   @override
-  double get minExtent => _element!.typedWidget.delegate.minExtent;
+  double get minExtent => _element!._typedWidget.delegate.minExtent;
 
   @override
-  double get maxExtent => _element!.typedWidget.delegate.maxExtent;
+  double get maxExtent => _element!._typedWidget.delegate.maxExtent;
 
   @override
   void updateChild(double shrinkOffset, bool overlapsContent) {

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -62,8 +62,6 @@ class SliverPrototypeExtentList extends SliverMultiBoxAdaptorWidget {
 class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   _SliverPrototypeExtentListElement(SliverPrototypeExtentList widget) : super(widget);
 
-  SliverPrototypeExtentList get _typedWidget => super.widget as SliverPrototypeExtentList;
-
   @override
   _RenderSliverPrototypeExtentList get renderObject => super.renderObject as _RenderSliverPrototypeExtentList;
 
@@ -112,14 +110,14 @@ class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _prototype = updateChild(_prototype, _typedWidget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, (widget as SliverPrototypeExtentList).prototypeItem, _prototypeSlot);
   }
 
   @override
   void update(SliverPrototypeExtentList newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _prototype = updateChild(_prototype, _typedWidget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, (widget as SliverPrototypeExtentList).prototypeItem, _prototypeSlot);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -62,8 +62,7 @@ class SliverPrototypeExtentList extends SliverMultiBoxAdaptorWidget {
 class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   _SliverPrototypeExtentListElement(SliverPrototypeExtentList widget) : super(widget);
 
-  @override
-  SliverPrototypeExtentList get typedWidget => super.widget as SliverPrototypeExtentList;
+  SliverPrototypeExtentList get _typedWidget => super.widget as SliverPrototypeExtentList;
 
   @override
   _RenderSliverPrototypeExtentList get renderObject => super.renderObject as _RenderSliverPrototypeExtentList;
@@ -113,14 +112,14 @@ class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _prototype = updateChild(_prototype, typedWidget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, _typedWidget.prototypeItem, _prototypeSlot);
   }
 
   @override
   void update(SliverPrototypeExtentList newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _prototype = updateChild(_prototype, typedWidget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, _typedWidget.prototypeItem, _prototypeSlot);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
+++ b/packages/flutter/lib/src/widgets/sliver_prototype_extent_list.dart
@@ -63,7 +63,7 @@ class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   _SliverPrototypeExtentListElement(SliverPrototypeExtentList widget) : super(widget);
 
   @override
-  SliverPrototypeExtentList get widget => super.widget as SliverPrototypeExtentList;
+  SliverPrototypeExtentList get typedWidget => super.widget as SliverPrototypeExtentList;
 
   @override
   _RenderSliverPrototypeExtentList get renderObject => super.renderObject as _RenderSliverPrototypeExtentList;
@@ -113,14 +113,14 @@ class _SliverPrototypeExtentListElement extends SliverMultiBoxAdaptorElement {
   @override
   void mount(Element? parent, Object? newSlot) {
     super.mount(parent, newSlot);
-    _prototype = updateChild(_prototype, widget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, typedWidget.prototypeItem, _prototypeSlot);
   }
 
   @override
   void update(SliverPrototypeExtentList newWidget) {
     super.update(newWidget);
     assert(widget == newWidget);
-    _prototype = updateChild(_prototype, widget.prototypeItem, _prototypeSlot);
+    _prototype = updateChild(_prototype, typedWidget.prototypeItem, _prototypeSlot);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -191,8 +191,6 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
 
   final Map<S, Element> _slotToChild = <S, Element>{};
 
-  SlottedMultiChildRenderObjectWidgetMixin<S> get _typedWidget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
-
   @override
   SlottedContainerRenderObjectMixin<S> get renderObject => super.renderObject as SlottedContainerRenderObjectMixin<S>;
 
@@ -226,14 +224,15 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
   List<S>? _debugPreviousSlots;
 
   void _updateChildren() {
+    final SlottedMultiChildRenderObjectWidgetMixin<S> slottedMultiChildRenderObjectWidgetMixin = widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
     assert(() {
-      _debugPreviousSlots ??= _typedWidget.slots.toList();
-      return listEquals(_debugPreviousSlots, _typedWidget.slots.toList());
+      _debugPreviousSlots ??= slottedMultiChildRenderObjectWidgetMixin.slots.toList();
+      return listEquals(_debugPreviousSlots, slottedMultiChildRenderObjectWidgetMixin.slots.toList());
     }(), '${widget.runtimeType}.slots must not change.');
-    assert(_typedWidget.slots.toSet().length == _typedWidget.slots.length, 'slots must be unique');
+    assert(slottedMultiChildRenderObjectWidgetMixin.slots.toSet().length == slottedMultiChildRenderObjectWidgetMixin.slots.length, 'slots must be unique');
 
-    for (final S slot in _typedWidget.slots) {
-      _updateChild(_typedWidget.childForSlot(slot), slot);
+    for (final S slot in slottedMultiChildRenderObjectWidgetMixin.slots) {
+      _updateChild(slottedMultiChildRenderObjectWidgetMixin.childForSlot(slot), slot);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -192,7 +192,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
   final Map<S, Element> _slotToChild = <S, Element>{};
 
   @override
-  SlottedMultiChildRenderObjectWidgetMixin<S> get widget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
+  SlottedMultiChildRenderObjectWidgetMixin<S> get typedWidget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
 
   @override
   SlottedContainerRenderObjectMixin<S> get renderObject => super.renderObject as SlottedContainerRenderObjectMixin<S>;
@@ -228,13 +228,13 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
 
   void _updateChildren() {
     assert(() {
-      _debugPreviousSlots ??= widget.slots.toList();
-      return listEquals(_debugPreviousSlots, widget.slots.toList());
+      _debugPreviousSlots ??= typedWidget.slots.toList();
+      return listEquals(_debugPreviousSlots, typedWidget.slots.toList());
     }(), '${widget.runtimeType}.slots must not change.');
-    assert(widget.slots.toSet().length == widget.slots.length, 'slots must be unique');
+    assert(typedWidget.slots.toSet().length == typedWidget.slots.length, 'slots must be unique');
 
-    for (final S slot in widget.slots) {
-      _updateChild(widget.childForSlot(slot), slot);
+    for (final S slot in typedWidget.slots) {
+      _updateChild(typedWidget.childForSlot(slot), slot);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -191,8 +191,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
 
   final Map<S, Element> _slotToChild = <S, Element>{};
 
-  @override
-  SlottedMultiChildRenderObjectWidgetMixin<S> get typedWidget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
+  SlottedMultiChildRenderObjectWidgetMixin<S> get _typedWidget => super.widget as SlottedMultiChildRenderObjectWidgetMixin<S>;
 
   @override
   SlottedContainerRenderObjectMixin<S> get renderObject => super.renderObject as SlottedContainerRenderObjectMixin<S>;
@@ -228,13 +227,13 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
 
   void _updateChildren() {
     assert(() {
-      _debugPreviousSlots ??= typedWidget.slots.toList();
-      return listEquals(_debugPreviousSlots, typedWidget.slots.toList());
+      _debugPreviousSlots ??= _typedWidget.slots.toList();
+      return listEquals(_debugPreviousSlots, _typedWidget.slots.toList());
     }(), '${widget.runtimeType}.slots must not change.');
-    assert(typedWidget.slots.toSet().length == typedWidget.slots.length, 'slots must be unique');
+    assert(_typedWidget.slots.toSet().length == _typedWidget.slots.length, 'slots must be unique');
 
-    for (final S slot in typedWidget.slots) {
-      _updateChild(typedWidget.childForSlot(slot), slot);
+    for (final S slot in _typedWidget.slots) {
+      _updateChild(_typedWidget.childForSlot(slot), slot);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -285,7 +285,7 @@ class _TableElement extends RenderObjectElement {
   _TableElement(Table widget) : super(widget);
 
   @override
-  Table get widget => super.widget as Table;
+  Table get typedWidget => super.widget as Table;
 
   @override
   RenderTable get renderObject => super.renderObject as RenderTable;
@@ -300,7 +300,7 @@ class _TableElement extends RenderObjectElement {
     _doingMountOrUpdate = true;
     super.mount(parent, newSlot);
     int rowIndex = -1;
-    _children = widget.children.map<_TableElementRow>((TableRow row) {
+    _children = typedWidget.children.map<_TableElementRow>((TableRow row) {
       int columnIndex = 0;
       rowIndex += 1;
       return _TableElementRow(

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -284,8 +284,6 @@ class Table extends RenderObjectWidget {
 class _TableElement extends RenderObjectElement {
   _TableElement(Table widget) : super(widget);
 
-  Table get _typedWidget => super.widget as Table;
-
   @override
   RenderTable get renderObject => super.renderObject as RenderTable;
 
@@ -299,7 +297,7 @@ class _TableElement extends RenderObjectElement {
     _doingMountOrUpdate = true;
     super.mount(parent, newSlot);
     int rowIndex = -1;
-    _children = _typedWidget.children.map<_TableElementRow>((TableRow row) {
+    _children = (widget as Table).children.map<_TableElementRow>((TableRow row) {
       int columnIndex = 0;
       rowIndex += 1;
       return _TableElementRow(

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -284,8 +284,7 @@ class Table extends RenderObjectWidget {
 class _TableElement extends RenderObjectElement {
   _TableElement(Table widget) : super(widget);
 
-  @override
-  Table get typedWidget => super.widget as Table;
+  Table get _typedWidget => super.widget as Table;
 
   @override
   RenderTable get renderObject => super.renderObject as RenderTable;
@@ -300,7 +299,7 @@ class _TableElement extends RenderObjectElement {
     _doingMountOrUpdate = true;
     super.mount(parent, newSlot);
     int rowIndex = -1;
-    _children = typedWidget.children.map<_TableElementRow>((TableRow row) {
+    _children = _typedWidget.children.map<_TableElementRow>((TableRow row) {
       int columnIndex = 0;
       rowIndex += 1;
       return _TableElementRow(

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -215,7 +215,7 @@ class _ViewportElement extends MultiChildRenderObjectElement {
   int? _centerSlotIndex;
 
   @override
-  Viewport get widget => super.widget as Viewport;
+  Viewport get typedWidget => super.widget as Viewport;
 
   @override
   RenderViewport get renderObject => super.renderObject as RenderViewport;
@@ -242,10 +242,10 @@ class _ViewportElement extends MultiChildRenderObjectElement {
 
   void _updateCenter() {
     // TODO(ianh): cache the keys to make this faster
-    if (widget.center != null) {
+    if (typedWidget.center != null) {
       int elementIndex = 0;
       for (final Element e in children) {
-        if (e.widget.key == widget.center) {
+        if (e.widget.key == typedWidget.center) {
           renderObject.center = e.renderObject as RenderSliver?;
           break;
         }

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -214,8 +214,7 @@ class _ViewportElement extends MultiChildRenderObjectElement {
   bool _doingMountOrUpdate = false;
   int? _centerSlotIndex;
 
-  @override
-  Viewport get typedWidget => super.widget as Viewport;
+  Viewport get _typedWidget => super.widget as Viewport;
 
   @override
   RenderViewport get renderObject => super.renderObject as RenderViewport;
@@ -242,10 +241,10 @@ class _ViewportElement extends MultiChildRenderObjectElement {
 
   void _updateCenter() {
     // TODO(ianh): cache the keys to make this faster
-    if (typedWidget.center != null) {
+    if (_typedWidget.center != null) {
       int elementIndex = 0;
       for (final Element e in children) {
-        if (e.widget.key == typedWidget.center) {
+        if (e.widget.key == _typedWidget.center) {
           renderObject.center = e.renderObject as RenderSliver?;
           break;
         }

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -214,8 +214,6 @@ class _ViewportElement extends MultiChildRenderObjectElement {
   bool _doingMountOrUpdate = false;
   int? _centerSlotIndex;
 
-  Viewport get _typedWidget => super.widget as Viewport;
-
   @override
   RenderViewport get renderObject => super.renderObject as RenderViewport;
 
@@ -241,10 +239,11 @@ class _ViewportElement extends MultiChildRenderObjectElement {
 
   void _updateCenter() {
     // TODO(ianh): cache the keys to make this faster
-    if (_typedWidget.center != null) {
+    final Viewport viewport = widget as Viewport;
+    if (viewport.center != null) {
       int elementIndex = 0;
       for (final Element e in children) {
-        if (e.widget.key == _typedWidget.center) {
+        if (e.widget.key == viewport.center) {
           renderObject.center = e.renderObject as RenderSliver?;
           break;
         }

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1585,10 +1585,7 @@ void main() {
     // https://github.com/flutter/flutter/issues/79605 for examples why this may
     // occur.
     expect(() => element.state, throwsA(isA<TypeError>()));
-
-    // Instead of nulling out widget, we replace it with a const null widget that
-    // throws on most methods. This reduces the cost of null checking the getter.
-    expect(element.widget.runtimeType.toString(), '_NullWidget');
+    expect(() => element.widget, throwsA(isA<TypeError>()));
   });
 
   testWidgets('LayerLink can be swapped between parent and child container layers', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1585,7 +1585,10 @@ void main() {
     // https://github.com/flutter/flutter/issues/79605 for examples why this may
     // occur.
     expect(() => element.state, throwsA(isA<TypeError>()));
-    expect(() => element.widget, throwsA(isA<TypeError>()));
+
+    // Instead of nulling out widget, we replace it with a const null widget that
+    // throws on most methods. This reduces the cost of null checking the getter.
+    expect(element.widget.runtimeType.toString(), '_NullWidget');
   });
 
   testWidgets('LayerLink can be swapped between parent and child container layers', (WidgetTester tester) async {

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -709,7 +709,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
       'therefore no restoration data has been collected to restore from. Did you forget to wrap '
       'your widget tree in a RootRestorationScope?',
     );
-    final Widget widget = (binding.renderViewElement! as RenderObjectToWidgetElement<RenderObject>).widget.child!;
+    final Widget widget = (binding.renderViewElement! as RenderObjectToWidgetElement<RenderObject>).typedWidget.child!;
     final TestRestorationData restorationData = binding.restorationManager.restorationData;
     runApp(Container(key: UniqueKey()));
     await pump();

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -709,7 +709,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
       'therefore no restoration data has been collected to restore from. Did you forget to wrap '
       'your widget tree in a RootRestorationScope?',
     );
-    final Widget widget = (binding.renderViewElement! as RenderObjectToWidgetElement<RenderObject>).typedWidget.child!;
+    final Widget widget = ((binding.renderViewElement! as RenderObjectToWidgetElement<RenderObject>).widget as RenderObjectToWidgetAdapter<RenderObject>).child!;
     final TestRestorationData restorationData = binding.restorationManager.restorationData;
     runApp(Container(key: UniqueKey()));
     await pump();


### PR DESCRIPTION
This is an alternative to the proposal to make Element generic. After investigation, I discovered that the majority of the casting was actually unnecessary: here is an explanation:

```
class A {
  Object get foo;
}

class B extends A {
  String get foo => super.foo as String;
}

void main() {
  A a = B();
  Object bar = a.foo;
}
```

Consider the snippet above. Despite the fact that we only need an Object, as long as the subtype B is used there will be a cast performed on `B.foo`. Consider the Element/BuildContext API: the vast majority of the framework interacts with `Element.widget` or `BuildContext.widget` expecting only a `Widget` - but since all Element subclasses override the type of widget and use a cast, almost all accesses have a cast inserted even if the more specific Widget type is not required by the call site.

This leaves an alternative optimization - introduce a different getter with a cast and avoid overriding Element.widget. Furthermore, this presents a chance to optimize Element.widget by making the field non-nullable and using _NullWidget as a sentinel. This null check is fairly expensive in dart2js.


To benchmark this I used my favorite benchmark from https://github.com/flutter/flutter/pull/95596

On the web the average time of this benchmark decreased from 1845 ms to 1688 ms (~9%). On my Pixel 4 there was essentially no difference, which may just represent the lower cost of casts/null checks in AOT


The change to make Element generic was https://github.com/flutter/flutter/pull/97249 and would cause a breaking change in package:nested