### PR TITLE
CircleAvatar make fit property accessible

### DIFF
--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -68,6 +68,7 @@ class CircleAvatar extends StatelessWidget {
     this.onBackgroundImageError,
     this.onForegroundImageError,
     this.foregroundColor,
+    this.fit = BoxFit.cover,
     this.radius,
     this.minRadius,
     this.maxRadius,
@@ -119,6 +120,10 @@ class CircleAvatar extends StatelessWidget {
   /// An optional error callback for errors emitted when loading
   /// [foregroundImage].
   final ImageErrorListener? onForegroundImageError;
+  
+  /// How to inscribe the child into the space allocated during layout.
+  /// The default is BoxFit.cover
+  final BoxFit fit;
 
   /// The size of the avatar, expressed as the radius (half the diameter).
   ///
@@ -230,7 +235,7 @@ class CircleAvatar extends StatelessWidget {
           ? DecorationImage(
               image: backgroundImage!,
               onError: onBackgroundImageError,
-              fit: BoxFit.cover,
+              fit: fit,
             )
           : null,
         shape: BoxShape.circle,
@@ -240,7 +245,7 @@ class CircleAvatar extends StatelessWidget {
               image: DecorationImage(
                 image: foregroundImage!,
                 onError: onForegroundImageError,
-                fit: BoxFit.cover,
+                fit: fit,
               ),
               shape: BoxShape.circle,
             )


### PR DESCRIPTION
This make it possible to chang the default BoxFit, for my case it was useful to make a image to scaledown

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
