### PR TITLE
[defunct] MediaQuery as InheritedModel

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -18,7 +18,7 @@
 version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/97928
-  - title: "Migrate to 'boldTextOverrideOf'"
+  - title: "Migrate to 'boldTextOf'"
     date: 2022-10-28
     element:
       uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
@@ -26,7 +26,7 @@ transforms:
       inClass: 'MediaQuery'
     changes:
       - kind: 'rename'
-        newName: 'boldTextOverrideOf'
+        newName: 'boldTextOf'
 
   # Changes made in https://github.com/flutter/flutter/pull/78588
   - title: "Migrate to 'buildOverscrollIndicator'"

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -17,6 +17,17 @@
 
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/97928
+  - title: "Migrate to 'boldTextOverrideOf'"
+    date: 2022-10-28
+    element:
+      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
+      method: 'boldTextOverride'
+      inClass: 'MediaQuery'
+    changes:
+      - kind: 'rename'
+        newName: 'boldTextOverrideOf'
+
   # Changes made in https://github.com/flutter/flutter/pull/78588
   - title: "Migrate to 'buildOverscrollIndicator'"
     date: 2021-03-18

--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -156,7 +156,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final double bottomPadding = MediaQuery.of(context).viewPadding.bottom;
+    final double bottomPadding = MediaQuery.viewPaddingOf(context).bottom;
 
     final Color backgroundColor = CupertinoDynamicColor.resolve(
       this.backgroundColor ?? CupertinoTheme.of(context).barBackgroundColor,

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -994,7 +994,7 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     }
     bool isHighContrastEnabled = false;
     if (_isHighContrastDependent) {
-      isHighContrastEnabled = MediaQuery.maybeOf(context)?.highContrast ?? false;
+      isHighContrastEnabled = MediaQuery.maybeHighContrastOf(context) ?? false;
     }
 
     final CupertinoUserInterfaceLevelData level = _isInterfaceElevationDependent

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -225,7 +225,7 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
   // it.
   _ContextMenuLocation get _contextMenuLocation {
     final Rect childRect = _getRect(_childGlobalKey);
-    final double screenWidth = MediaQuery.of(context).size.width;
+    final double screenWidth = MediaQuery.widthOf(context);
 
     final double center = screenWidth / 2;
     final bool centerDividesChild = childRect.left < center
@@ -1044,7 +1044,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
   Widget _buildChildAnimation(BuildContext context, Widget? child) {
     _lastScale = _getScale(
       widget.orientation,
-      MediaQuery.of(context).size.height,
+      MediaQuery.heightOf(context),
       _moveAnimation.value.dy,
     );
     return Transform.scale(

--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -225,7 +225,7 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
   // it.
   _ContextMenuLocation get _contextMenuLocation {
     final Rect childRect = _getRect(_childGlobalKey);
-    final double screenWidth = MediaQuery.widthOf(context);
+    final double screenWidth = MediaQuery.sizeOf(context).width;
 
     final double center = screenWidth / 2;
     final bool centerDividesChild = childRect.left < center
@@ -1044,7 +1044,7 @@ class _ContextMenuRouteStaticState extends State<_ContextMenuRouteStatic> with T
   Widget _buildChildAnimation(BuildContext context, Widget? child) {
     _lastScale = _getScale(
       widget.orientation,
-      MediaQuery.heightOf(context),
+      MediaQuery.sizeOf(context).height,
       _moveAnimation.value.dy,
     );
     return Transform.scale(

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -162,7 +162,7 @@ class _CupertinoDesktopTextSelectionControlsToolbarState extends State<_Cupertin
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
         MediaQuery.paddingOf(context).left,
-        MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right,
+        MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -158,11 +158,12 @@ class _CupertinoDesktopTextSelectionControlsToolbarState extends State<_Cupertin
     }
 
     assert(debugCheckHasMediaQuery(context));
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
 
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
-        MediaQuery.paddingOf(context).left,
-        MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right,
+        mediaQueryPadding.left,
+        MediaQuery.sizeOf(context).width - mediaQueryPadding.right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -158,12 +158,11 @@ class _CupertinoDesktopTextSelectionControlsToolbarState extends State<_Cupertin
     }
 
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
 
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
-        mediaQuery.padding.left,
-        mediaQuery.size.width - mediaQuery.padding.right,
+        MediaQuery.paddingOf(context).left,
+        MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );
@@ -171,7 +170,7 @@ class _CupertinoDesktopTextSelectionControlsToolbarState extends State<_Cupertin
     final List<Widget> items = <Widget>[];
     final CupertinoLocalizations localizations = CupertinoLocalizations.of(context);
     final Widget onePhysicalPixelVerticalDivider =
-        SizedBox(width: 1.0 / MediaQuery.of(context).devicePixelRatio);
+        SizedBox(width: 1.0 / MediaQuery.devicePixelRatioOf(context));
 
     void addToolbarButton(
       String text,

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection_toolbar.dart
@@ -85,9 +85,8 @@ class CupertinoDesktopTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
 
-    final double paddingAbove = mediaQuery.padding.top + _kToolbarScreenPadding;
+    final double paddingAbove = MediaQuery.paddingOf(context).top + _kToolbarScreenPadding;
     final Offset localAdjustment = Offset(_kToolbarScreenPadding, paddingAbove);
 
     return Padding(

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -614,9 +614,9 @@ class CupertinoActionSheet extends StatelessWidget {
     final Orientation orientation = MediaQuery.orientationOf(context);
     final double actionSheetWidth;
     if (orientation == Orientation.portrait) {
-      actionSheetWidth = MediaQuery.widthOf(context) - (_kActionSheetEdgeHorizontalPadding * 2);
+      actionSheetWidth = MediaQuery.sizeOf(context).width - (_kActionSheetEdgeHorizontalPadding * 2);
     } else {
-      actionSheetWidth = MediaQuery.heightOf(context) - (_kActionSheetEdgeHorizontalPadding * 2);
+      actionSheetWidth = MediaQuery.sizeOf(context).height - (_kActionSheetEdgeHorizontalPadding * 2);
     }
 
     return SafeArea(

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -149,8 +149,8 @@ const double _kMaxRegularTextScaleFactor = 1.4;
 // Accessibility mode on iOS is determined by the text scale factor that the
 // user has selected.
 bool _isInAccessibilityMode(BuildContext context) {
-  final MediaQueryData? data = MediaQuery.maybeOf(context);
-  return data != null && data.textScaleFactor > _kMaxRegularTextScaleFactor;
+  final double? factor = MediaQuery.maybeTextScaleFactorOf(context);
+  return factor != null && factor > _kMaxRegularTextScaleFactor;
 }
 
 /// An iOS-style alert dialog.
@@ -257,7 +257,7 @@ class CupertinoAlertDialog extends StatelessWidget {
   final Curve insetAnimationCurve;
 
   Widget _buildContent(BuildContext context) {
-    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
+    final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
 
     final List<Widget> children = <Widget>[
       if (title != null || content != null)
@@ -317,7 +317,7 @@ class CupertinoAlertDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final CupertinoLocalizations localizations = CupertinoLocalizations.of(context);
     final bool isInAccessibilityMode = _isInAccessibilityMode(context);
-    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
+    final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
     return CupertinoUserInterfaceLevel(
       data: CupertinoUserInterfaceLevelData.elevated,
       child: MediaQuery(
@@ -331,7 +331,7 @@ class CupertinoAlertDialog extends StatelessWidget {
           child: LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) {
               return AnimatedPadding(
-                padding: MediaQuery.of(context).viewInsets +
+                padding: MediaQuery.viewInsetsOf(context) +
                     const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
                 duration: insetAnimationDuration,
                 curve: insetAnimationCurve,
@@ -611,12 +611,12 @@ class CupertinoActionSheet extends StatelessWidget {
       if (cancelButton != null) _buildCancelButton(),
     ];
 
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     final double actionSheetWidth;
     if (orientation == Orientation.portrait) {
-      actionSheetWidth = MediaQuery.of(context).size.width - (_kActionSheetEdgeHorizontalPadding * 2);
+      actionSheetWidth = MediaQuery.widthOf(context) - (_kActionSheetEdgeHorizontalPadding * 2);
     } else {
-      actionSheetWidth = MediaQuery.of(context).size.height - (_kActionSheetEdgeHorizontalPadding * 2);
+      actionSheetWidth = MediaQuery.heightOf(context) - (_kActionSheetEdgeHorizontalPadding * 2);
     }
 
     return SafeArea(
@@ -797,7 +797,7 @@ class _CupertinoDialogRenderWidget extends RenderObjectWidget {
   @override
   RenderObject createRenderObject(BuildContext context) {
     return _RenderCupertinoDialog(
-      dividerThickness: _kDividerThickness / MediaQuery.of(context).devicePixelRatio,
+      dividerThickness: _kDividerThickness / MediaQuery.devicePixelRatioOf(context),
       isInAccessibilityMode: _isInAccessibilityMode(context) && !isActionSheet,
       dividerColor: CupertinoDynamicColor.resolve(dividerColor, context),
       isActionSheet: isActionSheet,
@@ -1464,7 +1464,7 @@ class _CupertinoAlertActionSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+    final double devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
 
     final List<Widget> interactiveButtons = <Widget>[];
     for (int i = 0; i < children.length; i += 1) {

--- a/packages/flutter/lib/src/cupertino/list_section.dart
+++ b/packages/flutter/lib/src/cupertino/list_section.dart
@@ -347,7 +347,7 @@ class CupertinoListSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color dividerColor = CupertinoColors.separator.resolveFrom(context);
-    final double dividerHeight = 1.0 / MediaQuery.of(context).devicePixelRatio;
+    final double dividerHeight = 1.0 / MediaQuery.devicePixelRatioOf(context);
 
     // Long divider is used for wrapping the top and bottom of rows.
     // Only used in CupertinoListSectionType.base mode.

--- a/packages/flutter/lib/src/cupertino/magnifier.dart
+++ b/packages/flutter/lib/src/cupertino/magnifier.dart
@@ -174,7 +174,7 @@ class _CupertinoTextMagnifierState extends State<CupertinoTextMagnifier>
               CupertinoMagnifier.kMagnifierAboveFocalPoint),
     );
 
-    final Rect screenRect = Offset.zero & MediaQuery.of(context).size;
+    final Rect screenRect = Offset.zero & MediaQuery.sizeOf(context);
 
     // Adjust the magnifier position so that it never exists outside the horizontal
     // padding.

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -754,7 +754,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
           actionsForegroundColor: CupertinoTheme.of(context).primaryColor,
           transitionBetweenRoutes: widget.transitionBetweenRoutes,
           heroTag: widget.heroTag,
-          persistentHeight: _kNavBarPersistentHeight + MediaQuery.of(context).padding.top,
+          persistentHeight: _kNavBarPersistentHeight + MediaQuery.paddingOf(context).top,
           alwaysShowMiddle: widget.alwaysShowMiddle && widget.middle != null,
           stretchConfiguration: widget.stretch ? OverScrollHeaderStretchConfiguration() : null,
         ),
@@ -989,7 +989,7 @@ class _PersistentNavigationBar extends StatelessWidget {
     }
 
     return SizedBox(
-      height: _kNavBarPersistentHeight + MediaQuery.of(context).padding.top,
+      height: _kNavBarPersistentHeight + MediaQuery.paddingOf(context).top,
       child: SafeArea(
         bottom: false,
         child: paddedToolbar,
@@ -1657,7 +1657,7 @@ class _NavigationBarTransition extends StatelessWidget {
     // can actually be outside the linearly lerp'ed Rect in the middle of
     // the animation, such as the topLargeTitle.
     return SizedBox(
-      height: math.max(heightTween.begin!, heightTween.end!) + MediaQuery.of(context).padding.top,
+      height: math.max(heightTween.begin!, heightTween.end!) + MediaQuery.paddingOf(context).top,
       width: double.infinity,
       child: Stack(
         children: children,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -690,8 +690,8 @@ class _CupertinoBackGestureDetectorState<T> extends State<_CupertinoBackGestureD
     // For devices with notches, the drag area needs to be larger on the side
     // that has the notch.
     double dragAreaWidth = Directionality.of(context) == TextDirection.ltr ?
-                           MediaQuery.of(context).padding.left :
-                           MediaQuery.of(context).padding.right;
+                           MediaQuery.paddingOf(context).left :
+                           MediaQuery.paddingOf(context).right;
     dragAreaWidth = max(dragAreaWidth, _kBackGestureWidth);
     return Stack(
       fit: StackFit.passthrough,

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -171,7 +171,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
       ..mainAxisMargin = _kScrollbarMainAxisMargin
       ..crossAxisMargin = _kScrollbarCrossAxisMargin
       ..radius = _radius
-      ..padding = MediaQuery.of(context).padding
+      ..padding = MediaQuery.paddingOf(context)
       ..minLength = _kScrollbarMinLength
       ..minOverscrollLength = _kScrollbarMinOverscrollLength
       ..scrollbarOrientation = widget.scrollbarOrientation;

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1224,7 +1224,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
     }
 
     final bool enabled = widget.enabled ?? true;
-    final Offset cursorOffset = Offset(_iOSHorizontalCursorOffsetPixels / MediaQuery.of(context).devicePixelRatio, 0);
+    final Offset cursorOffset = Offset(_iOSHorizontalCursorOffsetPixels / MediaQuery.devicePixelRatioOf(context), 0);
     final List<TextInputFormatter> formatters = <TextInputFormatter>[
       ...?widget.inputFormatters,
       if (widget.maxLength != null)

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -260,14 +260,14 @@ class _CupertinoTextSelectionControlsToolbarState extends State<_CupertinoTextSe
     }
 
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
 
     // The toolbar should appear below the TextField when there is not enough
     // space above the TextField to show it, assuming there's always enough
     // space at the bottom in this case.
     final double anchorX = clampDouble(widget.selectionMidpoint.dx + widget.globalEditableRegion.left,
-      _kArrowScreenPadding + mediaQuery.padding.left,
-      mediaQuery.size.width - mediaQuery.padding.right - _kArrowScreenPadding,
+      _kArrowScreenPadding + mediaQueryPadding.left,
+      MediaQuery.sizeOf(context).width - mediaQueryPadding.right - _kArrowScreenPadding,
     );
 
     final double topAmountInEditableRegion = widget.endpoints.first.point.dy - widget.textLineHeight;
@@ -289,7 +289,7 @@ class _CupertinoTextSelectionControlsToolbarState extends State<_CupertinoTextSe
     final List<Widget> items = <Widget>[];
     final CupertinoLocalizations localizations = CupertinoLocalizations.of(context);
     final Widget onePhysicalPixelVerticalDivider =
-        SizedBox(width: 1.0 / MediaQuery.of(context).devicePixelRatio);
+        SizedBox(width: 1.0 / MediaQuery.devicePixelRatioOf(context));
 
     void addToolbarButton(
       String text,

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -132,7 +132,7 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final mediaQueryPadding = MediaQuery.paddingOf(context);
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
 
     final double paddingAbove = mediaQueryPadding.top + _kToolbarScreenPadding;
     final double toolbarHeightNeeded = paddingAbove

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -132,9 +132,8 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
 
-    final double paddingAbove = mediaQuery.padding.top + _kToolbarScreenPadding;
+    final double paddingAbove = MediaQuery.paddingOf(context).top + _kToolbarScreenPadding;
     final double toolbarHeightNeeded = paddingAbove
         + _kToolbarContentDistance
         + _kToolbarHeight;
@@ -480,7 +479,7 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
           onPressed: _handlePreviousPage,
           text: '◀',
         ),
-        dividerWidth: 1.0 / MediaQuery.of(context).devicePixelRatio,
+        dividerWidth: 1.0 / MediaQuery.devicePixelRatioOf(context),
         nextButton: CupertinoTextSelectionToolbarButton.text(
           onPressed: _handleNextPage,
           text: '▶',

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -53,7 +53,7 @@ typedef CupertinoToolbarBuilder = Widget Function(
 class _CupertinoToolbarButtonDivider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return SizedBox(width: 1.0 / MediaQuery.of(context).devicePixelRatio);
+    return SizedBox(width: 1.0 / MediaQuery.devicePixelRatioOf(context));
   }
 }
 
@@ -132,8 +132,9 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
+    final mediaQueryPadding = MediaQuery.paddingOf(context);
 
-    final double paddingAbove = MediaQuery.paddingOf(context).top + _kToolbarScreenPadding;
+    final double paddingAbove = mediaQueryPadding.top + _kToolbarScreenPadding;
     final double toolbarHeightNeeded = paddingAbove
         + _kToolbarContentDistance
         + _kToolbarHeight;
@@ -141,8 +142,8 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
 
     // The arrow, which points to the anchor, has some margin so it can't get
     // too close to the horizontal edges of the screen.
-    final double leftMargin = _kArrowScreenPadding + mediaQuery.padding.left;
-    final double rightMargin = mediaQuery.size.width - mediaQuery.padding.right - _kArrowScreenPadding;
+    final double leftMargin = _kArrowScreenPadding + mediaQueryPadding.left;
+    final double rightMargin = MediaQuery.sizeOf(context).width - mediaQueryPadding.right - _kArrowScreenPadding;
 
     final Offset anchorAboveAdjusted = Offset(
       clampDouble(anchorAbove.dx, leftMargin, rightMargin),

--- a/packages/flutter/lib/src/cupertino/theme.dart
+++ b/packages/flutter/lib/src/cupertino/theme.dart
@@ -86,7 +86,7 @@ class CupertinoTheme extends StatelessWidget {
   ///   [MediaQueryData.platformBrightness] for descendant Cupertino widgets.
   static Brightness brightnessOf(BuildContext context) {
     final _InheritedCupertinoTheme? inheritedTheme = context.dependOnInheritedWidgetOfExactType<_InheritedCupertinoTheme>();
-    return inheritedTheme?.theme.data.brightness ?? MediaQuery.of(context).platformBrightness;
+    return inheritedTheme?.theme.data.brightness ?? MediaQuery.platformBrightnessOf(context);
   }
 
   /// Retrieves the [Brightness] to use for descendant Cupertino widgets, based
@@ -106,7 +106,7 @@ class CupertinoTheme extends StatelessWidget {
   ///   [MediaQuery] exists, instead of returning null.
   static Brightness? maybeBrightnessOf(BuildContext context) {
     final _InheritedCupertinoTheme? inheritedTheme = context.dependOnInheritedWidgetOfExactType<_InheritedCupertinoTheme>();
-    return inheritedTheme?.theme.data.brightness ?? MediaQuery.maybeOf(context)?.platformBrightness;
+    return inheritedTheme?.theme.data.brightness ?? MediaQuery.maybePlatformBrightnessOf(context);
   }
 
   /// The widget below this widget in the tree.

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -966,7 +966,7 @@ const double _wideGutterSize = 24.0;
 const double _narrowGutterSize = 12.0;
 
 double _getGutterSize(BuildContext context) =>
-    MediaQuery.widthOf(context) >= _materialGutterThreshold ? _wideGutterSize : _narrowGutterSize;
+    MediaQuery.sizeOf(context).width >= _materialGutterThreshold ? _wideGutterSize : _narrowGutterSize;
 
 /// Signature for the builder callback used by [_MasterDetailFlow].
 typedef _MasterViewBuilder = Widget Function(BuildContext context, bool isLateralUI);
@@ -1453,7 +1453,7 @@ class _DetailView extends StatelessWidget {
     if (_arguments == null) {
       return const SizedBox.shrink();
     }
-    final double screenHeight = MediaQuery.heightOf(context);
+    final double screenHeight = MediaQuery.sizeOf(context).height;
     final double minHeight = (screenHeight - kToolbarHeight) / screenHeight;
 
     return DraggableScrollableSheet(

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -966,7 +966,7 @@ const double _wideGutterSize = 24.0;
 const double _narrowGutterSize = 12.0;
 
 double _getGutterSize(BuildContext context) =>
-    MediaQuery.of(context).size.width >= _materialGutterThreshold ? _wideGutterSize : _narrowGutterSize;
+    MediaQuery.widthOf(context) >= _materialGutterThreshold ? _wideGutterSize : _narrowGutterSize;
 
 /// Signature for the builder callback used by [_MasterDetailFlow].
 typedef _MasterViewBuilder = Widget Function(BuildContext context, bool isLateralUI);
@@ -1453,7 +1453,7 @@ class _DetailView extends StatelessWidget {
     if (_arguments == null) {
       return const SizedBox.shrink();
     }
-    final double screenHeight = MediaQuery.of(context).size.height;
+    final double screenHeight = MediaQuery.heightOf(context);
     final double minHeight = (screenHeight - kToolbarHeight) / screenHeight;
 
     return DraggableScrollableSheet(

--- a/packages/flutter/lib/src/material/action_chip.dart
+++ b/packages/flutter/lib/src/material/action_chip.dart
@@ -239,7 +239,7 @@ class _ActionChipDefaultsM3 extends ChipThemeData {
   EdgeInsetsGeometry? get labelPadding => EdgeInsets.lerp(
     const EdgeInsets.symmetric(horizontal: 8.0),
     const EdgeInsets.symmetric(horizontal: 4.0),
-    clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+    clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
   )!;
 }
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -2091,7 +2091,7 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
   Widget build(BuildContext context) {
     assert(!widget.primary || debugCheckHasMediaQuery(context));
     final double bottomHeight = widget.bottom?.preferredSize.height ?? 0.0;
-    final double topPadding = widget.primary ? MediaQuery.of(context).padding.top : 0.0;
+    final double topPadding = widget.primary ? MediaQuery.paddingOf(context).top : 0.0;
     final double collapsedHeight = (widget.pinned && widget.floating && widget.bottom != null)
       ? (widget.collapsedHeight ?? 0.0) + bottomHeight + topPadding
       : (widget.collapsedHeight ?? widget.toolbarHeight) + bottomHeight + topPadding;
@@ -2205,7 +2205,7 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
   Widget build(BuildContext context) {
     late final ThemeData theme = Theme.of(context);
     final FlexibleSpaceBarSettings settings = context.dependOnInheritedWidgetOfExactType<FlexibleSpaceBarSettings>()!;
-    final double topPadding = primary ? MediaQuery.of(context).viewPadding.top : 0;
+    final double topPadding = primary ? MediaQuery.viewPaddingOf(context).top : 0;
     final double collapsedHeight = settings.minExtent - topPadding;
     final double scrollUnderHeight = settings.maxExtent - settings.minExtent;
     final _ScrollUnderFlexibleConfig config;

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -293,7 +293,7 @@ class _MaterialBannerState extends State<MaterialBanner> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQueryData = MediaQuery.of(context);
+    final bool accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
 
     assert(widget.actions.isNotEmpty);
 
@@ -399,7 +399,7 @@ class _MaterialBannerState extends State<MaterialBanner> {
       onDismiss: () {
         ScaffoldMessenger.of(context).removeCurrentMaterialBanner(reason: MaterialBannerClosedReason.dismiss);
       },
-      child: mediaQueryData.accessibleNavigation
+      child: accessibleNavigation
           ? materialBanner
           : SlideTransition(
         position: slideOutAnimation,
@@ -408,7 +408,7 @@ class _MaterialBannerState extends State<MaterialBanner> {
     );
 
     final Widget materialBannerTransition;
-    if (mediaQueryData.accessibleNavigation) {
+    if (accessibleNavigation) {
       materialBannerTransition = materialBanner;
     } else {
       materialBannerTransition = AnimatedBuilder(

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -1185,7 +1185,7 @@ class _Bar extends StatelessWidget {
         alignment: Alignment.bottomCenter,
         heightFactor: 1,
         child: SizedBox(
-          width: MediaQuery.heightOf(context),
+          width: MediaQuery.sizeOf(context).height,
           child: child,
         ),
       );

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -607,8 +607,7 @@ class _Tile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final MediaQueryData data = MediaQuery.of(context);
-    if (data.orientation == Orientation.landscape && layout == BottomNavigationBarLandscapeLayout.linear) {
+    if (MediaQuery.orientationOf(context) == Orientation.landscape && layout == BottomNavigationBarLandscapeLayout.linear) {
       return Align(
         heightFactor: 1,
         child: Row(
@@ -1114,7 +1113,7 @@ class _BottomNavigationBarState extends State<BottomNavigationBar> with TickerPr
     final BottomNavigationBarLandscapeLayout layout = widget.landscapeLayout
       ?? bottomTheme.landscapeLayout
       ?? BottomNavigationBarLandscapeLayout.spread;
-    final double additionalBottomPadding = MediaQuery.of(context).viewPadding.bottom;
+    final double additionalBottomPadding = MediaQuery.viewPaddingOf(context).bottom;
 
     Color? backgroundColor;
     switch (_effectiveType) {
@@ -1180,14 +1179,13 @@ class _Bar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final MediaQueryData data = MediaQuery.of(context);
     Widget alignedChild = child;
-    if (data.orientation == Orientation.landscape && layout == BottomNavigationBarLandscapeLayout.centered) {
+    if (MediaQuery.orientationOf(context) == Orientation.landscape && layout == BottomNavigationBarLandscapeLayout.centered) {
       alignedChild = Align(
         alignment: Alignment.bottomCenter,
         heightFactor: 1,
         child: SizedBox(
-          width: data.size.height,
+          width: MediaQuery.heightOf(context),
           child: child,
         ),
       );

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -409,7 +409,6 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final String routeLabel = _getRouteLabel(localizations);
 
@@ -436,7 +435,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
         // Disable the initial animation when accessible navigation is on so
         // that the semantics are added to the tree at the correct time.
         final double animationValue = animationCurve.transform(
-            mediaQuery.accessibleNavigation ? 1.0 : widget.route.animation!.value,
+            MediaQuery.accessibleNavigationOf(context) ? 1.0 : widget.route.animation!.value,
         );
         return Semantics(
           scopesRoute: true,

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1158,7 +1158,7 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     final EdgeInsetsGeometry defaultLabelPadding = EdgeInsets.lerp(
       const EdgeInsets.symmetric(horizontal: 8.0),
       const EdgeInsets.symmetric(horizontal: 4.0),
-      clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+      clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
     )!;
 
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -2257,7 +2257,7 @@ class _ChipDefaultsM3 extends ChipThemeData {
   EdgeInsetsGeometry? get labelPadding => EdgeInsets.lerp(
     const EdgeInsets.symmetric(horizontal: 8.0),
     const EdgeInsets.symmetric(horizontal: 4.0),
-    clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+    clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
   )!;
 }
 

--- a/packages/flutter/lib/src/material/choice_chip.dart
+++ b/packages/flutter/lib/src/material/choice_chip.dart
@@ -259,7 +259,7 @@ class _ChoiceChipDefaultsM3 extends ChipThemeData {
   EdgeInsetsGeometry? get labelPadding => EdgeInsets.lerp(
     const EdgeInsets.symmetric(horizontal: 8.0),
     const EdgeInsets.symmetric(horizontal: 4.0),
-    clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+    clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
   )!;
 }
 

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1514,7 +1514,7 @@ class _CalendarRangePickerDialog extends StatelessWidget {
           bottom: PreferredSize(
             preferredSize: const Size(double.infinity, 64),
             child: Row(children: <Widget>[
-              SizedBox(width: MediaQuery.widthOf(context) < 360 ? 42 : 72),
+              SizedBox(width: MediaQuery.sizeOf(context).width < 360 ? 42 : 72),
               Expanded(
                 child: Semantics(
                   label: '$helpText $startDateText to $endDateText',

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -425,7 +425,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
   }
 
   Size _dialogSize(BuildContext context) {
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     switch (_entryMode.value) {
       case DatePickerEntryMode.calendar:
       case DatePickerEntryMode.calendarOnly:
@@ -456,11 +456,11 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     final TextTheme textTheme = theme.textTheme;
     // Constrain the textScaleFactor to the largest supported value to prevent
     // layout issues.
-    final double textScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 1.3);
+    final double textScaleFactor = math.min(MediaQuery.textScaleFactorOf(context), 1.3);
 
     final String dateText = localizations.formatMediumDate(_selectedDate.value);
     final Color onPrimarySurface = colorScheme.brightness == Brightness.light
@@ -1308,9 +1308,8 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
 
   @override
   Widget build(BuildContext context) {
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
-    final Orientation orientation = mediaQuery.orientation;
-    final double textScaleFactor = math.min(mediaQuery.textScaleFactor, 1.3);
+    final Orientation orientation = MediaQuery.orientationOf(context);
+    final double textScaleFactor = math.min(MediaQuery.textScaleFactorOf(context), 1.3);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final ColorScheme colors = Theme.of(context).colorScheme;
     final Color onPrimarySurface = colors.brightness == Brightness.light
@@ -1351,7 +1350,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           confirmText: widget.saveText ?? localizations.saveButtonLabel,
           helpText: widget.helpText ?? localizations.dateRangePickerHelpText,
         );
-        size = mediaQuery.size;
+        size = MediaQuery.sizeOf(context);
         insetPadding = EdgeInsets.zero;
         shape = const RoundedRectangleBorder();
         elevation = 0;
@@ -1475,7 +1474,7 @@ class _CalendarRangePickerDialog extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     final TextTheme textTheme = theme.textTheme;
     final Color headerForeground = colorScheme.brightness == Brightness.light
         ? colorScheme.onPrimary
@@ -1515,7 +1514,7 @@ class _CalendarRangePickerDialog extends StatelessWidget {
           bottom: PreferredSize(
             preferredSize: const Size(double.infinity, 64),
             child: Row(children: <Widget>[
-              SizedBox(width: MediaQuery.of(context).size.width < 360 ? 42 : 72),
+              SizedBox(width: MediaQuery.widthOf(context) < 360 ? 42 : 72),
               Expanded(
                 child: Semantics(
                   label: '$helpText $startDateText to $endDateText',
@@ -1993,7 +1992,7 @@ class _DayHeaders extends StatelessWidget {
 
     return Container(
       constraints: BoxConstraints(
-        maxWidth: MediaQuery.of(context).orientation == Orientation.landscape
+        maxWidth: MediaQuery.orientationOf(context) == Orientation.landscape
           ? _maxCalendarWidthLandscape
           : _maxCalendarWidthPortrait,
         maxHeight: _monthItemRowHeight,
@@ -2444,7 +2443,7 @@ class _MonthItemState extends State<_MonthItem> {
       paddedDayItems.addAll(weekList);
     }
 
-    final double maxWidth = MediaQuery.of(context).orientation == Orientation.landscape
+    final double maxWidth = MediaQuery.orientationOf(context) == Orientation.landscape
       ? _maxCalendarWidthLandscape
       : _maxCalendarWidthPortrait;
     return Column(
@@ -2598,7 +2597,7 @@ class _InputDateRangePickerDialog extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     final TextTheme textTheme = theme.textTheme;
 
     final Color onPrimarySurfaceColor = colorScheme.brightness == Brightness.light

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -180,7 +180,7 @@ class _DesktopTextSelectionControlsToolbarState extends State<_DesktopTextSelect
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
         MediaQuery.paddingOf(context).left,
-        MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right,
+        MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -171,13 +171,13 @@ class _DesktopTextSelectionControlsToolbarState extends State<_DesktopTextSelect
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasMediaQuery(context));
-    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
 
     // Don't render the menu until the state of the clipboard is known.
     if (widget.handlePaste != null && widget.clipboardStatus?.value == ClipboardStatus.unknown) {
       return const SizedBox.shrink();
     }
 
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
         mediaQueryPadding.left,

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -171,6 +171,7 @@ class _DesktopTextSelectionControlsToolbarState extends State<_DesktopTextSelect
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasMediaQuery(context));
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
 
     // Don't render the menu until the state of the clipboard is known.
     if (widget.handlePaste != null && widget.clipboardStatus?.value == ClipboardStatus.unknown) {
@@ -179,8 +180,8 @@ class _DesktopTextSelectionControlsToolbarState extends State<_DesktopTextSelect
 
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
-        MediaQuery.paddingOf(context).left,
-        MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right,
+        mediaQueryPadding.left,
+        MediaQuery.sizeOf(context).width - mediaQueryPadding.right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -177,12 +177,10 @@ class _DesktopTextSelectionControlsToolbarState extends State<_DesktopTextSelect
       return const SizedBox.shrink();
     }
 
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
-
     final Offset midpointAnchor = Offset(
       clampDouble(widget.selectionMidpoint.dx - widget.globalEditableRegion.left,
-        mediaQuery.padding.left,
-        mediaQuery.size.width - mediaQuery.padding.right,
+        MediaQuery.paddingOf(context).left,
+        MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right,
       ),
       widget.selectionMidpoint.dy - widget.globalEditableRegion.top,
     );

--- a/packages/flutter/lib/src/material/desktop_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection_toolbar.dart
@@ -64,9 +64,8 @@ class DesktopTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
 
-    final double paddingAbove = mediaQuery.padding.top + _kToolbarScreenPadding;
+    final double paddingAbove = MediaQuery.paddingOf(context).top + _kToolbarScreenPadding;
     final Offset localAdjustment = Offset(_kToolbarScreenPadding, paddingAbove);
 
     return Padding(

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -217,7 +217,7 @@ class Dialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final DialogTheme dialogTheme = DialogTheme.of(context);
-    final EdgeInsets effectivePadding = MediaQuery.of(context).viewInsets + (insetPadding ?? EdgeInsets.zero);
+    final EdgeInsets effectivePadding = MediaQuery.viewInsetsOf(context) + (insetPadding ?? EdgeInsets.zero);
     final DialogTheme defaults = theme.useMaterial3
       ? (_fullscreen ? _DialogFullscreenDefaultsM3(context) : _DialogDefaultsM3(context))
       : _DialogDefaultsM2(context);
@@ -642,7 +642,7 @@ class AlertDialog extends StatelessWidget {
 
     // The paddingScaleFactor is used to adjust the padding of Dialog's
     // children.
-    final double paddingScaleFactor = _paddingScaleFactor(MediaQuery.of(context).textScaleFactor);
+    final double paddingScaleFactor = _paddingScaleFactor(MediaQuery.textScaleFactorOf(context));
     final TextDirection? textDirection = Directionality.maybeOf(context);
 
     Widget? iconWidget;
@@ -1075,7 +1075,7 @@ class SimpleDialog extends StatelessWidget {
 
     // The paddingScaleFactor is used to adjust the padding of Dialog
     // children.
-    final double paddingScaleFactor = _paddingScaleFactor(MediaQuery.of(context).textScaleFactor);
+    final double paddingScaleFactor = _paddingScaleFactor(MediaQuery.textScaleFactorOf(context));
     final TextDirection? textDirection = Directionality.maybeOf(context);
 
     Widget? titleWidget;

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -364,11 +364,11 @@ class DrawerController extends StatefulWidget {
   /// drawer.
   ///
   /// By default, the value used is 20.0 added to the padding edge of
-  /// `MediaQuery.of(context).padding` that corresponds to [alignment].
+  /// `MediaQuery.paddingOf(context)` that corresponds to [alignment].
   /// This ensures that the drag area for notched devices is not obscured. For
   /// example, if [alignment] is set to [DrawerAlignment.start] and
   /// `TextDirection.of(context)` is set to [TextDirection.ltr],
-  /// 20.0 will be added to `MediaQuery.of(context).padding.left`.
+  /// 20.0 will be added to `MediaQuery.paddingOf(context).left`.
   final double? edgeDragWidth;
 
   /// Whether or not the drawer is opened or closed.
@@ -606,7 +606,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
   Widget _buildDrawer(BuildContext context) {
     final bool drawerIsStart = widget.alignment == DrawerAlignment.start;
-    final EdgeInsets padding = MediaQuery.of(context).padding;
+    final EdgeInsets padding = MediaQuery.paddingOf(context);
     final TextDirection textDirection = Directionality.of(context);
     final bool isDesktop;
     switch (Theme.of(context).platform) {

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -606,7 +606,6 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
   Widget _buildDrawer(BuildContext context) {
     final bool drawerIsStart = widget.alignment == DrawerAlignment.start;
-    final EdgeInsets padding = MediaQuery.paddingOf(context);
     final TextDirection textDirection = Directionality.of(context);
     final bool isDesktop;
     switch (Theme.of(context).platform) {
@@ -624,6 +623,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
     double? dragAreaWidth = widget.edgeDragWidth;
     if (widget.edgeDragWidth == null) {
+      final EdgeInsets padding = MediaQuery.paddingOf(context);
       switch (textDirection) {
         case TextDirection.ltr:
           dragAreaWidth = _kEdgeDragWidth +

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -76,7 +76,7 @@ class DrawerHeader extends StatelessWidget {
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMediaQuery(context));
     final ThemeData theme = Theme.of(context);
-    final double statusBarHeight = MediaQuery.of(context).padding.top;
+    final double statusBarHeight = MediaQuery.paddingOf(context).top;
     return Container(
       height: statusBarHeight + _kDrawerHeaderHeight,
       margin: margin,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1333,7 +1333,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Similarly, we don't reduce the height of the button so much that its icon
   // would be clipped.
   double get _denseButtonHeight {
-    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
+    final double textScaleFactor = MediaQuery.textScaleFactorOf(context);
     final double fontSize = _textStyle!.fontSize ?? Theme.of(context).textTheme.titleMedium!.fontSize!;
     final double scaledFontSize = textScaleFactor * fontSize;
     return math.max(scaledFontSize, math.max(widget.iconSize, _kDenseButtonHeight));
@@ -1369,7 +1369,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.onChanged != null;
 
   Orientation _getOrientation(BuildContext context) {
-    Orientation? result = MediaQuery.maybeOf(context)?.orientation;
+    Orientation? result = MediaQuery.maybeOrientationOf(context);
     if (result == null) {
       // If there's no MediaQuery, then use the window aspect to determine
       // orientation.

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -252,7 +252,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// each state, and "others" means all other states.
   ///
   /// The `textScaleFactor` is the value of
-  /// `MediaQuery.of(context).textScaleFactor` and the names of the
+  /// `MediaQuery.textScaleFactorOf(context)` and the names of the
   /// EdgeInsets constructors and `EdgeInsetsGeometry.lerp` have been
   /// abbreviated for readability.
   ///
@@ -394,7 +394,7 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
     const EdgeInsets.symmetric(horizontal: 16),
     const EdgeInsets.symmetric(horizontal: 8),
     const EdgeInsets.symmetric(horizontal: 4),
-    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    MediaQuery.textScaleFactorOf(context),
   );
 }
 
@@ -500,7 +500,7 @@ class _ElevatedButtonWithIcon extends ElevatedButton {
       const EdgeInsetsDirectional.fromSTEB(12, 0, 16, 0),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsetsDirectional.fromSTEB(8, 0, 4, 0),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+      MediaQuery.textScaleFactorOf(context),
     );
     return super.defaultStyleOf(context).copyWith(
       padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(scaledPadding),
@@ -516,7 +516,7 @@ class _ElevatedButtonWithIconChild extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double scale = MediaQuery.maybeOf(context)?.textScaleFactor ?? 1;
+    final double scale = MediaQuery.textScaleFactorOf(context);
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -288,7 +288,7 @@ class FilledButton extends ButtonStyleButton {
   /// each state, and "others" means all other states.
   ///
   /// The `textScaleFactor` is the value of
-  /// `MediaQuery.of(context).textScaleFactor` and the names of the
+  /// `MediaQuery.textScaleFactorOf(context)` and the names of the
   /// EdgeInsets constructors and `EdgeInsetsGeometry.lerp` have been
   /// abbreviated for readability.
   ///
@@ -368,7 +368,7 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
     const EdgeInsets.symmetric(horizontal: 16),
     const EdgeInsets.symmetric(horizontal: 8),
     const EdgeInsets.symmetric(horizontal: 4),
-    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    MediaQuery.textScaleFactorOf(context),
   );
 }
 
@@ -471,7 +471,7 @@ class _FilledButtonWithIcon extends FilledButton {
       const EdgeInsetsDirectional.fromSTEB(12, 0, 16, 0),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsetsDirectional.fromSTEB(8, 0, 4, 0),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+      MediaQuery.textScaleFactorOf(context),
     );
     return super.defaultStyleOf(context).copyWith(
       padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(scaledPadding),
@@ -487,7 +487,7 @@ class _FilledButtonWithIconChild extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double scale = MediaQuery.maybeOf(context)?.textScaleFactor ?? 1;
+    final double scale = MediaQuery.textScaleFactorOf(context);
     // Adjust the gap based on the text scale factor. Start at 8, and lerp
     // to 4 based on how large the text is.
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;

--- a/packages/flutter/lib/src/material/filter_chip.dart
+++ b/packages/flutter/lib/src/material/filter_chip.dart
@@ -267,7 +267,7 @@ class _FilterChipDefaultsM3 extends ChipThemeData {
   EdgeInsetsGeometry? get labelPadding => EdgeInsets.lerp(
     const EdgeInsets.symmetric(horizontal: 8.0),
     const EdgeInsets.symmetric(horizontal: 4.0),
-    clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+    clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
   )!;
 }
 

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -999,7 +999,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   }
 
   bool get _shouldShowFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+    final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
         return enabled && _hasFocus;
@@ -1147,7 +1147,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   }
 
   bool get _canRequestFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+    final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
         return enabled && widget.canRequestFocus;

--- a/packages/flutter/lib/src/material/input_chip.dart
+++ b/packages/flutter/lib/src/material/input_chip.dart
@@ -310,7 +310,7 @@ class _InputChipDefaultsM3 extends ChipThemeData {
   EdgeInsetsGeometry? get labelPadding => EdgeInsets.lerp(
     const EdgeInsets.symmetric(horizontal: 8.0),
     const EdgeInsets.symmetric(horizontal: 4.0),
-    clampDouble(MediaQuery.of(context).textScaleFactor - 1.0, 0.0, 1.0),
+    clampDouble(MediaQuery.textScaleFactorOf(context) - 1.0, 0.0, 1.0),
   )!;
 }
 

--- a/packages/flutter/lib/src/material/magnifier.dart
+++ b/packages/flutter/lib/src/material/magnifier.dart
@@ -134,7 +134,7 @@ class _TextMagnifierState extends State<TextMagnifier> {
   void _determineMagnifierPositionAndFocalPoint() {
     final MagnifierInfo selectionInfo =
         widget.magnifierInfo.value;
-    final Rect screenRect = Offset.zero & MediaQuery.of(context).size;
+    final Rect screenRect = Offset.zero & MediaQuery.sizeOf(context);
 
     // Since by default we draw at the top left corner, this offset
     // shifts the magnifier so we draw at the center, and then also includes

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -307,7 +307,7 @@ class _MenuAnchorState extends State<MenuAnchor> {
     _position?.isScrollingNotifier.removeListener(_handleScroll);
     _position = Scrollable.maybeOf(context)?.position;
     _position?.isScrollingNotifier.addListener(_handleScroll);
-    final Size newSize = MediaQuery.of(context).size;
+    final Size newSize = MediaQuery.sizeOf(context);
     if (_viewSize != null && newSize != _viewSize) {
       // Close the menus if the view changes size.
       _root._close();

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -963,7 +963,7 @@ class _ClampTextScaleFactor extends StatelessWidget {
   Widget build(BuildContext context) {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
-        textScaleFactor: clampDouble(MediaQuery.of(context).textScaleFactor,
+        textScaleFactor: clampDouble(MediaQuery.textScaleFactorOf(context),
           0.0,
           upperLimit,
         ),

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -351,7 +351,7 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
     const EdgeInsets.symmetric(horizontal: 16),
     const EdgeInsets.symmetric(horizontal: 8),
     const EdgeInsets.symmetric(horizontal: 4),
-    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    MediaQuery.textScaleFactorOf(context),
   );
 }
 
@@ -437,7 +437,7 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double scale = MediaQuery.maybeOf(context)?.textScaleFactor ?? 1;
+    final double scale = MediaQuery.textScaleFactorOf(context);
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1285,7 +1285,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
   }
 
   bool get _canRequestFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+    final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
         return widget.enabled;

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -619,7 +619,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     // This size is used as the max bounds for the painting of the value
     // indicators. It must be kept in sync with the function with the same name
     // in slider.dart.
-    Size screenSize() => MediaQuery.of(context).size;
+    Size screenSize() => MediaQuery.sizeOf(context);
 
     return CompositedTransformTarget(
       link: _layerLink,
@@ -628,7 +628,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
         divisions: widget.divisions,
         labels: widget.labels,
         sliderTheme: sliderTheme,
-        textScaleFactor: MediaQuery.of(context).textScaleFactor,
+        textScaleFactor: MediaQuery.textScaleFactorOf(context),
         screenSize: screenSize(),
         onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
         onChangeStart: widget.onChangeStart != null ? _handleDragStart : null,
@@ -704,7 +704,7 @@ class _RangeSliderRenderObjectWidget extends LeafRenderObjectWidget {
       textDirection: Directionality.of(context),
       semanticFormatterCallback: semanticFormatterCallback,
       platform: Theme.of(context).platform,
-      gestureSettings: MediaQuery.of(context).gestureSettings,
+      gestureSettings: MediaQuery.gestureSettingsOf(context),
     );
   }
 
@@ -726,7 +726,7 @@ class _RangeSliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..textDirection = Directionality.of(context)
       ..semanticFormatterCallback = semanticFormatterCallback
       ..platform = Theme.of(context).platform
-      ..gestureSettings = MediaQuery.of(context).gestureSettings;
+      ..gestureSettings = MediaQuery.gestureSettingsOf(context);
   }
 }
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -191,18 +191,18 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
 
   @override
   void didChangeDependencies() {
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    final bool accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
     // If we transition from accessible navigation to non-accessible navigation
     // and there is a SnackBar that would have timed out that has already
     // completed its timer, dismiss that SnackBar. If the timer hasn't finished
     // yet, let it timeout as normal.
     if ((_accessibleNavigation ?? false)
-        && !mediaQuery.accessibleNavigation
+        && !accessibleNavigation
         && _snackBarTimer != null
         && !_snackBarTimer!.isActive) {
       hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);
     }
-    _accessibleNavigation = mediaQuery.accessibleNavigation;
+    _accessibleNavigation = accessibleNavigation;
     super.didChangeDependencies();
   }
 
@@ -562,8 +562,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
-    _accessibleNavigation = mediaQuery.accessibleNavigation;
+    _accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
 
     if (_snackBars.isNotEmpty) {
       final ModalRoute<dynamic>? route = ModalRoute.of(context);
@@ -576,8 +575,8 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
                 _snackBarController!.status == AnimationStatus.completed,
             );
             // Look up MediaQuery again in case the setting changed.
-            final MediaQueryData mediaQuery = MediaQuery.of(context);
-            if (mediaQuery.accessibleNavigation && snackBar.action != null) {
+            final bool accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
+            if (accessibleNavigation && snackBar.action != null) {
               return;
             }
             hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);
@@ -1812,11 +1811,11 @@ class Scaffold extends StatefulWidget {
   /// drawer.
   ///
   /// By default, the value used is 20.0 added to the padding edge of
-  /// `MediaQuery.of(context).padding` that corresponds to the surrounding
+  /// `MediaQuery.paddingOf(context)` that corresponds to the surrounding
   /// [TextDirection]. This ensures that the drag area for notched devices is
   /// not obscured. For example, if `TextDirection.of(context)` is set to
   /// [TextDirection.ltr], 20.0 will be added to
-  /// `MediaQuery.of(context).padding.left`.
+  /// `MediaQuery.paddingOf(context).left`.
   final double? drawerEdgeDragWidth;
 
   /// Determines if the [Scaffold.drawer] can be opened with a drag
@@ -2749,7 +2748,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasDirectionality(context));
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
     final ThemeData themeData = Theme.of(context);
     final TextDirection textDirection = Directionality.of(context);
 
@@ -2784,7 +2782,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     }
 
     if (widget.appBar != null) {
-      final double topPadding = widget.primary ? mediaQuery.padding.top : 0.0;
+      final double topPadding = widget.primary ? MediaQuery.paddingOf(context).top : 0.0;
       _appBarMaxHeight = AppBar.preferredHeightFor(context, widget.appBar!.preferredSize) + topPadding;
       assert(_appBarMaxHeight! >= 0.0 && _appBarMaxHeight!.isFinite);
       _addIfNonNull(
@@ -2961,14 +2959,14 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     }
 
     // The minimum insets for contents of the Scaffold to keep visible.
-    final EdgeInsets minInsets = mediaQuery.padding.copyWith(
-      bottom: _resizeToAvoidBottomInset ? mediaQuery.viewInsets.bottom : 0.0,
+    final EdgeInsets minInsets = MediaQuery.paddingOf(context).copyWith(
+      bottom: _resizeToAvoidBottomInset ? MediaQuery.viewInsetsOf(context).bottom : 0.0,
     );
 
     // The minimum viewPadding for interactive elements positioned by the
     // Scaffold to keep within safe interactive areas.
-    final EdgeInsets minViewPadding = mediaQuery.viewPadding.copyWith(
-      bottom: _resizeToAvoidBottomInset && mediaQuery.viewInsets.bottom != 0.0 ? 0.0 : null,
+    final EdgeInsets minViewPadding = MediaQuery.viewPaddingOf(context).copyWith(
+      bottom: _resizeToAvoidBottomInset && MediaQuery.viewInsetsOf(context).bottom != 0.0 ? 0.0 : null,
     );
 
     // extendBody locked when keyboard is open

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -575,8 +575,7 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
                 _snackBarController!.status == AnimationStatus.completed,
             );
             // Look up MediaQuery again in case the setting changed.
-            final bool accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
-            if (accessibleNavigation && snackBar.action != null) {
+            if (snackBar.action != null && MediaQuery.accessibleNavigationOf(context)) {
               return;
             }
             hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -427,7 +427,7 @@ class _MaterialScrollbarState extends RawScrollbarState<_MaterialScrollbar> {
       ..crossAxisMargin = _scrollbarTheme.crossAxisMargin ?? (_useAndroidScrollbar ? 0.0 : _kScrollbarMargin)
       ..mainAxisMargin = _scrollbarTheme.mainAxisMargin ?? 0.0
       ..minLength = _scrollbarTheme.minThumbLength ?? _kScrollbarMinLength
-      ..padding = MediaQuery.of(context).padding
+      ..padding = MediaQuery.paddingOf(context)
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..ignorePointer = !enableGestures;
   }

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -700,7 +700,7 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
     if (effectiveTextStyle == null || effectiveTextStyle.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(widget.style ?? _controller._textSpan.style);
     }
-    if (MediaQuery.boldTextOverrideOf(context)) {
+    if (MediaQuery.boldTextOf(context)) {
       effectiveTextStyle = effectiveTextStyle.merge(const TextStyle(fontWeight: FontWeight.bold));
     }
     final Widget child = RepaintBoundary(

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -700,7 +700,7 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
     if (effectiveTextStyle == null || effectiveTextStyle.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(widget.style ?? _controller._textSpan.style);
     }
-    if (MediaQuery.boldTextOverride(context)) {
+    if (MediaQuery.boldTextOverrideOf(context)) {
       effectiveTextStyle = effectiveTextStyle.merge(const TextStyle(fontWeight: FontWeight.bold));
     }
     final Widget child = RepaintBoundary(

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -659,7 +659,7 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? cupertinoTheme.primaryColor;
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
-        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
+        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
         break;
 
       case TargetPlatform.macOS:
@@ -671,7 +671,7 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? cupertinoTheme.primaryColor;
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
-        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
+        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
         break;
 
       case TargetPlatform.android:

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -805,7 +805,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     // This size is used as the max bounds for the painting of the value
     // indicators It must be kept in sync with the function with the same name
     // in range_slider.dart.
-    Size screenSize() => MediaQuery.of(context).size;
+    Size screenSize() => MediaQuery.sizeOf(context);
 
     VoidCallback? handleDidGainAccessibilityFocus;
     switch (theme.platform) {
@@ -826,7 +826,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
     }
 
     final Map<ShortcutActivator, Intent> shortcutMap;
-    switch (MediaQuery.of(context).navigationMode) {
+    switch (MediaQuery.navigationModeOf(context)) {
       case NavigationMode.directional:
         shortcutMap = _directionalNavShortcutMap;
         break;
@@ -857,7 +857,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
             divisions: widget.divisions,
             label: widget.label,
             sliderTheme: sliderTheme,
-            textScaleFactor: MediaQuery.of(context).textScaleFactor,
+            textScaleFactor: MediaQuery.textScaleFactorOf(context),
             screenSize: screenSize(),
             onChanged: (widget.onChanged != null) && (widget.max > widget.min) ? _handleChanged : null,
             onChangeStart: _handleDragStart,
@@ -965,7 +965,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       platform: Theme.of(context).platform,
       hasFocus: hasFocus,
       hovering: hovering,
-      gestureSettings: MediaQuery.of(context).gestureSettings,
+      gestureSettings: MediaQuery.gestureSettingsOf(context),
     );
   }
 
@@ -989,7 +989,7 @@ class _SliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..platform = Theme.of(context).platform
       ..hasFocus = hasFocus
       ..hovering = hovering
-      ..gestureSettings = MediaQuery.of(context).gestureSettings;
+      ..gestureSettings = MediaQuery.gestureSettingsOf(context);
     // Ticker provider cannot change since there's a 1:1 relationship between
     // the _SliderRenderObjectWidget object and the _SliderState object.
   }

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -437,7 +437,7 @@ class _SnackBarState extends State<SnackBar> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData mediaQueryData = MediaQuery.of(context);
+    final bool accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
     assert(widget.animation != null);
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
@@ -556,7 +556,7 @@ class _SnackBarState extends State<SnackBar> {
       color: backgroundColor,
       child: Theme(
         data: inverseTheme,
-        child: mediaQueryData.accessibleNavigation
+        child: accessibleNavigation
             ? snackBar
             : FadeTransition(
                 opacity: fadeOutAnimation,
@@ -612,7 +612,7 @@ class _SnackBarState extends State<SnackBar> {
     );
 
     final Widget snackBarTransition;
-    if (mediaQueryData.accessibleNavigation) {
+    if (accessibleNavigation) {
       snackBarTransition = snackBar;
     } else if (isFloatingSnackBar) {
       snackBarTransition = FadeTransition(

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -249,7 +249,7 @@ class TextButton extends ButtonStyleButton {
   /// each state and "others" means all other states.
   ///
   /// The `textScaleFactor` is the value of
-  /// `MediaQuery.of(context).textScaleFactor` and the names of the
+  /// `MediaQuery.textScaleFactorOf(context)` and the names of the
   /// EdgeInsets constructors and `EdgeInsetsGeometry.lerp` have been
   /// abbreviated for readability.
   ///
@@ -382,7 +382,7 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
     const EdgeInsets.all(8),
     const EdgeInsets.symmetric(horizontal: 8),
     const EdgeInsets.symmetric(horizontal: 4),
-    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    MediaQuery.textScaleFactorOf(context),
   );
 }
 
@@ -495,7 +495,7 @@ class _TextButtonWithIcon extends TextButton {
       const EdgeInsets.all(8),
       const EdgeInsets.symmetric(horizontal: 4),
       const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+      MediaQuery.textScaleFactorOf(context),
     );
     return super.defaultStyleOf(context).copyWith(
       padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(scaledPadding),
@@ -514,7 +514,7 @@ class _TextButtonWithIconChild extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double scale = MediaQuery.maybeOf(context)?.textScaleFactor ?? 1;
+    final double scale = MediaQuery.textScaleFactorOf(context);
     final double gap = scale <= 1 ? 8 : lerpDouble(8, 4, math.min(scale - 1, 1))!;
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -967,7 +967,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
   }
 
   bool get _canRequestFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+    final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
         return _isEnabled;
@@ -1215,7 +1215,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? cupertinoTheme.primaryColor;
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
-        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
+        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
         autocorrectionTextRectColor = selectionColor;
         break;
 
@@ -1228,7 +1228,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         cursorColor = widget.cursorColor ?? selectionStyle.cursorColor ?? cupertinoTheme.primaryColor;
         selectionColor = selectionStyle.selectionColor ?? cupertinoTheme.primaryColor.withOpacity(0.40);
         cursorRadius ??= const Radius.circular(2.0);
-        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.of(context).devicePixelRatio, 0);
+        cursorOffset = Offset(iOSHorizontalOffset / MediaQuery.devicePixelRatioOf(context), 0);
         handleDidGainAccessibilityFocus = () {
           // Automatically activate the TextField when it receives accessibility focus.
           if (!_effectiveFocusNode.hasFocus && _effectiveFocusNode.canRequestFocus) {

--- a/packages/flutter/lib/src/material/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar.dart
@@ -99,7 +99,7 @@ class TextSelectionToolbar extends StatelessWidget {
     final Offset anchorBelowPadded =
         anchorBelow + const Offset(0.0, _kToolbarContentDistanceBelow);
 
-    final double paddingAbove = MediaQuery.of(context).padding.top
+    final double paddingAbove = MediaQuery.paddingOf(context).top
         + _kToolbarScreenPadding;
     final double availableHeight = anchorAbovePadded.dy - _kToolbarContentDistance - paddingAbove;
     final bool fitsAbove = _kToolbarHeight <= availableHeight;

--- a/packages/flutter/lib/src/material/time.dart
+++ b/packages/flutter/lib/src/material/time.dart
@@ -108,7 +108,7 @@ class TimeOfDay {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     return localizations.formatTimeOfDay(
       this,
-      alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
+      alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
     );
   }
 

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -149,7 +149,7 @@ class _TimePickerHeader extends StatelessWidget {
     assert(debugCheckHasMediaQuery(context));
     final ThemeData themeData = Theme.of(context);
     final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat(
-      alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
+      alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
     );
 
     final _TimePickerFragmentContext fragmentContext = _TimePickerFragmentContext(
@@ -335,7 +335,7 @@ class _HourControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final bool alwaysUse24HourFormat = MediaQuery.of(context).alwaysUse24HourFormat;
+    final bool alwaysUse24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final String formattedHour = localizations.formatHour(
       fragmentContext.selectedTime,
@@ -577,7 +577,7 @@ class _DayPeriodControl extends StatelessWidget {
       side: borderSide,
     );
 
-    final double buttonTextScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
+    final double buttonTextScaleFactor = math.min(MediaQuery.textScaleFactorOf(context), 2.0);
 
     final Widget amButton = Material(
       color: MaterialStateProperty.resolveAs(backgroundColor, amStates),
@@ -986,7 +986,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   late ThemeData themeData;
   late MaterialLocalizations localizations;
-  late MediaQueryData media;
+  late bool alwaysUse24HourFormat;
   _DialPainter? painter;
 
   @override
@@ -995,7 +995,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
     assert(debugCheckHasMediaQuery(context));
     themeData = Theme.of(context);
     localizations = MaterialLocalizations.of(context);
-    media = MediaQuery.of(context);
+    alwaysUse24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
   }
 
   @override
@@ -1205,7 +1205,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
 
   _TappableLabel _buildTappableLabel(TextTheme textTheme, Color color, int value, String label, VoidCallback onTap) {
     final TextStyle style = textTheme.bodyLarge!.copyWith(color: color);
-    final double labelScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
+    final double labelScaleFactor = math.min(MediaQuery.textScaleFactorOf(context), 2.0);
     return _TappableLabel(
       value: value,
       painter: TextPainter(
@@ -1223,7 +1223,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         textTheme,
         color,
         timeOfDay.hour,
-        localizations.formatHour(timeOfDay, alwaysUse24HourFormat: media.alwaysUse24HourFormat),
+        localizations.formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat),
         () {
           _selectHour(timeOfDay.hour);
         },
@@ -1236,7 +1236,7 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
         textTheme,
         color,
         timeOfDay.hour,
-        localizations.formatHour(timeOfDay, alwaysUse24HourFormat: media.alwaysUse24HourFormat),
+        localizations.formatHour(timeOfDay, alwaysUse24HourFormat: alwaysUse24HourFormat),
         () {
           _selectHour(timeOfDay.hour);
         },
@@ -1402,7 +1402,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
       return null;
     }
 
-    if (MediaQuery.of(context).alwaysUse24HourFormat) {
+    if (MediaQuery.alwaysUse24HourFormatOf(context)) {
       if (newHour >= 0 && newHour < 24) {
         return newHour;
       }
@@ -1490,8 +1490,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData media = MediaQuery.of(context);
-    final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat(alwaysUse24HourFormat: media.alwaysUse24HourFormat);
+    final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat(alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context));
     final bool use24HourDials = hourFormat(of: timeOfDayFormat) != HourFormat.h;
     final ThemeData theme = Theme.of(context);
     final TextStyle hourMinuteStyle = TimePickerTheme.of(context).hourMinuteTextStyle ?? theme.textTheme.displayMedium!;
@@ -1751,7 +1750,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
   }
 
   String get _formattedValue {
-    final bool alwaysUse24HourFormat = MediaQuery.of(context).alwaysUse24HourFormat;
+    final bool alwaysUse24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     return !widget.isHour ? localizations.formatMinute(widget.selectedTime) : localizations.formatHour(
       widget.selectedTime,
@@ -1797,7 +1796,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
     //
     // TODO(rami-a): Once https://github.com/flutter/flutter/issues/67571 is
     // resolved, remove the window check for semantics being enabled on web.
-    final String? hintText = MediaQuery.of(context).accessibleNavigation || WidgetsBinding.instance.window.semanticsEnabled
+    final String? hintText = MediaQuery.accessibleNavigationOf(context) || WidgetsBinding.instance.window.semanticsEnabled
         ? widget.semanticHintText
         : (focusNode.hasFocus ? null : _formattedValue);
     inputDecoration = inputDecoration.copyWith(
@@ -2138,11 +2137,10 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
       return;
     }
 
-    final MediaQueryData media = MediaQuery.of(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     _announceToAccessibility(
       context,
-      localizations.formatTimeOfDay(widget.initialTime, alwaysUse24HourFormat: media.alwaysUse24HourFormat),
+      localizations.formatTimeOfDay(widget.initialTime, alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context)),
     );
     _announcedInitialTime.value = true;
   }
@@ -2187,12 +2185,12 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
   }
 
   Size _dialogSize(BuildContext context) {
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     final ThemeData theme = Theme.of(context);
     // Constrain the textScaleFactor to prevent layout issues. Since only some
     // parts of the time picker scale up with textScaleFactor, we cap the factor
     // to 1.1 as that provides enough space to reasonably fit all the content.
-    final double textScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 1.1);
+    final double textScaleFactor = math.min(MediaQuery.textScaleFactorOf(context), 1.1);
 
     final double timePickerWidth;
     final double timePickerHeight;
@@ -2226,12 +2224,11 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData media = MediaQuery.of(context);
-    final TimeOfDayFormat timeOfDayFormat = localizations.timeOfDayFormat(alwaysUse24HourFormat: media.alwaysUse24HourFormat);
+    final TimeOfDayFormat timeOfDayFormat = localizations.timeOfDayFormat(alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context));
     final bool use24HourDials = hourFormat(of: timeOfDayFormat) != HourFormat.h;
     final ThemeData theme = Theme.of(context);
     final ShapeBorder shape = TimePickerTheme.of(context).shape ?? _kDefaultShape;
-    final Orientation orientation = media.orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
 
     final Widget actions = Row(
       children: <Widget>[

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -884,7 +884,7 @@ class _TooltipOverlay extends StatelessWidget {
       );
     }
     return Positioned.fill(
-      bottom: MediaQuery.maybeOf(context)?.viewInsets.bottom ?? 0.0,
+      bottom: MediaQuery.maybeViewInsetsOf(context)?.bottom ?? 0.0,
       child: CustomSingleChildLayout(
         delegate: _TooltipPositionDelegate(
           target: target,

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1222,7 +1222,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
     }
 
     bool canRequestFocus(FocusableActionDetector target) {
-      final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+      final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
       switch (mode) {
         case NavigationMode.traditional:
           return target.enabled;
@@ -1263,7 +1263,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   }
 
   bool get _canRequestFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ?? NavigationMode.traditional;
+    final NavigationMode mode = MediaQuery.maybeNavigationModeOf(context) ?? NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
         return widget.enabled;

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -447,7 +447,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
 
   @override
   void didChangeDependencies() {
-    _recognizer!.gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    _recognizer!.gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
     super.didChangeDependencies();
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2407,7 +2407,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
 
     // Hide the text selection toolbar on mobile when orientation changes.
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     if (_lastOrientation == null) {
       _lastOrientation = orientation;
       return;
@@ -3586,7 +3586,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   @override
   TextEditingValue get textEditingValue => _value;
 
-  double get _devicePixelRatio => MediaQuery.of(context).devicePixelRatio;
+  double get _devicePixelRatio => MediaQuery.devicePixelRatioOf(context);
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause? cause) {

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -1017,7 +1017,7 @@ class GestureDetector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
-    final DeviceGestureSettings? gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    final DeviceGestureSettings? gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
 
     if (onTapDown != null ||
         onTapUp != null ||

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -53,7 +53,7 @@ export 'package:flutter/painting.dart' show
 ImageConfiguration createLocalImageConfiguration(BuildContext context, { Size? size }) {
   return ImageConfiguration(
     bundle: DefaultAssetBundle.of(context),
-    devicePixelRatio: MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
+    devicePixelRatio: MediaQuery.maybeDevicePixelRatioOf(context) ?? 1.0,
     locale: Localizations.maybeLocaleOf(context),
     textDirection: Directionality.maybeOf(context),
     size: size,
@@ -1106,7 +1106,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   }
 
   void _updateInvertColors() {
-    _invertColors = MediaQuery.maybeOf(context)?.invertColors
+    _invertColors = MediaQuery.maybeInvertColorsOf(context)
         ?? SemanticsBinding.instance.accessibilityFeatures.invertColors;
   }
 

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -26,47 +26,49 @@ enum Orientation {
   landscape
 }
 
-/// A specific part of MediaQueryData to depend on
+/// Specifies a part of MediaQueryData to depend on.
+///
+/// [MediaQuery] contains a large number of related properties. Widgets frequently
+/// depend on only a few of these attributes. For example, a widget that needs to
+/// rebuild when the [MediaQueryData.textScaleFactor] changes does not need to
+/// be notified when the [MediaQueryData.size] changes.  Specifying an aspect avoids
+/// unnecessary rebuilds.
 enum MediaQueryAspect {
-  /// MediaQueryData.size
+  /// Specifies the aspect corresponding to [MediaQueryData.size].
   size,
-  /// MediaQueryData.size.width
-  width,
-  /// MediaQueryData.size.height
-  height,
-  /// MediaQueryData.orientation
+  /// Specifies the aspect corresponding to [MediaQueryData.orientation].
   orientation,
-  /// MediaQueryData.devicePixelRatio
+  /// Specifies the aspect corresponding to [MediaQueryData.devicePixelRatio].
   devicePixelRatio,
-  /// MediaQueryData.textScaleFactor
+  /// Specifies the aspect corresponding to [MediaQueryData.textScaleFactor].
   textScaleFactor,
-  /// MediaQueryData.platformBrightness
+  /// Specifies the aspect corresponding to [MediaQueryData.platformBrightness].
   platformBrightness,
-  /// MediaQueryData.padding
+  /// Specifies the aspect corresponding to [MediaQueryData.padding].
   padding,
-  /// MediaQueryData.viewInsets
+  /// Specifies the aspect corresponding to [MediaQueryData.viewInsets].
   viewInsets,
-  /// MediaQueryData.systemGestureInsets
+  /// Specifies the aspect corresponding to [MediaQueryData.systemGestureInsets].
   systemGestureInsets,
-  /// MediaQueryData.viewPadding
+  /// Specifies the aspect corresponding to [MediaQueryData.viewPadding].
   viewPadding,
-  /// MediaQueryData.alwaysUse24HourFormat
+  /// Specifies the aspect corresponding to [MediaQueryData.alwaysUse24HourFormat].
   alwaysUse24HourFormat,
-  /// MediaQueryData.accessibleNavigation
+  /// Specifies the aspect corresponding to [MediaQueryData.accessibleNavigation].
   accessibleNavigation,
-  /// MediaQueryData.invertColors
+  /// Specifies the aspect corresponding to [MediaQueryData.invertColors].
   invertColors,
-  /// MediaQueryData.highContrast
+  /// Specifies the aspect corresponding to [MediaQueryData.highContrast].
   highContrast,
-  /// MediaQueryData.disableAnimations
+  /// Specifies the aspect corresponding to [MediaQueryData.disableAnimations].
   disableAnimations,
-  /// MediaQueryData.boldText
+  /// Specifies the aspect corresponding to [MediaQueryData.boldText].
   boldText,
-  /// MediaQueryData.navigationMode
+  /// Specifies the aspect corresponding to [MediaQueryData.navigationMode].
   navigationMode,
-  /// MediaQueryData.gestureSettings
+  /// Specifies the aspect corresponding to [MediaQueryData.gestureSettings].
   gestureSettings,
-  /// MediaQueryData.displayFeatures
+  /// Specifies the aspect corresponding to [MediaQueryData.displayFeatures].
   displayFeatures,
 }
 
@@ -924,6 +926,11 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// as well as other media parameters (see [MediaQueryData] for more
   /// examples). When that information changes, your widget will be scheduled to
   /// be rebuilt, keeping your widget up-to-date.
+  /// 
+  /// If the widget only requires a subset of properties of the [MediaQueryData]
+  /// object, it is preferred to use the specific methods (for example:
+  /// [MediaQuery.sizeOf] and [MediaQuery.paddingOf]), as those methods will not
+  /// cause your widget to rebuild when unrelated properties are updated.
   ///
   /// Typical usage is as follows:
   ///
@@ -941,11 +948,11 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///    [MediaQuery] ancestor, it returns null instead.
   static MediaQueryData of(BuildContext context) {
     assert(context != null);
-    assert(debugCheckHasMediaQuery(context));
     return _of(context);
   }
 
   static MediaQueryData _of(BuildContext context, [MediaQueryAspect? aspect]) {
+    assert(debugCheckHasMediaQuery(context));
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)!.data;
   }
 
@@ -962,6 +969,11 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// as well as other media parameters (see [MediaQueryData] for more
   /// examples). When that information changes, your widget will be scheduled to
   /// be rebuilt, keeping your widget up-to-date.
+  /// 
+  /// If the widget only requires a subset of properties of the [MediaQueryData]
+  /// object, it is preferred to use the specific methods (for example:
+  /// [MediaQuery.maybeSizeOf] and [MediaQuery.maybePaddingOf]), as those methods
+  /// will not cause your widget to rebuild when unrelated properties are updated.
   ///
   /// Typical usage is as follows:
   ///
@@ -991,6 +1003,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
   static Size sizeOf(BuildContext context) => _of(context, MediaQueryAspect.size).size;
+
   /// Returns size for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -998,38 +1011,13 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
   static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.size)?.size;
 
-  /// Returns width for the nearest MediaQuery ancestor or
-  /// throws an exception, if no such ancestor exists.
-  ///
-  /// Use of this method will cause the given [context] to rebuild any time that
-  /// the size.width property of the ancestor [MediaQuery] changes.
-  static double widthOf(BuildContext context) => _of(context, MediaQueryAspect.width).size.width;
-  /// Returns width for the nearest MediaQuery ancestor or
-  /// null, if no such ancestor exists.
-  ///
-  /// Use of this method will cause the given [context] to rebuild any time that
-  /// the size.width property of the ancestor [MediaQuery] changes.
-  static double? maybeWidthOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.width)?.size.width;
-
-  /// Returns height for the nearest MediaQuery ancestor or
-  /// throws an exception, if no such ancestor exists.
-  ///
-  /// Use of this method will cause the given [context] to rebuild any time that
-  /// the size.height property of the ancestor [MediaQuery] changes.
-  static double heightOf(BuildContext context) => _of(context, MediaQueryAspect.height).size.height;
-  /// Returns height for the nearest MediaQuery ancestor or
-  /// null, if no such ancestor exists.
-  ///
-  /// Use of this method will cause the given [context] to rebuild any time that
-  /// the size.height property of the ancestor [MediaQuery] changes.
-  static double? maybeHeightOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.height)?.size.width;
-
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
   static Orientation orientationOf(BuildContext context) => _of(context, MediaQueryAspect.orientation).orientation;
+
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1043,6 +1031,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
   static double devicePixelRatioOf(BuildContext context) => _of(context, MediaQueryAspect.devicePixelRatio).devicePixelRatio;
+
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1056,6 +1045,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
   static double textScaleFactorOf(BuildContext context) => maybeTextScaleFactorOf(context) ?? 1.0;
+
   /// Returns textScaleFactor for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1070,6 +1060,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// the [MediaQueryData.platformBrightness] property of the ancestor
   /// [MediaQuery] changes.
   static Brightness platformBrightnessOf(BuildContext context) => maybePlatformBrightnessOf(context) ?? Brightness.light;
+
   /// Returns platformBrightness for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1084,6 +1075,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.padding] property of the ancestor [MediaQuery] changes.
   static EdgeInsets paddingOf(BuildContext context) => _of(context, MediaQueryAspect.padding).padding;
+
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1097,6 +1089,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
   static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.viewInsets).viewInsets;
+
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1110,6 +1103,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
   static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.systemGestureInsets).systemGestureInsets;
+
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1123,6 +1117,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
   static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, MediaQueryAspect.viewPadding).viewPadding;
+
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1136,6 +1131,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
   static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
+
   /// Returns alwaysUse24HourFormat for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1149,6 +1145,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
   static bool accessibleNavigationOf(BuildContext context) => _of(context, MediaQueryAspect.accessibleNavigation).accessibleNavigation;
+
   /// Returns accessibleNavigation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1162,6 +1159,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
   static bool invertColorsOf(BuildContext context) => _of(context, MediaQueryAspect.invertColors).invertColors;
+
   /// Returns invertColors for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1180,6 +1178,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
   static bool highContrastOf(BuildContext context) => maybeHighContrastOf(context) ?? false;
+
   /// Returns highContrast for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1194,6 +1193,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// the [MediaQueryData.disableAnimations] property of the ancestor
   /// [MediaQuery] changes.
   static bool disableAnimationsOf(BuildContext context) => _of(context, MediaQueryAspect.disableAnimations).disableAnimations;
+
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1203,17 +1203,25 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
 
 
   /// Returns boldTextOverride for the nearest MediaQuery ancestor or
-  /// throws an exception, if no such ancestor exists.
+  /// false, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool boldTextOverrideOf(BuildContext context) => _of(context, MediaQueryAspect.boldText).boldText;
+  static bool boldTextOverrideOf(BuildContext context) => maybeBoldTextOverrideOf(context) ?? false;
+
   /// Returns the boldText accessibility setting for the nearest MediaQuery
   /// ancestor, or false if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool boldTextOverride(BuildContext context) => maybeBoldTextOverrideOf(context) ?? false;
+  ///
+  /// Deprecated in favor of [boldTextOverrideOf].
+  @Deprecated(
+    'Migrate to boldTextOverrideOf. '
+    'This feature was deprecated after v3.5.0-9.0.pre.'
+  )
+  static bool boldTextOverride(BuildContext context) => boldTextOverrideOf(context);
+
   /// Returns boldTextOverride for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1227,6 +1235,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
   static NavigationMode navigationModeOf(BuildContext context) => _of(context, MediaQueryAspect.navigationMode).navigationMode;
+
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1240,6 +1249,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
   static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, MediaQueryAspect.gestureSettings).gestureSettings;
+
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1253,6 +1263,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
   static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, MediaQueryAspect.displayFeatures).displayFeatures;
+
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
@@ -1272,8 +1283,6 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   @override
   bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<MediaQueryAspect> dependencies) {
     return (data.size != oldWidget.data.size && dependencies.contains(MediaQueryAspect.size))
-        || (data.size.width != oldWidget.data.size.width && dependencies.contains(MediaQueryAspect.width))
-        || (data.size.height != oldWidget.data.size.height && dependencies.contains(MediaQueryAspect.height))
         || (data.orientation != oldWidget.data.orientation && dependencies.contains(MediaQueryAspect.orientation))
         || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(MediaQueryAspect.devicePixelRatio))
         || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(MediaQueryAspect.textScaleFactor))

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -33,7 +33,7 @@ enum Orientation {
 /// rebuild when the [MediaQueryData.textScaleFactor] changes does not need to
 /// be notified when the [MediaQueryData.size] changes.  Specifying an aspect avoids
 /// unnecessary rebuilds.
-enum MediaQueryAspect {
+enum _MediaQueryAspect {
   /// Specifies the aspect corresponding to [MediaQueryData.size].
   size,
   /// Specifies the aspect corresponding to [MediaQueryData.orientation].
@@ -744,7 +744,7 @@ class MediaQueryData {
 ///  * [WidgetsApp] and [MaterialApp], which introduce a [MediaQuery] and keep
 ///    it up to date with the current screen metrics as they change.
 ///  * [MediaQueryData], the data structure that represents the metrics.
-class MediaQuery extends InheritedModel<MediaQueryAspect> {
+class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Creates a widget that provides [MediaQueryData] to its descendants.
   ///
   /// The [data] and [child] arguments must not be null.
@@ -951,7 +951,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
     return _of(context);
   }
 
-  static MediaQueryData _of(BuildContext context, [MediaQueryAspect? aspect]) {
+  static MediaQueryData _of(BuildContext context, [_MediaQueryAspect? aspect]) {
     assert(debugCheckHasMediaQuery(context));
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)!.data;
   }
@@ -993,7 +993,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
     return _maybeOf(context);
   }
 
-  static MediaQueryData? _maybeOf(BuildContext context, [MediaQueryAspect? aspect]) {
+  static MediaQueryData? _maybeOf(BuildContext context, [_MediaQueryAspect? aspect]) {
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)?.data;
   }
 
@@ -1002,42 +1002,42 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size sizeOf(BuildContext context) => _of(context, MediaQueryAspect.size).size;
+  static Size sizeOf(BuildContext context) => _of(context, _MediaQueryAspect.size).size;
 
   /// Returns size for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.size)?.size;
+  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.size)?.size;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation orientationOf(BuildContext context) => _of(context, MediaQueryAspect.orientation).orientation;
+  static Orientation orientationOf(BuildContext context) => _of(context, _MediaQueryAspect.orientation).orientation;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.orientation)?.orientation;
+  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.orientation)?.orientation;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double devicePixelRatioOf(BuildContext context) => _of(context, MediaQueryAspect.devicePixelRatio).devicePixelRatio;
+  static double devicePixelRatioOf(BuildContext context) => _of(context, _MediaQueryAspect.devicePixelRatio).devicePixelRatio;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
+  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
 
   /// Returns textScaleFactor for the nearest MediaQuery ancestor or
   /// 1.0, if no such ancestor exists.
@@ -1051,7 +1051,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
-  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.textScaleFactor)?.textScaleFactor;
+  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.textScaleFactor)?.textScaleFactor;
 
   /// Returns platformBrightness for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1067,105 +1067,105 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.platformBrightness] property of the ancestor
   /// [MediaQuery] changes.
-  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.platformBrightness)?.platformBrightness;
+  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.platformBrightness)?.platformBrightness;
 
   /// Returns padding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.padding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets paddingOf(BuildContext context) => _of(context, MediaQueryAspect.padding).padding;
+  static EdgeInsets paddingOf(BuildContext context) => _of(context, _MediaQueryAspect.padding).padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.padding)?.padding;
+  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.padding)?.padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.viewInsets).viewInsets;
+  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.viewInsets).viewInsets;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewInsets)?.viewInsets;
+  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewInsets)?.viewInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.systemGestureInsets).systemGestureInsets;
+  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.systemGestureInsets).systemGestureInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
+  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, MediaQueryAspect.viewPadding).viewPadding;
+  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, _MediaQueryAspect.viewPadding).viewPadding;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewPadding)?.viewPadding;
+  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewPadding)?.viewPadding;
 
   /// Returns alwaysUse for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
+  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, _MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
 
   /// Returns alwaysUse24HourFormat for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.alwaysUse24HourFormat] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
+  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
 
   /// Returns accessibleNavigationOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool accessibleNavigationOf(BuildContext context) => _of(context, MediaQueryAspect.accessibleNavigation).accessibleNavigation;
+  static bool accessibleNavigationOf(BuildContext context) => _of(context, _MediaQueryAspect.accessibleNavigation).accessibleNavigation;
 
   /// Returns accessibleNavigation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
+  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
 
   /// Returns invertColorsOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool invertColorsOf(BuildContext context) => _of(context, MediaQueryAspect.invertColors).invertColors;
+  static bool invertColorsOf(BuildContext context) => _of(context, _MediaQueryAspect.invertColors).invertColors;
 
   /// Returns invertColors for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.invertColors)?.invertColors;
+  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.invertColors)?.invertColors;
 
   /// Returns highContrast for the nearest MediaQuery ancestor or false, if no
   /// such ancestor exists.
@@ -1184,7 +1184,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
-  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.highContrast)?.highContrast;
+  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.highContrast)?.highContrast;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1192,14 +1192,14 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor
   /// [MediaQuery] changes.
-  static bool disableAnimationsOf(BuildContext context) => _of(context, MediaQueryAspect.disableAnimations).disableAnimations;
+  static bool disableAnimationsOf(BuildContext context) => _of(context, _MediaQueryAspect.disableAnimations).disableAnimations;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor [MediaQuery] changes.
-  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.disableAnimations)?.disableAnimations;
+  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.disableAnimations)?.disableAnimations;
 
 
   /// Returns boldTextOverride for the nearest MediaQuery ancestor or
@@ -1227,49 +1227,49 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.boldText)?.boldText;
+  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.boldText)?.boldText;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode navigationModeOf(BuildContext context) => _of(context, MediaQueryAspect.navigationMode).navigationMode;
+  static NavigationMode navigationModeOf(BuildContext context) => _of(context, _MediaQueryAspect.navigationMode).navigationMode;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.navigationMode)?.navigationMode;
+  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.navigationMode)?.navigationMode;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, MediaQueryAspect.gestureSettings).gestureSettings;
+  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, _MediaQueryAspect.gestureSettings).gestureSettings;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.gestureSettings)?.gestureSettings;
+  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.gestureSettings)?.gestureSettings;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, MediaQueryAspect.displayFeatures).displayFeatures;
+  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, _MediaQueryAspect.displayFeatures).displayFeatures;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.displayFeatures)?.displayFeatures;
+  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.displayFeatures)?.displayFeatures;
 
   @override
   bool updateShouldNotify(MediaQuery oldWidget) => data != oldWidget.data;
@@ -1281,24 +1281,24 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   }
 
   @override
-  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<MediaQueryAspect> dependencies) {
-    return (data.size != oldWidget.data.size && dependencies.contains(MediaQueryAspect.size))
-        || (data.orientation != oldWidget.data.orientation && dependencies.contains(MediaQueryAspect.orientation))
-        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(MediaQueryAspect.devicePixelRatio))
-        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(MediaQueryAspect.textScaleFactor))
-        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(MediaQueryAspect.platformBrightness))
-        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(MediaQueryAspect.viewInsets))
-        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(MediaQueryAspect.systemGestureInsets))
-        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(MediaQueryAspect.viewPadding))
-        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(MediaQueryAspect.alwaysUse24HourFormat))
-        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(MediaQueryAspect.accessibleNavigation))
-        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(MediaQueryAspect.invertColors))
-        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(MediaQueryAspect.highContrast))
-        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(MediaQueryAspect.disableAnimations))
-        || (data.boldText != oldWidget.data.boldText && dependencies.contains(MediaQueryAspect.boldText))
-        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(MediaQueryAspect.navigationMode))
-        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(MediaQueryAspect.gestureSettings))
-        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(MediaQueryAspect.displayFeatures));
+  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<_MediaQueryAspect> dependencies) {
+    return (data.size != oldWidget.data.size && dependencies.contains(_MediaQueryAspect.size))
+        || (data.orientation != oldWidget.data.orientation && dependencies.contains(_MediaQueryAspect.orientation))
+        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(_MediaQueryAspect.devicePixelRatio))
+        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(_MediaQueryAspect.textScaleFactor))
+        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(_MediaQueryAspect.platformBrightness))
+        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(_MediaQueryAspect.viewInsets))
+        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(_MediaQueryAspect.systemGestureInsets))
+        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(_MediaQueryAspect.viewPadding))
+        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(_MediaQueryAspect.alwaysUse24HourFormat))
+        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(_MediaQueryAspect.accessibleNavigation))
+        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(_MediaQueryAspect.invertColors))
+        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(_MediaQueryAspect.highContrast))
+        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(_MediaQueryAspect.disableAnimations))
+        || (data.boldText != oldWidget.data.boldText && dependencies.contains(_MediaQueryAspect.boldText))
+        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(_MediaQueryAspect.navigationMode))
+        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(_MediaQueryAspect.gestureSettings))
+        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(_MediaQueryAspect.displayFeatures));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -926,7 +926,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// as well as other media parameters (see [MediaQueryData] for more
   /// examples). When that information changes, your widget will be scheduled to
   /// be rebuilt, keeping your widget up-to-date.
-  /// 
+  ///
   /// If the widget only requires a subset of properties of the [MediaQueryData]
   /// object, it is preferred to use the specific methods (for example:
   /// [MediaQuery.sizeOf] and [MediaQuery.paddingOf]), as those methods will not
@@ -969,7 +969,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// as well as other media parameters (see [MediaQueryData] for more
   /// examples). When that information changes, your widget will be scheduled to
   /// be rebuilt, keeping your widget up-to-date.
-  /// 
+  ///
   /// If the widget only requires a subset of properties of the [MediaQueryData]
   /// object, it is preferred to use the specific methods (for example:
   /// [MediaQuery.maybeSizeOf] and [MediaQuery.maybePaddingOf]), as those methods

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -31,9 +31,9 @@ enum Orientation {
 /// [MediaQuery] contains a large number of related properties. Widgets frequently
 /// depend on only a few of these attributes. For example, a widget that needs to
 /// rebuild when the [MediaQueryData.textScaleFactor] changes does not need to
-/// be notified when the [MediaQueryData.size] changes.  Specifying an aspect avoids
+/// be notified when the [MediaQueryData.size] changes. Specifying an aspect avoids
 /// unnecessary rebuilds.
-enum MediaQueryAspect {
+enum _MediaQueryAspect {
   /// Specifies the aspect corresponding to [MediaQueryData.size].
   size,
   /// Specifies the aspect corresponding to [MediaQueryData.orientation].
@@ -744,7 +744,7 @@ class MediaQueryData {
 ///  * [WidgetsApp] and [MaterialApp], which introduce a [MediaQuery] and keep
 ///    it up to date with the current screen metrics as they change.
 ///  * [MediaQueryData], the data structure that represents the metrics.
-class MediaQuery extends InheritedModel<MediaQueryAspect> {
+class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Creates a widget that provides [MediaQueryData] to its descendants.
   ///
   /// The [data] and [child] arguments must not be null.
@@ -930,7 +930,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// If the widget only requires a subset of properties of the [MediaQueryData]
   /// object, it is preferred to use the specific methods (for example:
   /// [MediaQuery.sizeOf] and [MediaQuery.paddingOf]), as those methods will not
-  /// cause your widget to rebuild when unrelated properties are updated.
+  /// cause a widget to rebuild when unrelated properties are updated.
   ///
   /// Typical usage is as follows:
   ///
@@ -951,7 +951,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
     return _of(context);
   }
 
-  static MediaQueryData _of(BuildContext context, [MediaQueryAspect? aspect]) {
+  static MediaQueryData _of(BuildContext context, [_MediaQueryAspect? aspect]) {
     assert(debugCheckHasMediaQuery(context));
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)!.data;
   }
@@ -973,7 +973,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// If the widget only requires a subset of properties of the [MediaQueryData]
   /// object, it is preferred to use the specific methods (for example:
   /// [MediaQuery.maybeSizeOf] and [MediaQuery.maybePaddingOf]), as those methods
-  /// will not cause your widget to rebuild when unrelated properties are updated.
+  /// will not cause a widget to rebuild when unrelated properties are updated.
   ///
   /// Typical usage is as follows:
   ///
@@ -993,7 +993,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
     return _maybeOf(context);
   }
 
-  static MediaQueryData? _maybeOf(BuildContext context, [MediaQueryAspect? aspect]) {
+  static MediaQueryData? _maybeOf(BuildContext context, [_MediaQueryAspect? aspect]) {
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)?.data;
   }
 
@@ -1002,42 +1002,42 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size sizeOf(BuildContext context) => _of(context, MediaQueryAspect.size).size;
+  static Size sizeOf(BuildContext context) => _of(context, _MediaQueryAspect.size).size;
 
   /// Returns size for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.size)?.size;
+  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.size)?.size;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation orientationOf(BuildContext context) => _of(context, MediaQueryAspect.orientation).orientation;
+  static Orientation orientationOf(BuildContext context) => _of(context, _MediaQueryAspect.orientation).orientation;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.orientation)?.orientation;
+  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.orientation)?.orientation;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double devicePixelRatioOf(BuildContext context) => _of(context, MediaQueryAspect.devicePixelRatio).devicePixelRatio;
+  static double devicePixelRatioOf(BuildContext context) => _of(context, _MediaQueryAspect.devicePixelRatio).devicePixelRatio;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
+  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
 
   /// Returns textScaleFactor for the nearest MediaQuery ancestor or
   /// 1.0, if no such ancestor exists.
@@ -1051,7 +1051,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
-  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.textScaleFactor)?.textScaleFactor;
+  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.textScaleFactor)?.textScaleFactor;
 
   /// Returns platformBrightness for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1067,105 +1067,105 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.platformBrightness] property of the ancestor
   /// [MediaQuery] changes.
-  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.platformBrightness)?.platformBrightness;
+  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.platformBrightness)?.platformBrightness;
 
   /// Returns padding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.padding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets paddingOf(BuildContext context) => _of(context, MediaQueryAspect.padding).padding;
+  static EdgeInsets paddingOf(BuildContext context) => _of(context, _MediaQueryAspect.padding).padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.padding)?.padding;
+  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.padding)?.padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.viewInsets).viewInsets;
+  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.viewInsets).viewInsets;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewInsets)?.viewInsets;
+  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewInsets)?.viewInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.systemGestureInsets).systemGestureInsets;
+  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.systemGestureInsets).systemGestureInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
+  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, MediaQueryAspect.viewPadding).viewPadding;
+  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, _MediaQueryAspect.viewPadding).viewPadding;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewPadding)?.viewPadding;
+  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewPadding)?.viewPadding;
 
   /// Returns alwaysUse for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
+  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, _MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
 
   /// Returns alwaysUse24HourFormat for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.alwaysUse24HourFormat] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
+  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
 
   /// Returns accessibleNavigationOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool accessibleNavigationOf(BuildContext context) => _of(context, MediaQueryAspect.accessibleNavigation).accessibleNavigation;
+  static bool accessibleNavigationOf(BuildContext context) => _of(context, _MediaQueryAspect.accessibleNavigation).accessibleNavigation;
 
   /// Returns accessibleNavigation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
+  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
 
   /// Returns invertColorsOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool invertColorsOf(BuildContext context) => _of(context, MediaQueryAspect.invertColors).invertColors;
+  static bool invertColorsOf(BuildContext context) => _of(context, _MediaQueryAspect.invertColors).invertColors;
 
   /// Returns invertColors for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.invertColors)?.invertColors;
+  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.invertColors)?.invertColors;
 
   /// Returns highContrast for the nearest MediaQuery ancestor or false, if no
   /// such ancestor exists.
@@ -1184,7 +1184,7 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
-  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.highContrast)?.highContrast;
+  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.highContrast)?.highContrast;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1192,14 +1192,14 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor
   /// [MediaQuery] changes.
-  static bool disableAnimationsOf(BuildContext context) => _of(context, MediaQueryAspect.disableAnimations).disableAnimations;
+  static bool disableAnimationsOf(BuildContext context) => _of(context, _MediaQueryAspect.disableAnimations).disableAnimations;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor [MediaQuery] changes.
-  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.disableAnimations)?.disableAnimations;
+  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.disableAnimations)?.disableAnimations;
 
 
   /// Returns boldTextOverride for the nearest MediaQuery ancestor or
@@ -1227,49 +1227,49 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.boldText)?.boldText;
+  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.boldText)?.boldText;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode navigationModeOf(BuildContext context) => _of(context, MediaQueryAspect.navigationMode).navigationMode;
+  static NavigationMode navigationModeOf(BuildContext context) => _of(context, _MediaQueryAspect.navigationMode).navigationMode;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.navigationMode)?.navigationMode;
+  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.navigationMode)?.navigationMode;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, MediaQueryAspect.gestureSettings).gestureSettings;
+  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, _MediaQueryAspect.gestureSettings).gestureSettings;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.gestureSettings)?.gestureSettings;
+  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.gestureSettings)?.gestureSettings;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, MediaQueryAspect.displayFeatures).displayFeatures;
+  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, _MediaQueryAspect.displayFeatures).displayFeatures;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.displayFeatures)?.displayFeatures;
+  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.displayFeatures)?.displayFeatures;
 
   @override
   bool updateShouldNotify(MediaQuery oldWidget) => data != oldWidget.data;
@@ -1281,24 +1281,24 @@ class MediaQuery extends InheritedModel<MediaQueryAspect> {
   }
 
   @override
-  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<MediaQueryAspect> dependencies) {
-    return (data.size != oldWidget.data.size && dependencies.contains(MediaQueryAspect.size))
-        || (data.orientation != oldWidget.data.orientation && dependencies.contains(MediaQueryAspect.orientation))
-        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(MediaQueryAspect.devicePixelRatio))
-        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(MediaQueryAspect.textScaleFactor))
-        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(MediaQueryAspect.platformBrightness))
-        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(MediaQueryAspect.viewInsets))
-        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(MediaQueryAspect.systemGestureInsets))
-        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(MediaQueryAspect.viewPadding))
-        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(MediaQueryAspect.alwaysUse24HourFormat))
-        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(MediaQueryAspect.accessibleNavigation))
-        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(MediaQueryAspect.invertColors))
-        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(MediaQueryAspect.highContrast))
-        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(MediaQueryAspect.disableAnimations))
-        || (data.boldText != oldWidget.data.boldText && dependencies.contains(MediaQueryAspect.boldText))
-        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(MediaQueryAspect.navigationMode))
-        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(MediaQueryAspect.gestureSettings))
-        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(MediaQueryAspect.displayFeatures));
+  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<Object> dependencies) {
+    return (data.size != oldWidget.data.size && dependencies.contains(_MediaQueryAspect.size))
+        || (data.orientation != oldWidget.data.orientation && dependencies.contains(_MediaQueryAspect.orientation))
+        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(_MediaQueryAspect.devicePixelRatio))
+        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(_MediaQueryAspect.textScaleFactor))
+        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(_MediaQueryAspect.platformBrightness))
+        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(_MediaQueryAspect.viewInsets))
+        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(_MediaQueryAspect.systemGestureInsets))
+        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(_MediaQueryAspect.viewPadding))
+        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(_MediaQueryAspect.alwaysUse24HourFormat))
+        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(_MediaQueryAspect.accessibleNavigation))
+        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(_MediaQueryAspect.invertColors))
+        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(_MediaQueryAspect.highContrast))
+        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(_MediaQueryAspect.disableAnimations))
+        || (data.boldText != oldWidget.data.boldText && dependencies.contains(_MediaQueryAspect.boldText))
+        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(_MediaQueryAspect.navigationMode))
+        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(_MediaQueryAspect.gestureSettings))
+        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(_MediaQueryAspect.displayFeatures));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -12,6 +12,7 @@ import 'basic.dart';
 import 'binding.dart';
 import 'debug.dart';
 import 'framework.dart';
+import 'inherited_model.dart';
 
 // Examples can assume:
 // late BuildContext context;
@@ -23,6 +24,50 @@ enum Orientation {
 
   /// Wider than tall.
   landscape
+}
+
+/// A specific part of MediaQueryData to depend on
+enum MediaQueryAspect {
+  /// MediaQueryData.size
+  size,
+  /// MediaQueryData.size.width
+  width,
+  /// MediaQueryData.size.height
+  height,
+  /// MediaQueryData.orientation
+  orientation,
+  /// MediaQueryData.devicePixelRatio
+  devicePixelRatio,
+  /// MediaQueryData.textScaleFactor
+  textScaleFactor,
+  /// MediaQueryData.platformBrightness
+  platformBrightness,
+  /// MediaQueryData.padding
+  padding,
+  /// MediaQueryData.viewInsets
+  viewInsets,
+  /// MediaQueryData.systemGestureInsets
+  systemGestureInsets,
+  /// MediaQueryData.viewPadding
+  viewPadding,
+  /// MediaQueryData.alwaysUse24HourFormat
+  alwaysUse24HourFormat,
+  /// MediaQueryData.accessibleNavigation
+  accessibleNavigation,
+  /// MediaQueryData.invertColors
+  invertColors,
+  /// MediaQueryData.highContrast
+  highContrast,
+  /// MediaQueryData.disableAnimations
+  disableAnimations,
+  /// MediaQueryData.boldText
+  boldText,
+  /// MediaQueryData.navigationMode
+  navigationMode,
+  /// MediaQueryData.gestureSettings
+  gestureSettings,
+  /// MediaQueryData.displayFeatures
+  displayFeatures,
 }
 
 /// Information about a piece of media (e.g., a window).
@@ -178,6 +223,8 @@ class MediaQueryData {
   /// See also:
   ///
   ///  * [FlutterView.physicalSize], which returns the size in physical pixels.
+  ///  * [MediaQuery.sizeOf], a method to find and depend on the size defined
+  ///    for a [BuildContext].
   final Size size;
 
   /// The number of device pixels for each logical pixel. This number might not
@@ -192,7 +239,7 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [MediaQuery.textScaleFactorOf], a convenience method which returns the
+  ///  * [MediaQuery.textScaleFactorOf], a method to find and depend on the
   ///    textScaleFactor defined for a [BuildContext].
   final double textScaleFactor;
 
@@ -203,6 +250,11 @@ class MediaQueryData {
   ///
   /// Not all platforms necessarily support a concept of brightness mode. Those
   /// platforms will report [Brightness.light] in this property.
+  ///
+  /// See also:
+  ///
+  ///  * [MediaQuery.platformBrightnessOf], a method to find and depend on the
+  ///    platformBrightness defined for a [BuildContext].
   final Brightness platformBrightness;
 
   /// The parts of the display that are completely obscured by system UI,
@@ -690,7 +742,7 @@ class MediaQueryData {
 ///  * [WidgetsApp] and [MaterialApp], which introduce a [MediaQuery] and keep
 ///    it up to date with the current screen metrics as they change.
 ///  * [MediaQueryData], the data structure that represents the metrics.
-class MediaQuery extends InheritedWidget {
+class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Creates a widget that provides [MediaQueryData] to its descendants.
   ///
   /// The [data] and [child] arguments must not be null.
@@ -890,7 +942,11 @@ class MediaQuery extends InheritedWidget {
   static MediaQueryData of(BuildContext context) {
     assert(context != null);
     assert(debugCheckHasMediaQuery(context));
-    return context.dependOnInheritedWidgetOfExactType<MediaQuery>()!.data;
+    return _of(context);
+  }
+
+  static MediaQueryData _of(BuildContext context, [MediaQueryAspect? aspect]) {
+    return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)!.data;
   }
 
   /// The data from the closest instance of this class that encloses the given
@@ -922,23 +978,196 @@ class MediaQuery extends InheritedWidget {
   ///    instead of returning null.
   static MediaQueryData? maybeOf(BuildContext context) {
     assert(context != null);
-    return context.dependOnInheritedWidgetOfExactType<MediaQuery>()?.data;
+    return _maybeOf(context);
   }
 
-  /// Returns textScaleFactor for the nearest MediaQuery ancestor or 1.0, if
-  /// no such ancestor exists.
-  static double textScaleFactorOf(BuildContext context) {
-    return MediaQuery.maybeOf(context)?.textScaleFactor ?? 1.0;
+  static MediaQueryData? _maybeOf(BuildContext context, [MediaQueryAspect? aspect]) {
+    return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)?.data;
   }
+
+  /// Returns size for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
+  static Size sizeOf(BuildContext context) => _of(context, MediaQueryAspect.size).size;
+  /// Returns size for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
+  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.size)?.size;
+
+  /// Returns width for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the size.width property of the ancestor [MediaQuery] changes.
+  static double widthOf(BuildContext context) => _of(context, MediaQueryAspect.width).size.width;
+  /// Returns width for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the size.width property of the ancestor [MediaQuery] changes.
+  static double? maybeWidthOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.width)?.size.width;
+
+  /// Returns height for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the size.height property of the ancestor [MediaQuery] changes.
+  static double heightOf(BuildContext context) => _of(context, MediaQueryAspect.height).size.height;
+  /// Returns height for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the size.height property of the ancestor [MediaQuery] changes.
+  static double? maybeHeightOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.height)?.size.width;
+
+  /// Returns orientation for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
+  static Orientation orientationOf(BuildContext context) => _of(context, MediaQueryAspect.orientation).orientation;
+  /// Returns orientation for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
+  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.orientation)?.orientation;
+
+  /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
+  static double devicePixelRatioOf(BuildContext context) => _of(context, MediaQueryAspect.devicePixelRatio).devicePixelRatio;
+  /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
+  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
+
+  /// Returns textScaleFactor for the nearest MediaQuery ancestor or
+  /// 1.0, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
+  static double textScaleFactorOf(BuildContext context) => maybeTextScaleFactorOf(context) ?? 1.0;
+  /// Returns textScaleFactor for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
+  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.textScaleFactor)?.textScaleFactor;
 
   /// Returns platformBrightness for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
-  /// any property of the ancestor [MediaQuery] changes.
-  static Brightness platformBrightnessOf(BuildContext context) {
-    return MediaQuery.maybeOf(context)?.platformBrightness ?? Brightness.light;
-  }
+  /// the [MediaQueryData.platformBrightness] property of the ancestor
+  /// [MediaQuery] changes.
+  static Brightness platformBrightnessOf(BuildContext context) => maybePlatformBrightnessOf(context) ?? Brightness.light;
+  /// Returns platformBrightness for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.platformBrightness] property of the ancestor
+  /// [MediaQuery] changes.
+  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.platformBrightness)?.platformBrightness;
+
+  /// Returns padding for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.padding] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets paddingOf(BuildContext context) => _of(context, MediaQueryAspect.padding).padding;
+  /// Returns viewInsets for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.padding)?.padding;
+
+  /// Returns viewInsets for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.viewInsets).viewInsets;
+  /// Returns viewInsets for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewInsets)?.viewInsets;
+
+  /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.systemGestureInsets).systemGestureInsets;
+  /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
+
+  /// Returns viewPadding for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, MediaQueryAspect.viewPadding).viewPadding;
+  /// Returns viewPadding for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
+  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewPadding)?.viewPadding;
+
+  /// Returns alwaysUse for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
+  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
+  /// Returns alwaysUse24HourFormat for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.alwaysUse24HourFormat] property of the ancestor [MediaQuery] changes.
+  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
+
+  /// Returns accessibleNavigationOf for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
+  static bool accessibleNavigationOf(BuildContext context) => _of(context, MediaQueryAspect.accessibleNavigation).accessibleNavigation;
+  /// Returns accessibleNavigation for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
+  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
+
+  /// Returns invertColorsOf for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
+  static bool invertColorsOf(BuildContext context) => _of(context, MediaQueryAspect.invertColors).invertColors;
+  /// Returns invertColors for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
+  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.invertColors)?.invertColors;
 
   /// Returns highContrast for the nearest MediaQuery ancestor or false, if no
   /// such ancestor exists.
@@ -947,15 +1176,89 @@ class MediaQuery extends InheritedWidget {
   ///
   ///  * [MediaQueryData.highContrast], which indicates the platform's
   ///    desire to increase contrast.
-  static bool highContrastOf(BuildContext context) {
-    return MediaQuery.maybeOf(context)?.highContrast ?? false;
-  }
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
+  static bool highContrastOf(BuildContext context) => maybeHighContrastOf(context) ?? false;
+  /// Returns highContrast for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
+  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.highContrast)?.highContrast;
 
+  /// Returns disableAnimations for the nearest MediaQuery ancestor or
+  /// [Brightness.light], if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.disableAnimations] property of the ancestor
+  /// [MediaQuery] changes.
+  static bool disableAnimationsOf(BuildContext context) => _of(context, MediaQueryAspect.disableAnimations).disableAnimations;
+  /// Returns disableAnimations for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.disableAnimations] property of the ancestor [MediaQuery] changes.
+  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.disableAnimations)?.disableAnimations;
+
+
+  /// Returns boldTextOverride for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
+  static bool boldTextOverrideOf(BuildContext context) => _of(context, MediaQueryAspect.boldText).boldText;
   /// Returns the boldText accessibility setting for the nearest MediaQuery
   /// ancestor, or false if no such ancestor exists.
-  static bool boldTextOverride(BuildContext context) {
-    return MediaQuery.maybeOf(context)?.boldText ?? false;
-  }
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
+  static bool boldTextOverride(BuildContext context) => maybeBoldTextOverrideOf(context) ?? false;
+  /// Returns boldTextOverride for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
+  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.boldText)?.boldText;
+
+  /// Returns navigationMode for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
+  static NavigationMode navigationModeOf(BuildContext context) => _of(context, MediaQueryAspect.navigationMode).navigationMode;
+  /// Returns navigationMode for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
+  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.navigationMode)?.navigationMode;
+
+  /// Returns gestureSettings for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
+  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, MediaQueryAspect.gestureSettings).gestureSettings;
+  /// Returns gestureSettings for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
+  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.gestureSettings)?.gestureSettings;
+
+  /// Returns displayFeatures for the nearest MediaQuery ancestor or
+  /// throws an exception, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
+  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, MediaQueryAspect.displayFeatures).displayFeatures;
+  /// Returns displayFeatures for the nearest MediaQuery ancestor or
+  /// null, if no such ancestor exists.
+  ///
+  /// Use of this method will cause the given [context] to rebuild any time that
+  /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
+  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.displayFeatures)?.displayFeatures;
 
   @override
   bool updateShouldNotify(MediaQuery oldWidget) => data != oldWidget.data;
@@ -965,6 +1268,29 @@ class MediaQuery extends InheritedWidget {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<MediaQueryData>('data', data, showName: false));
   }
+
+  @override
+  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<MediaQueryAspect> dependencies) {
+    return (data.size != oldWidget.data.size && dependencies.contains(MediaQueryAspect.size))
+        || (data.size.width != oldWidget.data.size.width && dependencies.contains(MediaQueryAspect.width))
+        || (data.size.height != oldWidget.data.size.height && dependencies.contains(MediaQueryAspect.height))
+        || (data.orientation != oldWidget.data.orientation && dependencies.contains(MediaQueryAspect.orientation))
+        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(MediaQueryAspect.devicePixelRatio))
+        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(MediaQueryAspect.textScaleFactor))
+        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(MediaQueryAspect.platformBrightness))
+        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(MediaQueryAspect.viewInsets))
+        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(MediaQueryAspect.systemGestureInsets))
+        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(MediaQueryAspect.viewPadding))
+        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(MediaQueryAspect.alwaysUse24HourFormat))
+        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(MediaQueryAspect.accessibleNavigation))
+        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(MediaQueryAspect.invertColors))
+        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(MediaQueryAspect.highContrast))
+        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(MediaQueryAspect.disableAnimations))
+        || (data.boldText != oldWidget.data.boldText && dependencies.contains(MediaQueryAspect.boldText))
+        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(MediaQueryAspect.navigationMode))
+        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(MediaQueryAspect.gestureSettings))
+        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(MediaQueryAspect.displayFeatures));
+  }
 }
 
 /// Describes the navigation mode to be set by a [MediaQuery] widget.
@@ -972,7 +1298,7 @@ class MediaQuery extends InheritedWidget {
 /// The different modes indicate the type of navigation to be used in a widget
 /// subtree for those widgets sensitive to it.
 ///
-/// Use `MediaQuery.of(context).navigationMode` to determine the navigation mode
+/// Use `MediaQuery.navigationModeOf(context)` to determine the navigation mode
 /// in effect for the given context. Use a [MediaQuery] widget to set the
 /// navigation mode for its descendant widgets.
 enum NavigationMode {

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -1202,32 +1202,32 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.disableAnimations)?.disableAnimations;
 
 
-  /// Returns boldTextOverride for the nearest MediaQuery ancestor or
-  /// false, if no such ancestor exists.
+  /// Returns the boldText accessibility setting for the nearest MediaQuery
+  /// ancestor or false, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool boldTextOverrideOf(BuildContext context) => maybeBoldTextOverrideOf(context) ?? false;
+  static bool boldTextOf(BuildContext context) => maybeBoldTextOf(context) ?? false;
 
   /// Returns the boldText accessibility setting for the nearest MediaQuery
-  /// ancestor, or false if no such ancestor exists.
+  /// ancestor or false, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
   ///
-  /// Deprecated in favor of [boldTextOverrideOf].
+  /// Deprecated in favor of [boldTextOf].
   @Deprecated(
-    'Migrate to boldTextOverrideOf. '
+    'Migrate to boldTextOf. '
     'This feature was deprecated after v3.5.0-9.0.pre.'
   )
-  static bool boldTextOverride(BuildContext context) => boldTextOverrideOf(context);
+  static bool boldTextOverride(BuildContext context) => boldTextOf(context);
 
-  /// Returns boldTextOverride for the nearest MediaQuery ancestor or
-  /// null, if no such ancestor exists.
+  /// Returns the boldText accessibility setting for the nearest MediaQuery
+  /// ancestor or null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.boldText)?.boldText;
+  static bool? maybeBoldTextOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.boldText)?.boldText;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -33,7 +33,7 @@ enum Orientation {
 /// rebuild when the [MediaQueryData.textScaleFactor] changes does not need to
 /// be notified when the [MediaQueryData.size] changes.  Specifying an aspect avoids
 /// unnecessary rebuilds.
-enum _MediaQueryAspect {
+enum MediaQueryAspect {
   /// Specifies the aspect corresponding to [MediaQueryData.size].
   size,
   /// Specifies the aspect corresponding to [MediaQueryData.orientation].
@@ -744,7 +744,7 @@ class MediaQueryData {
 ///  * [WidgetsApp] and [MaterialApp], which introduce a [MediaQuery] and keep
 ///    it up to date with the current screen metrics as they change.
 ///  * [MediaQueryData], the data structure that represents the metrics.
-class MediaQuery extends InheritedModel<_MediaQueryAspect> {
+class MediaQuery extends InheritedModel<MediaQueryAspect> {
   /// Creates a widget that provides [MediaQueryData] to its descendants.
   ///
   /// The [data] and [child] arguments must not be null.
@@ -951,7 +951,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
     return _of(context);
   }
 
-  static MediaQueryData _of(BuildContext context, [_MediaQueryAspect? aspect]) {
+  static MediaQueryData _of(BuildContext context, [MediaQueryAspect? aspect]) {
     assert(debugCheckHasMediaQuery(context));
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)!.data;
   }
@@ -993,7 +993,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
     return _maybeOf(context);
   }
 
-  static MediaQueryData? _maybeOf(BuildContext context, [_MediaQueryAspect? aspect]) {
+  static MediaQueryData? _maybeOf(BuildContext context, [MediaQueryAspect? aspect]) {
     return InheritedModel.inheritFrom<MediaQuery>(context, aspect: aspect)?.data;
   }
 
@@ -1002,42 +1002,42 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size sizeOf(BuildContext context) => _of(context, _MediaQueryAspect.size).size;
+  static Size sizeOf(BuildContext context) => _of(context, MediaQueryAspect.size).size;
 
   /// Returns size for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.size] property of the ancestor [MediaQuery] changes.
-  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.size)?.size;
+  static Size? maybeSizeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.size)?.size;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation orientationOf(BuildContext context) => _of(context, _MediaQueryAspect.orientation).orientation;
+  static Orientation orientationOf(BuildContext context) => _of(context, MediaQueryAspect.orientation).orientation;
 
   /// Returns orientation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.orientation] property of the ancestor [MediaQuery] changes.
-  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.orientation)?.orientation;
+  static Orientation? maybeOrientationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.orientation)?.orientation;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double devicePixelRatioOf(BuildContext context) => _of(context, _MediaQueryAspect.devicePixelRatio).devicePixelRatio;
+  static double devicePixelRatioOf(BuildContext context) => _of(context, MediaQueryAspect.devicePixelRatio).devicePixelRatio;
 
   /// Returns devicePixelRatio for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
+  static double? maybeDevicePixelRatioOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.devicePixelRatio)?.devicePixelRatio;
 
   /// Returns textScaleFactor for the nearest MediaQuery ancestor or
   /// 1.0, if no such ancestor exists.
@@ -1051,7 +1051,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.textScaleFactor] property of the ancestor [MediaQuery] changes.
-  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.textScaleFactor)?.textScaleFactor;
+  static double? maybeTextScaleFactorOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.textScaleFactor)?.textScaleFactor;
 
   /// Returns platformBrightness for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1067,105 +1067,105 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.platformBrightness] property of the ancestor
   /// [MediaQuery] changes.
-  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.platformBrightness)?.platformBrightness;
+  static Brightness? maybePlatformBrightnessOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.platformBrightness)?.platformBrightness;
 
   /// Returns padding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.padding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets paddingOf(BuildContext context) => _of(context, _MediaQueryAspect.padding).padding;
+  static EdgeInsets paddingOf(BuildContext context) => _of(context, MediaQueryAspect.padding).padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.padding)?.padding;
+  static EdgeInsets? maybePaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.padding)?.padding;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.viewInsets).viewInsets;
+  static EdgeInsets viewInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.viewInsets).viewInsets;
 
   /// Returns viewInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewInsets)?.viewInsets;
+  static EdgeInsets? maybeViewInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewInsets)?.viewInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, _MediaQueryAspect.systemGestureInsets).systemGestureInsets;
+  static EdgeInsets systemGestureInsetsOf(BuildContext context) => _of(context, MediaQueryAspect.systemGestureInsets).systemGestureInsets;
 
   /// Returns systemGestureInsets for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.systemGestureInsets] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
+  static EdgeInsets? maybeSystemGestureInsetsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.systemGestureInsets)?.systemGestureInsets;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, _MediaQueryAspect.viewPadding).viewPadding;
+  static EdgeInsets viewPaddingOf(BuildContext context) => _of(context, MediaQueryAspect.viewPadding).viewPadding;
 
   /// Returns viewPadding for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.viewPadding] property of the ancestor [MediaQuery] changes.
-  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.viewPadding)?.viewPadding;
+  static EdgeInsets? maybeViewPaddingOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.viewPadding)?.viewPadding;
 
   /// Returns alwaysUse for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.devicePixelRatio] property of the ancestor [MediaQuery] changes.
-  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, _MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
+  static bool alwaysUse24HourFormatOf(BuildContext context) => _of(context, MediaQueryAspect.alwaysUse24HourFormat).alwaysUse24HourFormat;
 
   /// Returns alwaysUse24HourFormat for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.alwaysUse24HourFormat] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
+  static bool? maybeAlwaysUse24HourFormatOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.alwaysUse24HourFormat)?.alwaysUse24HourFormat;
 
   /// Returns accessibleNavigationOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool accessibleNavigationOf(BuildContext context) => _of(context, _MediaQueryAspect.accessibleNavigation).accessibleNavigation;
+  static bool accessibleNavigationOf(BuildContext context) => _of(context, MediaQueryAspect.accessibleNavigation).accessibleNavigation;
 
   /// Returns accessibleNavigation for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.accessibleNavigation] property of the ancestor [MediaQuery] changes.
-  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
+  static bool? maybeAccessibleNavigationOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.accessibleNavigation)?.accessibleNavigation;
 
   /// Returns invertColorsOf for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool invertColorsOf(BuildContext context) => _of(context, _MediaQueryAspect.invertColors).invertColors;
+  static bool invertColorsOf(BuildContext context) => _of(context, MediaQueryAspect.invertColors).invertColors;
 
   /// Returns invertColors for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.invertColors] property of the ancestor [MediaQuery] changes.
-  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.invertColors)?.invertColors;
+  static bool? maybeInvertColorsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.invertColors)?.invertColors;
 
   /// Returns highContrast for the nearest MediaQuery ancestor or false, if no
   /// such ancestor exists.
@@ -1184,7 +1184,7 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.highContrast] property of the ancestor [MediaQuery] changes.
-  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.highContrast)?.highContrast;
+  static bool? maybeHighContrastOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.highContrast)?.highContrast;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// [Brightness.light], if no such ancestor exists.
@@ -1192,14 +1192,14 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor
   /// [MediaQuery] changes.
-  static bool disableAnimationsOf(BuildContext context) => _of(context, _MediaQueryAspect.disableAnimations).disableAnimations;
+  static bool disableAnimationsOf(BuildContext context) => _of(context, MediaQueryAspect.disableAnimations).disableAnimations;
 
   /// Returns disableAnimations for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.disableAnimations] property of the ancestor [MediaQuery] changes.
-  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.disableAnimations)?.disableAnimations;
+  static bool? maybeDisableAnimationsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.disableAnimations)?.disableAnimations;
 
 
   /// Returns boldTextOverride for the nearest MediaQuery ancestor or
@@ -1227,49 +1227,49 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.boldText] property of the ancestor [MediaQuery] changes.
-  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.boldText)?.boldText;
+  static bool? maybeBoldTextOverrideOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.boldText)?.boldText;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode navigationModeOf(BuildContext context) => _of(context, _MediaQueryAspect.navigationMode).navigationMode;
+  static NavigationMode navigationModeOf(BuildContext context) => _of(context, MediaQueryAspect.navigationMode).navigationMode;
 
   /// Returns navigationMode for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.navigationMode] property of the ancestor [MediaQuery] changes.
-  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.navigationMode)?.navigationMode;
+  static NavigationMode? maybeNavigationModeOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.navigationMode)?.navigationMode;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, _MediaQueryAspect.gestureSettings).gestureSettings;
+  static DeviceGestureSettings gestureSettingsOf(BuildContext context) => _of(context, MediaQueryAspect.gestureSettings).gestureSettings;
 
   /// Returns gestureSettings for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.gestureSettings] property of the ancestor [MediaQuery] changes.
-  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.gestureSettings)?.gestureSettings;
+  static DeviceGestureSettings? maybeGestureSettingsOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.gestureSettings)?.gestureSettings;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// throws an exception, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, _MediaQueryAspect.displayFeatures).displayFeatures;
+  static List<ui.DisplayFeature> displayFeaturesOf(BuildContext context) => _of(context, MediaQueryAspect.displayFeatures).displayFeatures;
 
   /// Returns displayFeatures for the nearest MediaQuery ancestor or
   /// null, if no such ancestor exists.
   ///
   /// Use of this method will cause the given [context] to rebuild any time that
   /// the [MediaQueryData.displayFeatures] property of the ancestor [MediaQuery] changes.
-  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, _MediaQueryAspect.displayFeatures)?.displayFeatures;
+  static List<ui.DisplayFeature>? maybeDisplayFeaturesOf(BuildContext context) => _maybeOf(context, MediaQueryAspect.displayFeatures)?.displayFeatures;
 
   @override
   bool updateShouldNotify(MediaQuery oldWidget) => data != oldWidget.data;
@@ -1281,24 +1281,24 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   }
 
   @override
-  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<_MediaQueryAspect> dependencies) {
-    return (data.size != oldWidget.data.size && dependencies.contains(_MediaQueryAspect.size))
-        || (data.orientation != oldWidget.data.orientation && dependencies.contains(_MediaQueryAspect.orientation))
-        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(_MediaQueryAspect.devicePixelRatio))
-        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(_MediaQueryAspect.textScaleFactor))
-        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(_MediaQueryAspect.platformBrightness))
-        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(_MediaQueryAspect.viewInsets))
-        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(_MediaQueryAspect.systemGestureInsets))
-        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(_MediaQueryAspect.viewPadding))
-        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(_MediaQueryAspect.alwaysUse24HourFormat))
-        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(_MediaQueryAspect.accessibleNavigation))
-        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(_MediaQueryAspect.invertColors))
-        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(_MediaQueryAspect.highContrast))
-        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(_MediaQueryAspect.disableAnimations))
-        || (data.boldText != oldWidget.data.boldText && dependencies.contains(_MediaQueryAspect.boldText))
-        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(_MediaQueryAspect.navigationMode))
-        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(_MediaQueryAspect.gestureSettings))
-        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(_MediaQueryAspect.displayFeatures));
+  bool updateShouldNotifyDependent(MediaQuery oldWidget, Set<MediaQueryAspect> dependencies) {
+    return (data.size != oldWidget.data.size && dependencies.contains(MediaQueryAspect.size))
+        || (data.orientation != oldWidget.data.orientation && dependencies.contains(MediaQueryAspect.orientation))
+        || (data.devicePixelRatio != oldWidget.data.devicePixelRatio && dependencies.contains(MediaQueryAspect.devicePixelRatio))
+        || (data.textScaleFactor != oldWidget.data.textScaleFactor && dependencies.contains(MediaQueryAspect.textScaleFactor))
+        || (data.platformBrightness != oldWidget.data.platformBrightness && dependencies.contains(MediaQueryAspect.platformBrightness))
+        || (data.viewInsets != oldWidget.data.viewInsets && dependencies.contains(MediaQueryAspect.viewInsets))
+        || (data.systemGestureInsets != oldWidget.data.systemGestureInsets && dependencies.contains(MediaQueryAspect.systemGestureInsets))
+        || (data.viewPadding != oldWidget.data.viewPadding && dependencies.contains(MediaQueryAspect.viewPadding))
+        || (data.alwaysUse24HourFormat != oldWidget.data.alwaysUse24HourFormat && dependencies.contains(MediaQueryAspect.alwaysUse24HourFormat))
+        || (data.accessibleNavigation != oldWidget.data.accessibleNavigation && dependencies.contains(MediaQueryAspect.accessibleNavigation))
+        || (data.invertColors != oldWidget.data.invertColors && dependencies.contains(MediaQueryAspect.invertColors))
+        || (data.highContrast != oldWidget.data.highContrast && dependencies.contains(MediaQueryAspect.highContrast))
+        || (data.disableAnimations != oldWidget.data.disableAnimations && dependencies.contains(MediaQueryAspect.disableAnimations))
+        || (data.boldText != oldWidget.data.boldText && dependencies.contains(MediaQueryAspect.boldText))
+        || (data.navigationMode != oldWidget.data.navigationMode && dependencies.contains(MediaQueryAspect.navigationMode))
+        || (data.gestureSettings != oldWidget.data.gestureSettings && dependencies.contains(MediaQueryAspect.gestureSettings))
+        || (data.displayFeatures != oldWidget.data.displayFeatures && dependencies.contains(MediaQueryAspect.displayFeatures));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -774,7 +774,7 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
 
   @override
   Widget build(BuildContext context) {
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
     double mainAxisSize;
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1163,7 +1163,7 @@ class ReorderableDragStartListener extends StatelessWidget {
   }
 
   void _startDragging(BuildContext context, PointerDownEvent event) {
-    final DeviceGestureSettings? gestureSettings = MediaQuery.maybeOf(context)?.gestureSettings;
+    final DeviceGestureSettings? gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
     final SliverReorderableListState? list = SliverReorderableList.maybeOf(context);
     list?.startItemDragReorder(
       index: index,

--- a/packages/flutter/lib/src/widgets/safe_area.dart
+++ b/packages/flutter/lib/src/widgets/safe_area.dart
@@ -93,11 +93,10 @@ class SafeArea extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final MediaQueryData data = MediaQuery.of(context);
-    EdgeInsets padding = data.padding;
+    EdgeInsets padding = MediaQuery.paddingOf(context);
     // Bottom padding has been consumed - i.e. by the keyboard
     if (maintainBottomViewPadding) {
-      padding = padding.copyWith(bottom: data.viewPadding.bottom);
+      padding = padding.copyWith(bottom: MediaQuery.viewPaddingOf(context).bottom);
     }
 
     return Padding(
@@ -192,7 +191,7 @@ class SliverSafeArea extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final EdgeInsets padding = MediaQuery.of(context).padding;
+    final EdgeInsets padding = MediaQuery.paddingOf(context);
     return SliverPadding(
       padding: EdgeInsets.only(
         left: math.max(left ? padding.left : 0.0, minimum.left),

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -461,7 +461,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   late ScrollBehavior _configuration;
   ScrollPhysics? _physics;
   ScrollController? _fallbackScrollController;
-  MediaQueryData? _mediaQueryData;
+  DeviceGestureSettings? _mediaQueryGestureSettings;
 
   ScrollController get _effectiveScrollController => widget.controller ?? _fallbackScrollController!;
 
@@ -516,7 +516,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
 
   @override
   void didChangeDependencies() {
-    _mediaQueryData = MediaQuery.maybeOf(context);
+    _mediaQueryGestureSettings = MediaQuery.maybeGestureSettingsOf(context);
     _updatePosition();
     super.didChangeDependencies();
   }
@@ -635,7 +635,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior
-                  ..gestureSettings = _mediaQueryData?.gestureSettings;
+                  ..gestureSettings = _mediaQueryGestureSettings;
               },
             ),
           };
@@ -656,7 +656,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
                   ..dragStartBehavior = widget.dragStartBehavior
-                  ..gestureSettings = _mediaQueryData?.gestureSettings;
+                  ..gestureSettings = _mediaQueryGestureSettings;
               },
             ),
           };

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1672,7 +1672,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
       ..textDirection = Directionality.of(context)
       ..thickness = widget.thickness ?? _kScrollbarThickness
       ..radius = widget.radius
-      ..padding = widget.padding ?? MediaQuery.of(context).padding
+      ..padding = widget.padding ?? MediaQuery.paddingOf(context)
       ..scrollbarOrientation = widget.scrollbarOrientation
       ..mainAxisMargin = widget.mainAxisMargin
       ..shape = widget.shape

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -342,7 +342,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
     }
 
     // Hide the text selection toolbar on mobile when orientation changes.
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     if (_lastOrientation == null) {
       _lastOrientation = orientation;
       return;

--- a/packages/flutter/lib/src/widgets/snapshot_widget.dart
+++ b/packages/flutter/lib/src/widgets/snapshot_widget.dart
@@ -134,7 +134,7 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
     return _RenderSnapshotWidget(
       controller: controller,
       mode: mode,
-      devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
+      devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       painter: painter,
     );
   }
@@ -145,7 +145,7 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
     (renderObject as _RenderSnapshotWidget)
       ..controller = controller
       ..mode = mode
-      ..devicePixelRatio = MediaQuery.of(context).devicePixelRatio
+      ..devicePixelRatio = MediaQuery.devicePixelRatioOf(context)
       ..painter = painter;
   }
 }

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -598,7 +598,7 @@ class Text extends StatelessWidget {
     if (style == null || style!.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(style);
     }
-    if (MediaQuery.boldTextOverride(context)) {
+    if (MediaQuery.boldTextOverrideOf(context)) {
       effectiveTextStyle = effectiveTextStyle!.merge(const TextStyle(fontWeight: FontWeight.bold));
     }
     final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -598,7 +598,7 @@ class Text extends StatelessWidget {
     if (style == null || style!.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(style);
     }
-    if (MediaQuery.boldTextOverrideOf(context)) {
+    if (MediaQuery.boldTextOf(context)) {
       effectiveTextStyle = effectiveTextStyle!.merge(const TextStyle(fontWeight: FontWeight.bold));
     }
     final SelectionRegistrar? registrar = SelectionContainer.maybeOf(context);

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -362,7 +362,7 @@ void main() {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesActionSheet(
         Builder(builder: (BuildContext context) {
-          screenHeight = MediaQuery.of(context).size.height;
+          screenHeight = MediaQuery.heightOf(context);
           return MediaQuery(
             data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
             child: CupertinoActionSheet(

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -362,7 +362,7 @@ void main() {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesActionSheet(
         Builder(builder: (BuildContext context) {
-          screenHeight = MediaQuery.heightOf(context);
+          screenHeight = MediaQuery.sizeOf(context).height;
           return MediaQuery(
             data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
             child: CupertinoActionSheet(

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -588,7 +588,7 @@ void main() {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesDialog(
         dialogBuilder: (BuildContext context) {
-          dividerWidth = 1.0 / MediaQuery.of(context).devicePixelRatio;
+          dividerWidth = 1.0 / MediaQuery.devicePixelRatioOf(context);
           return CupertinoAlertDialog(
             title: const Text('The Title'),
             content: const Text('The message'),
@@ -633,7 +633,7 @@ void main() {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesDialog(
         dialogBuilder: (BuildContext context) {
-          dividerThickness = 1.0 / MediaQuery.of(context).devicePixelRatio;
+          dividerThickness = 1.0 / MediaQuery.devicePixelRatioOf(context);
           return CupertinoAlertDialog(
             title: const Text('The Title'),
             content: const Text('The message'),
@@ -841,7 +841,7 @@ void main() {
     await tester.pumpWidget(
       createAppWithButtonThatLaunchesDialog(
         dialogBuilder: (BuildContext context) {
-          dividerThickness = 1.0 / MediaQuery.of(context).devicePixelRatio;
+          dividerThickness = 1.0 / MediaQuery.devicePixelRatioOf(context);
           return CupertinoAlertDialog(
             title: const Text('The Title'),
             content: const Text('The message'),

--- a/packages/flutter/test/cupertino/magnifier_test.dart
+++ b/packages/flutter/test/cupertino/magnifier_test.dart
@@ -117,14 +117,14 @@ void main() {
               caretRect: reasonableTextField,
               // The tap position is far out of the right side of the app.
               globalGesturePosition:
-                  Offset(MediaQuery.widthOf(context) + 100, 0),
+                  Offset(MediaQuery.sizeOf(context).width + 100, 0),
             ),
           ),
         );
 
         // Should be less than the right edge, since we have padding.
         expect(getMagnifierPosition(tester).dx,
-            lessThan(MediaQuery.widthOf(context)));
+            lessThan(MediaQuery.sizeOf(context).width));
       });
 
       testWidgets('should have some vertical drag', (WidgetTester tester) async {
@@ -150,7 +150,7 @@ void main() {
               caretRect: reasonableTextField,
               // The tap position is dragBelow units below the text field.
               globalGesturePosition: Offset(
-                  MediaQuery.widthOf(context) / 2,
+                  MediaQuery.sizeOf(context).width / 2,
                   dragPositionBelowTextField),
             ),
           ),
@@ -184,7 +184,7 @@ void main() {
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
             globalGesturePosition: Offset(
-                MediaQuery.widthOf(context) / 2, reasonableTextField.top),
+                MediaQuery.sizeOf(context).width / 2, reasonableTextField.top),
           ),
         );
 
@@ -223,7 +223,7 @@ void main() {
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
-            globalGesturePosition: Offset(MediaQuery.widthOf(context) / 2, reasonableTextField.top),
+            globalGesturePosition: Offset(MediaQuery.sizeOf(context).width / 2, reasonableTextField.top),
           ),
         );
 
@@ -247,7 +247,7 @@ void main() {
             currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
-            globalGesturePosition: Offset(MediaQuery.widthOf(context) / 2,
+            globalGesturePosition: Offset(MediaQuery.sizeOf(context).width / 2,
                 reasonableTextField.top));
         await tester.pumpAndSettle();
 

--- a/packages/flutter/test/cupertino/magnifier_test.dart
+++ b/packages/flutter/test/cupertino/magnifier_test.dart
@@ -117,14 +117,14 @@ void main() {
               caretRect: reasonableTextField,
               // The tap position is far out of the right side of the app.
               globalGesturePosition:
-                  Offset(MediaQuery.of(context).size.width + 100, 0),
+                  Offset(MediaQuery.widthOf(context) + 100, 0),
             ),
           ),
         );
 
         // Should be less than the right edge, since we have padding.
         expect(getMagnifierPosition(tester).dx,
-            lessThan(MediaQuery.of(context).size.width));
+            lessThan(MediaQuery.widthOf(context)));
       });
 
       testWidgets('should have some vertical drag', (WidgetTester tester) async {
@@ -150,7 +150,7 @@ void main() {
               caretRect: reasonableTextField,
               // The tap position is dragBelow units below the text field.
               globalGesturePosition: Offset(
-                  MediaQuery.of(context).size.width / 2,
+                  MediaQuery.widthOf(context) / 2,
                   dragPositionBelowTextField),
             ),
           ),
@@ -184,7 +184,7 @@ void main() {
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
             globalGesturePosition: Offset(
-                MediaQuery.of(context).size.width / 2, reasonableTextField.top),
+                MediaQuery.widthOf(context) / 2, reasonableTextField.top),
           ),
         );
 
@@ -223,7 +223,7 @@ void main() {
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
-            globalGesturePosition: Offset(MediaQuery.of(context).size.width / 2, reasonableTextField.top),
+            globalGesturePosition: Offset(MediaQuery.widthOf(context) / 2, reasonableTextField.top),
           ),
         );
 
@@ -247,7 +247,7 @@ void main() {
             currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
-            globalGesturePosition: Offset(MediaQuery.of(context).size.width / 2,
+            globalGesturePosition: Offset(MediaQuery.widthOf(context) / 2,
                 reasonableTextField.top));
         await tester.pumpAndSettle();
 

--- a/packages/flutter/test/cupertino/tab_scaffold_test.dart
+++ b/packages/flutter/test/cupertino/tab_scaffold_test.dart
@@ -501,7 +501,7 @@ void main() {
                   items: List<BottomNavigationBarItem>.generate(2, tabGenerator),
                 ),
                 tabBuilder: (BuildContext context, int index) {
-                  contentPadding = MediaQuery.of(context).padding;
+                  contentPadding = MediaQuery.paddingOf(context);
                   return const Placeholder();
                 },
               ),

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -28,7 +28,7 @@ class _CustomCupertinoTextSelectionControls extends CupertinoTextSelectionContro
   ) {
     final double anchorX = (selectionMidpoint.dx + globalEditableRegion.left).clamp(
       _kArrowScreenPadding + MediaQuery.paddingOf(context).left,
-      MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right - _kArrowScreenPadding,
+      MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right - _kArrowScreenPadding,
     );
     final Offset anchorAbove = Offset(
       anchorX,

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -26,9 +26,10 @@ class _CustomCupertinoTextSelectionControls extends CupertinoTextSelectionContro
     ValueNotifier<ClipboardStatus>? clipboardStatus,
     Offset? lastSecondaryTapDownPosition,
   ) {
+    final EdgeInsets mediaQueryPadding = MediaQuery.paddingOf(context);
     final double anchorX = (selectionMidpoint.dx + globalEditableRegion.left).clamp(
-      _kArrowScreenPadding + MediaQuery.paddingOf(context).left,
-      MediaQuery.sizeOf(context).width - MediaQuery.paddingOf(context).right - _kArrowScreenPadding,
+      _kArrowScreenPadding + mediaQueryPadding.left,
+      MediaQuery.sizeOf(context).width - mediaQueryPadding.right - _kArrowScreenPadding,
     );
     final Offset anchorAbove = Offset(
       anchorX,

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -26,10 +26,9 @@ class _CustomCupertinoTextSelectionControls extends CupertinoTextSelectionContro
     ValueNotifier<ClipboardStatus>? clipboardStatus,
     Offset? lastSecondaryTapDownPosition,
   ) {
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
     final double anchorX = (selectionMidpoint.dx + globalEditableRegion.left).clamp(
-      _kArrowScreenPadding + mediaQuery.padding.left,
-      mediaQuery.size.width - mediaQuery.padding.right - _kArrowScreenPadding,
+      _kArrowScreenPadding + MediaQuery.paddingOf(context).left,
+      MediaQuery.widthOf(context) - MediaQuery.paddingOf(context).right - _kArrowScreenPadding,
     );
     final Offset anchorAbove = Offset(
       anchorX,

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -475,7 +475,7 @@ void main() {
     double? textScaleFactor;
     await tester.pumpWidget(MaterialApp(
       home: Builder(builder:(BuildContext context) {
-        textScaleFactor = MediaQuery.of(context).textScaleFactor;
+        textScaleFactor = MediaQuery.textScaleFactorOf(context);
         return Container();
       }),
     ));

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -438,7 +438,7 @@ void main() {
         home: Scaffold(
           body: Builder(
             builder: (BuildContext context) {
-              width = MediaQuery.of(context).size.width;
+              width = MediaQuery.widthOf(context);
               return CustomScrollView(
                 slivers: <Widget>[
                   SliverAppBar(

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -438,7 +438,7 @@ void main() {
         home: Scaffold(
           body: Builder(
             builder: (BuildContext context) {
-              width = MediaQuery.widthOf(context);
+              width = MediaQuery.sizeOf(context).width;
               return CustomScrollView(
                 slivers: <Widget>[
                   SliverAppBar(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2443,7 +2443,7 @@ void main() {
                       value: 1,
                       child: Builder(
                         builder: (BuildContext context) {
-                          mediaQueryPadding = MediaQuery.of(context).padding;
+                          mediaQueryPadding = MediaQuery.paddingOf(context);
                           return Text('-1-' * 500); // A long long text string.
                         },
                       ),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1957,7 +1957,7 @@ void main() {
       MaterialApp(
         home: Builder(
           builder: (BuildContext context) {
-            screenWidth = MediaQuery.widthOf(context);
+            screenWidth = MediaQuery.sizeOf(context).width;
             return Scaffold(
               endDrawer: const Drawer(
                 child: Text('Drawer'),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -925,7 +925,7 @@ void main() {
               extendBody: extendBody,
               body: Builder(
                 builder: (BuildContext context) {
-                  mediaQueryBottom = MediaQuery.of(context).padding.bottom;
+                  mediaQueryBottom = MediaQuery.paddingOf(context).bottom;
                   return Container(key: bodyKey);
                 },
               ),
@@ -998,7 +998,7 @@ void main() {
                   ),
                   body: Builder(
                     builder: (BuildContext context) {
-                      mediaQueryTop = MediaQuery.of(context).padding.top;
+                      mediaQueryTop = MediaQuery.paddingOf(context).top;
                       return Container(key: bodyKey);
                     },
                   ),
@@ -1957,7 +1957,7 @@ void main() {
       MaterialApp(
         home: Builder(
           builder: (BuildContext context) {
-            screenWidth = MediaQuery.of(context).size.width;
+            screenWidth = MediaQuery.widthOf(context);
             return Scaffold(
               endDrawer: const Drawer(
                 child: Text('Drawer'),

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -229,7 +229,7 @@ void main() {
       home: Scaffold(
         body: Builder(
           builder: (BuildContext context) {
-            width = MediaQuery.widthOf(context);
+            width = MediaQuery.sizeOf(context).width;
 
             return GestureDetector(
               key: tapTarget,

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -229,7 +229,7 @@ void main() {
       home: Scaffold(
         body: Builder(
           builder: (BuildContext context) {
-            width = MediaQuery.of(context).size.width;
+            width = MediaQuery.widthOf(context);
 
             return GestureDetector(
               key: tapTarget,

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -502,7 +502,7 @@ void main() {
             children: <Widget>[
               const Text('top', textDirection: TextDirection.ltr),
               Builder(builder: (BuildContext context) {
-                innerMediaQueryPadding = MediaQuery.of(context).padding;
+                innerMediaQueryPadding = MediaQuery.paddingOf(context);
                 return Container();
               }),
             ],

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -686,21 +686,21 @@ void main() {
     expect(insideHighContrast, true);
   });
 
-  testWidgets('MediaQuery.boldTextOverride', (WidgetTester tester) async {
+  testWidgets('MediaQuery.boldTextOverrideOf', (WidgetTester tester) async {
     late bool outsideBoldTextOverride;
     late bool insideBoldTextOverride;
 
     await tester.pumpWidget(
       Builder(
         builder: (BuildContext context) {
-          outsideBoldTextOverride = MediaQuery.boldTextOverride(context);
+          outsideBoldTextOverride = MediaQuery.boldTextOverrideOf(context);
           return MediaQuery(
             data: const MediaQueryData(
               boldText: true,
             ),
             child: Builder(
               builder: (BuildContext context) {
-                insideBoldTextOverride = MediaQuery.boldTextOverride(context);
+                insideBoldTextOverride = MediaQuery.boldTextOverrideOf(context);
                 return Container();
               },
             ),

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -686,21 +686,21 @@ void main() {
     expect(insideHighContrast, true);
   });
 
-  testWidgets('MediaQuery.boldTextOverrideOf', (WidgetTester tester) async {
+  testWidgets('MediaQuery.boldTextOf', (WidgetTester tester) async {
     late bool outsideBoldTextOverride;
     late bool insideBoldTextOverride;
 
     await tester.pumpWidget(
       Builder(
         builder: (BuildContext context) {
-          outsideBoldTextOverride = MediaQuery.boldTextOverrideOf(context);
+          outsideBoldTextOverride = MediaQuery.boldTextOf(context);
           return MediaQuery(
             data: const MediaQueryData(
               boldText: true,
             ),
             child: Builder(
               builder: (BuildContext context) {
-                insideBoldTextOverride = MediaQuery.boldTextOverrideOf(context);
+                insideBoldTextOverride = MediaQuery.boldTextOf(context);
                 return Container();
               },
             ),

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -950,7 +950,7 @@ void main() {
     final Widget showWidth = Builder(
       builder: (BuildContext context) {
         widthBuildCount++;
-        return Text('width: ${MediaQuery.widthOf(context).toStringAsFixed(1)}');
+        return Text('width: ${MediaQuery.sizeOf(context).width.toStringAsFixed(1)}');
       }
     );
 
@@ -964,7 +964,7 @@ void main() {
     final Widget showHeight = Builder(
       builder: (BuildContext context) {
         heightBuildCount++;
-        return Text('height: ${MediaQuery.heightOf(context).toStringAsFixed(1)}');
+        return Text('height: ${MediaQuery.sizeOf(context).height.toStringAsFixed(1)}');
       }
     );
 

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -940,19 +940,12 @@ void main() {
 
   testWidgets('MediaQuery can be partially depended-on', (WidgetTester tester) async {
     MediaQueryData data = const MediaQueryData(
-      size: Size(800, 600)
+      size: Size(800, 600),
+      textScaleFactor: 1.1
     );
 
-    int widthBuildCount = 0;
     int sizeBuildCount = 0;
-    int heightBuildCount = 0;
-
-    final Widget showWidth = Builder(
-      builder: (BuildContext context) {
-        widthBuildCount++;
-        return Text('width: ${MediaQuery.sizeOf(context).width.toStringAsFixed(1)}');
-      }
-    );
+    int textScaleFactorBuildCount = 0;
 
     final Widget showSize = Builder(
       builder: (BuildContext context) {
@@ -961,10 +954,10 @@ void main() {
       }
     );
 
-    final Widget showHeight = Builder(
+    final Widget showTextScaleFactor = Builder(
       builder: (BuildContext context) {
-        heightBuildCount++;
-        return Text('height: ${MediaQuery.sizeOf(context).height.toStringAsFixed(1)}');
+        textScaleFactorBuildCount++;
+        return Text('textScaleFactor: ${MediaQuery.textScaleFactorOf(context).toStringAsFixed(1)}');
       }
     );
 
@@ -975,9 +968,8 @@ void main() {
           child: Center(
             child: Column(
               children: <Widget>[
-                showWidth,
                 showSize,
-                showHeight,
+                showTextScaleFactor,
                 ElevatedButton(
                   onPressed: () {
                     setState(() {
@@ -989,10 +981,10 @@ void main() {
                 ElevatedButton(
                   onPressed: () {
                     setState(() {
-                      data = data.copyWith(size: Size(data.size.width, data.size.height + 100));
+                      data = data.copyWith(textScaleFactor: data.textScaleFactor + 0.1);
                     });
                   },
-                  child: const Text('Increase height by 100')
+                  child: const Text('Increase textScaleFactor by 0.1')
                 )
               ]
             )
@@ -1002,29 +994,23 @@ void main() {
     );
 
     await tester.pumpWidget(MaterialApp(home: page));
-    expect(find.text('width: 800.0'), findsOneWidget);
     expect(find.text('size: Size(800.0, 600.0)'), findsOneWidget);
-    expect(find.text('height: 600.0'), findsOneWidget);
-    expect(widthBuildCount, 1);
+    expect(find.text('textScaleFactor: 1.1'), findsOneWidget);
     expect(sizeBuildCount, 1);
-    expect(heightBuildCount, 1);
+    expect(textScaleFactorBuildCount, 1);
 
     await tester.tap(find.text('Increase width by 100'));
     await tester.pumpAndSettle();
-    expect(find.text('width: 900.0'), findsOneWidget);
     expect(find.text('size: Size(900.0, 600.0)'), findsOneWidget);
-    expect(find.text('height: 600.0'), findsOneWidget);
-    expect(widthBuildCount, 2);
+    expect(find.text('textScaleFactor: 1.1'), findsOneWidget);
     expect(sizeBuildCount, 2);
-    expect(heightBuildCount, 1);
+    expect(textScaleFactorBuildCount, 1);
 
-    await tester.tap(find.text('Increase height by 100'));
+    await tester.tap(find.text('Increase textScaleFactor by 0.1'));
     await tester.pumpAndSettle();
-    expect(find.text('width: 900.0'), findsOneWidget);
-    expect(find.text('size: Size(900.0, 700.0)'), findsOneWidget);
-    expect(find.text('height: 700.0'), findsOneWidget);
-    expect(widthBuildCount, 2);
-    expect(sizeBuildCount, 3);
-    expect(heightBuildCount, 2);
+    expect(find.text('size: Size(900.0, 600.0)'), findsOneWidget);
+    expect(find.text('textScaleFactor: 1.2'), findsOneWidget);
+    expect(sizeBuildCount, 2);
+    expect(textScaleFactorBuildCount, 2);
   });
 }

--- a/packages/flutter/test/widgets/render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/render_object_widget_test.dart
@@ -28,7 +28,7 @@ class TestOrientedBox extends SingleChildRenderObjectWidget {
   const TestOrientedBox({ super.key, super.child });
 
   Decoration _getDecoration(BuildContext context) {
-    final Orientation orientation = MediaQuery.of(context).orientation;
+    final Orientation orientation = MediaQuery.orientationOf(context);
     switch (orientation) {
       case Orientation.landscape:
         return const BoxDecoration(color: Color(0xFF00FF00));

--- a/packages/flutter/test_fixes/cupertino.dart
+++ b/packages/flutter/test_fixes/cupertino.dart
@@ -235,4 +235,7 @@ void main() {
   scrollBehavior.buildViewportChrome(context, child, axisDirection);
   final CupertinoScrollBehavior cupertinoScrollBehavior = CupertinoScrollBehavior();
   cupertinoScrollBehavior.buildViewportChrome(context, child, axisDirection);
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverride(context);
 }

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -235,4 +235,7 @@ void main() {
   scrollBehavior.buildOverscrollIndicator(context, child, axisDirection);
   final CupertinoScrollBehavior cupertinoScrollBehavior = CupertinoScrollBehavior();
   cupertinoScrollBehavior.buildOverscrollIndicator(context, child, axisDirection);
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverrideOf(context);
 }

--- a/packages/flutter/test_fixes/cupertino.dart.expect
+++ b/packages/flutter/test_fixes/cupertino.dart.expect
@@ -237,5 +237,5 @@ void main() {
   cupertinoScrollBehavior.buildOverscrollIndicator(context, child, axisDirection);
 
   // Changes made in https://github.com/flutter/flutter/pull/97928
-  MediaQuery.boldTextOverrideOf(context);
+  MediaQuery.boldTextOf(context);
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -707,4 +707,7 @@ void main() {
   ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(showTrackOnHover: nowShowing);
   scrollbarTheme.copyWith(showTrackOnHover: nowShowing);
   scrollbarTheme.showTrackOnHover;
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverride(context);
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -889,7 +889,7 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/110162
   ThemeData themeData = ThemeData();
-  themeData = ThemeData(colorScheme: ColorScheme(background: Colors.grey).copyWith(error: Colors.red));
+  themeData = ThemeData(colorScheme: ColorScheme(error: Colors.red).copyWith(background: Colors.grey));
   themeData = ThemeData.raw(colorScheme: ColorScheme(error: Colors.red).copyWith(background: Colors.grey));
   themeData = themeData.copyWith(colorScheme: ColorScheme(error: Colors.red).copyWith(background: Colors.grey));
 

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -913,5 +913,5 @@ void main() {
   scrollbarTheme.trackVisibility;
 
   // Changes made in https://github.com/flutter/flutter/pull/97928
-  MediaQuery.boldTextOverrideOf(context);
+  MediaQuery.boldTextOf(context);
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -911,4 +911,7 @@ void main() {
   ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(trackVisibility: nowShowing);
   scrollbarTheme.copyWith(trackVisibility: nowShowing);
   scrollbarTheme.trackVisibility;
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverrideOf(context);
 }

--- a/packages/flutter/test_fixes/widgets.dart
+++ b/packages/flutter/test_fixes/widgets.dart
@@ -188,4 +188,7 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/78588
   final ScrollBehavior scrollBehavior = ScrollBehavior();
   scrollBehavior.buildViewportChrome(context, child, axisDirection);
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverride(context);
 }

--- a/packages/flutter/test_fixes/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets.dart.expect
@@ -188,4 +188,7 @@ void main() {
   // Changes made in https://github.com/flutter/flutter/pull/78588
   final ScrollBehavior scrollBehavior = ScrollBehavior();
   scrollBehavior.buildOverscrollIndicator(context, child, axisDirection);
+
+  // Changes made in https://github.com/flutter/flutter/pull/97928
+  MediaQuery.boldTextOverrideOf(context);
 }

--- a/packages/flutter/test_fixes/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets.dart.expect
@@ -190,5 +190,5 @@ void main() {
   scrollBehavior.buildOverscrollIndicator(context, child, axisDirection);
 
   // Changes made in https://github.com/flutter/flutter/pull/97928
-  MediaQuery.boldTextOverrideOf(context);
+  MediaQuery.boldTextOf(context);
 }


### PR DESCRIPTION
When some aspect of the flutter `MediaQuery` changes, every widget which depends on `MediaQuery.of(context)` is rebuilt. Most of these rebuilds are unnecessary, since most changes to `MediaQuery` do not change more than 1 or 2 fields at a time (window resizing, system brightness changing, system font scale changing). 

MediaQuery does not change often on mobile, but resizing desktop windows happens often and flutter should be able to handle being resized without dropping frames. There is one place that MediaQuery is rapidly updated on mobile: on iOS, as the keyboard opens, `MediaQuery` is updated every frame with the only change being the keyboard insets. 

Here is a demo program, resizing the window causes `MyHomePage` to rebuild needlessly. The issue here could be alleviated by better Widget encapsulation, but many framework widgets are rebuilt on every change in `MediaQuery` when they depend on rarely-changing properties such as `platformBrightness` or `textScaleFactor`. 

```dart
import 'package:flutter/cupertino.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const CupertinoApp(
      title: 'Flutter Demo',
      home: MyHomePage()
    );
  }
}

class MyHomePage extends StatelessWidget {
  const MyHomePage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Container(
      color: CupertinoDynamicColor.resolve(CupertinoColors.systemFill, context),
      child: ListView(
        children: <Widget>[
          // Some expensive build function
          for (int i = 0; i < 100000; i++) Text('Item $i', textAlign: TextAlign.center)
        ]
      )
    );
  }
}
```

This change makes `MediaQuery` an `InheritedModel` rather than an `InheritedWidget`, so any widget which knows it only depends on a specific property of `MediaQuery` the ability to declare that when reading the `MediaQuery` from the context. 

For example,
```dart
MediaQuery.of(context).platformBrightness
```
could become
```dart
MediaQuery.of(context, MediaQueryAspect.platformBrightness).platformBrightness
```
as a performance optimization. 

`MediaQuery.of(context)` will continue to work as it always has. 

Fixes #102060

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
