### PR TITLE
[framework] use platform touchslop on Android

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -150,7 +150,7 @@ class MediaQueryData {
       highContrast = window.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat,
       navigationMode = NavigationMode.traditional,
-      gestureSettings = DeviceGestureSettings.fromWindow(window),
+      gestureSettings = MediaQuery.enableDeviceGestureSettings ? DeviceGestureSettings.fromWindow(window) : const DeviceGestureSettings(),
       displayFeatures = window.displayFeatures;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).
@@ -876,6 +876,10 @@ class MediaQuery extends InheritedWidget {
       child: child,
     );
   }
+
+  /// If false, device gesture settings are not read from the window and left as their
+  /// default.
+  static bool enableDeviceGestureSettings = true;
 
   /// Contains information about the current media.
   ///

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -150,7 +150,7 @@ class MediaQueryData {
       highContrast = window.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = window.alwaysUse24HourFormat,
       navigationMode = NavigationMode.traditional,
-      gestureSettings = MediaQuery.enableDeviceGestureSettings ? DeviceGestureSettings.fromWindow(window) : const DeviceGestureSettings(),
+      gestureSettings = DeviceGestureSettings.fromWindow(window),
       displayFeatures = window.displayFeatures;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).
@@ -876,10 +876,6 @@ class MediaQuery extends InheritedWidget {
       child: child,
     );
   }
-
-  /// If false, device gesture settings are not read from the window and left as their
-  /// default.
-  static bool enableDeviceGestureSettings = true;
 
   /// Contains information about the current media.
   ///

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -15,6 +15,7 @@ import 'basic.dart';
 import 'focus_manager.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
+import 'media_query.dart';
 import 'notification_listener.dart';
 import 'primary_scroll_controller.dart';
 import 'restoration.dart';
@@ -399,6 +400,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   late ScrollBehavior _configuration;
   ScrollPhysics? _physics;
   ScrollController? _fallbackScrollController;
+  MediaQueryData? _mediaQueryData;
 
   ScrollController get _effectiveScrollController => widget.controller ?? _fallbackScrollController!;
 
@@ -452,6 +454,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
 
   @override
   void didChangeDependencies() {
+    _mediaQueryData = MediaQuery.maybeOf(context);
     _updatePosition();
     super.didChangeDependencies();
   }
@@ -565,7 +568,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
-                  ..dragStartBehavior = widget.dragStartBehavior;
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..gestureSettings = _mediaQueryData?.gestureSettings;
               },
             ),
           };
@@ -585,7 +589,8 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
                   ..minFlingVelocity = _physics?.minFlingVelocity
                   ..maxFlingVelocity = _physics?.maxFlingVelocity
                   ..velocityTrackerBuilder = _configuration.velocityTrackerBuilder(context)
-                  ..dragStartBehavior = widget.dragStartBehavior;
+                  ..dragStartBehavior = widget.dragStartBehavior
+                  ..gestureSettings = _mediaQueryData?.gestureSettings;
               },
             ),
           };

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show Brightness, DisplayFeature, DisplayFeatureState, DisplayFeatureType;
+import 'dart:ui' show Brightness, DisplayFeature, DisplayFeatureState, DisplayFeatureType, GestureSettings, ViewConfiguration;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
@@ -913,5 +913,19 @@ void main() {
     expect(subScreenMediaQuery.boldText, true);
     expect(subScreenMediaQuery.highContrast, true);
     expect(subScreenMediaQuery.displayFeatures, <DisplayFeature>[cutoutDisplayFeature]);
+  });
+
+  testWidgets('MediaQuery.enableDeviceGestureSettings allows disabling gesture settings', (WidgetTester tester) async {
+    tester.binding.window.viewConfigurationTestValue = const ViewConfiguration(
+      gestureSettings: GestureSettings(physicalDoubleTapSlop: 100, physicalTouchSlop: 100),
+    );
+
+    MediaQuery.enableDeviceGestureSettings = false;
+
+    expect(MediaQueryData.fromWindow(tester.binding.window).gestureSettings, const DeviceGestureSettings());
+
+    MediaQuery.enableDeviceGestureSettings = true;
+
+    expect(MediaQueryData.fromWindow(tester.binding.window).gestureSettings.touchSlop, closeTo(33.33, 0.1)); // Repeating, of course
   });
 }

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -920,12 +920,7 @@ void main() {
       gestureSettings: GestureSettings(physicalDoubleTapSlop: 100, physicalTouchSlop: 100),
     );
 
-    MediaQuery.enableDeviceGestureSettings = false;
-
-    expect(MediaQueryData.fromWindow(tester.binding.window).gestureSettings, const DeviceGestureSettings());
-
-    MediaQuery.enableDeviceGestureSettings = true;
-
     expect(MediaQueryData.fromWindow(tester.binding.window).gestureSettings.touchSlop, closeTo(33.33, 0.1)); // Repeating, of course
+    tester.binding.window.viewConfigurationTestValue = null;
   });
 }


### PR DESCRIPTION
Reland of https://github.com/flutter/flutter/pull/88534 .

Because this caused odd test failures in g3, I added a static that can be used to disable it - which I think we could probably remove before another release.

Fixes https://github.com/flutter/flutter/issues/87322