### PR TITLE
Expose smart punctuation options on CupertinoSearchTextField

### DIFF
--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
@@ -9,6 +10,8 @@ import 'colors.dart';
 import 'icons.dart';
 import 'localizations.dart';
 import 'text_field.dart';
+
+export 'package:flutter/services.dart' show SmartQuotesType, SmartDashesType;
 
 /// A [CupertinoTextField] that mimics the look and behavior of UIKit's
 /// `UISearchTextField`.
@@ -117,6 +120,7 @@ class CupertinoSearchTextField extends StatefulWidget {
     this.restorationId,
     this.focusNode,
     this.smartQuotesType,
+    this.smartDashesType,
     this.autofocus = false,
     this.onTap,
     this.autocorrect = true,
@@ -265,6 +269,9 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
   final SmartQuotesType? smartQuotesType;
 
+  /// {@macro flutter.services.TextInputConfiguration.smartDashesType}
+  final SmartDashesType? smartDashesType;
+
   /// Disables the text field when false.
   ///
   /// Text fields in disabled states have a light grey background and don't
@@ -405,6 +412,7 @@ class _CupertinoSearchTextFieldState extends State<CupertinoSearchTextField>
       autofocus: widget.autofocus,
       autocorrect: widget.autocorrect,
       smartQuotesType: widget.smartQuotesType,
+      smartDashesType: widget.smartDashesType,
       textInputAction: TextInputAction.search,
     );
   }

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -266,10 +266,46 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
 
-  /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
+  /// Whether to allow the platform to automatically format quotes.
+  ///
+  /// This flag only affects iOS. It sets
+  /// [`UITextSmartQuotesType`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype?language=objc)
+  /// in the engine. When true, it passes
+  /// [`UITextSmartQuotesTypeYes`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype/uitextsmartquotestypeyes?language=objc),
+  /// and when false, it passes
+  /// [`UITextSmartQuotesTypeNo`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype/uitextsmartquotestypeno?language=objc).
+  ///
+  /// As an example of what this does, a standard vertical double quote
+  /// character will be automatically replaced by a left or right double quote
+  /// depending on its position in a word.
+  ///
+  /// Defaults to true.
+  ///
+  /// See also:
+  ///
+  ///  * [smartDashesType]
+  ///  * <https://developer.apple.com/documentation/uikit/uitextinputtraits>
   final SmartQuotesType? smartQuotesType;
 
-  /// {@macro flutter.services.TextInputConfiguration.smartDashesType}
+  /// Whether to allow the platform to automatically format dashes.
+  ///
+  /// This flag only affects iOS versions 11 and above. It sets
+  /// [`UITextSmartDashesType`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype?language=objc)
+  /// in the engine. When true, it passes
+  /// [`UITextSmartDashesTypeYes`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype/uitextsmartdashestypeyes?language=objc),
+  /// and when false, it passes
+  /// [`UITextSmartDashesTypeNo`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype/uitextsmartdashestypeno?language=objc).
+  ///
+  /// As an example of what this does, two consecutive hyphen characters will be
+  /// automatically replaced with one en dash, and three consecutive hyphens
+  /// will become one em dash.
+  ///
+  /// Defaults to true.
+  ///
+  /// See also:
+  ///
+  ///  * [smartQuotesType]
+  ///  * <https://developer.apple.com/documentation/uikit/uitextinputtraits>
   final SmartDashesType? smartDashesType;
 
   /// Disables the text field when false.

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -268,18 +268,20 @@ class CupertinoSearchTextField extends StatefulWidget {
 
   /// Whether to allow the platform to automatically format quotes.
   ///
-  /// This flag only affects iOS. It sets
-  /// [`UITextSmartQuotesType`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype?language=objc)
-  /// in the engine. When true, it passes
+  /// This flag only affects iOS, where it is equivalent to [`UITextSmartQuotesType`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype?language=objc).
+  ///
+  /// When set to [SmartQuotesType.enabled], it passes
   /// [`UITextSmartQuotesTypeYes`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype/uitextsmartquotestypeyes?language=objc),
-  /// and when false, it passes
+  /// and when set to [SmartQuotesType.disabled], it passes
   /// [`UITextSmartQuotesTypeNo`](https://developer.apple.com/documentation/uikit/uitextsmartquotestype/uitextsmartquotestypeno?language=objc).
+  ///
+  /// If set to null, [SmartQuotesType.enabled] will be used.
   ///
   /// As an example of what this does, a standard vertical double quote
   /// character will be automatically replaced by a left or right double quote
   /// depending on its position in a word.
   ///
-  /// Defaults to true.
+  /// Defaults to null.
   ///
   /// See also:
   ///
@@ -289,18 +291,20 @@ class CupertinoSearchTextField extends StatefulWidget {
 
   /// Whether to allow the platform to automatically format dashes.
   ///
-  /// This flag only affects iOS versions 11 and above. It sets
-  /// [`UITextSmartDashesType`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype?language=objc)
-  /// in the engine. When true, it passes
+  /// This flag only affects iOS versions 11 and above, where it is equivalent to [`UITextSmartDashesType`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype?language=objc).
+  ///
+  /// When set to [SmartDashesType.enabled], it passes
   /// [`UITextSmartDashesTypeYes`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype/uitextsmartdashestypeyes?language=objc),
-  /// and when false, it passes
+  /// and when set to [SmartDashesType.disabled], it passes
   /// [`UITextSmartDashesTypeNo`](https://developer.apple.com/documentation/uikit/uitextsmartdashestype/uitextsmartdashestypeno?language=objc).
+  ///
+  /// If set to null, [SmartDashesType.enabled] will be used.
   ///
   /// As an example of what this does, two consecutive hyphen characters will be
   /// automatically replaced with one en dash, and three consecutive hyphens
   /// will become one em dash.
   ///
-  /// Defaults to true.
+  /// Defaults to null.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/cupertino/search_field.dart
+++ b/packages/flutter/lib/src/cupertino/search_field.dart
@@ -116,6 +116,7 @@ class CupertinoSearchTextField extends StatefulWidget {
     this.onSuffixTap,
     this.restorationId,
     this.focusNode,
+    this.smartQuotesType,
     this.autofocus = false,
     this.onTap,
     this.autocorrect = true,
@@ -261,6 +262,9 @@ class CupertinoSearchTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.autocorrect}
   final bool autocorrect;
 
+  /// {@macro flutter.services.TextInputConfiguration.smartQuotesType}
+  final SmartQuotesType? smartQuotesType;
+
   /// Disables the text field when false.
   ///
   /// Text fields in disabled states have a light grey background and don't
@@ -400,6 +404,7 @@ class _CupertinoSearchTextFieldState extends State<CupertinoSearchTextField>
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       autocorrect: widget.autocorrect,
+      smartQuotesType: widget.smartQuotesType,
       textInputAction: TextInputAction.search,
     );
   }

--- a/packages/flutter/test/cupertino/search_field_test.dart
+++ b/packages/flutter/test/cupertino/search_field_test.dart
@@ -593,4 +593,19 @@ void main() {
     final CupertinoTextField textField = tester.widget(find.byType(CupertinoTextField));
     expect(textField.smartQuotesType, SmartQuotesType.disabled);
   });
+
+  testWidgets('smartDashesType is properly forwarded to the inner text field', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: CupertinoSearchTextField(
+            smartDashesType: SmartDashesType.disabled,
+          ),
+        ),
+      ),
+    );
+
+    final CupertinoTextField textField = tester.widget(find.byType(CupertinoTextField));
+    expect(textField.smartDashesType, SmartDashesType.disabled);
+  });
 }

--- a/packages/flutter/test/cupertino/search_field_test.dart
+++ b/packages/flutter/test/cupertino/search_field_test.dart
@@ -578,4 +578,19 @@ void main() {
 
     expect(focusNode.hasFocus, isTrue);
   });
+
+  testWidgets('smartQuotesType is properly forwarded to the inner text field', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: Center(
+          child: CupertinoSearchTextField(
+            smartQuotesType: SmartQuotesType.disabled,
+          ),
+        ),
+      ),
+    );
+
+    final CupertinoTextField textField = tester.widget(find.byType(CupertinoTextField));
+    expect(textField.smartQuotesType, SmartQuotesType.disabled);
+  });
 }


### PR DESCRIPTION
Let users of `CupertinoSearchTextField` choose to disable automatic directional quotes, en-dashes, and em-dashes.

Fixes #102058

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
