### PR TITLE
Allow remove listener on disposed change notifier

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -180,7 +180,7 @@ class ChangeNotifier implements Listenable {
         _listeners = List<VoidCallback?>.filled(1, null);
       } else {
         final List<VoidCallback?> newListeners =
-        List<VoidCallback?>.filled(_listeners.length * 2, null);
+            List<VoidCallback?>.filled(_listeners.length * 2, null);
         for (int i = 0; i < _count; i++) {
           newListeners[i] = _listeners[i];
         }

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -103,7 +103,7 @@ abstract class ValueListenable<T> extends Listenable {
 ///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
 class ChangeNotifier implements Listenable {
   int _count = 0;
-  // The _listeners is intentionally set to a fixed length _GrowableList instead
+  // The _listeners is intentionally set to a fixed-length _GrowableList instead
   // of const [] for performance reasons.
   // See https://github.com/flutter/flutter/pull/71947/files#r545722476 for
   // more details.

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -107,7 +107,8 @@ class ChangeNotifier implements Listenable {
   // of const [] for performance reasons.
   // See https://github.com/flutter/flutter/pull/71947/files#r545722476 for
   // more details.
-  List<VoidCallback?> _listeners = List<VoidCallback?>.filled(0, null);
+  static final List<VoidCallback?> _emptyListeners = List<VoidCallback?>.filled(0, null);
+  List<VoidCallback?> _listeners = _emptyListeners;
   int _notificationCallStackDepth = 0;
   int _reentrantlyRemovedListeners = 0;
   bool _debugDisposed = false;
@@ -234,11 +235,11 @@ class ChangeNotifier implements Listenable {
   ///    changes.
   @override
   void removeListener(VoidCallback listener) {
-    // This method is allowed to be called on disposed instance for usability
-    // reason. Due to how our frame scheduling logic between render object and
-    // overlay, it is common that the owner of this instance would be disposed a
-    // frame earlier than the listeners. Allows calls to this method after it is
-    // disposed make it easier for listeners to properly clean up.
+    // This method is allowed to be called on disposed instances for usability
+    // reasons. Due to how our frame scheduling logic between render objects and
+    // overlays, it is common that the owner of this instance would be disposed a
+    // frame earlier than the listeners. Allowing calls to this method after it
+    // is disposed makes it easier for listeners to properly clean up.
     for (int i = 0; i < _count; i++) {
       final VoidCallback? listenerAtIndex = _listeners[i];
       if (listenerAtIndex == listener) {
@@ -271,7 +272,7 @@ class ChangeNotifier implements Listenable {
       _debugDisposed = true;
       return true;
     }());
-    _listeners = List<VoidCallback?>.filled(0, null);
+    _listeners = _emptyListeners;
     _count = 0;
   }
 

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -234,6 +234,11 @@ class ChangeNotifier implements Listenable {
   ///    changes.
   @override
   void removeListener(VoidCallback listener) {
+    // This method is allowed to be called on disposed instance for usability
+    // reason. Due to how our frame scheduling logic between render object and
+    // overlay, it is common that the owner of this instance would be disposed a
+    // frame earlier than the listeners. Allows calls to this method after it is
+    // disposed make it easier for listeners to properly clean up.
     for (int i = 0; i < _count; i++) {
       final VoidCallback? listenerAtIndex = _listeners[i];
       if (listenerAtIndex == listener) {

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -323,14 +323,11 @@ void main() {
     expect(log, isEmpty);
   });
 
-  test('Cannot use a disposed ChangeNotifier', () {
+  test('Cannot use a disposed ChangeNotifier except for remove listener', () {
     final TestNotifier source = TestNotifier();
     source.dispose();
     expect(() {
       source.addListener(() {});
-    }, throwsFlutterError);
-    expect(() {
-      source.removeListener(() {});
     }, throwsFlutterError);
     expect(() {
       source.dispose();
@@ -338,6 +335,18 @@ void main() {
     expect(() {
       source.notify();
     }, throwsFlutterError);
+  });
+
+  test('Can remove listener on a disposed ChangeNotifier', () {
+    final TestNotifier source = TestNotifier();
+    FlutterError? error;
+    try {
+      source.dispose();
+      source.removeListener(() {});
+    } on FlutterError catch (e) {
+      error = e;
+    }
+    expect(error, isNull);
   });
 
   test('Value notifier', () {


### PR DESCRIPTION
The current logic causes problem when there are overlay involve. The owner of an overlay entry is usually a State of a statefulwidget. The problem occur when the overlay entry usually out-lived the owner for one frame. so it is very hard to figure out the clean up order if there are change notifiers involved. This PR allows removeListen calls to a disposed change notifier.   

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
