### PR TITLE
Add a benchmark for simple DisplayLists to exercise the Raster Cache's cache admission algorithm

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2086,6 +2086,7 @@ targets:
 
   - name: Linux_android picture_cache_complexity_scoring_perf__timeline_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:
@@ -3403,6 +3404,7 @@ targets:
 
   - name: Mac_ios picture_cache_complexity_scoring_perf__timeline_summary
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2084,6 +2084,16 @@ targets:
       task_name: picture_cache_perf__timeline_summary
     scheduler: luci
 
+  - name: Linux_android picture_cache_complexity_scoring_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: picture_cache_complexity_scoring_perf__timeline_summary
+    scheduler: luci
+
   - name: Linux_android platform_channels_benchmarks
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3389,6 +3399,16 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: new_gallery_ios__transition_perf
+    scheduler: luci
+
+  - name: Mac_ios picture_cache_complexity_scoring_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac"]
+      task_name: picture_cache_complexity_scoring_perf__timeline_summary
     scheduler: luci
 
   - name: Mac_ios platform_channel_sample_test_ios

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -113,6 +113,7 @@
 /dev/devicelab/bin/tasks/microbenchmarks.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/new_gallery__transition_perf.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/picture_cache_perf__timeline_summary.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/picture_cache_complexity_scoring_perf__timeline_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/platform_channel_sample_test.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/platform_interaction_test.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/platform_view__start_up.dart @zanderso @flutter/engine

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -8,6 +8,7 @@ const String kBackdropFilterRouteName = '/backdrop_filter';
 const String kPostBackdropFilterRouteName = '/post_backdrop_filter';
 const String kSimpleAnimationRouteName = '/simple_animation';
 const String kPictureCacheRouteName = '/picture_cache';
+const String kPictureCacheComplexityScoringRouteName = '/picture_cache_complexity_scoring';
 const String kLargeImageChangerRouteName = '/large_image_changer';
 const String kLargeImagesRouteName = '/large_images';
 const String kTextRouteName = '/text';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -21,6 +21,7 @@ import 'src/large_images.dart';
 import 'src/multi_widget_construction.dart';
 import 'src/opacity_peephole.dart';
 import 'src/picture_cache.dart';
+import 'src/picture_cache_complexity_scoring.dart';
 import 'src/post_backdrop_filter.dart';
 import 'src/simple_animation.dart';
 import 'src/simple_scroll.dart';
@@ -47,6 +48,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kPostBackdropFilterRouteName: (BuildContext context) => const PostBackdropFilterPage(),
         kSimpleAnimationRouteName: (BuildContext context) => const SimpleAnimationPage(),
         kPictureCacheRouteName: (BuildContext context) => const PictureCachePage(),
+        kPictureCacheComplexityScoringRouteName: (BuildContext context) => const PictureCacheComplexityScoringPage(),
         kLargeImageChangerRouteName: (BuildContext context) => const LargeImageChangerPage(),
         kLargeImagesRouteName: (BuildContext context) => const LargeImagesPage(),
         kTextRouteName: (BuildContext context) => const TextPage(),
@@ -120,6 +122,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Picture Cache'),
             onPressed: () {
               Navigator.pushNamed(context, kPictureCacheRouteName);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kPictureCacheComplexityScoringRouteName),
+            child: const Text('Picture Cache'),
+            onPressed: () {
+              Navigator.pushNamed(context, kPictureCacheComplexityScoringRouteName);
             },
           ),
           ElevatedButton(

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -126,7 +126,7 @@ class HomePage extends StatelessWidget {
           ),
           ElevatedButton(
             key: const Key(kPictureCacheComplexityScoringRouteName),
-            child: const Text('Picture Cache'),
+            child: const Text('Picture Cache Complexity Scoring'),
             onPressed: () {
               Navigator.pushNamed(context, kPictureCacheComplexityScoringRouteName);
             },

--- a/dev/benchmarks/macrobenchmarks/lib/src/picture_cache_complexity_scoring.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/picture_cache_complexity_scoring.dart
@@ -24,7 +24,7 @@ class PictureCacheComplexityScoringPage extends StatelessWidget {
           ),
         ),
         body: TabBarView(
-          key: const Key('tabbar_view'), // this key is used by the driver test
+          key: const Key('tabbar_view_complexity'), // this key is used by the driver test
           children: kTabNames.map((String name) {
             return _buildComplexityScoringWidgets(name);
           }).toList(),

--- a/dev/benchmarks/macrobenchmarks/lib/src/picture_cache_complexity_scoring.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/picture_cache_complexity_scoring.dart
@@ -1,0 +1,47 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class PictureCacheComplexityScoringPage extends StatelessWidget {
+  const PictureCacheComplexityScoringPage({Key? key}) : super(key: key);
+
+  static const List<String> kTabNames = <String>['1', '2'];
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: kTabNames.length, // This is the number of tabs.
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Picture Cache Complexity Scoring'),
+          // pinned: true,
+          // expandedHeight: 50.0,
+          // forceElevated: innerBoxIsScrolled,
+          bottom: TabBar(
+            tabs: kTabNames.map((String name) => Tab(text: name)).toList(),
+          ),
+        ),
+        body: TabBarView(
+          key: const Key('tabbar_view'), // this key is used by the driver test
+          children: kTabNames.map((String name) {
+            return _buildComplexityScoringWidgets(name);
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  // For now we just test a single case where the widget being cached is actually
+  // relatively cheap to rasterise, and so should not be in the cache.
+  //
+  // Eventually we can extend this to add new test cases based on the tab name.
+  Widget _buildComplexityScoringWidgets(String name) {
+    return Column(children: <Widget>[
+      Slider(value: 50, label: 'Slider 1', onChanged: (double _) {}, max: 100, divisions: 10,),
+      Slider(value: 50, label: 'Slider 2', onChanged: (double _) {}, max: 100, divisions: 10,),
+      Slider(value: 50, label: 'Slider 3', onChanged: (double _) {}, max: 100, divisions: 10,),
+    ]);
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_complexity_scoring_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_complexity_scoring_perf_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTest(
+    'picture_cache_complexity_scoring_perf',
+    kPictureCacheComplexityScoringRouteName,
+    pageDelay: const Duration(seconds: 1),
+    driverOps: (FlutterDriver driver) async {
+      final SerializableFinder tabBarView = find.byValueKey('tabbar_view');
+      Future<void> _scrollOnce(double offset) async {
+        // Technically it's not scrolling but moving
+        await driver.scroll(tabBarView, offset, 0.0, const Duration(milliseconds: 300));
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      }
+      // When we eventually add more test panes we will want to tweak these
+      // to go through all the panes
+      for (int i = 0; i < 6; i += 1) {
+        await _scrollOnce(-300.0);
+        await _scrollOnce(300.0);
+      }
+    },
+  );
+}

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_complexity_scoring_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_complexity_scoring_perf_test.dart
@@ -13,7 +13,7 @@ void main() {
     kPictureCacheComplexityScoringRouteName,
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
-      final SerializableFinder tabBarView = find.byValueKey('tabbar_view');
+      final SerializableFinder tabBarView = find.byValueKey('tabbar_view_complexity');
       Future<void> _scrollOnce(double offset) async {
         // Technically it's not scrolling but moving
         await driver.scroll(tabBarView, offset, 0.0, const Duration(milliseconds: 300));

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
@@ -13,7 +13,7 @@ void main() {
     kPictureCacheRouteName,
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
-      final SerializableFinder tabBarView = find.byValueKey('tabbar_view');
+      final SerializableFinder tabBarView = find.byValueKey('tabbar_view_complexity');
       Future<void> _scrollOnce(double offset) async {
         // Technically it's not scrolling but moving
         await driver.scroll(tabBarView, offset, 0.0, const Duration(milliseconds: 300));

--- a/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/picture_cache_perf_test.dart
@@ -13,7 +13,7 @@ void main() {
     kPictureCacheRouteName,
     pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
-      final SerializableFinder tabBarView = find.byValueKey('tabbar_view_complexity');
+      final SerializableFinder tabBarView = find.byValueKey('tabbar_view');
       Future<void> _scrollOnce(double offset) async {
         // Technically it's not scrolling but moving
         await driver.scroll(tabBarView, offset, 0.0, const Duration(milliseconds: 300));

--- a/dev/devicelab/bin/tasks/picture_cache_complexity_scoring_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/picture_cache_complexity_scoring_perf__timeline_summary.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createPictureCacheComplexityScoringPerfTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -215,6 +215,15 @@ TaskFunction createPictureCachePerfE2ETest() {
   ).run;
 }
 
+TaskFunction createPictureCacheComplexityScoringPerfTest() {
+  return PerfTest(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test_driver/run_app.dart',
+    'picture_cache_complexity_scoring_perf',
+    testDriver: 'test_driver/picture_cache_complexity_scoring_perf_test.dart',
+  ).run;
+}
+
 TaskFunction createFlutterGalleryStartupTest({String target = 'lib/main.dart'}) {
   return StartupTest(
     '${flutterDirectory.path}/dev/integration_tests/flutter_gallery',


### PR DESCRIPTION
This is an initial benchmark that allows us to track the status quo for a simple DisplayList that is cheap to rasterise but still gets cached anyway.

https://github.com/flutter/flutter/issues/86728

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
