### PR TITLE
Use ValueKey finder instead of text finder in keyboard_textfield_test

### DIFF
--- a/dev/integration_tests/ui/lib/keyboard_textfield.dart
+++ b/dev/integration_tests/ui/lib/keyboard_textfield.dart
@@ -55,16 +55,17 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    final String softKeyboardVisibility = MediaQuery.of(context).viewInsets.bottom > 100
-      ? 'keyboard visible'
-      : 'keyboard not visible';
+    final bool isSoftKeyboardVisible = MediaQuery.of(context).viewInsets.bottom > 100;
     return Scaffold(
       body: Column(
         children: <Widget>[
           Text('$offset',
             key: const ValueKey<String>(keys.kOffsetText),
           ),
-          Text(softKeyboardVisibility),
+          if (isSoftKeyboardVisible) const Text(
+            'keyboard visible',
+            key: ValueKey<String>(keys.kKeyboardVisibleView),
+          ),
           Expanded(
             child: ListView(
               key: const ValueKey<String>(keys.kListView),

--- a/dev/integration_tests/ui/lib/keys.dart
+++ b/dev/integration_tests/ui/lib/keys.dart
@@ -7,3 +7,4 @@ const String kHeightText = 'height_text';
 const String kUnfocusButton = 'unfocus_button';
 const String kOffsetText = 'offset_text';
 const String kListView = 'list_view';
+const String kKeyboardVisibleView = 'keyboard_visible';

--- a/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
+++ b/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
@@ -24,7 +24,7 @@ void main() {
       final SerializableFinder listViewFinder = find.byValueKey(keys.kListView);
       final SerializableFinder textFieldFinder = find.byValueKey(keys.kDefaultTextField);
       final SerializableFinder offsetFinder = find.byValueKey(keys.kOffsetText);
-      final SerializableFinder keyboardVisibilityIndicatorFinder = find.text('keyboard visible');
+      final SerializableFinder keyboardVisibilityIndicatorFinder = find.byValueKey(keys.kKeyboardVisibleView);
 
       // Align TextField with bottom edge to ensure it would be covered when keyboard comes up.
       await driver.waitForAbsent(textFieldFinder);


### PR DESCRIPTION
My last ditch effort for figuring what went wrong in https://github.com/flutter/flutter/issues/96787

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
