### PR TITLE
Marks Mac module_test_ios to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2696,6 +2696,7 @@ targets:
 
   - name: Mac module_test_ios
     recipe: devicelab/devicelab_drone
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/89175
     timeout: 60
     properties:
       caches: >-


### PR DESCRIPTION
<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
{
  "name": "Mac module_test_ios"
}
-->
Issue link: https://github.com/flutter/flutter/issues/89175
