### PR TITLE
[framework] defer image load to next event loop

### DIFF
--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'image_provider.dart' as image_provider;
 import 'image_stream.dart';
@@ -66,7 +67,7 @@ class NetworkImage
 
     return MultiFrameImageStreamCompleter(
       chunkEvents: chunkEvents.stream,
-      codec: _loadAsync(key, decode, chunkEvents),
+      codec: SchedulerBinding.instance.scheduleAsyncTask(() =>_loadAsync(key, decode, chunkEvents), Priority.animation),
       scale: key.scale,
       debugLabel: key.url,
       informationCollector: _imageStreamInformationCollector(key),
@@ -97,9 +98,6 @@ class NetworkImage
     StreamController<ImageChunkEvent> chunkEvents,
   ) async {
     assert(key == this);
-    // Ensure that the image load occurs in the next event loop and not in
-    // the frame workload.
-    await Future<void>.delayed(Duration.zero);
 
     final Uri resolved = Uri.base.resolve(key.url);
 

--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -66,7 +66,7 @@ class NetworkImage
 
     return MultiFrameImageStreamCompleter(
       chunkEvents: chunkEvents.stream,
-      codec: _loadAsync(key as NetworkImage, decode, chunkEvents),
+      codec: _loadAsync(key, decode, chunkEvents),
       scale: key.scale,
       debugLabel: key.url,
       informationCollector: _imageStreamInformationCollector(key),
@@ -92,11 +92,14 @@ class NetworkImage
   // here is ignored and the web-only `ui.webOnlyInstantiateImageCodecFromUrl` will be used
   // directly in place of the typical `instantiateImageCodec` method.
   Future<ui.Codec> _loadAsync(
-    NetworkImage key,
+    image_provider.NetworkImage key,
     image_provider.DecoderCallback decode,
     StreamController<ImageChunkEvent> chunkEvents,
   ) async {
     assert(key == this);
+    // Ensure that the image load occurs in the next event loop and not in
+    // the frame workload.
+    await Future<void>.delayed(Duration.zero);
 
     final Uri resolved = Uri.base.resolve(key.url);
 

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -415,7 +415,7 @@ mixin SchedulerBinding on BindingBase {
   /// Defaults to [defaultSchedulingStrategy].
   SchedulingStrategy schedulingStrategy = defaultSchedulingStrategy;
 
-  static int _taskSorter (_BaseTask e1, _BaseTask e2) {
+  static int _taskSorter(_BaseTask e1, _BaseTask e2) {
     return -e1.priority.compareTo(e2.priority);
   }
   final PriorityQueue<_BaseTask> _taskQueue = HeapPriorityQueue<_BaseTask>(_taskSorter);
@@ -498,7 +498,15 @@ mixin SchedulerBinding on BindingBase {
     if (_hasRequestedAnEventLoopCallback)
       return;
     _hasRequestedAnEventLoopCallback = true;
-    Timer.run(_runTasks);
+    scheduleTasks(_runTasks);
+  }
+
+  /// Schedules tasks outside of the current event loop.
+  ///
+  /// By default this uses [Timer.run].
+  @protected
+  void scheduleTasks(void Function() callback) {
+    Timer.run(callback);
   }
 
   // Scheduled by _ensureEventLoopCallback.

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -230,6 +230,13 @@ abstract class CachingAssetBundle extends AssetBundle {
 class PlatformAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async {
+    // Ensure that the image load occurs in the next event loop and not in
+    // the frame workload.
+    await Future<void>.delayed(Duration.zero);
+    return _load(key);
+  }
+
+  Future<ByteData> _load(String key) async {
     final Uint8List encoded = utf8.encoder.convert(Uri(path: Uri.encodeFull(key)).path);
     final ByteData? asset =
         await ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData());

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'binding.dart';
 
@@ -230,10 +231,7 @@ abstract class CachingAssetBundle extends AssetBundle {
 class PlatformAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async {
-    // Ensure that the image load occurs in the next event loop and not in
-    // the frame workload.
-    await Future<void>.delayed(Duration.zero);
-    return _load(key);
+    return SchedulerBinding.instance.scheduleAsyncTask(() =>_load(key), Priority.animation);
   }
 
   Future<ByteData> _load(String key) async {

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -40,7 +40,7 @@ void main() {
     scheduler = TestSchedulerBinding();
   });
 
-  test('Tasks are executed in the right order', () {
+  test('Tasks are executed in the right order', () async {
     final TestStrategy strategy = TestStrategy();
     scheduler.schedulingStrategy = strategy.shouldRunTaskWithPriority;
     final List<int> input = <int>[2, 23, 23, 11, 0, 80, 3];
@@ -54,19 +54,19 @@ void main() {
 
     strategy.allowedPriority = 100;
     for (int i = 0; i < 3; i += 1)
-      expect(scheduler.handleEventLoopCallback(), isFalse);
+      expect(await scheduler.handleEventLoopCallback(), isFalse);
     expect(executedTasks.isEmpty, isTrue);
 
     strategy.allowedPriority = 50;
     for (int i = 0; i < 3; i += 1)
-      expect(scheduler.handleEventLoopCallback(), i == 0 ? isTrue : isFalse);
+      expect(await scheduler.handleEventLoopCallback(), i == 0 ? isTrue : isFalse);
     expect(executedTasks, hasLength(1));
     expect(executedTasks.single, equals(80));
     executedTasks.clear();
 
     strategy.allowedPriority = 20;
     for (int i = 0; i < 3; i += 1)
-      expect(scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
+      expect(await scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
     expect(executedTasks, hasLength(2));
     expect(executedTasks[0], equals(23));
     expect(executedTasks[1], equals(23));
@@ -77,7 +77,7 @@ void main() {
     scheduleAddingTask(5);
     scheduleAddingTask(97);
     for (int i = 0; i < 3; i += 1)
-      expect(scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
+      expect(await scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
     expect(executedTasks, hasLength(2));
     expect(executedTasks[0], equals(99));
     expect(executedTasks[1], equals(97));
@@ -85,7 +85,7 @@ void main() {
 
     strategy.allowedPriority = 10;
     for (int i = 0; i < 3; i += 1)
-      expect(scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
+      expect(await scheduler.handleEventLoopCallback(), i < 2 ? isTrue : isFalse);
     expect(executedTasks, hasLength(2));
     expect(executedTasks[0], equals(19));
     expect(executedTasks[1], equals(11));
@@ -93,7 +93,7 @@ void main() {
 
     strategy.allowedPriority = 1;
     for (int i = 0; i < 4; i += 1)
-      expect(scheduler.handleEventLoopCallback(), i < 3 ? isTrue : isFalse);
+      expect(await scheduler.handleEventLoopCallback(), i < 3 ? isTrue : isFalse);
     expect(executedTasks, hasLength(3));
     expect(executedTasks[0], equals(5));
     expect(executedTasks[1], equals(3));
@@ -101,7 +101,7 @@ void main() {
     executedTasks.clear();
 
     strategy.allowedPriority = 0;
-    expect(scheduler.handleEventLoopCallback(), isFalse);
+    expect(await scheduler.handleEventLoopCallback(), isFalse);
     expect(executedTasks, hasLength(1));
     expect(executedTasks[0], equals(0));
   });
@@ -137,7 +137,7 @@ void main() {
 
     // As events are locked, make scheduleTask execute after the test or it
     // will execute during following tests and risk failure.
-    addTearDown(() => scheduler.handleEventLoopCallback());
+    addTearDown(scheduler.handleEventLoopCallback);
   });
 
   test('Flutter.Frame event fired', () async {

--- a/packages/flutter/test/widgets/image_scheduler_test.dart
+++ b/packages/flutter/test/widgets/image_scheduler_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late int originalCacheSize;
+
+  setUp(() async {
+    originalCacheSize = imageCache.maximumSize;
+    imageCache.clear();
+    imageCache.clearLiveImages();
+  });
+
+  tearDown(() {
+    imageCache.maximumSize = originalCacheSize;
+  });
+
+  testWidgets('asset image is loaded through scheduler task', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(Center(
+      child: RepaintBoundary(
+        key: key,
+        child: Container(
+          width: 150.0,
+          height: 50.0,
+          decoration: BoxDecoration(
+            border: Border.all(
+              width: 2.0,
+              color: const Color(0xFF00FF99),
+            ),
+          ),
+          child: Image.asset('missing-asset-x'),
+        ),
+      ),
+    ));
+
+    // Ensure AssetManifest is loaded before attempting to test
+    // individual asset load.
+    expect(tester.takeException(), isNotNull);
+    tester.binding.immediatelyScheduleTasks = false;
+
+    await tester.pumpWidget(Center(
+      child: RepaintBoundary(
+        key: key,
+        child: Container(
+          width: 150.0,
+          height: 50.0,
+          decoration: BoxDecoration(
+            border: Border.all(
+              width: 2.0,
+              color: const Color(0xFF00FF99),
+            ),
+          ),
+          child: Image.asset('missing-asset-y'),
+        ),
+      ),
+    ));
+
+    await tester.pump();
+    await SchedulerBinding.instance.handleEventLoopCallback();
+    await tester.pump();
+
+    expect(tester.takeException(), isNotNull);
+  }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/74935 (broken assets not being reported on web)
+}

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1950,6 +1950,7 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('image_test.missing.1.png'),
     );
+    await tester.pump(const Duration(seconds: 1));
     expect(tester.takeException().toString(), startsWith('Unable to load asset: '));
     await tester.pump();
     await expectLater(

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1950,7 +1950,6 @@ void main() {
       find.byKey(key),
       matchesGoldenFile('image_test.missing.1.png'),
     );
-    await tester.pump(const Duration(seconds: 1));
     expect(tester.takeException().toString(), startsWith('Unable to load asset: '));
     await tester.pump();
     await expectLater(

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1031,7 +1031,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<void> pump([ Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate ]) {
-    return TestAsyncUtils.guard<void>(() async {
+    return TestAsyncUtils.guard<void>(() {
       assert(inTest);
       assert(_clock != null);
       if (duration != null)

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -176,6 +176,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _restorationManager = null;
     resetGestureBinding();
     testTextInput.reset();
+    immediatelyScheduleTasks = true;
     if (registerTestTextInput)
       _testTextInput.register();
   }
@@ -216,6 +217,14 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// application testing, including working with real network responses.
   @protected
   bool get overrideHttpClient => true;
+
+  /// Whether tasks scheduled by [SchedulerBinding.scheduleTask] or
+  /// [SchedulerBinding.scheduleAsyncTask] are automatically run when
+  /// scheduled.
+  ///
+  /// If this value is false, then tasks must be executed by calling
+  /// [SchedulerBinding.handleEventLoopCallback].
+  bool immediatelyScheduleTasks = true;
 
   /// Determines whether the binding automatically registers [testTextInput] as
   /// a fake keyboard implementation.
@@ -1053,7 +1062,8 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   void scheduleTasks(void Function() callback) {
-    callback();
+    if (immediatelyScheduleTasks)
+      callback();
   }
 
   @override

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1031,7 +1031,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
 
   @override
   Future<void> pump([ Duration? duration, EnginePhase newPhase = EnginePhase.sendSemanticsUpdate ]) {
-    return TestAsyncUtils.guard<void>(() {
+    return TestAsyncUtils.guard<void>(() async {
       assert(inTest);
       assert(_clock != null);
       if (duration != null)
@@ -1049,6 +1049,11 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       _currentFakeAsync!.flushMicrotasks();
       return Future<void>.value();
     });
+  }
+
+  @override
+  void scheduleTasks(void Function() callback) {
+    callback();
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/97990

Currently flutter web will begin loading images during an animation frame. This can be surprisingly expensive and contributes to making janky frames even jankier.

Instead force them to run during the next event loop by awaiting a zero duration future. `await null` would move to the next microtask which happens at the end of the frame workload