### PR TITLE
ExpandIcon: allow custom IconData

### DIFF
--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -185,7 +185,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,
-          child: const Icon(widget.iconData ?? Icons.expand_more),
+          child: widget.iconData != null ? Icon(widget.iconData) : const Icon(Icons.expand_more),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -185,7 +185,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,
-          child: widget.iconData ? const Icon(widget.iconData) : const Icon(Icons.expand_more),
+          child: const Icon(widget.iconData ?? Icons.expand_more),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -185,7 +185,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,
-          child: iconData ? const Icon(iconData) : const Icon(Icons.expand_more),
+          child: widget.iconData ? const Icon(widget.iconData) : const Icon(Icons.expand_more),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -185,7 +185,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,
-          child: const Icon(iconData ?? Icons.expand_more),
+          child: iconData ? const Icon(iconData) : const Icon(Icons.expand_more),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -39,6 +39,7 @@ class ExpandIcon extends StatefulWidget {
     this.color,
     this.disabledColor,
     this.expandedColor,
+    this.iconData,
   }) : assert(isExpanded != null),
        assert(size != null),
        assert(padding != null),
@@ -95,6 +96,11 @@ class ExpandIcon extends StatefulWidget {
   /// Material Design specifications for [icons](https://material.io/design/iconography/system-icons.html#color)
   /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color? expandedColor;
+
+  /// An optional [IconData] for the [IconButton].
+  ///
+  /// If not provided the [IconButton] will default to [Icons.expand_more].
+  final IconData? iconData;
 
   @override
   State<ExpandIcon> createState() => _ExpandIconState();
@@ -179,7 +185,7 @@ class _ExpandIconState extends State<ExpandIcon> with SingleTickerProviderStateM
         onPressed: widget.onPressed == null ? null : _handlePressed,
         icon: RotationTransition(
           turns: _iconTurns,
-          child: const Icon(Icons.expand_more),
+          child: const Icon(iconData ?? Icons.expand_more),
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -99,7 +99,7 @@ class ExpandIcon extends StatefulWidget {
 
   /// An optional [IconData] for the [IconButton].
   ///
-  /// If not provided the [IconButton] will default to [Icons.expand_more].
+  /// If not provided, the [IconButton] will default to [Icons.expand_more].
   final IconData? iconData;
 
   @override

--- a/packages/flutter/lib/src/material/expand_icon.dart
+++ b/packages/flutter/lib/src/material/expand_icon.dart
@@ -97,9 +97,9 @@ class ExpandIcon extends StatefulWidget {
   /// and for [dark theme](https://material.io/design/color/dark-theme.html#ui-application)
   final Color? expandedColor;
 
-  /// An optional [IconData] for the [IconButton].
+  /// The icon used by the button.
   ///
-  /// If not provided, the [IconButton] will default to [Icons.expand_more].
+  /// If null, [Icons.expand_more] will be used.
   final IconData? iconData;
 
   @override

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -316,10 +316,11 @@ void main() {
   testWidgets('Expand Icon test', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
-          body: ExpandIcon(
-        onPressed: (v) {},
-        iconData: Icons.hearing,
-      )),
+        body: ExpandIcon(
+          onPressed: (v) {},
+          iconData: Icons.hearing,
+        ),
+      ),
     ));
 
     expect(find.byType(IconButton), findsOneWidget);

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -327,9 +327,10 @@ void main() {
     expect(find.byType(ExpandIcon), findsOneWidget);
 
     expect(
-        find.ancestor(
-            of: find.byIcon(Icons.hearing),
-            matching: find.byWidgetPredicate((widget) => widget is IconButton)),
-        findsOneWidget);
+      find.ancestor(
+        of: find.byIcon(Icons.hearing),
+        matching: find.byWidgetPredicate((widget) => widget is IconButton),
+      ),
+      findsOneWidget);
   });
 }

--- a/packages/flutter/test/material/expand_icon_test.dart
+++ b/packages/flutter/test/material/expand_icon_test.dart
@@ -312,4 +312,23 @@ void main() {
     iconTheme = tester.firstWidget(find.byType(IconTheme).last);
     expect(iconTheme.data.color, equals(Colors.cyan));
   });
+
+  testWidgets('Expand Icon test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+          body: ExpandIcon(
+        onPressed: (v) {},
+        iconData: Icons.hearing,
+      )),
+    ));
+
+    expect(find.byType(IconButton), findsOneWidget);
+    expect(find.byType(ExpandIcon), findsOneWidget);
+
+    expect(
+        find.ancestor(
+            of: find.byIcon(Icons.hearing),
+            matching: find.byWidgetPredicate((widget) => widget is IconButton)),
+        findsOneWidget);
+  });
 }


### PR DESCRIPTION
This adds an optional `IconData?` field to `ExpandIcon`.
The `IconButton` of `ExpandIcon` defaults to `Icons.expand_more` if the `iconData` is null.

There are no visual differences if not wanted so I hope it is okay to skip before/after screenshots.
Here is a small gif of a custom icon in action:
![ya](https://user-images.githubusercontent.com/15329494/152976775-969ffb37-9970-42fa-b0ea-92df5e6a2e95.gif)


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

Closes #98021