### PR TITLE
Fix NavigationRail Indicator alignment for `NavigationRailLabelType.none`

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -579,12 +579,14 @@ class _RailDestination extends StatelessWidget {
         final Widget iconPart = SizedBox(
           width: minWidth,
           height: minWidth,
-          child: _AddIndicator(
-            addIndicator: useIndicator,
-            indicatorColor: indicatorColor,
-            isCircular: true,
-            indicatorAnimation: destinationAnimation,
-            child: themedIcon,
+          child: Align(
+            child: _AddIndicator(
+              addIndicator: useIndicator,
+              indicatorColor: indicatorColor,
+              isCircular: true,
+              indicatorAnimation: destinationAnimation,
+              child: themedIcon,
+            ),
           ),
         );
         if (extendedTransitionAnimation.value == 0) {

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -579,7 +579,7 @@ class _RailDestination extends StatelessWidget {
         final Widget iconPart = SizedBox(
           width: minWidth,
           height: minWidth,
-          child: Align(
+          child: Center(
             child: _AddIndicator(
               addIndicator: useIndicator,
               indicatorColor: indicatorColor,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2350,7 +2350,7 @@ void main() {
     expect(indicator.height, 32);
   });
 
-  testWidgets('NavigationRailDestination - [labelType]=none (default) has center aligned indicator', (WidgetTester tester) async {
+  testWidgets('NavigationRailDestination - [labelType]=none has center aligned indicator', (WidgetTester tester) async {
       // This is a regression test for
       // https://github.com/flutter/flutter/issues/97753
     await _pumpNavigationRail(

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2350,7 +2350,7 @@ void main() {
     expect(indicator.height, 32);
   });
 
-  testWidgets('NavigationRailDestination - [labelType]=none has center aligned indicator', (WidgetTester tester) async {
+  testWidgets('NavigationRailDestination has center aligned indicator - [labelType]=none', (WidgetTester tester) async {
       // This is a regression test for
       // https://github.com/flutter/flutter/issues/97753
     await _pumpNavigationRail(

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2349,6 +2349,50 @@ void main() {
     expect(indicator.width, 56);
     expect(indicator.height, 32);
   });
+
+  testWidgets('NavigationRailDestination - [labelType]=none (default) has center aligned indicator', (WidgetTester tester) async {
+      // This is a regression test for
+      // https://github.com/flutter/flutter/issues/97753
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        labelType: NavigationRailLabelType.none,
+        selectedIndex: 0,
+        destinations:  <NavigationRailDestination>[
+          NavigationRailDestination(
+            icon: Stack(
+              children: const <Widget>[
+                Icon(Icons.umbrella),
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: Text(
+                    'Text',
+                    style: TextStyle(fontSize: 10, color: Colors.red),
+                  ),
+                ),
+              ],
+            ),
+            label: const Text('Abc'),
+          ),
+          const NavigationRailDestination(
+            icon: Icon(Icons.umbrella),
+            label: Text('Def'),
+          ),
+          const NavigationRailDestination(
+            icon: Icon(Icons.bookmark_border),
+            label: Text('Ghi'),
+          ),
+        ],
+      ),
+    );
+    // Indicator with Stack widget
+    final RenderBox firstIndicator = tester.renderObject(find.byType(Icon).first);
+    expect(firstIndicator.localToGlobal(Offset.zero).dx, 24.0);
+    // Indicator without Stack widget
+    final RenderBox lastIndicator = tester.renderObject(find.byType(Icon).last);
+    expect(lastIndicator.localToGlobal(Offset.zero).dx, 24.0);
+  });
 }
 
 TestSemantics _expectedSemantics() {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2351,8 +2351,8 @@ void main() {
   });
 
   testWidgets('NavigationRailDestination has center aligned indicator - [labelType]=none', (WidgetTester tester) async {
-      // This is a regression test for
-      // https://github.com/flutter/flutter/issues/97753
+    // This is a regression test for
+    // https://github.com/flutter/flutter/issues/97753
     await _pumpNavigationRail(
       tester,
       navigationRail: NavigationRail(


### PR DESCRIPTION
Details: https://github.com/flutter/flutter/issues/97753#issuecomment-1032552272

fixes https://github.com/flutter/flutter/issues/97753

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
