### PR TITLE
Add `keyLog` and `connectionFactory` to HttpClient implementations

### DIFF
--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -115,7 +115,6 @@ class _MockHttpClient implements HttpClient {
   void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) { }
 
   @override
-  // ignore: override_on_non_overriding_member
   Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)?
       connectionFactory;
 
@@ -129,7 +128,6 @@ class _MockHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
-  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -115,8 +115,8 @@ class _MockHttpClient implements HttpClient {
   void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) { }
 
   @override
-  Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)?
-      connectionFactory;
+  // ignore: override_on_non_overriding_member
+  Future<ConnectionTask<Socket>> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;
@@ -128,6 +128,7 @@ class _MockHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
+  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -115,6 +115,11 @@ class _MockHttpClient implements HttpClient {
   void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) { }
 
   @override
+  // ignore: override_on_non_overriding_member
+  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)?
+      connectionFactory;
+
+  @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;
 
   @override
@@ -122,6 +127,10 @@ class _MockHttpClient implements HttpClient {
 
   @override
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
+
+  @override
+  // ignore: override_on_non_overriding_member
+  Function(String line)? keyLog;
 
   @override
   void close({ bool force = false }) { }

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -116,7 +116,7 @@ class _MockHttpClient implements HttpClient {
 
   @override
   // ignore: override_on_non_overriding_member
-  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)?
+  Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)?
       connectionFactory;
 
   @override

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -161,7 +161,6 @@ class FakeHttpClient implements HttpClient {
   }
 
   @override
-  // ignore: override_on_non_overriding_member
   Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
@@ -352,7 +351,6 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 
   @override
-  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -162,7 +162,7 @@ class FakeHttpClient implements HttpClient {
 
   @override
   // ignore: override_on_non_overriding_member
-  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)? connectionFactory;
+  Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -161,7 +161,8 @@ class FakeHttpClient implements HttpClient {
   }
 
   @override
-  Future<ConnectionTask> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
+  // ignore: override_on_non_overriding_member
+  Future<ConnectionTask<Socket>> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;
@@ -173,6 +174,7 @@ class FakeHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
+  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override
@@ -521,8 +523,4 @@ class _FakeHttpHeaders extends HttpHeaders {
   String? value(String name) {
     return _backingData[name]?.join('; ');
   }
-}
-
-void main() {
-  FakeHttpClient.any();
 }

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -173,6 +173,9 @@ class FakeHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
+  Function(String line)? keyLog;
+
+  @override
   void close({bool force = false}) { }
 
   @override
@@ -351,9 +354,6 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 
   @override
-  Function(String line)? keyLog;
-
-  @override
   Future<HttpClientResponse> close() async {
     final Completer<void> completer = Completer<void>();
     Timer.run(() {
@@ -521,4 +521,8 @@ class _FakeHttpHeaders extends HttpHeaders {
   String? value(String name) {
     return _backingData[name]?.join('; ');
   }
+}
+
+void main() {
+  FakeHttpClient.any();
 }

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -60,8 +60,7 @@ String _toMethodString(HttpMethod method) {
 ///
 /// This should only be used when the http client cannot be set directly, such as
 /// when testing `package:http` code.
-Future<void> overrideHttpClients(
-    Future<void> Function() callback, FakeHttpClient httpClient) async {
+Future<void> overrideHttpClients(Future<void> Function() callback,  FakeHttpClient httpClient) async {
   final HttpOverrides overrides = _FakeHttpClientOverrides(httpClient);
   await HttpOverrides.runWithHttpOverrides(callback, overrides);
 }
@@ -84,8 +83,7 @@ class _FakeHttpClientOverrides extends HttpOverrides {
 /// empty response. If [responseError] is non-null, will throw this instead
 /// of returning the response when closing the request.
 class FakeRequest {
-  const FakeRequest(
-    this.uri, {
+  const FakeRequest(this.uri, {
     this.method = HttpMethod.get,
     this.response = FakeResponse.empty,
     this.responseError,
@@ -129,12 +127,10 @@ class FakeHttpClient implements HttpClient {
   /// This does not enforce any order on the requests, but if multiple
   /// requests match then the first will be selected;
   FakeHttpClient.list(List<FakeRequest> requests)
-      : _requests = requests.toList();
+    : _requests = requests.toList();
 
   /// Creates an HTTP client that always returns an empty 200 request.
-  FakeHttpClient.any()
-      : _any = true,
-        _requests = <FakeRequest>[];
+  FakeHttpClient.any() : _any = true, _requests = <FakeRequest>[];
 
   bool _any = false;
   final List<FakeRequest> _requests;
@@ -155,39 +151,30 @@ class FakeHttpClient implements HttpClient {
   String? userAgent;
 
   @override
-  void addCredentials(
-      Uri url, String realm, HttpClientCredentials credentials) {
+  void addCredentials(Uri url, String realm, HttpClientCredentials credentials) {
     throw UnimplementedError();
   }
 
   @override
-  void addProxyCredentials(
-      String host, int port, String realm, HttpClientCredentials credentials) {
+  void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) {
     throw UnimplementedError();
   }
 
   @override
   // ignore: override_on_non_overriding_member
-  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)?
-      connectionFactory;
+  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)? connectionFactory;
 
   @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;
 
   @override
-  Future<bool> Function(String host, int port, String scheme, String realm)?
-      authenticateProxy;
+  Future<bool> Function(String host, int port, String scheme, String realm)? authenticateProxy;
 
   @override
-  bool Function(X509Certificate cert, String host, int port)?
-      badCertificateCallback;
+  bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
-  // ignore: override_on_non_overriding_member
-  Function(String line)? keyLog;
-
-  @override
-  void close({bool force = false}) {}
+  void close({bool force = false}) { }
 
   @override
   Future<HttpClientRequest> delete(String host, int port, String path) {
@@ -226,8 +213,7 @@ class FakeHttpClient implements HttpClient {
   }
 
   @override
-  Future<HttpClientRequest> open(
-      String method, String host, int port, String path) {
+  Future<HttpClientRequest> open(String method, String host, int port, String path) {
     final Uri uri = Uri(host: host, port: port, path: path);
     return openUrl(method, uri);
   }
@@ -272,8 +258,7 @@ class FakeHttpClient implements HttpClient {
 
   int _requestCount = 0;
 
-  _FakeHttpClientRequest _findRequest(
-      HttpMethod method, Uri uri, StackTrace stackTrace) {
+  _FakeHttpClientRequest _findRequest(HttpMethod method, Uri uri, StackTrace stackTrace) {
     // Ensure the fake client throws similar errors to the real client.
     if (uri.host.isEmpty) {
       throw ArgumentError('No host specified in URI $uri');
@@ -293,16 +278,16 @@ class FakeHttpClient implements HttpClient {
     }
     FakeRequest? matchedRequest;
     for (final FakeRequest request in _requests) {
-      if (request.method == method &&
-          request.uri.toString() == uri.toString()) {
+      if (request.method == method && request.uri.toString() == uri.toString()) {
         matchedRequest = request;
         break;
       }
     }
     if (matchedRequest == null) {
       throw StateError(
-          'Unexpected request for $method to $uri after $_requestCount requests.\n'
-          'Pending requests: ${_requests.join(',')}');
+        'Unexpected request for $method to $uri after $_requestCount requests.\n'
+        'Pending requests: ${_requests.join(',')}'
+      );
     }
     _requestCount += 1;
     _requests.remove(matchedRequest);
@@ -318,8 +303,7 @@ class FakeHttpClient implements HttpClient {
 }
 
 class _FakeHttpClientRequest implements HttpClientRequest {
-  _FakeHttpClientRequest(this._response, this._uri, this._method,
-      this._responseError, this._expectedBody, this._stackTrace);
+  _FakeHttpClientRequest(this._response, this._uri, this._method, this._responseError, this._expectedBody, this._stackTrace);
 
   final FakeResponse _response;
   final String _method;
@@ -358,7 +342,7 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 
   @override
-  void addError(Object error, [StackTrace? stackTrace]) {}
+  void addError(Object error, [StackTrace? stackTrace]) { }
 
   @override
   Future<void> addStream(Stream<List<int>> stream) async {
@@ -368,15 +352,17 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 
   @override
+  // ignore: override_on_non_overriding_member
+  Function(String line)? keyLog;
+
+  @override
   Future<HttpClientResponse> close() async {
     final Completer<void> completer = Completer<void>();
     Timer.run(() {
-      if (_expectedBody != null &&
-          !const ListEquality<int>().equals(_expectedBody, _body)) {
-        completer.completeError(
-            StateError(
-                'Expected a request with the following body:\n$_expectedBody\n but found:\n$_body'),
-            _stackTrace);
+      if (_expectedBody != null && !const ListEquality<int>().equals(_expectedBody, _body)) {
+        completer.completeError(StateError(
+          'Expected a request with the following body:\n$_expectedBody\n but found:\n$_body'
+        ), _stackTrace);
       } else {
         completer.complete();
       }
@@ -398,7 +384,7 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   Future<HttpClientResponse> get done => throw UnimplementedError();
 
   @override
-  Future<void> flush() async {}
+  Future<void> flush() async { }
 
   @override
   final HttpHeaders headers = _FakeHttpHeaders(<String, List<String>>{});
@@ -430,11 +416,9 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 }
 
-class _FakeHttpClientResponse extends Stream<List<int>>
-    implements HttpClientResponse {
+class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientResponse {
   _FakeHttpClientResponse(this._response)
-      : headers =
-            _FakeHttpHeaders(Map<String, List<String>>.from(_response.headers));
+      : headers = _FakeHttpHeaders(Map<String, List<String>>.from(_response.headers));
 
   final FakeResponse _response;
 
@@ -442,8 +426,7 @@ class _FakeHttpClientResponse extends Stream<List<int>>
   X509Certificate get certificate => throw UnimplementedError();
 
   @override
-  HttpClientResponseCompressionState get compressionState =>
-      throw UnimplementedError();
+  HttpClientResponseCompressionState get compressionState => throw UnimplementedError();
 
   @override
   HttpConnectionInfo get connectionInfo => throw UnimplementedError();
@@ -472,12 +455,10 @@ class _FakeHttpClientResponse extends Stream<List<int>>
     void Function()? onDone,
     bool? cancelOnError,
   }) {
-    final Stream<List<int>> response =
-        Stream<List<int>>.fromIterable(<List<int>>[
+    final Stream<List<int>> response = Stream<List<int>>.fromIterable(<List<int>>[
       _response.body,
     ]);
-    return response.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return response.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @override
@@ -487,8 +468,7 @@ class _FakeHttpClientResponse extends Stream<List<int>>
   String get reasonPhrase => 'OK';
 
   @override
-  Future<HttpClientResponse> redirect(
-      [String? method, Uri? url, bool? followLoops]) {
+  Future<HttpClientResponse> redirect([String? method, Uri? url, bool? followLoops]) {
     throw UnimplementedError();
   }
 
@@ -519,10 +499,10 @@ class _FakeHttpHeaders extends HttpHeaders {
   }
 
   @override
-  void forEach(void Function(String name, List<String> values) action) {}
+  void forEach(void Function(String name, List<String> values) action) { }
 
   @override
-  void noFolding(String name) {}
+  void noFolding(String name) {  }
 
   @override
   void remove(String name, Object value) {

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -60,7 +60,8 @@ String _toMethodString(HttpMethod method) {
 ///
 /// This should only be used when the http client cannot be set directly, such as
 /// when testing `package:http` code.
-Future<void> overrideHttpClients(Future<void> Function() callback,  FakeHttpClient httpClient) async {
+Future<void> overrideHttpClients(
+    Future<void> Function() callback, FakeHttpClient httpClient) async {
   final HttpOverrides overrides = _FakeHttpClientOverrides(httpClient);
   await HttpOverrides.runWithHttpOverrides(callback, overrides);
 }
@@ -83,7 +84,8 @@ class _FakeHttpClientOverrides extends HttpOverrides {
 /// empty response. If [responseError] is non-null, will throw this instead
 /// of returning the response when closing the request.
 class FakeRequest {
-  const FakeRequest(this.uri, {
+  const FakeRequest(
+    this.uri, {
     this.method = HttpMethod.get,
     this.response = FakeResponse.empty,
     this.responseError,
@@ -127,10 +129,12 @@ class FakeHttpClient implements HttpClient {
   /// This does not enforce any order on the requests, but if multiple
   /// requests match then the first will be selected;
   FakeHttpClient.list(List<FakeRequest> requests)
-    : _requests = requests.toList();
+      : _requests = requests.toList();
 
   /// Creates an HTTP client that always returns an empty 200 request.
-  FakeHttpClient.any() : _any = true, _requests = <FakeRequest>[];
+  FakeHttpClient.any()
+      : _any = true,
+        _requests = <FakeRequest>[];
 
   bool _any = false;
   final List<FakeRequest> _requests;
@@ -151,26 +155,39 @@ class FakeHttpClient implements HttpClient {
   String? userAgent;
 
   @override
-  void addCredentials(Uri url, String realm, HttpClientCredentials credentials) {
+  void addCredentials(
+      Uri url, String realm, HttpClientCredentials credentials) {
     throw UnimplementedError();
   }
 
   @override
-  void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) {
+  void addProxyCredentials(
+      String host, int port, String realm, HttpClientCredentials credentials) {
     throw UnimplementedError();
   }
+
+  @override
+  // ignore: override_on_non_overriding_member
+  Future<ConnectionTask> Function(Uri url, String proxyHost, int proxyPort)?
+      connectionFactory;
 
   @override
   Future<bool> Function(Uri url, String scheme, String realm)? authenticate;
 
   @override
-  Future<bool> Function(String host, int port, String scheme, String realm)? authenticateProxy;
+  Future<bool> Function(String host, int port, String scheme, String realm)?
+      authenticateProxy;
 
   @override
-  bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
+  bool Function(X509Certificate cert, String host, int port)?
+      badCertificateCallback;
 
   @override
-  void close({bool force = false}) { }
+  // ignore: override_on_non_overriding_member
+  Function(String line)? keyLog;
+
+  @override
+  void close({bool force = false}) {}
 
   @override
   Future<HttpClientRequest> delete(String host, int port, String path) {
@@ -209,7 +226,8 @@ class FakeHttpClient implements HttpClient {
   }
 
   @override
-  Future<HttpClientRequest> open(String method, String host, int port, String path) {
+  Future<HttpClientRequest> open(
+      String method, String host, int port, String path) {
     final Uri uri = Uri(host: host, port: port, path: path);
     return openUrl(method, uri);
   }
@@ -254,7 +272,8 @@ class FakeHttpClient implements HttpClient {
 
   int _requestCount = 0;
 
-  _FakeHttpClientRequest _findRequest(HttpMethod method, Uri uri, StackTrace stackTrace) {
+  _FakeHttpClientRequest _findRequest(
+      HttpMethod method, Uri uri, StackTrace stackTrace) {
     // Ensure the fake client throws similar errors to the real client.
     if (uri.host.isEmpty) {
       throw ArgumentError('No host specified in URI $uri');
@@ -274,16 +293,16 @@ class FakeHttpClient implements HttpClient {
     }
     FakeRequest? matchedRequest;
     for (final FakeRequest request in _requests) {
-      if (request.method == method && request.uri.toString() == uri.toString()) {
+      if (request.method == method &&
+          request.uri.toString() == uri.toString()) {
         matchedRequest = request;
         break;
       }
     }
     if (matchedRequest == null) {
       throw StateError(
-        'Unexpected request for $method to $uri after $_requestCount requests.\n'
-        'Pending requests: ${_requests.join(',')}'
-      );
+          'Unexpected request for $method to $uri after $_requestCount requests.\n'
+          'Pending requests: ${_requests.join(',')}');
     }
     _requestCount += 1;
     _requests.remove(matchedRequest);
@@ -299,7 +318,8 @@ class FakeHttpClient implements HttpClient {
 }
 
 class _FakeHttpClientRequest implements HttpClientRequest {
-  _FakeHttpClientRequest(this._response, this._uri, this._method, this._responseError, this._expectedBody, this._stackTrace);
+  _FakeHttpClientRequest(this._response, this._uri, this._method,
+      this._responseError, this._expectedBody, this._stackTrace);
 
   final FakeResponse _response;
   final String _method;
@@ -338,7 +358,7 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 
   @override
-  void addError(Object error, [StackTrace? stackTrace]) { }
+  void addError(Object error, [StackTrace? stackTrace]) {}
 
   @override
   Future<void> addStream(Stream<List<int>> stream) async {
@@ -351,10 +371,12 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   Future<HttpClientResponse> close() async {
     final Completer<void> completer = Completer<void>();
     Timer.run(() {
-      if (_expectedBody != null && !const ListEquality<int>().equals(_expectedBody, _body)) {
-        completer.completeError(StateError(
-          'Expected a request with the following body:\n$_expectedBody\n but found:\n$_body'
-        ), _stackTrace);
+      if (_expectedBody != null &&
+          !const ListEquality<int>().equals(_expectedBody, _body)) {
+        completer.completeError(
+            StateError(
+                'Expected a request with the following body:\n$_expectedBody\n but found:\n$_body'),
+            _stackTrace);
       } else {
         completer.complete();
       }
@@ -376,7 +398,7 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   Future<HttpClientResponse> get done => throw UnimplementedError();
 
   @override
-  Future<void> flush() async { }
+  Future<void> flush() async {}
 
   @override
   final HttpHeaders headers = _FakeHttpHeaders(<String, List<String>>{});
@@ -408,9 +430,11 @@ class _FakeHttpClientRequest implements HttpClientRequest {
   }
 }
 
-class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientResponse {
+class _FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
   _FakeHttpClientResponse(this._response)
-      : headers = _FakeHttpHeaders(Map<String, List<String>>.from(_response.headers));
+      : headers =
+            _FakeHttpHeaders(Map<String, List<String>>.from(_response.headers));
 
   final FakeResponse _response;
 
@@ -418,7 +442,8 @@ class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientRes
   X509Certificate get certificate => throw UnimplementedError();
 
   @override
-  HttpClientResponseCompressionState get compressionState => throw UnimplementedError();
+  HttpClientResponseCompressionState get compressionState =>
+      throw UnimplementedError();
 
   @override
   HttpConnectionInfo get connectionInfo => throw UnimplementedError();
@@ -447,10 +472,12 @@ class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientRes
     void Function()? onDone,
     bool? cancelOnError,
   }) {
-    final Stream<List<int>> response = Stream<List<int>>.fromIterable(<List<int>>[
+    final Stream<List<int>> response =
+        Stream<List<int>>.fromIterable(<List<int>>[
       _response.body,
     ]);
-    return response.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    return response.listen(onData,
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @override
@@ -460,7 +487,8 @@ class _FakeHttpClientResponse extends Stream<List<int>> implements HttpClientRes
   String get reasonPhrase => 'OK';
 
   @override
-  Future<HttpClientResponse> redirect([String? method, Uri? url, bool? followLoops]) {
+  Future<HttpClientResponse> redirect(
+      [String? method, Uri? url, bool? followLoops]) {
     throw UnimplementedError();
   }
 
@@ -491,10 +519,10 @@ class _FakeHttpHeaders extends HttpHeaders {
   }
 
   @override
-  void forEach(void Function(String name, List<String> values) action) { }
+  void forEach(void Function(String name, List<String> values) action) {}
 
   @override
-  void noFolding(String name) {  }
+  void noFolding(String name) {}
 
   @override
   void remove(String name, Object value) {


### PR DESCRIPTION
Add two setters that will be added in Dart 2.7:
  https://github.com/dart-lang/sdk/issues/48093
  https://github.com/dart-lang/sdk/issues/47887

One this PR is merged, my plan is to fill another issue (assigned to myself) to remove the `// ignore: override_on_non_overriding_member` comments when the engine has been updated to Dart 2.17.