### PR TITLE
[flutter_tools] Make variants of Pub have consistent method signatures

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -96,7 +96,7 @@ abstract class Pub {
   /// Defaults to true.
   Future<void> get({
     required PubContext context,
-    String directory,
+    String? directory,
     bool skipIfAbsent = false,
     bool upgrade = false,
     bool offline = false,
@@ -122,11 +122,11 @@ abstract class Pub {
   Future<void> batch(
     List<String> arguments, {
     required PubContext context,
-    String directory,
-    MessageFilter filter,
+    String? directory,
+    MessageFilter? filter,
     String failureMessage = 'pub failed',
     required bool retry,
-    bool showTraceForErrors,
+    bool? showTraceForErrors,
   });
 
   /// Runs pub in 'interactive' mode.


### PR DESCRIPTION
The abstract class `Pub` and its implementations (`_DefaultPub`, `ThrowingPub`, and etc.) have slightly different method signatures. For example, `_DefaultPub.batch` allows null directory paths while `Pub.batch` doesn't (this is grammatically correct because `Pub` is an abstract class):

https://github.com/flutter/flutter/blob/c54a27dc8790a6d454ec710c16b42101cd2ecf22/packages/flutter_tools/lib/src/dart/pub.dart#L122-L130

https://github.com/flutter/flutter/blob/c54a27dc8790a6d454ec710c16b42101cd2ecf22/packages/flutter_tools/lib/src/dart/pub.dart#L300-L309

This discrepancy has been caused by manual null safety migration in https://github.com/flutter/flutter/pull/80548 and seems to be a simple human error.

This change doesn't fix any existing error, and also doesn't change the tool's behavior, so there should be no need for tests.

cc @jmagman