### PR TITLE
Support Samsung phone when getting device `wakefulness` status

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -505,7 +505,13 @@ class AndroidDevice extends Device {
   /// See: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/os/PowerManagerInternal.java
   Future<String> _getWakefulness() async {
     final String powerInfo = await shellEval('dumpsys', <String>['power']);
-    final String wakefulness = grep('mWakefulness=', from: powerInfo).single.split('=')[1].trim();
+    // A motoG4 phone returns `mWakefulness=Awake`.
+    List<String> wakefulnessList = grep('mWakefulness=', from: powerInfo).toList();
+    // A Samsung phone returns `getWakefullnessLocked()=Awake`.
+    if (wakefulnessList.isEmpty) {
+      wakefulnessList = grep('getWakefullnessLocked()=', from: powerInfo).toList();
+    }
+    final String wakefulness = wakefulnessList.single.split('=')[1].trim();
     return wakefulness;
   }
 

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -506,12 +506,9 @@ class AndroidDevice extends Device {
   Future<String> _getWakefulness() async {
     final String powerInfo = await shellEval('dumpsys', <String>['power']);
     // A motoG4 phone returns `mWakefulness=Awake`.
-    List<String> wakefulnessList = grep('mWakefulness=', from: powerInfo).toList();
     // A Samsung phone returns `getWakefullnessLocked()=Awake`.
-    if (wakefulnessList.isEmpty) {
-      wakefulnessList = grep('getWakefullnessLocked()=', from: powerInfo).toList();
-    }
-    final String wakefulness = wakefulnessList.single.split('=')[1].trim();
+    final RegExp wakefulnessRegexp = RegExp(r'.*(mWakefulness=|getWakefulnessLocked\(\)=).*');
+    final String wakefulness = grep(wakefulnessRegexp, from: powerInfo).single.split('=')[1].trim();
     return wakefulness;
   }
 

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -40,6 +40,12 @@ void main() {
         expect(await device.isAsleep(), isFalse);
       });
 
+      test('reads Awake - samsung devices', () async {
+        FakeDevice.pretendAwakeSamsung();
+        expect(await device.isAwake(), isTrue);
+        expect(await device.isAsleep(), isFalse);
+      });
+
       test('reads Asleep', () async {
         FakeDevice.pretendAsleep();
         expect(await device.isAwake(), isFalse);
@@ -187,6 +193,12 @@ class FakeDevice extends AndroidDevice {
   static void pretendAwake() {
     output = '''
       mWakefulness=Awake
+    ''';
+  }
+
+  static void pretendAwakeSamsung() {
+    output = '''
+      getWakefullnessLocked()=Awake
     ''';
   }
 

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -198,7 +198,7 @@ class FakeDevice extends AndroidDevice {
 
   static void pretendAwakeSamsung() {
     output = '''
-      getWakefullnessLocked()=Awake
+      getWakefulnessLocked()=Awake
     ''';
   }
 


### PR DESCRIPTION
Current device assumes single pattern on all devices, and uses `mWakefulness=Awake` to get the wakefulness status. This fails when it's a Samsung phone, which returns `getWakefullnessLocked()=Awake`.

This PR adds support for Samsung phones.

Fixes: https://github.com/flutter/flutter/issues/97235