### PR TITLE
Refactor TextSelectionOverlay

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1089,7 +1089,7 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   final SelectionChangedCallback? onSelectionChanged;
 
-  /// {@macro flutter.widgets.TextSelectionOverlay.onSelectionHandleTapped}
+  /// {@macro flutter.widgets.SelectionOverlay.onSelectionHandleTapped}
   final VoidCallback? onSelectionHandleTapped;
 
   /// {@template flutter.widgets.editableText.inputFormatters}

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1641,7 +1641,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// Copy current selection to [Clipboard].
   @override
   void copySelection(SelectionChangedCause cause) {
-    print('copy selection');
     final TextSelection selection = textEditingValue.selection;
     assert(selection != null);
     if (selection.isCollapsed || widget.obscureText) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1641,6 +1641,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// Copy current selection to [Clipboard].
   @override
   void copySelection(SelectionChangedCause cause) {
+    print('copy selection');
     final TextSelection selection = textEditingValue.selection;
     assert(selection != null);
     if (selection.isCollapsed || widget.obscureText) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -925,8 +925,8 @@ class SelectionOverlay {
   Widget _buildEndHandle(BuildContext context) {
     final Widget handle;
     final TextSelectionControls? selectionControls = this.selectionControls;
-    if (selectionControls == null)
-      handle = Container(); // hide the second handle when collapsed
+    if (selectionControls == null || _startHandleType == TextSelectionHandleType.collapsed)
+      handle = Container(); // hide the second handle when collapsed.
     else {
       handle = _SelectionHandleOverlay(
         type: _endHandleType,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -416,8 +416,6 @@ class TextSelectionOverlay {
     renderObject.selectionStartInViewport.removeListener(_updateHandleVisibilities);
     renderObject.selectionEndInViewport.removeListener(_updateHandleVisibilities);
     _selectionOverlay.dispose();
-    _effectiveStartHandleVisibility.dispose();
-    _effectiveEndHandleVisibility.dispose();
   }
 
   double _getStartGlyphHeight() {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -416,7 +416,7 @@ class TextSelectionOverlay {
   void hide() => _selectionOverlay.hide();
 
   /// {@macro flutter.widgets.SelectionOverlay.hideToolbar}
-  void hideToolbar() => _selectionOverlay.hideHandles();
+  void hideToolbar() => _selectionOverlay.hideToolbar();
 
   /// {@macro flutter.widgets.SelectionOverlay.dispose}
   void dispose() {
@@ -561,13 +561,13 @@ class SelectionOverlay {
     this.debugRequiredFor,
     required TextSelectionHandleType startHandleType,
     required double lineHeightAtStart,
-    ValueListenable<bool>? startHandlesVisible,
+    this.startHandlesVisible,
     this.onStartHandleDragStart,
     this.onStartHandleDragUpdate,
     this.onStartHandleDragEnd,
     required TextSelectionHandleType endHandleType,
     required double lineHeightAtEnd,
-    ValueListenable<bool>? endHandlesVisible,
+    this.endHandlesVisible,
     this.onEndHandleDragStart,
     this.onEndHandleDragUpdate,
     this.onEndHandleDragEnd,
@@ -583,10 +583,8 @@ class SelectionOverlay {
     Offset? toolbarLocation,
   }) : _startHandleType = startHandleType,
        _lineHeightAtStart = lineHeightAtStart,
-       _startHandlesVisible = startHandlesVisible,
        _endHandleType = endHandleType,
        _lineHeightAtEnd = lineHeightAtEnd,
-       _endHandlesVisible = endHandlesVisible,
        _selectionEndPoints = selectionEndPoints,
        _toolbarLocation = toolbarLocation {
     final OverlayState? overlay = Overlay.of(context, rootOverlay: true);
@@ -597,12 +595,6 @@ class SelectionOverlay {
       'app content was created above the Navigator with the WidgetsApp builder parameter.',
     );
     _toolbarController = AnimationController(duration: fadeDuration, vsync: overlay!);
-    if (_startHandlesVisible == null) {
-      _defaultStartHandlesVisible = ValueNotifier<bool>(false);
-    }
-    if (_endHandlesVisible == null) {
-      _defaultEndHandlesVisible = ValueNotifier<bool>(false);
-    }
   }
 
   /// The context in which the selection handles should appear.
@@ -641,9 +633,9 @@ class SelectionOverlay {
   ///
   /// If the value changes, the start handle uses [FadeTransition] to transition
   /// itself on and off the screen.
-  ValueListenable<bool> get startHandlesVisible => _startHandlesVisible ?? _defaultStartHandlesVisible;
-  final ValueListenable<bool>? _startHandlesVisible;
-  late final ValueNotifier<bool> _defaultStartHandlesVisible;
+  ///
+  /// If this is null, the start selection handle will always be visible.
+  final ValueListenable<bool>? startHandlesVisible;
 
   /// Called when the users start dragging the start selection handles.
   final ValueChanged<DragStartDetails>? onStartHandleDragStart;
@@ -685,9 +677,9 @@ class SelectionOverlay {
   ///
   /// If the value changes, the end handle uses [FadeTransition] to transition
   /// itself on and off the screen.
-  ValueListenable<bool> get endHandlesVisible => _endHandlesVisible ?? _defaultEndHandlesVisible;
-  final ValueListenable<bool>? _endHandlesVisible;
-  late final ValueNotifier<bool> _defaultEndHandlesVisible;
+  ///
+  /// If this is null, the end selection handle will always be visible.
+  final ValueListenable<bool>? endHandlesVisible;
 
   /// Called when the users start dragging the end selection handles.
   final ValueChanged<DragStartDetails>? onEndHandleDragStart;
@@ -904,12 +896,6 @@ class SelectionOverlay {
   void dispose() {
     hide();
     _toolbarController.dispose();
-    if (_startHandlesVisible == null) {
-      _defaultStartHandlesVisible.dispose();
-    }
-    if (_endHandlesVisible == null) {
-      _defaultEndHandlesVisible.dispose();
-    }
   }
 
   Widget _buildStartHandle(BuildContext context) {
@@ -1027,7 +1013,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
     this.onSelectionHandleDragUpdate,
     this.onSelectionHandleDragEnd,
     required this.selectionControls,
-    required this.visibility,
+    this.visibility,
     required this.preferredLineHeight,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : super(key: key);
@@ -1038,7 +1024,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
   final ValueChanged<DragUpdateDetails>? onSelectionHandleDragUpdate;
   final ValueChanged<DragEndDetails>? onSelectionHandleDragEnd;
   final TextSelectionControls selectionControls;
-  final ValueListenable<bool> visibility;
+  final ValueListenable<bool>? visibility;
   final double preferredLineHeight;
   final TextSelectionHandleType type;
   final DragStartBehavior dragStartBehavior;
@@ -1060,11 +1046,11 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
     _controller = AnimationController(duration: SelectionOverlay.fadeDuration, vsync: this);
 
     _handleVisibilityChanged();
-    widget.visibility.addListener(_handleVisibilityChanged);
+    widget.visibility?.addListener(_handleVisibilityChanged);
   }
 
   void _handleVisibilityChanged() {
-    if (widget.visibility.value) {
+    if (widget.visibility?.value != false) {
       _controller.forward();
     } else {
       _controller.reverse();
@@ -1074,14 +1060,14 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
   @override
   void didUpdateWidget(_SelectionHandleOverlay oldWidget) {
     super.didUpdateWidget(oldWidget);
-    oldWidget.visibility.removeListener(_handleVisibilityChanged);
+    oldWidget.visibility?.removeListener(_handleVisibilityChanged);
     _handleVisibilityChanged();
-    widget.visibility.addListener(_handleVisibilityChanged);
+    widget.visibility?.addListener(_handleVisibilityChanged);
   }
 
   @override
   void dispose() {
-    widget.visibility.removeListener(_handleVisibilityChanged);
+    widget.visibility?.removeListener(_handleVisibilityChanged);
     _controller.dispose();
     super.dispose();
   }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -239,138 +239,82 @@ abstract class TextSelectionControls {
   }
 }
 
-/// An object that manages a pair of text selection handles.
+/// An object that manages a pair of text selection handles for [RenderEditable].
 ///
-/// The selection handles are displayed in the [Overlay] that most closely
-/// encloses the given [BuildContext].
+/// This class is a wrapper of [SelectionOverlay] to provide API specific for
+/// [RenderEditable]. Use [SelectionOverlay] to manage selection handles for
+/// other custom widgets.
 class TextSelectionOverlay {
   /// Creates an object that manages overlay entries for selection handles.
   ///
   /// The [context] must not be null and must have an [Overlay] as an ancestor.
   TextSelectionOverlay({
     required TextEditingValue value,
-    required this.context,
-    this.debugRequiredFor,
-    required this.toolbarLayerLink,
-    required this.startHandleLayerLink,
-    required this.endHandleLayerLink,
+    required BuildContext context,
+    Widget? debugRequiredFor,
+    required LayerLink toolbarLayerLink,
+    required LayerLink startHandleLayerLink,
+    required LayerLink endHandleLayerLink,
     required this.renderObject,
     this.selectionControls,
     bool handlesVisible = false,
     required this.selectionDelegate,
-    this.dragStartBehavior = DragStartBehavior.start,
-    this.onSelectionHandleTapped,
-    this.clipboardStatus,
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    VoidCallback? onSelectionHandleTapped,
+    ClipboardStatusNotifier? clipboardStatus,
   }) : assert(value != null),
        assert(context != null),
        assert(handlesVisible != null),
        _handlesVisible = handlesVisible,
        _value = value {
-    final OverlayState? overlay = Overlay.of(context, rootOverlay: true);
-    assert(
-      overlay != null,
-      'No Overlay widget exists above $context.\n'
-      'Usually the Navigator created by WidgetsApp provides the overlay. Perhaps your '
-      'app content was created above the Navigator with the WidgetsApp builder parameter.',
-    );
     renderObject.selectionStartInViewport.addListener(_updateHandleVisibilities);
     renderObject.selectionEndInViewport.addListener(_updateHandleVisibilities);
     _updateHandleVisibilities();
-    _toolbarController = AnimationController(duration: fadeDuration, vsync: overlay!);
+    _selectionOverlay = SelectionOverlay(
+      context: context,
+      debugRequiredFor: debugRequiredFor,
+      // The metrics will be set when show handles.
+      startHandleType: TextSelectionHandleType.collapsed,
+      startHandlesVisible: _effectiveStartHandleVisibility,
+      lineHeightAtStart: 0.0,
+      onStartHandleDragStart: _handleSelectionStartHandleDragStart,
+      onStartHandleDragUpdate: _handleSelectionStartHandleDragUpdate,
+      endHandleType: TextSelectionHandleType.collapsed,
+      endHandlesVisible: _effectiveEndHandleVisibility,
+      lineHeightAtEnd: 0.0,
+      onEndHandleDragStart: _handleSelectionEndHandleDragStart,
+      onEndHandleDragUpdate: _handleSelectionEndHandleDragUpdate,
+      selectionEndPoints: const <TextSelectionPoint>[],
+      selectionControls: selectionControls,
+      selectionDelegate: selectionDelegate,
+      clipboardStatus: clipboardStatus,
+      startHandleLayerLink: startHandleLayerLink,
+      endHandleLayerLink: endHandleLayerLink,
+      toolbarLayerLink: toolbarLayerLink,
+      onSelectionHandleTapped: onSelectionHandleTapped,
+      dragStartBehavior: dragStartBehavior,
+      toolbarLocation: renderObject.lastSecondaryTapDownPosition,
+    );
   }
-
-  /// The context in which the selection handles should appear.
-  ///
-  /// This context must have an [Overlay] as an ancestor because this object
-  /// will display the text selection handles in that [Overlay].
-  final BuildContext context;
-
-  /// Debugging information for explaining why the [Overlay] is required.
-  final Widget? debugRequiredFor;
-
-  /// The object supplied to the [CompositedTransformTarget] that wraps the text
-  /// field.
-  final LayerLink toolbarLayerLink;
-
-  /// The objects supplied to the [CompositedTransformTarget] that wraps the
-  /// location of start selection handle.
-  final LayerLink startHandleLayerLink;
-
-  /// The objects supplied to the [CompositedTransformTarget] that wraps the
-  /// location of end selection handle.
-  final LayerLink endHandleLayerLink;
 
   // TODO(mpcomplete): what if the renderObject is removed or replaced, or
   // moves? Not sure what cases I need to handle, or how to handle them.
   /// The editable line in which the selected text is being displayed.
   final RenderEditable renderObject;
 
-  /// Builds text selection handles and toolbar.
+  /// {@macro flutter.widgets.SelectionOverlay.selectionControls}
   final TextSelectionControls? selectionControls;
 
-  /// The delegate for manipulating the current selection in the owning
-  /// text field.
+  /// {@macro flutter.widgets.SelectionOverlay.selectionDelegate}
   final TextSelectionDelegate selectionDelegate;
 
-  /// Determines the way that drag start behavior is handled.
-  ///
-  /// If set to [DragStartBehavior.start], handle drag behavior will
-  /// begin at the position where the drag gesture won the arena. If set to
-  /// [DragStartBehavior.down] it will begin at the position where a down
-  /// event is first detected.
-  ///
-  /// In general, setting this to [DragStartBehavior.start] will make drag
-  /// animation smoother and setting it to [DragStartBehavior.down] will make
-  /// drag behavior feel slightly more reactive.
-  ///
-  /// By default, the drag start behavior is [DragStartBehavior.start].
-  ///
-  /// See also:
-  ///
-  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
-  final DragStartBehavior dragStartBehavior;
-
-  /// {@template flutter.widgets.TextSelectionOverlay.onSelectionHandleTapped}
-  /// A callback that's optionally invoked when a selection handle is tapped.
-  ///
-  /// The [TextSelectionControls.buildHandle] implementation the text field
-  /// uses decides where the handle's tap "hotspot" is, or whether the
-  /// selection handle supports tap gestures at all. For instance,
-  /// [MaterialTextSelectionControls] calls [onSelectionHandleTapped] when the
-  /// selection handle's "knob" is tapped, while
-  /// [CupertinoTextSelectionControls] builds a handle that's not sufficiently
-  /// large for tapping (as it's not meant to be tapped) so it does not call
-  /// [onSelectionHandleTapped] even when tapped.
-  /// {@endtemplate}
-  // See https://github.com/flutter/flutter/issues/39376#issuecomment-848406415
-  // for provenance.
-  final VoidCallback? onSelectionHandleTapped;
-
-  /// Maintains the status of the clipboard for determining if its contents can
-  /// be pasted or not.
-  ///
-  /// Useful because the actual value of the clipboard can only be checked
-  /// asynchronously (see [Clipboard.getData]).
-  final ClipboardStatusNotifier? clipboardStatus;
-
-  /// Controls the fade-in and fade-out animations for the toolbar and handles.
-  static const Duration fadeDuration = Duration(milliseconds: 150);
-
-  late final AnimationController _toolbarController;
-  Animation<double> get _toolbarOpacity => _toolbarController.view;
+  late final SelectionOverlay _selectionOverlay;
 
   /// Retrieve current value.
   @visibleForTesting
   TextEditingValue get value => _value;
 
   TextEditingValue _value;
-
-  /// A pair of handles. If this is non-null, there are always 2, though the
-  /// second is hidden when the selection is collapsed.
-  List<OverlayEntry>? _handles;
-
-  /// A copy/paste toolbar.
-  OverlayEntry? _toolbar;
 
   TextSelection get _selection => _value.selection;
 
@@ -405,35 +349,19 @@ class TextSelectionOverlay {
     _updateHandleVisibilities();
   }
 
-  /// Builds the handles by inserting them into the [context]'s overlay.
+  /// {@macro flutter.widgets.SelectionOverlay.showHandles}
   void showHandles() {
-    if (_handles != null)
-      return;
-
-    _handles = <OverlayEntry>[
-      OverlayEntry(builder: (BuildContext context) => _buildStartHandle(context)),
-      OverlayEntry(builder: (BuildContext context) => _buildEndHandle(context)),
-    ];
-
-    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
-      .insertAll(_handles!);
+    _updateSelectionOverlay();
+    _selectionOverlay.showHandles();
   }
 
-  /// Destroys the handles by removing them from overlay.
-  void hideHandles() {
-    if (_handles != null) {
-      _handles![0].remove();
-      _handles![1].remove();
-      _handles = null;
-    }
-  }
+  /// {@macro flutter.widgets.SelectionOverlay.hideHandles}
+  void hideHandles() => _selectionOverlay.hideHandles();
 
-  /// Shows the toolbar by inserting it into the [context]'s overlay.
+  /// {@macro flutter.widgets.SelectionOverlay.showToolbar}
   void showToolbar() {
-    assert(_toolbar == null);
-    _toolbar = OverlayEntry(builder: _buildToolbar);
-    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!.insert(_toolbar!);
-    _toolbarController.forward(from: 0.0);
+    _updateSelectionOverlay();
+    _selectionOverlay.showToolbar();
   }
 
   /// Updates the overlay after the selection has changed.
@@ -449,117 +377,54 @@ class TextSelectionOverlay {
     if (_value == newValue)
       return;
     _value = newValue;
-    if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks) {
-      SchedulerBinding.instance.addPostFrameCallback(_markNeedsBuild);
-    } else {
-      _markNeedsBuild();
-    }
+    _updateSelectionOverlay();
+  }
+
+  void _updateSelectionOverlay() {
+    _selectionOverlay
+      // Update selection handle metrics.
+      ..startHandleType = _chooseType(
+        renderObject.textDirection,
+        TextSelectionHandleType.left,
+        TextSelectionHandleType.right,
+      )
+      ..lineHeightAtStart = _getStartGlyphHeight()
+      ..endHandleType = _chooseType(
+        renderObject.textDirection,
+        TextSelectionHandleType.right,
+        TextSelectionHandleType.left,
+      )
+      ..lineHeightAtEnd = _getEndGlyphHeight()
+      // Update selection toolbar metrics.
+      ..selectionEndPoints = renderObject.getEndpointsForSelection(_selection)
+      ..toolbarLocation = renderObject.lastSecondaryTapDownPosition;
   }
 
   /// Causes the overlay to update its rendering.
   ///
   /// This is intended to be called when the [renderObject] may have changed its
   /// text metrics (e.g. because the text was scrolled).
-  void updateForScroll() {
-    _markNeedsBuild();
-  }
-
-  void _markNeedsBuild([ Duration? duration ]) {
-    if (_handles != null) {
-      _handles![0].markNeedsBuild();
-      _handles![1].markNeedsBuild();
-    }
-    _toolbar?.markNeedsBuild();
-  }
+  void updateForScroll() => _updateSelectionOverlay();
 
   /// Whether the handles are currently visible.
-  bool get handlesAreVisible => _handles != null && handlesVisible;
+  bool get handlesAreVisible => _selectionOverlay._handles != null && handlesVisible;
 
   /// Whether the toolbar is currently visible.
-  bool get toolbarIsVisible => _toolbar != null;
+  bool get toolbarIsVisible => _selectionOverlay._toolbar != null;
 
-  /// Hides the entire overlay including the toolbar and the handles.
-  void hide() {
-    if (_handles != null) {
-      _handles![0].remove();
-      _handles![1].remove();
-      _handles = null;
-    }
-    if (_toolbar != null) {
-      hideToolbar();
-    }
-  }
+  /// {@macro flutter.widgets.SelectionOverlay.hide}
+  void hide() => _selectionOverlay.hide();
 
-  /// Hides the toolbar part of the overlay.
-  ///
-  /// To hide the whole overlay, see [hide].
-  void hideToolbar() {
-    assert(_toolbar != null);
-    _toolbarController.stop();
-    _toolbar?.remove();
-    _toolbar = null;
-  }
+  /// {@macro flutter.widgets.SelectionOverlay.hideToolbar}
+  void hideToolbar() => _selectionOverlay.hideHandles();
 
-  /// Final cleanup.
+  /// {@macro flutter.widgets.SelectionOverlay.dispose}
   void dispose() {
-    hide();
-    _toolbarController.dispose();
     renderObject.selectionStartInViewport.removeListener(_updateHandleVisibilities);
     renderObject.selectionEndInViewport.removeListener(_updateHandleVisibilities);
-  }
-
-  Widget _buildStartHandle(BuildContext context) {
-    final Widget handle;
-    final TextSelectionControls? selectionControls = this.selectionControls;
-    if (selectionControls == null)
-      handle = Container();
-    else {
-      handle = _SelectionHandleOverlay(
-        type: _chooseType(
-          renderObject.textDirection,
-          TextSelectionHandleType.left,
-          TextSelectionHandleType.right,
-        ),
-        handleLayerLink: startHandleLayerLink,
-        onSelectionHandleTapped: onSelectionHandleTapped,
-        onSelectionHandleDragStart: _handleSelectionStartHandleDragStart,
-        onSelectionHandleDragUpdate: _handleSelectionStartHandleDragUpdate,
-        selectionControls: selectionControls,
-        visibility: _effectiveStartHandleVisibility,
-        preferredLineHeight: _getStartGlyphHeight(),
-        dragStartBehavior: dragStartBehavior,
-      );
-    }
-    return ExcludeSemantics(
-      child: handle,
-    );
-  }
-
-  Widget _buildEndHandle(BuildContext context) {
-    final Widget handle;
-    final TextSelectionControls? selectionControls = this.selectionControls;
-    if (_selection.isCollapsed || selectionControls == null)
-      handle = Container(); // hide the second handle when collapsed
-    else {
-      handle = _SelectionHandleOverlay(
-        type: _chooseType(
-          renderObject.textDirection,
-          TextSelectionHandleType.right,
-          TextSelectionHandleType.left,
-        ),
-        handleLayerLink: endHandleLayerLink,
-        onSelectionHandleTapped: onSelectionHandleTapped,
-        onSelectionHandleDragStart: _handleSelectionEndHandleDragStart,
-        onSelectionHandleDragUpdate: _handleSelectionEndHandleDragUpdate,
-        selectionControls: selectionControls,
-        visibility: _effectiveEndHandleVisibility,
-        preferredLineHeight: _getEndGlyphHeight(),
-        dragStartBehavior: dragStartBehavior,
-      );
-    }
-    return ExcludeSemantics(
-      child: handle,
-    );
+    _selectionOverlay.dispose();
+    _effectiveStartHandleVisibility.dispose();
+    _effectiveEndHandleVisibility.dispose();
   }
 
   double _getStartGlyphHeight() {
@@ -656,61 +521,6 @@ class TextSelectionOverlay {
     _handleSelectionHandleChanged(newSelection, isEnd: false);
   }
 
-  Widget _buildToolbar(BuildContext context) {
-    if (selectionControls == null)
-      return Container();
-
-    // Find the horizontal midpoint, just above the selected text.
-    final List<TextSelectionPoint> endpoints =
-        renderObject.getEndpointsForSelection(_selection);
-
-    final Rect editingRegion = Rect.fromPoints(
-      renderObject.localToGlobal(Offset.zero),
-      renderObject.localToGlobal(renderObject.size.bottomRight(Offset.zero)),
-    );
-
-    final bool isMultiline = endpoints.last.point.dy - endpoints.first.point.dy >
-          renderObject.preferredLineHeight / 2;
-
-    // If the selected text spans more than 1 line, horizontally center the toolbar.
-    // Derived from both iOS and Android.
-    final double midX = isMultiline
-      ? editingRegion.width / 2
-      : (endpoints.first.point.dx + endpoints.last.point.dx) / 2;
-
-    final Offset midpoint = Offset(
-      midX,
-      // The y-coordinate won't be made use of most likely.
-      endpoints[0].point.dy - renderObject.preferredLineHeight,
-    );
-
-    return Directionality(
-      textDirection: Directionality.of(this.context),
-      child: FadeTransition(
-        opacity: _toolbarOpacity,
-        child: CompositedTransformFollower(
-          link: toolbarLayerLink,
-          showWhenUnlinked: false,
-          offset: -editingRegion.topLeft,
-          child: Builder(
-            builder: (BuildContext context) {
-              return selectionControls!.buildToolbar(
-                context,
-                editingRegion,
-                renderObject.preferredLineHeight,
-                midpoint,
-                endpoints,
-                selectionDelegate,
-                clipboardStatus!,
-                renderObject.lastSecondaryTapDownPosition,
-              );
-            },
-          ),
-        ),
-      ),
-    );
-  }
-
   void _handleSelectionHandleChanged(TextSelection newSelection, {required bool isEnd}) {
     final TextPosition textPosition = isEnd ? newSelection.extent : newSelection.base;
     selectionDelegate.userUpdateTextEditingValue(
@@ -738,6 +548,473 @@ class TextSelectionOverlay {
   }
 }
 
+/// An object that manages a pair of selection handles.
+///
+/// The selection handles are displayed in the [Overlay] that most closely
+/// encloses the given [BuildContext].
+class SelectionOverlay {
+  /// Creates an object that manages overlay entries for selection handles.
+  ///
+  /// The [context] must not be null and must have an [Overlay] as an ancestor.
+  SelectionOverlay({
+    required this.context,
+    this.debugRequiredFor,
+    required TextSelectionHandleType startHandleType,
+    required double lineHeightAtStart,
+    ValueListenable<bool>? startHandlesVisible,
+    this.onStartHandleDragStart,
+    this.onStartHandleDragUpdate,
+    this.onStartHandleDragEnd,
+    required TextSelectionHandleType endHandleType,
+    required double lineHeightAtEnd,
+    ValueListenable<bool>? endHandlesVisible,
+    this.onEndHandleDragStart,
+    this.onEndHandleDragUpdate,
+    this.onEndHandleDragEnd,
+    required List<TextSelectionPoint> selectionEndPoints,
+    required this.selectionControls,
+    required this.selectionDelegate,
+    required this.clipboardStatus,
+    required this.startHandleLayerLink,
+    required this.endHandleLayerLink,
+    required this.toolbarLayerLink,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.onSelectionHandleTapped,
+    Offset? toolbarLocation,
+  }) : _startHandleType = startHandleType,
+       _lineHeightAtStart = lineHeightAtStart,
+       _startHandlesVisible = startHandlesVisible,
+       _endHandleType = endHandleType,
+       _lineHeightAtEnd = lineHeightAtEnd,
+       _endHandlesVisible = endHandlesVisible,
+       _selectionEndPoints = selectionEndPoints,
+       _toolbarLocation = toolbarLocation {
+    final OverlayState? overlay = Overlay.of(context, rootOverlay: true);
+    assert(
+      overlay != null,
+      'No Overlay widget exists above $context.\n'
+      'Usually the Navigator created by WidgetsApp provides the overlay. Perhaps your '
+      'app content was created above the Navigator with the WidgetsApp builder parameter.',
+    );
+    _toolbarController = AnimationController(duration: fadeDuration, vsync: overlay!);
+    if (_startHandlesVisible == null) {
+      _defaultStartHandlesVisible = ValueNotifier<bool>(false);
+    }
+    if (_endHandlesVisible == null) {
+      _defaultEndHandlesVisible = ValueNotifier<bool>(false);
+    }
+  }
+
+  /// The context in which the selection handles should appear.
+  ///
+  /// This context must have an [Overlay] as an ancestor because this object
+  /// will display the text selection handles in that [Overlay].
+  final BuildContext context;
+
+  /// The type of start selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  TextSelectionHandleType get startHandleType => _startHandleType;
+  TextSelectionHandleType _startHandleType;
+  set startHandleType(TextSelectionHandleType value) {
+    if (_startHandleType == value)
+      return;
+    _startHandleType = value;
+    _markNeedsBuild();
+  }
+
+  /// The line height at the selection start.
+  ///
+  /// This value is used for calculating the size of the start selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  double get lineHeightAtStart => _lineHeightAtStart;
+  double _lineHeightAtStart;
+  set lineHeightAtStart(double value) {
+    if (_lineHeightAtStart == value)
+      return;
+    _lineHeightAtStart = value;
+    _markNeedsBuild();
+  }
+
+  /// Whether the start handle is visible.
+  ///
+  /// If the value changes, the start handle uses [FadeTransition] to transition
+  /// itself on and off the screen.
+  ValueListenable<bool> get startHandlesVisible => _startHandlesVisible ?? _defaultStartHandlesVisible;
+  final ValueListenable<bool>? _startHandlesVisible;
+  late final ValueNotifier<bool> _defaultStartHandlesVisible;
+
+  /// Called when the users start dragging the start selection handles.
+  final ValueChanged<DragStartDetails>? onStartHandleDragStart;
+
+  /// Called when the users drag the start selection handles to new locations.
+  final ValueChanged<DragUpdateDetails>? onStartHandleDragUpdate;
+
+  /// Called when the users lift their fingers after dragging the start selection
+  /// handles.
+  final ValueChanged<DragEndDetails>? onStartHandleDragEnd;
+
+  /// The type of end selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  TextSelectionHandleType get endHandleType => _endHandleType;
+  TextSelectionHandleType _endHandleType;
+  set endHandleType(TextSelectionHandleType value) {
+    if (_endHandleType == value)
+      return;
+    _endHandleType = value;
+    _markNeedsBuild();
+  }
+
+  /// The line height at the selection end.
+  ///
+  /// This value is used for calculating the size of the end selection handle.
+  ///
+  /// Changing the value while the handles are visible causes them to rebuild.
+  double get lineHeightAtEnd => _lineHeightAtEnd;
+  double _lineHeightAtEnd;
+  set lineHeightAtEnd(double value) {
+    if (_lineHeightAtEnd == value)
+      return;
+    _lineHeightAtEnd = value;
+    _markNeedsBuild();
+  }
+
+  /// Whether the end handle is visible.
+  ///
+  /// If the value changes, the end handle uses [FadeTransition] to transition
+  /// itself on and off the screen.
+  ValueListenable<bool> get endHandlesVisible => _endHandlesVisible ?? _defaultEndHandlesVisible;
+  final ValueListenable<bool>? _endHandlesVisible;
+  late final ValueNotifier<bool> _defaultEndHandlesVisible;
+
+  /// Called when the users start dragging the end selection handles.
+  final ValueChanged<DragStartDetails>? onEndHandleDragStart;
+
+  /// Called when the users drag the end selection handles to new locations.
+  final ValueChanged<DragUpdateDetails>? onEndHandleDragUpdate;
+
+  /// Called when the users lift their fingers after dragging the end selection
+  /// handles.
+  final ValueChanged<DragEndDetails>? onEndHandleDragEnd;
+
+  /// The text selection positions of selection start and end.
+  List<TextSelectionPoint> get selectionEndPoints => _selectionEndPoints;
+  List<TextSelectionPoint> _selectionEndPoints;
+  set selectionEndPoints(List<TextSelectionPoint> value) {
+    if (!listEquals(_selectionEndPoints, value)) {
+      _markNeedsBuild();
+    }
+    _selectionEndPoints = value;
+  }
+
+  /// Debugging information for explaining why the [Overlay] is required.
+  final Widget? debugRequiredFor;
+
+  /// The object supplied to the [CompositedTransformTarget] that wraps the text
+  /// field.
+  final LayerLink toolbarLayerLink;
+
+  /// The objects supplied to the [CompositedTransformTarget] that wraps the
+  /// location of start selection handle.
+  final LayerLink startHandleLayerLink;
+
+  /// The objects supplied to the [CompositedTransformTarget] that wraps the
+  /// location of end selection handle.
+  final LayerLink endHandleLayerLink;
+
+  /// {@template flutter.widgets.SelectionOverlay.selectionControls}
+  /// Builds text selection handles and toolbar.
+  /// {@endtemplate}
+  final TextSelectionControls? selectionControls;
+
+  /// {@template flutter.widgets.SelectionOverlay.selectionDelegate}
+  /// The delegate for manipulating the current selection in the owning
+  /// text field.
+  /// {@endtemplate}
+  final TextSelectionDelegate selectionDelegate;
+
+  /// Determines the way that drag start behavior is handled.
+  ///
+  /// If set to [DragStartBehavior.start], handle drag behavior will
+  /// begin at the position where the drag gesture won the arena. If set to
+  /// [DragStartBehavior.down] it will begin at the position where a down
+  /// event is first detected.
+  ///
+  /// In general, setting this to [DragStartBehavior.start] will make drag
+  /// animation smoother and setting it to [DragStartBehavior.down] will make
+  /// drag behavior feel slightly more reactive.
+  ///
+  /// By default, the drag start behavior is [DragStartBehavior.start].
+  ///
+  /// See also:
+  ///
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for the different behaviors.
+  final DragStartBehavior dragStartBehavior;
+
+  /// {@template flutter.widgets.SelectionOverlay.onSelectionHandleTapped}
+  /// A callback that's optionally invoked when a selection handle is tapped.
+  ///
+  /// The [TextSelectionControls.buildHandle] implementation the text field
+  /// uses decides where the handle's tap "hotspot" is, or whether the
+  /// selection handle supports tap gestures at all. For instance,
+  /// [MaterialTextSelectionControls] calls [onSelectionHandleTapped] when the
+  /// selection handle's "knob" is tapped, while
+  /// [CupertinoTextSelectionControls] builds a handle that's not sufficiently
+  /// large for tapping (as it's not meant to be tapped) so it does not call
+  /// [onSelectionHandleTapped] even when tapped.
+  /// {@endtemplate}
+  // See https://github.com/flutter/flutter/issues/39376#issuecomment-848406415
+  // for provenance.
+  final VoidCallback? onSelectionHandleTapped;
+
+  /// Maintains the status of the clipboard for determining if its contents can
+  /// be pasted or not.
+  ///
+  /// Useful because the actual value of the clipboard can only be checked
+  /// asynchronously (see [Clipboard.getData]).
+  final ClipboardStatusNotifier? clipboardStatus;
+
+  /// The location of where the toolbar should be drawn in relative to the
+  /// location of [toolbarLayerLink].
+  ///
+  /// If this is null, the toolbar is drawn based on [selectionEndPoints] and
+  /// the rect of render object of [context].
+  ///
+  /// For mobile devices, the toolbar is a
+  Offset? get toolbarLocation => _toolbarLocation;
+  Offset? _toolbarLocation;
+  set toolbarLocation(Offset? value) {
+    if (_toolbarLocation == value) {
+      return;
+    }
+    _toolbarLocation = value;
+    _markNeedsBuild();
+  }
+
+  /// Controls the fade-in and fade-out animations for the toolbar and handles.
+  static const Duration fadeDuration = Duration(milliseconds: 150);
+
+  late final AnimationController _toolbarController;
+  Animation<double> get _toolbarOpacity => _toolbarController.view;
+
+  /// A pair of handles. If this is non-null, there are always 2, though the
+  /// second is hidden when the selection is collapsed.
+  List<OverlayEntry>? _handles;
+
+  /// A copy/paste toolbar.
+  OverlayEntry? _toolbar;
+
+  /// {@template flutter.widgets.SelectionOverlay.showHandles}
+  /// Builds the handles by inserting them into the [context]'s overlay.
+  /// {@endtemplate}
+  void showHandles() {
+    if (_handles != null)
+      return;
+
+    _handles = <OverlayEntry>[
+      OverlayEntry(builder: (BuildContext context) => _buildStartHandle(context)),
+      OverlayEntry(builder: (BuildContext context) => _buildEndHandle(context)),
+    ];
+
+    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
+        .insertAll(_handles!);
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.hideHandles}
+  /// Destroys the handles by removing them from overlay.
+  /// {@endtemplate}
+  void hideHandles() {
+    if (_handles != null) {
+      _handles![0].remove();
+      _handles![1].remove();
+      _handles = null;
+    }
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.showToolbar}
+  /// Shows the toolbar by inserting it into the [context]'s overlay.
+  /// {@endtemplate}
+  void showToolbar() {
+    if (_toolbar != null) {
+      return;
+    }
+    _toolbar = OverlayEntry(builder: _buildToolbar);
+    Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!.insert(_toolbar!);
+    _toolbarController.forward(from: 0.0);
+  }
+
+  bool _buildScheduled = false;
+  void _markNeedsBuild() {
+    if (_handles == null && _toolbar == null)
+      return;
+    // If we are in build state, it will be too late to update visibility.
+    // We will need to schedule the build in next frame.
+    if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks) {
+      if (_buildScheduled)
+        return;
+      _buildScheduled = true;
+      SchedulerBinding.instance.addPostFrameCallback((Duration duration) {
+        _buildScheduled = false;
+        if (_handles != null) {
+          _handles![0].markNeedsBuild();
+          _handles![1].markNeedsBuild();
+        }
+        _toolbar?.markNeedsBuild();
+      });
+    } else {
+      if (_handles != null) {
+        _handles![0].markNeedsBuild();
+        _handles![1].markNeedsBuild();
+      }
+      _toolbar?.markNeedsBuild();
+    }
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.hide}
+  /// Hides the entire overlay including the toolbar and the handles.
+  /// {@endtemplate}
+  void hide() {
+    if (_handles != null) {
+      _handles![0].remove();
+      _handles![1].remove();
+      _handles = null;
+    }
+    if (_toolbar != null) {
+      hideToolbar();
+    }
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.hideToolbar}
+  /// Hides the toolbar part of the overlay.
+  ///
+  /// To hide the whole overlay, see [hide].
+  /// {@endtemplate}
+  void hideToolbar() {
+    assert(_toolbar != null);
+    _toolbarController.stop();
+    _toolbar?.remove();
+    _toolbar = null;
+  }
+
+  /// {@template flutter.widgets.SelectionOverlay.dispose}
+  /// Disposes this object and release resources.
+  /// {@endtemplate}
+  void dispose() {
+    hide();
+    _toolbarController.dispose();
+    if (_startHandlesVisible == null) {
+      _defaultStartHandlesVisible.dispose();
+    }
+    if (_endHandlesVisible == null) {
+      _defaultEndHandlesVisible.dispose();
+    }
+  }
+
+  Widget _buildStartHandle(BuildContext context) {
+    final Widget handle;
+    final TextSelectionControls? selectionControls = this.selectionControls;
+    if (selectionControls == null)
+      handle = Container();
+    else {
+      handle = _SelectionHandleOverlay(
+        type: _startHandleType,
+        handleLayerLink: startHandleLayerLink,
+        onSelectionHandleTapped: onSelectionHandleTapped,
+        onSelectionHandleDragStart: onStartHandleDragStart,
+        onSelectionHandleDragUpdate: onStartHandleDragUpdate,
+        onSelectionHandleDragEnd: onStartHandleDragEnd,
+        selectionControls: selectionControls,
+        visibility: startHandlesVisible,
+        preferredLineHeight: _lineHeightAtStart,
+        dragStartBehavior: dragStartBehavior,
+      );
+    }
+    return ExcludeSemantics(
+      child: handle,
+    );
+  }
+
+  Widget _buildEndHandle(BuildContext context) {
+    final Widget handle;
+    final TextSelectionControls? selectionControls = this.selectionControls;
+    if (selectionControls == null)
+      handle = Container(); // hide the second handle when collapsed
+    else {
+      handle = _SelectionHandleOverlay(
+        type: _endHandleType,
+        handleLayerLink: endHandleLayerLink,
+        onSelectionHandleTapped: onSelectionHandleTapped,
+        onSelectionHandleDragStart: onEndHandleDragStart,
+        onSelectionHandleDragUpdate: onEndHandleDragUpdate,
+        onSelectionHandleDragEnd: onEndHandleDragEnd,
+        selectionControls: selectionControls,
+        visibility: endHandlesVisible,
+        preferredLineHeight: _lineHeightAtEnd,
+        dragStartBehavior: dragStartBehavior,
+      );
+    }
+    return ExcludeSemantics(
+      child: handle,
+    );
+  }
+
+  Widget _buildToolbar(BuildContext context) {
+    if (selectionControls == null)
+      return Container();
+
+    final RenderBox renderBox = this.context.findRenderObject()! as RenderBox;
+
+    final Rect editingRegion = Rect.fromPoints(
+      renderBox.localToGlobal(Offset.zero),
+      renderBox.localToGlobal(renderBox.size.bottomRight(Offset.zero)),
+    );
+
+    final bool isMultiline = selectionEndPoints.last.point.dy - selectionEndPoints.first.point.dy >
+        lineHeightAtEnd / 2;
+
+    // If the selected text spans more than 1 line, horizontally center the toolbar.
+    // Derived from both iOS and Android.
+    final double midX = isMultiline
+        ? editingRegion.width / 2
+        : (selectionEndPoints.first.point.dx + selectionEndPoints.last.point.dx) / 2;
+
+    final Offset midpoint = Offset(
+      midX,
+      // The y-coordinate won't be made use of most likely.
+      selectionEndPoints.first.point.dy - lineHeightAtStart,
+    );
+
+    return Directionality(
+      textDirection: Directionality.of(this.context),
+      child: FadeTransition(
+        opacity: _toolbarOpacity,
+        child: CompositedTransformFollower(
+          link: toolbarLayerLink,
+          showWhenUnlinked: false,
+          offset: -editingRegion.topLeft,
+          child: Builder(
+            builder: (BuildContext context) {
+              return selectionControls!.buildToolbar(
+                context,
+                editingRegion,
+                lineHeightAtStart,
+                midpoint,
+                selectionEndPoints,
+                selectionDelegate,
+                clipboardStatus!,
+                toolbarLocation,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+
 /// This widget represents a single draggable selection handle.
 class _SelectionHandleOverlay extends StatefulWidget {
   /// Create selection overlay.
@@ -748,6 +1025,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
     this.onSelectionHandleTapped,
     this.onSelectionHandleDragStart,
     this.onSelectionHandleDragUpdate,
+    this.onSelectionHandleDragEnd,
     required this.selectionControls,
     required this.visibility,
     required this.preferredLineHeight,
@@ -758,6 +1036,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
   final VoidCallback? onSelectionHandleTapped;
   final ValueChanged<DragStartDetails>? onSelectionHandleDragStart;
   final ValueChanged<DragUpdateDetails>? onSelectionHandleDragUpdate;
+  final ValueChanged<DragEndDetails>? onSelectionHandleDragEnd;
   final TextSelectionControls selectionControls;
   final ValueListenable<bool> visibility;
   final double preferredLineHeight;
@@ -778,7 +1057,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
   void initState() {
     super.initState();
 
-    _controller = AnimationController(duration: TextSelectionOverlay.fadeDuration, vsync: this);
+    _controller = AnimationController(duration: SelectionOverlay.fadeDuration, vsync: this);
 
     _handleVisibilityChanged();
     widget.visibility.addListener(_handleVisibilityChanged);
@@ -850,6 +1129,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay> with S
             dragStartBehavior: widget.dragStartBehavior,
             onPanStart: widget.onSelectionHandleDragStart,
             onPanUpdate: widget.onSelectionHandleDragUpdate,
+            onPanEnd: widget.onSelectionHandleDragEnd,
             child: Padding(
               padding: EdgeInsets.only(
                 left: padding.left,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -805,7 +805,7 @@ class SelectionOverlay {
     ];
 
     Overlay.of(context, rootOverlay: true, debugRequiredFor: debugRequiredFor)!
-        .insertAll(_handles!);
+      .insertAll(_handles!);
   }
 
   /// {@template flutter.widgets.SelectionOverlay.hideHandles}
@@ -878,7 +878,8 @@ class SelectionOverlay {
   /// To hide the whole overlay, see [hide].
   /// {@endtemplate}
   void hideToolbar() {
-    assert(_toolbar != null);
+    if (_toolbar == null)
+      return;
     _toolbarController.stop();
     _toolbar?.remove();
     _toolbar = null;
@@ -957,8 +958,8 @@ class SelectionOverlay {
     // If the selected text spans more than 1 line, horizontally center the toolbar.
     // Derived from both iOS and Android.
     final double midX = isMultiline
-        ? editingRegion.width / 2
-        : (selectionEndPoints.first.point.dx + selectionEndPoints.last.point.dx) / 2;
+      ? editingRegion.width / 2
+      : (selectionEndPoints.first.point.dx + selectionEndPoints.last.point.dx) / 2;
 
     final Offset midpoint = Offset(
       midX,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -239,11 +239,12 @@ abstract class TextSelectionControls {
   }
 }
 
-/// An object that manages a pair of text selection handles for [RenderEditable].
+/// An object that manages a pair of text selection handles for a
+/// [RenderEditable].
 ///
-/// This class is a wrapper of [SelectionOverlay] to provide API specific for
-/// [RenderEditable]. Use [SelectionOverlay] to manage selection handles for
-/// other custom widgets.
+/// This class is a wrapper of [SelectionOverlay] to provide APIs specific for
+/// [RenderEditable]s. To manage selection handles for custom widgets, use
+/// [SelectionOverlay] instead.
 class TextSelectionOverlay {
   /// Creates an object that manages overlay entries for selection handles.
   ///
@@ -329,14 +330,6 @@ class TextSelectionOverlay {
   ///
   /// Set to false if you want to hide the handles. Use this property to show or
   /// hide the handle without rebuilding them.
-  ///
-  /// If this method is called while the [SchedulerBinding.schedulerPhase] is
-  /// [SchedulerPhase.persistentCallbacks], i.e. during the build, layout, or
-  /// paint phases (see [WidgetsBinding.drawFrame]), then the update is delayed
-  /// until the post-frame callbacks phase. Otherwise the update is done
-  /// synchronously. This means that it is safe to call during builds, but also
-  /// that if you do call this during a build, the UI will not update until the
-  /// next frame (i.e. many milliseconds later).
   ///
   /// Defaults to false.
   bool get handlesVisible => _handlesVisible;
@@ -774,7 +767,8 @@ class SelectionOverlay {
   /// If this is null, the toolbar is drawn based on [selectionEndPoints] and
   /// the rect of render object of [context].
   ///
-  /// For mobile devices, the toolbar is a
+  /// This is useful for displaying toolbars at the mouse right-click locations
+  /// in desktop devices.
   Offset? get toolbarLocation => _toolbarLocation;
   Offset? _toolbarLocation;
   set toolbarLocation(Offset? value) {

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -993,7 +993,6 @@ class SelectionOverlay {
   }
 }
 
-
 /// This widget represents a single draggable selection handle.
 class _SelectionHandleOverlay extends StatefulWidget {
   /// Create selection overlay.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1326,7 +1326,7 @@ void main() {
 
     // Move the gesture very slightly
     await gesture.moveBy(const Offset(1.0, 1.0));
-    await tester.pump(TextSelectionOverlay.fadeDuration * 0.5);
+    await tester.pump(SelectionOverlay.fadeDuration * 0.5);
     handle = tester.widget(fadeFinder.at(0));
 
     // The handle should still be fully opaque.

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -4709,14 +4709,14 @@ void main() {
       if (expectedRightVisibleBefore)
         expect(right.opacity.value, equals(1.0));
 
-      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+      await tester.pump(SelectionOverlay.fadeDuration ~/ 2);
 
       if (expectedLeftVisible != expectedLeftVisibleBefore)
         expect(left.opacity.value, equals(0.5));
       if (expectedRightVisible != expectedRightVisibleBefore)
         expect(right.opacity.value, equals(0.5));
 
-      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+      await tester.pump(SelectionOverlay.fadeDuration ~/ 2);
 
       if (expectedLeftVisible)
         expect(left.opacity.value, equals(1.0));
@@ -6515,14 +6515,14 @@ void main() {
       if (expectedRightVisibleBefore)
         expect(right.opacity.value, equals(1.0));
 
-      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+      await tester.pump(SelectionOverlay.fadeDuration ~/ 2);
 
       if (expectedLeftVisible != expectedLeftVisibleBefore)
         expect(left.opacity.value, equals(0.5));
       if (expectedRightVisible != expectedRightVisibleBefore)
         expect(right.opacity.value, equals(0.5));
 
-      await tester.pump(TextSelectionOverlay.fadeDuration ~/ 2);
+      await tester.pump(SelectionOverlay.fadeDuration ~/ 2);
 
       if (expectedLeftVisible)
         expect(left.opacity.value, equals(1.0));

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -568,7 +568,7 @@ void main() {
 
     // Move the gesture very slightly
     await gesture.moveBy(const Offset(1.0, 1.0));
-    await tester.pump(TextSelectionOverlay.fadeDuration * 0.5);
+    await tester.pump(SelectionOverlay.fadeDuration * 0.5);
     handle = tester.widget(fadeFinder.at(0));
 
     // The handle should still be fully opaque.

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -865,8 +865,8 @@ void main() {
       await tester.pump();
       Text leftHandle = tester.widget(find.byKey(spy.leftHandleKey)) as Text;
       Text rightHandle = tester.widget(find.byKey(spy.rightHandleKey)) as Text;
-      expect(leftHandle.data, 'height 10.0');
-      expect(rightHandle.data, 'height 11.0');
+      expect(leftHandle.data, 'height 10');
+      expect(rightHandle.data, 'height 11');
 
       selectionOverlay
         ..startHandleType = TextSelectionHandleType.right
@@ -876,8 +876,8 @@ void main() {
       await tester.pump();
       leftHandle = tester.widget(find.byKey(spy.leftHandleKey)) as Text;
       rightHandle = tester.widget(find.byKey(spy.rightHandleKey)) as Text;
-      expect(leftHandle.data, 'height 13.0');
-      expect(rightHandle.data, 'height 12.0');
+      expect(leftHandle.data, 'height 13');
+      expect(rightHandle.data, 'height 12');
     });
 
     testWidgets('can trigger selection handle onTap', (WidgetTester tester) async {
@@ -1211,11 +1211,11 @@ class TextSelectionControlsSpy extends TextSelectionControls {
   Widget buildHandle(BuildContext context, TextSelectionHandleType type, double textLineHeight, [VoidCallback? onTap]) {
     switch (type) {
       case TextSelectionHandleType.left:
-        return ElevatedButton(onPressed: onTap, child: Text('height $textLineHeight', key: leftHandleKey));
+        return ElevatedButton(onPressed: onTap, child: Text('height ${textLineHeight.toInt()}', key: leftHandleKey));
       case TextSelectionHandleType.right:
-        return ElevatedButton(onPressed: onTap, child: Text('height $textLineHeight', key: rightHandleKey));
+        return ElevatedButton(onPressed: onTap, child: Text('height ${textLineHeight.toInt()}', key: rightHandleKey));
       case TextSelectionHandleType.collapsed:
-        return ElevatedButton(onPressed: onTap, child: Text('height $textLineHeight', key: collapsedHandleKey));
+        return ElevatedButton(onPressed: onTap, child: Text('height ${textLineHeight.toInt()}', key: collapsedHandleKey));
     }
   }
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -755,7 +755,7 @@ void main() {
               child: const Text('toolbar'),
             ),
           ],
-        )
+        ),
       ));
 
       return SelectionOverlay(

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -734,20 +734,32 @@ void main() {
       VoidCallback? onSelectionHandleTapped,
       TextSelectionControls? selectionControls,
     }) async {
-      final UniqueKey sizedBox = UniqueKey();
-      await tester.pumpWidget(MaterialApp(
-        home: SizedBox(
-          key: sizedBox,
-          width: 100,
-          height: 100,
-        ),
-      ));
-
+      final UniqueKey column = UniqueKey();
       final LayerLink startHandleLayerLink = LayerLink();
       final LayerLink endHandleLayerLink = LayerLink();
       final LayerLink toolbarLayerLink = LayerLink();
+      await tester.pumpWidget(MaterialApp(
+        home: Column(
+          key: column,
+          children: <Widget>[
+            CompositedTransformTarget(
+              link: startHandleLayerLink,
+              child: const Text('start handle'),
+            ),
+            CompositedTransformTarget(
+              link: endHandleLayerLink,
+              child: const Text('end handle'),
+            ),
+            CompositedTransformTarget(
+              link: toolbarLayerLink,
+              child: const Text('toolbar'),
+            ),
+          ],
+        )
+      ));
+
       return SelectionOverlay(
-        context: tester.element(find.byKey(sizedBox)),
+        context: tester.element(find.byKey(column)),
         onSelectionHandleTapped: onSelectionHandleTapped,
         startHandleType: TextSelectionHandleType.collapsed,
         startHandleLayerLink: startHandleLayerLink,
@@ -812,6 +824,164 @@ void main() {
       expect(find.byKey(spy.leftHandleKey), findsNothing);
       expect(find.byKey(spy.rightHandleKey), findsNothing);
       expect(find.byKey(spy.toolBarKey), findsNothing);
+    });
+
+    testWidgets('only paints one collapsed handle', (WidgetTester tester) async {
+      final TextSelectionControlsSpy spy = TextSelectionControlsSpy();
+      final SelectionOverlay selectionOverlay = await pumpApp(
+        tester,
+        selectionControls: spy,
+      );
+      selectionOverlay
+        ..startHandleType = TextSelectionHandleType.collapsed
+        ..endHandleType = TextSelectionHandleType.collapsed
+        ..selectionEndPoints = const <TextSelectionPoint>[
+          TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
+          TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
+        ];
+      selectionOverlay.showHandles();
+      await tester.pump();
+      expect(find.byKey(spy.leftHandleKey), findsNothing);
+      expect(find.byKey(spy.rightHandleKey), findsNothing);
+      expect(find.byKey(spy.collapsedHandleKey), findsOneWidget);
+    });
+
+    testWidgets('can change handle parameter', (WidgetTester tester) async {
+      final TextSelectionControlsSpy spy = TextSelectionControlsSpy();
+      final SelectionOverlay selectionOverlay = await pumpApp(
+        tester,
+        selectionControls: spy,
+      );
+      selectionOverlay
+        ..startHandleType = TextSelectionHandleType.left
+        ..lineHeightAtStart = 10.0
+        ..endHandleType = TextSelectionHandleType.right
+        ..lineHeightAtEnd = 11.0
+        ..selectionEndPoints = const <TextSelectionPoint>[
+          TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
+          TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
+        ];
+      selectionOverlay.showHandles();
+      await tester.pump();
+      Text leftHandle = tester.widget(find.byKey(spy.leftHandleKey)) as Text;
+      Text rightHandle = tester.widget(find.byKey(spy.rightHandleKey)) as Text;
+      expect(leftHandle.data, 'height 10.0');
+      expect(rightHandle.data, 'height 11.0');
+
+      selectionOverlay
+        ..startHandleType = TextSelectionHandleType.right
+        ..lineHeightAtStart = 12.0
+        ..endHandleType = TextSelectionHandleType.left
+        ..lineHeightAtEnd = 13.0;
+      await tester.pump();
+      leftHandle = tester.widget(find.byKey(spy.leftHandleKey)) as Text;
+      rightHandle = tester.widget(find.byKey(spy.rightHandleKey)) as Text;
+      expect(leftHandle.data, 'height 13.0');
+      expect(rightHandle.data, 'height 12.0');
+    });
+
+    testWidgets('can trigger selection handle onTap', (WidgetTester tester) async {
+      bool selectionHandleTapped = false;
+      void handleTapped() => selectionHandleTapped = true;
+      final TextSelectionControlsSpy spy = TextSelectionControlsSpy();
+      final SelectionOverlay selectionOverlay = await pumpApp(
+        tester,
+        onSelectionHandleTapped: handleTapped,
+        selectionControls: spy,
+      );
+      selectionOverlay
+        ..startHandleType = TextSelectionHandleType.left
+        ..lineHeightAtStart = 10.0
+        ..endHandleType = TextSelectionHandleType.right
+        ..lineHeightAtEnd = 11.0
+        ..selectionEndPoints = const <TextSelectionPoint>[
+          TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
+          TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
+        ];
+      selectionOverlay.showHandles();
+      await tester.pump();
+      expect(find.byKey(spy.leftHandleKey), findsOneWidget);
+      expect(find.byKey(spy.rightHandleKey), findsOneWidget);
+      expect(selectionHandleTapped, isFalse);
+
+      await tester.tap(find.byKey(spy.leftHandleKey));
+      expect(selectionHandleTapped, isTrue);
+
+      selectionHandleTapped = false;
+      await tester.tap(find.byKey(spy.rightHandleKey));
+      expect(selectionHandleTapped, isTrue);
+    });
+
+    testWidgets('can trigger selection handle drag', (WidgetTester tester) async {
+      DragStartDetails? startDragStartDetails;
+      DragUpdateDetails? startDragUpdateDetails;
+      DragEndDetails? startDragEndDetails;
+      DragStartDetails? endDragStartDetails;
+      DragUpdateDetails? endDragUpdateDetails;
+      DragEndDetails? endDragEndDetails;
+      void startDragStart(DragStartDetails details) => startDragStartDetails = details;
+      void startDragUpdate(DragUpdateDetails details) => startDragUpdateDetails = details;
+      void startDragEnd(DragEndDetails details) => startDragEndDetails = details;
+      void endDragStart(DragStartDetails details) => endDragStartDetails = details;
+      void endDragUpdate(DragUpdateDetails details) => endDragUpdateDetails = details;
+      void endDragEnd(DragEndDetails details) => endDragEndDetails = details;
+      final TextSelectionControlsSpy spy = TextSelectionControlsSpy();
+      final SelectionOverlay selectionOverlay = await pumpApp(
+        tester,
+        onStartDragStart: startDragStart,
+        onStartDragUpdate: startDragUpdate,
+        onStartDragEnd: startDragEnd,
+        onEndDragStart: endDragStart,
+        onEndDragUpdate: endDragUpdate,
+        onEndDragEnd: endDragEnd,
+        selectionControls: spy,
+      );
+      selectionOverlay
+        ..startHandleType = TextSelectionHandleType.left
+        ..lineHeightAtStart = 10.0
+        ..endHandleType = TextSelectionHandleType.right
+        ..lineHeightAtEnd = 11.0
+        ..selectionEndPoints = const <TextSelectionPoint>[
+          TextSelectionPoint(Offset(10, 10), TextDirection.ltr),
+          TextSelectionPoint(Offset(20, 20), TextDirection.ltr),
+        ];
+      selectionOverlay.showHandles();
+      await tester.pump();
+      expect(find.byKey(spy.leftHandleKey), findsOneWidget);
+      expect(find.byKey(spy.rightHandleKey), findsOneWidget);
+      expect(startDragStartDetails, isNull);
+      expect(startDragUpdateDetails, isNull);
+      expect(startDragEndDetails, isNull);
+      expect(endDragStartDetails, isNull);
+      expect(endDragUpdateDetails, isNull);
+      expect(endDragEndDetails, isNull);
+
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(spy.leftHandleKey)));
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(startDragStartDetails!.globalPosition, tester.getCenter(find.byKey(spy.leftHandleKey)));
+
+      const Offset newLocation = Offset(20, 20);
+      await gesture.moveTo(newLocation);
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(startDragUpdateDetails!.globalPosition, newLocation);
+
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(startDragEndDetails, isNotNull);
+
+      final TestGesture gesture2 = await tester.startGesture(tester.getCenter(find.byKey(spy.rightHandleKey)));
+      addTearDown(gesture2.removePointer);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(endDragStartDetails!.globalPosition, tester.getCenter(find.byKey(spy.rightHandleKey)));
+
+      await gesture2.moveTo(newLocation);
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(endDragUpdateDetails!.globalPosition, newLocation);
+
+      await gesture2.up();
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(endDragEndDetails, isNotNull);
     });
   });
 


### PR DESCRIPTION
Refactoring TextSelectionOverlay by pulling out dependencies on renderEditable.

This PR creates a base class SelectionOverlay that set up overlay without depending on renderEditable and makes the original TextSelectionOverlay to wrap around SelectionOverlay.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
