### PR TITLE
CupertinoSegmentedControl: Add an interactive example

### DIFF
--- a/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
+++ b/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for CupertinoSegmentedControl
+
+import 'package:flutter/cupertino.dart';
+
+enum Sky { midnight, viridian, cerulean }
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'CupertinoSegmentedControl Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      title: _title,
+      home: SegmentedControlSample(),
+    );
+  }
+}
+
+class SegmentedControlSample extends StatefulWidget {
+  const SegmentedControlSample({Key? key}) : super(key: key);
+
+  @override
+  State<SegmentedControlSample> createState() => _SegmentedControlSampleState();
+}
+
+class _SegmentedControlSampleState extends State<SegmentedControlSample> {
+  Sky _selectedSegment = Sky.midnight;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        // This Cupertino segmented control has enum as the type.
+        middle: CupertinoSegmentedControl<Sky>(
+          // Provide a horizontal padding around children.
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          // This represent a currently selected segmented control. 
+          groupValue: _selectedSegment,
+          // Callback that sets the selected segmented control.
+          onValueChanged: (Sky value) {
+            setState(() {
+              _selectedSegment = value;
+            });
+          },
+          children: const <Sky, Widget>{
+            Sky.midnight: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: Text('Midnight'),
+            ),
+            Sky.viridian: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: Text('Viridian'),
+            ),
+            Sky.cerulean: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20),
+              child: Text('Cerulean'),
+            ),
+          },
+        ),
+      ),
+      child: Center(
+        child: Text('Selected Segment: ${_selectedSegment.name}'),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
+++ b/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
@@ -8,6 +8,12 @@ import 'package:flutter/cupertino.dart';
 
 enum Sky { midnight, viridian, cerulean }
 
+Map<Sky, Color> skyColors = <Sky, Color> {
+  Sky.midnight: const Color(0xff191970),
+  Sky.viridian: const Color(0xff40826d),
+  Sky.cerulean: const Color(0xff007ba7),
+};
+
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
@@ -37,12 +43,14 @@ class _SegmentedControlSampleState extends State<SegmentedControlSample> {
   @override
   Widget build(BuildContext context) {
     return CupertinoPageScaffold(
+      backgroundColor: skyColors[_selectedSegment],
       navigationBar: CupertinoNavigationBar(
-        // This Cupertino segmented control has enum as the type.
+        // This Cupertino segmented control has the enum "Sky" as the type.
         middle: CupertinoSegmentedControl<Sky>(
-          // Provide a horizontal padding around children.
+          selectedColor: skyColors[_selectedSegment],
+          // Provide horizontal padding around the children.
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          // This represent a currently selected segmented control.
+          // This represents a currently selected segmented control.
           groupValue: _selectedSegment,
           // Callback that sets the selected segmented control.
           onValueChanged: (Sky value) {
@@ -53,21 +61,33 @@ class _SegmentedControlSampleState extends State<SegmentedControlSample> {
           children: const <Sky, Widget>{
             Sky.midnight: Padding(
               padding: EdgeInsets.symmetric(horizontal: 20),
-              child: Text('Midnight'),
+              child: Text(
+                'Midnight',
+                style: TextStyle(color: CupertinoColors.white),
+              ),
             ),
             Sky.viridian: Padding(
               padding: EdgeInsets.symmetric(horizontal: 20),
-              child: Text('Viridian'),
+              child: Text(
+                'Viridian',
+                style: TextStyle(color: CupertinoColors.white),
+              ),
             ),
             Sky.cerulean: Padding(
               padding: EdgeInsets.symmetric(horizontal: 20),
-              child: Text('Cerulean'),
+              child: Text(
+                'Cerulean',
+                style: TextStyle(color: CupertinoColors.white),
+              ),
             ),
           },
         ),
       ),
       child: Center(
-        child: Text('Selected Segment: ${_selectedSegment.name}'),
+        child: Text(
+          'Selected Segment: ${_selectedSegment.name}',
+          style: const TextStyle(color: CupertinoColors.white),
+        ),
       ),
     );
   }

--- a/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
+++ b/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
@@ -42,7 +42,7 @@ class _SegmentedControlSampleState extends State<SegmentedControlSample> {
         middle: CupertinoSegmentedControl<Sky>(
           // Provide a horizontal padding around children.
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          // This represent a currently selected segmented control. 
+          // This represent a currently selected segmented control.
           groupValue: _selectedSegment,
           // Callback that sets the selected segmented control.
           onValueChanged: (Sky value) {

--- a/examples/api/test/cupertino/segmented_control/cupertino_segmented_control.0_test.dart
+++ b/examples/api/test/cupertino/segmented_control/cupertino_segmented_control.0_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_api_samples/cupertino/segmented_control/cupertino_segmented_control.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Can change a selected segmented control', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    expect(find.text('Selected Segment: midnight'), findsOneWidget);
+    await tester.tap(find.text('Cerulean'));
+    await tester.pumpAndSettle();
+    expect(find.text('Selected Segment: cerulean'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -58,6 +58,15 @@ const Duration _kFadeDuration = Duration(milliseconds: 165);
 /// arguments can be used to override the segmented control's colors from
 /// [CupertinoTheme] defaults.
 ///
+/// {@tool dartpad}
+/// This example shows a [CupertinoSegmentedControl] with an enum type.
+///
+/// The callback provided to [onValueChanged] should update the state of
+/// the parent [StatefulWidget] using the [State.setState] method, so that
+/// the parent gets rebuilt; for example:
+///
+/// ** See code in examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart **
+/// {@end-tool}
 /// See also:
 ///
 ///  * [CupertinoSegmentedControl], a segmented control widget in the style used
@@ -118,44 +127,6 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   /// The segmented control passes the newly selected widget's associated key
   /// to the callback but does not actually change state until the parent
   /// widget rebuilds the segmented control with the new [groupValue].
-  ///
-  /// The callback provided to [onValueChanged] should update the state of
-  /// the parent [StatefulWidget] using the [State.setState] method, so that
-  /// the parent gets rebuilt; for example:
-  ///
-  /// {@tool snippet}
-  ///
-  /// ```dart
-  /// class SegmentedControlExample extends StatefulWidget {
-  ///   const SegmentedControlExample({Key? key}) : super(key: key);
-  ///
-  ///   @override
-  ///   State createState() => SegmentedControlExampleState();
-  /// }
-  ///
-  /// class SegmentedControlExampleState extends State<SegmentedControlExample> {
-  ///   final Map<int, Widget> children = const <int, Widget>{
-  ///     0: Text('Child 1'),
-  ///     1: Text('Child 2'),
-  ///   };
-  ///
-  ///   late int currentValue;
-  ///
-  ///   @override
-  ///   Widget build(BuildContext context) {
-  ///     return CupertinoSegmentedControl<int>(
-  ///       children: children,
-  ///       onValueChanged: (int newValue) {
-  ///         setState(() {
-  ///           currentValue = newValue;
-  ///         });
-  ///       },
-  ///       groupValue: currentValue,
-  ///     );
-  ///   }
-  /// }
-  /// ```
-  /// {@end-tool}
   final ValueChanged<T> onValueChanged;
 
   /// The color used to fill the backgrounds of unselected widgets and as the


### PR DESCRIPTION
This adds an interactive example to https://master-api.flutter.dev/flutter/cupertino/CupertinoSegmentedControl-class.html
and remove a code sample from `onValueChanged` example as main example would cover the `onValueChanged` 


Matches this screenshot from https://docs.flutter.dev/development/ui/widgets/cupertino
![image](https://user-images.githubusercontent.com/48603081/153300160-23ebc358-6b66-4b02-a518-ffa2cb207ac6.png)

Related https://github.com/flutter/flutter/issues/72926


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
