### PR TITLE
Revert "Update plugin lint test for federated url_launcher plugin"

### DIFF
--- a/dev/devicelab/bin/tasks/plugin_lint_mac.dart
+++ b/dev/devicelab/bin/tasks/plugin_lint_mac.dart
@@ -399,7 +399,7 @@ Future<void> main() async {
 
       final File podfileLockFile = File(path.join(swiftAppPath, 'ios', 'Podfile.lock'));
       final String podfileLockOutput = podfileLockFile.readAsStringSync();
-      if (!podfileLockOutput.contains(':path: ".symlinks/plugins/url_launcher_ios/ios"')
+      if (!podfileLockOutput.contains(':path: ".symlinks/plugins/url_launcher/ios"')
         || !podfileLockOutput.contains(':path: Flutter')
           // test_plugin_objc no longer supports iOS, shouldn't be present.
         || podfileLockOutput.contains(':path: ".symlinks/plugins/test_plugin_objc/ios"')
@@ -417,7 +417,7 @@ Future<void> main() async {
 
       checkDirectoryExists(path.join(
         pluginSymlinks,
-        'url_launcher_ios',
+        'url_launcher',
         'ios',
       ));
 
@@ -447,7 +447,7 @@ void _validateIosPodfile(String appPath) {
 
   final File podfileLockFile = File(path.join(appPath, 'ios', 'Podfile.lock'));
   final String podfileLockOutput = podfileLockFile.readAsStringSync();
-  if (!podfileLockOutput.contains(':path: ".symlinks/plugins/url_launcher_ios/ios"')
+  if (!podfileLockOutput.contains(':path: ".symlinks/plugins/url_launcher/ios"')
     || !podfileLockOutput.contains(':path: Flutter')
     || !podfileLockOutput.contains(':path: ".symlinks/plugins/test_plugin_objc/ios"')
     || !podfileLockOutput.contains(':path: ".symlinks/plugins/test_plugin_swift/ios"')
@@ -479,7 +479,7 @@ void _validateIosPodfile(String appPath) {
 
   checkDirectoryExists(path.join(
     pluginSymlinks,
-    'url_launcher_ios',
+    'url_launcher',
     'ios',
   ));
 
@@ -516,7 +516,7 @@ void _validateMacOSPodfile(String appPath) {
   if (!podfileLockOutput.contains(':path: Flutter/ephemeral\n')
       || !podfileLockOutput.contains(':path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos')
       || !podfileLockOutput.contains(':path: Flutter/ephemeral/.symlinks/plugins/test_plugin_swift/macos')
-      || podfileLockOutput.contains('url_launcher_ios/')) {
+      || podfileLockOutput.contains('url_launcher/')) {
     print(podfileLockOutput);
     throw TaskResult.failure('macOS Podfile.lock does not contain expected pods');
   }
@@ -546,7 +546,7 @@ void _validateMacOSPodfile(String appPath) {
 
   checkDirectoryNotExists(path.join(
     pluginSymlinks,
-    'url_launcher_ios',
+    'url_launcher',
   ));
 
   checkDirectoryExists(path.join(


### PR DESCRIPTION
Reverts flutter/flutter#94374

https://github.com/flutter/flutter/issues/98165

`url_launcher` became unfederated somehow.  Temporarily reverting this to re-open the tree.
https://github.com/flutter/flutter/issues/98165

Test that needs to pass: https://ci.chromium.org/p/flutter/builders/try/Mac%20plugin_lint_mac/11005