### PR TITLE
Dismiss Modal Barrier on `handleTapCancel` 

### DIFF
--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -234,9 +234,7 @@ class _AnyTapGestureRecognizer extends BaseTapGestureRecognizer {
   @protected
   @override
   bool isPointerAllowed(PointerDownEvent event) {
-    if (onAnyTapUp == null) {
-      return false;
-    } else if (onAnyTapCancel == null) {
+    if (onAnyTapUp == null && onAnyTapCancel == null) {
       return false;
     }
     return super.isPointerAllowed(event);

--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -47,7 +47,8 @@ class ModalBarrier extends StatelessWidget {
   ///    [ModalBarrier] built by [ModalRoute] pages.
   final Color? color;
 
-  /// Specifies if the barrier will be dismissed when the user taps on it.
+  /// Specifies if the barrier will be dismissed when the user taps or
+  /// performs a scroll gesture on it.
   ///
   /// If true, and [onDismiss] is non-null, [onDismiss] will be called,
   /// otherwise the current route will be popped from the ambient [Navigator].
@@ -228,12 +229,16 @@ class _AnyTapGestureRecognizer extends BaseTapGestureRecognizer {
     : super(debugOwner: debugOwner);
 
   VoidCallback? onAnyTapUp;
+  VoidCallback? onAnyTapCancel;
 
   @protected
   @override
   bool isPointerAllowed(PointerDownEvent event) {
-    if (onAnyTapUp == null)
+    if (onAnyTapUp == null) {
       return false;
+    } else if (onAnyTapCancel == null) {
+      return false;
+    }
     return super.isPointerAllowed(event);
   }
 
@@ -252,7 +257,7 @@ class _AnyTapGestureRecognizer extends BaseTapGestureRecognizer {
   @protected
   @override
   void handleTapCancel({PointerDownEvent? down, PointerCancelEvent? cancel, String? reason}) {
-    // Do nothing.
+    onAnyTapCancel?.call();
   }
 
   @override
@@ -272,9 +277,10 @@ class _ModalBarrierSemanticsDelegate extends SemanticsGestureDelegate {
 
 
 class _AnyTapGestureRecognizerFactory extends GestureRecognizerFactory<_AnyTapGestureRecognizer> {
-  const _AnyTapGestureRecognizerFactory({this.onAnyTapUp});
+  const _AnyTapGestureRecognizerFactory({this.onAnyTapUp, this.onAnyTapCancel});
 
   final VoidCallback? onAnyTapUp;
+  final VoidCallback? onAnyTapCancel;
 
   @override
   _AnyTapGestureRecognizer constructor() => _AnyTapGestureRecognizer();
@@ -282,6 +288,7 @@ class _AnyTapGestureRecognizerFactory extends GestureRecognizerFactory<_AnyTapGe
   @override
   void initializer(_AnyTapGestureRecognizer instance) {
     instance.onAnyTapUp = onAnyTapUp;
+    instance.onAnyTapCancel = onAnyTapCancel;
   }
 }
 
@@ -307,7 +314,7 @@ class _ModalBarrierGestureDetector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{
-      _AnyTapGestureRecognizer: _AnyTapGestureRecognizerFactory(onAnyTapUp: onDismiss),
+      _AnyTapGestureRecognizer: _AnyTapGestureRecognizerFactory(onAnyTapUp: onDismiss, onAnyTapCancel: onDismiss),
     };
 
     return RawGestureDetector(

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -251,6 +251,39 @@ void main() {
     );
   });
 
+  testWidgets('ModalBarrier pops the Navigator when dismissed by tap cancel', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => const FirstWidget(),
+      '/modal': (BuildContext context) => const SecondWidget(),
+    };
+
+    await tester.pumpWidget(MaterialApp(routes: routes));
+
+    // Initially the barrier is not visible
+    expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+    // Tapping on X routes to the barrier
+    await tester.tap(find.text('X'));
+    await tester.pump(); // begin transition
+    await tester.pump(const Duration(seconds: 1)); // end transition
+
+    // Press the barrier; it shouldn't dismiss yet
+    final TestGesture gesture = await tester.press(
+      find.byKey(const ValueKey<String>('barrier')),
+    );
+    await tester.pumpAndSettle(); // begin transition
+    expect(find.byKey(const ValueKey<String>('barrier')), findsOneWidget);
+
+    // Cancel the pointer; the barrier should be dismissed
+    await gesture.cancel();
+    await tester.pumpAndSettle(const Duration(seconds: 1)); // end transition
+    expect(
+      find.byKey(const ValueKey<String>('barrier')),
+      findsNothing,
+      reason: 'The route should have been dismissed by tapping the barrier.',
+    );
+  });
+
   testWidgets('ModalBarrier may pop the Navigator when competing with other gestures', (WidgetTester tester) async {
     final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
       '/': (BuildContext context) => const FirstWidget(),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90223

This PR adds dismiss callback to onTapCancel modal barrier.

### Native

https://user-images.githubusercontent.com/48603081/153480378-b26ef604-555c-485e-97c4-389b7b1f20dd.mp4

### Flutter (with this PR)




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
