### PR TITLE
Override OS and Xcode version for plugin_lint_mac

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2752,6 +2752,8 @@ targets:
       tags: >
         ["devicelab","hostonly"]
       task_name: plugin_lint_mac
+      os: Mac-12  # Override OS and Xcode for https://github.com/flutter/flutter/issues/97303
+      xcode: 13a233
     scheduler: luci
     runIf:
       - dev/**


### PR DESCRIPTION
Work around https://github.com/flutter/flutter/issues/97303 by trying the newer version of Xcode and macOS.