### PR TITLE
Fix a Tabs crash when change the TabControllers

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1365,6 +1365,7 @@ class TabBarView extends StatefulWidget {
 class _TabBarViewState extends State<TabBarView> {
   TabController? _controller;
   late PageController _pageController;
+  Key _pageViewKey = UniqueKey();
   late List<Widget> _children;
   late List<Widget> _childrenWithKey;
   int? _currentIndex;
@@ -1420,7 +1421,8 @@ class _TabBarViewState extends State<TabBarView> {
     if (widget.controller != oldWidget.controller) {
       _updateTabController();
       _currentIndex = _controller!.index;
-      _pageController.jumpToPage(_currentIndex!);
+      _pageController = PageController(initialPage: _currentIndex!);
+      _pageViewKey = UniqueKey();
     }
     if (widget.children != oldWidget.children && _warpUnderwayCount == 0)
       _updateChildren();
@@ -1541,6 +1543,7 @@ class _TabBarViewState extends State<TabBarView> {
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: PageView(
+        key: _pageViewKey,
         dragStartBehavior: widget.dragStartBehavior,
         controller: _pageController,
         physics: widget.physics == null

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1365,7 +1365,6 @@ class TabBarView extends StatefulWidget {
 class _TabBarViewState extends State<TabBarView> {
   TabController? _controller;
   late PageController _pageController;
-  Key _pageViewKey = UniqueKey();
   late List<Widget> _children;
   late List<Widget> _childrenWithKey;
   int? _currentIndex;
@@ -1421,8 +1420,9 @@ class _TabBarViewState extends State<TabBarView> {
     if (widget.controller != oldWidget.controller) {
       _updateTabController();
       _currentIndex = _controller!.index;
-      _pageController = PageController(initialPage: _currentIndex!);
-      _pageViewKey = UniqueKey();
+      _warpUnderwayCount++;
+      _pageController.jumpToPage(_currentIndex!);
+      _warpUnderwayCount--;
     }
     if (widget.children != oldWidget.children && _warpUnderwayCount == 0)
       _updateChildren();
@@ -1543,7 +1543,6 @@ class _TabBarViewState extends State<TabBarView> {
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
       child: PageView(
-        key: _pageViewKey,
         dragStartBehavior: widget.dragStartBehavior,
         controller: _pageController,
         physics: widget.physics == null

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1420,9 +1420,9 @@ class _TabBarViewState extends State<TabBarView> {
     if (widget.controller != oldWidget.controller) {
       _updateTabController();
       _currentIndex = _controller!.index;
-      _warpUnderwayCount++;
+      _warpUnderwayCount += 1;
       _pageController.jumpToPage(_currentIndex!);
-      _warpUnderwayCount--;
+      _warpUnderwayCount -= 1;
     }
     if (widget.children != oldWidget.children && _warpUnderwayCount == 0)
       _updateChildren();

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -4253,7 +4253,7 @@ void main() {
   testWidgets('Change the TabController should make both TabBar and TabBarView return to the initial index.', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/93237
 
-    Widget buildFrame(TabController controller, bool showLast) {
+    Widget buildFrame(TabController controller, {required bool showLast}) {
       return boilerplate(
         child: Column(
           children: <Widget>[
@@ -4295,7 +4295,7 @@ void main() {
       length: 3,
     );
 
-    await tester.pumpWidget(buildFrame(controller1, true));
+    await tester.pumpWidget(buildFrame(controller1, showLast: true));
     final PageView pageView = tester.widget(find.byType(PageView));
     final PageController pageController = pageView.controller;
     await tester.tap(find.text('three'));
@@ -4304,13 +4304,13 @@ void main() {
     expect(pageController.page, 2);
 
     // Change TabController from 3 items to 2.
-    await tester.pumpWidget(buildFrame(controller2, false));
+    await tester.pumpWidget(buildFrame(controller2, showLast: false));
     await tester.pumpAndSettle();
     expect(controller2.index, 0);
     expect(pageController.page, 0);
 
     // Change TabController from 2 items to 3.
-    await tester.pumpWidget(buildFrame(controller3, true));
+    await tester.pumpWidget(buildFrame(controller3, showLast: true));
     await tester.pumpAndSettle();
     expect(controller3.index, 0);
     expect(pageController.page, 0);
@@ -4325,7 +4325,7 @@ void main() {
   testWidgets('Do not crash when the new TabController.index is longer than the old length.', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/97441
 
-    Widget buildFrame(TabController controller, bool showLast) {
+    Widget buildFrame(TabController controller, {required bool showLast}) {
       return boilerplate(
         child: Column(
           children: <Widget>[
@@ -4362,7 +4362,7 @@ void main() {
       length: 2,
     );
 
-    await tester.pumpWidget(buildFrame(controller1, true));
+    await tester.pumpWidget(buildFrame(controller1, showLast: true));
     PageView pageView = tester.widget(find.byType(PageView));
     PageController pageController = pageView.controller;
     await tester.tap(find.text('three'));
@@ -4371,7 +4371,7 @@ void main() {
     expect(pageController.page, 2);
 
     // Change TabController from controller1 to controller2.
-    await tester.pumpWidget(buildFrame(controller2, false));
+    await tester.pumpWidget(buildFrame(controller2, showLast: false));
     await tester.pumpAndSettle();
     pageView = tester.widget(find.byType(PageView));
     pageController = pageView.controller;
@@ -4379,7 +4379,7 @@ void main() {
     expect(pageController.page, 0);
 
     // Change TabController back to 'controller1' whose index is 2.
-    await tester.pumpWidget(buildFrame(controller1, true));
+    await tester.pumpWidget(buildFrame(controller1, showLast: true));
     await tester.pumpAndSettle();
     pageView = tester.widget(find.byType(PageView));
     pageController = pageView.controller;

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -4296,8 +4296,8 @@ void main() {
     );
 
     await tester.pumpWidget(buildFrame(controller1, true));
-    PageView pageView = tester.widget(find.byType(PageView));
-    PageController pageController = pageView.controller;
+    final PageView pageView = tester.widget(find.byType(PageView));
+    final PageController pageController = pageView.controller;
     await tester.tap(find.text('three'));
     await tester.pumpAndSettle();
     expect(controller1.index, 2);
@@ -4306,16 +4306,12 @@ void main() {
     // Change TabController from 3 items to 2.
     await tester.pumpWidget(buildFrame(controller2, false));
     await tester.pumpAndSettle();
-    pageView = tester.widget(find.byType(PageView));
-    pageController = pageView.controller;
     expect(controller2.index, 0);
     expect(pageController.page, 0);
 
     // Change TabController from 2 items to 3.
     await tester.pumpWidget(buildFrame(controller3, true));
     await tester.pumpAndSettle();
-    pageView = tester.widget(find.byType(PageView));
-    pageController = pageView.controller;
     expect(controller3.index, 0);
     expect(pageController.page, 0);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/97441

(#94339) If the `TabController` changed, we will call `_pageController.jumpToPage` to change the view position.
But if the old pageView's metrics are small than the new controller index, it will abnormal.

### My solution
If the controller changes, inflate a new `PageView` element with the initial index.

