### PR TITLE
Add `clipBehavior` to `Snackbar`

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -204,7 +204,7 @@ class SnackBar extends StatefulWidget {
     this.animation,
     this.onVisible,
     this.dismissDirection = DismissDirection.down,
-    this.clipBehavior = Clip.none,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(elevation == null || elevation >= 0.0),
        assert(content != null),
        assert(
@@ -340,7 +340,7 @@ class SnackBar extends StatefulWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// Defaults to [Clip.hardEdge], and must not be null.
   final Clip clipBehavior;
 
   // API for ScaffoldMessengerState.showSnackBar():

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -204,6 +204,7 @@ class SnackBar extends StatefulWidget {
     this.animation,
     this.onVisible,
     this.dismissDirection = DismissDirection.down,
+    this.clipBehavior = Clip.none,
   }) : assert(elevation == null || elevation >= 0.0),
        assert(content != null),
        assert(
@@ -211,6 +212,7 @@ class SnackBar extends StatefulWidget {
          'Width and margin can not be used together',
        ),
        assert(duration != null),
+       assert(clipBehavior != null),
        super(key: key);
 
   /// The primary content of the snack bar.
@@ -336,6 +338,11 @@ class SnackBar extends StatefulWidget {
   /// Cannot be null, defaults to [DismissDirection.down].
   final DismissDirection dismissDirection;
 
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  final Clip clipBehavior;
+
   // API for ScaffoldMessengerState.showSnackBar():
 
   /// Creates an animation controller useful for driving a snack bar's entrance and exit animation.
@@ -367,6 +374,7 @@ class SnackBar extends StatefulWidget {
       animation: newAnimation,
       onVisible: onVisible,
       dismissDirection: dismissDirection,
+      clipBehavior: clipBehavior,
     );
   }
 
@@ -612,7 +620,10 @@ class _SnackBarState extends State<SnackBar> {
 
     return Hero(
       tag: '<SnackBar Hero tag - ${widget.content}>',
-      child: snackBarTransition,
+      child: ClipRect(
+        clipBehavior: widget.clipBehavior,
+        child: snackBarTransition,
+      ),
     );
   }
 }

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2561,7 +2561,7 @@ void main() {
     );
   });
 
-  testWidgets('Setting clipBehavior clips the Snackbar with ClipRect', (WidgetTester tester) async {
+  testWidgets('Snackbar by default clips BackdropFilter', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/98205
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -2574,7 +2574,6 @@ void main() {
       find.byType(ScaffoldMessenger),
     );
     scaffoldMessengerState.showSnackBar(SnackBar(
-      clipBehavior: Clip.hardEdge,
       backgroundColor: Colors.transparent,
       content: BackdropFilter(
         filter: ImageFilter.blur(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -6,6 +6,8 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart' show FlutterExceptionHandler;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -2557,6 +2559,39 @@ void main() {
       'Width can only be used with floating behavior. SnackBarBehavior.fixed '
       'was set by default.',
     );
+  });
+
+  testWidgets('Setting clipBehavior clips the Snackbar with ClipRect', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/98205
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: const Scaffold(),
+        floatingActionButton: FloatingActionButton(onPressed: () {}),
+      ),
+    ));
+
+    final ScaffoldMessengerState scaffoldMessengerState = tester.state<ScaffoldMessengerState>(
+      find.byType(ScaffoldMessenger),
+    );
+    scaffoldMessengerState.showSnackBar(SnackBar(
+      clipBehavior: Clip.hardEdge,
+      backgroundColor: Colors.transparent,
+      content: BackdropFilter(
+        filter: ImageFilter.blur(
+          sigmaX: 20.0,
+          sigmaY: 20.0,
+        ),
+        child: const Text('I am a snack bar.'),
+      ),
+      duration: const Duration(seconds: 2),
+      action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+      behavior: SnackBarBehavior.fixed,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('I am a snack bar.'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('snack_bar.goldenTest.backdropFilter.png'));
   });
 }
 


### PR DESCRIPTION
regression: https://github.com/flutter/flutter/pull/94811
context: https://github.com/flutter/flutter/pull/94811#pullrequestreview-825661456
fixes: https://github.com/flutter/flutter/issues/98205

We didn't know why `ClipRect` was present as it wasn't failing any test but looks like it does affect `BackdropFilter` when applied to Snackbar's content

For regular widgets, `BackdropFilter` could use some clipping thus ClipRect is usually applied, see this https://github.com/flutter/flutter/issues/16614#issuecomment-680897806
For Snackbar, it is not possible since you can only provide Snackbar to `showSnackbar` function and [this issue shows](https://github.com/flutter/flutter/issues/98205) when trying to apply `BackdropFilter` Snackbar's Content to achieve the desired results, blur area is not clipped.

So this PR introduces clip behavior, which when not set to `Clip.none`, applies `ClipRect` to the Snackbar itself. This is same as `CupertinoFormSection` clipBehavior [code](https://github.com/flutter/flutter/blob/d6d3283c8d7afe31dd0b613ac9b3e1f8d80d16b9/packages/flutter/lib/src/cupertino/form_section.dart#L294-L303). 

This way clipping is achievable when needed without breaking [previous issue](https://github.com/flutter/flutter/issues/94701) or [new issue](https://github.com/flutter/flutter/pull/94811).


<details> 
<summary>minimal code sample</summary> 

```dart
import 'dart:ui';

import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key, this.dark = false}) : super(key: key);

  final bool dark;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      title: 'Material App',
      theme: dark ? ThemeData.dark() : ThemeData.light(),
      home: const SnackarSample(),
    );
  }
}

class SnackarSample extends StatelessWidget {
  const SnackarSample({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Snackar Sample'),
      ),
      body: Center(
        child: OutlinedButton(
          onPressed: () {
            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
              clipBehavior: Clip.hardEdge,
              backgroundColor: Colors.transparent,
              content: BackdropFilter(
                filter: ImageFilter.blur(
                  sigmaX: 20.0,
                  sigmaY: 20.0,
                ),
                child: const Text('I am a snack bar.'),
              ),
              duration: const Duration(seconds: 2),
              action: SnackBarAction(label: 'ACTION', onPressed: () {}),
              behavior: SnackBarBehavior.fixed,
            ));
          },
          child: const Text('Show Snackbar'),
        ),
      ),
      floatingActionButton: FloatingActionButton(onPressed: () {}),
    );
  }
}
``` 
	
</details>

<details> 
<summary>Preview</summary> 

![Screenshot 2022-02-11 at 14 10 00](https://user-images.githubusercontent.com/48603081/153595398-8b098be9-3894-43f9-92c5-eb7d072a099f.png)

</details>

<details> 
<summary>Golden test</summary> 

![snack_bar goldenTest backdropFilter](https://user-images.githubusercontent.com/48603081/153595516-ee17fb94-1d65-4cca-b12f-dc18949b2f50.png)

</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
