### PR TITLE
Revert "Update Xcode version to 13a233"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -63,10 +63,10 @@ platform_properties:
         ]
       dependencies: >-
         []
-      os: Mac-12
+      os: Mac-10.15
       device_type: none
       mac_model: Macmini8,1
-      xcode: 13a233
+      xcode: 12c33
   mac_android:
     properties:
       caches: >-
@@ -85,7 +85,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:84"},
           {"dependency": "open_jdk"}
         ]
-      os: Mac-12
+      os: Mac-12.0
       device_os: N
   mac_ios:
     properties:
@@ -106,7 +106,7 @@ platform_properties:
           {"dependency": "gems"},
           {"dependency": "ios_signing"}
         ]
-      os: Mac-12
+      os: Mac-12.0
       device_os: iOS-15.1
       xcode: 13a233
   windows:


### PR DESCRIPTION
Reverts flutter/flutter#98144

[Mac web_tool_tests](https://ci.chromium.org/p/flutter/builders/try/Mac%20web_tool_tests) is failing repeatedly after this commit. That test also failed in presubmit on the same PR: https://ci.chromium.org/ui/p/flutter/builders/try/Mac%20web_tool_tests/12308/overview.