### PR TITLE
[flutter_tools] fix type error in flutter update-packages --jobs=n

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -498,7 +498,8 @@ class UpdatePackagesCommand extends FlutterCommand {
       'Running "flutter pub get" in affected packages...',
     );
     try {
-      final TaskQueue<void> queue = TaskQueue<void>(maxJobs: intArg('jobs'));
+      final int/*?*/ maxJobs = int.tryParse(stringArg('jobs'));
+      final TaskQueue<void> queue = TaskQueue<void>(maxJobs: maxJobs);
       for (final Directory dir in packages) {
         unawaited(queue.add(() async {
           final Stopwatch stopwatch = Stopwatch();

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -498,7 +498,8 @@ class UpdatePackagesCommand extends FlutterCommand {
       'Running "flutter pub get" in affected packages...',
     );
     try {
-      final int/*?*/ maxJobs = int.tryParse(stringArg('jobs'));
+      // int.tryParse will convert an empty string to null
+      final int/*?*/ maxJobs = int.tryParse(stringArg('jobs') ?? '');
       final TaskQueue<void> queue = TaskQueue<void>(maxJobs: maxJobs);
       for (final Directory dir in packages) {
         unawaited(queue.add(() async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -148,6 +148,30 @@ void main() {
         processManager: FakeProcessManager.any(),
       ),
     });
+
+    testUsingContext('force updates packages --jobs=1', () async {
+      final UpdatePackagesCommand command = UpdatePackagesCommand();
+      await createTestCommandRunner(command).run(<String>[
+        'update-packages',
+        '--force-upgrade',
+        '--jobs=1',
+      ]);
+      expect(pub.pubGetDirectories, equals(<String>[
+        '/.tmp_rand0/flutter_update_packages.rand0',
+        '/flutter/examples',
+        '/flutter/packages/flutter',
+      ]));
+      expect(pub.pubBatchDirectories, equals(<String>[
+        '/.tmp_rand0/flutter_update_packages.rand0',
+      ]));
+    }, overrides: <Type, Generator>{
+      Pub: () => pub,
+      FileSystem: () => fileSystem,
+      ProcessManager: () => FakeProcessManager.any(),
+      Cache: () => Cache.test(
+        processManager: FakeProcessManager.any(),
+      ),
+    });
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98284

The original code was:

```
      final TaskQueue<void> queue = TaskQueue<void>(maxJobs: intArg('jobs'));
```

but the `intArg()` function casts a dynamic -> int?, but jobs is actually a String?

I started to do a null-safety migration, but I think I will land that in a different PR in case it needs to be reverted.