### PR TITLE
[flutter_tools] Add timeout duration to error and handle exceptions for HttpHostValidator.

### DIFF
--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -32,7 +32,6 @@ List<String> androidRequiredHttpHosts(Platform platform) {
   ];
 }
 
-
 // Validator that checks all provided hosts are reachable and responsive
 class HttpHostValidator extends DoctorValidator {
   HttpHostValidator({

--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -37,7 +37,7 @@ class HttpHostValidator extends DoctorValidator {
   HttpHostValidator({
     required Platform platform,
     required FeatureFlags featureFlags,
-    required HttpClient httpClient
+    required HttpClient httpClient,
   }) : _platform = platform,
       _featureFlags = featureFlags,
       _httpClient = httpClient,
@@ -80,8 +80,8 @@ class HttpHostValidator extends DoctorValidator {
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
-
-    final List<_HostValidationResult> availabilityResults = await Future.wait(_requiredHosts.map(_checkHostAvailability));
+    final Iterable<Future<_HostValidationResult>> availabilityResultFutures = _requiredHosts.map(_checkHostAvailability);
+    final List<_HostValidationResult> availabilityResults = await Future.wait(availabilityResultFutures);
 
     if (availabilityResults.every((_HostValidationResult result) => result.available)) {
       return ValidationResult(

--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -35,22 +35,21 @@ List<String> androidRequiredHttpHosts(Platform platform) {
 
 // Validator that checks all provided hosts are reachable and responsive
 class HttpHostValidator extends DoctorValidator {
-  HttpHostValidator(
-      {required Platform platform,
-        required FeatureFlags featureFlags,
-        required HttpClient httpClient})
-      : _platform = platform,
-        _featureFlags = featureFlags,
-        _httpClient = httpClient,
-        super('HTTP Host Availability');
+  HttpHostValidator({
+    required Platform platform,
+    required FeatureFlags featureFlags,
+    required HttpClient httpClient
+  }) : _platform = platform,
+      _featureFlags = featureFlags,
+      _httpClient = httpClient,
+      super('HTTP Host Availability');
 
   final Platform _platform;
   final FeatureFlags _featureFlags;
   final HttpClient _httpClient;
 
   @override
-  String get slowWarning =>
-      'HTTP Host availability check is taking a long time...';
+  String get slowWarning => 'HTTP Host availability check is taking a long time...';
 
   List<String> get _requiredHosts => <String>[
     if (_featureFlags.isMacOSEnabled) ...macOSRequiredHttpHosts,
@@ -59,71 +58,60 @@ class HttpHostValidator extends DoctorValidator {
     _platform.environment[kEnvCloudUrl] ?? kgCloudHttpHost,
   ];
 
-  /// Make a head request to the HTTP host. HTTP Host is available if no exception happened
+  /// Make a head request to the HTTP host for checking availability
   Future<_HostValidationResult> _checkHostAvailability(String host) async {
+    late final int timeout;
     try {
-      final int timeout =
-      int.parse(_platform.environment[kDoctorHostTimeout] ?? '10');
+      timeout = int.parse(_platform.environment[kDoctorHostTimeout] ?? '10');
       final HttpClientRequest req = await _httpClient.headUrl(Uri.parse(host));
       await req.close().timeout(Duration(seconds: timeout));
-      // HTTP Host is available if no exception happened
+      // HTTP host is available if no exception happened
       return _HostValidationResult.success(host);
     } on TimeoutException {
-      return _HostValidationResult.fail(
-          host, 'Failed to connect to $host in seconds');
+      return _HostValidationResult.fail(host, 'Failed to connect to host in $timeout second${timeout == 1 ? '': 's'}');
     } on SocketException catch (e) {
-      return _HostValidationResult.fail(
-          host, 'An error occurred while checking the HTTP host: ${e.message}');
+      return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: ${e.message}');
     } on HttpException catch (e) {
-      return _HostValidationResult.fail(host,
-          'An error occurred while checking the HTTP host: ${e.toString()}');
+      return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: ${e.message}');
     } on OSError catch (e) {
-      return _HostValidationResult.fail(
-          host, 'An error occurred while checking the HTTP host: ${e.message}');
+      return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: ${e.message}');
     }
   }
 
   @override
   Future<ValidationResult> validate() async {
     final List<ValidationMessage> messages = <ValidationMessage>[];
-    final Iterable<Future<_HostValidationResult>> availabilityResultFutures =
-    _requiredHosts.map(_checkHostAvailability);
 
-    final List<_HostValidationResult> availabilityResults =
-    (await Future.wait(availabilityResultFutures)).toList();
+    final List<_HostValidationResult> availabilityResults = await Future.wait(_requiredHosts.map(_checkHostAvailability));
 
-    if (availabilityResults
-        .every((_HostValidationResult result) => result.available)) {
+    if (availabilityResults.every((_HostValidationResult result) => result.available)) {
       return ValidationResult(
           ValidationType.installed,
-          messages
-            ..add(const ValidationMessage(
-                'All required HTTP hosts are available')));
+          messages..add(const ValidationMessage('All required HTTP hosts are available')),
+      );
     }
 
-    availabilityResults
-        .removeWhere((_HostValidationResult result) => result.available);
+    availabilityResults.removeWhere((_HostValidationResult result) => result.available);
 
     for (final _HostValidationResult result in availabilityResults) {
-      messages.add(ValidationMessage.error(
-          'HTTP host ${result.host} is not reachable. Reason: ${result.failResultInfo}'));
+      messages.add(ValidationMessage.error('HTTP host ${result.host} is not reachable. Reason: ${result.failResultInfo}'));
     }
 
     return ValidationResult(
-        availabilityResults.length == _requiredHosts.length
-            ? ValidationType.notAvailable
-            : ValidationType.partial,
-        messages);
+      availabilityResults.length == _requiredHosts.length
+        ? ValidationType.notAvailable
+        : ValidationType.partial,
+      messages,
+    );
   }
 }
 
 class _HostValidationResult {
   _HostValidationResult.success(this.host)
-      : failResultInfo = '',
-        available = true;
+    : failResultInfo = '',
+      available = true;
 
-  _HostValidationResult.fail(this.host, this.failResultInfo)
-      : available = false;
+  _HostValidationResult.fail(this.host, this.failResultInfo) : available = false;
 
   final String failResultInfo;
   final String host;

--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -84,9 +84,8 @@ class HttpHostValidator extends DoctorValidator {
           return _HostValidationResult.fail(host, 'The value of $kEnvPubHostedUrl(${_platform.environment[kEnvPubHostedUrl]}) could not be parsed as a valid url');
         }
         return _HostValidationResult.fail(host, 'The value of $kEnvCloudUrl(${_platform.environment[kEnvCloudUrl]}) could not be parsed as a valid url');
-      } else {
-        return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: ${e.message}');
       }
+      return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: ${e.message}');
     } on ArgumentError catch (e) {
       final String exceptionMessage = e.message.toString();
       if (exceptionMessage.contains('No host specified')) {
@@ -96,9 +95,8 @@ class HttpHostValidator extends DoctorValidator {
           return _HostValidationResult.fail(host, 'The value of $kEnvPubHostedUrl(${_platform.environment[kEnvPubHostedUrl]}) is not a valid host');
         }
         return _HostValidationResult.fail(host, 'The value of $kEnvCloudUrl(${_platform.environment[kEnvCloudUrl]}) is not a valid host');
-      } else {
-        return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: $exceptionMessage');
       }
+      return _HostValidationResult.fail(host, 'An error occurred while checking the HTTP host: $exceptionMessage');
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
@@ -69,30 +69,7 @@ void main() {
         }
       });
 
-      testWithoutContext('one http hosts are not available', () async {
-        // Run the check for all operating systems one by one
-        for(final String os in osTested) {
-          final Platform platform = FakePlatform(operatingSystem: os);
-          final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: platform,
-            featureFlags: TestFeatureFlags(),
-            httpClient: FakeHttpClient.list(<FakeRequest>[
-              FakeRequest(Uri.parse(kgCloudHttpHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts(platform)[0]), method: HttpMethod.head),
-              FakeRequest(Uri.parse(kPubDevHttpHost), method: HttpMethod.head),
-              FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
-            ]),
-          );
-
-          // Run the validation check and get the results
-          final ValidationResult result = await httpHostValidator.validate();
-
-          // Check for a ValidationType.partial result
-          expect(result.type, equals(ValidationType.partial));
-        }
-      });
-
-      testWithoutContext('one http hosts are not available', () async {
+      testWithoutContext('one http host is not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
           final Platform platform = FakePlatform(operatingSystem: os);
@@ -158,29 +135,7 @@ void main() {
         }
       });
 
-      testWithoutContext('one http hosts are not available', () async {
-        // Run the check for all operating systems one by one
-        for(final String os in osTested) {
-          final Platform platform = FakePlatform(operatingSystem: os, environment: kTestEnvironment);
-          final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: platform,
-            featureFlags: TestFeatureFlags(),
-            httpClient: FakeHttpClient.list(<FakeRequest>[
-              FakeRequest(Uri.parse(kTestEnvGCloudHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(kTestEnvPubHost), method: HttpMethod.head),
-              FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
-            ]),
-          );
-
-          // Run the validation check and get the results
-          final ValidationResult result = await httpHostValidator.validate();
-
-          // Check for a ValidationType.partial result
-          expect(result.type, equals(ValidationType.partial));
-        }
-      });
-
-      testWithoutContext('one http hosts are not available', () async {
+      testWithoutContext('one http host is not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
           final Platform platform = FakePlatform(operatingSystem: os, environment: kTestEnvironment);

--- a/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_tools/src/base/platform.dart';
@@ -63,7 +64,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.notAvailable result
           expect(result.type, equals(ValidationType.notAvailable));
         }
       });
@@ -86,7 +87,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.partial result
           expect(result.type, equals(ValidationType.partial));
         }
       });
@@ -109,7 +110,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.partial result
           expect(result.type, equals(ValidationType.partial));
         }
       });
@@ -152,7 +153,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.notAvailable result
           expect(result.type, equals(ValidationType.notAvailable));
         }
       });
@@ -174,7 +175,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.partial result
           expect(result.type, equals(ValidationType.partial));
         }
       });
@@ -196,7 +197,7 @@ void main() {
           // Run the validation check and get the results
           final ValidationResult result = await httpHostValidator.validate();
 
-          // Check for a ValidationType.installed result
+          // Check for a ValidationType.partial result
           expect(result.type, equals(ValidationType.partial));
         }
       });
@@ -266,5 +267,25 @@ void main() {
         }
       });
     });
+  });
+
+  testWithoutContext('Http host validator timeout message includes timeout duration.', () async {
+    final HttpHostValidator httpHostValidator = HttpHostValidator(
+      platform: FakePlatform(environment: kTestEnvironment),
+      featureFlags: TestFeatureFlags(isAndroidEnabled: false),
+      httpClient: FakeHttpClient.list(<FakeRequest>[
+        FakeRequest(Uri.parse(kTestEnvPubHost), method: HttpMethod.head, responseError: TimeoutException('Timeout error')),
+        FakeRequest(Uri.parse(kTestEnvGCloudHost), method: HttpMethod.head),
+      ]),
+    );
+
+    // Run the validation check and get the results
+    final ValidationResult result = await httpHostValidator.validate();
+
+    // Timeout duration for tests is set to 1 second
+    expect(
+      result.messages,
+      contains(const ValidationMessage.error('HTTP host $kTestEnvPubHost is not reachable. Reason: Failed to connect to host in 1 second')),
+    );
   });
 }


### PR DESCRIPTION
Includes the timeout duration, handles exceptions for invalid `FLUTTER_DOCTOR_HOST_TIMEOUT`, `PUB_HOSTED_URL` or `FLUTTER_STORAGE_BASE_URL` environment variables of `HttpHostValidator`.

Also includes some code hand-formatting/cleanup for readability.

Adds tests to make sure the timeout is being displayed and exceptions are handled accordingly.

Fixes #98286.
Fixes #98328.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
