### PR TITLE
[flutter_tools] do not validate maven upstream if cloud storage override provided

### DIFF
--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -23,6 +23,16 @@ const List<String> macOSRequiredHttpHosts = <String>[
   'https://cocoapods.org/',
 ];
 
+/// Android specific required HTTP hosts.
+List<String> androidRequiredHttpHosts(Platform platform) {
+  return <String>[
+    // If kEnvCloudUrl is set, it will be used as the maven host
+    if (!platform.environment.containsKey(kEnvCloudUrl))
+      'https://maven.google.com/',
+  ];
+}
+
+
 // Validator that checks all provided hosts are reachable and responsive
 class HttpHostValidator extends DoctorValidator {
   HttpHostValidator(
@@ -38,21 +48,13 @@ class HttpHostValidator extends DoctorValidator {
   final FeatureFlags _featureFlags;
   final HttpClient _httpClient;
 
-  /// Android specific required HTTP hosts.
-  late final List<String> androidRequiredHttpHosts = <String>[
-    // If kEnvCloudUrl is set, it will be used as the maven host
-    if (!_platform.environment.containsKey(kEnvCloudUrl))
-      'https://maven.google.com/',
-  ];
-
-
   @override
   String get slowWarning =>
       'HTTP Host availability check is taking a long time...';
 
   List<String> get _requiredHosts => <String>[
     if (_featureFlags.isMacOSEnabled) ...macOSRequiredHttpHosts,
-    if (_featureFlags.isAndroidEnabled) ...androidRequiredHttpHosts,
+    if (_featureFlags.isAndroidEnabled) ...androidRequiredHttpHosts(_platform),
     _platform.environment[kEnvPubHostedUrl] ?? kPubDevHttpHost,
     _platform.environment[kEnvCloudUrl] ?? kgCloudHttpHost,
   ];

--- a/packages/flutter_tools/lib/src/http_host_validator.dart
+++ b/packages/flutter_tools/lib/src/http_host_validator.dart
@@ -18,11 +18,6 @@ const String kDoctorHostTimeout = 'FLUTTER_DOCTOR_HOST_TIMEOUT';
 const String kPubDevHttpHost = 'https://pub.dev/';
 const String kgCloudHttpHost = 'https://cloud.google.com/';
 
-/// Android specific required HTTP hosts.
-const List<String> androidRequiredHttpHosts = <String>[
-  'https://maven.google.com/',
-];
-
 /// MacOS specific required HTTP hosts.
 const List<String> macOSRequiredHttpHosts = <String>[
   'https://cocoapods.org/',
@@ -42,6 +37,14 @@ class HttpHostValidator extends DoctorValidator {
   final Platform _platform;
   final FeatureFlags _featureFlags;
   final HttpClient _httpClient;
+
+  /// Android specific required HTTP hosts.
+  late final List<String> androidRequiredHttpHosts = <String>[
+    // If kEnvCloudUrl is set, it will be used as the maven host
+    if (!_platform.environment.containsKey(kEnvCloudUrl))
+      'https://maven.google.com/',
+  ];
+
 
   @override
   String get slowWarning =>

--- a/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/http_host_validator_test.dart
@@ -48,12 +48,13 @@ void main() {
       testWithoutContext('all http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kgCloudHttpHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
+              FakeRequest(Uri.parse(androidRequiredHttpHosts(platform)[0]), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
               FakeRequest(Uri.parse(kPubDevHttpHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
             ]),
@@ -70,12 +71,13 @@ void main() {
       testWithoutContext('one http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kgCloudHttpHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head),
+              FakeRequest(Uri.parse(androidRequiredHttpHosts(platform)[0]), method: HttpMethod.head),
               FakeRequest(Uri.parse(kPubDevHttpHost), method: HttpMethod.head),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
             ]),
@@ -92,12 +94,13 @@ void main() {
       testWithoutContext('one http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kgCloudHttpHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head),
+              FakeRequest(Uri.parse(androidRequiredHttpHosts(platform)[0]), method: HttpMethod.head),
               FakeRequest(Uri.parse(kPubDevHttpHost), method: HttpMethod.head),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
             ]),
@@ -135,12 +138,12 @@ void main() {
       testWithoutContext('all http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os, environment: kTestEnvironment);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os, environment: kTestEnvironment),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kTestEnvGCloudHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
               FakeRequest(Uri.parse(kTestEnvPubHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
             ]),
@@ -157,12 +160,12 @@ void main() {
       testWithoutContext('one http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os, environment: kTestEnvironment);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os, environment: kTestEnvironment),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kTestEnvGCloudHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head),
               FakeRequest(Uri.parse(kTestEnvPubHost), method: HttpMethod.head),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
             ]),
@@ -179,12 +182,12 @@ void main() {
       testWithoutContext('one http hosts are not available', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os, environment: kTestEnvironment);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os, environment: kTestEnvironment),
+            platform: platform,
             featureFlags: TestFeatureFlags(),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kTestEnvGCloudHost), method: HttpMethod.head, responseError: const OSError('Name or service not known', -2)),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head),
               FakeRequest(Uri.parse(kTestEnvPubHost), method: HttpMethod.head),
               FakeRequest(Uri.parse(macOSRequiredHttpHosts[0]), method: HttpMethod.head),
             ]),
@@ -224,13 +227,14 @@ void main() {
       testWithoutContext('all http hosts are available - iOS disabled', () async {
         // Run the check for all operating systems one by one
         for(final String os in osTested) {
+          final Platform platform = FakePlatform(operatingSystem: os);
           final HttpHostValidator httpHostValidator = HttpHostValidator(
-            platform: FakePlatform(operatingSystem: os),
+            platform: platform,
             featureFlags: TestFeatureFlags(isIOSEnabled: false),
             httpClient: FakeHttpClient.list(<FakeRequest>[
               FakeRequest(Uri.parse(kgCloudHttpHost), method: HttpMethod.head),
               FakeRequest(Uri.parse(kPubDevHttpHost), method: HttpMethod.head),
-              FakeRequest(Uri.parse(androidRequiredHttpHosts[0]), method: HttpMethod.head),
+              FakeRequest(Uri.parse(androidRequiredHttpHosts(platform)[0]), method: HttpMethod.head),
             ]),
           );
 


### PR DESCRIPTION
If a user provides the `FLUTTER_STORAGE_BASE_URL` env variable, this will be used as the maven host URL. However, the flutter http host doctor validator would still try to validate the upstream maven URL.

This PR updates the validator to only check the upstream maven host if `FLUTTER_STORAGE_BASE_URL` is NOT provided.

Fixes https://github.com/flutter/flutter/issues/98170