### PR TITLE
Dump app on keyboard_textfield_test timeout

### DIFF
--- a/dev/integration_tests/ui/lib/keyboard_textfield.dart
+++ b/dev/integration_tests/ui/lib/keyboard_textfield.dart
@@ -62,10 +62,11 @@ class _MyHomePageState extends State<MyHomePage> {
           Text('$offset',
             key: const ValueKey<String>(keys.kOffsetText),
           ),
-          if (isSoftKeyboardVisible) const Text(
-            'keyboard visible',
-            key: ValueKey<String>(keys.kKeyboardVisibleView),
+          Text(
+            isSoftKeyboardVisible ? 'keyboard visible' : 'keyboard hidden',
+            key: const ValueKey<String>(keys.kKeyboardVisibleView),
           ),
+          const ElevatedButton(onPressed: debugDumpApp, child: Text('dump app')),
           Expanded(
             child: ListView(
               key: const ValueKey<String>(keys.kListView),

--- a/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
+++ b/dev/integration_tests/ui/test_driver/keyboard_textfield_test.dart
@@ -40,8 +40,23 @@ void main() {
       // Bring up keyboard
       await driver.tap(textFieldFinder);
 
+      const int keyboardTimeout = 3;
+      bool keyboardVisible = false;
+      for (int i = 0; i < keyboardTimeout; i++) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+        final String keyboardVisibilityText = await driver.getText(keyboardVisibilityIndicatorFinder);
+        keyboardVisible = keyboardVisibilityText == 'keyboard visible';
+        if (keyboardVisible) {
+          break;
+        }
+      }
+
+      if (!keyboardVisible) {
+        await driver.tap(find.text('dump app'));
+      }
+
       // TODO(jmagman): Remove timeout once flake has been diagnosed. https://github.com/flutter/flutter/issues/96787
-      await driver.waitFor(keyboardVisibilityIndicatorFinder, timeout: const Duration(seconds: 5));
+      expect(keyboardVisible, isTrue);
 
       // Ensure that TextField is visible again
       await driver.waitFor(textFieldFinder);


### PR DESCRIPTION
Help investigate https://github.com/flutter/flutter/issues/96787

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
