### PR TITLE
Improve container widget

### DIFF
--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -391,8 +391,9 @@ class Container extends StatelessWidget {
       );
     }
 
-    else if (alignment != null)
+    else if (alignment != null) {
       current = Align(alignment: alignment!, child: current);
+    }
 
     final EdgeInsetsGeometry? effectivePadding = _paddingIncludingDecoration;
     if (effectivePadding != null)

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -389,7 +389,9 @@ class Container extends StatelessWidget {
         maxHeight: 0.0,
         child: ConstrainedBox(constraints: const BoxConstraints.expand()),
       );
-    } else if (alignment != null) {
+    }
+
+    else if (alignment != null) {
       current = Align(alignment: alignment!, child: current);
     }
 

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -390,7 +390,7 @@ class Container extends StatelessWidget {
         child: ConstrainedBox(constraints: const BoxConstraints.expand()),
       );
     } else if (alignment != null) {
-      current = Align(alignment: alignment, child: current);
+      current = Align(alignment: alignment!, child: current);
     }
 
     final EdgeInsetsGeometry? effectivePadding = _paddingIncludingDecoration;

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -391,7 +391,7 @@ class Container extends StatelessWidget {
       );
     }
 
-    if (alignment != null)
+    else if (alignment != null)
       current = Align(alignment: alignment!, child: current);
 
     final EdgeInsetsGeometry? effectivePadding = _paddingIncludingDecoration;

--- a/packages/flutter/lib/src/widgets/container.dart
+++ b/packages/flutter/lib/src/widgets/container.dart
@@ -389,10 +389,8 @@ class Container extends StatelessWidget {
         maxHeight: 0.0,
         child: ConstrainedBox(constraints: const BoxConstraints.expand()),
       );
-    }
-
-    else if (alignment != null) {
-      current = Align(alignment: alignment!, child: current);
+    } else if (alignment != null) {
+      current = Align(alignment: alignment, child: current);
     }
 
     final EdgeInsetsGeometry? effectivePadding = _paddingIncludingDecoration;

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -633,7 +633,11 @@ void main() {
     expect(tapped, false);
   });
 
+<<<<<<< HEAD
   testWidgets('Container discards alignment when the child parameter is null and constraints is not Tight', (WidgetTester tester) async {
+=======
+  testWidgets('Container discards alignment when child, width and height parameters are null', (WidgetTester tester) async {
+>>>>>>> a93da1f156 (add test)
     await tester.pumpWidget(
       Container(
         decoration: const BoxDecoration(

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -633,6 +633,21 @@ void main() {
     expect(tapped, false);
   });
 
+  testWidgets('Container discards alignment when child, width and height parameters are null', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Container(
+        decoration: const BoxDecoration(
+        borderRadius: BorderRadius.all(Radius.circular(1)),
+      ),
+      alignment: Alignment.centerLeft
+    ));
+
+    expect(
+      find.byType(Align),
+      findsNothing,
+    );
+  });
+
   testWidgets('using clipBehaviour and shadow, should not clip the shadow', (WidgetTester tester) async {
     final Container container = Container(
       clipBehavior: Clip.hardEdge,

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -633,7 +633,7 @@ void main() {
     expect(tapped, false);
   });
 
-  testWidgets('Container discards alignment when child, width and height parameters are null', (WidgetTester tester) async {
+  testWidgets('Container discards alignment when the child parameter is null and constraints is not Tight', (WidgetTester tester) async {
     await tester.pumpWidget(
       Container(
         decoration: const BoxDecoration(

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -633,11 +633,7 @@ void main() {
     expect(tapped, false);
   });
 
-<<<<<<< HEAD
-  testWidgets('Container discards alignment when the child parameter is null and constraints is not Tight', (WidgetTester tester) async {
-=======
   testWidgets('Container discards alignment when child, width and height parameters are null', (WidgetTester tester) async {
->>>>>>> a93da1f156 (add test)
     await tester.pumpWidget(
       Container(
         decoration: const BoxDecoration(


### PR DESCRIPTION
in Container Widget when the `child` parameter is null and `constraints` is not Tight, there is no need to add the [Align] widget when the `alignment` parameter is provided.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.