### PR TITLE
Remove unused parameter and consequently unused variable

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -851,17 +851,16 @@ class HeroController extends NavigatorObserver {
     if (toRoute != fromRoute && toRoute is PageRoute<dynamic> && fromRoute is PageRoute<dynamic>) {
       final PageRoute<dynamic> from = fromRoute;
       final PageRoute<dynamic> to = toRoute;
-      final Animation<double> animation = (flightType == HeroFlightDirection.push) ? to.animation! : from.animation!;
 
       // A user gesture may have already completed the pop, or we might be the initial route
       switch (flightType) {
         case HeroFlightDirection.pop:
-          if (animation.value == 0.0) {
+          if (from.animation!.value == 0.0) {
             return;
           }
           break;
         case HeroFlightDirection.push:
-          if (animation.value == 1.0) {
+          if (to.animation!.value == 1.0) {
             return;
           }
           break;
@@ -871,7 +870,7 @@ class HeroController extends NavigatorObserver {
       // maintainState = true, then the hero's final dimensions can be measured
       // immediately because their page's layout is still valid.
       if (isUserGestureTransition && flightType == HeroFlightDirection.pop && to.maintainState) {
-        _startHeroTransition(from, to, animation, flightType, isUserGestureTransition);
+        _startHeroTransition(from, to, flightType, isUserGestureTransition);
       } else {
         // Otherwise, delay measuring until the end of the next frame to allow
         // the 'to' route to build and layout.
@@ -882,7 +881,7 @@ class HeroController extends NavigatorObserver {
         to.offstage = to.animation!.value == 0.0;
 
         WidgetsBinding.instance.addPostFrameCallback((Duration value) {
-          _startHeroTransition(from, to, animation, flightType, isUserGestureTransition);
+          _startHeroTransition(from, to, flightType, isUserGestureTransition);
         });
       }
     }
@@ -893,7 +892,6 @@ class HeroController extends NavigatorObserver {
   void _startHeroTransition(
     PageRoute<dynamic> from,
     PageRoute<dynamic> to,
-    Animation<double> animation,
     HeroFlightDirection flightType,
     bool isUserGestureTransition,
   ) {


### PR DESCRIPTION
The method `_startHeroTransition`, from `HeroController`, receives an `Animation<double> animation`, but does nothing with it. This PR removes the parameter.

Consequently, it removes the `animation` variable from `_maybeStartHeroTransition`, as it was being created only to be passed to `_startHeroTransition`. The conditional that would create this variable depending on the hero type could then be merged into the switch below.

Fixes #98548

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
