### PR TITLE
reads min/target sdk versions from localproperties

### DIFF
--- a/examples/api/android/app/build.gradle
+++ b/examples/api/android/app/build.gradle
@@ -29,6 +29,16 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +58,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.flutter.flutter_api_samples"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -38,8 +48,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -38,8 +48,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -39,8 +49,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -38,8 +48,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.layers"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -38,8 +48,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -38,8 +48,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -97,7 +97,7 @@ variable to be set. The full invocation to run everything might
 therefore look something like:
 
 ```shell
-$ FLUTTER_ROOT=~/path/to/flutter-sdk
+$ export FLUTTER_ROOT=~/path/to/flutter-sdk
 $ flutter test --concurrency 1
 ```
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -425,16 +425,15 @@ class FlutterPlugin implements Plugin<Project> {
             // Checks if there is a mismatch between the plugin minSdkVersion and the project minSdkVersion.
             if(pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel > project.android.defaultConfig?.minSdkVersion?.apiLevel) {
                 project.logger.quiet("Warning: The plugin ${pluginName} requires minSdkVersion ${pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel}.")
+                showBuildConfigurationMessage = true
                 
                 if (!resolveProperty("flutter.minSdkVersion", null)) {
                     project.logger.quiet("flutter.minSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.minSdkVersion.apiLevel} as default.")
-                    showBuildConfigurationMessage = true
                 }
 
                 // Additionally checks if the targetSdkVersion was set.
                 if (!resolveProperty("flutter.targetSdkVersion", null)) {
                     project.logger.quiet("flutter.targetSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.targetSdkVersion.apiLevel} as default.")
-                    showBuildConfigurationMessage = true
                 }
             }
             

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -139,6 +139,11 @@ class FlutterPlugin implements Plugin<Project> {
     private Properties localProperties
     private String engineVersion
 
+    /**
+     * Flutter Docs Website references URLs for help messages.
+     */
+    private final String kWebsiteDeploymentAndroidBuildConfig = 'https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration'
+
     @Override
     void apply(Project project) {
         this.project = project
@@ -300,7 +305,7 @@ class FlutterPlugin implements Plugin<Project> {
             localEngine = engineOut.name
             localEngineSrcPath = engineOut.parentFile.parent
         }
-        project.android.buildTypes.all this.&addFlutterDependencies
+        project.android.buildTypes.all this.&addFlutterDependencies        
     }
 
     private static Boolean shouldShrinkResources(Project project) {
@@ -409,9 +414,34 @@ class FlutterPlugin implements Plugin<Project> {
 
         // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
+            Boolean showBuildConfigurationMessage = false
+            
+            // Checks if there is a mismatch between the plugin compileSdkVersion and the project compileSdkVersion.
             if (pluginProject.android.compileSdkVersion > project.android.compileSdkVersion) {
                 project.logger.quiet("Warning: The plugin ${pluginName} requires Android SDK version ${pluginProject.android.compileSdkVersion.substring(8)}.")
+                showBuildConfigurationMessage = true
             }
+
+            // Checks if there is a mismatch between the plugin minSdkVersion and the project minSdkVersion.
+            if(pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel > project.android.defaultConfig?.minSdkVersion?.apiLevel) {
+                project.logger.quiet("Warning: The plugin ${pluginName} requires minSdkVersion ${pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel}.")
+                
+                if (!resolveProperty("flutter.minSdkVersion", null)) {
+                    project.logger.quiet("flutter.minSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.minSdkVersion.apiLevel} as default.")
+                    showBuildConfigurationMessage = true
+                }
+
+                // Additionally checks if the targetSdkVersion was set.
+                if (!resolveProperty("flutter.targetSdkVersion", null)) {
+                    project.logger.quiet("flutter.targetSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.targetSdkVersion.apiLevel} as default.")
+                    showBuildConfigurationMessage = true
+                }
+            }
+            
+            if (showBuildConfigurationMessage) {
+                project.logger.quiet("For more information about build configuration, see $kWebsiteDeploymentAndroidBuildConfig.")
+            }
+
             project.android.buildTypes.all addEmbeddingDependencyToPlugin
         }
     }

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -390,27 +390,24 @@ final GradleHandledError minSdkVersion = GradleHandledError(
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final File gradleFile = project.directory
+    final File localPropertiesFile = project.directory
         .childDirectory('android')
-        .childDirectory('app')
-        .childFile('build.gradle');
+        .childFile('local.properties');
 
     final Match? minSdkVersionMatch = _minSdkVersionPattern.firstMatch(line);
     assert(minSdkVersionMatch?.groupCount == 3);
 
     final String textInBold = globals.logger.terminal.bolden(
-      'Fix this issue by adding the following to the file ${gradleFile.path}:\n'
-      'android {\n'
-      '  defaultConfig {\n'
-      '    minSdkVersion ${minSdkVersionMatch?.group(2)}\n'
-      '  }\n'
-      '}\n'
+      'Fix this issue by adding the following to the file ${localPropertiesFile.path}:\n'
+      '\n'
+      'flutter.minSdkVersion=${minSdkVersionMatch?.group(2)}\n'
     );
     globals.printBox(
       'The plugin ${minSdkVersionMatch?.group(3)} requires a higher Android SDK version.\n'
       '$textInBold\n'
       "Note that your app won't be available to users running Android SDKs below ${minSdkVersionMatch?.group(2)}.\n"
-      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.',
+      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.\n'
+      'For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;
@@ -518,8 +515,8 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final Match? minSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
-    assert(minSdkVersionMatch?.groupCount == 1);
+    final Match? minCompileSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
+    assert(minCompileSdkVersionMatch?.groupCount == 1);
 
     final File gradleFile = project.directory
         .childDirectory('android')
@@ -529,7 +526,7 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
       '${globals.logger.terminal.warningMark} Your project requires a higher compileSdkVersion.\n'
       'Fix this issue by bumping the compileSdkVersion in ${gradleFile.path}:\n'
       'android {\n'
-      '  compileSdkVersion ${minSdkVersionMatch?.group(1)}\n'
+      '  compileSdkVersion ${minCompileSdkVersionMatch?.group(1)}\n'
       '}',
       title: _boxTitle,
     );

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -25,6 +25,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -37,8 +49,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -28,13 +28,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
 if (flutterMinSdkVersion == null) {
     flutterMinSdkVersion = flutter.minSdkVersion
-    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
 }
 
 def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
 if (flutterTargetSdkVersion == null) {
     flutterTargetSdkVersion = flutter.targetSdkVersion
-    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
 }
 
 android {

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -25,6 +25,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -45,8 +57,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -28,13 +28,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
 if (flutterMinSdkVersion == null) {
     flutterMinSdkVersion = flutter.minSdkVersion
-    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
 }
 
 def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
 if (flutterTargetSdkVersion == null) {
     flutterTargetSdkVersion = flutter.targetSdkVersion
-    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
 }
 
 android {

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -26,6 +26,18 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.library'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
+}
+
 group '{{androidIdentifier}}'
 version '1.0'
 
@@ -39,8 +51,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -29,13 +29,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
 if (flutterMinSdkVersion == null) {
     flutterMinSdkVersion = flutter.minSdkVersion
-    logger.quiet("flutter.minSdkVersion not found on android/local.properties, consider adding it. Using ${flutterMinSdkVersion} as default.")
 }
 
 def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
 if (flutterTargetSdkVersion == null) {
     flutterTargetSdkVersion = flutter.targetSdkVersion
-    logger.quiet("flutter.targetSdkVersion not found on android/local.properties, consider adding it. Using ${flutterTargetSdkVersion} as default.")
 }
 
 group '{{androidIdentifier}}'

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2479,7 +2479,7 @@ void main() {
     expect(env['flutter'].allows(Version(2, 4, 9)), false);
   });
 
-  testUsingContext('default app uses flutter default versions', () async {
+  testUsingContext('default app uses local properties or flutter default versions', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
@@ -2493,7 +2493,8 @@ void main() {
 
     expect(buildContent.contains('compileSdkVersion flutter.compileSdkVersion'), true);
     expect(buildContent.contains('ndkVersion flutter.ndkVersion'), true);
-    expect(buildContent.contains('targetSdkVersion flutter.targetSdkVersion'), true);
+    expect(buildContent.contains('minSdkVersion flutterMinSdkVersion'), true);
+    expect(buildContent.contains('targetSdkVersion flutterTargetSdkVersion'), true);
   });
 
   testUsingContext('Linux plugins handle partially camel-case project names correctly', () async {

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -778,16 +778,15 @@ assembleProfile
           '\n'
           '┌─ Flutter Fix ─────────────────────────────────────────────────────────────────────────────────┐\n'
           '│ The plugin webview_flutter requires a higher Android SDK version.                             │\n'
-          '│ Fix this issue by adding the following to the file /android/app/build.gradle:                 │\n'
-          '│ android {                                                                                     │\n'
-          '│   defaultConfig {                                                                             │\n'
-          '│     minSdkVersion 19                                                                          │\n'
-          '│   }                                                                                           │\n'
-          '│ }                                                                                             │\n'
+          '│ Fix this issue by adding the following to the file /android/local.properties:                 │\n'
+          '│                                                                                               │\n'
+          '│ flutter.minSdkVersion=19                                                                      │\n'
           '│                                                                                               │\n'
           "│ Note that your app won't be available to users running Android SDKs below 19.                 │\n"
           '│ Alternatively, try to find a version of this plugin that supports these lower versions of the │\n'
           '│ Android SDK.                                                                                  │\n'
+          '│ For more information, see:                                                                    │\n'
+          '│ https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration                 │\n'
           '└───────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -28,6 +28,16 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = flutter.minSdkVersion
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = flutter.targetSdkVersion
+}
+
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -39,8 +49,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.integration_test_example"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This PR changes the `build.gradle` files to read the `flutter.minSdkVersion` and `flutter.targetSdkVersion` from the generated local.properties, and if not found, keep the default one (which is set at flutter.gradle)

It changes all `build.gradle` files from examples/* and the integration_test/example.
It doesn't change `build.gradle` files from dev projects at dev/* but they can be changed too upon further request.
It changes both java and kotlin `build.gradle` templates.
It changes the default app test to expect the new strings on `build.gradle`.
It doesn't apply the same concept to `flutter.compileSdkVersion`, so having it on `local.properties` doesn't change the value set at `flutter.gradle`, this can also be added upon further request.

This PR also changes `flutter.gradle` to detect and warn the developer with a `logger.quiet` message about mismatches with plugins API level. If a mismatch is found, it also checks if the variables `flutter.minSdkVersion` and `flutter.targetSdkVersion` were set at `local.properties`

It also changes the `gradle_errors.dart` to update the box message about how to fix the API level error, while adding a reference to the docs. The test was also updated.

**Images:**

<details>
<summary>[Before] New project with a dependency requiring higher sdk version.</summary>

![image](https://user-images.githubusercontent.com/6067887/153695824-305385c1-026d-4b49-97c0-b5c5a9ca4c9c.png)

</details>

<details>
<summary>[After] New project with a dependency requiring higher sdk version.</summary>

![image](https://user-images.githubusercontent.com/6067887/153695696-060bf1f2-6100-4f17-95be-4ef56d878e4e.png)

</details>

<details>
<summary>[After] New project with the variables INcorrectly set at local.properties.</summary>

![image](https://user-images.githubusercontent.com/6067887/153695961-2f3dfbce-44ea-4188-8e76-e322920f4d5d.png)

</details>

<details>
<summary>[After] New project with the variables correctly set at local.properties.</summary>

![image](https://user-images.githubusercontent.com/6067887/153695920-fd6a7dac-90af-4611-b5b0-8a7a31d7298d.png)

</details>

It closes #95533
Partially solves #95485 (Android part)
Could be a solution to #95514

**Extra - Not related:** at https://github.com/flutter/flutter/pull/95684/commits/044079046a3765cfba82991e7002a3339af9b7d7 I fixed the command required to export the `FLUTTER_ROOT` variable in order to run tests.