### PR TITLE
Enable `fullscreen_textfield_perf` tests in prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1910,6 +1910,28 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_android fullscreen_textfield_perf
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: fullscreen_textfield_perf
+      benchmark: "true"
+    scheduler: luci
+
+  - name: Linux_android fullscreen_textfield_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: fullscreen_textfield_perf__e2e_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android fullscreen_textfield_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -47,6 +47,8 @@
 /dev/devicelab/bin/tasks/flutter_gallery_v2_web_compile_test.dart @yjbanov @flutter/web
 /dev/devicelab/bin/tasks/flutter_test_performance.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/frame_policy_delay_test_android.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/fullscreen_textfield_perf.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/fullscreen_textfield_perf__e2e_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/gradle_java8_compile_test.dart @blasten @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_linux__benchmark.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/image_list_jit_reported_duration.dart @zanderso @flutter/engine


### PR DESCRIPTION
This is a long due change to enable `fullscreen_textfield_perf` and `fullscreen_textfield_perf__e2e_summary` in prod. These two tests have been validated in staging for a while, and this PR directly enables them in prod without further `bringup: true` validation.

https://ci.chromium.org/p/flutter/builders/staging/Linux_android_staging%20fullscreen_textfield_perf?limit=200
https://ci.chromium.org/p/flutter/builders/staging/Linux_android_staging%20fullscreen_textfield_perf__e2e_summary?limit=200

Related issue: https://github.com/flutter/flutter/issues/86802#issuecomment-901519361