### PR TITLE
`CupertinoPicker`: Update example

### DIFF
--- a/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
+++ b/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
@@ -8,12 +8,12 @@ import 'package:flutter/cupertino.dart';
 
 const double _kItemExtent = 32.0;
 const List<String> _fruitNames = <String>[
-  '🍎 Apple',
-  '🥭 Mango',
-  '🍌 Banana',
-  '🍊 Orange',
-  '🍍 Pineapple',
-  '🍓 Strawberry',
+  'Apple',
+  'Mango',
+  'Banana',
+  'Orange',
+  'Pineapple',
+  'Strawberry',
 ];
 
 void main() => runApp(const MyApp());

--- a/examples/api/test/cupertino/picker/cupertino_picker.0_test.dart
+++ b/examples/api/test/cupertino/picker/cupertino_picker.0_test.dart
@@ -14,11 +14,11 @@ void main() {
     );
 
     // Open the Cupertino picker.
-    await tester.tap(find.text('🍎 Apple'));
+    await tester.tap(find.text('Apple'));
     await tester.pumpAndSettle();
 
     // Drag the wheel to change fruit selection.
-    await tester.drag(find.text('🥭 Mango'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
+    await tester.drag(find.text('Mango'), _kRowOffset, touchSlopY: 0, warnIfMissed: false); // see top of file
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -27,6 +27,6 @@ void main() {
     await tester.tapAt(const Offset(1.0, 1.0));
     await tester.pumpAndSettle();
 
-    expect(find.text('🍌 Banana'), findsOneWidget);
+    expect(find.text('Banana'), findsOneWidget);
   });
 }


### PR DESCRIPTION
It would have been nice to have emojis for cool fruit picker example but look like dartpad doesn't support emoji

context: https://github.com/flutter/flutter/pull/93622#issuecomment-1040636208

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
