### PR TITLE
Remove deprecated VelocityTracker constructor

### DIFF
--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -144,12 +144,6 @@ class _PointAtTime {
 /// The quality of the velocity estimation will be better if more data points
 /// have been received.
 class VelocityTracker {
-  /// Create a new velocity tracker for a pointer [kind].
-  @Deprecated(
-    'Use VelocityTracker.withKind and provide the PointerDeviceKind associated with the gesture being tracked. '
-    'This feature was deprecated after v1.22.0-12.1.pre.',
-  )
-  VelocityTracker([this.kind = PointerDeviceKind.touch]);
 
   /// Create a new velocity tracker for a pointer [kind].
   VelocityTracker.withKind(this.kind);


### PR DESCRIPTION
This removes the default constructor from 
- `VelocityTracker`

This deprecated property has reached end of life after the release of Flutter 2.10

- The replacement is `VelocityTracker.withKind`.
- ✅  This migration is supported by the dart fix tool. 
- 🕐  This API was deprecated in https://github.com/flutter/flutter/pull/66043, first tagged v1.22

Part of https://github.com/flutter/flutter/issues/98537
For the full list of deprecations being removed in this batch, see [flutter.dev/go/deprecations-removed-after-2-10](https://docs.google.com/spreadsheets/d/12krawYCu6X_g_5wLGpmiAIi-VcTRV6xG7RGbRovuatQ/edit?usp=sharing)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
