### PR TITLE
Dump backtrace when cannot attach to observatory

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -437,12 +437,12 @@ class IOSDevice extends Device {
       final Uri? localUri = await observatoryDiscovery?.uri;
       timer.cancel();
       if (localUri == null) {
-        iosDeployDebugger?.detach();
+        await iosDeployDebugger?.stopAndDumpBacktrace();
         return LaunchResult.failed();
       }
       return LaunchResult.succeeded(observatoryUri: localUri);
     } on ProcessException catch (e) {
-      iosDeployDebugger?.detach();
+      await iosDeployDebugger?.stopAndDumpBacktrace();
       _logger.printError(e.message);
       return LaunchResult.failed();
     } finally {

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -293,6 +293,15 @@ class IOSDeployDebugger {
   // (lldb) Process 6152 stopped
   static final RegExp _lldbProcessStopped = RegExp(r'Process \d* stopped');
 
+  // (lldb) Process 6152 detached
+  static final RegExp _lldbProcessDetached = RegExp(r'Process \d* detached');
+
+  // Send signal to stop (pause) the app. Used before a backtrace dump.
+  static const String _signalStop = 'process signal SIGSTOP';
+
+  // Print backtrace for all threads while app is stopped.
+  static const String _backTraceAll = 'thread backtrace all';
+
   /// Launch the app on the device, and attach the debugger.
   ///
   /// Returns whether or not the debugger successfully attached.
@@ -330,16 +339,41 @@ class IOSDeployDebugger {
           }
           return;
         }
-        if (line.contains('PROCESS_STOPPED') ||
-            line.contains('PROCESS_EXITED') ||
-            _lldbProcessExit.hasMatch(line) ||
-            _lldbProcessStopped.hasMatch(line)) {
+        if (line == _signalStop) {
+          // The app is about to be stopped. Only show in verbose mode.
+          _logger.printTrace(line);
+          return;
+        }
+        if (line == _backTraceAll) {
+          // The app is stopped and the backtrace for all threads will be printed.
+          _logger.printTrace(line);
+          // Even though we're not "detached", just stopped, mark as detached so the backtrace
+          // is only show in verbose.
+          _debuggerState = _IOSDeployDebuggerState.detached;
+          return;
+        }
+
+        if (line.contains('PROCESS_STOPPED') || _lldbProcessStopped.hasMatch(line)) {
+          // The app has been stopped. Dump the backtrace, and detach.
+          _logger.printTrace(line);
+          _iosDeployProcess?.stdin.writeln(_backTraceAll);
+          detach();
+          return;
+        }
+        if (line.contains('PROCESS_EXITED') || _lldbProcessExit.hasMatch(line)) {
           // The app exited or crashed, so exit. Continue passing debugging
           // messages to the log reader until it exits to capture crash dumps.
           _logger.printTrace(line);
           exit();
           return;
         }
+        if (_lldbProcessDetached.hasMatch(line)) {
+          // The debugger has detached from the app, and there will be no more debugging messages.
+          // Kill the ios-deploy process.
+          exit();
+          return;
+        }
+
         if (_debuggerState != _IOSDeployDebuggerState.attached) {
           _logger.printTrace(line);
           return;
@@ -395,6 +429,22 @@ class IOSDeployDebugger {
     return success;
   }
 
+  Future<void> stopAndDumpBacktrace() async {
+    if (!debuggerAttached) {
+      return;
+    }
+
+    try {
+      // Stop the app, which will prompt the backtrace to be printed for all threads in the stdoutSubscription handler.
+      _iosDeployProcess?.stdin.writeln(_signalStop);
+    } on SocketException catch (error) {
+      // Best effort, try to detach, but maybe the app already exited or already detached.
+      _logger.printTrace('Could not stop app from debugger: $error');
+    }
+    // Wait for logging to finish on process exit.
+    return logLines.drain();
+  }
+
   void detach() {
     if (!debuggerAttached) {
       return;
@@ -403,7 +453,6 @@ class IOSDeployDebugger {
     try {
       // Detach lldb from the app process.
       _iosDeployProcess?.stdin.writeln('process detach');
-      _debuggerState = _IOSDeployDebuggerState.detached;
     } on SocketException catch (error) {
       // Best effort, try to detach, but maybe the app already exited or already detached.
       _logger.printTrace('Could not detach from debugger: $error');


### PR DESCRIPTION
When the tool launches the app, but can't connect to the observatory, print the backtrace of all threads before failing and killing the app.  This could help detect deadlocks.

https://github.com/flutter/flutter/issues/97958#issuecomment-1039431678

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
