### PR TITLE
Revert "Dismiss text selection toolbar with ESC"

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3150,7 +3150,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     ReplaceTextIntent: _replaceTextAction,
     UpdateSelectionIntent: _updateSelectionAction,
     DirectionalFocusIntent: DirectionalFocusAction.forTextField(),
-    DismissIntent: CallbackAction<DismissIntent>(onInvoke: (_) => hideToolbar(false)),
 
     // Delete
     DeleteCharacterIntent: _makeOverridable(_DeleteTextAction<DeleteCharacterIntent>(this, _characterBoundary)),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -1316,41 +1316,6 @@ void main() {
     expect(find.text('Paste'), kIsWeb ? findsNothing : findsOneWidget);
   });
 
-  testWidgets('can hide toolbar with DismissIntent', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: EditableText(
-          backgroundCursorColor: Colors.grey,
-          controller: controller,
-          focusNode: focusNode,
-          style: textStyle,
-          cursorColor: cursorColor,
-          selectionControls: materialTextSelectionControls,
-        ),
-      ),
-    );
-
-    final EditableTextState state =
-    tester.state<EditableTextState>(find.byType(EditableText));
-
-    // Show the toolbar
-    state.renderEditable.selectWordsInRange(
-      from: Offset.zero,
-      cause: SelectionChangedCause.tap,
-    );
-    await tester.pump();
-
-    // On web, we don't let Flutter show the toolbar.
-    expect(state.showToolbar(), kIsWeb ? isFalse : isTrue);
-    await tester.pumpAndSettle();
-    expect(find.text('Paste'), kIsWeb ? findsNothing : findsOneWidget);
-
-    // Hide the menu using the DismissIntent.
-    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
-    await tester.pump();
-    expect(find.text('Paste'), findsNothing);
-  });
-
   testWidgets('Paste is shown only when there is something to paste', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Turns out https://github.com/flutter/flutter/pull/98511 broke https://github.com/flutter/flutter/pull/97790 by always consuming the input @justinmc 

I think the basic `CallbackAction` always consumes the input since it can't be disabled like `_AutocompleteCallbackAction`. Either way it broke the test for https://github.com/flutter/flutter/pull/97790 and should get reverted and fixed. I think the PR checker was behind ToT since I rebased just before https://github.com/flutter/flutter/pull/98511 landed.

Reverts flutter/flutter#98511