### PR TITLE
Call bringIntoView after RenderEditable updates on paste

### DIFF
--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -10948,12 +10948,12 @@ void main() {
 
     // Paste
     await resetSelectionAndScrollOffset();
-    textSelectionDelegate.pasteText(SelectionChangedCause.keyboard);
+    await textSelectionDelegate.pasteText(SelectionChangedCause.keyboard);
     await tester.pump();
     expect(scrollController.offset, maxScrollExtent);
 
     await resetSelectionAndScrollOffset();
-    textSelectionDelegate.pasteText(SelectionChangedCause.toolbar);
+    await textSelectionDelegate.pasteText(SelectionChangedCause.toolbar);
     await tester.pump();
     expect(scrollController.offset.roundToDouble(), 0.0);
 
@@ -10978,6 +10978,50 @@ void main() {
     textSelectionDelegate.copySelection(SelectionChangedCause.toolbar);
     await tester.pump();
     expect(scrollController.offset.roundToDouble(), 0.0);
+  });
+
+  testWidgets('Should not scroll on paste if caret already visible', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/96658.
+    final ScrollController scrollController = ScrollController();
+    final TextEditingController controller = TextEditingController(
+      text: 'Lorem ipsum please paste here: \n${".\n" * 50}',
+    );
+    final FocusNode focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            height: 600.0,
+            width: 600.0,
+            child: EditableText(
+              controller: controller,
+              scrollController: scrollController,
+              focusNode: focusNode,
+              maxLines: null,
+              style: const TextStyle(fontSize: 36.0),
+              backgroundCursorColor: Colors.grey,
+              cursorColor: cursorColor,
+            ),
+          ),
+        ),
+      )
+    );
+
+    await Clipboard.setData(const ClipboardData(text: 'Fairly long text to be pasted'));
+    focusNode.requestFocus();
+
+    final EditableTextState state =
+        tester.state<EditableTextState>(find.byType(EditableText));
+
+    expect(scrollController.offset, 0.0);
+
+    controller.selection = const TextSelection.collapsed(offset: 31);
+    await state.pasteText(SelectionChangedCause.toolbar);
+    await tester.pumpAndSettle();
+
+    // No scroll should happen as the caret is in the viewport all the time.
+    expect(scrollController.offset, 0.0);
   });
 
   testWidgets('Autofill enabled by default', (WidgetTester tester) async {


### PR DESCRIPTION
This PR ensures EditableText.bringIntoView() is called after the RenderEditable is updated with the new text value. This avoids incorrect scroll offset changes on paste.

Fixes #96658.

All relevants tests are passing:
```
% ../../bin/flutter test \
  test/widgets/editable_text_cursor_test.dart \
  test/widgets/editable_text_show_on_screen_test.dart \
  test/widgets/editable_text_shortcuts_tests.dart \
  test/widgets/editable_text_test.dart \
  test/cupertino/text_field_restoration_test.dart \
  test/cupertino/text_field_test.dart \
  test/cupertino/text_form_field_row_test.dart \
  test/cupertino/text_selection_test.dart \
  test/cupertino/text_selection_toolbar_button_test.dart \
  test/cupertino/text_selection_toolbar_test.dart \
  test/material/text_field_focus_test.dart \
  test/material/text_field_helper_text_test.dart \
  test/material/text_field_restoration_test.dart \
  test/material/text_field_splash_test.dart \
  test/material/text_field_test.dart \
  test/material/text_form_field_restoration_test.dart \
  test/material/text_form_field_test.dart \
  test/material/text_selection_test.dart \
  test/material/text_selection_toolbar_test.dart \
  test/material/text_selection_toolbar_text_button_test.dart \
  test/rendering/editable_gesture_test.dart \
  test/rendering/editable_test.dart \
  test/widgets/text_selection_test.dart \
  test/widgets/text_selection_toolbar_layout_delegate_test.dart

02:41 +1431: All tests passed!                 
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
