### PR TITLE
Remove deprecated UpdateLiveRegionEvent

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -132,33 +132,3 @@ class TapSemanticEvent extends SemanticsEvent {
   @override
   Map<String, dynamic> getDataMap() => const <String, dynamic>{};
 }
-
-/// An event which triggers a polite announcement of a live region.
-///
-/// This requires that the semantics node has already been marked as a live
-/// region. On Android, TalkBack will make a verbal announcement, as long as
-/// the label of the semantics node has changed since the last live region
-/// update. iOS does not currently support this event.
-///
-/// Deprecated. This message was never implemented, and references to it should
-/// be removed.
-///
-/// See also:
-///
-///  * [SemanticsFlag.isLiveRegion], for a description of live regions.
-///
-@Deprecated(
-  'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '
-  'This feature was deprecated after v1.26.0-18.0.pre.',
-)
-class UpdateLiveRegionEvent extends SemanticsEvent {
-  /// Creates a new [UpdateLiveRegionEvent].
-  @Deprecated(
-    'This event has never been implemented and will be removed in a future version of Flutter. References to it should be removed. '
-    'This feature was deprecated after v1.26.0-18.0.pre.',
-  )
-  const UpdateLiveRegionEvent() : super('updateLiveRegion');
-
-  @override
-  Map<String, dynamic> getDataMap() => const <String, dynamic>{};
-}


### PR DESCRIPTION
This removes `UpdateLiveRegionEvent` 

This deprecated class has reached end of life after the release of Flutter 2.10

- The is no replacement for this class, it is not used in the framework.
- 🕐  This API was deprecated in https://github.com/flutter/flutter/pull/45940, and extended in #75813, tagged v1.26

Part of https://github.com/flutter/flutter/issues/98537
For the full list of deprecations being removed in this batch, see [flutter.dev/go/deprecations-removed-after-2-10](https://docs.google.com/spreadsheets/d/12krawYCu6X_g_5wLGpmiAIi-VcTRV6xG7RGbRovuatQ/edit?usp=sharing)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
