### PR TITLE
[flutter_conductor] fix auto-tagging branch point

### DIFF
--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -12,7 +12,7 @@ const String gsutilBinary = 'gsutil.py';
 const String kFrameworkDefaultBranch = 'master';
 const String kForceFlag = 'force';
 
-const List<String> kBaseReleaseChannels = <String>['stable', 'beta', 'dev'];
+const List<String> kBaseReleaseChannels = <String>['stable', 'beta'];
 
 const List<String> kReleaseChannels = <String>[...kBaseReleaseChannels, FrameworkRepository.defaultBranch];
 

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -448,11 +448,13 @@ class StartContext extends Context {
       // The branch point is tagged, no work to be done
       return requestedVersion;
     }
-    assert(
-      requestedVersion.n == 0,
-      'Tried to tag the branch point, however the target version is '
-      '$requestedVersion, which does not have n == 0',
-    );
+    if (requestedVersion.n != 0) {
+      stdio.printError(
+        'Tried to tag the branch point, however the target version is '
+        '$requestedVersion, which does not have n == 0!',
+      );
+      return requestedVersion;
+    }
 
     final bool response = await prompt(
       'About to tag the release candidate branch branchpoint of $branchPoint '

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -438,15 +438,20 @@ class StartContext extends Context {
     Version requestedVersion,
     FrameworkRepository framework,
   ) async {
-    if (incrementLetter != 'm') {
-      // in this case, there must have been a previous tagged release, so skip
-      // tagging the branch point
-      return requestedVersion;
-    }
     final String branchPoint = await framework.branchPoint(
       candidateBranch,
       FrameworkRepository.defaultBranch,
     );
+    if (await framework.isCommitTagged(branchPoint)) {
+      // The branch point is tagged, no work to be done
+      return requestedVersion;
+    }
+    assert(
+      requestedVersion.n == 0,
+      'Tried to tag the branch point, however the target version is '
+      '$requestedVersion, which does not have n == 0',
+    );
+
     final bool response = await prompt(
       'About to tag the release candidate branch branchpoint of $branchPoint '
       'as $requestedVersion and push it to ${framework.upstreamRemote.url}. '

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -383,7 +383,9 @@ class StartContext extends Context {
     }
 
     Version nextVersion = calculateNextVersion(lastVersion);
-    nextVersion = await ensureBranchPointTagged(nextVersion, framework);
+    if (!force) {
+      nextVersion = await ensureBranchPointTagged(nextVersion, framework);
+    }
 
     state.releaseVersion = nextVersion.toString();
 

--- a/dev/conductor/core/test/next_test.dart
+++ b/dev/conductor/core/test/next_test.dart
@@ -191,7 +191,7 @@ void main() {
 
       test('updates lastPhase if user responds yes', () async {
         const String remoteUrl = 'https://github.com/org/repo.git';
-        const String releaseChannel = 'dev';
+        const String releaseChannel = 'beta';
         stdio.stdin.add('y');
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
@@ -1175,7 +1175,7 @@ void _initializeCiYamlFile(
   File file, {
   List<String>? enabledBranches,
 }) {
-  enabledBranches ??= <String>['master', 'dev', 'beta', 'stable'];
+  enabledBranches ??= <String>['master', 'beta', 'stable'];
   file.createSync(recursive: true);
   final StringBuffer buffer = StringBuffer('enabled_branches:\n');
   for (final String branch in enabledBranches) {

--- a/dev/conductor/core/test/repository_test.dart
+++ b/dev/conductor/core/test/repository_test.dart
@@ -409,9 +409,6 @@ vars = {
           command: <String>['git', 'checkout', 'beta', '--'],
         ),
         const FakeCommand(
-          command: <String>['git', 'checkout', 'dev', '--'],
-        ),
-        const FakeCommand(
           command: <String>['git', 'checkout', FrameworkRepository.defaultBranch, '--'],
         ),
         const FakeCommand(

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -247,14 +247,6 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', candidateBranch, 'master'],
-          stdout: branchPointRevision,
-        ),
-        // check if commit is tagged, zero exit means it is tagged
-        const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
-        ),
-        const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
           stdout: revision3,
         ),

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -19,6 +19,7 @@ import './common.dart';
 
 void main() {
   group('start command', () {
+    const String branchPointRevision = '5131a6e5e0c50b8b7b2906cd58dab8746d6450be';
     const String flutterRoot = '/flutter';
     const String checkoutsParentDirectory = '$flutterRoot/dev/tools/';
     const String frameworkMirror = 'https://github.com/user/flutter.git';
@@ -246,6 +247,14 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
+          command: <String>['git', 'merge-base', candidateBranch, 'master'],
+          stdout: branchPointRevision,
+        ),
+        // check if commit is tagged, zero exit means it is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+        ),
+        const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
           stdout: revision3,
         ),
@@ -309,7 +318,6 @@ void main() {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String branchPointRevision = 'deadbeef';
       const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
       const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
@@ -434,6 +442,12 @@ void main() {
         const FakeCommand(
           command: <String>['git', 'merge-base', candidateBranch, 'master'],
           stdout: branchPointRevision,
+        ),
+        // check if commit is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          // non-zero exit means commit is not tagged
+          exitCode: 128,
         ),
         const FakeCommand(
           command: <String>['git', 'tag', branchPointTag, branchPointRevision],
@@ -625,6 +639,14 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
+          command: <String>['git', 'merge-base', candidateBranch, 'master'],
+          stdout: branchPointRevision,
+        ),
+        // check if commit is tagged, 0 exit code thus it is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+        ),
+        const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
           stdout: revision3,
         ),
@@ -810,6 +832,12 @@ void main() {
         const FakeCommand(
           command: <String>['git', 'merge-base', candidateBranch, 'master'],
           stdout: branchPointRevision,
+        ),
+        // check if commit is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          // non-zero exit code means branch point is NOT tagged
+          exitCode: 128,
         ),
         const FakeCommand(
           command: <String>['git', 'tag', branchPointTag, branchPointRevision],

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -93,7 +93,7 @@ void main() {
           '--$kCandidateOption',
           candidateBranch,
           '--$kReleaseOption',
-          'dev',
+          'beta',
           '--$kStateOption',
           '/path/to/statefile.json',
           '--$kIncrementOption',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/92809

When I initially implemented the `ensureBranchPointTagged()` method, I had it early exit unless the increment was `m`.

This PR removes that check, and instead explicitly checks the branch point for a release tag. If it already has one, it exits early. In addition, there is an assert that verifies the `n` value of the next version is 0 (if it's not 0, then we are in a bad state and likely cannot recover).

In addition, this PR overrides the branch point check if `--force` was provided.