### PR TITLE
Increase recommended CocoaPods version to 1.11

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -69,7 +69,7 @@ enum CocoaPodsStatus {
 }
 
 const Version cocoaPodsMinimumVersion = Version.withText(1, 9, 0, '1.9.0');
-const Version cocoaPodsRecommendedVersion = Version.withText(1, 10, 0, '1.10.0');
+const Version cocoaPodsRecommendedVersion = Version.withText(1, 11, 0, '1.11.0');
 
 /// Cocoapods is a dependency management solution for iOS and macOS applications.
 ///

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -165,13 +165,13 @@ void main() {
 
     testWithoutContext('detects at recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('1.11.0');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
     });
 
     testWithoutContext('detects above recommended version', () async {
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.1');
+      pretendPodVersionIs('1.11.1');
       expect(await cocoaPodsUnderTest.evaluateCocoaPodsInstallation, CocoaPodsStatus.recommended);
     });
   });
@@ -410,7 +410,7 @@ void main() {
     testUsingContext('prints warning if macOS Podfile parses .flutter-plugins', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       fakeProcessManager.addCommands(const <FakeCommand>[
         FakeCommand(
           command: <String>['pod', 'install', '--verbose'],
@@ -449,7 +449,7 @@ void main() {
     testUsingContext('throws, if specs repo is outdated.', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -499,7 +499,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       testUsingContext('ffi $errorName failure on ARM macOS prompts gem install', () async {
         final FlutterProject projectUnderTest = setupProjectUnderTest();
         pretendPodIsInstalled();
-        pretendPodVersionIs('1.10.0');
+        pretendPodVersionIs('100.0.0');
         fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
           ..createSync()
           ..writeAsStringSync('Existing Podfile');
@@ -542,7 +542,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('ffi failure on x86 macOS does not prompt gem install', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -586,7 +586,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('run pod install, if Podfile.lock is missing', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -613,7 +613,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs iOS pod install, if Manifest.lock is missing', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -642,7 +642,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs macOS pod install, if Manifest.lock is missing', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.macos.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -671,7 +671,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if Manifest.lock different from Podspec.lock', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -703,7 +703,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if flutter framework changed', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -735,7 +735,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('runs pod install, if Podfile.lock is older than Podfile', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');
@@ -789,7 +789,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     testUsingContext('a failed pod install deletes Pods/Manifest.lock', () async {
       final FlutterProject projectUnderTest = setupProjectUnderTest();
       pretendPodIsInstalled();
-      pretendPodVersionIs('1.10.0');
+      pretendPodVersionIs('100.0.0');
       projectUnderTest.ios.podfile
         ..createSync()
         ..writeAsStringSync('Existing Podfile');

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_validator_test.dart
@@ -40,7 +40,7 @@ void main() {
       final ValidationMessage message = result.messages.first;
       expect(message.type, ValidationMessageType.hint);
       expect(message.message, contains('CocoaPods $currentVersion out of date'));
-      expect(message.message, contains('(1.10.0 is recommended)'));
+      expect(message.message, contains('(1.11.0 is recommended)'));
     });
   });
 }


### PR DESCRIPTION
I was recently hitting a plugins issue that only reproduced on CocoaPods 1.10 and not 1.11 https://github.com/flutter/samples/issues/1004#issuecomment-1028239645

While I couldn't exactly pin down what was wrong, it seems prudent to recommend CocoaPods 1.11 (released Sept 2021) to encourage developers to start upgrading ASAP before we bump the required version.  

The recommended (not required) version only impacts `flutter doctor` output.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
