### PR TITLE
[devicelab] Web benchmarks now run on Chromium 89+

### DIFF
--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -505,8 +505,17 @@ class BlinkTraceEvent {
   /// This event does not include non-UI thread scripting, such as web workers,
   /// service workers, and CSS Paint paintlets.
   ///
+  /// WebViewImpl::beginFrame was used in earlier versions of Chrome, kept
+  /// for compatibility.
+  ///
   /// This event is a duration event that has its `tdur` populated.
-  bool get isBeginFrame => ph == 'X' && name == 'WebViewImpl::beginFrame';
+  bool get isBeginFrame {
+    return ph == 'X' && (
+      name == 'WebViewImpl::beginFrame' ||
+      name == 'WebFrameWidgetBase::BeginMainFrame' ||
+      name == 'WebFrameWidgetImpl::BeginMainFrame'
+    );
+  }
 
   /// An "update all lifecycle phases" event contains UI thread computations
   /// related to an animation frame that's outside the scripting phase.
@@ -514,8 +523,16 @@ class BlinkTraceEvent {
   /// This event includes style recalculation, layer tree update, layout,
   /// painting, and parts of compositing work.
   ///
+  /// WebViewImpl::updateAllLifecyclePhases was used in earlier versions of
+  /// Chrome, kept for compatibility.
+  ///
   /// This event is a duration event that has its `tdur` populated.
-  bool get isUpdateAllLifecyclePhases => ph == 'X' && name == 'WebViewImpl::updateAllLifecyclePhases';
+  bool get isUpdateAllLifecyclePhases {
+    return ph == 'X' && (
+      name == 'WebViewImpl::updateAllLifecyclePhases' ||
+      name == 'WebFrameWidgetImpl::UpdateLifecycle'
+    );
+  }
 
   /// Whether this is the beginning of a "measured_frame" event.
   ///

--- a/dev/devicelab/test/framework/browser_test.dart
+++ b/dev/devicelab/test/framework/browser_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/browser.dart';
+
+import '../common.dart';
+import 'browser_test_json_samples.dart';
+
+void main() {
+  group('BlinkTraceEvent works with Chrome 89+', () {
+    // Used to test 'false' results
+    final BlinkTraceEvent unrelatedPhX =
+        BlinkTraceEvent.fromJson(unrelatedPhXJson);
+    final BlinkTraceEvent anotherUnrelated =
+        BlinkTraceEvent.fromJson(anotherUnrelatedJson);
+
+    test('isBeginFrame', () {
+      final BlinkTraceEvent event =
+          BlinkTraceEvent.fromJson(beginMainFrameJson_89plus);
+
+      expect(event.isBeginFrame, isTrue);
+      expect(unrelatedPhX.isBeginFrame, isFalse);
+      expect(anotherUnrelated.isBeginFrame, isFalse);
+    });
+
+    test('isUpdateAllLifecyclePhases', () {
+      final BlinkTraceEvent event =
+          BlinkTraceEvent.fromJson(updateLifecycleJson_89plus);
+
+      expect(event.isUpdateAllLifecyclePhases, isTrue);
+      expect(unrelatedPhX.isUpdateAllLifecyclePhases, isFalse);
+      expect(anotherUnrelated.isUpdateAllLifecyclePhases, isFalse);
+    });
+
+    test('isBeginMeasuredFrame', () {
+      final BlinkTraceEvent event =
+          BlinkTraceEvent.fromJson(beginMeasuredFrameJson_89plus);
+
+      expect(event.isBeginMeasuredFrame, isTrue);
+      expect(unrelatedPhX.isBeginMeasuredFrame, isFalse);
+      expect(anotherUnrelated.isBeginMeasuredFrame, isFalse);
+    });
+
+    test('isEndMeasuredFrame', () {
+      final BlinkTraceEvent event =
+          BlinkTraceEvent.fromJson(endMeasuredFrameJson_89plus);
+
+      expect(event.isEndMeasuredFrame, isTrue);
+      expect(unrelatedPhX.isEndMeasuredFrame, isFalse);
+      expect(anotherUnrelated.isEndMeasuredFrame, isFalse);
+    });
+  });
+}

--- a/dev/devicelab/test/framework/browser_test_json_samples.dart
+++ b/dev/devicelab/test/framework/browser_test_json_samples.dart
@@ -1,0 +1,103 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert' show jsonDecode;
+
+// JSON Event samples taken from running an instrumented version of the
+// integration tests of this package that dumped all the data as captured.
+
+/// To test isBeginFrame. (Sampled from Chrome 89+)
+final Map<String, Object?> beginMainFrameJson_89plus = jsonDecode('''
+{
+    "args": {
+        "frameTime": 2338687248768
+    },
+    "cat": "blink",
+    "dur": 6836,
+    "name": "WebFrameWidgetImpl::BeginMainFrame",
+    "ph": "X",
+    "pid": 1367081,
+    "tdur": 393,
+    "tid": 1,
+    "ts": 2338687258440,
+    "tts": 375499
+}
+''') as Map<String, Object?>;
+
+/// To test isUpdateAllLifecyclePhases. (Sampled from Chrome 89+)
+final Map<String, Object?> updateLifecycleJson_89plus = jsonDecode('''
+{
+    "args": {},
+    "cat": "blink",
+    "dur": 103,
+    "name": "WebFrameWidgetImpl::UpdateLifecycle",
+    "ph": "X",
+    "pid": 1367081,
+    "tdur": 102,
+    "tid": 1,
+    "ts": 2338687265284,
+    "tts": 375900
+}
+''') as Map<String, Object?>;
+
+/// To test isBeginMeasuredFrame. (Sampled from Chrome 89+)
+final Map<String, Object?> beginMeasuredFrameJson_89plus = jsonDecode('''
+{
+    "args": {},
+    "cat": "blink.user_timing",
+    "id": "0xea2a8b45",
+    "name": "measured_frame",
+    "ph": "b",
+    "pid": 1367081,
+    "scope": "blink.user_timing",
+    "tid": 1,
+    "ts": 2338687265932
+}
+''') as Map<String, Object?>;
+
+/// To test isEndMeasuredFrame. (Sampled from Chrome 89+)
+final Map<String, Object?> endMeasuredFrameJson_89plus = jsonDecode('''
+{
+    "args": {},
+    "cat": "blink.user_timing",
+    "id": "0xea2a8b45",
+    "name": "measured_frame",
+    "ph": "e",
+    "pid": 1367081,
+    "scope": "blink.user_timing",
+    "tid": 1,
+    "ts": 2338687440485
+}
+''') as Map<String, Object?>;
+
+/// An unrelated data frame to test negative cases.
+final Map<String, Object?> unrelatedPhXJson = jsonDecode('''
+{
+    "args": {},
+    "cat": "blink,rail",
+    "dur": 2,
+    "name": "PageAnimator::serviceScriptedAnimations",
+    "ph": "X",
+    "pid": 1367081,
+    "tdur": 2,
+    "tid": 1,
+    "ts": 2338691143317,
+    "tts": 1685405
+}
+''') as Map<String, Object?>;
+
+/// Another unrelated data frame to test negative cases.
+final Map<String, Object?> anotherUnrelatedJson = jsonDecode('''
+{
+    "args": {
+        "sort_index": -1
+    },
+    "cat": "__metadata",
+    "name": "thread_sort_index",
+    "ph": "M",
+    "pid": 1367081,
+    "tid": 1,
+    "ts": 2338692906482
+}
+''') as Map<String, Object?>;


### PR DESCRIPTION
In Chromium 89, some of the performance event names used by the benchmarks changed. This didn't matter much because benchmarks run in Chromium 84.

The problem is that now we need to upgrade Chromium to something less ancient, so we need to update the code of the web benchmarks to recognize the new event names.

* **This is a backport from `package:web_benchmarks`**
  * https://github.com/flutter/packages/pull/518

Partially addresses: https://github.com/flutter/flutter/issues/97324 (and probably anything related to old-Chromium related crashes/unavailability)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
