### PR TITLE
fix(flutter_tools): Format `gen-l10n` output files with `dart format`

### DIFF
--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -74,6 +74,7 @@ void main() {
   /* late */ String defaultL10nPathString;
   /* late */ String syntheticPackagePath;
   /* late */ String syntheticL10nPackagePath;
+  /* late */ ProcessManager processManager;
 
   setUp(() {
     fs = MemoryFileSystem.test();
@@ -81,6 +82,16 @@ void main() {
     defaultL10nPathString = fs.path.join('lib', 'l10n');
     syntheticPackagePath = fs.path.join('.dart_tool', 'flutter_gen');
     syntheticL10nPackagePath = fs.path.join(syntheticPackagePath, 'gen_l10n');
+    processManager = FakeProcessManager.list(
+      <FakeCommand>[
+        const FakeCommand(
+          command: <String>[
+            'dart',
+            'format'
+          ],
+        ),
+      ],
+    );
     precacheLanguageAndRegionTags();
   });
 
@@ -508,7 +519,7 @@ void main() {
       expect(outputList, contains(contains('unimplemented_message_translations.json')));
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => FakeProcessManager.any(),
+      ProcessManager: () => processManager,
     }
   );
 
@@ -698,7 +709,7 @@ void main() {
       expect(outputList, contains(fs.path.absolute(syntheticL10nPackagePath, 'output-localization-file_es.dart')));
     },
     overrides: <Type, Generator>{
-      ProcessManager: () => FakeProcessManager.any(),
+      ProcessManager: () => processManager,
     },
   );
 
@@ -821,7 +832,7 @@ class FooEn extends Foo {
 ''');
       },
       overrides: <Type, Generator>{
-        ProcessManager: () => FakeProcessManager.any(),
+        ProcessManager: () => processManager,
       },
     );
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -68,7 +68,7 @@ void _standardFlutterDirectoryL10nSetup(FileSystem fs) {
 }
 
 void main() {
-  // TODO(MichaelDark): revert `late` modifer 
+  // TODO(MichaelDark): revert `late` modifer
   // once `text/src/context.dart` will be migrated to sound null-safety
   /* late */ MemoryFileSystem fs;
   /* late */ String defaultL10nPathString;
@@ -480,7 +480,7 @@ void main() {
   );
 
   testUsingContext(
-    'untranslated messages file included in generated JSON list of outputs', 
+    'untranslated messages file included in generated JSON list of outputs',
     () {
       _standardFlutterDirectoryL10nSetup(fs);
 
@@ -665,7 +665,7 @@ void main() {
   );
 
   testUsingContext(
-    'creates list of inputs and outputs when file path is specified', 
+    'creates list of inputs and outputs when file path is specified',
     () {
       _standardFlutterDirectoryL10nSetup(fs);
 
@@ -762,7 +762,7 @@ void main() {
 
   group('generateLocalizations', () {
     testUsingContext(
-      'forwards arguments correctly', 
+      'forwards arguments correctly',
       () async {
         _standardFlutterDirectoryL10nSetup(fs);
         final LocalizationOptions options = LocalizationOptions(


### PR DESCRIPTION
Format `gen-l10n` output with `dart format` 

Fixes:
- https://github.com/flutter/flutter/issues/98122

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.