### PR TITLE
Added a microbenchmark for Timeline events.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/foundation/timeline_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/timeline_bench.dart
@@ -1,0 +1,53 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:developer';
+
+import '../common.dart';
+
+const int _kNumIterations = 10000;
+
+void main() {
+  assert(false,
+      "Don't run benchmarks in checked mode! Use 'flutter run --release'.");
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+
+  final Stopwatch watch = Stopwatch();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    Timeline.startSync('foo');
+    Timeline.finishSync();
+  }
+  watch.stop();
+
+  printer.addResult(
+    description: 'timeline events without arguments',
+    value: watch.elapsedMicroseconds.toDouble() / _kNumIterations,
+    unit: 'us per iteration',
+    name: 'timeline_without_arguments',
+  );
+
+  watch.reset();
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    Timeline.startSync('foo', arguments: <String, dynamic>{
+      'int': 1234,
+      'double': 0.3,
+      'list': <int>[1, 2, 3, 4],
+      'map': <String, dynamic>{'map': true},
+      'bool': false,
+    });
+    Timeline.finishSync();
+  }
+  watch.stop();
+
+  printer.addResult(
+    description: 'timeline events with arguments',
+    value: watch.elapsedMicroseconds.toDouble() / _kNumIterations,
+    unit: 'us per iteration',
+    name: 'timeline_with_arguments',
+  );
+
+  printer.printToStdout();
+}

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -60,6 +60,7 @@ TaskFunction createMicrobenchmarkTask() {
       ...await _runMicrobench('lib/language/sync_star_semantics_bench.dart'),
       ...await _runMicrobench('lib/foundation/all_elements_bench.dart'),
       ...await _runMicrobench('lib/foundation/change_notifier_bench.dart'),
+      ...await _runMicrobench('lib/foundation/timeline_bench.dart'),
     };
 
     return TaskResult.success(allResults,


### PR DESCRIPTION
Minimizing the overhead for performance tracking tools should be a goal.  I see there might be some room for optimization here.

Test exempt: This is a test.

cc @iskakaushik 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
