### PR TITLE
Make `Spacer` extend `Expanded`

### DIFF
--- a/packages/flutter/lib/src/widgets/spacer.dart
+++ b/packages/flutter/lib/src/widgets/spacer.dart
@@ -38,29 +38,17 @@ import 'framework.dart';
 ///  * [Row] and [Column], which are the most common containers to use a Spacer
 ///    in.
 ///  * [SizedBox], to create a box with a specific size and an optional child.
-class Spacer extends StatelessWidget {
+class Spacer extends Expanded {
   /// Creates a flexible space to insert into a [Flexible] widget.
   ///
   /// The [flex] parameter may not be null or less than one.
-  const Spacer({Key? key, this.flex = 1})
+  const Spacer({Key? key, int flex = 1})
     : assert(flex != null),
       assert(flex > 0),
-      super(key: key);
+      super(
+        flex: flex,
+        child: const SizedBox.shrink(),
+        key: key,
+      );
 
-  /// The flex factor to use in determining how much space to take up.
-  ///
-  /// The amount of space the [Spacer] can occupy in the main axis is determined
-  /// by dividing the free space proportionately, after placing the inflexible
-  /// children, according to the flex factors of the flexible children.
-  ///
-  /// Defaults to one.
-  final int flex;
-
-  @override
-  Widget build(BuildContext context) {
-    return Expanded(
-      flex: flex,
-      child: const SizedBox.shrink(),
-    );
-  }
 }


### PR DESCRIPTION
I made `Spacer` extend `Expanded` instead of `StatelessWidget`.

Attempt to fix https://github.com/flutter/flutter/issues/98787


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
