### PR TITLE
fixed issue in font fallback in case user is using packages

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -564,7 +564,7 @@ class TextStyle with Diagnosticable {
   /// prefixed with 'packages/package_name/' (e.g. 'packages/cool_fonts/Roboto').
   /// The package name should be provided by the `package` argument in the
   /// constructor.
-  List<String>? get fontFamilyFallback => _package != null && _fontFamilyFallback != null ? _fontFamilyFallback!.map((String str) => 'packages/$_package/$str').toList() : _fontFamilyFallback;
+  List<String>? get fontFamilyFallback => _package != null && _fontFamilyFallback != null ? _fontFamilyFallback!.map((String str) => !str.contains('packages/$_package/') ? 'packages/$_package/$str' : str).toList() : _fontFamilyFallback;
   final List<String>? _fontFamilyFallback;
 
   // This is stored in order to prefix the fontFamilies in _fontFamilyFallback


### PR DESCRIPTION
Problem that I faced :
	I was using fontFamilyFallback attribute of TextStyle. I defined package attribute of TextStyle to load font from a package but font was not getting picked from fontFamilyFallback list. I have defined TextStyle as:

        TextStyle(
  			color: Colors.blue,
  			fontWeight: FontWeight.w400,
  			fontFamily: 'VerdanaPro',
  			fontFamilyFallback: const <String>['TimesNewRoman'],
  			package: 'lib_style',
  			fontStyle: FontStyle.normal,
  			fontSize: 18.0,
		);


During debugging I found out that package's path ('packages/package_name') are getting appended multiple times for each font family in fontFamilyFallback list. 

TextStyle(inherit: true, color: Color(0xff999999), family: packages/lib_style/VerdanaPro, familyFallback: [packages/lib_style/packages/lib_style/TimesNewRoman], size: 12.0, weight: 400, style: normal)


Fix: 
 	In this PR I have applied check, if font family in fontFamilyFallback list are already prefixed with 'packages/package_name/' then don't prefixed it again. After adding the check log for style is as:

 TextStyle(inherit: true, color: Color(0xff999999), family: packages/lib_style/VerdanaPro, familyFallback: [packages/lib_style/TimesNewRoman], size: 12.0, weight: 400, style: normal)

Issue 
      1. https://github.com/flutter/flutter/issues/53241